### PR TITLE
Remove dependency from the Realm project in the examples

### DIFF
--- a/examples/RealmPerformanceExample/RealmPerformanceExample.xcodeproj/project.pbxproj
+++ b/examples/RealmPerformanceExample/RealmPerformanceExample.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		4DFD433D191A5CD300ABBFFE /* Performance.m in Sources */ = {isa = PBXBuildFile; fileRef = 4DFD4333191A5CD300ABBFFE /* Performance.m */; };
 		4DFD433F191A5CD300ABBFFE /* Utils.m in Sources */ = {isa = PBXBuildFile; fileRef = 4DFD4337191A5CD300ABBFFE /* Utils.m */; };
 		4DFD4340191A5CD300ABBFFE /* ViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 4DFD4339191A5CD300ABBFFE /* ViewController.m */; };
+		B1387DE4195977EE00D49C15 /* Realm.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B1387DE3195977EE00D49C15 /* Realm.framework */; };
 		E8615DCA191AF5A8005DD6C4 /* ViewController_iPad.xib in Resources */ = {isa = PBXBuildFile; fileRef = E8615DC8191AF5A8005DD6C4 /* ViewController_iPad.xib */; };
 		E8615DCB191AF5A8005DD6C4 /* ViewController_iPhone.xib in Resources */ = {isa = PBXBuildFile; fileRef = E8615DC9191AF5A8005DD6C4 /* ViewController_iPhone.xib */; };
 		E9D58B4F1541A375009150B1 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E9D58B4E1541A375009150B1 /* UIKit.framework */; };
@@ -23,47 +24,8 @@
 		E9D58B5B1541A375009150B1 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = E9D58B5A1541A375009150B1 /* main.m */; };
 /* End PBXBuildFile section */
 
-/* Begin PBXContainerItemProxy section */
-		42515D7F194729DD001C3DDF /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 42515D77194729DD001C3DDF /* Realm.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 02C4145E191DE49600F858D9;
-			remoteInfo = "OSX Framework";
-		};
-		42515D81194729DD001C3DDF /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 42515D77194729DD001C3DDF /* Realm.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 02C4146E191DE49600F858D9;
-			remoteInfo = "OSX Tests";
-		};
-		42515D83194729DD001C3DDF /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 42515D77194729DD001C3DDF /* Realm.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 02C415051921B0C300F858D9;
-			remoteInfo = "iOS Library";
-		};
-		42515D85194729DD001C3DDF /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 42515D77194729DD001C3DDF /* Realm.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 02C415121921B0C400F858D9;
-			remoteInfo = "iOS Tests";
-		};
-		42515D87194729EB001C3DDF /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 42515D77194729DD001C3DDF /* Realm.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = 421A99481933646F00F5E4D4;
-			remoteInfo = "iOS Framework";
-		};
-/* End PBXContainerItemProxy section */
-
 /* Begin PBXFileReference section */
 		410B4DD2156E59A30048E4C8 /* libsqlite3.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libsqlite3.dylib; path = usr/lib/libsqlite3.dylib; sourceTree = SDKROOT; };
-		42515D77194729DD001C3DDF /* Realm.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = Realm.xcodeproj; path = ../../Realm.xcodeproj; sourceTree = "<group>"; };
 		42515D8919472A0F001C3DDF /* libc++.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = "libc++.dylib"; path = "usr/lib/libc++.dylib"; sourceTree = SDKROOT; };
 		4D49F55718A912CD0071DDC1 /* Default-568h@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Default-568h@2x.png"; sourceTree = "<group>"; };
 		4DFD432D191A5CD300ABBFFE /* AppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AppDelegate.h; path = RealmPerformanceExample/AppDelegate.h; sourceTree = SOURCE_ROOT; };
@@ -75,6 +37,7 @@
 		4DFD4338191A5CD300ABBFFE /* ViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ViewController.h; path = RealmPerformanceExample/ViewController.h; sourceTree = SOURCE_ROOT; };
 		4DFD4339191A5CD300ABBFFE /* ViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = ViewController.m; path = RealmPerformanceExample/ViewController.m; sourceTree = SOURCE_ROOT; };
 		4DFD4341191A5E1500ABBFFE /* Realm.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Realm.framework; path = ../../Realm.framework; sourceTree = "<group>"; };
+		B1387DE3195977EE00D49C15 /* Realm.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Realm.framework; path = ../../build/Release/Realm.framework; sourceTree = "<group>"; };
 		E8615DC8191AF5A8005DD6C4 /* ViewController_iPad.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = ViewController_iPad.xib; sourceTree = "<group>"; };
 		E8615DC9191AF5A8005DD6C4 /* ViewController_iPhone.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = ViewController_iPhone.xib; sourceTree = "<group>"; };
 		E9D58B4A1541A375009150B1 /* RealmPerformanceExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = RealmPerformanceExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -92,6 +55,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B1387DE4195977EE00D49C15 /* Realm.framework in Frameworks */,
 				42515D8A19472A0F001C3DDF /* libc++.dylib in Frameworks */,
 				410B4DD3156E59A30048E4C8 /* libsqlite3.dylib in Frameworks */,
 				E9D58B4F1541A375009150B1 /* UIKit.framework in Frameworks */,
