### PR TITLE
Fixed bug that didn't allow docset installation in Dash via the weblink

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -743,7 +743,7 @@ EOF
         cat >docs/output/$(sh build.sh get-version)/realm.xml <<EOF
 <entry>
     <version>$(sh build.sh get-version)</version>
-    <sha1>$(shasum -a 1 docs/output/$(sh build.sh get-version)/realm.tgz | cut -f1 -d" ")</sha1>
+    <sha1>$(sha1sum -b docs/output/$(sh build.sh get-version)/realm.tgz | cut -c 1-40)</sha1>
     <url>http://static.realm.io/docs/ios/$(sh build.sh get-version)/realm.tgz</url>
 </entry>
 EOF


### PR DESCRIPTION
Added sha1 key/value to realm.xml docset feed. @timanglade
