### PR TITLE
Improve error message for invalid literals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 ### Enhancements
 
 * Add support for querying for nil object properties.
+* Improve error message when specifying invalid literals when creating or 
+  initializing RLMObjects.
 
 ### Bugfixes
 

--- a/Realm/RLMUtil.mm
+++ b/Realm/RLMUtil.mm
@@ -146,14 +146,15 @@ BOOL RLMIsObjectValidForProperty(id obj, RLMProperty *property) {
 id RLMValidatedObjectForProperty(id obj, RLMProperty *prop, RLMSchema *schema) {
     if (!RLMIsObjectValidForProperty(obj, prop)) {
         // check for object or array literals
-        RLMObjectSchema *objSchema = schema[prop.objectClassName];
         if (prop.type == RLMPropertyTypeObject) {
             // for object create and try to initialize with obj
+            RLMObjectSchema *objSchema = schema[prop.objectClassName];
             return [[objSchema.objectClass alloc] initWithObject:obj];
         }
         else if (prop.type == RLMPropertyTypeArray && [obj isKindOfClass:NSArray.class]) {
             // for arrays, create objects for each literal object and return new array
             NSArray *arrayElements = obj;
+            RLMObjectSchema *objSchema = schema[prop.objectClassName];
             RLMArray *objects = [RLMArray standaloneArrayWithObjectClassName:objSchema.className];
             for (id el in arrayElements) {
                 [objects addObject:[[objSchema.objectClass alloc] initWithObject:el]];
@@ -162,7 +163,7 @@ id RLMValidatedObjectForProperty(id obj, RLMProperty *prop, RLMSchema *schema) {
         }
 
         // if not a literal throw
-        NSString *message = [NSString stringWithFormat:@"Invalid value type '%@' for property '%@'", obj ?: @"nil", prop.name];
+        NSString *message = [NSString stringWithFormat:@"Invalid value '%@' for property '%@'", obj ?: @"nil", prop.name];
         @throw [NSException exceptionWithName:@"RLMException" reason:message userInfo:nil];
     }
     return obj;

--- a/Realm/Tests/ObjectTests.m
+++ b/Realm/Tests/ObjectTests.m
@@ -197,6 +197,8 @@
 
     NSArray *invalidArray = @[@"company", @[@[@"Alex", @29, @2]]];
     XCTAssertThrows([[CompanyObject alloc] initWithObject:invalidArray], @"Invalid sub-literal should throw");
+    NSDictionary *invalidDict= @{@"employees": @[@[@"Alex", @29, @2]]};
+    XCTAssertThrows([[CompanyObject alloc] initWithObject:invalidDict], @"Dictionary missing properties should throw");
 
     OwnerObject *owner = [[OwnerObject alloc] initWithObject:@[@"Brian", @{@"dogName": @"Brido"}]];
     XCTAssertEqualObjects(owner.dog.dogName, @"Brido");

--- a/Realm/Tests/RLMTestCase.m
+++ b/Realm/Tests/RLMTestCase.m
@@ -134,7 +134,6 @@ void RLMDeleteRealmFilesAtPath(NSString *path) {
 #if !defined(SWIFT)
 - (void)waitForExpectationsWithTimeout:(NSTimeInterval)interval handler:(__unused id)noop {
     NSDate *endDate = [NSDate dateWithTimeIntervalSinceNow:interval];
-    NSLog(@"start");
     while (!_expectations.count && [endDate timeIntervalSinceNow] > 0) {
         for (NSInteger i = (NSInteger)_expectations.count-1; i > 0; i--) {
             if (((XCTestExpectation *)_expectations[i])->_fulfilled) {
@@ -143,7 +142,6 @@ void RLMDeleteRealmFilesAtPath(NSString *path) {
         }
         [[NSRunLoop currentRunLoop] runMode:NSDefaultRunLoopMode beforeDate:endDate];
     }
-    NSLog(@"end");
 
     if (_expectations.count) {
         XCTFail(@"Wait for expectation timed out after %f seconds", interval);


### PR DESCRIPTION
@tgoyne 

Addresses #752 

Previous message:

> Object type '(null)' not persisted in Realm

is now:

> Invalid value 'nil' for property 'name'
