### PR TITLE
Fix for crash when double clicking on a .realm file to launch the Realm Browser

### DIFF
--- a/tools/VisualEditor/RealmVisualEditor/Classes/RLMApplicationDelegate.m
+++ b/tools/VisualEditor/RealmVisualEditor/Classes/RLMApplicationDelegate.m
@@ -40,7 +40,7 @@ const NSUInteger kTopTipDelay = 250;
 
 - (BOOL)application:(NSApplication *)application openFile:(NSString *)filename
 {
-	NSURL *fileUrl = [NSURL fileURLWithPath:filename];
+    NSURL *fileUrl = [NSURL fileURLWithPath:filename];
     
     NSDocumentController *documentController = [[NSDocumentController alloc] init];
     [documentController openDocumentWithContentsOfURL:fileUrl


### PR DESCRIPTION
The use of URLWithString will not escape/encode spaces or special character which will result in fileUrl being nil and causes the app to crash.
