### PR TITLE
Ignore useless appledoc warnings, raise threshold to 1

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -680,6 +680,10 @@ EOF
                     --create-html \
                     --no-create-docset \
                     --no-repeat-first-par \
+                    --no-warn-missing-arg \
+                    --no-warn-invalid-crossref \
+                    --no-warn-undocumented-object \
+                    --no-warn-undocumented-member \
                     --ignore src/realm/objc/RLMColumnProxy.h \
                     --ignore src/realm/objc/RLMProxy.h \
                     --ignore src/realm/objc/RLMQuery.h \
@@ -689,7 +693,7 @@ EOF
                     --ignore "src/realm/objc/test/*" \
                     --index-desc doc/index.md \
                     --template doc/templates \
-                    --exit-threshold 2 \
+                    --exit-threshold 1 \
                     src/realm/objc/ || exit 1
 
         echo "Generating docset docs..."
@@ -705,6 +709,10 @@ EOF
                     --docset-feed-url "http://realm.io/docs/appledoc" \
                     --company-id "io.realm" \
                     --no-repeat-first-par \
+                    --no-warn-missing-arg \
+                    --no-warn-invalid-crossref \
+                    --no-warn-undocumented-object \
+                    --no-warn-undocumented-member \
                     --ignore src/realm/objc/RLMColumnProxy.h \
                     --ignore src/realm/objc/RLMProxy.h \
                     --ignore src/realm/objc/RLMQuery.h \
@@ -714,7 +722,7 @@ EOF
                     --ignore "src/realm/objc/test/*" \
                     --index-desc doc/index.md \
                     --template doc/templates \
-                    --exit-threshold 2 \
+                    --exit-threshold 1 \
                     src/realm/objc/ || exit 1
         echo "Done generating docs under docs/appledocs"
         exit 0


### PR DESCRIPTION
Found a few args that silence the warnings we don’t care about but do let some more important errors through.

Actually, running `sh build.sh docs` should output one error message on this branch (the error in question is fixed in #277).

I raised the error threshold back to 1 so we can let Jenkins fail branches on doc errors.

@emanuelez please review?
