### PR TITLE
Fix compilation of the browser

### DIFF
--- a/tools/RealmBrowser/RealmBrowser/Classes/RLMRealmBrowserWindowController.m
+++ b/tools/RealmBrowser/RealmBrowser/Classes/RLMRealmBrowserWindowController.m
@@ -24,6 +24,10 @@
 - (RLMArray *)objects:(NSString *)className where:(NSString *)predicateFormat, ...;
 @end
 
+@interface RLMArray (Private)
+- (instancetype)initWithObjectClassName:(NSString *)objectClassName;
+@end
+
 const NSUInteger kMaxNumberOfArrayEntriesInToolTip = 5;
 
 @implementation RLMRealmBrowserWindowController {
@@ -177,7 +181,7 @@ const NSUInteger kMaxNumberOfArrayEntriesInToolTip = 5;
         result = [realm objects:typeNode.name where:predicate];
     }
     else {
-        result = [[RLMArray alloc] init];
+        result = [[RLMArray alloc] initWithObjectClassName:typeNode.name];
     }
 
     RLMQueryNavigationState *state = [[RLMQueryNavigationState alloc] initWithQuery:searchText type:typeNode results:result];


### PR DESCRIPTION
Creating RLMArrays directly as it did is forbidden and the special-case for
empty predicates appears to be unnecessary anyway, so just remove it.
