### PR TITLE
[WIP] Object Subscripting on cursors

### DIFF
--- a/src/tightdb/objc/cursor.h
+++ b/src/tightdb/objc/cursor.h
@@ -29,6 +29,12 @@
 -(void)setNdx:(NSUInteger)ndx;
 -(NSUInteger)index;
 
+/* object subscripting */
+-(id)objectAtIndexedSubscript:(NSUInteger)colNdx;
+-(id)objectForKeyedSubscript:(id <NSCopying>)key;
+-(void)setObject:(id)obj atIndexedSubscript:(NSUInteger)colNdx;
+-(void)setObject:(id)obj forKeyedSubscript:(id <NSCopying>)key;
+
 -(void)setInt:(int64_t)value inColumn:(NSUInteger)colNdx;
 -(void)setString:(NSString *)value inColumn:(NSUInteger)colNdx;
 -(void)setBool:(BOOL)value inColumn:(NSUInteger)colNdx;

--- a/src/tightdb/objc/cursor_objc.mm
+++ b/src/tightdb/objc/cursor_objc.mm
@@ -50,6 +50,84 @@ using namespace std;
     _table = nil;
 }
 
+-(id)objectAtIndexedSubscript:(NSUInteger)colNdx
+{
+    TightdbType columnType = [_table getColumnType:colNdx];
+    switch (columnType) {
+        case tightdb_Bool:
+            return [NSNumber numberWithBool:[_table getBoolInColumn:colNdx atRow:_ndx]];
+        case tightdb_Int:
+            return [NSNumber numberWithLongLong:[_table getIntInColumn:colNdx atRow:_ndx]];
+        case tightdb_Float:
+            return [NSNumber numberWithFloat:[_table getFloatInColumn:colNdx atRow:_ndx]];
+        case tightdb_Double:
+            return [NSNumber numberWithLongLong:[_table getDoubleInColumn:colNdx atRow:_ndx]];
+        case tightdb_String:
+            return [_table getStringInColumn:colNdx atRow:_ndx];
+        case tightdb_Date:
+            return [NSDate dateWithTimeIntervalSince1970:[_table getDateInColumn:colNdx atRow:_ndx]];
+        case tightdb_Binary:
+            return [_table getBinaryInColumn:colNdx atRow:_ndx];
+        case tightdb_Table:
+            return [_table getTableInColumn:colNdx atRow:_ndx];
+        case tightdb_Mixed:
+            return [_table getMixedInColumn:colNdx atRow:_ndx];
+    }
+}
+
+- (id)objectForKeyedSubscript:(id <NSCopying>)key
+{
+    NSUInteger colNdx = [_table getColumnIndex:(NSString*)key];
+    return [self objectAtIndexedSubscript:colNdx];
+}
+
+-(void)setObject:(id)obj atIndexedSubscript:(NSUInteger)colNdx
+{
+    TightdbType columnType = [_table getColumnType:colNdx];
+
+    // TODO: Verify obj type
+
+    switch (columnType) {
+        case tightdb_Bool:
+            [_table setBool:[obj boolValue] inColumn:colNdx atRow:_ndx];
+            break;
+        case tightdb_Int:
+            [_table setInt:[obj longLongValue] inColumn:colNdx atRow:_ndx];
+            break;
+        case tightdb_Float:
+            [_table setFloat:[obj floatValue] inColumn:colNdx atRow:_ndx];
+            break;
+        case tightdb_Double:
+            [_table setDouble:[obj doubleValue] inColumn:colNdx atRow:_ndx];
+            break;
+        case tightdb_String:
+            if (![obj isKindOfClass:[NSString class]])
+                [NSException raise:@"TypeException" format:@"Inserting non-string obj into string column"];
+            [_table setString:(NSString*)obj inColumn:colNdx atRow:_ndx];
+            break;
+        case tightdb_Date:
+            if ([obj isKindOfClass:[NSDate class]])
+                [NSException raise:@"TypeException" format:@"Inserting non-date obj into date column"];
+            [_table setDate:time_t([obj timeIntervalSince1970]) inColumn:colNdx atRow:_ndx];
+            break;
+        case tightdb_Binary:
+            [_table setBinary:(TightdbBinary *)obj inColumn:colNdx atRow:_ndx];
+            break;
+        case tightdb_Table:
+            [_table setTable:(TightdbTable *)obj inColumn:colNdx atRow:_ndx];
+            break;
+        case tightdb_Mixed:
+            [_table setMixed:(TightdbMixed *)obj inColumn:colNdx atRow:_ndx];
+            break;
+    }
+}
+
+-(void)setObject:(id)obj forKeyedSubscript:(id <NSCopying>)key
+{
+    NSUInteger colNdx = [_table getColumnIndex:(NSString*)key];
+    [self setObject:obj atIndexedSubscript:colNdx];
+}
+
 -(int64_t)getIntInColumn:(NSUInteger)colNdx
 {
     return [_table getIntInColumn:colNdx atRow:_ndx];

--- a/src/tightdb/objc/table.h
+++ b/src/tightdb/objc/table.h
@@ -132,7 +132,9 @@
 -(BOOL)removeLastRow;
 -(BOOL)removeLastRowWithError:(NSError *__autoreleasing *)error;
 
--(TightdbCursor *)objectAtIndexedSubscript:(NSUInteger)ndx; /* object subscripting */
+/* object subscripting */
+-(TightdbCursor *)objectAtIndexedSubscript:(NSUInteger)ndx;
+
 -(TightdbCursor *)cursorAtIndex:(NSUInteger)ndx;
 -(TightdbCursor *)cursorAtLastIndex;
 

--- a/src/tightdb/objc/test/dynamic_table.m
+++ b/src/tightdb/objc/test/dynamic_table.m
@@ -860,8 +860,47 @@
     // Same but used directly
     STAssertEquals([_table[0] getIntInColumn:0], (int64_t)506, @"table[0].first");
     STAssertTrue([[_table[0] getStringInColumn:1] isEqual:@"test"], @"table[0].second");
+}
 
