### PR TITLE
Upgrade to use core library version 0.80.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Bugfixes
 
 * Fixed bug related to querying on float properties: `floatProperty = 1.7` now works.
+* Fixed potential bug related to the handling of array properties (RLMArray).
 
 
 0.81.0 Release notes (2014-07-22)

--- a/build.sh
+++ b/build.sh
@@ -15,7 +15,7 @@ set -o pipefail
 # You can override the version of the core library
 # Otherwise, use the default value
 if [ -z "$REALM_CORE_VERSION" ]; then
-    REALM_CORE_VERSION=0.80.3
+    REALM_CORE_VERSION=0.80.4
 fi
 
 PATH=/usr/local/bin:/usr/bin:/bin:/usr/libexec:$PATH


### PR DESCRIPTION
Another bugfix release.

For details, see https://github.com/Tightdb/tightdb/blob/master/release_notes.md#0804-release-notes