@@ -103,21 +67,9 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		42515D78194729DD001C3DDF /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				42515D80194729DD001C3DDF /* Realm.framework */,
-				42515D82194729DD001C3DDF /* OSX Tests.xctest */,
-				42515D84194729DD001C3DDF /* libRealm.a */,
-				42515D86194729DD001C3DDF /* iOS Tests.xctest */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
 		E9D58B3F1541A374009150B1 = {
 			isa = PBXGroup;
 			children = (
-				42515D77194729DD001C3DDF /* Realm.xcodeproj */,
 				4D49F55718A912CD0071DDC1 /* Default-568h@2x.png */,
 				410B4DD2156E59A30048E4C8 /* libsqlite3.dylib */,
 				E9D58B541541A375009150B1 /* RealmPerformanceExample */,
@@ -137,6 +89,7 @@
 		E9D58B4D1541A375009150B1 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				B1387DE3195977EE00D49C15 /* Realm.framework */,
 				42515D8919472A0F001C3DDF /* libc++.dylib */,
 				4DFD4341191A5E1500ABBFFE /* Realm.framework */,
 				E9D58B4E1541A375009150B1 /* UIKit.framework */,
@@ -189,7 +142,6 @@
 			buildRules = (
 			);
 			dependencies = (
-				42515D88194729EB001C3DDF /* PBXTargetDependency */,
 			);
 			name = RealmPerformanceExample;
 			productName = TightDbExample;
@@ -215,49 +167,12 @@
 			mainGroup = E9D58B3F1541A374009150B1;
 			productRefGroup = E9D58B4B1541A375009150B1 /* Products */;
 			projectDirPath = "";
-			projectReferences = (
-				{
-					ProductGroup = 42515D78194729DD001C3DDF /* Products */;
-					ProjectRef = 42515D77194729DD001C3DDF /* Realm.xcodeproj */;
-				},
-			);
 			projectRoot = "";
 			targets = (
 				E9D58B491541A375009150B1 /* RealmPerformanceExample */,
 			);
 		};
 /* End PBXProject section */
-
-/* Begin PBXReferenceProxy section */
-		42515D80194729DD001C3DDF /* Realm.framework */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.framework;
-			path = Realm.framework;
-			remoteRef = 42515D7F194729DD001C3DDF /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		42515D82194729DD001C3DDF /* OSX Tests.xctest */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.cfbundle;
-			path = "OSX Tests.xctest";
-			remoteRef = 42515D81194729DD001C3DDF /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		42515D84194729DD001C3DDF /* libRealm.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = libRealm.a;
-			remoteRef = 42515D83194729DD001C3DDF /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		42515D86194729DD001C3DDF /* iOS Tests.xctest */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.cfbundle;
-			path = "iOS Tests.xctest";
-			remoteRef = 42515D85194729DD001C3DDF /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-/* End PBXReferenceProxy section */
 
 /* Begin PBXResourcesBuildPhase section */
 		E9D58B481541A375009150B1 /* Resources */ = {
@@ -287,14 +202,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
-
-/* Begin PBXTargetDependency section */
-		42515D88194729EB001C3DDF /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "iOS Framework";
-			targetProxy = 42515D87194729EB001C3DDF /* PBXContainerItemProxy */;
-		};
-/* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
 		E9D58B571541A375009150B1 /* InfoPlist.strings */ = {
@@ -372,10 +279,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					../../,
-					"$(PROJECT_DIR)",
 					"${SRCROOT}/../../build/${CONFIGURATION}",
+					../../,
+					"$(inherited)",
+					"$(PROJECT_DIR)",
 				);
 				GCC_C_LANGUAGE_STANDARD = "compiler-default";
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
@@ -399,10 +306,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				FRAMEWORK_SEARCH_PATHS = (
+					"${SRCROOT}/../../build/${CONFIGURATION}",
 					"$(inherited)",
 					../../,
 					"$(PROJECT_DIR)",
-					"${SRCROOT}/../../build/${CONFIGURATION}",
 				);
 				GCC_C_LANGUAGE_STANDARD = "compiler-default";
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;

--- a/examples/RealmSimpleExample/RealmSimpleExample.xcodeproj/project.pbxproj
+++ b/examples/RealmSimpleExample/RealmSimpleExample.xcodeproj/project.pbxproj
@@ -29,41 +29,6 @@
 			remoteGlobalIDString = 4DE0B126194747F70092154B;
 			remoteInfo = RealmSimpleExample;
 		};
