### PR TITLE
Our JSON example cannot compile using Xcode 6

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -290,7 +290,7 @@ case "$COMMAND" in
         xc "-project objc/RealmMigrationExample/RealmMigrationExample.xcodeproj -scheme RealmMigrationExample -configuration Release clean build ${CODESIGN_PARAMS}"
         xc "-project objc/RealmRestExample/RealmRestExample.xcodeproj -scheme RealmRestExample -configuration Release clean build ${CODESIGN_PARAMS}"
 
-        # Not all examples can be build using Xcode 6
+        # Not all examples can be built using Xcode 6
         if [[ "$XCVERSION" != "6" ]]; then
             xc "-project objc/RealmJSONImportExample/RealmJSONImportExample.xcodeproj -scheme RealmJSONImportExample -configuration Release clean build ${CODESIGN_PARAMS}"
         fi
@@ -308,7 +308,7 @@ case "$COMMAND" in
         xc "-project objc/RealmMigrationExample/RealmMigrationExample.xcodeproj -scheme RealmMigrationExample -configuration Debug clean build ${CODESIGN_PARAMS}"
         xc "-project objc/RealmRestExample/RealmRestExample.xcodeproj -scheme RealmRestExample -configuration Debug clean build ${CODESIGN_PARAMS}"
 
-        # Not all examples can be build using Xcode 6
+        # Not all examples can be built using Xcode 6
         if [[ "$XCVERSION" != "6" ]]; then
             xc "-project objc/RealmJSONImportExample/RealmJSONImportExample.xcodeproj -scheme RealmJSONImportExample -configuration Debug clean build ${CODESIGN_PARAMS}"
         fi 


### PR DESCRIPTION
so it is disables for the `examples` and `examples-debug` targets in `build.sh`.

@jpsim @emanuelez @bmunkholm 
