### PR TITLE
Type conversion when in setting a date column

### DIFF
--- a/src/tightdb/objc/TDBTable.mm
+++ b/src/tightdb/objc/TDBTable.mm
@@ -565,7 +565,7 @@ using namespace std;
 -(void)TDB_setDate:(NSDate *)value inColumnWithIndex:(NSUInteger)col_ndx atRowIndex:(NSUInteger)row_ndx
 {
     TIGHTDB_EXCEPTION_HANDLER_SETTERS(
-        m_table->set_datetime(col_ndx, row_ndx, (size_t)[value timeIntervalSince1970]);,
+       m_table->set_datetime(col_ndx, row_ndx, tightdb::DateTime((time_t)[value timeIntervalSince1970]));,
        TDBDateType);
 }
 


### PR DESCRIPTION
We have seen that a unit test fails sporadicly. It seems that setting a timestamp in a date column is done wrong.

@emanuelez @mekjaer @bmunkholm 
