### PR TITLE
Added back SimpleExample's AppDelegate, which was mistakenly overwritten...

### DIFF
--- a/examples/objc/RealmSimpleExample/RealmSimpleExample/AppDelegate.m
+++ b/examples/objc/RealmSimpleExample/RealmSimpleExample/AppDelegate.m
@@ -32,8 +32,8 @@
 RLM_ARRAY_TYPE(Dog)
 
 @interface Person : RLMObject
-@property NSString        *name;
-@property RLMArray<Dog>   *dogs;
+@property NSString      *name;
+@property RLMArray<Dog> *dogs;
 @end
 
 @implementation Person
@@ -84,7 +84,7 @@ RLM_ARRAY_TYPE(Dog)
     [realm commitWriteTransaction];
 
     // Thread-safety
-    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT,	0),	^{
+    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
         RLMRealm *otherRealm = [RLMRealm defaultRealm];
         RLMArray *otherResults = [Dog objectsInRealm:otherRealm where:@"name contains 'Rex'"];
         NSLog(@"Number of dogs: %li", (unsigned long)otherResults.count);


### PR DESCRIPTION
... with the content of EncryptionExample in this commit: https://github.com/realm/realm-cocoa/commit/e4ac3011452b5f30b35d138694ae6d809cd6e514

Thanks to StanislavK for reporting! Fixes #625 !

(CHANGELOG.md not updated as it was never released.)

Review: @jpsim 
