### PR TITLE
Handle object cycles in -description.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 ### Bugfixes
 
+* Handle object cycles in -[RLMObject description] and -[RLMArray description].
+
 0.83.0 Release notes (2014-08-13)
 =============================================================
 

--- a/Realm/RLMArray.mm
+++ b/Realm/RLMArray.mm
@@ -241,12 +241,28 @@ static void RLMValidateMatchingObjectType(RLMArray *array, RLMObject *object) {
 
 - (NSString *)description
 {
+    return [self descriptionWithMaxDepth:5];
+}
+
+- (NSString *)descriptionWithMaxDepth:(NSUInteger)depth {
+    if (depth == 0) {
+        return @"<Maximum depth exceeded>";
+    }
+
     const NSUInteger maxObjects = 100;
     NSMutableString *mString = [NSMutableString stringWithFormat:@"RLMArray <0x%lx> (\n", (long)self];
     unsigned long index = 0, skipped = 0;
-    for (NSObject *obj in self) {
+    for (id obj in self) {
+        NSString *sub;
+        if ([obj respondsToSelector:@selector(descriptionWithMaxDepth:)]) {
+            sub = [obj descriptionWithMaxDepth:depth - 1];
+        }
+        else {
+            sub = [obj description];
+        }
+
         // Indent child objects
-        NSString *objDescription = [obj.description stringByReplacingOccurrencesOfString:@"\n" withString:@"\n\t"];
+        NSString *objDescription = [sub stringByReplacingOccurrencesOfString:@"\n" withString:@"\n\t"];
         [mString appendFormat:@"\t[%lu] %@,\n", index++, objDescription];
         if (index >= maxObjects) {
             skipped = self.count - maxObjects;

--- a/Realm/RLMObject.mm
+++ b/Realm/RLMObject.mm
@@ -202,12 +202,28 @@
 
 - (NSString *)description
 {
+    return [self descriptionWithMaxDepth:5];
+}
+
+- (NSString *)descriptionWithMaxDepth:(NSUInteger)depth {
+    if (depth == 0) {
+        return @"<Maximum depth exceeded>";
+    }
+
     NSString *baseClassName = self.objectSchema.className;
     NSMutableString *mString = [NSMutableString stringWithFormat:@"%@ {\n", baseClassName];
     RLMObjectSchema *objectSchema = self.realm.schema[baseClassName];
     
     for (RLMProperty *property in objectSchema.properties) {
-        [mString appendFormat:@"\t%@ = %@;\n", property.name, [self[property.name] description]];
+        id object = self[property.name];
+        NSString *sub;
+        if ([object respondsToSelector:@selector(descriptionWithMaxDepth:)]) {
+            sub = [object descriptionWithMaxDepth:depth - 1];
+        }
+        else {
+            sub = [object description];
+        }
+        [mString appendFormat:@"\t%@ = %@;\n", property.name, sub];
     }
     [mString appendString:@"}"];
     

--- a/Realm/Tests/ObjectTests.m
+++ b/Realm/Tests/ObjectTests.m
@@ -85,6 +85,16 @@
 }
 @end
 
+#pragma mark CycleObject
+@class CycleObject;
+RLM_ARRAY_TYPE(CycleObject)
+@interface CycleObject :RLMObject
+@property RLMArray<CycleObject> *objects;
+@end
+
+@implementation CycleObject
+@end
+
 #pragma mark - Private
 
 @interface RLMRealm ()
@@ -642,7 +652,7 @@
     [realm addObject:soInit];
     
     // description asserts block
-    void(^descriptionAsserts)(NSString *) = ^(NSString *description) {
+    void (^descriptionAsserts)(NSString *) = ^(NSString *description) {
         XCTAssertTrue([description rangeOfString:@"name"].location != NSNotFound, @"column names should be displayed when calling \"description\" on RLMObject subclasses");
         XCTAssertTrue([description rangeOfString:@"Peter"].location != NSNotFound, @"column values should be displayed when calling \"description\" on RLMObject subclasses");
         
@@ -661,6 +671,16 @@
     // Test description in read block
     NSString *objDescription = [[[EmployeeObject objectsWithPredicate:nil] firstObject] description];
     descriptionAsserts(objDescription);
+}
+
+- (void)testObjectCycleDescription
+{
+    CycleObject *obj = [[CycleObject alloc] init];
+    [RLMRealm.defaultRealm transactionWithBlock:^{
+        [RLMRealm.defaultRealm addObject:obj];
+        [obj.objects addObject:obj];
+    }];
+    XCTAssertNoThrow(obj.description);
 }
 
 #pragma mark - Indexing Tests


### PR DESCRIPTION
Track which RLMObjects/RLMArrays we've seen in mutable set and just return "<cycle>" as the description if we hit one already seen.

@alazier 
