### PR TITLE
The installation test is now very simple

### DIFF
--- a/test-installed/test.m
+++ b/test-installed/test.m
@@ -1,14 +1,15 @@
-#import <tightdb/objc/group.h>
-#import <tightdb/objc/tightdb.h>
-
-TIGHTDB_TABLE_1(TestTable,
-                Value, Int)
+#import <tightdb/objc/Tightdb.h>
 
 int main()
 {
     @autoreleasepool {
-        TightdbGroup *db = [TightdbGroup group];
-        TestTable *t = (TestTable *)[db getTable:@"test" withClass:[TestTable class]];
-        return t ? 0 : 1;
+        TDBTable* table = [[TDBTable alloc] init];
+
+        [table addColumnWithName:@"first" andType:TDBIntType];
+        [table addColumnWithName:@"second" andType:TDBIntType];
+
+        [table addRow:@[@1, @2]];
+
+        return [table rowCount]>0?0:1;
     }
 }


### PR DESCRIPTION
After removal of `group.h` from the public interface, `sh build.sh test-installed` has been failing (see https://app.asana.com/0/search/11240103084782/11156922587634).

The test has been rewritten so it only uses features in the public interface.

@mekjaer @kspangsege 
