### PR TITLE
Fix for test failures, Test cleanup

### DIFF
--- a/Realm.xcodeproj/project.pbxproj
+++ b/Realm.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		02026CAB19363B5300E4EEF8 /* ArrayTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 02026CAA19363B5300E4EEF8 /* ArrayTests.m */; };
+		02026CAC19363B5300E4EEF8 /* ArrayTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 02026CAA19363B5300E4EEF8 /* ArrayTests.m */; };
 		02C4145F191DE49600F858D9 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E918909C177B677900653D7A /* Cocoa.framework */; };
 		02C41465191DE49600F858D9 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 02C41463191DE49600F858D9 /* InfoPlist.strings */; };
 		02C4146F191DE49600F858D9 /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4B7ACCD718FDD8E4008B7B95 /* XCTest.framework */; };
@@ -96,10 +98,10 @@
 		02E4D6ED192E58320082808D /* RLMTestObjects.m in Sources */ = {isa = PBXBuildFile; fileRef = 02E4D6EB192E58320082808D /* RLMTestObjects.m */; };
 		4D3F56501923668700240A75 /* ObjectTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 4D3F564E1923667700240A75 /* ObjectTests.m */; };
 		4D3F56511923668700240A75 /* ObjectTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 4D3F564E1923667700240A75 /* ObjectTests.m */; };
-		4D8D90B1192B80F0004C89AA /* MisuseTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 4D8D90AF192B7FC4004C89AA /* MisuseTests.m */; };
-		4D8D90B2192B825E004C89AA /* MisuseTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 4D8D90AF192B7FC4004C89AA /* MisuseTests.m */; };
-		4DFB045D192F877300F36C59 /* ClassExtensionTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 4DFB045C192F877300F36C59 /* ClassExtensionTest.m */; };
-		4DFB045E192F877300F36C59 /* ClassExtensionTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 4DFB045C192F877300F36C59 /* ClassExtensionTest.m */; };
+		4D8D90B1192B80F0004C89AA /* TransactionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 4D8D90AF192B7FC4004C89AA /* TransactionTests.m */; };
+		4D8D90B2192B825E004C89AA /* TransactionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 4D8D90AF192B7FC4004C89AA /* TransactionTests.m */; };
+		4DFB045D192F877300F36C59 /* ObjectInterfaceTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 4DFB045C192F877300F36C59 /* ObjectInterfaceTests.m */; };
+		4DFB045E192F877300F36C59 /* ObjectInterfaceTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 4DFB045C192F877300F36C59 /* ObjectInterfaceTests.m */; };
 		4DFB0460192F9DD700F36C59 /* CHANGELOG.md in Resources */ = {isa = PBXBuildFile; fileRef = 4DFB045F192F9DD700F36C59 /* CHANGELOG.md */; };
 /* End PBXBuildFile section */
 
