### PR TITLE
Fix for updating link array accessors

### DIFF
--- a/Realm/RLMObject.mm
+++ b/Realm/RLMObject.mm
@@ -111,7 +111,7 @@
     return obj;
 }
 
--(void)setBackingTable:(tightdb::Table *)backingTable {
+-(void)setBackingTable:(tightdb::TableRef)backingTable {
     _backingTable = backingTable;
     _backingTableIndex = backingTable->get_index_in_parent();
 }

--- a/Realm/RLMObjectStore.mm
+++ b/Realm/RLMObjectStore.mm
@@ -107,7 +107,7 @@ void RLMAddObjectToRealm(RLMObject *object, RLMRealm *realm) {
     NSString *objectClassName = object.schema.className;
     object.realm = realm;
     object.schema = realm.schema[objectClassName];
-    object.backingTable = RLMTableForObjectClass(realm, objectClassName).get();
+    object.backingTable = RLMTableForObjectClass(realm, objectClassName);
     object.objectIndex = object.backingTable->add_empty_row();
     
     // change object class to insertion accessor
@@ -178,7 +178,7 @@ RLMObject *RLMCreateObjectAccessor(RLMRealm *realm, NSString *objectClassName, N
                                                  defaultValues:NO];
 
     tightdb::TableRef table = RLMTableForObjectClass(realm, objectClassName);
-    accessor.backingTable = table.get();
+    accessor.backingTable = table;
     accessor.objectIndex = index;
     accessor.writable = (realm.transactionMode == RLMTransactionModeWrite);
     

--- a/Realm/RLMObject_Private.h
+++ b/Realm/RLMObject_Private.h
@@ -32,7 +32,7 @@
 @property (nonatomic, readwrite) RLMRealm *realm;
 @property (nonatomic, assign) NSUInteger objectIndex;
 @property (nonatomic, assign) NSUInteger backingTableIndex;
-@property (nonatomic, assign) tightdb::Table *backingTable;
+@property (nonatomic, assign) tightdb::TableRef backingTable;
 @property (nonatomic) RLMObjectSchema *schema;
 
 @end

--- a/Realm/RLMRealm.mm
+++ b/Realm/RLMRealm.mm
@@ -499,9 +499,8 @@ static NSArray *s_objectDescriptors = nil;
             // FIXME - check is_attached instead of all of this nonsense one we have self-updating accessors
             //
             if ([obj isKindOfClass:RLMObject.class]) {
-                assert(!((RLMObject *)obj).backingTable->is_attached());
                 TableRef tableRef = group->get_table([(RLMObject *)obj backingTableIndex]); // Throws
-                ((RLMObject *)obj).backingTable = tableRef.get();
+                ((RLMObject *)obj).backingTable = tableRef;
                 obj.writable = writable;
             }
             else if([obj isKindOfClass:RLMArrayLinkView.class]) {


### PR DESCRIPTION
This pr fixes two issues:
- We were holding onto Table\* instances rather than TableRefs in RLMObject instances causing us to access invalid memory. We now hold onto TableRefs
- Not all objects were updated before updating LinkViews due to the previous issue. This was causing spurious issues in ci.
