### PR TITLE
Check that $CONFIG_MK is writable.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -303,6 +303,8 @@ case "$MODE" in
         else
             tightdb_echo "Could not find home of TightDB core library built for iPhone"
         fi
+	
+	touch "$CONFIG_MK" || { echo "Can't overwrite $CONFIG_MK." ; exit 1 ; }
 
         cat >"$CONFIG_MK" <<EOF
 INSTALL_PREFIX      = $install_prefix


### PR DESCRIPTION
I discovered this issue having installed XCode from the command line. When
running config, it would ask me to run as root so that I could accept the
license agreement. Running as root creates a $CONFIG_MK, with root priveleges.
It is only then that I was told that I should run a special tool instead to
accept the license agreement. Running config afterwards, clearly disallowed me
to overwrite the config, but the script didn't report this in a pretty way.

@kspangsege @kneth 
