### PR TITLE
When ignoredProperties is overridden on Swift, the schema ends up invalid

### DIFF
--- a/Realm/Swift/RLMSwiftSupport.swift
+++ b/Realm/Swift/RLMSwiftSupport.swift
@@ -61,7 +61,7 @@ import Foundation
         // super is an implicit property on Swift objects
         for i in 1..<reflection.count {
             let propertyName = reflection[i].0
-            if ignoredPropertiesForClass?.containsObject(propertyName) {
+            if ignoredPropertiesForClass && ignoredPropertiesForClass!.containsObject(propertyName) {
                 continue
             }
 


### PR DESCRIPTION
When overridden ignoredProperties on an RLMObject subclass (Swift), the entire schema gets invalid (it ends up with 0 properties). The reason why this is happening is, to say at least, tricky:

I'm unclear if this is a Swift bug or just an intended language "feature". But when the conditional includes an unwrapping and a method call, only the unwrapping gets evaluated. Meaning that when you do:

```
ignoredPropertiesForClass?.containsObject(propertyName)
```

If ignoredPropertiesForClass is not nil, it doesn't matter what the containsObject method returns, that conditional is always going to be true. _Note that I only tested this on Xcode Beta4._
