### PR TITLE
Integers in Swift were down casted to 32 bits integers. Fixed #688

### DIFF
--- a/Realm-Xcode6.xcodeproj/project.pbxproj
+++ b/Realm-Xcode6.xcodeproj/project.pbxproj
@@ -17,6 +17,8 @@
 		0207AB88195DFA15007EFB12 /* MigrationTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 0207AB85195DFA15007EFB12 /* MigrationTests.mm */; };
 		0207AB89195DFA15007EFB12 /* SchemaTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 0207AB86195DFA15007EFB12 /* SchemaTests.mm */; };
 		0207AB8A195DFA15007EFB12 /* SchemaTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 0207AB86195DFA15007EFB12 /* SchemaTests.mm */; };
+		2671BF29198640DB00824A7D /* SwiftPropertyTypeTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2671BF2619863F2000824A7D /* SwiftPropertyTypeTest.swift */; };
+		2671BF2A198640DC00824A7D /* SwiftPropertyTypeTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2671BF2619863F2000824A7D /* SwiftPropertyTypeTest.swift */; };
 		E81A1F851955FC9300FDED82 /* RLMAccessor.h in Headers */ = {isa = PBXBuildFile; fileRef = E81A1F631955FC9300FDED82 /* RLMAccessor.h */; };
 		E81A1F861955FC9300FDED82 /* RLMAccessor.mm in Sources */ = {isa = PBXBuildFile; fileRef = E81A1F641955FC9300FDED82 /* RLMAccessor.mm */; };
 		E81A1F881955FC9300FDED82 /* RLMArray_Private.hpp in Headers */ = {isa = PBXBuildFile; fileRef = E81A1F651955FC9300FDED82 /* RLMArray_Private.hpp */; };
@@ -244,6 +246,7 @@
 		0207AB7D195DF9FB007EFB12 /* RLMMigration.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RLMMigration.h; sourceTree = "<group>"; };
 		0207AB7E195DF9FB007EFB12 /* RLMMigration.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = RLMMigration.mm; sourceTree = "<group>"; };
 		0207AB85195DFA15007EFB12 /* MigrationTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MigrationTests.mm; sourceTree = "<group>"; };
+		2671BF2619863F2000824A7D /* SwiftPropertyTypeTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwiftPropertyTypeTest.swift; sourceTree = "<group>"; };
 		0207AB86195DFA15007EFB12 /* SchemaTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = SchemaTests.mm; sourceTree = "<group>"; };
 		E81A1F621955FC9300FDED82 /* Realm-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "Realm-Info.plist"; sourceTree = "<group>"; };
 		E81A1F631955FC9300FDED82 /* RLMAccessor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RLMAccessor.h; sourceTree = "<group>"; };
@@ -371,6 +374,7 @@
 				E82FA60F195632F20043A3C3 /* SwiftObjectInterfaceTests.swift */,
 				E83AF538196DDE58002275B2 /* SwiftDynamicTests.swift */,
 				E844CC62196DE91F0005A5E7 /* SwiftMixedTests.swift */,
+				2671BF2619863F2000824A7D /* SwiftPropertyTypeTest.swift */,
 				E891759A197A1B600068ACC6 /* SwiftUnicodeTests.swift */,
 			);
 			path = Swift;
@@ -888,6 +892,7 @@
 				E83AF53A196DDE58002275B2 /* SwiftDynamicTests.swift in Sources */,
 				E8A5DEEE1968E521006A50F6 /* RLMPredicateUtil.m in Sources */,
 				E891759C197A1B600068ACC6 /* SwiftUnicodeTests.swift in Sources */,
+				2671BF2A198640DC00824A7D /* SwiftPropertyTypeTest.swift in Sources */,
 				E8F8D90F196CB8DD00475368 /* SwiftTestObjects.swift in Sources */,
 				E856D228195615B800FB2FCF /* SwiftRealmTests.swift in Sources */,
 				E856D21D195615A900FB2FCF /* QueryTests.m in Sources */,
@@ -954,6 +959,7 @@
 				E83AF539196DDE58002275B2 /* SwiftDynamicTests.swift in Sources */,
 				E8A5DEED1968E520006A50F6 /* RLMPredicateUtil.m in Sources */,
 				E891759B197A1B600068ACC6 /* SwiftUnicodeTests.swift in Sources */,
