### PR TITLE
RLMArray backingView as ivar instead of property

### DIFF
--- a/Realm/RLMArray.mm
+++ b/Realm/RLMArray.mm
@@ -36,6 +36,7 @@
 //
 @interface RLMArray ()
 @property (nonatomic, assign) tightdb::Query *backingQuery;
+// When getting the backingView using dot notation, the tableview is copied in core. Use _backingView instead when accessing.
 @property (nonatomic, assign) tightdb::TableView backingView;
 @property (nonatomic, copy) NSString *objectClassName;
 @end


### PR DESCRIPTION
Getting a tableview using properties caused a copy of the tableview in core, resulting in errors for aggregations.
Made tableview an ivar instead

@alazier @rrrlasse @kspangsege 
