### PR TITLE
A couple negative objectForKeyedSubscript tests

### DIFF
--- a/Realm/Tests/ObjectTests.m
+++ b/Realm/Tests/ObjectTests.m
@@ -632,7 +632,7 @@
     IntObject *obj = [[IntObject alloc] init];
     XCTAssertThrowsSpecificNamed([obj objectForKeyedSubscript:@""], NSException,
                                  @"NSUnknownKeyException");
-    XCTAssertThrowsSpecificNamed([obj setObject:0 forKeyedSubscript:@""], NSException,
+    XCTAssertThrowsSpecificNamed([obj setObject:@0 forKeyedSubscript:@""], NSException,
                                  @"NSUnknownKeyException");
 }
 


### PR DESCRIPTION
Maybe we should really throw the same exception, but for now, this just increases branch coverage slightly.

@alazier @kspangsege 
