### PR TITLE
Using instance of RLMRealm in write transactions

### DIFF
--- a/Realm/Tests/ArrayPropertyTests.m
+++ b/Realm/Tests/ArrayPropertyTests.m
@@ -275,9 +275,10 @@
     });
     OSSpinLockLock(&spinlock);
 
-    [RLMRealm.defaultRealm beginWriteTransaction];
-    [RLMRealm.defaultRealm addObject:company];
-    [RLMRealm.defaultRealm commitWriteTransaction];
+    RLMRealm *realm = [RLMRealm defaultRealm];
+    [realm beginWriteTransaction];
+    [realm addObject:company];
+    [realm commitWriteTransaction];
 
     employees = company.employees;
     XCTAssertNoThrow(company.employees);

--- a/Realm/Tests/ObjectTests.m
+++ b/Realm/Tests/ObjectTests.m
@@ -688,9 +688,11 @@
     });
     OSSpinLockLock(&spinlock);
 
-    [RLMRealm.defaultRealm beginWriteTransaction];
-    [RLMRealm.defaultRealm addObject:obj];
-    [RLMRealm.defaultRealm commitWriteTransaction];
+
+    RLMRealm *realm = [RLMRealm defaultRealm];
+    [realm beginWriteTransaction];
+    [realm addObject:obj];
+    [realm commitWriteTransaction];
 
     XCTAssertNoThrow(obj.intCol);
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{

--- a/Realm/Tests/RealmTests.m
+++ b/Realm/Tests/RealmTests.m
@@ -17,6 +17,7 @@
 ////////////////////////////////////////////////////////////////////////////
 
 #import "RLMTestCase.h"
+#import "RLMRealm_Dynamic.h"
 
 #import <libkern/OSAtomic.h>
 
@@ -371,9 +372,9 @@
     __block OSSpinLock spinlock = OS_SPINLOCK_INIT;
     OSSpinLockLock(&spinlock);
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
-        XCTAssertThrows([realm beginWriteTransaction]);
-        XCTAssertThrows([realm allObjects:@"IntObject"]);
-        XCTAssertThrows([realm objects:@"IntObject" where:@"intCol = 0"]);
+        XCTAssertThrows([realm beginWriteTransaction], @"No exception");
+        XCTAssertThrows([realm allObjects:@"IntObject"], @"No exception");
+        XCTAssertThrows([realm objects:@"IntObject" where:@"intCol = 0"], @"No exception");
         OSSpinLockUnlock(&spinlock);
     });
     OSSpinLockLock(&spinlock);


### PR DESCRIPTION
In release mode, write transactions must be performed using an instance of RLMRealm.

The unit tests performed within Xcode are executed in debug mode while `sh build.sh test` will execute in release mode. Apparently, `[RLMRealm.defaultRealm beginWriteTransaction]` will - in release mode - do a commit while the write transaction will remain open in debug mode. I guess that the Objective C runtime will deallocate objects earlier in release mode, and an auto commit is performed too early.

@alazier @tgoyne 
