### PR TITLE
Fixed NSPredicates using NSDate comparisons and added relevant tests

### DIFF
--- a/src/realm/objc/RLMTable.mm
+++ b/src/realm/objc/RLMTable.mm
@@ -1254,6 +1254,35 @@ void add_string_constraint_to_query(tightdb::Query & query,
     }
 }
 
+void add_datetime_constraint_to_query(tightdb::Query & query,
+                                      NSPredicateOperatorType operatorType,
+                                      NSUInteger index,
+                                      double value) {
+    switch (operatorType) {
+        case NSLessThanPredicateOperatorType:
+            query.less_datetime(index, value);
+            break;
+        case NSLessThanOrEqualToPredicateOperatorType:
+            query.less_equal_datetime(index, value);
+            break;
+        case NSGreaterThanPredicateOperatorType:
+            query.greater_datetime(index, value);
+            break;
+        case NSGreaterThanOrEqualToPredicateOperatorType:
+            query.greater_equal_datetime(index, value);
+            break;
+        case NSEqualToPredicateOperatorType:
+            query.equal_datetime(index, value);
+            break;
+        case NSNotEqualToPredicateOperatorType:
+            query.not_equal_datetime(index, value);
+            break;
+        default:
+            @throw predicate_exception(@"Invalid operator type", [NSString stringWithFormat:@"Operator type %lu not supported for type NSDate", (unsigned long)operatorType]);
+            break;
+    }
+}
+
 void update_query_with_value_expression(RLMTable * table, tightdb::Query & query,
     NSString * columnName, id value, NSPredicateOperatorType operatorType) {
 
@@ -1272,9 +1301,8 @@ void update_query_with_value_expression(RLMTable * table, tightdb::Query & query
                                          bool([(NSNumber *)value boolValue]));
             break;
         case tightdb::type_DateTime:
-            // TODO: change datetime so method signaturs match other numeric types
-            @throw predicate_exception(@"Unsupported predicate value type",
-                                       @"Not supporting dates temporarily");
+            add_datetime_constraint_to_query(query, operatorType, index,
+                                             double([(NSDate *)value timeIntervalSince1970]));
             break;
         case tightdb::type_Double:
             add_numeric_constraint_to_query(query, type, operatorType,

--- a/src/realm/objc/test/query.m
+++ b/src/realm/objc/test/query.m
@@ -446,4 +446,90 @@ REALM_TABLE_9(TestQueryAllTypes,
     }];
 }
 
+- (void)testPredicateQueries {
+    [self createTestTableWithWriteBlock:^(RLMTable *table) {
+        [table addColumnWithName:@"date" type:RLMTypeDate];
+        NSArray *dates = @[[NSDate dateWithTimeIntervalSince1970:0],
+                           [NSDate dateWithTimeIntervalSince1970:1],
+                           [NSDate dateWithTimeIntervalSince1970:2],
+                           [NSDate dateWithTimeIntervalSince1970:3]];
+        for (NSDate *date in dates) {
+            [table addRow:@[date]];
+        }
+        
+        NSDate *date = [NSDate dateWithTimeIntervalSince1970:1];
+        
+        {
+            // Lesser than
+            NSPredicate *predicate = [NSPredicate predicateWithFormat:@"date < %@", date];
+            RLMView *view = [table where:predicate];
+            NSArray *results = [dates subarrayWithRange:NSMakeRange(0, 1)];
+            XCTAssertEqual(view.rowCount, results.count, @"lesser than predicate should return correct count");
+            [results enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
+                XCTAssertEqualObjects(obj, view[idx][@"date"], @"lesser than predicate should return correct results");
+            }];
+        }
+        {
+            // Lesser than or equal
+            NSPredicate *predicate = [NSPredicate predicateWithFormat:@"date <= %@", date];
+            RLMView *view = [table where:predicate];
+            NSArray *results = [dates subarrayWithRange:NSMakeRange(0, 2)];
+            XCTAssertEqual(view.rowCount, results.count, @"lesser than or equal predicate should return correct count");
+            [results enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
+                XCTAssertEqualObjects(obj, view[idx][@"date"], @"lesser than or equal predicate should return correct results");
+            }];
+        }
+        {
+            // Equal (single '=')
+            NSPredicate *predicate = [NSPredicate predicateWithFormat:@"date = %@", date];
+            RLMView *view = [table where:predicate];
+            NSArray *results = [dates subarrayWithRange:NSMakeRange(1, 1)];
+            XCTAssertEqual(view.rowCount, results.count, @"equal(1) predicate should return correct count");
+            [results enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
+                XCTAssertEqualObjects(obj, view[idx][@"date"], @"equal(1) predicate should return correct results");
+            }];
+        }
+        {
+            // Equal (double '=')
+            NSPredicate *predicate = [NSPredicate predicateWithFormat:@"date == %@", date];
+            RLMView *view = [table where:predicate];
+            NSArray *results = [dates subarrayWithRange:NSMakeRange(1, 1)];
+            XCTAssertEqual(view.rowCount, results.count, @"equal(2) predicate should return correct");
+            [results enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
+                XCTAssertEqualObjects(obj, view[idx][@"date"], @"equal(2) predicate should return correct results");
+            }];
+        }
+        {
+            // Greater than or equal
+            NSPredicate *predicate = [NSPredicate predicateWithFormat:@"date >= %@", date];
+            RLMView *view = [table where:predicate];
+            NSArray *results = [dates subarrayWithRange:NSMakeRange(1, 3)];
+            XCTAssertEqual(view.rowCount, results.count, @"greater than or equal predicate should return correct count");
+            [results enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
+                XCTAssertEqualObjects(obj, view[idx][@"date"], @"greater than or equal predicate should return correct results");
+            }];
+        }
+        {
+            // Greater than
+            NSPredicate *predicate = [NSPredicate predicateWithFormat:@"date > %@", date];
+            RLMView *view = [table where:predicate];
+            NSArray *results = [dates subarrayWithRange:NSMakeRange(2, 2)];
+            XCTAssertEqual(view.rowCount, results.count, @"greater than predicate should return correct count");
+            [results enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
+                XCTAssertEqualObjects(obj, view[idx][@"date"], @"greater than predicate should return correct results");
+            }];
+        }
+        {
+            // Not equal
+            NSPredicate *predicate = [NSPredicate predicateWithFormat:@"date != %@", date];
+            RLMView *view = [table where:predicate];
+            NSArray *results = [[dates subarrayWithRange:NSMakeRange(0, 1)] arrayByAddingObjectsFromArray:[dates subarrayWithRange:NSMakeRange(2, 2)]];
+            XCTAssertEqual(view.rowCount, results.count, @"not equal predicate should return correct count");
+            [results enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
+                XCTAssertEqualObjects(obj, view[idx][@"date"], @"not equal predicate should return correct results");
+            }];
+        }
+    }];
+}
+
 @end


### PR DESCRIPTION
Using predicates with `NSDate` comparisons currently throws an exception. This re-enables that functionality.
