### PR TITLE
isReadonly property should only use "is" in the custom getter

### DIFF
--- a/Realm/RLMRealm.h
+++ b/Realm/RLMRealm.h
@@ -93,7 +93,7 @@ typedef void (^RLMMigrationBlock)(RLMMigrationRealm *realm);
  
  @return    Boolean value indicating if this RLMRealm instance is readonly.
  */
-@property (nonatomic, readonly) BOOL isReadOnly;
+@property (nonatomic, readonly, getter = isReadOnly) BOOL readOnly;
 
 
 #pragma mark -

--- a/Realm/RLMRealm.mm
+++ b/Realm/RLMRealm.mm
@@ -115,7 +115,6 @@ inline void clearRealmCache() {
 
 @interface RLMRealm ()
 @property (nonatomic) NSString *path;
-@property (nonatomic) BOOL isReadOnly;
 @property (nonatomic, readwrite) RLMSchema *schema;
 @end
 
@@ -156,7 +155,7 @@ static NSArray *s_objectDescriptors = nil;
                                              valueOptions:NSPointerFunctionsWeakMemory
                                                  capacity:128];
         _notificationHandlers = [NSMutableArray array];
-        _isReadOnly = readonly;
+        _readOnly = readonly;
         _updateTimer = [NSTimer scheduledTimerWithTimeInterval:0.1
                                                         target:[RLMWeakTarget createWithRealm:self]
                                                       selector:@selector(checkForUpdate)


### PR DESCRIPTION
"is" doesn't belong in property names. This is feedback we got from a user and I feel the same way. Minor, but it adds up.
