### PR TITLE
Explicitly autorelease realms returned from RLMRealm class methods

### DIFF
--- a/Realm/RLMRealm.mm
+++ b/Realm/RLMRealm.mm
@@ -349,9 +349,14 @@ static NSArray *s_objectDescriptors = nil;
 
     // apply schema
     [realm beginWriteTransaction];
-    RLMRealmSetSchema(realm, schema);
-    [realm commitWriteTransaction];
-    
+    @try {
+        RLMRealmSetSchema(realm, schema);
+    }
+    @finally {
+        // FIXME: should rollback on exceptions rather than commit once that's implemented
+        [realm commitWriteTransaction];
+    }
+
     // cache realm at this path if using a vanilla realm
     if (!dynamic && !customSchema) {
         cacheRealm(realm, path);


### PR DESCRIPTION
Currently whether they are or aren't depends on the whims of ARC, which
means that it's inconsistent as to whether or not the following code
works:

```
[[RLMRealm defaultRealm] beginWriteTransaction];
// ...
[[RLMRealm defaultRealm] commitWriteTransaction];
```

Currently this works only in debug modes or if there is anything else
keeping the realm alive, which is rather confusing.
