### PR TITLE
Reject invalid subclassing of RLMObjects at schema generation time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 
 * Realm-Xcode6.xcodeproj now only builds using Xcode6-Beta5.
 * Properties to be persisted in Swift classes must be explicitly declared as `dynamic`.
+* Subclasses of RLMObject subclasses now throw an exception on startup, rather
+  than when added to a Realm.
 
 ### Enhancements
 

--- a/Realm/Tests/ObjectInterfaceTests.m
+++ b/Realm/Tests/ObjectInterfaceTests.m
@@ -20,15 +20,6 @@
 
 #pragma mark - Test Objects
 
-#pragma mark InvalidSubclassObject
-
-@interface InvalidSubclassObject : StringObject
-@property NSString *invalid;
-@end
-
-@implementation InvalidSubclassObject
-@end
-
 #pragma mark - Tests
 
 @interface ObjectInterfaceTests : RLMTestCase
@@ -64,17 +55,6 @@
     
     CustomAccessorsObject *objectFromRealm = [CustomAccessorsObject allObjects][0];
     XCTAssertEqual((int)objectFromRealm.age, (int)99, @"age property should be 99");
-}
-
-- (void)testObjectSubclass
-{
-    RLMRealm *realm = [RLMRealm defaultRealm];
-    
-    [realm beginWriteTransaction];
-    NSArray *obj = @[@1, @"throw"];
-    XCTAssertThrows([InvalidSubclassObject createInRealm:realm withObject:obj],
-                    @"Adding invalid object should throw");
-    [realm commitWriteTransaction];
 }
 
 - (void)testClassExtension


### PR DESCRIPTION
Rather than producing weird errors and bizarre behavior when they're actually used.

Remove the unit test which was testing them since there's no way to have an invalid subclass for just a single test.

@alazier 
