### PR TITLE
Improve the error message when properties are of an invalid type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 * Fixed a bug where initializing a standalone object with an array literal would 
   trigger an exception.
 * Clarified exception messages when using unsupported NSPredicate operators.
+* Clarified exception messages when using unsupported property types on RLMObject subclasses.
 
 
 0.81.0 Release notes (2014-07-22)

--- a/Realm/RLMProperty.m
+++ b/Realm/RLMProperty.m
@@ -174,7 +174,7 @@
                                                      userInfo:nil];
                     }
                     @throw [NSException exceptionWithName:@"RLMException"
-                                                   reason:[NSString stringWithFormat:@"Property of type '%@' must descend from RLMObject", self.objectClassName]
+                                                   reason:[NSString stringWithFormat:@"'%@' is not supported as an RLMObject property. All properties must be primitives, NSString, NSDate, NSData, RLMArray, or subclasses of RLMObject. See http://realm.io/docs/cocoa/latest/api/Classes/RLMObject.html for more information.", self.objectClassName]
                                                  userInfo:nil];
                 }
             }


### PR DESCRIPTION
Try to make it clearer what the problem is, list the legal types for
properties, and add the relevant documentation URL.