@@ -133,6 +135,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		02026CAA19363B5300E4EEF8 /* ArrayTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ArrayTests.m; sourceTree = "<group>"; };
 		02C4145E191DE49600F858D9 /* Realm.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Realm.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		02C41462191DE49600F858D9 /* Realm-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "Realm-Info.plist"; sourceTree = "<group>"; };
 		02C41464191DE49600F858D9 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
@@ -192,8 +195,8 @@
 		02E4D6EE192E583A0082808D /* RLMTestObjects.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RLMTestObjects.h; sourceTree = "<group>"; };
 		4B7ACCD718FDD8E4008B7B95 /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
 		4D3F564E1923667700240A75 /* ObjectTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ObjectTests.m; sourceTree = "<group>"; };
-		4D8D90AF192B7FC4004C89AA /* MisuseTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MisuseTests.m; sourceTree = "<group>"; };
-		4DFB045C192F877300F36C59 /* ClassExtensionTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ClassExtensionTest.m; sourceTree = "<group>"; };
+		4D8D90AF192B7FC4004C89AA /* TransactionTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TransactionTests.m; sourceTree = "<group>"; };
+		4DFB045C192F877300F36C59 /* ObjectInterfaceTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ObjectInterfaceTests.m; sourceTree = "<group>"; };
 		4DFB045F192F9DD700F36C59 /* CHANGELOG.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = CHANGELOG.md; sourceTree = "<group>"; };
 		E918909C177B677900653D7A /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = System/Library/Frameworks/Cocoa.framework; sourceTree = SDKROOT; };
 		E918909F177B677900653D7A /* AppKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppKit.framework; path = System/Library/Frameworks/AppKit.framework; sourceTree = SDKROOT; };
@@ -297,18 +300,19 @@
 		02C41474191DE49600F858D9 /* RealmTests */ = {
 			isa = PBXGroup;
 			children = (
-				4DFB045C192F877300F36C59 /* ClassExtensionTest.m */,
+				02026CAA19363B5300E4EEF8 /* ArrayTests.m */,
+				02E4D6E8192E58250082808D /* MixedTests.m */,
+				4DFB045C192F877300F36C59 /* ObjectInterfaceTests.m */,
 				4D3F564E1923667700240A75 /* ObjectTests.m */,
 				02C414D71921939D00F858D9 /* QueryTests.m */,
 				02C4147A191DE49600F858D9 /* RealmTests.m */,
-				02E4D6E8192E58250082808D /* MixedTests.m */,
+				4D8D90AF192B7FC4004C89AA /* TransactionTests.m */,
 				02C4148E191DE68900F858D9 /* RLMTestCase.h */,
 				02C4148F191DE68900F858D9 /* RLMTestCase.m */,
 				02E4D6EE192E583A0082808D /* RLMTestObjects.h */,
 				02E4D6EB192E58320082808D /* RLMTestObjects.m */,
 				02C41490191DE68900F858D9 /* XCTestCase+AsyncTesting.h */,
 				02C41491191DE68900F858D9 /* XCTestCase+AsyncTesting.m */,
-				4D8D90AF192B7FC4004C89AA /* MisuseTests.m */,
 				02C41475191DE49600F858D9 /* Supporting Files */,
 			);
 			name = RealmTests;
@@ -610,14 +614,15 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				4D8D90B2192B825E004C89AA /* MisuseTests.m in Sources */,
+				4D8D90B2192B825E004C89AA /* TransactionTests.m in Sources */,
 				4D3F56501923668700240A75 /* ObjectTests.m in Sources */,
 				02E4D6E9192E58250082808D /* MixedTests.m in Sources */,
+				02026CAB19363B5300E4EEF8 /* ArrayTests.m in Sources */,
 				02C414D81921939D00F858D9 /* QueryTests.m in Sources */,
 				02E4D6EC192E58320082808D /* RLMTestObjects.m in Sources */,
 				02C4147B191DE49600F858D9 /* RealmTests.m in Sources */,
 				02C41493191DE68900F858D9 /* XCTestCase+AsyncTesting.m in Sources */,
-				4DFB045D192F877300F36C59 /* ClassExtensionTest.m in Sources */,
+				4DFB045D192F877300F36C59 /* ObjectInterfaceTests.m in Sources */,
 				02C41492191DE68900F858D9 /* RLMTestCase.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -648,11 +653,12 @@
 				4D3F56511923668700240A75 /* ObjectTests.m in Sources */,
 				02E4D6EA192E58250082808D /* MixedTests.m in Sources */,
 				02C415431921B4FE00F858D9 /* RLMTestCase.m in Sources */,
+				02026CAC19363B5300E4EEF8 /* ArrayTests.m in Sources */,
 				02E4D6ED192E58320082808D /* RLMTestObjects.m in Sources */,
 				02C415441921B50000F858D9 /* XCTestCase+AsyncTesting.m in Sources */,
 				02C4153E1921B25000F858D9 /* QueryTests.m in Sources */,
-				4D8D90B1192B80F0004C89AA /* MisuseTests.m in Sources */,
-				4DFB045E192F877300F36C59 /* ClassExtensionTest.m in Sources */,
+				4D8D90B1192B80F0004C89AA /* TransactionTests.m in Sources */,
+				4DFB045E192F877300F36C59 /* ObjectInterfaceTests.m in Sources */,
 				02C4153F1921B25000F858D9 /* RealmTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -721,6 +727,7 @@
 				INFOPLIST_FILE = "Realm/Realm-Info.plist";
 				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				STRIP_INSTALLED_PRODUCT = YES;
 				WRAPPER_EXTENSION = framework;
 			};
 			name = Debug;
@@ -751,6 +758,7 @@
 				INFOPLIST_FILE = "Realm/Realm-Info.plist";
 				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				STRIP_INSTALLED_PRODUCT = YES;
 				WRAPPER_EXTENSION = framework;
 			};
 			name = Release;

--- a/Realm/RLMRealm.mm
+++ b/Realm/RLMRealm.mm
@@ -43,6 +43,13 @@ void throw_objc_exception(exception &ex) {
     NSString *errorMessage = [NSString stringWithUTF8String:ex.what()];
     @throw [NSException exceptionWithName:@"RLMException" reason:errorMessage userInfo:nil];
 }
+ 
+// create NSError from c++ exception
+inline NSError* make_realm_error(RLMError code, exception &ex) {
+    NSMutableDictionary* details = [NSMutableDictionary dictionary];
+    [details setValue:[NSString stringWithUTF8String:ex.what()] forKey:NSLocalizedDescriptionKey];
+    return [NSError errorWithDomain:@"io.realm" code:code userInfo:details];
+}
 
 } // anonymous namespace
 
@@ -98,12 +105,10 @@ inline NSArray *realmsAtPath(NSString *path) {
     }
 }
 
-
-inline NSError* make_realm_error(RLMError code, exception &ex)
-{
-    NSMutableDictionary* details = [NSMutableDictionary dictionary];
-    [details setValue:[NSString stringWithUTF8String:ex.what()] forKey:NSLocalizedDescriptionKey];
-    return [NSError errorWithDomain:@"io.realm" code:code userInfo:details];
+inline void clearRealmCache() {
+    @synchronized(s_realmsPerPath) {
+        s_realmsPerPath = [NSMutableDictionary dictionary];
+    }
 }
 
 
@@ -134,7 +139,7 @@ static NSArray *s_objectDescriptors = nil;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
         // initilize realm cache
-        s_realmsPerPath = [NSMutableDictionary dictionary];
+        clearRealmCache();
         
         // initialize object store
         RLMInitializeObjectStore();
@@ -285,6 +290,10 @@ static NSArray *s_objectDescriptors = nil;
     }
     
     return realm;
+}
+
++ (void)clearRealmCache {
+    clearRealmCache();
 }
 
 - (void)addNotificationBlock:(RLMNotificationBlock)block {

--- a/Realm/Tests/ArrayTests.m
+++ b/Realm/Tests/ArrayTests.m
@@ -1,0 +1,169 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// TIGHTDB CONFIDENTIAL
+// __________________
+//
+//  [2011] - [2014] TightDB Inc
+//  All Rights Reserved.
+//
+// NOTICE:  All information contained herein is, and remains
+// the property of TightDB Incorporated and its suppliers,
+// if any.  The intellectual and technical concepts contained
+// herein are proprietary to TightDB Incorporated
+// and its suppliers and may be covered by U.S. and Foreign Patents,
+// patents in process, and are protected by trade secret or copyright law.
+// Dissemination of this information or reproduction of this material
+// is strictly forbidden unless prior written permission is obtained
+// from TightDB Incorporated.
+//
+////////////////////////////////////////////////////////////////////////////
+
+#import "RLMTestCase.h"
+
+@interface AggregateObject : RLMObject
+@property int intCol;
+@property float floatCol;
+@property double doubleCol;
+@property BOOL boolCol;
+@property NSDate *dateCol;
+@end
+
+@implementation AggregateObject
+@end
+
+
+@interface ArrayTests : RLMTestCase
+@end
+
+@implementation ArrayTests
+
+
+- (void)testObjectAggregate
+{
+    RLMRealm *realm = [RLMRealm defaultRealm];
+    
+    [realm beginWriteTransaction];
+    
+    NSDate *dateMinInput = [NSDate date];
+    NSDate *dateMaxInput = [dateMinInput dateByAddingTimeInterval:1000];
+    
+    [AggregateObject createInRealm:realm withObject:@[@0, @1.2f, @0.0, @YES, dateMinInput]];
+    [AggregateObject createInRealm:realm withObject:@[@1, @0.0f, @2.5, @NO, dateMaxInput]];
+    [AggregateObject createInRealm:realm withObject:@[@0, @1.2f, @0.0, @YES, dateMinInput]];
+    [AggregateObject createInRealm:realm withObject:@[@1, @0.0f, @2.5, @NO, dateMaxInput]];
+    [AggregateObject createInRealm:realm withObject:@[@0, @1.2f, @0.0, @YES, dateMinInput]];
+    [AggregateObject createInRealm:realm withObject:@[@1, @0.0f, @2.5, @NO, dateMaxInput]];
+    [AggregateObject createInRealm:realm withObject:@[@0, @1.2f, @0.0, @YES, dateMinInput]];
+    [AggregateObject createInRealm:realm withObject:@[@1, @0.0f, @2.5, @NO, dateMaxInput]];
+    [AggregateObject createInRealm:realm withObject:@[@0, @1.2f, @0.0, @YES, dateMinInput]];
+    [AggregateObject createInRealm:realm withObject:@[@0, @1.2f, @0.0, @YES, dateMinInput]];
+    
+    [realm commitWriteTransaction];
+    
+    RLMArray *noArray = [AggregateObject objectsWhere:@"boolCol == NO"];
+    RLMArray *yesArray = [AggregateObject objectsWhere:@"boolCol == YES"];
+    
+    // SUM ::::::::::::::::::::::::::::::::::::::::::::::
+    // Test int sum
+    XCTAssertEqual([noArray sumOfProperty:@"intCol"].integerValue, (NSInteger)4, @"Sum should be 4");
+    XCTAssertEqual([yesArray sumOfProperty:@"intCol"].integerValue, (NSInteger)0, @"Sum should be 0");
+    
+    // Test float sum
+    XCTAssertEqualWithAccuracy([noArray sumOfProperty:@"floatCol"].floatValue, (float)0.0f, 0.1f, @"Sum should be 0.0");
+    XCTAssertEqualWithAccuracy([yesArray sumOfProperty:@"floatCol"].floatValue, (float)7.2f, 0.1f, @"Sum should be 7.2");
+    
+    // Test double sum
+    XCTAssertEqualWithAccuracy([noArray sumOfProperty:@"doubleCol"].doubleValue, (double)10.0, 0.1f, @"Sum should be 10.0");
+    XCTAssertEqualWithAccuracy([yesArray sumOfProperty:@"doubleCol"].doubleValue, (double)0.0, 0.1f, @"Sum should be 0.0");
+    
+    // Test invalid column name
+    XCTAssertThrows([yesArray sumOfProperty:@"foo"], @"Should throw exception");
+    
+    // Test operation not supported
+    XCTAssertThrows([yesArray sumOfProperty:@"boolCol"], @"Should throw exception");
+    
+    
+    // Average ::::::::::::::::::::::::::::::::::::::::::::::
+    // Test int average
+    XCTAssertEqualWithAccuracy([noArray averageOfProperty:@"intCol"].doubleValue, (double)1.0, 0.1f, @"Average should be 1.0");
+    XCTAssertEqualWithAccuracy([yesArray averageOfProperty:@"intCol"].doubleValue, (double)0.0, 0.1f, @"Average should be 0.0");
+    
+    // Test float average
+    XCTAssertEqualWithAccuracy([noArray averageOfProperty:@"floatCol"].doubleValue, (double)0.0f, 0.1f, @"Average should be 0.0");
+    XCTAssertEqualWithAccuracy([yesArray averageOfProperty:@"floatCol"].doubleValue, (double)1.2f, 0.1f, @"Average should be 1.2");
+    
+    // Test double average
+    XCTAssertEqualWithAccuracy([noArray averageOfProperty:@"doubleCol"].doubleValue, (double)2.5, 0.1f, @"Average should be 2.5");
+    XCTAssertEqualWithAccuracy([yesArray averageOfProperty:@"doubleCol"].doubleValue, (double)0.0, 0.1f, @"Average should be 0.0");
+    
+    // Test invalid column name
+    XCTAssertThrows([yesArray averageOfProperty:@"foo"], @"Should throw exception");
+    
+    // Test operation not supported
+    XCTAssertThrows([yesArray averageOfProperty:@"boolCol"], @"Should throw exception");
+    
+    // MIN ::::::::::::::::::::::::::::::::::::::::::::::
+    // Test int min
+    NSNumber *min = [noArray minOfProperty:@"intCol"];
+    XCTAssertEqual(min.intValue, (NSInteger)1, @"Minimum should be 1");
+    min = [yesArray minOfProperty:@"intCol"];
+    XCTAssertEqual(min.intValue, (NSInteger)0, @"Minimum should be 0");
+    
+    // Test float min
+    min = [noArray minOfProperty:@"floatCol"];
+    XCTAssertEqualWithAccuracy(min.floatValue, (float)0.0f, 0.1f, @"Minimum should be 0.0f");
+    min = [yesArray minOfProperty:@"floatCol"];
+    XCTAssertEqualWithAccuracy(min.floatValue, (float)1.2f, 0.1f, @"Minimum should be 1.2f");
+    
+    // Test double min
+    min = [noArray minOfProperty:@"doubleCol"];
+    XCTAssertEqualWithAccuracy(min.doubleValue, (double)2.5, 0.1f, @"Minimum should be 1.5");
+    min = [yesArray minOfProperty:@"doubleCol"];
+    XCTAssertEqualWithAccuracy(min.doubleValue, (double)0.0, 0.1f, @"Minimum should be 0.0");
+    
+    // Test date min
+    NSDate *dateMinOutput = [noArray minOfProperty:@"dateCol"];
+    XCTAssertEqualWithAccuracy(dateMinOutput.timeIntervalSince1970, dateMaxInput.timeIntervalSince1970, 1, @"Minimum should be dateMaxInput");
+    dateMinOutput = [yesArray minOfProperty:@"dateCol"];
+    XCTAssertEqualWithAccuracy(dateMinOutput.timeIntervalSince1970, dateMinInput.timeIntervalSince1970, 1, @"Minimum should be dateMinInput");
+    
+    // Test invalid column name
+    XCTAssertThrows([noArray minOfProperty:@"foo"], @"Should throw exception");
+    
+    // Test operation not supported
+    XCTAssertThrows([noArray minOfProperty:@"boolCol"], @"Should throw exception");
+    
+    
+    // MAX ::::::::::::::::::::::::::::::::::::::::::::::
+    // Test int max
+    NSNumber *max = [noArray maxOfProperty:@"intCol"];
+    XCTAssertEqual(max.integerValue, (NSInteger)1, @"Maximum should be 8");
+    max = [yesArray maxOfProperty:@"intCol"];
+    XCTAssertEqual(max.integerValue, (NSInteger)0, @"Maximum should be 10");
+    
+    // Test float max
+    max = [noArray maxOfProperty:@"floatCol"];
+    XCTAssertEqualWithAccuracy(max.floatValue, (float)0.0f, 0.1f, @"Maximum should be 0.0f");
+    max = [yesArray maxOfProperty:@"floatCol"];
+    XCTAssertEqualWithAccuracy(max.floatValue, (float)1.2f, 0.1f, @"Maximum should be 1.2f");
+    
+    // Test double max
+    max = [noArray maxOfProperty:@"doubleCol"];
+    XCTAssertEqualWithAccuracy(max.doubleValue, (double)2.5, 0.1f, @"Maximum should be 3.5");
+    max = [yesArray maxOfProperty:@"doubleCol"];
+    XCTAssertEqualWithAccuracy(max.doubleValue, (double)0.0, 0.1f, @"Maximum should be 0.0");
+    
+    // Test date max
+    NSDate *dateMaxOutput = [noArray maxOfProperty:@"dateCol"];
+    XCTAssertEqualWithAccuracy(dateMaxOutput.timeIntervalSince1970, dateMaxInput.timeIntervalSince1970, 1, @"Maximum should be dateMaxInput");
+    dateMaxOutput = [yesArray maxOfProperty:@"dateCol"];
+    XCTAssertEqualWithAccuracy(dateMaxOutput.timeIntervalSince1970, dateMinInput.timeIntervalSince1970, 1, @"Maximum should be dateMinInput");
+    
+    // Test invalid column name
+    XCTAssertThrows([noArray maxOfProperty:@"foo"], @"Should throw exception");
+    
+    // Test operation not supported
+    XCTAssertThrows([noArray maxOfProperty:@"boolCol"], @"Should throw exception");
+}
+
+@end

--- a/Realm/Tests/MixedTests.m
+++ b/Realm/Tests/MixedTests.m
@@ -11,11 +11,11 @@
 @end
 
 
-@interface RLMMixedTests : RLMTestCase
+@interface MixedTests : RLMTestCase
 @property (nonatomic, strong) RLMRealm *realm;
 @end
 
-@implementation RLMMixedTests
+@implementation MixedTests
 
 #pragma mark - commons
 

--- a/Realm/Tests/ObjectInterfaceTests.m
+++ b/Realm/Tests/ObjectInterfaceTests.m
@@ -19,8 +19,34 @@
 ////////////////////////////////////////////////////////////////////////////
 
 #import "RLMTestCase.h"
+#import "RLMTestObjects.h"
+
+//
+// for custom accessor test
+//
+@interface CustomAccessors : RLMObject
+@property (getter = getThatName) NSString * name;
+@property (setter = setTheInt:) int age;
+@end
+
+@implementation CustomAccessors
+@end
 
 
+//
+// for subclass test
+//
+@interface InvalidSubclassObject : RLMTestObject
+@property NSString *invalid;
+@end
+
+@implementation InvalidSubclassObject
+@end
+
+
+//
+// for class extension test
+//
 @interface BaseClassTestObject : RLMObject
 @property NSInteger intCol;
 @end
@@ -34,10 +60,36 @@
 @end
 
 
-@interface ClassExtensionTest : RLMTestCase
 
+@interface ObjectInterfaceTests : RLMTestCase
 @end
-@implementation ClassExtensionTest
+
+@implementation ObjectInterfaceTests
+
+
+- (void)testCustomAccessors
+{
+    RLMRealm *realm = [RLMRealm defaultRealm];
+    
+    [realm beginWriteTransaction];
+    CustomAccessors *ca = [CustomAccessors createInRealm:realm withObject:@[@"name", @2]];
+    XCTAssertEqualObjects([ca getThatName], @"name", @"name property should be name.");
+    
+    [ca setTheInt:99];
+    XCTAssertEqual((int)ca.age, (int)99, @"age property should be 99");
+    [realm commitWriteTransaction];
+}
+
+- (void)testObjectSubclass
+{
+    RLMRealm *realm = [RLMRealm defaultRealm];
+    
+    [realm beginWriteTransaction];
+    NSArray *obj = @[@1, @"throw"];
+    XCTAssertThrows([InvalidSubclassObject createInRealm:realm withObject:obj],
+                    @"Adding invalid object should throw");
+    [realm commitWriteTransaction];
+}
 
 - (void)testClassExtension
 {

--- a/Realm/Tests/ObjectTests.m
+++ b/Realm/Tests/ObjectTests.m
@@ -40,14 +40,6 @@
 @implementation AgeObject
 @end
 
-@interface InvalidSubclassObject : AgeObject
-@property NSString *invalid;
-@end
-
-@implementation InvalidSubclassObject
-@end
-
-
 @interface KeyedObject : RLMObject
 @property NSString * name;
 @property int objID;
@@ -57,31 +49,10 @@
 @end
 
 
-@interface CustomAccessors : RLMObject
-@property (getter = getThatName) NSString * name;
-@property (setter = setTheInt:) int age;
+@interface ObjectTests : RLMTestCase
 @end
 
-@implementation CustomAccessors
-@end
-
-
-@interface AggregateObject : RLMObject
-@property int intCol;
-@property float floatCol;
-@property double doubleCol;
-@property BOOL boolCol;
-@property NSDate *dateCol;
-@end
-
-@implementation AggregateObject
-@end
-
-
-@interface RLMObjectTests : RLMTestCase
-@end
-
-@implementation RLMObjectTests
+@implementation ObjectTests
 
 -(void)testObjectInit
 {
@@ -154,19 +125,6 @@
     XCTAssertEqualObjects(obj0[@"name"], @"newName",  @"Name should be newName");
 }
 
-- (void)testCustomAccessors
-{
-    RLMRealm *realm = [RLMRealm defaultRealm];
-    
-    [realm beginWriteTransaction];
-    CustomAccessors *ca = [CustomAccessors createInRealm:realm withObject:@[@"name", @2]];
-    XCTAssertEqualObjects([ca getThatName], @"name", @"name property should be name.");
-        
-    [ca setTheInt:99];
-    XCTAssertEqual((int)ca.age, (int)99, @"age property should be 99");
-    [realm commitWriteTransaction];
-}
-
 - (void)testObjectCount
 {
     RLMRealm *realm = [RLMRealm defaultRealm];
@@ -186,145 +144,6 @@
     XCTAssertEqual([AgeObject objectsWhere:@"age == 1"].count, (NSUInteger)0, @"count should return 0");
     XCTAssertEqual([AgeObject objectsWhere:@"age == 2"].count, (NSUInteger)1, @"count should return 1");
     XCTAssertEqual([AgeObject objectsWhere:@"age < 30"].count, (NSUInteger)7, @"count should return 7");
-}
-
-- (void)testObjectAggregate
-{
-    RLMRealm *realm = [RLMRealm defaultRealm];
-    
-    [realm beginWriteTransaction];
-    
-    NSDate *dateMinInput = [NSDate date];
-    NSDate *dateMaxInput = [dateMinInput dateByAddingTimeInterval:1000];
-    
-    [AggregateObject createInRealm:realm withObject:@[@0, @1.2f, @0.0, @YES, dateMinInput]];
-    [AggregateObject createInRealm:realm withObject:@[@1, @0.0f, @2.5, @NO, dateMaxInput]];
-    [AggregateObject createInRealm:realm withObject:@[@0, @1.2f, @0.0, @YES, dateMinInput]];
-    [AggregateObject createInRealm:realm withObject:@[@1, @0.0f, @2.5, @NO, dateMaxInput]];
-    [AggregateObject createInRealm:realm withObject:@[@0, @1.2f, @0.0, @YES, dateMinInput]];
-    [AggregateObject createInRealm:realm withObject:@[@1, @0.0f, @2.5, @NO, dateMaxInput]];
-    [AggregateObject createInRealm:realm withObject:@[@0, @1.2f, @0.0, @YES, dateMinInput]];
-    [AggregateObject createInRealm:realm withObject:@[@1, @0.0f, @2.5, @NO, dateMaxInput]];
-    [AggregateObject createInRealm:realm withObject:@[@0, @1.2f, @0.0, @YES, dateMinInput]];
-    [AggregateObject createInRealm:realm withObject:@[@0, @1.2f, @0.0, @YES, dateMinInput]];
-    
-    [realm commitWriteTransaction];
-        
-    RLMArray *noArray = [AggregateObject objectsWhere:@"boolCol == NO"];
-    RLMArray *yesArray = [AggregateObject objectsWhere:@"boolCol == YES"];
-    
-    // SUM ::::::::::::::::::::::::::::::::::::::::::::::
-    // Test int sum
-    XCTAssertEqual([noArray sumOfProperty:@"intCol"].integerValue, (NSInteger)4, @"Sum should be 4");
-    XCTAssertEqual([yesArray sumOfProperty:@"intCol"].integerValue, (NSInteger)0, @"Sum should be 0");
-        
-    // Test float sum
-    XCTAssertEqualWithAccuracy([noArray sumOfProperty:@"floatCol"].floatValue, (float)0.0f, 0.1f, @"Sum should be 0.0");
-    XCTAssertEqualWithAccuracy([yesArray sumOfProperty:@"floatCol"].floatValue, (float)7.2f, 0.1f, @"Sum should be 7.2");
-        
-    // Test double sum
-    XCTAssertEqualWithAccuracy([noArray sumOfProperty:@"doubleCol"].doubleValue, (double)10.0, 0.1f, @"Sum should be 10.0");
-    XCTAssertEqualWithAccuracy([yesArray sumOfProperty:@"doubleCol"].doubleValue, (double)0.0, 0.1f, @"Sum should be 0.0");
-        
-    // Test invalid column name
-    XCTAssertThrows([yesArray sumOfProperty:@"foo"], @"Should throw exception");
-        
-    // Test operation not supported
-    XCTAssertThrows([yesArray sumOfProperty:@"boolCol"], @"Should throw exception");
-    
-    
-    // Average ::::::::::::::::::::::::::::::::::::::::::::::
-    // Test int average
-    XCTAssertEqualWithAccuracy([noArray averageOfProperty:@"intCol"].doubleValue, (double)1.0, 0.1f, @"Average should be 1.0");
-    XCTAssertEqualWithAccuracy([yesArray averageOfProperty:@"intCol"].doubleValue, (double)0.0, 0.1f, @"Average should be 0.0");
-    
-    // Test float average
-    XCTAssertEqualWithAccuracy([noArray averageOfProperty:@"floatCol"].doubleValue, (double)0.0f, 0.1f, @"Average should be 0.0");
-    XCTAssertEqualWithAccuracy([yesArray averageOfProperty:@"floatCol"].doubleValue, (double)1.2f, 0.1f, @"Average should be 1.2");
-    
-    // Test double average
-    XCTAssertEqualWithAccuracy([noArray averageOfProperty:@"doubleCol"].doubleValue, (double)2.5, 0.1f, @"Average should be 2.5");
-    XCTAssertEqualWithAccuracy([yesArray averageOfProperty:@"doubleCol"].doubleValue, (double)0.0, 0.1f, @"Average should be 0.0");
-    
-    // Test invalid column name
-    XCTAssertThrows([yesArray averageOfProperty:@"foo"], @"Should throw exception");
-    
-    // Test operation not supported
-    XCTAssertThrows([yesArray averageOfProperty:@"boolCol"], @"Should throw exception");
-    
-    // MIN ::::::::::::::::::::::::::::::::::::::::::::::
-    // Test int min
-    NSNumber *min = [noArray minOfProperty:@"intCol"];
-    XCTAssertEqual(min.intValue, (NSInteger)1, @"Minimum should be 1");
-    min = [yesArray minOfProperty:@"intCol"];
-    XCTAssertEqual(min.intValue, (NSInteger)0, @"Minimum should be 0");
-    
-    // Test float min
-    min = [noArray minOfProperty:@"floatCol"];
-    XCTAssertEqualWithAccuracy(min.floatValue, (float)0.0f, 0.1f, @"Minimum should be 0.0f");
-    min = [yesArray minOfProperty:@"floatCol"];
-    XCTAssertEqualWithAccuracy(min.floatValue, (float)1.2f, 0.1f, @"Minimum should be 1.2f");
-    
-    // Test double min
-    min = [noArray minOfProperty:@"doubleCol"];
-    XCTAssertEqualWithAccuracy(min.doubleValue, (double)2.5, 0.1f, @"Minimum should be 1.5");
-    min = [yesArray minOfProperty:@"doubleCol"];
-    XCTAssertEqualWithAccuracy(min.doubleValue, (double)0.0, 0.1f, @"Minimum should be 0.0");
-    
-    // Test date min
-    NSDate *dateMinOutput = [noArray minOfProperty:@"dateCol"];
-    XCTAssertEqualWithAccuracy(dateMinOutput.timeIntervalSince1970, dateMaxInput.timeIntervalSince1970, 1, @"Minimum should be dateMaxInput");
-    dateMinOutput = [yesArray minOfProperty:@"dateCol"];
-    XCTAssertEqualWithAccuracy(dateMinOutput.timeIntervalSince1970, dateMinInput.timeIntervalSince1970, 1, @"Minimum should be dateMinInput");
-    
-    // Test invalid column name
-    XCTAssertThrows([noArray minOfProperty:@"foo"], @"Should throw exception");
-    
-    // Test operation not supported
-    XCTAssertThrows([noArray minOfProperty:@"boolCol"], @"Should throw exception");
-    
-    
-    // MAX ::::::::::::::::::::::::::::::::::::::::::::::
-    // Test int max
-    NSNumber *max = [noArray maxOfProperty:@"intCol"];
-    XCTAssertEqual(max.integerValue, (NSInteger)1, @"Maximum should be 8");
-    max = [yesArray maxOfProperty:@"intCol"];
-    XCTAssertEqual(max.integerValue, (NSInteger)0, @"Maximum should be 10");
-    
-    // Test float max
-    max = [noArray maxOfProperty:@"floatCol"];
-    XCTAssertEqualWithAccuracy(max.floatValue, (float)0.0f, 0.1f, @"Maximum should be 0.0f");
-    max = [yesArray maxOfProperty:@"floatCol"];
-    XCTAssertEqualWithAccuracy(max.floatValue, (float)1.2f, 0.1f, @"Maximum should be 1.2f");
-    
-    // Test double max
-    max = [noArray maxOfProperty:@"doubleCol"];
-    XCTAssertEqualWithAccuracy(max.doubleValue, (double)2.5, 0.1f, @"Maximum should be 3.5");
-    max = [yesArray maxOfProperty:@"doubleCol"];
-    XCTAssertEqualWithAccuracy(max.doubleValue, (double)0.0, 0.1f, @"Maximum should be 0.0");
-    
-    // Test date max
-    NSDate *dateMaxOutput = [noArray maxOfProperty:@"dateCol"];
-    XCTAssertEqualWithAccuracy(dateMaxOutput.timeIntervalSince1970, dateMaxInput.timeIntervalSince1970, 1, @"Maximum should be dateMaxInput");
-    dateMaxOutput = [yesArray maxOfProperty:@"dateCol"];
-    XCTAssertEqualWithAccuracy(dateMaxOutput.timeIntervalSince1970, dateMinInput.timeIntervalSince1970, 1, @"Maximum should be dateMinInput");
-    
-    // Test invalid column name
-    XCTAssertThrows([noArray maxOfProperty:@"foo"], @"Should throw exception");
-    
-    // Test operation not supported
-    XCTAssertThrows([noArray maxOfProperty:@"boolCol"], @"Should throw exception");
-}
-
-- (void)testObjectSubclass
-{
-    RLMRealm *realm = [RLMRealm defaultRealm];
-    
-    [realm beginWriteTransaction];
-    NSArray *obj = @[@1, @"throw"];
-    XCTAssertThrows([InvalidSubclassObject createInRealm:realm withObject:obj],
-                    @"Adding invalid object should throw");
-    [realm commitWriteTransaction];
 }
 
 - (void)testDataTypes

--- a/Realm/Tests/QueryTests.m
+++ b/Realm/Tests/QueryTests.m
@@ -56,10 +56,10 @@
 @implementation TestQueryObject
 @end
 
-@interface RLMQueryTests : RLMTestCase
+@interface QueryTests : RLMTestCase
 @end
 
-@implementation RLMQueryTests
+@implementation QueryTests
 
 #pragma mark - Tests
 
@@ -113,6 +113,8 @@
     
     // query on class
     RLMArray *all = [PersonQueryObject allObjects];
+    XCTAssertEqual(all.count, 3, @"Expecting 3 results");
+
     RLMArray *some = [PersonQueryObject objectsOrderedBy:@"age" where:@"age > 28"];
     
     // query/order on array

--- a/Realm/Tests/RLMTestObjects.h
+++ b/Realm/Tests/RLMTestObjects.h
@@ -35,3 +35,8 @@
 //@property AgeTable      *tableCol;
 @end
 
+
+@interface RLMTestObject : RLMObject
+@property (nonatomic, copy) NSString *column;
+@end
+

--- a/Realm/Tests/RLMTestObjects.m
+++ b/Realm/Tests/RLMTestObjects.m
@@ -22,3 +22,6 @@
 
 @implementation AllTypesObject
 @end
+
+@implementation RLMTestObject
+@end

--- a/Realm/Tests/RealmTests.m
+++ b/Realm/Tests/RealmTests.m
@@ -19,19 +19,13 @@
 ////////////////////////////////////////////////////////////////////////////
 
 #import "RLMTestCase.h"
+#import "RLMTestObjects.h"
 #import "XCTestCase+AsyncTesting.h"
 
-@interface RLMTestObject : RLMObject
-@property (nonatomic, copy) NSString *column;
+@interface RealmTests : RLMTestCase
 @end
 
-@implementation RLMTestObject
-@end
-
-@interface RLMRealmTests : RLMTestCase
-@end
-
-@implementation RLMRealmTests
+@implementation RealmTests
 
 #pragma mark - Tests
 
@@ -66,14 +60,6 @@
     XCTAssertEqualObjects([objects.firstObject column], @"b", @"Expecting column to be 'b'");
 }
 
-- (void)testRealmModifyObjectsOutsideOfWriteTransaction {
-    RLMRealm *realm = [self realmWithTestPath];
-    [realm beginWriteTransaction];
-    RLMTestObject *obj = [RLMTestObject createInRealm:realm withObject:@[@"a"]];
-    [realm commitWriteTransaction];
-    
-    XCTAssertThrows([obj setColumn:@"throw"], @"Setter should throw when called outside of transaction.");
-}
 
 - (void)testRealmIsUpdatedAfterBackgroundUpdate {
     NSString *realmFilePath = RLMRealmPathForFile(@"async.bg.realm");


### PR DESCRIPTION
This fixes the spurious errors we were getting when running tests. We are wrapping each test invocation in an autoreleasepool now to make sure that Realm instances do not stay alive between tests. This fixes most of the issues. Manually wiping the realm cache between tests solves the other set of failures.

I also cleaned up/reorganized some of the tests as there was inconsistency in the naming of our test suites.

This is in response to #339 
