### PR TITLE
Allow arrays and object properties to be missing when initializing from a dictionary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 * Throw an exception when an RLMObject is used from the incorrect thread rather
   than crashing in confusing ways.
 * Speed up RLMRealm instantiation and array property iteration.
+* Allow array and objection relation properties to be missing or null when
+  creating a RLMObject from a NSDictionary.
 
 ### Bugfixes
 

--- a/Realm/RLMUtil.mm
+++ b/Realm/RLMUtil.mm
@@ -134,7 +134,7 @@ BOOL RLMIsObjectValidForProperty(id obj, RLMProperty *property) {
                 }
                 return YES;
             }
-            if (obj == NSNull.null) {
+            if (!obj || obj == NSNull.null) {
                 return YES;
             }
             return NO;
@@ -177,7 +177,9 @@ NSDictionary *RLMValidatedDictionaryForObjectSchema(NSDictionary *dict, RLMObjec
         // set out object to validated input or default value
         id obj = dict[prop.name];
         obj = obj ?: defaults[prop.name];
-        outDict[prop.name] = RLMValidatedObjectForProperty(obj, prop, schema);
+        obj = RLMValidatedObjectForProperty(obj, prop, schema);
+        if (obj && obj != NSNull.null)
+            outDict[prop.name] = obj;
     }
     return outDict;
 }

--- a/Realm/Tests/ObjectTests.m
+++ b/Realm/Tests/ObjectTests.m
@@ -209,6 +209,30 @@
     XCTAssertEqualObjects(ownerArrayDog.dog.dogName, @"PJ");
 }
 
+- (void)testInitFromDictionaryMissingPropertyKey {
+    CompanyObject *co = nil;
+    XCTAssertThrows([[CompanyObject alloc] initWithObject:@{}]);
+    XCTAssertNoThrow(co = [[CompanyObject alloc] initWithObject:@{@"name": @"a"}]);
+    XCTAssertEqualObjects(co.name, @"a");
+    XCTAssertEqual(co.employees.count, 0);
+
+    OwnerObject *oo = nil;
+    XCTAssertNoThrow(oo = [[OwnerObject alloc] initWithObject:@{@"name": @"a"}]);
+    XCTAssertEqualObjects(oo.name, @"a");
+    XCTAssertNil(oo.dog);
+}
+
+- (void)testInitFromDictionaryPropertyKey {
+    CompanyObject *co = nil;
+    XCTAssertNoThrow((co = [[CompanyObject alloc] initWithObject:@{@"name": @"a", @"employees": NSNull.null}]));
+    XCTAssertEqualObjects(co.name, @"a");
+    XCTAssertEqual(co.employees.count, 0);
+
+    OwnerObject *oo = nil;
+    XCTAssertNoThrow((oo = [[OwnerObject alloc] initWithObject:@{@"name": @"a", @"employees": NSNull.null}]));
+    XCTAssertEqualObjects(oo.name, @"a");
+    XCTAssertNil(oo.dog);
+}
 
 -(void)testObjectInitWithObjectTypeOther
 {


### PR DESCRIPTION
Handle missing keys and NSNull values for arrays and relationships which don't
have a default specified as there's an obvious default for them and people are
confused by them being required.

@alazier 
