### PR TITLE
No C99/C++ comments allowed in Obj-C files (discounting Obj-C++ files)

### DIFF
--- a/doc/ref/examples/ex_objc_group_intro.m
+++ b/doc/ref/examples/ex_objc_group_intro.m
@@ -1,4 +1,4 @@
-// @@Example: ex_objc_group_intro @@
+/* @@Example: ex_objc_group_intro @@ */
 
 #import <tightdb/objc/group.h>
 #import <tightdb/objc/table.h>
@@ -18,30 +18,30 @@ int main()
 {
     @autoreleasepool {
 
-        // Creates a group and uses it to create a new table.
+        /* Creates a group and uses it to create a new table. */
 
         TightdbGroup *group = [TightdbGroup group];
         PeopleTable *table = [group getTable:@"people" withClass:[PeopleTable class]];
 
-        // Adds values to the table.
+        /* Adds values to the table. */
 
         [table addName:@"Mary" Age:14];
         [table addName:@"Joe" Age:17];
 
-        // Write the group (and the contained table) to a specified file.
+        /* Write the group (and the contained table) to a specified file. */
 
         [[NSFileManager defaultManager] removeItemAtPath:@"filename.tightdb" error:nil];
         [group write:@"filename.tightdb"];
 
-        // Adds another row to the table. Note the update is NOT persisted
-        // automatically (delete the old file and use write again).
+        /* Adds another row to the table. Note the update is NOT persisted
+           automatically (delete the old file and use write again). */
 
         [table addName:@"Sam" Age:17];
 
         [[NSFileManager defaultManager] removeItemAtPath:@"filename.tightdb" error:nil];
         [group write:@"filename.tightdb"];
 
-        // Retrieves an in memory buffer from the group.
+        /* Retrieves an in memory buffer from the group. */
 
         size_t size;
         const char *buffer = [group writeToMem:&size];
@@ -54,14 +54,13 @@ int main()
             NSLog(@"Name: %@", cursor.Name);
         }
 
-        // Caution: Calling free(..) on the "buffer" is sometimes required to avoid leakage. However,
-        // the group that retrieves data from memeory takes responsibilty for the memory allocation in this example.
+        /* Caution: Calling free(..) on the "buffer" is sometimes required to avoid leakage. However,
+           the group that retrieves data from memeory takes responsibilty for the memory allocation in this example. */
 
-        // free((char*)buffer); // not needed in this particular situation.
-
+        /* free((char*)buffer); */ /* not needed in this particular situation. */
     }
 }
 
 
 
-// @@EndExample@@
+/* @@EndExample@@ */

--- a/doc/ref/examples/ex_objc_query_dynamic_intro.m
+++ b/doc/ref/examples/ex_objc_query_dynamic_intro.m
@@ -1,4 +1,4 @@
-// @@Example: ex_objc_query_dynamic_intro @@
+/* @@Example: ex_objc_query_dynamic_intro @@ */
 
 #import <tightdb/objc/table.h>
 #import <tightdb/objc/tightdb.h>
