### PR TITLE
Makefile upgraded to latest version from core library

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -303,8 +303,8 @@ case "$MODE" in
         else
             tightdb_echo "Could not find home of TightDB core library built for iPhone"
         fi
-	
-	touch "$CONFIG_MK" || { echo "Can't overwrite $CONFIG_MK." ; exit 1 ; }
+
+	touch "$CONFIG_MK" || { echo "Can't overwrite $CONFIG_MK."; exit 1; }
 
         cat >"$CONFIG_MK" <<EOF
 INSTALL_PREFIX      = $install_prefix
@@ -424,36 +424,36 @@ EOF
 
     "test")
         require_config || exit 1
-        $MAKE test-norun || exit 1
+        $MAKE check-norun || exit 1
         TEMP_DIR="$(mktemp -d /tmp/tightdb.objc.test.XXXX)" || exit 1
         mkdir -p "$TEMP_DIR/unit-tests.octest/Contents/MacOS" || exit 1
         cp "src/tightdb/objc/test/unit-tests" "$TEMP_DIR/unit-tests.octest/Contents/MacOS/" || exit 1
         XCODE_HOME="$(xcode-select --print-path)" || exit 1
-        OBJC_DISABLE_GC=YES "$XCODE_HOME/Tools/otest" "$TEMP_DIR/unit-tests.octest" || exit 1
+        DYLD_LIBRARY_PATH="$TIGHTDB_OBJC_HOME/src/tightdb/objc" OBJC_DISABLE_GC=YES "$XCODE_HOME/Tools/otest" "$TEMP_DIR/unit-tests.octest" || exit 1
         echo "Test passed"
         exit 0
         ;;
 
     "test-debug")
         require_config || exit 1
-        $MAKE test-debug-norun || exit 1
+        $MAKE check-debug-norun || exit 1
         TEMP_DIR="$(mktemp -d /tmp/tightdb.objc.test-debug.XXXX)" || exit 1
         mkdir -p "$TEMP_DIR/unit-tests-dbg.octest/Contents/MacOS" || exit 1
         cp "src/tightdb/objc/test/unit-tests-dbg" "$TEMP_DIR/unit-tests-dbg.octest/Contents/MacOS/" || exit 1
         XCODE_HOME="$(xcode-select --print-path)" || exit 1
-        OBJC_DISABLE_GC=YES "$XCODE_HOME/Tools/otest" "$TEMP_DIR/unit-tests-dbg.octest" || exit 1
+        DYLD_LIBRARY_PATH="$TIGHTDB_OBJC_HOME/src/tightdb/objc" OBJC_DISABLE_GC=YES "$XCODE_HOME/Tools/otest" "$TEMP_DIR/unit-tests-dbg.octest" || exit 1
         echo "Test passed"
         exit 0
         ;;
 
     "test-gdb")
         require_config || exit 1
-        $MAKE test-debug-norun || exit 1
+        $MAKE check-debug-norun || exit 1
         TEMP_DIR="$(mktemp -d /tmp/tightdb.objc.test-gdb.XXXX)" || exit 1
         mkdir -p "$TEMP_DIR/unit-tests-dbg.octest/Contents/MacOS" || exit 1
         cp "src/tightdb/objc/test/unit-tests-dbg" "$TEMP_DIR/unit-tests-dbg.octest/Contents/MacOS/" || exit 1
         XCODE_HOME="$(xcode-select --print-path)" || exit 1
-        OBJC_DISABLE_GC=YES gdb --args "$XCODE_HOME/Tools/otest" "$TEMP_DIR/unit-tests-dbg.octest"
+        DYLD_LIBRARY_PATH="$TIGHTDB_OBJC_HOME/src/tightdb/objc" OBJC_DISABLE_GC=YES gdb --args "$XCODE_HOME/Tools/otest" "$TEMP_DIR/unit-tests-dbg.octest"
         ;;
 
     "test-examples")
@@ -492,14 +492,14 @@ EOF
 
     "install-prod")
         require_config || exit 1
-        $MAKE install-only DESTDIR="$DESTDIR" INSTALL_FILTER=shared-libs || exit 1
+        $MAKE install-only DESTDIR="$DESTDIR" INSTALL_FILTER="shared-libs,progs" || exit 1
         tightdb_echo "Done installing"
         exit 0
         ;;
 
     "install-devel")
         require_config || exit 1
-        $MAKE install-only DESTDIR="$DESTDIR" INSTALL_FILTER=static-libs,progs,headers || exit 1
+        $MAKE install-only DESTDIR="$DESTDIR" INSTALL_FILTER="static-libs,dev-progs,headers" || exit 1
         tigtdb_echo "Done installing"
         exit 0
         ;;
@@ -513,14 +513,14 @@ EOF
 
     "uninstall-prod")
         require_config || exit 1
-        $MAKE uninstall INSTALL_FILTER=shared-libs || exit 1
+        $MAKE uninstall INSTALL_FILTER="shared-libs,progs" || exit 1
         echo "Done uninstalling"
         exit 0
         ;;
 
     "uninstall-devel")
         require_config || exit 1
