### PR TITLE
Upgrade to use core library version 0.80.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 ### Bugfixes
 
 * Improved Unicode support in property names and string contents (Chinese, Russian, etc.). Closing #612 and #604.
-* Potential bugs fixed related to migration when properties are removed.
+* Potential bugs fixed relating to migration (addition/removal of properties).
 * Fixed keyed subscripting for standalone RLMObjects.
 
 0.80.0 Release notes (2014-07-15)

--- a/build.sh
+++ b/build.sh
@@ -15,7 +15,7 @@ set -o pipefail
 # You can override the version of the core library
 # Otherwise, use the default value
 if [ -z "$REALM_CORE_VERSION" ]; then
-    REALM_CORE_VERSION=0.80.2
+    REALM_CORE_VERSION=0.80.3
 fi
 
 PATH=/usr/local/bin:/usr/bin:/bin:/usr/libexec:$PATH


### PR DESCRIPTION
This core release fixes bugs and adds new link-related features to the query system. See https://github.com/Tightdb/tightdb/blob/master/release_notes.md for details.

@astigsen @jpsim @alazier 
