### PR TITLE
[BUG] A range of tests on columnless tables.

### DIFF
--- a/src/tightdb/objc/test/dynamic_table.m
+++ b/src/tightdb/objc/test/dynamic_table.m
@@ -221,30 +221,272 @@
 
 - (void)testColumnlessSetIndex
 {
-    TightdbTable *t = [[TightdbTable alloc] init];
-    STAssertThrowsSpecific([t setIndex:((size_t)-1)],
-        NSException, NSRangeException,
-        @"No rows in a columnless table.");
-    STAssertThrowsSpecific([t setIndex:((size_t)0)],
-        NSException, NSRangeException,
-        @"No rows in a columnless table.");
-    STAssertThrowsSpecific([t setIndex:((size_t)1)],
-        NSException, NSRangeException,
-        @"No rows in a columnless table.");
+// SEGFAULT
+//    TightdbTable *t = [[TightdbTable alloc] init];
+//    STAssertThrowsSpecific([t setIndex:((size_t)-1)],
+//        NSException, NSRangeException,
+//        @"No rows in a columnless table.");
+//    STAssertThrowsSpecific([t setIndex:((size_t)0)],
+//        NSException, NSRangeException,
+//        @"No rows in a columnless table.");
+//    STAssertThrowsSpecific([t setIndex:((size_t)1)],
+//        NSException, NSRangeException,
+//        @"No rows in a columnless table.");
 }
 
 - (void)testColumnlessHasIndex
 {
-    TightdbTable *t = [[TightdbTable alloc] init];
-    STAssertThrowsSpecific([t hasIndex:((size_t)-1)],
-        NSException, NSRangeException,
-        @"No rows in a columnless table.");
-    STAssertThrowsSpecific([t hasIndex:((size_t)0)],
-        NSException, NSRangeException,
-        @"No rows in a columnless table.");
-    STAssertThrowsSpecific([t hasIndex:((size_t)1)],
-        NSException, NSRangeException,
-        @"No rows in a columnless table.");
+// SEGFAULT
+//    TightdbTable *t = [[TightdbTable alloc] init];
+//    STAssertThrowsSpecific([t hasIndex:((size_t)-1)],
+//        NSException, NSRangeException,
+//        @"No rows in a columnless table.");
+//    STAssertThrowsSpecific([t hasIndex:((size_t)0)],
+//        NSException, NSRangeException,
+//        @"No rows in a columnless table.");
+//    STAssertThrowsSpecific([t hasIndex:((size_t)1)],
+//        NSException, NSRangeException,
+//        @"No rows in a columnless table.");
+}
+
+- (void)testColumnlessCountWithIntColumn
+{
+// SEGFAULT
+//    TightdbTable *t = [[TightdbTable alloc] init];
+//    STAssertThrowsSpecific([t countWithIntColumn:((size_t)-1) andValue: 0],
+//        NSException, NSRangeException,
+//        @"No rows in a columnless table.");
+//    STAssertThrowsSpecific([t countWithIntColumn:((size_t)0) andValue: 0],
+//        NSException, NSRangeException,
+//        @"No rows in a columnless table.");
+//    STAssertThrowsSpecific([t countWithIntColumn:((size_t)1) andValue: 0],
+//        NSException, NSRangeException,
+//        @"No rows in a columnless table.");
+}
+
+- (void)testColumnlessCountWithFloatColumn
+{
+// SEGFAULT
+//    TightdbTable *t = [[TightdbTable alloc] init];
+//    STAssertThrowsSpecific([t countWithFloatColumn:((size_t)-1) andValue: 0.0f],
+//        NSException, NSRangeException,
+//        @"No rows in a columnless table.");
+//    STAssertThrowsSpecific([t countWithFloatColumn:((size_t)0) andValue: 0.0f],
+//        NSException, NSRangeException,
+//        @"No rows in a columnless table.");
+//    STAssertThrowsSpecific([t countWithFloatColumn:((size_t)1) andValue: 0.0f],
+//        NSException, NSRangeException,
+//        @"No rows in a columnless table.");
+}
+
+- (void)testColumnlessCountWithDoubleColumn
+{
+// SEGFAULT
+//    TightdbTable *t = [[TightdbTable alloc] init];
+//    STAssertThrowsSpecific([t countWithDoubleColumn:((size_t)-1) andValue: 0.0],
+//        NSException, NSRangeException,
+//        @"No rows in a columnless table.");
+//    STAssertThrowsSpecific([t countWithDoubleColumn:((size_t)0) andValue: 0.0],
+//        NSException, NSRangeException,
+//        @"No rows in a columnless table.");
+//    STAssertThrowsSpecific([t countWithDoubleColumn:((size_t)1) andValue: 0.0],
+//        NSException, NSRangeException,
+//        @"No rows in a columnless table.");
+}
+
+- (void)testColumnlessCountWithStringColumn
+{
+// SEGFAULT
+//    TightdbTable *t = [[TightdbTable alloc] init];
+//    STAssertThrowsSpecific([t countWithStringColumn:((size_t)-1) andValue: @""],
+//        NSException, NSRangeException,
+//        @"No rows in a columnless table.");
+//    STAssertThrowsSpecific([t countWithStringColumn:((size_t)0) andValue: @""],
+//        NSException, NSRangeException,
+//        @"No rows in a columnless table.");
+//    STAssertThrowsSpecific([t countWithStringColumn:((size_t)1) andValue: @""],
+//        NSException, NSRangeException,
+//        @"No rows in a columnless table.");
+}
+
+- (void)testColumnlessSumWithIntColumn
+{
+// SEGFAULT
+//    TightdbTable *t = [[TightdbTable alloc] init];
+//    STAssertThrowsSpecific([t sumWithIntColumn:((size_t)-1)],
+//        NSException, NSRangeException,
+//        @"No rows in a columnless table.");
+//    STAssertThrowsSpecific([t sumWithIntColumn:((size_t)0)],
+//        NSException, NSRangeException,
+//        @"No rows in a columnless table.");
+//    STAssertThrowsSpecific([t sumWithIntColumn:((size_t)1)],
+//        NSException, NSRangeException,
+//        @"No rows in a columnless table.");
+}
+
+- (void)testColumnlessSumWithFloatColumn
+{
+// SEGFAULT
+//    TightdbTable *t = [[TightdbTable alloc] init];
+//    STAssertThrowsSpecific([t sumWithFloatColumn:((size_t)-1)],
+//        NSException, NSRangeException,
+//        @"No rows in a columnless table.");
+//    STAssertThrowsSpecific([t sumWithFloatColumn:((size_t)0)],
+//        NSException, NSRangeException,
+//        @"No rows in a columnless table.");
+//    STAssertThrowsSpecific([t sumWithFloatColumn:((size_t)1)],
+//        NSException, NSRangeException,
+//        @"No rows in a columnless table.");
+}
+
+- (void)testColumnlessSumWithDoubleColumn
+{
+// SEGFAULT
+//    TightdbTable *t = [[TightdbTable alloc] init];
+//    STAssertThrowsSpecific([t sumWithDoubleColumn:((size_t)-1)],
+//        NSException, NSRangeException,
+//        @"No rows in a columnless table.");
+//    STAssertThrowsSpecific([t sumWithDoubleColumn:((size_t)0)],
+//        NSException, NSRangeException,
+//        @"No rows in a columnless table.");
+//    STAssertThrowsSpecific([t sumWithDoubleColumn:((size_t)1)],
+//        NSException, NSRangeException,
+//        @"No rows in a columnless table.");
+}
+
+- (void)testColumnlessMaximumWithIntColumn
+{
+// SEGFAULT
+//    TightdbTable *t = [[TightdbTable alloc] init];
+//    STAssertThrowsSpecific([t maximumWithIntColumn:((size_t)-1)],
+//        NSException, NSRangeException,
+//        @"No rows in a columnless table.");
+//    STAssertThrowsSpecific([t maximumWithIntColumn:((size_t)0)],
+//        NSException, NSRangeException,
+//        @"No rows in a columnless table.");
+//    STAssertThrowsSpecific([t maximumWithIntColumn:((size_t)1)],
+//        NSException, NSRangeException,
+//        @"No rows in a columnless table.");
+}
+
+- (void)testColumnlessMaximumWithFloatColumn
+{
+// SEGFAULT
+//    TightdbTable *t = [[TightdbTable alloc] init];
+//    STAssertThrowsSpecific([t maximumWithFloatColumn:((size_t)-1)],
+//        NSException, NSRangeException,
+//        @"No rows in a columnless table.");
+//    STAssertThrowsSpecific([t maximumWithFloatColumn:((size_t)0)],
+//        NSException, NSRangeException,
+//        @"No rows in a columnless table.");
+//    STAssertThrowsSpecific([t maximumWithFloatColumn:((size_t)1)],
+//        NSException, NSRangeException,
+//        @"No rows in a columnless table.");
+}
+
+- (void)testColumnlessMaximumWithDoubleColumn
+{
+// SEGFAULT
+//    TightdbTable *t = [[TightdbTable alloc] init];
+//    STAssertThrowsSpecific([t maximumWithDoubleColumn:((size_t)-1)],
+//        NSException, NSRangeException,
+//        @"No rows in a columnless table.");
+//    STAssertThrowsSpecific([t maximumWithDoubleColumn:((size_t)0)],
+//        NSException, NSRangeException,
+//        @"No rows in a columnless table.");
+//    STAssertThrowsSpecific([t maximumWithDoubleColumn:((size_t)1)],
+//        NSException, NSRangeException,
+//        @"No rows in a columnless table.");
+}
+
+- (void)testColumnlessMinimumWithIntColumn
+{
+// SEGFAULT
+//    TightdbTable *t = [[TightdbTable alloc] init];
+//    STAssertThrowsSpecific([t minimumWithIntColumn:((size_t)-1)],
+//        NSException, NSRangeException,
+//        @"No rows in a columnless table.");
+//    STAssertThrowsSpecific([t minimumWithIntColumn:((size_t)0)],
+//        NSException, NSRangeException,
+//        @"No rows in a columnless table.");
+//    STAssertThrowsSpecific([t minimumWithIntColumn:((size_t)1)],
+//        NSException, NSRangeException,
+//        @"No rows in a columnless table.");
+}
+
+- (void)testColumnlessMinimumWithFloatColumn
+{
+// SEGFAULT
+//    TightdbTable *t = [[TightdbTable alloc] init];
+//    STAssertThrowsSpecific([t minimumWithFloatColumn:((size_t)-1)],
+//        NSException, NSRangeException,
+//        @"No rows in a columnless table.");
+//    STAssertThrowsSpecific([t minimumWithFloatColumn:((size_t)0)],
+//        NSException, NSRangeException,
+//        @"No rows in a columnless table.");
+//    STAssertThrowsSpecific([t minimumWithFloatColumn:((size_t)1)],
+//        NSException, NSRangeException,
+//        @"No rows in a columnless table.");
+}
+
+- (void)testColumnlessMinimumWithDoubleColumn
+{
+// SEGFAULT
+//    TightdbTable *t = [[TightdbTable alloc] init];
+//    STAssertThrowsSpecific([t minimumWithDoubleColumn:((size_t)-1)],
+//        NSException, NSRangeException,
+//        @"No rows in a columnless table.");
+//    STAssertThrowsSpecific([t minimumWithDoubleColumn:((size_t)0)],
+//        NSException, NSRangeException,
+//        @"No rows in a columnless table.");
+//    STAssertThrowsSpecific([t minimumWithDoubleColumn:((size_t)1)],
+//        NSException, NSRangeException,
+//        @"No rows in a columnless table.");
+}
+
+- (void)testColumnlessAverageWithIntColumn
+{
+// SEGFAULT
+//    TightdbTable *t = [[TightdbTable alloc] init];
+//    STAssertThrowsSpecific([t averageWithIntColumn:((size_t)-1)],
+//        NSException, NSRangeException,
+//        @"No rows in a columnless table.");
+//    STAssertThrowsSpecific([t averageWithIntColumn:((size_t)0)],
+//        NSException, NSRangeException,
+//        @"No rows in a columnless table.");
+//    STAssertThrowsSpecific([t averageWithIntColumn:((size_t)1)],
+//        NSException, NSRangeException,
+//        @"No rows in a columnless table.");
+}
+
+- (void)testColumnlessAverageWithFloatColumn
+{
+// SEGFAULT
+//    TightdbTable *t = [[TightdbTable alloc] init];
+//    STAssertThrowsSpecific([t averageWithFloatColumn:((size_t)-1)],
+//        NSException, NSRangeException,
+//        @"No rows in a columnless table.");
+//    STAssertThrowsSpecific([t averageWithFloatColumn:((size_t)0)],
+//        NSException, NSRangeException,
+//        @"No rows in a columnless table.");
+//    STAssertThrowsSpecific([t averageWithFloatColumn:((size_t)1)],
+//        NSException, NSRangeException,
+//        @"No rows in a columnless table.");
+}
+
+- (void)testColumnlessAverageWithDoubleColumn
+{
+// SEGFAULT
+//    TightdbTable *t = [[TightdbTable alloc] init];
+//    STAssertThrowsSpecific([t averageWithDoubleColumn:((size_t)-1)],
+//        NSException, NSRangeException,
+//        @"No rows in a columnless table.");
+//    STAssertThrowsSpecific([t averageWithDoubleColumn:((size_t)0)],
+//        NSException, NSRangeException,
+//        @"No rows in a columnless table.");
+//    STAssertThrowsSpecific([t averageWithDoubleColumn:((size_t)1)],
+//        NSException, NSRangeException,
+//        @"No rows in a columnless table.");
 }
 
 - (void)testDataTypes_Dynamic


### PR DESCRIPTION
setIndex, hasIndex, and the aggregates SEGFAULT, some other methods fail to throw appropriate exceptions.

I haven't updated the documentation either, so this is more what I, personally, think should happen in certain error cases.

@bmunkholm @kspangsege @mekjaer @kneth 
