### PR TITLE
Don't `#import <Realm/` from within the framework

### DIFF
--- a/Realm/RLMObject.h
+++ b/Realm/RLMObject.h
@@ -17,7 +17,7 @@
 ////////////////////////////////////////////////////////////////////////////
 
 #import <Foundation/Foundation.h>
-#import <Realm/RLMConstants.h>
+#import "RLMConstants.h"
 
 @class RLMRealm;
 @class RLMArray;

--- a/Realm/RLMProperty.h
+++ b/Realm/RLMProperty.h
@@ -18,8 +18,8 @@
 
 
 #import <Foundation/Foundation.h>
-#import <Realm/RLMConstants.h>
-#import <Realm/RLMObject.h>
+#import "RLMConstants.h"
+#import "RLMObject.h"
 
 // object property definition
 @interface RLMProperty : NSObject


### PR DESCRIPTION
This fixes an issue preventing the framework from building on iOS the first time, because that location doesn't exist. Subsequent builds worked though.

@alazier 
