### PR TITLE
Fixed wrong comment.

### DIFF
--- a/src/realm/objc/RLMTable.h
+++ b/src/realm/objc/RLMTable.h
@@ -356,8 +356,7 @@
 // Table type and schema
 -(BOOL)isEqual:(id)otherTableClass;
 -(id)castToTypedTableClass:(Class)typedTableClass;
-// FIXME: implement method below and reenable and document it
-// -(BOOL)hasSameDescriptorAs:(Class)otherTableClass;
+-(BOOL)hasSameDescriptorAs:(Class)otherTableClass;
 
 -(RLMType)mixedTypeForColumnWithIndex:(NSUInteger)colIndex atRowIndex:(NSUInteger)rowIndex;
 


### PR DESCRIPTION
The method hasSameDescriptorAs: in RLMTable is implemented. Not sure for now if this will be needed in coming API. Leaving it enabled for now.
