### PR TITLE
Remove default: cases from switches on enums

### DIFF
--- a/Realm/RLMAccessor.mm
+++ b/Realm/RLMAccessor.mm
@@ -182,30 +182,31 @@ static inline id RLMGetAnyProperty(__unsafe_unretained RLMObject *obj, NSUIntege
 
     tightdb::Mixed mixed = obj->_row.get_mixed(col_ndx);
     switch (mixed.get_type()) {
-        case RLMPropertyTypeString:
+        case tightdb::type_String:
             return RLMStringDataToNSString(mixed.get_string());
-        case RLMPropertyTypeInt: {
+        case tightdb::type_Int: {
             return @(mixed.get_int());
-        case RLMPropertyTypeFloat:
+        case tightdb::type_Float:
             return @(mixed.get_float());
-        case RLMPropertyTypeDouble:
+        case tightdb::type_Double:
             return @(mixed.get_double());
-        case RLMPropertyTypeBool:
+        case tightdb::type_Bool:
             return @(mixed.get_bool());
-        case RLMPropertyTypeDate:
+        case tightdb::type_DateTime:
             return [NSDate dateWithTimeIntervalSince1970:mixed.get_datetime().get_datetime()];
-        case RLMPropertyTypeData: {
+        case tightdb::type_Binary: {
             tightdb::BinaryData bd = mixed.get_binary();
             NSData *d = [NSData dataWithBytes:bd.data() length:bd.size()];
             return d;
         }
-        case RLMPropertyTypeArray:
+        case tightdb::type_LinkList:
             @throw [NSException exceptionWithName:@"RLMNotImplementedException"
                                            reason:@"RLMArray not yet supported" userInfo:nil];
 
             // for links and other unsupported types throw
-        case RLMPropertyTypeObject:
-        default:
+        case tightdb::type_Link:
+        case tightdb::type_Mixed:
+        case tightdb::type_Table:
             @throw [NSException exceptionWithName:@"RLMException" reason:@"Invalid data type for RLMPropertyTypeAny property." userInfo:nil];
         }
     }

--- a/Realm/RLMArrayTableView.mm
+++ b/Realm/RLMArrayTableView.mm
@@ -230,7 +230,12 @@ static inline void RLMArrayTableViewValidateInWriteTransaction(RLMArrayTableView
             tightdb::DateTime dt = _backingView.minimum_datetime(colIndex);
             return [NSDate dateWithTimeIntervalSince1970:dt.get_datetime()];
         }
-        default:
+        case RLMPropertyTypeAny:
+        case RLMPropertyTypeArray:
+        case RLMPropertyTypeBool:
+        case RLMPropertyTypeData:
+        case RLMPropertyTypeObject:
+        case RLMPropertyTypeString:
             @throw [NSException exceptionWithName:@"RLMOperationNotSupportedException"
                                            reason:@"minOfProperty only supported for int, float, double and date properties."
                                          userInfo:nil];
@@ -254,7 +259,12 @@ static inline void RLMArrayTableViewValidateInWriteTransaction(RLMArrayTableView
             tightdb::DateTime dt = _backingView.maximum_datetime(colIndex);
             return [NSDate dateWithTimeIntervalSince1970:dt.get_datetime()];
         }
-        default:
+        case RLMPropertyTypeAny:
+        case RLMPropertyTypeArray:
+        case RLMPropertyTypeBool:
+        case RLMPropertyTypeData:
+        case RLMPropertyTypeObject:
+        case RLMPropertyTypeString:
             @throw [NSException exceptionWithName:@"RLMOperationNotSupportedException"
                                            reason:@"maxOfProperty only supported for int, float, double and date properties."
                                          userInfo:nil];
@@ -274,7 +284,13 @@ static inline void RLMArrayTableViewValidateInWriteTransaction(RLMArrayTableView
             return @(_backingView.sum_double(colIndex));
         case RLMPropertyTypeFloat:
             return @(_backingView.sum_float(colIndex));
-        default:
+        case RLMPropertyTypeAny:
+        case RLMPropertyTypeArray:
+        case RLMPropertyTypeBool:
+        case RLMPropertyTypeData:
+        case RLMPropertyTypeDate:
+        case RLMPropertyTypeObject:
+        case RLMPropertyTypeString:
             @throw [NSException exceptionWithName:@"RLMOperationNotSupportedException"
                                            reason:@"sumOfProperty only supported for int, float and double properties."
                                          userInfo:nil];
@@ -294,7 +310,13 @@ static inline void RLMArrayTableViewValidateInWriteTransaction(RLMArrayTableView
             return @(_backingView.average_double(colIndex));
         case RLMPropertyTypeFloat:
             return @(_backingView.average_float(colIndex));
-        default:
+        case RLMPropertyTypeAny:
+        case RLMPropertyTypeArray:
+        case RLMPropertyTypeBool:
+        case RLMPropertyTypeData:
+        case RLMPropertyTypeDate:
+        case RLMPropertyTypeObject:
+        case RLMPropertyTypeString:
             @throw [NSException exceptionWithName:@"RLMOperationNotSupportedException"
                                            reason:@"averageOfProperty only supported for int, float and double properties."
                                          userInfo:nil];


### PR DESCRIPTION
And make it so that the types in the cases always match the type being switched
on, so that the compiler can provide more useful warnings.

@alazier 
