### PR TITLE
Bug fixes for standalone arrays and indexOfObject:

### DIFF
--- a/Realm/RLMAccessor.mm
+++ b/Realm/RLMAccessor.mm
@@ -350,7 +350,7 @@ IMP RLMAccessorSetter(NSUInteger colIndex, char accessorCode) {
                 RLMSetLink(obj, colIndex, link);
             });
         case 't':
-            return imp_implementationWithBlock(^(RLMObject *obj, id<NSFastEnumeration> val) {
+            return imp_implementationWithBlock(^(RLMObject *obj, RLMArray *val) {
                 RLMSetArray(obj, colIndex, val);
             });
         case '@':
@@ -364,24 +364,49 @@ IMP RLMAccessorSetter(NSUInteger colIndex, char accessorCode) {
     }
 }
 
-// getter for standalone
+// call getter for superclass for property at colIndex
+id RLMSuperGet(RLMObject *obj, NSUInteger colIndex) {
+    typedef id (*getter_type)(RLMObject *, SEL);
+    RLMProperty *prop = obj.objectSchema.properties[colIndex];
+    Class superClass = class_getSuperclass(obj.class);
+    SEL selector = NSSelectorFromString(prop.getterName);
+    getter_type superGetter = (getter_type)class_getMethodImplementation(superClass, selector);
+    return superGetter(obj, selector);
+}
+
+// call setter for superclass for property at colIndex
+void RLMSuperSet(RLMObject *obj, NSUInteger colIndex, id val) {
+    typedef id (*setter_type)(RLMObject *, SEL, RLMArray *ar);
+    RLMProperty *prop = obj.objectSchema.properties[colIndex];
+    Class superClass = class_getSuperclass(obj.class);
+    SEL selector = NSSelectorFromString(prop.setterName);
+    setter_type superSetter = (setter_type)class_getMethodImplementation(superClass, selector);
+    superSetter(obj, selector, val);
+}
+
+// getter/setter for standalone
 IMP RLMAccessorStandaloneGetter(NSUInteger colIndex, char accessorCode, NSString *objectClassName) {
     // only override getters for RLMArray properties
     if (accessorCode == 't') {
         return imp_implementationWithBlock(^(RLMObject *obj) {
-            typedef id (*getter_type)(RLMObject *, SEL);
-            RLMProperty *prop = obj.objectSchema.properties[colIndex];
-            Class superClass = class_getSuperclass(obj.class);
-            getter_type superGetter = (getter_type)class_getMethodImplementation(superClass, NSSelectorFromString(prop.getterName));
-            id val = superGetter(obj, NSSelectorFromString(prop.getterName));
+            id val = RLMSuperGet(obj, colIndex);
             if (!val) {
-                SEL setterSel = NSSelectorFromString(prop.setterName);
-                typedef void (*setter_type)(RLMObject *, SEL, id);
-                setter_type setter = (setter_type)class_getMethodImplementation(obj.class, setterSel);
                 val = [RLMArray standaloneArrayWithObjectClassName:objectClassName];
-                setter(obj, setterSel, val);
+                RLMSuperSet(obj, colIndex, val);
             }
             return val;
+        });
+    }
+    return nil;
+}
+IMP RLMAccessorStandaloneSetter(NSUInteger colIndex, char accessorCode) {
+    // only override getters for RLMArray properties
+    if (accessorCode == 't') {
+        return imp_implementationWithBlock(^(RLMObject *obj, RLMArray *ar) {
+            // make copy when setting (as is the case for all other variants)
+            RLMArray *standaloneAr = [RLMArray standaloneArrayWithObjectClassName:ar.objectClassName];
+            [standaloneAr addObjectsFromArray:ar];
+            RLMSuperSet(obj, colIndex, standaloneAr);
         });
     }
     return nil;
@@ -526,7 +551,7 @@ Class RLMAccessorClassForObjectClass(Class objectClass, RLMObjectSchema *schema)
 
 Class RLMStandaloneAccessorClassForObjectClass(Class objectClass, RLMObjectSchema *schema) {
     return RLMCreateAccessorClass(objectClass, schema, @"RLMStandalone_",
-                                  RLMAccessorStandaloneGetter, NULL);
+                                  RLMAccessorStandaloneGetter, RLMAccessorStandaloneSetter);
 }
 
 // Dynamic accessor name for a classname

--- a/Realm/RLMArray.mm
+++ b/Realm/RLMArray.mm
@@ -18,6 +18,7 @@
 
 #import "RLMArray_Private.hpp"
 #import "RLMObject.h"
+#import "RLMObjectSchema.h"
 
 @implementation RLMArray
 
@@ -93,6 +94,14 @@
 // Stanalone RLMArray implementation
 //
 
+void RLMValidateMatchingObjectType(RLMArray *array, RLMObject *object) {
+    if (![array->_objectClassName isEqualToString:object.objectSchema.className]) {
+        @throw [NSException exceptionWithName:@"RLMException"
+                                       reason:@"Object type does not match RLMArray"
+                                     userInfo:nil];
+    }
+}
+
 + (instancetype)standaloneArrayWithObjectClassName:(NSString *)objectClassName {
     RLMArray *ar = [[RLMArray alloc] initWithObjectClassName:objectClassName];
     ar->_backingArray = [NSMutableArray array];
@@ -112,6 +121,7 @@
 }
 
 - (void)insertObject:(RLMObject *)anObject atIndex:(NSUInteger)index {
+    RLMValidateMatchingObjectType(self, anObject);
     [_backingArray insertObject:anObject atIndex:index];
 }
 
@@ -120,10 +130,12 @@
 }
 
 - (void)replaceObjectAtIndex:(NSUInteger)index withObject:(id)anObject {
+    RLMValidateMatchingObjectType(self, anObject);
     [_backingArray replaceObjectAtIndex:index withObject:anObject];
 }
 
 - (NSUInteger)indexOfObject:(RLMObject *)object {
+    RLMValidateMatchingObjectType(self, object);
     return [_backingArray indexOfObject:object];
 }
 

