### PR TITLE
removed `rm -rf core` since it will never be called

### DIFF
--- a/scripts/download-core.sh
+++ b/scripts/download-core.sh
@@ -7,7 +7,6 @@ fi
 
 if ! [ -d core ]; then
     /usr/bin/curl -s http://static.realm.io/downloads/core/core-${REALM_CORE_VERSION}.zip -o /tmp/core-${REALM_CORE_VERSION}.zip
-    /bin/rm -rf ${SRCROOT}/core
     cd ${SRCROOT}
     /usr/bin/unzip /tmp/core-${REALM_CORE_VERSION}.zip
     /bin/rm -f /tmp/core-${REALM_CORE_VERSION}.zip


### PR DESCRIPTION
Since we check for `! [ -d core ]`, we'd never enter this `if` block if the directory exists, so there's no use in keeping this line. /cc @kneth
