### PR TITLE
Throwing an exception when error == nil

### DIFF
--- a/Realm/RLMRealm.mm
+++ b/Realm/RLMRealm.mm
@@ -270,7 +270,7 @@ static NSArray *s_objectDescriptors = nil;
     if (!realm) {
         return nil;
     }
-    
+
     NSError *error = nil;
     try {
         if (s_useInMemoryDefaultRealm && [path isEqualToString:RLMRealm.defaultPath]) { // Only for default realm
@@ -302,8 +302,13 @@ static NSArray *s_objectDescriptors = nil;
     if (error) {
         if (outError) {
             *outError = error;
+            return nil;
         }
-        return nil;
+        else {
+            @throw [NSException exceptionWithName:@"RLMException"
+                                           reason:[error localizedDescription]
+                                         userInfo:nil];
+        }
     }
     
     // begin read

--- a/Realm/Tests/RealmTests.m
+++ b/Realm/Tests/RealmTests.m
@@ -46,6 +46,12 @@
     XCTAssertEqual([realm class], [RLMRealm class], @"realm should be of class RLMRealm");
 }
 
+-(void)testRealmFailure
+{
+    XCTAssertThrows([RLMRealm realmWithPath:@"/dev/null"], @"Shouldn't exist");
+
+}
+
 - (void)testRealmPath
 {
     RLMRealm *defaultRealm = [RLMRealm defaultRealm];


### PR DESCRIPTION
Using error variable is a hack but keeps the changes to a minimum. The unit test is using `/dev/null` as a file name - which cannot be a realm file.

@alazier @mekjaer 

See also https://app.asana.com/0/1442494018425/12977206643240