-        $MAKE uninstall INSTALL_FILTER=static-libs,progs,extra || exit 1
+        $MAKE uninstall INSTALL_FILTER="static-libs,dev-progs,headers" || exit 1
         echo "Done uninstalling"
         exit 0
         ;;
@@ -532,7 +532,7 @@ EOF
         export TIGHTDB_OBJC_INCLUDEDIR="$install_includedir"
         export TIGHTDB_OBJC_LIBDIR="$install_libdir"
         $MAKE -C "test-installed" clean || exit 1
-        $MAKE -C "test-installed" test  || exit 1
+        $MAKE -C "test-installed" check  || exit 1
         echo "Test passed"
         exit 0
         ;;

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,7 +1,6 @@
-TEST_PROGRAMS = tutorial
+check_PROGRAMS = tutorial
 
-tutorial_SOURCES = \
-tutorial.m 
+tutorial_SOURCES = tutorial.m
 
 tutorial_CFLAGS  = -Wno-comment -fobjc-arc -fobjc-abi-version=2
 tutorial_LDFLAGS = -fobjc-link-runtime

--- a/src/project.mk
+++ b/src/project.mk
@@ -1,39 +1,48 @@
-SOURCE_ROOT = .
+INCLUDE_ROOT = .
 ENABLE_INSTALL_DEBUG_LIBS  = 1
 
 # Construct fat binaries on Darwin when using Clang
 ifneq ($(TIGHTDB_ENABLE_FAT_BINARIES),)
-ifneq ($(call CC_CXX_AND_LD_ARE,clang),)
-ifeq ($(OS),Darwin)
-CFLAGS_ARCH += -arch i386 -arch x86_64
-endif
-endif
+  ifneq ($(call CC_CXX_AND_LD_ARE,clang),)
+    ifeq ($(OS),Darwin)
+      CFLAGS_ARCH += -arch i386 -arch x86_64
+    endif
+  endif
 endif
 
 ifeq ($(OS),Darwin)
-CFLAGS_ARCH += -mmacosx-version-min=10.7
+  CFLAGS_ARCH += -mmacosx-version-min=10.7
 endif
 
 # FIXME: '-fno-elide-constructors' currently causes TightDB to fail
 #CFLAGS_DEBUG   += -fno-elide-constructors
-CFLAGS_PTHREAD += -pthread
+CFLAGS_PTHREADS += -pthread
 CFLAGS_GENERAL += -Wextra -ansi
+
+# Avoid a warning from Clang when linking on OS X. By default,
+# `LDFLAGS_PTHREADS` inherits its value from `CFLAGS_PTHREADS`, so we
+# have to override that with an empty value.
+ifneq ($(call CC_CXX_AND_LD_ARE,clang),)
+  ifeq ($(OS),Darwin)
+    LDFLAGS_PTHREADS = $(EMPTY)
+  endif
+endif
 
 # Load dynamic configuration
 ifeq ($(NO_CONFIG_MK),)
-CONFIG_MK = $(GENERIC_MK_DIR)/config.mk
-DEP_MAKEFILES += $(CONFIG_MK)
-include $(CONFIG_MK)
-prefix      = $(INSTALL_PREFIX)
-exec_prefix = $(INSTALL_EXEC_PREFIX)
-includedir  = $(INSTALL_INCLUDEDIR)
-bindir      = $(INSTALL_BINDIR)
-libdir      = $(INSTALL_LIBDIR)
-libexecdir  = $(INSTALL_LIBEXECDIR)
-PROJECT_CFLAGS_OPTIM  = $(TIGHTDB_CFLAGS)
-PROJECT_CFLAGS_DEBUG  = $(TIGHTDB_CFLAGS_DBG)
-PROJECT_CFLAGS_COVER  = $(TIGHTDB_CFLAGS_DBG)
-PROJECT_LDFLAGS_OPTIM = $(TIGHTDB_LDFLAGS)
-PROJECT_LDFLAGS_DEBUG = $(TIGHTDB_LDFLAGS_DBG)
-PROJECT_LDFLAGS_COVER = $(TIGHTDB_LDFLAGS_DBG)
+  CONFIG_MK = $(GENERIC_MK_DIR)/config.mk
+  DEP_MAKEFILES += $(CONFIG_MK)
+  include $(CONFIG_MK)
+  prefix      = $(INSTALL_PREFIX)
+  exec_prefix = $(INSTALL_EXEC_PREFIX)
+  includedir  = $(INSTALL_INCLUDEDIR)
+  bindir      = $(INSTALL_BINDIR)
+  libdir      = $(INSTALL_LIBDIR)
+  libexecdir  = $(INSTALL_LIBEXECDIR)
+  PROJECT_CFLAGS_OPTIM  = $(TIGHTDB_CFLAGS)
+  PROJECT_CFLAGS_DEBUG  = $(TIGHTDB_CFLAGS_DBG)
+  PROJECT_CFLAGS_COVER  = $(TIGHTDB_CFLAGS_DBG)
+  PROJECT_LDFLAGS_OPTIM = $(TIGHTDB_LDFLAGS)
+  PROJECT_LDFLAGS_DEBUG = $(TIGHTDB_LDFLAGS_DBG)
+  PROJECT_LDFLAGS_COVER = $(TIGHTDB_LDFLAGS_DBG)
 endif