--- a/Realm/RLMObject.mm
+++ b/Realm/RLMObject.mm
@@ -210,4 +210,25 @@ void RLMPopulateObjectWithArray(RLMObject *obj, NSArray *array) {
     return [NSString stringWithString:mString];
 }
 
+- (BOOL)isEqualToObject:(RLMObject *)object {
+    // if identical object
+    if (self == object) {
+        return YES;
+    }
+    // if not in realm or differing realms
+    if (_realm == nil || _realm != object.realm) {
+        return NO;
+    }
+    // if either are detached
+    if (!_row.is_attached() || !object->_row.is_attached()) {
+        return NO;
+    }
+    // if table and index are the same
+    return _row.get_table() == object->_row.get_table() && _row.get_index() == object->_row.get_index();
+}
+
+- (BOOL)isEqual:(id)object {
+    return [self isEqualToObject:object];
+}
+
 @end

--- a/Realm/Tests/ArrayTests.m
+++ b/Realm/Tests/ArrayTests.m
@@ -326,6 +326,7 @@
     EmployeeObject *po3 = [EmployeeObject createInRealm:realm withObject:@{@"name": @"Jill", @"age": @25, @"hired": @YES}];
     [realm commitWriteTransaction];
 
+    // test TableView RLMArray
     RLMArray *results = [EmployeeObject objectsWithPredicateFormat:@"hired = YES"];
     XCTAssertEqual((NSUInteger)0, [results indexOfObject:po1]);
     XCTAssertEqual((NSUInteger)1, [results indexOfObject:po3]);

--- a/Realm/Tests/RLMTestObjects.h
+++ b/Realm/Tests/RLMTestObjects.h
@@ -179,6 +179,7 @@ RLM_ARRAY_TYPE(EmployeeObject)
 
 @property NSString *name;
 @property RLMArray<StringObject> *array;
+@property RLMArray<IntObject> *intArray;
 
 @end
 


### PR DESCRIPTION
Fixes the following bugs:
- indexOfObject: would throw when in some cases when not necessary (standalone object or objects in other realms)
- standalone arrays allowed you to add objects of the wrong type
- manually setting a readonly RLMArray to a standalone array would result in that array being returned on subsequent access (rather than copying the data and returning a mutable array)
- indexOfObject: implementations did not ensure objects were attached
- indesOfObject: on standalone arrays was not functional - fixed by implmenting isEqual: for RLMObject

@astigsen @jpsim @bmunkholm 
