### PR TITLE
Docs cleanup

### DIFF
--- a/Realm/RLMObject.h
+++ b/Realm/RLMObject.h
@@ -174,17 +174,17 @@ typedef NS_ENUM(NSUInteger, RLMPropertyAttributes) {
 @end
 
 
-/**---------------------------------------------------------------------------------------
- *  @name RLMArray Property Declaration
- *  ---------------------------------------------------------------------------------------
- *
- * Properties on RLMObjects of type RLMArray must have an associated type. A type is associated
- * with an RLMArray property by defining a protocol for the object type which the RLMArray will 
- * hold. To define an protocol for an object you can use the macro RLM_OBJECT_PROTOCOL:
- *
- * ie. RLM_OBJECT_PROTOCOL(ObjectType)
- *     \@property RLMArray<ObjectType> *arrayOfObjectTypes;
- */
+//---------------------------------------------------------------------------------------
+// @name RLMArray Property Declaration
+//---------------------------------------------------------------------------------------
+//
+// Properties on RLMObjects of type RLMArray must have an associated type. A type is associated
+// with an RLMArray property by defining a protocol for the object type which the RLMArray will
+// hold. To define an protocol for an object you can use the macro RLM_OBJECT_PROTOCOL:
+//
+// ie. RLM_OBJECT_PROTOCOL(ObjectType)
+//     \@property RLMArray<ObjectType> *arrayOfObjectTypes;
+//
 #define RLM_OBJECT_PROTOCOL(RLM_OBJECT_SUBCLASS)\
 @protocol RLM_OBJECT_SUBCLASS <NSObject>        \
 @end

--- a/Realm/RLMRealm.h
+++ b/Realm/RLMRealm.h
@@ -299,21 +299,18 @@ typedef void(^RLMNotificationBlock)(NSString *notification, RLMRealm *realm);
 @class RLMSchema;
 
 @interface RLMRealm (Schema)
-/**---------------------------------------------------------------------------------------
- *  @name Realm and Object Schema
- *  ---------------------------------------------------------------------------------------
- */
-/**
- Returns the schema used by this realm. This can be used to enumerate and introspect object
- types during migrations for dynamic introspection.
- 
- @see       RLMObjectSchema
- */
+//---------------------------------------------------------------------------------------
+// @name Realm and Object Schema
+//---------------------------------------------------------------------------------------
+//
+// Returns the schema used by this realm. This can be used to enumerate and introspect object
+// types during migrations for dynamic introspection.
+//
 @property (nonatomic, readonly) RLMSchema *schema;
 
-/**
- The schema version for this Realm.
- */
+//
+// The schema version for this Realm.
+// 
 @property (nonatomic, readonly) NSUInteger schemaVersion;
 
 @end

--- a/build.sh
+++ b/build.sh
@@ -681,14 +681,23 @@ EOF
                     --no-warn-invalid-crossref \
                     --no-warn-undocumented-object \
                     --no-warn-undocumented-member \
+                    --ignore "Realm/RLMConstants.h" \
+                    --ignore "Realm/RLMArrayAccessor.h" \
+                    --ignore "Realm/RLMArrayAccessor.mm" \
+                    --ignore "Realm/RLMProperty.h" \
+                    --ignore "Realm/RLMProperty.m" \
+                    --ignore "Realm/RLMObjectSchema.h" \
+                    --ignore "Realm/RLMSchema.h" \
                     --ignore "Realm/RLMQueryUtil.h" \
                     --ignore "Realm/RLMUtil.h" \
+                    --ignore "Realm/Tests/QueryTests.m" \
                     --ignore "Realm/Tests/*" \
                     --index-desc docs/source/index.md \
                     --template docs/templates \
                     --exit-threshold 1 \
                     Realm || exit 1
         mkdir -p docs/output
+        rm -rf docs/output/$(sh build.sh get-version)
         mv docs/html docs/output/$(sh build.sh get-version)
         echo "Done generating HTML docs under docs/output/"
 
@@ -712,9 +721,17 @@ EOF
                     --no-warn-invalid-crossref \
                     --no-warn-undocumented-object \
                     --no-warn-undocumented-member \
+                    --ignore "Realm/RLMConstants.h" \
+                    --ignore "Realm/RLMArrayAccessor.h" \
+                    --ignore "Realm/RLMArrayAccessor.mm" \
+                    --ignore "Realm/RLMProperty.h" \
+                    --ignore "Realm/RLMProperty.m" \
+                    --ignore "Realm/RLMObjectSchema.h" \
+                    --ignore "Realm/RLMSchema.h" \
                     --ignore "Realm/RLMQueryUtil.h" \
                     --ignore "Realm/RLMUtil.h" \
-                    --ignore "Realm/Tests" \
+                    --ignore "Realm/Tests/QueryTests.m" \
+                    --ignore "Realm/Tests/*" \
                     --index-desc docs/source/index.md \
                     --template docs/templates \
                     --exit-threshold 1 \


### PR DESCRIPTION
Removes not absolutely necessary Classes & methods from our docs output to keep things simple. I may have been a bit overzealous so please feel free to make the case for re-adding a few of these.

@alazier @mekjaer @jpsim Please review.