--- a/src/tightdb/objc/Makefile
+++ b/src/tightdb/objc/Makefile
@@ -1,7 +1,9 @@
 SUBDIRS = test
 test_DEPS = .
 
-INST_HEADERS = type.h cursor.h group.h query.h table.h group_shared.h helper_macros.h tightdb.h
+nobase_subinclude_HEADERS = type.h cursor.h group.h query.h table.h group_shared.h helper_macros.h tightdb.h
+
+nobase_subinclude_HEADERS_EXTRA_UNINSTALL = *.h
 
 lib_LIBRARIES = libtightdb-objc.a
 
@@ -32,24 +34,19 @@ libtightdb_objc_a_LDFLAGS = -fobjc-link-runtime -framework Cocoa
 # http://www.gnu.org/software/libtool/manual/libtool.html#Libtool-versioning
 libtightdb_objc_a_VERSION = 2:0:0
 
-ifeq ($(DISABLE_CHEETAH_CODE_GEN),)
-GENERATED_SOURCES += tightdb.h
-endif
-
-include ../../generic.mk
 
 # Code generation
 ifeq ($(DISABLE_CHEETAH_CODE_GEN),)
+GENERATED_SOURCES += tightdb.h
 tightdb.h: tightdb.h.cheetah cheetah.sh
 	$(SHELL) cheetah.sh $< $@
 endif
 
-uninstall/extra:
-	$(RM) $(DESTDIR)$(includedir)/tightdb/objc/*.h
-	-rmdir $(DESTDIR)$(includedir)/tightdb/objc
-	-rmdir $(DESTDIR)$(includedir)/tightdb
 
 # Used by ../../../build.sh
 .PHONY: get-inst-headers
 get-inst-headers:
-	@echo $(INST_HEADERS)
+	@echo $(subinclude_HEADERS)
+
+
+include ../../generic.mk

--- a/src/tightdb/objc/test/Makefile
+++ b/src/tightdb/objc/test/Makefile
@@ -1,4 +1,4 @@
-TEST_PROGRAMS = unit-tests
+check_PROGRAMS = unit-tests
 
 unit_tests_SOURCES = \
 data_type.mm table.m group.m group_misc_2.m table_delete_all.m tutorial.m enumerator.m \

--- a/test-installed/Makefile
+++ b/test-installed/Makefile
@@ -1,4 +1,4 @@
-TEST_PROGRAMS = test-installed
+check_PROGRAMS = test-installed
 
 test_installed_SOURCES = test.mm
 test_installed_CFLAGS  = -fobjc-arc -fobjc-abi-version=2

--- a/test-installed/project.mk
+++ b/test-installed/project.mk
@@ -1,14 +1,23 @@
 ifeq ($(OS),Darwin)
-CFLAGS_ARCH += -mmacosx-version-min=10.7
+  CFLAGS_ARCH += -mmacosx-version-min=10.7
 endif
 
-CFLAGS_PTHREAD += -pthread
+CFLAGS_PTHREADS += -pthread
 CFLAGS_GENERAL += -Wextra -ansi -pedantic -Wno-long-long
 
+# Avoid a warning from Clang when linking on OS X. By default,
+# `LDFLAGS_PTHREADS` inherits its value from `CFLAGS_PTHREADS`, so we
+# have to override that with an empty value.
+ifneq ($(call CC_CXX_AND_LD_ARE,clang),)
+  ifeq ($(OS),Darwin)
+    LDFLAGS_PTHREADS = $(EMPTY)
+  endif
+endif
+
 ifneq ($(TIGHTDB_OBJC_INCLUDEDIR),)
-PROJECT_CFLAGS = -I$(TIGHTDB_OBJC_INCLUDEDIR)
+  PROJECT_CFLAGS = -I$(TIGHTDB_OBJC_INCLUDEDIR)
 endif
 
 ifneq ($(TIGHTDB_OBJC_LIBDIR),)
-PROJECT_LDFLAGS = -L$(TIGHTDB_OBJC_LIBDIR) -Wl,-rpath,$(TIGHTDB_OBJC_LIBDIR)
+  PROJECT_LDFLAGS = -L$(TIGHTDB_OBJC_LIBDIR) -Wl,-rpath,$(TIGHTDB_OBJC_LIBDIR)
 endif


### PR DESCRIPTION
Makefile (generic.mk) upgraded to version 1.0.1 (latest) from core library.

This adds support for major goal `test-cover-norun`, and much much more.

@Tightdb/oleks @mekjaer @bmunkholm @emanuelez @oleks 