-		4DE0B161194748060092154B /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 4DE0B159194748060092154B /* Realm.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 02C4145E191DE49600F858D9;
-			remoteInfo = "OSX Framework";
-		};
-		4DE0B163194748060092154B /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 4DE0B159194748060092154B /* Realm.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 02C4146E191DE49600F858D9;
-			remoteInfo = "OSX Tests";
-		};
-		4DE0B165194748060092154B /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 4DE0B159194748060092154B /* Realm.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 02C415051921B0C300F858D9;
-			remoteInfo = "iOS Library";
-		};
-		4DE0B167194748060092154B /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 4DE0B159194748060092154B /* Realm.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 02C415121921B0C400F858D9;
-			remoteInfo = "iOS Tests";
-		};
-		4DE0B1691947481D0092154B /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 4DE0B159194748060092154B /* Realm.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = 421A99481933646F00F5E4D4;
-			remoteInfo = "iOS Framework";
-		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
@@ -80,7 +45,6 @@
 		4DE0B13C194747F70092154B /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
 		4DE0B142194747F70092154B /* RealmSimpleExampleTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RealmSimpleExampleTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		4DE0B143194747F70092154B /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
-		4DE0B159194748060092154B /* Realm.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = Realm.xcodeproj; path = ../../Realm.xcodeproj; sourceTree = "<group>"; };
 		4DE0B16B194748560092154B /* libc++.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = "libc++.dylib"; path = "usr/lib/libc++.dylib"; sourceTree = SDKROOT; };
 		4DE0B18219486DD60092154B /* Realm.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Realm.framework; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -114,7 +78,6 @@
 		4DE0B11E194747F70092154B = {
 			isa = PBXGroup;
 			children = (
-				4DE0B159194748060092154B /* Realm.xcodeproj */,
 				4DE0B130194747F70092154B /* RealmSimpleExample */,
 				4DE0B129194747F70092154B /* Frameworks */,
 				4DE0B128194747F70092154B /* Products */,
@@ -165,17 +128,6 @@
 			name = "Supporting Files";
 			sourceTree = "<group>";
 		};
-		4DE0B15A194748060092154B /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				4DE0B162194748060092154B /* Realm.framework */,
-				4DE0B164194748060092154B /* OSX Tests.xctest */,
-				4DE0B166194748060092154B /* libRealm.a */,
-				4DE0B168194748060092154B /* iOS Tests.xctest */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -190,7 +142,6 @@
 			buildRules = (
 			);
 			dependencies = (
-				4DE0B16A1947481D0092154B /* PBXTargetDependency */,
 			);
 			name = RealmSimpleExample;
 			productName = RealmSimpleExample;
@@ -239,12 +190,6 @@
 			mainGroup = 4DE0B11E194747F70092154B;
 			productRefGroup = 4DE0B128194747F70092154B /* Products */;
 			projectDirPath = "";
-			projectReferences = (
-				{
-					ProductGroup = 4DE0B15A194748060092154B /* Products */;
-					ProjectRef = 4DE0B159194748060092154B /* Realm.xcodeproj */;
-				},
-			);
 			projectRoot = "";
 			targets = (
 				4DE0B126194747F70092154B /* RealmSimpleExample */,
@@ -252,37 +197,6 @@
 			);
 		};
 /* End PBXProject section */
