### PR TITLE
Support added for checking documentation examples

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,13 @@
 SUBDIRS = src
 PASSIVE_SUBDIRS = examples
 
-include src/generic.mk
+PASSIVE_SUBDIRS += doc/ref/examples
+doc_ref_examples_DEPS = src
+
+# Build and run documentation examples
+.PHONY: check-doc-examples
+check-doc-examples: check-debug-norun/subdir/src
+	@$(MAKE) -C doc/ref/examples check-debug
 
 # Used by build.sh
 .PHONY: get-exec-prefix get-includedir get-bindir get-libdir get-libexecdir
@@ -15,3 +21,6 @@ get-libdir:
 	@echo $(libdir)
 get-libexecdir:
 	@echo $(libexecdir)
+
+
+include src/generic.mk

--- a/build.sh
+++ b/build.sh
@@ -423,7 +423,7 @@ EOF
 	;;
 
     "test")
-        require_config || exit 1
+        auto_configure || exit 1
         $MAKE check-norun || exit 1
         TEMP_DIR="$(mktemp -d /tmp/tightdb.objc.test.XXXX)" || exit 1
         mkdir -p "$TEMP_DIR/unit-tests.octest/Contents/MacOS" || exit 1
@@ -435,7 +435,7 @@ EOF
         ;;
 
     "test-debug")
-        require_config || exit 1
+        auto_configure || exit 1
         $MAKE check-debug-norun || exit 1
         TEMP_DIR="$(mktemp -d /tmp/tightdb.objc.test-debug.XXXX)" || exit 1
         mkdir -p "$TEMP_DIR/unit-tests-dbg.octest/Contents/MacOS" || exit 1
@@ -447,7 +447,7 @@ EOF
         ;;
 
     "test-gdb")
-        require_config || exit 1
+        auto_configure || exit 1
         $MAKE check-debug-norun || exit 1
         TEMP_DIR="$(mktemp -d /tmp/tightdb.objc.test-gdb.XXXX)" || exit 1
         mkdir -p "$TEMP_DIR/unit-tests-dbg.octest/Contents/MacOS" || exit 1
@@ -456,9 +456,14 @@ EOF
         DYLD_LIBRARY_PATH="$TIGHTDB_OBJC_HOME/src/tightdb/objc" OBJC_DISABLE_GC=YES gdb --args "$XCODE_HOME/Tools/otest" "$TEMP_DIR/unit-tests-dbg.octest"
         ;;
 
+    "check-doc-examples")
+        auto_configure || exit 1
+        $MAKE check-doc-examples || exit 1
+        ;;
+
     "test-examples")
-        require_config || exit 1
-        $MAKE test  -C "examples" || exit 1
+        auto_configure || exit 1
+        $MAKE test -C "examples" || exit 1
         ;;
 
     "install-report")

--- a/doc/ref/examples/.gitignore
+++ b/doc/ref/examples/.gitignore
@@ -1,0 +1,4 @@
+*.d
+*.o
+*.example
+*.tightdb

--- a/doc/ref/examples/Makefile
+++ b/doc/ref/examples/Makefile
@@ -1,0 +1,18 @@
+EXAMPLES := $(wildcard *.m)
+
+check_PROGRAMS := $(patsubst %.m,%,$(EXAMPLES))
+
+PROG_SUFFIX = .example
+
+EXTRA_CLEAN = *.example
+
+define EXAMPLE_PROPS
+$(1)_SOURCES = $(2)
+$(1)_CFLAGS  = -fobjc-arc -fobjc-abi-version=2
+$(1)_LDFLAGS = -fobjc-link-runtime -framework Cocoa
+$(1)_LIBS    = ../../../src/tightdb/objc/libtightdb-objc.a
+endef
+
+$(foreach x,$(EXAMPLES),$(eval $(call EXAMPLE_PROPS,$(subst -,_,$(patsubst %.m,%,$(x))),$(x))))
+
+include ../../../src/generic.mk


### PR DESCRIPTION
Support added for checking documentation examples using

```
sh build.sh check-doc-examples
```

Note that this is similar to how it is done in the core library.

@kneth @emanuelez @bmunkholm @mekjaer 