@@ -8,9 +8,9 @@
 int main()
 {
     @autoreleasepool {
-        // TODO: Update example to the cursor.
+        /* TODO: Update example to the cursor. */
 
-        // Creates a new table dynamically.
+        /* Creates a new table dynamically. */
 
         TightdbTable *table = [[TightdbTable alloc] init];
 
@@ -18,13 +18,13 @@ int main()
         size_t const AGE = [table addColumnWithType:tightdb_Int andName:@"Age"];
         size_t const HIRED = [table addColumnWithType:tightdb_Bool andName:@"Hired"];
 
-        // Add some people.
+        /* Add some people. */
 
-        // Add rows and values.
+        /* Add rows and values. */
 
         TightdbCursor *cursor;
 
-        // Row 0
+        /* Row 0 */
 
         cursor = [table addRow];
 
@@ -32,7 +32,7 @@ int main()
         [cursor setString:@"Joe" inColumn:NAME];
         [cursor setBool:YES inColumn:HIRED];
 
-        // Row 1
+        /* Row 1 */
 
         cursor = [table addRow];
 
@@ -40,7 +40,7 @@ int main()
         [cursor setString:@"Simon" inColumn:NAME];
         [cursor setBool:YES inColumn:HIRED];
 
-        // Row 2
+        /* Row 2 */
 
         cursor = [table addRow];
 
@@ -48,7 +48,7 @@ int main()
         [cursor setString:@"Steve" inColumn:NAME];
         [cursor setBool:NO inColumn:HIRED];
 
-        // Row 3
+        /* Row 3 */
 
         cursor = [table addRow];
 
@@ -56,16 +56,16 @@ int main()
         [cursor setString:@"Nick" inColumn:NAME];
         [cursor setBool:YES inColumn:HIRED];
 
-        // Set up a query to search for employees.
+        /* Set up a query to search for employees. */
 
         TightdbQuery *q =  [[[table where] column: AGE   isBetweenInt:0 and_:60]
                                            column: HIRED isEqualToBool:YES];
 
-        // Execute the query.
+        /* Execute the query. */
 
         TightdbView *view = [q findAll];
 
-        // Print the names.
+        /* Print the names. */
 
         for (TightdbCursor *c in view) {
 
@@ -79,4 +79,4 @@ int main()
     }
 }
 
-// @@EndExample@@
+/* @@EndExample@@ */

--- a/doc/ref/examples/ex_objc_query_typed_intro.m
+++ b/doc/ref/examples/ex_objc_query_typed_intro.m
@@ -1,9 +1,9 @@
-// @@Example: ex_objc_query_typed_intro @@
+/* @@Example: ex_objc_query_typed_intro @@ */
 
 #import <tightdb/objc/table.h>
 #import <tightdb/objc/tightdb.h>
 
-// Defines a new table with two columns Name and Age.
+/* Defines a new table with two columns Name and Age. */
 
 TIGHTDB_TABLE_2(PeopleTable,
                 Name, String,
@@ -13,11 +13,11 @@ int main()
 {
     @autoreleasepool {
 
-        // Creates a new table of the type defined above.
+        /* Creates a new table of the type defined above. */
 
         PeopleTable *table = [[PeopleTable alloc] init];
 
-        // Adds rows to the table.
+        /* Adds rows to the table. */
 
         [table addName:@"Brian" Age:14];
         [table addName:@"Joe" Age:17];
@@ -25,11 +25,11 @@ int main()
         [table addName:@"Sam" Age:34];
         [table addName:@"Bob" Age:10];
 
-        // Create a query.
+        /* Create a query. */
 
         PeopleTable_Query *query = [[[[table where].Age columnIsGreaterThan:20] or].Name columnIsEqualTo:@"Bob"];
 
-        // Iterate over the query result.
+        /* Iterate over the query result. */
 
         for (PeopleTable_Cursor *curser in query) {
             NSLog(@"Person matching query: %@", [curser Name]);
@@ -38,4 +38,4 @@ int main()
     }
 }
 
-// @@EndExample@@
+/* @@EndExample@@ */

--- a/doc/ref/examples/ex_objc_sharedgroup_intro.m
+++ b/doc/ref/examples/ex_objc_sharedgroup_intro.m
@@ -1,4 +1,4 @@
-// @@Example: ex_objc_sharedgroup_intro @@
+/* @@Example: ex_objc_sharedgroup_intro @@ */
 
 #import <tightdb/objc/group.h>
 #import <tightdb/objc/group_shared.h>
@@ -14,33 +14,33 @@ int main()
 {
     @autoreleasepool {
 
-        // Creates a group and uses it to create a new table.
+        /* Creates a group and uses it to create a new table. */
 
         TightdbSharedGroup *shared = [TightdbSharedGroup groupWithFilename:@"sharedgroup.tightdb"];
 
-        // A write transaction (with rollback if not first writer to employees table).
+        /* A write transaction (with rollback if not first writer to employees table). */
 
         [shared writeTransaction:^(TightdbGroup *group) {
 
-            // Write transactions with the shared group are possible via the provided variable binding named group.
+            /* Write transactions with the shared group are possible via the provided variable binding named group. */
 
             PeopleTable *table = [group getTable:@"employees" withClass:[PeopleTable class]];
             if ([table count] > 0) {
                 NSLog(@"Not empty!");
-                return NO; // Rollback
+                return NO; /* Rollback */
             }
 
             [table addName:@"Bill" Age:53 Hired:YES];
             NSLog(@"Row added!");
-            return YES; // Commit
+            return YES; /* Commit */
 
         }];
 
-        // A read transaction
+        /* A read transaction */
 
         [shared readTransaction:^(TightdbGroup *group) {
 
-            // Read transactions with the shared group are possible via the provided variable binding named group.
+            /* Read transactions with the shared group are possible via the provided variable binding named group. */
 
             PeopleTable *table = [group getTable:@"employees" withClass:[PeopleTable class]];
 
@@ -53,4 +53,4 @@ int main()
     }
 
 }
-// @@EndExample@@
+/* @@EndExample@@ */

--- a/doc/ref/examples/ex_objc_table_dynamic_intro.m
+++ b/doc/ref/examples/ex_objc_table_dynamic_intro.m
@@ -1,4 +1,4 @@
-// @@Example: ex_objc_table_dynamic_intro @@
+/* @@Example: ex_objc_table_dynamic_intro @@ */
 
 #import <tightdb/objc/table.h>
 #import <tightdb/objc/tightdb.h>
@@ -9,52 +9,52 @@ int main()
 {
     @autoreleasepool {
 
-        // Create a new table dynamically.
+        /* Create a new table dynamically. */
 
         TightdbTable *table = [[TightdbTable alloc] init];
 
         size_t const NAME = [table addColumnWithType:tightdb_String andName:@"Name"];
         size_t const AGE = [table addColumnWithType:tightdb_Int andName:@"Age"];
 
-        // Add rows and values.
+        /* Add rows and values. */
 
         TightdbCursor *cursor;
 
-        // Row 0
+        /* Row 0 */
 
         cursor = [table addRow];
 
         [cursor setInt:23 inColumn:AGE];
         [cursor setString:@"Joe" inColumn:NAME];
 
-        // Row 1
+        /* Row 1 */
 
         cursor = [table addRow];
 
         [cursor setInt:32 inColumn:AGE];
         [cursor setString:@"Simon" inColumn:NAME];
 
-        // Row 2
+        /* Row 2 */
 
         cursor = [table addRow];
 
         [cursor setInt:12 inColumn:AGE];
         [cursor setString:@"Steve" inColumn:NAME];
 
-        // Row 3
+        /* Row 3 */
 
         cursor = [table addRow];
 
         [cursor setInt:100 inColumn:AGE];
         [cursor setString:@"Nick" inColumn:NAME];
 
-        // Print using a cursor.
+        /* Print using a cursor. */
 
         for (TightdbCursor *ite in table)
             NSLog(@"Name: %@ Age: %lld", [ite getStringInColumn:NAME], [ite getIntInColumn:AGE]);
 
 
-        // Insert a row and print.
+        /* Insert a row and print. */
 
         cursor = [table insertRowAtIndex:2];
         [cursor setInt:21 inColumn:AGE];
@@ -67,7 +67,7 @@ int main()
             NSLog(@"Name: %@ Age: %lld", [ite getStringInColumn:NAME], [ite getIntInColumn:AGE]);
 
 
-        // Update a few rows and print again.
+        /* Update a few rows and print again. */
 
         cursor = [table cursorAtIndex:2];
         [cursor setString:@"Now I'm UPDATED" inColumn:NAME];
@@ -80,7 +80,7 @@ int main()
         for (TightdbCursor *ite in table)
             NSLog(@"Name: %@ Age: %lld", [ite getStringInColumn:NAME], [ite getIntInColumn:AGE]);
 
-        // Index not existing.
+        /* Index not existing. */
 
         TightdbCursor *c2 = [table cursorAtIndex:[table count]];
         if (c2 != nil)
@@ -90,4 +90,4 @@ int main()
     }
 }
 
-// @@EndExample@@
+/* @@EndExample@@ */

--- a/doc/ref/examples/ex_objc_table_typed_intro.m
+++ b/doc/ref/examples/ex_objc_table_typed_intro.m
@@ -1,11 +1,11 @@
-// @@Example: ex_objc_table_typed_intro @@
+/* @@Example: ex_objc_table_typed_intro @@ */
 
 
 #import <tightdb/objc/table.h>
 #import <tightdb/objc/tightdb.h>
 
 
-// Defines a new table with two columns Name and Age.
+/* Defines a new table with two columns Name and Age. */
 
 TIGHTDB_TABLE_2(PeopleTable,
                 Name, String,
@@ -16,7 +16,7 @@ int main()
 {
     @autoreleasepool {
 
-        // Creates a new table of the type defined above.
+        /* Creates a new table of the type defined above. */
 
         PeopleTable *table = [[PeopleTable alloc] init];
 
@@ -58,4 +58,4 @@ int main()
 
 
 
-// @@EndExample@@
+/* @@EndExample@@ */

--- a/doc/ref/examples/ex_objc_table_typed_intro_with_many_comments.m
+++ b/doc/ref/examples/ex_objc_table_typed_intro_with_many_comments.m
@@ -1,13 +1,13 @@
-// @@Example: not_used @@
+/* @@Example: not_used @@ */
 
 #import <tightdb/objc/table.h>
 #import <tightdb/objc/tightdb.h>
 
-// Defines a new table with two columns Name and Age. IMPORTANT: the column
-// names MUST begin with a capital. This table definition triggers a macro
-// defining the classes PeopleTable, PeopleTable_Query, PeopleTable_Curser
-// and PeopleTable_View. The column types must be TightDB types (refer to
-// the constructor TIGHTDB_TABLE_* in the documentation.
+/* Defines a new table with two columns Name and Age. IMPORTANT: the column
+ * names MUST begin with a capital. This table definition triggers a macro
+ * defining the classes PeopleTable, PeopleTable_Query, PeopleTable_Curser
+ * and PeopleTable_View. The column types must be TightDB types (refer to
+ * the constructor TIGHTDB_TABLE_* in the documentation. */
 
 TIGHTDB_TABLE_2(PeopleTable,
                 Name, String,
@@ -17,12 +17,12 @@ int main()
 {
     @autoreleasepool {
 
-        // Creates a new table of the type defined above.
+        /* Creates a new table of the type defined above. */
 
         PeopleTable *table = [[PeopleTable alloc] init];
 
-        // Adds rows to the table. Notice that the signtaure of the method for
-        // adding rows includes the custom defined column nammes.
+        /* Adds rows to the table. Notice that the signtaure of the method for
+         * adding rows includes the custom defined column nammes. */
 
         [table addName:@"Mary" Age:14];
         [table addName:@"Joe" Age:17];
@@ -31,31 +31,31 @@ int main()
         [table addName:@"Simon" Age:16];
         [table addName:@"Carol" Age:66];
 
-        // Creates a query expression to filter on age. Note that the
-        // quiry is defined but not executed here.
+        /* Creates a query expression to filter on age. Note that the
+         * quiry is defined but not executed here. */
 
-        PeopleTable_Query *query = [[table where].Age between:13 to:19];
+        PeopleTable_Query *query = [[table where].Age columnIsBetween:13 and_:19];
 
-        // Accesses query result directly on the quiry object. The quiry is
-        // executed once.
+        /* Accesses query result directly on the quiry object. The quiry is
+         * executed once. */
 
         for (PeopleTable_Cursor *curser in query)
             NSLog(@"Name: %@", [curser Name]);
 
-        // For time consuming queries (in particular) the following is
-        // inefficient becuase the quiry is executed again.
+        /* For time consuming queries (in particular) the following is
+         * inefficient becuase the quiry is executed again. */
 
         for (PeopleTable_Cursor *curser in query)
             NSLog(@"Name: %lld", [curser Age]);
 
-        // To avoid repeating the same quiry, the result may be stored in
-        // a table view for multiple access. The following code executes the
-        // query once and saves the result in a table view.
+        /* To avoid repeating the same quiry, the result may be stored in
+         * a table view for multiple access. The following code executes the
+         * query once and saves the result in a table view. */
 
         PeopleTable_View *tableView = [query findAll];
 
-        // Iterates over all rows in the result (view) 2 times based on the single
-        // query executed above.
+        /* Iterates over all rows in the result (view) 2 times based on the single
+         * query executed above. */
 
         for (PeopleTable_Cursor *curser in tableView)
             NSLog(@"Name: %@", [curser Name]);
@@ -66,4 +66,4 @@ int main()
     }
 }
 
-// @@EndExample@@
+/* @@EndExample@@ */

--- a/doc/ref/examples/ex_objc_tableview_dynamic_intro.m
+++ b/doc/ref/examples/ex_objc_tableview_dynamic_intro.m
@@ -1,4 +1,4 @@
-// @@Example: ex_objc_tableview_dynamic_intro @@
+/* @@Example: ex_objc_tableview_dynamic_intro @@ */
 
 #import <tightdb/objc/table.h>
 #import <tightdb/objc/tightdb.h>
@@ -8,23 +8,23 @@ int main()
 {
     @autoreleasepool {
 
-        // Creates a new table dynamically.
+        /* Creates a new table dynamically. */
 
         TightdbTable *table = [[TightdbTable alloc] init];
 
-        // Add some colomns (obsolete style, see typed table example).
+        /* Add some colomns (obsolete style, see typed table example). */
 
         size_t const NAME  = [table addColumnWithType:tightdb_String andName:@"Name"];
         size_t const AGE   = [table addColumnWithType:tightdb_Int andName:@"Age"];
         size_t const HIRED = [table addColumnWithType:tightdb_Bool andName:@"Hired"];
 
-        // Add some people.
+        /* Add some people. */
 
-        // Add rows and values.
+        /* Add rows and values. */
 
         TightdbCursor *cursor;
 
-        // Row 0
+        /* Row 0 */
 
         cursor = [table addRow];
 
@@ -32,7 +32,7 @@ int main()
         [cursor setString:@"Joe" inColumn:NAME];
         [cursor setBool:YES inColumn:HIRED];
 
-        // Row 1
+        /* Row 1 */
 
         cursor = [table addRow];
 
@@ -40,7 +40,7 @@ int main()
         [cursor setString:@"Simon" inColumn:NAME];
         [cursor setBool:YES inColumn:HIRED];
 
-        // Row 2
+        /* Row 2 */
 
         cursor = [table addRow];
 
@@ -48,7 +48,7 @@ int main()
         [cursor setString:@"Steve" inColumn:NAME];
         [cursor setBool:NO inColumn:HIRED];
 
-        // Row 3
+        /* Row 3 */
 
         cursor = [table addRow];
 
@@ -56,30 +56,30 @@ int main()
         [cursor setString:@"Nick" inColumn:NAME];
         [cursor setBool:YES inColumn:HIRED];
 
-        // Set up a query to search for employees.
+        /* Set up a query to search for employees. */
 
         TightdbQuery *q =  [[[table where] column: AGE   isBetweenInt:30 and_:60]
                                            column: HIRED isEqualToBool:YES];
 
-        // Execute the query.
+        /* Execute the query. */
 
         TightdbView *view = [q findAll];
 
-        // Print the names.
+        /* Print the names. */
 
         for (TightdbCursor *ite in view) {
             NSLog(@"With iterator.......name: %@",[ite getStringInColumn:NAME]);
         }
 
-        // Take a curser at index one in the view.
-        // Note: the index of this row is different in the underlaying table.
+        /* Take a curser at index one in the view. */
+        /* Note: the index of this row is different in the underlaying table. */
 
         TightdbCursor *c = [view cursorAtIndex:1];
         if (c != nil)
             NSLog(@"With fixed index....name: %@",[c getStringInColumn:NAME]);
 
 
-        // Index out-of-bounds index.
+        /* Index out-of-bounds index. */
 
         TightdbCursor *c2 = [view cursorAtIndex:[view count]];
         if (c2 != nil)
@@ -87,4 +87,4 @@ int main()
 
     }
 }
-// @@EndExample@@
+/* @@EndExample@@ */

--- a/doc/ref/examples/ex_objc_tableview_typed_intro.m
+++ b/doc/ref/examples/ex_objc_tableview_typed_intro.m
@@ -1,9 +1,9 @@
-// @@Example: ex_objc_tableview_typed_intro @@
+/* @@Example: ex_objc_tableview_typed_intro @@ */
 
 #import <tightdb/objc/table.h>
 #import <tightdb/objc/tightdb.h>
 
-// Defines a new table with two columns Name and Age.
+/* Defines a new table with two columns Name and Age. */
 
 TIGHTDB_TABLE_2(PeopleTable,
                 Name, String,
@@ -13,11 +13,11 @@ int main()
 {
     @autoreleasepool {
 
-        // Creates a new table of the type defined above.
+        /* Creates a new table of the type defined above. */
 
         PeopleTable *table = [[PeopleTable alloc] init];
 
-        // Adds rows to the table.
+        /* Adds rows to the table. */
 
         PeopleTable_Cursor *cursor = [table addRow];
         cursor.Name = @"Brian";
@@ -31,11 +31,11 @@ int main()
         cursor.Name = @"Sam";
         cursor.Age = 76;
 
-        // Place the result of a query in a table view.
+        /* Place the result of a query in a table view. */
 
         PeopleTable_View *tableView = [[[table where].Age columnIsGreaterThan:20] findAll];
 
-        // Itereato over the result in the table view.
+        /* Itereato over the result in the table view. */
 
         for (PeopleTable_Cursor *curser in tableView) {
             NSLog(@"This person is over the age of 20: %@", [curser Name]);
@@ -46,4 +46,4 @@ int main()
     }
 }
 
-// @@EndExample@@
+/* @@EndExample@@ */

--- a/src/tightdb/objc/group.h
+++ b/src/tightdb/objc/group.h
@@ -36,29 +36,35 @@
 
 -(BOOL)hasTable:(NSString *)name;
 
-/// This method returns NO if it encounters a memory allocation error
-/// (out of memory).
-///
-/// The specified table class must be one that is declared by using
-/// one of the table macros TIGHTDB_TABLE_*.
+/**
+ * This method returns NO if it encounters a memory allocation error
+ * (out of memory).
+ *
+ * The specified table class must be one that is declared by using
+ * one of the table macros TIGHTDB_TABLE_*.
+ */
 -(BOOL)hasTable:(NSString *)name withClass:(Class)obj;
 
-/// This method returns nil if it encounters a memory allocation error
-/// (out of memory).
+/**
+ * This method returns nil if it encounters a memory allocation error
+ * (out of memory).
+ */
 -(TightdbTable *)getTable:(NSString *)name;
 -(TightdbTable *)getTable:(NSString *)name error:(NSError *__autoreleasing *)error;
 
-/// This method returns nil if the group already contains a table with
-/// the specified name, but its type is incompatible with the
-/// specified table class. This method also returns nil if it
-/// encounters a memory allocation error (out of memory).
-///
-/// The specified table class must be one that is declared by using
-/// one of the table macros TIGHTDB_TABLE_*.
+/**
+ * This method returns nil if the group already contains a table with
+ * the specified name, but its type is incompatible with the
+ * specified table class. This method also returns nil if it
+ * encounters a memory allocation error (out of memory).
+ *
+ * The specified table class must be one that is declared by using
+ * one of the table macros TIGHTDB_TABLE_*.
+ */
 -(id)getTable:(NSString *)name withClass:(Class)obj;
 -(id)getTable:(NSString *)name withClass:(Class)obj error:(NSError *__autoreleasing *)error;
 
-// Serialization
+/* Serialization */
 -(BOOL)write:(NSString *)filePath;
 -(BOOL)write:(NSString *)filePath error:(NSError *__autoreleasing *)error;
 -(const char*)writeToMem:(size_t*)size;

--- a/src/tightdb/objc/helper_macros.h
+++ b/src/tightdb/objc/helper_macros.h
@@ -56,7 +56,7 @@
 
 
 
-// TIGHTDB_ARG_TYPE
+/* TIGHTDB_ARG_TYPE */
 
 #define TIGHTDB_ARG_TYPE(type)                 TIGHTDB_ARG_TYPE_2(TIGHTDB_IS_SUBTABLE(type), type)
 #define TIGHTDB_ARG_TYPE_2(is_subtable, type)  TIGHTDB_ARG_TYPE_3(is_subtable, type)
@@ -66,7 +66,7 @@
 
 
 
-// TIGHTDB_COLUMN_PROXY
+/* TIGHTDB_COLUMN_PROXY */
 
 #define TIGHTDB_COLUMN_PROXY_DEF(name, type)                 TIGHTDB_COLUMN_PROXY_DEF_2(TIGHTDB_IS_SUBTABLE(type), name, type)
 #define TIGHTDB_COLUMN_PROXY_DEF_2(is_subtable, name, type)  TIGHTDB_COLUMN_PROXY_DEF_3(is_subtable, name, type)
@@ -84,7 +84,7 @@
 
 
 
-// TIGHTDB_ADD_COLUMN
+/* TIGHTDB_ADD_COLUMN */
 
 #define TIGHTDB_ADD_COLUMN(desc, name, type)                TIGHTDB_ADD_COLUMN_2(TIGHTDB_IS_SUBTABLE(type), desc, name, type)
 #define TIGHTDB_ADD_COLUMN_2(is_subtable, desc, name, type) TIGHTDB_ADD_COLUMN_3(is_subtable, desc, name, type)
@@ -111,7 +111,7 @@
 
 
 
-// TIGHTDB_CHECK_COLUMN_TYPE
+/* TIGHTDB_CHECK_COLUMN_TYPE */
 
 #define TIGHTDB_CHECK_COLUMN_TYPE(desc, col, name, type)                TIGHTDB_CHECK_COLUMN_TYPE_2(TIGHTDB_IS_SUBTABLE(type), desc, col, name, type)
 #define TIGHTDB_CHECK_COLUMN_TYPE_2(is_subtable, desc, col, name, type) TIGHTDB_CHECK_COLUMN_TYPE_3(is_subtable, desc, col, name, type)
@@ -138,7 +138,7 @@
 
 
 
-// TIGHTDB_COLUMN_INSERT
+/* TIGHTDB_COLUMN_INSERT */
 
 #define TIGHTDB_COLUMN_INSERT(table, col, row, value, type)                TIGHTDB_COLUMN_INSERT_2(TIGHTDB_IS_SUBTABLE(type), table, col, row, value, type)
 #define TIGHTDB_COLUMN_INSERT_2(is_subtable, table, col, row, value, type) TIGHTDB_COLUMN_INSERT_3(is_subtable, table, col, row, value, type)
@@ -146,7 +146,7 @@
 #define TIGHTDB_COLUMN_INSERT_4_Y(table, col, _row, value, type)           [table _insertSubtableCopy:col row:_row subtable:value]
 #define TIGHTDB_COLUMN_INSERT_4_N(table, col, row, _value, type)           [table insert##type:col ndx:row value:_value]
 
-// TIGHTDB_COLUMN_INSERT_ERROR
+/* TIGHTDB_COLUMN_INSERT_ERROR */
 
 #define TIGHTDB_COLUMN_INSERT_ERROR(table, col, row, value, type, error)                TIGHTDB_COLUMN_INSERT_ERROR_2(TIGHTDB_IS_SUBTABLE(type), table, col, row, value, type, error)
 #define TIGHTDB_COLUMN_INSERT_ERROR_2(is_subtable, table, col, row, value, type, error) TIGHTDB_COLUMN_INSERT_ERROR_3(is_subtable, table, col, row, value, type, error)
@@ -156,7 +156,7 @@
 
 
 
-// TIGHTDB_CURSOR_PROPERTY
+/* TIGHTDB_CURSOR_PROPERTY */
 
 #define TIGHTDB_CURSOR_PROPERTY_DEF(name, type)                 TIGHTDB_CURSOR_PROPERTY_DEF_2(TIGHTDB_IS_SUBTABLE(type), name, type)
 #define TIGHTDB_CURSOR_PROPERTY_DEF_2(is_subtable, name, type)  TIGHTDB_CURSOR_PROPERTY_DEF_3(is_subtable, name, type)
@@ -206,7 +206,7 @@
     [_##name setSubtable:subtable]; \
 } \
 
-// TIGHTDB_QUERY_ACCESSOR
+/* TIGHTDB_QUERY_ACCESSOR */
 
 #define TIGHTDB_QUERY_ACCESSOR_DEF(table, col_name, col_type)                 TIGHTDB_QUERY_ACCESSOR_DEF_2(TIGHTDB_IS_SUBTABLE(col_type), table, col_name, col_type)
 #define TIGHTDB_QUERY_ACCESSOR_DEF_2(is_subtable, table, col_name, col_type)  TIGHTDB_QUERY_ACCESSOR_DEF_3(is_subtable, table, col_name, col_type)
@@ -221,7 +221,7 @@
 #define TIGHTDB_QUERY_ACCESSOR_IMPL_4_N(table, col_name, col_type)            TIGHTDB_QUERY_ACCESSOR_IMPL_##col_type(table, col_name)
 
 
-// Boolean
+/* Boolean */
 
 #define TIGHTDB_QUERY_ACCESSOR_DEF_Bool(table, col_name) \
 @interface table##_QueryAccessor_##col_name : TightdbQueryAccessorBool \
@@ -237,7 +237,7 @@
 @end
 
 
-// Integer
+/* Integer */
 
 #define TIGHTDB_QUERY_ACCESSOR_DEF_Int(table, col_name) \
 @interface table##_QueryAccessor_##col_name : TightdbQueryAccessorInt \
@@ -283,7 +283,7 @@
 @end
 
 
-// Float
+/* Float */
 
 #define TIGHTDB_QUERY_ACCESSOR_DEF_Float(table, col_name) \
 @interface table##_QueryAccessor_##col_name : TightdbQueryAccessorFloat \
@@ -329,7 +329,7 @@
 @end
 
 
-// Double
+/* Double */
 
 #define TIGHTDB_QUERY_ACCESSOR_DEF_Double(table, col_name) \
 @interface table##_QueryAccessor_##col_name : TightdbQueryAccessorDouble \
@@ -375,7 +375,7 @@
 @end
 
 
-// String
+/* String */
 
 #define TIGHTDB_QUERY_ACCESSOR_DEF_String(table, col_name) \
 @interface table##_QueryAccessor_##col_name : TightdbQueryAccessorString \
@@ -436,7 +436,7 @@
 @end
 
 
-// Binary
+/* Binary */
 
 #define TIGHTDB_QUERY_ACCESSOR_DEF_Binary(table, col_name) \
 @interface table##_QueryAccessor_##col_name : TightdbQueryAccessorBinary \
@@ -472,7 +472,7 @@
 @end
 
 
-// Date
+/* Date */
 
 #define TIGHTDB_QUERY_ACCESSOR_DEF_Date(table, col_name) \
 @interface table##_QueryAccessor_##col_name : TightdbQueryAccessorDate \
@@ -518,7 +518,7 @@
 @end
 
 
-// Subtable
+/* Subtable */
 
 #define TIGHTDB_QUERY_ACCESSOR_DEF_SUBTABLE(table, col_name, col_type) \
 @interface table##_QueryAccessor_##col_name : TightdbQueryAccessorSubtable \
@@ -529,7 +529,7 @@
 @end
 
 
-// Mixed
+/* Mixed */
 
 #define TIGHTDB_QUERY_ACCESSOR_DEF_Mixed(table, col_name) \
 @interface table##_QueryAccessor_##col_name : TightdbQueryAccessorMixed \

--- a/src/tightdb/objc/query.h
+++ b/src/tightdb/objc/query.h
@@ -22,9 +22,9 @@
 
 @class TightdbBinary;
 @class TightdbTable;
-@class TightdbTableView; // jjepsen: this must be an error?
+@class TightdbTableView; /* jjepsen: this must be an error? */
 
-// jjepsen: please review this
+/* jjepsen: please review this */
 @class TightdbView;
 
 
@@ -68,12 +68,12 @@
 -(size_t)find:(size_t)last;
 -(size_t)find:(size_t)last error:(NSError *__autoreleasing *)error;
 
-// jjepsen: please review this.
+/* jjepsen: please review this. */
 -(TightdbView *)findAll;
 
 -(NSUInteger)countByEnumeratingWithState:(NSFastEnumerationState *)state objects:(id __unsafe_unretained *)stackbuf count:(NSUInteger)len;
 
-// Conditions:
+/* Conditions: */
 
 -(TightdbQuery *)column:(size_t)colNdx isBetweenInt:(int64_t)from and_:(int64_t)to;
 -(TightdbQuery *)column:(size_t)colNdx isBetweenFloat:(float)from and_:(float)to;

--- a/src/tightdb/objc/table.h
+++ b/src/tightdb/objc/table.h
@@ -33,7 +33,9 @@
 -(const char *)getData;
 -(size_t)getSize;
 
-/// Compare the referenced binary data for equality.
+/**
+ * Compare the referenced binary data for equality.
+ */
 -(BOOL)isEqual:(TightdbBinary *)bin;
 @end
 
@@ -62,10 +64,14 @@
 
 
 @interface TightdbDescriptor: NSObject
-/// Returns NO on memory allocation error.
+/**
+ * Returns NO on memory allocation error.
+ */
 -(BOOL)addColumnWithType:(TightdbType)type andName:(NSString *)name;
 -(BOOL)addColumnWithType:(TightdbType)type andName:(NSString *)name error:(NSError *__autoreleasing *)error;
-/// Returns nil on memory allocation error.
+/**
+ * Returns nil on memory allocation error.
+ */
 -(TightdbDescriptor *)addColumnTable:(NSString *)name;
 -(TightdbDescriptor *)addColumnTable:(NSString *)name error:(NSError *__autoreleasing *)error;
 -(TightdbDescriptor *)getSubdescriptor:(size_t)colNdx;
@@ -82,37 +88,44 @@
 
 -(BOOL)isEqual:(TightdbTable *)other;
 
-//@{
-/// If the specified column is neither a subtable column, nor a mixed
-/// column, then these methods return nil. They also return nil for a
-/// mixed column, if the mixed value at the specified row is not a
-/// subtable. The second method also returns nil if the type of the
-/// subtable is not compatible with the specified table
-/// class. Finally, these methods return nil if they encounter a
-/// memory allocation error (out of memory).
-///
-/// The specified table class must be one that is declared by using
-/// one of the table macros TIGHTDB_TABLE_*.
+/**
+ * @{
+ *
+ * If the specified column is neither a subtable column, nor a mixed
+ * column, then these methods return nil. They also return nil for a
+ * mixed column, if the mixed value at the specified row is not a
+ * subtable. The second method also returns nil if the type of the
+ * subtable is not compatible with the specified table
+ * class. Finally, these methods return nil if they encounter a
+ * memory allocation error (out of memory).
+ *
+ * The specified table class must be one that is declared by using
+ * one of the table macros TIGHTDB_TABLE_*.
+ */
 -(TightdbTable *)getSubtable:(size_t)colNdx ndx:(size_t)ndx;
 -(id)getSubtable:(size_t)colNdx ndx:(size_t)ndx withClass:(Class)obj;
-//@}
+/** @} */
 
-/// This method will return NO if it encounters a memory allocation
-/// error (out of memory).
-///
-/// The specified table class must be one that is declared by using
-/// one of the table macros TIGHTDB_TABLE_*.
+/**
+ * This method will return NO if it encounters a memory allocation
+ * error (out of memory).
+ *
+ * The specified table class must be one that is declared by using
+ * one of the table macros TIGHTDB_TABLE_*.
+ */
 -(BOOL)isClass:(Class)obj;
 
-/// If the type of this table is not compatible with the specified
-/// table class, then this method returns nil. It also returns nil if
-/// it encounters a memory allocation error (out of memory).
-///
-/// The specified table class must be one that is declared by using
-/// one of the table macros TIGHTDB_TABLE_*.
+/**
+ * If the type of this table is not compatible with the specified
+ * table class, then this method returns nil. It also returns nil if
+ * it encounters a memory allocation error (out of memory).
+ *
+ * The specified table class must be one that is declared by using
+ * one of the table macros TIGHTDB_TABLE_*.
+ */
 -(id)castClass:(Class)obj;
 
-//Column meta info
+/* Column meta info */
 -(size_t)getColumnCount;
 -(NSString *)getColumnName:(size_t)ndx;
 -(size_t)getColumnIndex:(NSString *)name;
@@ -123,8 +136,8 @@
 -(size_t)count;
 -(TightdbCursor *)addRow;
 
-// Only curser based add should be public. This is just a temporaray way to hide the methods.
-// TODO: Move to class extension.
+/* Only curser based add should be public. This is just a temporaray way to hide the methods. */
+/* TODO: Move to class extension. */
 -(size_t)_addRow;
 -(size_t)_addRowWithError:(NSError *__autoreleasing *)error;
 -(size_t)_addRows:(size_t)rowCount;
@@ -145,8 +158,8 @@
 -(BOOL)insertRow:(size_t)ndx;
 -(BOOL)insertRow:(size_t)ndx error:(NSError *__autoreleasing *)error;
 
-// Adaptive ints.
-// FIXME: Should be getInt:(int64_t)value inColumn:(size_t)colNdx andRow:(size_t)rowNdx;
+/* Adaptive ints. */
+/* FIXME: Should be getInt:(int64_t)value inColumn:(size_t)colNdx andRow:(size_t)rowNdx; */
 -(int64_t)get:(size_t)colNdx ndx:(size_t)ndx;
 -(BOOL)set:(size_t)colNdx ndx:(size_t)ndx value:(int64_t)value;
 -(BOOL)set:(size_t)colNdx ndx:(size_t)ndx value:(int64_t)value error:(NSError *__autoreleasing *)error;
@@ -163,9 +176,9 @@
 -(BOOL)setDate:(size_t)colNdx ndx:(size_t)ndx value:(time_t)value;
 -(BOOL)setDate:(size_t)colNdx ndx:(size_t)ndx value:(time_t)value error:(NSError *__autoreleasing *)error;
 
-// NOTE: Low-level insert functions. Always insert in all columns at once
-// and call InsertDone after to avoid table getting un-balanced.
-// FIXME: Should be insertBool:(BOOL)value inColumn:(size_t)colNdx andRow:(size_t)rowNdx;
+/* NOTE: Low-level insert functions. Always insert in all columns at once
+   and call InsertDone after to avoid table getting un-balanced. */
+/* FIXME: Should be insertBool:(BOOL)value inColumn:(size_t)colNdx andRow:(size_t)rowNdx; */
 -(BOOL)insertBool:(size_t)colNdx ndx:(size_t)ndx value:(BOOL)value;
 -(BOOL)insertBool:(size_t)colNdx ndx:(size_t)ndx value:(BOOL)value error:(NSError *__autoreleasing *)error;
 -(BOOL)insertInt:(size_t)colNdx ndx:(size_t)ndx value:(int64_t)value;
@@ -185,19 +198,19 @@
 -(BOOL)insertDone;
 -(BOOL)insertDoneWithError:(NSError *__autoreleasing *)error;
 
-// Strings
+/* Strings */
 -(NSString *)getString:(size_t)colNdx ndx:(size_t)ndx;
 -(BOOL)setString:(size_t)colNdx ndx:(size_t)ndx value:(NSString *)value;
 -(BOOL)setString:(size_t)colNdx ndx:(size_t)ndx value:(NSString *)value error:(NSError *__autoreleasing *)error;
 
-// Binary
+/* Binary */
 -(TightdbBinary *)getBinary:(size_t)colNdx ndx:(size_t)ndx;
 -(BOOL)setBinary:(size_t)colNdx ndx:(size_t)ndx value:(TightdbBinary *)value;
 -(BOOL)setBinary:(size_t)colNdx ndx:(size_t)ndx value:(TightdbBinary *)value error:(NSError *__autoreleasing *)error;
 -(BOOL)setBinary:(size_t)colNdx ndx:(size_t)ndx data:(const char *)data size:(size_t)size;
 -(BOOL)setBinary:(size_t)colNdx ndx:(size_t)ndx data:(const char *)data size:(size_t)size error:(NSError *__autoreleasing *)error;
 
-// Subtables
+/* Subtables */
 -(size_t)getTableSize:(size_t)colNdx ndx:(size_t)ndx;
 -(BOOL)insertSubtable:(size_t)colNdx ndx:(size_t)ndx;
 -(BOOL)insertSubtable:(size_t)colNdx ndx:(size_t)ndx error:(NSError *__autoreleasing *)error;
@@ -205,7 +218,7 @@
 -(BOOL)clearSubtable:(size_t)colNdx ndx:(size_t)ndx error:(NSError *__autoreleasing *)error;
 -(BOOL)setSubtable:(size_t)col_ndx ndx:(size_t)ndx withTable:(TightdbTable *)subtable;
 
-// Mixed
+/* Mixed */
 -(TightdbMixed *)getMixed:(size_t)colNdx ndx:(size_t)ndx;
 -(TightdbType)getMixedType:(size_t)colNdx ndx:(size_t)ndx;
 -(BOOL)insertMixed:(size_t)colNdx ndx:(size_t)ndx value:(TightdbMixed *)value;
@@ -216,8 +229,8 @@
 -(size_t)addColumnWithType:(TightdbType)type andName:(NSString *)name;
 -(size_t)addColumnWithType:(TightdbType)type andName:(NSString *)name error:(NSError *__autoreleasing *)error;
 
-// Searching
-// FIXME: Should be findBool:(BOOL)value inColumn:(size_t)colNdx;
+/* Searching */
+/* FIXME: Should be findBool:(BOOL)value inColumn:(size_t)colNdx; */
 -(size_t)findBool:(size_t)colNdx value:(BOOL)value;
 -(size_t)findInt:(size_t)colNdx value:(int64_t)value;
 -(size_t)findFloat:(size_t)colNdx value:(float)value;
@@ -227,9 +240,9 @@
 -(size_t)findDate:(size_t)colNdx value:(time_t)value;
 -(size_t)findMixed:(size_t)colNdx value:(TightdbMixed *)value;
 
-// FIXME: The naming scheme used here is superior to the one used in
-// most of the other methods in this class. As time allows, this
-// scheme must be migrated to all those other methods.
+/* FIXME: The naming scheme used here is superior to the one used in
+   most of the other methods in this class. As time allows, this
+   scheme must be migrated to all those other methods. */
 -(TightdbView *)findAllBool:(BOOL)value              inColumn:(size_t)colNdx;
 -(TightdbView *)findAllInt:(int64_t)value            inColumn:(size_t)colNdx;
 -(TightdbView *)findAllFloat:(float)value            inColumn:(size_t)colNdx;
@@ -242,19 +255,19 @@
 -(TightdbQuery *)where;
 -(TightdbQuery *)whereWithError:(NSError *__autoreleasing *)error;
 
-// Indexing
+/* Indexing */
 -(BOOL)hasIndex:(size_t)colNdx;
 -(void)setIndex:(size_t)colNdx;
 
-// Optimizing
+/* Optimizing */
 -(BOOL)optimize;
 -(BOOL)optimizeWithError:(NSError *__autoreleasing *)error;
 
-// Conversion
-// FIXME: Do we want to conversion methods? Maybe use NSData.
+/* Conversion */
+/* FIXME: Do we want to conversion methods? Maybe use NSData. */
 
-// Aggregate functions
-// FIXME: Should be countInt:(int64_t)value inColumn:(size_t)colNdx;
+/* Aggregate functions */
+/* FIXME: Should be countInt:(int64_t)value inColumn:(size_t)colNdx; */
 -(size_t)countWithIntColumn:(size_t)colNdx andValue:(int64_t)target;
 -(size_t)countWithFloatColumn:(size_t)colNdx andValue:(float)target;
 -(size_t)countWithDoubleColumn:(size_t)colNdx andValue:(double)target;
@@ -276,7 +289,7 @@
 -(void)verify;
 #endif
 
-// Private
+/* Private */
 -(id)_initRaw;
 -(BOOL)_insertSubtableCopy:(size_t)colNdx row:(size_t)rowNdx subtable:(TightdbTable *)subtable;
 -(BOOL)_insertSubtableCopy:(size_t)colNdx row:(size_t)rowNdx subtable:(TightdbTable *)subtable error:(NSError *__autoreleasing *)error;
@@ -298,7 +311,7 @@
 -(size_t)getSourceIndex:(size_t)ndx;
 - (NSUInteger)countByEnumeratingWithState:(NSFastEnumerationState *)state objects:(id __unsafe_unretained *)stackbuf count:(NSUInteger)len;
 
-// Private
+/* Private */
 -(id)_initWithQuery:(TightdbQuery *)query;
 @end
 

--- a/src/tightdb/objc/type.h
+++ b/src/tightdb/objc/type.h
@@ -20,7 +20,7 @@
 #ifndef TIGHTDB_OBJC_TYPE_H
 #define TIGHTDB_OBJC_TYPE_H
 
-// Make sure numbers match those in <tightdb/data_type.hpp>
+/* Make sure numbers match those in <tightdb/data_type.hpp> */
 typedef enum {
     tightdb_Bool   =  1,
     tightdb_Int    =  0,
@@ -33,4 +33,4 @@ typedef enum {
     tightdb_Mixed  =  6,
 } TightdbType;
 
-#endif // TIGHTDB_OBJC_TYPE_H
+#endif /* TIGHTDB_OBJC_TYPE_H */


### PR DESCRIPTION
We are talking about `//` comments. They are not allowed when compiling in Obj-C mode, and produce warnings if they are there.

@mekjaer @emanuelez @bmunkholm @bjchrist @astigsen @oleks @Tightdb/oleks @kneth 
