### PR TITLE
Fix the test-all target for build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -187,13 +187,17 @@ case "$COMMAND" in
         ;;
 
     "test-all")
-        sudo xcode-select -s /Applications/Xcode.app/Contents/Developer
+        sudo xcode-select -s /Applications/Xcode.app/Contents/Developer || exit 1
         sh build.sh test "$XCMODE" || exit 1
         sh build.sh test-debug "$XCMODE" || exit 1
-        sudo xcode-select -s /Applications/Xcode6-Beta2.app/Contents/Developer
-        sh build.sh test "$XCMODE" || exit 1
-        sh build.sh test-debug "$XCMODE" || exit 1
-        exit 0
+        sudo xcode-select -s /Applications/Xcode6-Beta2.app/Contents/Developer || exit 1
+        fail=0
+        (
+            sh build.sh test "$XCMODE" || exit 1
+            sh build.sh test-debug "$XCMODE" || exit 1
+        ) || fail=1
+        sudo xcode-select -s /Applications/Xcode.app/Contents/Developer || exit 1
+        exit $fail
         ;;
 
     "test-ios")


### PR DESCRIPTION
The target left xcode6 as the used environment
It was also very fragile in case xcode-select failed 
so more checks were added
