### PR TITLE
Fixed Xcode 6 project's RLMPredicateUtil's target membership to tests instead of framework

### DIFF
--- a/Realm-Xcode6.xcodeproj/project.pbxproj
+++ b/Realm-Xcode6.xcodeproj/project.pbxproj
@@ -125,10 +125,8 @@
 		E856D21F195615B100FB2FCF /* RLMTestCase.m in Sources */ = {isa = PBXBuildFile; fileRef = E81A1FC51955FE0100FDED82 /* RLMTestCase.m */; };
 		E856D220195615B100FB2FCF /* RLMTestObjects.m in Sources */ = {isa = PBXBuildFile; fileRef = E81A1FC71955FE0100FDED82 /* RLMTestObjects.m */; };
 		E856D228195615B800FB2FCF /* SwiftRealmTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E81A1FD01955FE0100FDED82 /* SwiftRealmTests.swift */; };
-		E8A543AF195C9C9E00990A20 /* RLMPredicateUtil.h in Headers */ = {isa = PBXBuildFile; fileRef = E8A543AD195C9C9E00990A20 /* RLMPredicateUtil.h */; };
-		E8A543B0195C9C9E00990A20 /* RLMPredicateUtil.h in Headers */ = {isa = PBXBuildFile; fileRef = E8A543AD195C9C9E00990A20 /* RLMPredicateUtil.h */; };
-		E8A543B1195C9C9E00990A20 /* RLMPredicateUtil.m in Sources */ = {isa = PBXBuildFile; fileRef = E8A543AE195C9C9E00990A20 /* RLMPredicateUtil.m */; };
-		E8A543B2195C9C9E00990A20 /* RLMPredicateUtil.m in Sources */ = {isa = PBXBuildFile; fileRef = E8A543AE195C9C9E00990A20 /* RLMPredicateUtil.m */; };
+		E8A5DEED1968E520006A50F6 /* RLMPredicateUtil.m in Sources */ = {isa = PBXBuildFile; fileRef = E8A543AE195C9C9E00990A20 /* RLMPredicateUtil.m */; };
+		E8A5DEEE1968E521006A50F6 /* RLMPredicateUtil.m in Sources */ = {isa = PBXBuildFile; fileRef = E8A543AE195C9C9E00990A20 /* RLMPredicateUtil.m */; };
 		E8D89B9E1955FC6D00CF2B9A /* Realm.h in Headers */ = {isa = PBXBuildFile; fileRef = E8D89B9D1955FC6D00CF2B9A /* Realm.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		E8D89BA41955FC6D00CF2B9A /* Realm.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E8D89B981955FC6D00CF2B9A /* Realm.framework */; };
 /* End PBXBuildFile section */
@@ -435,7 +433,6 @@
 				E856D1F51956154C00FB2FCF /* RLMArray.h in Headers */,
 				0207AB82195DF9FB007EFB12 /* RLMMigration.h in Headers */,
 				E856D2051956154C00FB2FCF /* RLMProperty.h in Headers */,
-				E8A543B0195C9C9E00990A20 /* RLMPredicateUtil.h in Headers */,
 				E856D2021956154C00FB2FCF /* RLMObjectStore.h in Headers */,
 				E856D2071956154C00FB2FCF /* RLMQueryUtil.hpp in Headers */,
 				0207AB80195DF9FB007EFB12 /* RLMMigration_Private.h in Headers */,
@@ -463,7 +460,6 @@
 				E81A1FA11955FC9300FDED82 /* RLMProperty.h in Headers */,
 				0207AB81195DF9FB007EFB12 /* RLMMigration.h in Headers */,
 				E81A1F891955FC9300FDED82 /* RLMArray.h in Headers */,
-				E8A543AF195C9C9E00990A20 /* RLMPredicateUtil.h in Headers */,
 				E81A1F851955FC9300FDED82 /* RLMAccessor.h in Headers */,
 				E81A1F9D1955FC9300FDED82 /* RLMObjectStore.h in Headers */,
 				0207AB7F195DF9FB007EFB12 /* RLMMigration_Private.h in Headers */,
@@ -673,7 +669,6 @@
 				E856D1F91956154C00FB2FCF /* RLMArrayTableView.mm in Sources */,
 				E856D1F61956154C00FB2FCF /* RLMArray.mm in Sources */,
 				E856D20B1956154C00FB2FCF /* RLMRealm.mm in Sources */,
-				E8A543B2195C9C9E00990A20 /* RLMPredicateUtil.m in Sources */,
 				E856D2121956154C00FB2FCF /* RLMUtil.mm in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -689,6 +684,7 @@
 				E856D216195615A900FB2FCF /* DynamicTests.m in Sources */,
 				E856D213195615A900FB2FCF /* TransactionTests.m in Sources */,
 				E82FA611195632F20043A3C3 /* SwiftArrayPropertyTests.swift in Sources */,
+				E8A5DEEE1968E521006A50F6 /* RLMPredicateUtil.m in Sources */,
 				E856D228195615B800FB2FCF /* SwiftRealmTests.swift in Sources */,
 				E82FA619195632F20043A3C3 /* SwiftMixedTests.swift in Sources */,
 				E856D21D195615A900FB2FCF /* QueryTests.m in Sources */,
@@ -725,7 +721,6 @@
 				E81A1F9E1955FC9300FDED82 /* RLMObjectStore.mm in Sources */,
 				E81A1F901955FC9300FDED82 /* RLMArrayTableView.mm in Sources */,
 				E81A1F8A1955FC9300FDED82 /* RLMArray.mm in Sources */,
-				E8A543B1195C9C9E00990A20 /* RLMPredicateUtil.m in Sources */,
 				E81A1FA91955FC9300FDED82 /* RLMRealm.mm in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -741,6 +736,7 @@
 				E81A20021955FE0100FDED82 /* TransactionTests.m in Sources */,
 				E81A1FDF1955FE0100FDED82 /* MixedTests.m in Sources */,
 				E82FA610195632F20043A3C3 /* SwiftArrayPropertyTests.swift in Sources */,
+				E8A5DEED1968E520006A50F6 /* RLMPredicateUtil.m in Sources */,
 				E81A1FEB1955FE0100FDED82 /* RealmTests.m in Sources */,
 				E82FA618195632F20043A3C3 /* SwiftMixedTests.swift in Sources */,
 				E81A1FEE1955FE0100FDED82 /* RLMTestCase.m in Sources */,

--- a/build.sh
+++ b/build.sh
@@ -121,7 +121,7 @@ case "$COMMAND" in
     ######################################
     "download-core")
         if ! [ -d core ]; then
-            curl -s "http://static.realm.io/downloads/core/realm-core-${REALM_CORE_VERSION}.zip" -o "/tmp/core-${REALM_CORE_VERSION}.zip" || exit 1
+            curl -L -s "http://static.realm.io/downloads/core/realm-core-${REALM_CORE_VERSION}.zip" -o "/tmp/core-${REALM_CORE_VERSION}.zip" || exit 1
             unzip "/tmp/core-${REALM_CORE_VERSION}.zip" || exit 1
             rm -f "/tmp/core-${REALM_CORE_VERSION}.zip" || exit 1
         else


### PR DESCRIPTION
When these were added to the Xcode 6 project, they were added to the wrong target (framework instead of tests).

Also, build.sh download-core now follows redirects.
