### PR TITLE
Updated RLMRealm.h to better match documentation.

### DIFF
--- a/Realm/RLMRealm.h
+++ b/Realm/RLMRealm.h
@@ -217,6 +217,15 @@ typedef void(^RLMNotificationBlock)(NSString *notification, RLMRealm *realm);
  */
 - (void)deleteObjects:(id)array;
 
+/**
+ Get all objects of a given type in this Realm.
+
+ @param objectClassName  NSString name of the RLMObject subclass to retrieve on e.g. MyClass.className.
+ 
+ @return An RLMArray of all objects in this realm of the given type.
+ */
+- (RLMArray *)allObjects:(NSString *)objectClassName
+
 #pragma mark - Migrations
 
 /**


### PR DESCRIPTION
This method is described in the [docs](http://realm.io/docs/ios/0.80.0/api/Classes/RLMRealm.html#//api/name/allObjects:) but wasn't actually in the header, so XCode throws a fit.
