### PR TITLE
updated wording on exception thrown when getting a realm from a thread without a runloop

### DIFF
--- a/Realm/RLMConstants.h
+++ b/Realm/RLMConstants.h
@@ -57,7 +57,7 @@ typedef NS_ENUM(NSUInteger, RLMPropertyAttributes) {
  to customize the properties’ delete rule. This rule is mutually exclusive with
  `RLMPropertyAttributeDeleteIfOnlyOwner` and `RLMPropertyAttributeDeleteAlways`.
  */
-    RLMPropertyAttributeDeleteNever = 0,
+//    RLMPropertyAttributeDeleteNever = 0,
     
 /**
  Delete a child object (or object in an RLMArray) when the parent is deleted or the object is

--- a/Realm/RLMObject.mm
+++ b/Realm/RLMObject.mm
@@ -120,7 +120,8 @@
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunused-parameter"
 + (RLMPropertyAttributes)attributesForProperty:(NSString *)propertyName {
-    return RLMPropertyAttributeDeleteNever;
+    return (RLMPropertyAttributes)0;
+    // FIXME: return RLMPropertyAttributeDeleteNever;
 }
 #pragma clang diagnostic pop
 

--- a/Realm/RLMRealm.mm
+++ b/Realm/RLMRealm.mm
@@ -239,11 +239,10 @@ static NSArray *s_objectDescriptors = nil;
     if (!currentRunloop) {
         @throw [NSException exceptionWithName:@"realm:runloop_exception"
                                        reason:[NSString stringWithFormat:@"%@ \
-                                               can only be called from a thread with a runloop. \
-                                               Use an RLMTransactionManager read or write block \
-                                               instead.", NSStringFromSelector(_cmd)] userInfo:nil];
+                                               can only be called from a thread with a runloop.",
+                                               NSStringFromSelector(_cmd)] userInfo:nil];
     }
-
+    
     // try to reuse existing realm first
     RLMRealm *realm = cachedRealm(path);
     if (realm) {


### PR DESCRIPTION
Also re-commented out RLMPropertyAttributeDeleteNever like before to remove it from docs.

Merging now since @bmunkholm already gave +1 on this from #393.
