### PR TITLE
Fix podspec license

### DIFF
--- a/Realm.podspec
+++ b/Realm.podspec
@@ -21,5 +21,5 @@ Pod::Spec.new do |s|
   s.social_media_url    = "https://twitter.com/realm"
   s.documentation_url   = "http://realm.io/docs/ios/#{s.version}"
   s.vendored_frameworks = "Realm.framework"
-  s.license          = { :type => 'Apache 2.0', :file => 'LICENSE' }
+  s.license             = { :type => 'Apache 2.0', :file => 'Realm.framework/Resources/LICENSE' }
 end


### PR DESCRIPTION
I believe this is the reason why pushing the podspec throws the following warning:

```
[!] Unable to read the license file `/private/tmp/CocoaPods/Lint/Pods/Realm/LICENSE` for the spec `Realm (0.22.0)`
```

@emanuelez 
