### PR TITLE
Fix for notification tests 

### DIFF
--- a/Realm/RLMRealm.mm
+++ b/Realm/RLMRealm.mm
@@ -145,7 +145,7 @@ static NSString *s_defaultRealmPath = nil;
 static NSArray *s_objectDescriptors = nil;
 
 @implementation RLMRealm {
-    NSRunLoop *_runLoop;
+    NSThread *_thread;
     NSTimer *_updateTimer;
     NSMapTable *_notificationHandlers;
     
@@ -176,7 +176,7 @@ static NSArray *s_objectDescriptors = nil;
     self = [super init];
     if (self) {
         _path = path;
-        _runLoop = [NSRunLoop currentRunLoop];
+        _thread = [NSThread currentThread];
         _notificationHandlers = [NSMapTable mapTableWithKeyOptions:NSPointerFunctionsWeakMemory valueOptions:NSPointerFunctionsWeakMemory];
         _readOnly = readonly;
         _updateTimer = [NSTimer scheduledTimerWithTimeInterval:0.1
@@ -412,7 +412,7 @@ static NSArray *s_objectDescriptors = nil;
             NSArray *realms = realmsAtPath(_path);
             for (RLMRealm *realm in realms) {
                 if (![realm isEqual:self]) {
-                    [realm->_runLoop performSelector:@selector(refresh) withObject:realm afterDelay:0.0 inModes:@[NSRunLoopCommonModes]];
+                    [realm performSelector:@selector(refresh) onThread:realm->_thread withObject:nil waitUntilDone:NO];
                 }
             }
             

--- a/Realm/Tests/RealmTests.m
+++ b/Realm/Tests/RealmTests.m
@@ -88,10 +88,14 @@
 - (void)testRealmIsUpdatedAfterBackgroundUpdate {
     RLMRealm *realm = [self realmWithTestPath];
 
+    // we have two notifications, one for opening the realm, and a second when performing our transaction
+    __block NSUInteger noteCount = 0;
     XCTestExpectation *notificationFired = [self expectationWithDescription:@"notification fired"];
     RLMNotificationToken *token = [realm addNotificationBlock:^(__unused NSString *note, RLMRealm * realm) {
         XCTAssertNotNil(realm, @"Realm should not be nil");
-        [notificationFired fulfill];
+        if (++noteCount == 2) {
+            [notificationFired fulfill];
+        }
     }];
     
     dispatch_queue_t queue = dispatch_queue_create("background", 0);
@@ -114,10 +118,14 @@
 - (void)testRealmIsUpdatedImmediatelyAfterBackgroundUpdate {
     RLMRealm *realm = [self realmWithTestPath];
 
+    // we have two notifications, one for opening the realm, and a second when performing our transaction
+    __block NSUInteger noteCount = 0;
     XCTestExpectation *notificationFired = [self expectationWithDescription:@"notification fired"];
     RLMNotificationToken *token = [realm addNotificationBlock:^(__unused NSString *note, RLMRealm * realm) {
         XCTAssertNotNil(realm, @"Realm should not be nil");
-        [notificationFired fulfill];
+        if (++noteCount == 2) {
+            [notificationFired fulfill];
+        }
      }];
     
     dispatch_queue_t queue = dispatch_queue_create("background", 0);
@@ -134,7 +142,7 @@
     });
     
     // this should complete very fast before the timer
-    [self waitForExpectationsWithTimeout:2.0 handler:nil];
+    [self waitForExpectationsWithTimeout:0.01 handler:nil];
     [realm removeNotification:token];
         
     // get object


### PR DESCRIPTION
Fixes https://app.asana.com/0/861870036984/13586593995277

This takes into account the fact that a write transaction takes place when opening a Realm instance. With this change we now can properly test that Realms in other threads are updated immediately and have also switched over to using NSThread instead of NSRunloop to get lower latency notifications and better swift support.

@bmunkholm @jpsim 
