### PR TITLE
Add mixed support to object interface

### DIFF
--- a/src/realm/objc/RLMProperty.mm
+++ b/src/realm/objc/RLMProperty.mm
@@ -215,6 +215,7 @@ const char * setterTypeStringForCode(char code) {
         case '@':
         {
             NSString *type = [NSString stringWithUTF8String:code];
+            // if one charachter, this is an untyped id, ie [type isEqualToString:@"@"]
             if (type.length == 1) {
                 self.type = RLMTypeMixed;
             }

--- a/src/realm/objc/test/typed_table.m
+++ b/src/realm/objc/test/typed_table.m
@@ -107,83 +107,86 @@ RLM_TABLE_TYPE_FOR_OBJECT_TYPE(AggregateTable, AggregateObject)
 
 - (void)testDataTypes_Typed
 {
-    // create table and set object class
-    AllTypesTable *table = [AllTypesTable tableInRealm:realm named:@"table"];
-    
-    NSLog(@"Table: %@", table);
-    XCTAssertNotNil(table, @"Table is nil");
+    [self.managerWithTestPath writeUsingBlock:^(RLMRealm *realm) {
 
-    // Verify column types
-    XCTAssertEqual(RLMTypeBool,   [table columnTypeOfColumnWithIndex:0], @"First column not bool");
-    XCTAssertEqual(RLMTypeInt,    [table columnTypeOfColumnWithIndex:1], @"Second column not int");
-    XCTAssertEqual(RLMTypeFloat,  [table columnTypeOfColumnWithIndex:2], @"Third column not float");
-    XCTAssertEqual(RLMTypeDouble, [table columnTypeOfColumnWithIndex:3], @"Fourth column not double");
-    XCTAssertEqual(RLMTypeString, [table columnTypeOfColumnWithIndex:4], @"Fifth column not string");
-    XCTAssertEqual(RLMTypeBinary, [table columnTypeOfColumnWithIndex:5], @"Sixth column not binary");
-    XCTAssertEqual(RLMTypeDate,   [table columnTypeOfColumnWithIndex:6], @"Seventh column not date");
-    XCTAssertEqual(RLMTypeTable,  [table columnTypeOfColumnWithIndex:7], @"Eighth column not table");
-    XCTAssertEqual(RLMTypeBool,   [table columnTypeOfColumnWithIndex:8], @"Ninth column not bool");
-    XCTAssertEqual(RLMTypeInt,    [table columnTypeOfColumnWithIndex:9], @"Tenth column not long");
-    XCTAssertEqual(RLMTypeMixed,    [table columnTypeOfColumnWithIndex:10], @"Eleventh column not mixed");
+        // create table and set object class
+        AllTypesTable *table = [AllTypesTable tableInRealm:realm named:@"table"];
+        
+        NSLog(@"Table: %@", table);
+        XCTAssertNotNil(table, @"Table is nil");
 
-    const char bin[4] = { 0, 1, 2, 3 };
-    NSData* bin1 = [[NSData alloc] initWithBytes:bin length:sizeof bin / 2];
-    NSData* bin2 = [[NSData alloc] initWithBytes:bin length:sizeof bin];
-    NSDate *timeNow = [NSDate dateWithTimeIntervalSince1970:1000000];
-    NSDate *timeZero = [NSDate dateWithTimeIntervalSince1970:0];
+        // Verify column types
+        XCTAssertEqual(RLMTypeBool,   [table columnTypeOfColumnWithIndex:0], @"First column not bool");
+        XCTAssertEqual(RLMTypeInt,    [table columnTypeOfColumnWithIndex:1], @"Second column not int");
+        XCTAssertEqual(RLMTypeFloat,  [table columnTypeOfColumnWithIndex:2], @"Third column not float");
+        XCTAssertEqual(RLMTypeDouble, [table columnTypeOfColumnWithIndex:3], @"Fourth column not double");
+        XCTAssertEqual(RLMTypeString, [table columnTypeOfColumnWithIndex:4], @"Fifth column not string");
+        XCTAssertEqual(RLMTypeBinary, [table columnTypeOfColumnWithIndex:5], @"Sixth column not binary");
+        XCTAssertEqual(RLMTypeDate,   [table columnTypeOfColumnWithIndex:6], @"Seventh column not date");
+        XCTAssertEqual(RLMTypeTable,  [table columnTypeOfColumnWithIndex:7], @"Eighth column not table");
+        XCTAssertEqual(RLMTypeBool,   [table columnTypeOfColumnWithIndex:8], @"Ninth column not bool");
+        XCTAssertEqual(RLMTypeInt,    [table columnTypeOfColumnWithIndex:9], @"Tenth column not long");
+        XCTAssertEqual(RLMTypeMixed,    [table columnTypeOfColumnWithIndex:10], @"Eleventh column not mixed");
 
-    AgeTable *subtab1 = [AgeTable tableInRealm:realm named:@"subtab1"];
-    AgeTable *subtab2 = [AgeTable tableInRealm:realm named:@"subtab2"];
+        const char bin[4] = { 0, 1, 2, 3 };
+        NSData* bin1 = [[NSData alloc] initWithBytes:bin length:sizeof bin / 2];
+        NSData* bin2 = [[NSData alloc] initWithBytes:bin length:sizeof bin];
+        NSDate *timeNow = [NSDate dateWithTimeIntervalSince1970:1000000];
+        NSDate *timeZero = [NSDate dateWithTimeIntervalSince1970:0];
 
-    [subtab1 addRow:@[@200]]; // NOTE: the name is simply add+name of first column!
-    [subtab2 addRow:@[@100]];
+        AgeTable *subtab1 = [AgeTable tableInRealm:realm named:@"subtab1"];
+        AgeTable *subtab2 = [AgeTable tableInRealm:realm named:@"subtab2"];
 
-    AllTypes * c;
+        [subtab1 addRow:@[@200]]; // NOTE: the name is simply add+name of first column!
+        [subtab2 addRow:@[@100]];
 
-    // addEmptyRow not supported yet
-    [table addRow:nil];
-    c = table.lastRow;
-    
-    c.BoolCol   = NO   ; c.IntCol  = 54 ; c.FloatCol = 0.7     ; c.DoubleCol = 0.8     ; c.StringCol = @"foo";
-    c.BinaryCol = bin1 ; c.DateCol = timeZero  ; c.TableCol = subtab1     ; c.cBoolCol = false; c.longCol = 99;
-    NSDate *date = [NSDate date];
-    c.mixedCol = date;
-    
-    [table addRow:nil];
-    c = table.lastRow; 
-    
-    c.BoolCol   = YES  ; c.IntCol  = 506     ; c.FloatCol = 7.7         ; c.DoubleCol = 8.8       ; c.StringCol = @"banach";
-    c.BinaryCol = bin2 ; c.DateCol = timeNow ; c.TableCol = subtab2     ; c.cBoolCol = true;    c.longCol = -20;
-    c.mixedCol = @2;
-    
-    //AllTypes* row1 = [table rowAtIndex:0];
-    //AllTypes* row2 = [table rowAtIndex:1];
-    AllTypes* row1 = table[0];
-    AllTypes* row2 = table[1];
+        AllTypes * c;
 
-    XCTAssertEqual(row1.boolCol, NO,                 @"row1.BoolCol");
-    XCTAssertEqual(row2.boolCol, YES,                @"row2.BoolCol");
-    XCTAssertEqual(row1.intCol, 54,             @"row1.IntCol");
-    XCTAssertEqual(row2.intCol, 506,            @"row2.IntCol");
-    XCTAssertEqual(row1.floatCol, 0.7f,              @"row1.FloatCol");
-    XCTAssertEqual(row2.floatCol, 7.7f,              @"row2.FloatCol");
-    XCTAssertEqual(row1.doubleCol, 0.8,              @"row1.DoubleCol");
-    XCTAssertEqual(row2.doubleCol, 8.8,              @"row2.DoubleCol");
-    XCTAssertTrue([row1.stringCol isEqual:@"foo"],    @"row1.StringCol");
-    XCTAssertTrue([row2.stringCol isEqual:@"banach"], @"row2.StringCol");
-    XCTAssertTrue([row1.binaryCol isEqual:bin1],      @"row1.BinaryCol");
-    XCTAssertTrue([row2.binaryCol isEqual:bin2],      @"row2.BinaryCol");
-    XCTAssertTrue(([row1.dateCol isEqual:timeZero]),  @"row1.DateCol");
-    XCTAssertTrue(([row2.dateCol isEqual:timeNow]),   @"row2.DateCol");
-    XCTAssertTrue([row1.tableCol isEqual:subtab1],    @"row1.TableCol");
-    XCTAssertTrue([row2.tableCol isEqual:subtab2],    @"row2.TableCol");
-    XCTAssertEqual(row1.cBoolCol, (bool)false,        @"row1.cBoolCol");
-    XCTAssertEqual(row2.cBoolCol, (bool)true,         @"row2.cBoolCol");
-    XCTAssertEqual(row1.longCol, 99L,                 @"row1.IntCol");
-    XCTAssertEqual(row2.longCol, -20L,                @"row2.IntCol");
-    
-    XCTAssertTrue([row1.mixedCol isEqualToDate:date], @"row1.mixedCol");
-    XCTAssertEqualObjects(row2.mixedCol, @2,          @"row2.mixedCol");
+        // addEmptyRow not supported yet
+        [table addRow:nil];
+        c = table.lastRow;
+        
+        c.BoolCol   = NO   ; c.IntCol  = 54 ; c.FloatCol = 0.7     ; c.DoubleCol = 0.8     ; c.StringCol = @"foo";
+        c.BinaryCol = bin1 ; c.DateCol = timeZero  ; c.TableCol = subtab1     ; c.cBoolCol = false; c.longCol = 99;
+        NSString *string = @"string";
+        c.mixedCol = @"string";
+        
+        [table addRow:nil];
+        c = table.lastRow; 
+        
+        c.BoolCol   = YES  ; c.IntCol  = 506     ; c.FloatCol = 7.7         ; c.DoubleCol = 8.8       ; c.StringCol = @"banach";
+        c.BinaryCol = bin2 ; c.DateCol = timeNow ; c.TableCol = subtab2     ; c.cBoolCol = true;    c.longCol = -20;
+        c.mixedCol = @2;
+        
+        //AllTypes* row1 = [table rowAtIndex:0];
+        //AllTypes* row2 = [table rowAtIndex:1];
+        AllTypes* row1 = table[0];
+        AllTypes* row2 = table[1];
+
+        XCTAssertEqual(row1.boolCol, NO,                 @"row1.BoolCol");
+        XCTAssertEqual(row2.boolCol, YES,                @"row2.BoolCol");
+        XCTAssertEqual(row1.intCol, 54,             @"row1.IntCol");
+        XCTAssertEqual(row2.intCol, 506,            @"row2.IntCol");
+        XCTAssertEqual(row1.floatCol, 0.7f,              @"row1.FloatCol");
+        XCTAssertEqual(row2.floatCol, 7.7f,              @"row2.FloatCol");
+        XCTAssertEqual(row1.doubleCol, 0.8,              @"row1.DoubleCol");
+        XCTAssertEqual(row2.doubleCol, 8.8,              @"row2.DoubleCol");
+        XCTAssertTrue([row1.stringCol isEqual:@"foo"],    @"row1.StringCol");
+        XCTAssertTrue([row2.stringCol isEqual:@"banach"], @"row2.StringCol");
+        XCTAssertTrue([row1.binaryCol isEqual:bin1],      @"row1.BinaryCol");
+        XCTAssertTrue([row2.binaryCol isEqual:bin2],      @"row2.BinaryCol");
+        XCTAssertTrue(([row1.dateCol isEqual:timeZero]),  @"row1.DateCol");
+        XCTAssertTrue(([row2.dateCol isEqual:timeNow]),   @"row2.DateCol");
+        XCTAssertTrue([row1.tableCol isEqual:subtab1],    @"row1.TableCol");
+        XCTAssertTrue([row2.tableCol isEqual:subtab2],    @"row2.TableCol");
+        XCTAssertEqual(row1.cBoolCol, (bool)false,        @"row1.cBoolCol");
+        XCTAssertEqual(row2.cBoolCol, (bool)true,         @"row2.cBoolCol");
+        XCTAssertEqual(row1.longCol, 99L,                 @"row1.IntCol");
+        XCTAssertEqual(row2.longCol, -20L,                @"row2.IntCol");
+        
+        XCTAssertTrue([row1.mixedCol isEqualToString:string], @"row1.mixedCol");
+        XCTAssertEqualObjects(row2.mixedCol, @2,          @"row2.mixedCol");
+    }];
 }
 
 - (void)testTableTyped_Subscripting


### PR DESCRIPTION
This adds mixed support for the object interface. You can declare a mixed property simply by using id.
