### PR TITLE
disabled test due to changes in core

### DIFF
--- a/Realm/Tests/QueryTests.m
+++ b/Realm/Tests/QueryTests.m
@@ -371,6 +371,7 @@
     
 }
 
+// FIXME Reenable when issue has been resolved: https://app.asana.com/0/861870036984/13392049000660
 //- (void)testTwoColumnComparisonQuery
 //{
 //    RLMRealm *realm = [RLMRealm defaultRealm];


### PR DESCRIPTION
A recent change in core have made this test fail. The fallout has been reported and is actively being figured out. https://app.asana.com/0/861870036984/13392049000660
In the meantime, this test is disabled so PR's can be tested

@realm/cocoa @rrrlasse @astigsen @emanuelez 
