### PR TITLE
Test cover

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -470,7 +470,7 @@ EOF
         XCODE_HOME="$(xcode-select --print-path)" || exit 1
         DYLD_LIBRARY_PATH="$TIGHTDB_OBJC_HOME/src/tightdb/objc" OBJC_DISABLE_GC=YES "$XCODE_HOME/Tools/otest" "$TEMP_DIR/unit-tests-cov.octest" || exit 1
         echo "Generating 'gcovr.xml'.."
-        gcovr --filter='.*/tightdb_objc/src/.*' --xml > gcovr.xml
+        gcovr -f '.*/tightdb_objc/src/.*' -e '.*/test/.*' -x > gcovr.xml
         echo "Test passed."
         exit 0
         ;;


### PR DESCRIPTION
The structure here is different from core, but for the lack of a better inspiration elsewhere, and out of technical considerations, I implemented this as a build.sh mode, test-cover.

So sh build.sh test-cover (after clean and config). Will generate two XML files, binding-coverage.xml and core-coverage.xml. See the commit message for 8692494e013f0c633a5e45acdfa81b0e4ecf66e1 for more details.

@emanuelez @bmunkholm @kspangsege 
