### PR TITLE
Adding convenient method to call a block inside a transaction

### DIFF
--- a/Realm/RLMRealm.h
+++ b/Realm/RLMRealm.h
@@ -158,6 +158,12 @@ typedef void(^RLMNotificationBlock)(NSString *notification, RLMRealm *realm);
  */
 - (void)commitWriteTransaction;
 
+
+/**
+ Convenient method to call a block inside a transaction
+ */
+- (void)doWriteTransaction:(void (^)(void))transactionBlock;
+
 /**
  Update an RLMRealm and outstanding objects to point to the most recent data for this RLMRealm.
  */

--- a/Realm/RLMRealm.mm
+++ b/Realm/RLMRealm.mm
@@ -377,6 +377,14 @@ static NSArray *s_objectDescriptors = nil;
     }
 }
 
+- (void)doWriteTransaction:(void (^)(void))transactionBlock {
+    NSParameterAssert(transactionBlock);
+    
+    [self beginWriteTransaction];
+    transactionBlock();
+    [self commitWriteTransaction];
+}
+
 - (void)beginWriteTransaction {
     if (!self.inWriteTransaction) {
         try {


### PR DESCRIPTION
It's an amazing library and is helping me a lot! Thank you guys for all the efforts on this.

During my development I found myself doing a lot of:

``` objective-c
[realm beginWriteTransaction];
//code
[realm commitWriteTransaction];
```

So I thought about adding a convenient method to do a block inside a transaction.
What you guys think? It's a really small change and I want to start contributing a little bit more on the project!
But this is my small start.

Thank you guys in advance.
