### PR TITLE
[BUG+DECIDE] Deeper RLMObejct subclassing

### DIFF
--- a/Realm/Tests/ObjectTests.m
+++ b/Realm/Tests/ObjectTests.m
@@ -136,7 +136,7 @@
 
 @implementation ObjectTests
 
-#pramga mark ObjectModularisation
+#pragma mark ObjectModularisation
 
 - (void)testSubclassing
 {


### PR DESCRIPTION
Should arbitrarily deep RLMObject subclasses be stored in Realm?

If not, what error should we throw?

Currently, the code fails unexpectedly if you try to initialise a
sub(-sub)+class of RLMObject.

PS. Indirect subclasses of RLMObject are also silently ignored, as far as I can
see from RLMSchema.mm:73.

@astigsen @alazier @bmunkholm 