-
-/* Begin PBXReferenceProxy section */
-		4DE0B162194748060092154B /* Realm.framework */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.framework;
-			path = Realm.framework;
-			remoteRef = 4DE0B161194748060092154B /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		4DE0B164194748060092154B /* OSX Tests.xctest */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.cfbundle;
-			path = "OSX Tests.xctest";
-			remoteRef = 4DE0B163194748060092154B /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		4DE0B166194748060092154B /* libRealm.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = libRealm.a;
-			remoteRef = 4DE0B165194748060092154B /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		4DE0B168194748060092154B /* iOS Tests.xctest */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.cfbundle;
-			path = "iOS Tests.xctest";
-			remoteRef = 4DE0B167194748060092154B /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-/* End PBXReferenceProxy section */
 
 /* Begin PBXResourcesBuildPhase section */
 		4DE0B125194747F70092154B /* Resources */ = {
@@ -327,11 +241,6 @@
 			isa = PBXTargetDependency;
 			target = 4DE0B126194747F70092154B /* RealmSimpleExample */;
 			targetProxy = 4DE0B147194747F70092154B /* PBXContainerItemProxy */;
-		};
-		4DE0B16A1947481D0092154B /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "iOS Framework";
-			targetProxy = 4DE0B1691947481D0092154B /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -423,8 +332,8 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
 				FRAMEWORK_SEARCH_PATHS = (
-					"$(PROJECT_DIR)",
 					"${SRCROOT}/../../build/${CONFIGURATION}",
+					"$(PROJECT_DIR)",
 				);
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "RealmSimpleExample/RealmSimpleExample-Prefix.pch";
@@ -441,8 +350,8 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
 				FRAMEWORK_SEARCH_PATHS = (
-					"$(PROJECT_DIR)",
 					"${SRCROOT}/../../build/${CONFIGURATION}",
+					"$(PROJECT_DIR)",
 				);
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "RealmSimpleExample/RealmSimpleExample-Prefix.pch";

--- a/examples/RealmTableViewExample/RealmTableViewExample.xcodeproj/project.pbxproj
+++ b/examples/RealmTableViewExample/RealmTableViewExample.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		42C2CEAF19471699001D0E13 /* libc++.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 42C2CEAE19471699001D0E13 /* libc++.dylib */; };
+		B1387DE719597A2800D49C15 /* Realm.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B1387DE619597A2800D49C15 /* Realm.framework */; };
 		E80762D418FEFFD70071CFAB /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E80762D318FEFFD70071CFAB /* Foundation.framework */; };
 		E80762D618FEFFD70071CFAB /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E80762D518FEFFD70071CFAB /* CoreGraphics.framework */; };
 		E80762D818FEFFD70071CFAB /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E80762D718FEFFD70071CFAB /* UIKit.framework */; };
@@ -18,50 +19,12 @@
 		E807630418FEFFF80071CFAB /* TableViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = E807630318FEFFF80071CFAB /* TableViewController.m */; };
 /* End PBXBuildFile section */
 
-/* Begin PBXContainerItemProxy section */
-		02026CD8193D05D000E4EEF8 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 02026CCF193D05D000E4EEF8 /* Realm.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 02C4145E191DE49600F858D9;
-			remoteInfo = Realm;
-		};
-		02026CDA193D05D000E4EEF8 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 02026CCF193D05D000E4EEF8 /* Realm.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 02C4146E191DE49600F858D9;
-			remoteInfo = RealmTests;
-		};
-		02026CDC193D05D000E4EEF8 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 02026CCF193D05D000E4EEF8 /* Realm.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 02C415051921B0C300F858D9;
-			remoteInfo = "Realm-iOS";
-		};
-		02026CDE193D05D000E4EEF8 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 02026CCF193D05D000E4EEF8 /* Realm.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 02C415121921B0C400F858D9;
-			remoteInfo = "RealmTests-iOS";
-		};
-		02026CE0193D05D800E4EEF8 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 02026CCF193D05D000E4EEF8 /* Realm.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = 421A99481933646F00F5E4D4;
-			remoteInfo = "Realm-iOS-framework";
-		};
-/* End PBXContainerItemProxy section */
-
 /* Begin PBXFileReference section */
 		02026CCB193D039900E4EEF8 /* Realm.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Realm.framework; path = ../../build/Debug/Realm.framework; sourceTree = "<group>"; };
 		02026CCD193D041E00E4EEF8 /* libRealm.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libRealm.a; path = "../../build/Debug-iphoneos/libRealm.a"; sourceTree = "<group>"; };
-		02026CCF193D05D000E4EEF8 /* Realm.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = Realm.xcodeproj; path = ../../Realm.xcodeproj; sourceTree = "<group>"; };
 		02C415551921C26600F858D9 /* libRealm.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libRealm.a; path = "../../build/Debug-iphoneos/libRealm.a"; sourceTree = "<group>"; };
 		42C2CEAE19471699001D0E13 /* libc++.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = "libc++.dylib"; path = "usr/lib/libc++.dylib"; sourceTree = SDKROOT; };
+		B1387DE619597A2800D49C15 /* Realm.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Realm.framework; path = ../../build/Release/Realm.framework; sourceTree = "<group>"; };
 		E80762D018FEFFD70071CFAB /* RealmTableViewExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = RealmTableViewExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		E80762D318FEFFD70071CFAB /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		E80762D518FEFFD70071CFAB /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
@@ -84,6 +47,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B1387DE719597A2800D49C15 /* Realm.framework in Frameworks */,
 				42C2CEAF19471699001D0E13 /* libc++.dylib in Frameworks */,
 				E80762D618FEFFD70071CFAB /* CoreGraphics.framework in Frameworks */,
 				E80762D818FEFFD70071CFAB /* UIKit.framework in Frameworks */,
