### PR TITLE
Log xcpretty builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ DerivedData
 *.iml
 # backup and crash files
 *.swp
+
+# xcpretty
+build.log

--- a/build.sh
+++ b/build.sh
@@ -56,8 +56,9 @@ xc() {
     if [[ "$XCMODE" == "xcodebuild" ]]; then
         xcodebuild $1 || exit 1
     elif [[ "$XCMODE" == "xcpretty" ]]; then
-        xcodebuild $1 | xcpretty -c ${XCPRETTY_PARAMS}
+        xcodebuild $1 | tee build.log | xcpretty -c ${XCPRETTY_PARAMS}
         if [ "$?" -ne 0 ]; then
+            echo "The raw xcodebuild output is available in build.log"
             exit 1
         fi
     elif [[ "$XCMODE" == "xctool" ]]; then


### PR DESCRIPTION
If the build fails while xcpretty is being used it is nice to have a full xcodebuild log to inspect.
