### PR TITLE
Migration example rewrite

### DIFF
--- a/Realm/RLMAccessor.mm
+++ b/Realm/RLMAccessor.mm
@@ -370,7 +370,7 @@ IMP RLMAccessorStandaloneGetter(NSUInteger colIndex, char accessorCode, NSString
     if (accessorCode == 't') {
         return imp_implementationWithBlock(^(RLMObject *obj) {
             typedef id (*getter_type)(RLMObject *, SEL);
-            RLMProperty *prop = obj.RLMObject_schema.properties[colIndex];
+            RLMProperty *prop = obj.objectSchema.properties[colIndex];
             Class superClass = class_getSuperclass(obj.class);
             getter_type superGetter = (getter_type)class_getMethodImplementation(superClass, NSSelectorFromString(prop.getterName));
             id val = superGetter(obj, NSSelectorFromString(prop.getterName));
@@ -536,7 +536,7 @@ inline NSString *RLMDynamicClassName(NSString *className, NSUInteger version) {
 
 
 void RLMDynamicValidatedSet(RLMObject *obj, NSString *propName, id val) {
-    RLMProperty *prop = obj.RLMObject_schema[propName];
+    RLMProperty *prop = obj.objectSchema[propName];
     if (!prop) {
         @throw [NSException exceptionWithName:@"RLMException"
                                        reason:@"Invalid property name"
@@ -595,7 +595,7 @@ void RLMDynamicSet(__unsafe_unretained RLMObject *obj, __unsafe_unretained RLMPr
 }
 
 id RLMDynamicGet(__unsafe_unretained RLMObject *obj, __unsafe_unretained NSString *propName) {
-    RLMProperty *prop = obj.RLMObject_schema[propName];
+    RLMProperty *prop = obj.objectSchema[propName];
     if (!prop) {
         @throw [NSException exceptionWithName:@"RLMException"
                                        reason:@"Invalid property name"

--- a/Realm/RLMMigration.mm
+++ b/Realm/RLMMigration.mm
@@ -53,9 +53,22 @@
 
 - (void)enumerateObjects:(NSString *)className block:(RLMObjectMigrationBlock)block {
     // get all objects
-    RLMArray *objects = [_realm allObjects:className], *oldObjects = [_oldRealm allObjects:className];
-    for (NSUInteger i = 0; i < oldObjects.count; i++) {
-        block(oldObjects[i], objects[i]);
+    RLMArray *objects = [_realm.schema schemaForClassName:className] ? [_realm allObjects:className] : nil;
+    RLMArray *oldObjects = [_oldRealm.schema schemaForClassName:className] ? [_oldRealm allObjects:className] : nil;
+    if (objects && oldObjects) {
+        for (NSUInteger i = 0; i < oldObjects.count; i++) {
+            block(oldObjects[i], objects[i]);
+        }
+    }
+    else if (objects) {
+        for (NSUInteger i = 0; i < objects.count; i++) {
+            block(nil, objects[i]);
+        }
+    }
+    else if (oldObjects) {
+        for (NSUInteger i = 0; i < oldObjects.count; i++) {
+            block(oldObjects[i], nil);
+        }
     }
 }
 

--- a/Realm/RLMObject.h
+++ b/Realm/RLMObject.h
@@ -21,7 +21,7 @@
 
 @class RLMRealm;
 @class RLMArray;
-
+@class RLMObjectSchema;
 
 /**
  
@@ -142,6 +142,11 @@
  The Realm in which this object is persisted. Returns nil for standalone objects.
  */
 @property (nonatomic, readonly) RLMRealm *realm;
+
+/**
+ The ObjectSchema which lists the persisted properties for this object.
+ */
+@property (nonatomic, readonly) RLMObjectSchema *objectSchema;
 
 
 /**---------------------------------------------------------------------------------------

--- a/Realm/RLMObject.mm
+++ b/Realm/RLMObject.mm
@@ -28,7 +28,7 @@
 @implementation RLMObject
 
 @synthesize realm = _realm;
-@synthesize RLMObject_schema = _RLMObject_schema;
+@synthesize objectSchema = _objectSchema;
 
 
 // standalone init
@@ -36,7 +36,7 @@
     self = [self initWithRealm:nil schema:[self.class sharedSchema] defaultValues:YES];
 
     // set standalone accessor class
-    object_setClass(self, self.RLMObject_schema.standaloneClass);
+    object_setClass(self, self.objectSchema.standaloneClass);
     
     return self;
 }
@@ -65,7 +65,7 @@
     self = [super init];
     if (self) {
         _realm = realm;
-        _RLMObject_schema = schema;
+        _objectSchema = schema;
         if (useDefaults) {
             // set default values
             // FIXME: Cache defaultPropertyValues in this instance
@@ -83,7 +83,7 @@
 }
 
 void RLMPopulateObjectWithDictionary(RLMObject *obj, NSDictionary *values) {
-    RLMObjectSchema *schema = obj.RLMObject_schema;
+    RLMObjectSchema *schema = obj.objectSchema;
     for (NSString *name in values) {
         // Validate Value
         RLMProperty *prop = schema[name];
@@ -100,7 +100,7 @@ void RLMPopulateObjectWithDictionary(RLMObject *obj, NSDictionary *values) {
 }
 
 void RLMPopulateObjectWithArray(RLMObject *obj, NSArray *array) {
-    NSArray *properties = obj.RLMObject_schema.properties;
+    NSArray *properties = obj.objectSchema.properties;
 
     if (array.count != properties.count) {
         @throw [NSException exceptionWithName:@"RLMException" reason:@"Invalid array input. Number of array elements does not match number of properties." userInfo:nil];
@@ -186,7 +186,7 @@ void RLMPopulateObjectWithArray(RLMObject *obj, NSArray *array) {
 
 - (NSString *)description
 {
-    NSString *baseClassName = self.RLMObject_schema.className;
+    NSString *baseClassName = self.objectSchema.className;
     NSMutableString *mString = [NSMutableString stringWithFormat:@"%@ {\n", baseClassName];
     RLMObjectSchema *objectSchema = self.realm.schema[baseClassName];
     

--- a/Realm/RLMObjectStore.mm
+++ b/Realm/RLMObjectStore.mm
@@ -230,7 +230,7 @@ void RLMAddObjectToRealm(RLMObject *object, RLMRealm *realm) {
     // set the realm and schema
     NSString *objectClassName = [object.class className];
     RLMObjectSchema *schema = realm.schema[objectClassName];
-    object.RLMObject_schema = schema;
+    object.objectSchema = schema;
     object.realm = realm;
 
     // create row in table

--- a/Realm/RLMObject_Private.h
+++ b/Realm/RLMObject_Private.h
@@ -34,7 +34,7 @@
 
 // namespace properties to prevent collision with user properties
 @property (nonatomic, readwrite) RLMRealm *realm;
-@property (nonatomic) RLMObjectSchema *RLMObject_schema;
+@property (nonatomic, readwrite) RLMObjectSchema *objectSchema;
 
 // shared schema for this class
 + (RLMObjectSchema *)sharedSchema;


### PR DESCRIPTION
Addresses https://app.asana.com/0/861870036984/14408232093074 per @timanglade 's request.

We are now exposing the objectSchema property on RLMObject so that this can be accessed/introspected during migrations. Also fixed a bug caused by the performance changes (enumerating objects which don't exist in the old version, but are added during the migration).

@jpsim @bmunkholm 
