### PR TITLE
Fixed an issue in RLMAccessor.mm

### DIFF
--- a/Realm/RLMAccessor.mm
+++ b/Realm/RLMAccessor.mm
@@ -256,13 +256,15 @@ IMP RLMAccessorStandaloneGetter(NSUInteger col, char accessorCode, NSString *obj
     // only override getters for RLMArray properties
     if (accessorCode == 't') {
         return imp_implementationWithBlock(^(RLMObject *obj) {
+            typedef id (*getter_type)(RLMObject *, SEL);
             RLMProperty *prop = obj.schema.properties[col];
             Class superClass = class_getSuperclass(obj.class);
-            IMP superGetter = class_getMethodImplementation(superClass, NSSelectorFromString(prop.getterName));
+            getter_type superGetter = (getter_type)class_getMethodImplementation(superClass, NSSelectorFromString(prop.getterName));
             id val = superGetter(obj, NSSelectorFromString(prop.getterName));
             if (!val) {
                 SEL setterSel = NSSelectorFromString(prop.setterName);
-                IMP setter = class_getMethodImplementation(obj.class, setterSel);
+                typedef void (*setter_type)(RLMObject *, SEL, id);
+                setter_type setter = (setter_type)class_getMethodImplementation(obj.class, setterSel);
                 val = [RLMArray standaloneArrayWithObjectClassName:objectClassName];
                 setter(obj, setterSel, val);
             }


### PR DESCRIPTION
exposed by clang 3.5, this is backwards compatible with earlier versions.
[PDF link explaining this new "feature" in clang](https://www.google.com/url?sa=t&rct=j&q=&esrc=s&source=web&cd=1&ved=0CBwQFjAA&url=http%3A%2F%2Fdevstreaming.apple.com%2Fvideos%2Fwwdc%2F2014%2F417xx2zsyyp8zcs%2F417%2F417_whats_new_in_llvm.pdf%3Fdl%3D1&ei=DI2XU6_-F4mGogSQpIHgAw&usg=AFQjCNED5jCk4hV6B5Ct66GsPWOGgcAXEg&sig2=tEhBCHuqiYdTT9by9JPF2w&cad=rja)
