### PR TITLE
Use anonymous namespace for stuff that is private to a translation unit

### DIFF
--- a/src/realm/objc/RLMRealm.mm
+++ b/src/realm/objc/RLMRealm.mm
@@ -35,14 +35,15 @@ using namespace std;
 using namespace tightdb;
 using namespace tightdb::util;
 
-namespace rlm {
-    // create NSException from c++ exception
-    void throw_objc_exception(exception &ex) {
-        NSString *errorMessage = [NSString stringWithUTF8String:ex.what()];
-        @throw [NSException exceptionWithName:@"RLMException" reason:errorMessage userInfo:nil];
-    }
+namespace {
+
+// create NSException from c++ exception
+void throw_objc_exception(exception &ex) {
+    NSString *errorMessage = [NSString stringWithUTF8String:ex.what()];
+    @throw [NSException exceptionWithName:@"RLMException" reason:errorMessage userInfo:nil];
 }
-using namespace rlm;
+
+} // anonymous namespace
 
 
 // simple weak wrapper for a weak target timer


### PR DESCRIPTION
Note that an anonymous namespace plays the same role for C++ as the `static` keyword plays for C. It makes stuff local to the translation unit. This eliminates risk of symbol collision when the customer uses the framework, and also of collisions between our individual translation units.

@alazier @jpsim 
