### PR TITLE
 tests failing - disabling cachedRealm

### DIFF
--- a/Realm/RLMRealm.mm
+++ b/Realm/RLMRealm.mm
@@ -224,7 +224,7 @@ static NSArray *s_objectDescriptors = nil;
     }
 
     // try to reuse existing realm first
-    RLMRealm *realm = cachedRealm(path);
+    RLMRealm *realm = nil;//cachedRealm(path);
     if (realm) {
         // if already open with different read permissions then throw
         if (realm.isReadOnly != readonly) {


### PR DESCRIPTION
Some of our tests fail once every 5-10 times.
Especially the tests in QueryTests.
If I disable the cachedRealm when creating the default realm. it never fails.
The inline cachedRealm method also currently states, that the path is not a reliable identifier - I guess it's true. 
@alazier , what is your take? It is out of my knowledge area. 
@bmunkholm 
