### PR TITLE
Use of tightdb::TableRef improved in various places

### DIFF
--- a/Realm/RLMSchema.mm
+++ b/Realm/RLMSchema.mm
@@ -144,7 +144,7 @@ static NSMutableDictionary *s_classNameToMangledName;
         if (className) {
             tightdb::TableRef table = realm.group->get_table(i);
             RLMObjectSchema *object = [RLMObjectSchema schemaForTable:table.get() className:className];
-            object->_table = table;
+            object->_table = move(table);
             [schemaArray addObject:object];
         }
     }
@@ -163,18 +163,18 @@ inline tightdb::TableRef RLMVersionTable(RLMRealm *realm) {
         
         // set initial version
         table->add_empty_row();
-        (*table)[0].set_int(c_versionColumnIndex, 0);
+        table->get(0).set_int(c_versionColumnIndex, 0);
     }
-    return table;
+    return move(table);
 }
 
 NSUInteger RLMRealmSchemaVersion(RLMRealm *realm) {
-    return (NSUInteger)(*RLMVersionTable(realm))[0].get_int(c_versionColumnIndex);
+    return NSUInteger(RLMVersionTable(realm)->get(0).get_int(c_versionColumnIndex));
 
 }
 
 void RLMRealmSetSchemaVersion(RLMRealm *realm, NSUInteger version) {
-    (*RLMVersionTable(realm))[0].set_int(c_versionColumnIndex, version);
+    RLMVersionTable(realm)->get(0).set_int(c_versionColumnIndex, version);
 }
 
 + (Class)classForString:(NSString *)className {


### PR DESCRIPTION
The general pattern of these changes are:
- When there is already a "stable" owner of the table accessor such as in the case of `objectSchema->_table`, avoid copying the TableRef. It is more efficient to create a `&` reference, which, in terms of efficiency, is like copying a plain pointer. In these cases, for syntactical reasons, it is more convenient to use `&` references than actual pointers.
- When making a copy of a TableRef object from a named variable `t`, and `t` is not used after that point, use `move(t)`, because that is more efficient (move semantics).