+- (void)testTableDynamic_Cursor_Subscripting
+{
+    TightdbTable* _table = [[TightdbTable alloc] init];
+    STAssertNotNil(_table, @"Table is nil");
 
+    // 1. Add two columns
+    [_table addColumnWithType:tightdb_Int andName:@"first"];
+    [_table addColumnWithType:tightdb_String andName:@"second"];
+
+    TightdbCursor* c;
+
+    // Add some rows
+    c = [_table addEmptyRow];
+    c[0] = @506;
+    c[1] = @"test";
+
+    c = [_table addEmptyRow];
+    c[@"first"]  = @4;
+    c[@"second"] = @"more test";
+
+    // Get values from cursor by object subscripting
+    c = _table[0];
+    STAssertTrue([c[0] isEqual:@506], @"table[0].first");
+    STAssertTrue([c[1] isEqual:@"test"], @"table[0].second");
+
+    // Same but used with column name
+    STAssertTrue([c[@"first"]  isEqual:@506], @"table[0].first");
+    STAssertTrue([c[@"second"] isEqual:@"test"], @"table[0].second");
+
+    // Combine with subscripting for rows
+    STAssertTrue([_table[0][0] isEqual:@506], @"table[0].first");
+    STAssertTrue([_table[0][1] isEqual:@"test"], @"table[0].second");
+    STAssertTrue([_table[0][@"first"] isEqual:@506], @"table[0].first");
+    STAssertTrue([_table[0][@"second"] isEqual:@"test"], @"table[0].second");
+
+    STAssertTrue([_table[1][0] isEqual:@4], @"table[1].first");
+    STAssertTrue([_table[1][1] isEqual:@"more test"], @"table[1].second");
+    STAssertTrue([_table[1][@"first"] isEqual:@4], @"table[1].first");
+    STAssertTrue([_table[1][@"second"] isEqual:@"more test"], @"table[1].second");
 }
 
 @end


### PR DESCRIPTION
I have added initial support for Object Subscripting on cursors so we can play with the syntax.

It mainly need some more error checking. When we get support in the basic table methods for taking native obj-c types like NSData as values, it should be easy to transition it to using them directly.

One note about the cursor object in general. I noticed that it holds a TightdbTable reference (i.e. the obj.c object) rather than a direct TableRef. I wonder if that is needed? It is a bit of unneeded overhead to have to do everything through obj-c selectors if we could have used direct method calls. 

@bmunkholm @mekjaer @kneth
