### PR TITLE
Don't add a duplicate copy of libtightdb-ios.a to the framework

### DIFF
--- a/scripts/build-fat.sh
+++ b/scripts/build-fat.sh
@@ -62,6 +62,3 @@ xcrun xcodebuild -project "${PROJECT_FILE_PATH}" -target "${REALM_TARGET_NAME}" 
 # Step 2 - move files and make fat
 mkdir -p "${BUILD_DIR}/${CONFIGURATION}"
 xcrun lipo -create "${SF_LIB_PATH}" "${SF_OTHER_LIB_PATH}" -output "${SF_FAT_PATH}"
-
-# Step 3 - combine with core library
-xcrun libtool -static -o "${SF_COMBINED_PATH}" "${SF_FAT_PATH}" "${SF_CORE_PATH}"

--- a/scripts/build-framework.sh
+++ b/scripts/build-framework.sh
@@ -6,7 +6,7 @@ set +u
 
 # lib/framework paths
 SF_FRAMEWORK_PATH="${SRCROOT}/build/${CONFIGURATION}/${PRODUCT_NAME}.framework"
-SF_COMBINED_PATH="${BUILD_DIR}/${CONFIGURATION}/libRealm-combined.a"
+SF_COMBINED_PATH="${BUILD_DIR}/${CONFIGURATION}/libRealm-fat.a"
 
 # very simple structure - it doesn't follow Apple's documentation
 rm -rf "${SF_FRAMEWORK_PATH}"


### PR DESCRIPTION
I'm not entirely clear on how, but libRealm-fat.a already has a copy of
tightdb, so adding a second copy with libtool is unnecessary and makes the
final framework 25% larger.

@alazier @jpsim 
