### PR TITLE
Test iOS Release configuration in simulator

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -131,8 +131,7 @@ case "$COMMAND" in
     # Testing
     ######################################
     "test")
-        # FIXME: how to run on a device?
-        #xcrealm "-scheme iOS -configuration Release -sdk iphoneos build test"
+        xcrealm "-scheme iOS -configuration Release -sdk iphonesimulator build test"
         xcrealm "-scheme OSX -configuration Release build test"
         exit 0
     ;;


### PR DESCRIPTION
Not sure why this was commented out. Sure, it'd be great to test on real devices, but that shouldn't stop us from testing Release in the simulator too.