+				2671BF29198640DB00824A7D /* SwiftPropertyTypeTest.swift in Sources */,
 				E8F8D90E196CB8DD00475368 /* SwiftTestObjects.swift in Sources */,
 				E81A1FEB1955FE0100FDED82 /* RealmTests.m in Sources */,
 				E81A1FEE1955FE0100FDED82 /* RLMTestCase.m in Sources */,

--- a/Realm/RLMAccessor.mm
+++ b/Realm/RLMAccessor.mm
@@ -258,9 +258,6 @@ inline void RLMSetAnyProperty(__unsafe_unretained RLMObject *obj, NSUInteger col
 IMP RLMAccessorGetter(NSUInteger colIndex, char accessorCode, NSString *objectClassName) {
     switch (accessorCode) {
         case 'i':
-            return imp_implementationWithBlock(^(RLMObject *obj) {
-                return (int)RLMGetLong(obj, colIndex);
-            });
         case 'l':
             return imp_implementationWithBlock(^(RLMObject *obj) {
                 return RLMGetLong(obj, colIndex);
@@ -311,9 +308,6 @@ IMP RLMAccessorGetter(NSUInteger colIndex, char accessorCode, NSString *objectCl
 IMP RLMAccessorSetter(NSUInteger colIndex, char accessorCode) {
     switch (accessorCode) {
         case 'i':
-            return imp_implementationWithBlock(^(RLMObject *obj, int val) {
-                RLMSetLong(obj, colIndex, val);
-            });
         case 'l':
             return imp_implementationWithBlock(^(RLMObject *obj, long val) {
                 RLMSetLong(obj, colIndex, val);
@@ -630,7 +624,7 @@ id RLMDynamicGet(__unsafe_unretained RLMObject *obj, __unsafe_unretained NSStrin
     }
     NSUInteger col = prop.column;
     switch (accessorCodeForType(prop.objcType, prop.type)) {
-        case 'i': return @((int)RLMGetLong(obj, col));
+        case 'i':
         case 'l': return @(RLMGetLong(obj, col));
         case 'f': return @(RLMGetFloat(obj, col));
         case 'd': return @(RLMGetDouble(obj, col));

--- a/Realm/Tests/Swift/SwiftPropertyTypeTest.swift
+++ b/Realm/Tests/Swift/SwiftPropertyTypeTest.swift
@@ -1,0 +1,51 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2014 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+import XCTest
+import Realm
+import TestFramework
+
+class SwiftPropertyTypeTest: SwiftTestCase {
+
+    func testLongType() {
+        let longNumber = Int(pow(2.0, 34.0))
+        let shortNumber = 1234
+        let negativeLongNumber = -Int(pow(2.0, 33.0))
+        let updatedLongNumber = Int(pow(2.0, 33.0))
+
+        let realm = realmWithTestPath()
+        
+        realm.beginWriteTransaction()
+        SwiftIntObject.createInRealm(realm, withObject: [longNumber])
+        SwiftIntObject.createInRealm(realm, withObject: [shortNumber])
+        SwiftIntObject.createInRealm(realm, withObject: [negativeLongNumber])
+        realm.commitWriteTransaction()
+        
+        let objects = SwiftIntObject.allObjectsInRealm(realm)
+        XCTAssertEqual(objects.count, 3, "3 rows expected")
+        XCTAssertEqual((objects[0] as SwiftIntObject).intCol, longNumber, "2 ^ 34 expected")
+        XCTAssertEqual((objects[1] as SwiftIntObject).intCol, shortNumber, "1234 expected")
+        XCTAssertEqual((objects[2] as SwiftIntObject).intCol, negativeLongNumber, "-2 ^ 33 expected")
+
+        realm.beginWriteTransaction()
+        (objects[0] as SwiftIntObject).intCol = updatedLongNumber
+        realm.commitWriteTransaction()
+
+        XCTAssertEqual((objects[0] as SwiftIntObject).intCol, updatedLongNumber, "After update: 2 ^ 33 expected")
+    }
+}


### PR DESCRIPTION
See #688 for more information.
