### PR TITLE
Fixed live updating of query results

### DIFF
--- a/Realm/RLMArrayTableView.mm
+++ b/Realm/RLMArrayTableView.mm
@@ -53,6 +53,7 @@ inline void RLMArrayTableViewValidateAttached(RLMArrayTableView *ar) {
     if (!ar->_backingView.is_attached()) {
         @throw [NSException exceptionWithName:@"RLMException" reason:@"RLMArray is no longer valid" userInfo:nil];
     }
+    ar->_backingView.sync_if_needed();
 }
 
 //


### PR DESCRIPTION
Query results in RLMArrays did not update correctly on changes. The fix was minor, but it depends on core PR #481 

@alazier @jpsim 
