### PR TITLE
Rename set_row methods in util.mm to be clear they're update_row methods

### DIFF
--- a/src/realm/objc/RLMTable.mm
+++ b/src/realm/objc/RLMTable.mm
@@ -403,20 +403,20 @@ using namespace std;
     tightdb::ConstDescriptorRef desc = table.get_descriptor();
     
     if ([anObject isKindOfClass:[NSArray class]]) {
-        verify_row(*desc, (NSArray *)anObject);
-        insert_row(size_t(rowIndex), table, (NSArray *)anObject);
+        verify_row_with_array(*desc, (NSArray *) anObject);
+        insert_row_with_array(size_t(rowIndex), table, (NSArray *) anObject);
         return;
     }
     
     if ([anObject isKindOfClass:[NSDictionary class]]) {
-        verify_row_with_labels(*desc, (NSDictionary *)anObject);
-        insert_row_with_labels(size_t(rowIndex), table, (NSDictionary *)anObject);
+        verify_row_with_dictionary(*desc, (NSDictionary *) anObject);
+        insert_row_with_dictionary(size_t(rowIndex), table, (NSDictionary *) anObject);
         return;
     }
     
     if ([anObject isKindOfClass:[NSObject class]]) {
-        verify_row_from_object(*desc, (NSObject *)anObject);
-        insert_row_from_object(size_t(rowIndex), table, (NSObject *)anObject);
+        verify_row_with_object(*desc, (NSObject *) anObject);
+        insert_row_with_object(size_t(rowIndex), table, (NSObject *) anObject);
         return;
     }
 
@@ -442,19 +442,19 @@ using namespace std;
     
     // These should call update_row. Will re-implement update_row_with_array() when setRow:atIndex is implemented.
     if ([anObject isKindOfClass:[NSArray class]]) {
-        verify_row(*desc, (NSArray *)anObject);
+        verify_row_with_array(*desc, (NSArray *) anObject);
         update_row_with_array(size_t(rowIndex), table, (NSArray *) anObject);
         return;
     }
     
     if ([anObject isKindOfClass:[NSDictionary class]]) {
-        verify_row_with_labels(*desc, (NSDictionary *)anObject);
+        verify_row_with_dictionary(*desc, (NSDictionary *) anObject);
         update_row_with_dictionary(size_t(rowIndex), table, (NSDictionary *) anObject);
         return;
     }
     
     if ([anObject isKindOfClass:[NSObject class]]) {
-        verify_row_from_object(*desc, (NSObject *)anObject);
+        verify_row_with_object(*desc, (NSObject *) anObject);
         update_row_with_object(size_t(rowIndex), table, (NSObject *) anObject);
         return;
     }

--- a/src/realm/objc/util.mm
+++ b/src/realm/objc/util.mm
@@ -250,7 +250,7 @@ BOOL verify_cell(const Descriptor& descr, size_t col_ndx, NSObject *obj)
                 while (subobj = [subenumerator nextObject]) {
                     if (![subobj isKindOfClass:[NSArray class]])
                         return NO;
-                    verify_row(*subdescr, (NSArray *)subobj);
+                    verify_row_with_array(*subdescr, (NSArray *) subobj);
                 }
                 break;
             }
@@ -264,7 +264,7 @@ BOOL verify_cell(const Descriptor& descr, size_t col_ndx, NSObject *obj)
 }
 
 