@@ -94,21 +58,9 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		02026CD0193D05D000E4EEF8 /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				02026CD9193D05D000E4EEF8 /* Realm.framework */,
-				02026CDB193D05D000E4EEF8 /* OSX Tests.xctest */,
-				02026CDD193D05D000E4EEF8 /* libRealm.a */,
-				02026CDF193D05D000E4EEF8 /* iOS Tests.xctest */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
 		E80762C718FEFFD70071CFAB = {
 			isa = PBXGroup;
 			children = (
-				02026CCF193D05D000E4EEF8 /* Realm.xcodeproj */,
 				E80762D918FEFFD70071CFAB /* RealmTableViewExample */,
 				E80762D218FEFFD70071CFAB /* Frameworks */,
 				E80762D118FEFFD70071CFAB /* Products */,
@@ -126,6 +78,7 @@
 		E80762D218FEFFD70071CFAB /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				B1387DE619597A2800D49C15 /* Realm.framework */,
 				42C2CEAE19471699001D0E13 /* libc++.dylib */,
 				02026CCD193D041E00E4EEF8 /* libRealm.a */,
 				02026CCB193D039900E4EEF8 /* Realm.framework */,
@@ -177,7 +130,6 @@
 			buildRules = (
 			);
 			dependencies = (
-				02026CE1193D05D800E4EEF8 /* PBXTargetDependency */,
 			);
 			name = RealmTableViewExample;
 			productName = Demo;
@@ -204,49 +156,12 @@
 			mainGroup = E80762C718FEFFD70071CFAB;
 			productRefGroup = E80762D118FEFFD70071CFAB /* Products */;
 			projectDirPath = "";
-			projectReferences = (
-				{
-					ProductGroup = 02026CD0193D05D000E4EEF8 /* Products */;
-					ProjectRef = 02026CCF193D05D000E4EEF8 /* Realm.xcodeproj */;
-				},
-			);
 			projectRoot = "";
 			targets = (
 				E80762CF18FEFFD70071CFAB /* RealmTableViewExample */,
 			);
 		};
 /* End PBXProject section */
-
-/* Begin PBXReferenceProxy section */
-		02026CD9193D05D000E4EEF8 /* Realm.framework */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.framework;
-			path = Realm.framework;
-			remoteRef = 02026CD8193D05D000E4EEF8 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		02026CDB193D05D000E4EEF8 /* OSX Tests.xctest */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.cfbundle;
-			path = "OSX Tests.xctest";
-			remoteRef = 02026CDA193D05D000E4EEF8 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		02026CDD193D05D000E4EEF8 /* libRealm.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = libRealm.a;
-			remoteRef = 02026CDC193D05D000E4EEF8 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		02026CDF193D05D000E4EEF8 /* iOS Tests.xctest */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.cfbundle;
-			path = "iOS Tests.xctest";
-			remoteRef = 02026CDE193D05D000E4EEF8 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-/* End PBXReferenceProxy section */
 
 /* Begin PBXResourcesBuildPhase section */
 		E80762CE18FEFFD70071CFAB /* Resources */ = {
@@ -272,14 +187,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
-
-/* Begin PBXTargetDependency section */
-		02026CE1193D05D800E4EEF8 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "Realm-iOS-framework";
-			targetProxy = 02026CE0193D05D800E4EEF8 /* PBXContainerItemProxy */;
-		};
-/* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
 		E80762DC18FEFFD70071CFAB /* InfoPlist.strings */ = {
@@ -371,8 +278,8 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
 				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
 					"${SRCROOT}/../../build/${CONFIGURATION}",
+					"$(inherited)",
 				);
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "RealmTableViewExample/RealmTableViewExample-Prefix.pch";
@@ -393,8 +300,8 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
 				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
 					"${SRCROOT}/../../build/${CONFIGURATION}",
+					"$(inherited)",
 				);
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "RealmTableViewExample/RealmTableViewExample-Prefix.pch";


### PR DESCRIPTION
A dependency on Realm.framework was added instead.
It is expected to be found in $(SRCROOT)/build/$(CONFIGURATION)