-void verify_row(const Descriptor& descr, NSArray* data)
+void verify_row_with_array(const Descriptor &descr, NSArray *data)
 {
     if (descr.get_column_count() != [data count]) {
         @throw [NSException exceptionWithName:@"realm:wrong_column_count"
@@ -288,7 +288,7 @@ void verify_row(const Descriptor& descr, NSArray* data)
     }
 }
 
-void verify_row_with_labels(const Descriptor& descr, NSDictionary* data)
+void verify_row_with_dictionary(const Descriptor &descr, NSDictionary *data)
 {
     size_t n = descr.get_column_count();
     for (size_t i = 0; i < n; ++i) {
@@ -305,7 +305,7 @@ void verify_row_with_labels(const Descriptor& descr, NSDictionary* data)
     }
 }
 
-void verify_row_from_object(const Descriptor& descr, NSObject* data)
+void verify_row_with_object(const Descriptor &descr, NSObject *data)
 {
     size_t count = descr.get_column_count();
     for (size_t col_ndx = 0; col_ndx < count; ++col_ndx) {
@@ -444,7 +444,7 @@ bool insert_cell(size_t col_ndx, size_t row_ndx, Table& table, NSObject *obj)
 }
 
 
-void insert_row(size_t row_ndx, tightdb::Table& table, NSArray * data)
+void insert_row_with_array(size_t row_ndx, tightdb::Table &table, NSArray *data)
 {
     NSEnumerator *enumerator = [data objectEnumerator];
     id obj;
@@ -481,14 +481,14 @@ void insert_row(size_t row_ndx, tightdb::Table& table, NSArray * data)
                 }
 
                 // Fill in data
-                insert_row(subtable->size(), *subtable, subobj);
+                insert_row_with_array(subtable->size(), *subtable, subobj);
                 ++sub_ndx;
             }
         }
     }
 }
 
-void insert_row_with_labels(size_t row_ndx, Table& table, NSDictionary *data)
+void insert_row_with_dictionary(size_t row_ndx, Table &table, NSDictionary *data)
 {
     bool subtables_seen = false;
 
@@ -518,12 +518,12 @@ void insert_row_with_labels(size_t row_ndx, Table& table, NSDictionary *data)
             TableRef subtable = table.get_subtable(col_ndx, row_ndx);
 
             // fill in data
-            insert_row_with_labels(row_ndx, *subtable, (NSDictionary *)value);
+            insert_row_with_dictionary(row_ndx, *subtable, (NSDictionary *) value);
         }
     }
 }
 
-void insert_row_from_object(size_t row_ndx, Table& table, NSObject *data) {
+void insert_row_with_object(size_t row_ndx, Table &table, NSObject *data) {
     bool subtables_seen = false;
 
     size_t count = table.get_column_count();
@@ -555,7 +555,7 @@ void insert_row_from_object(size_t row_ndx, Table& table, NSObject *data) {
                 continue;
             }
             TableRef subtable = table.get_subtable(col_ndx, row_ndx);
-            insert_row_from_object(row_ndx, *subtable, value);
+            insert_row_with_object(row_ndx, *subtable, value);
         }
     }
 }

--- a/src/realm/objc/util_noinst.hpp
+++ b/src/realm/objc/util_noinst.hpp
@@ -198,16 +198,16 @@ BOOL verify_object_is_type(id obj, tightdb::DataType type);
 BOOL verify_cell(const tightdb::Descriptor& descr, size_t col_ndx, NSObject *obj);
 NSObject* get_cell(size_t col_ndx, size_t row_ndx, tightdb::Table& table);
 
-void verify_row(const tightdb::Descriptor& descr, NSArray * data);
-void insert_row(size_t ndx, tightdb::Table& table, NSArray * data);
+void verify_row_with_array(const tightdb::Descriptor &descr, NSArray *data);
+void insert_row_with_array(size_t ndx, tightdb::Table &table, NSArray *data);
 void update_row_with_array(size_t ndx, tightdb::Table &table, NSArray *data);
 
-void verify_row_with_labels(const tightdb::Descriptor& descr, NSDictionary* data);
-void insert_row_with_labels(size_t row_ndx, tightdb::Table& table, NSDictionary *data);
+void verify_row_with_dictionary(const tightdb::Descriptor &descr, NSDictionary *data);
+void insert_row_with_dictionary(size_t row_ndx, tightdb::Table &table, NSDictionary *data);
 void update_row_with_dictionary(size_t row_ndx, tightdb::Table &table, NSDictionary *data);
 
-void verify_row_from_object(const tightdb::Descriptor& descr, NSObject* data);
-void insert_row_from_object(size_t row_ndx, tightdb::Table& table, NSObject *data);
+void verify_row_with_object(const tightdb::Descriptor &descr, NSObject *data);
+void insert_row_with_object(size_t row_ndx, tightdb::Table &table, NSObject *data);
 void update_row_with_object(size_t row_ndx, tightdb::Table &table, NSObject *data);
 
 


### PR DESCRIPTION
This is a prerequisite for creating set_row_with_\* methods that update a row entirely
