### PR TITLE
Copy `_notificationHandlers ` in case it is mutated while being enumerated

### DIFF
--- a/Realm/RLMRealm.mm
+++ b/Realm/RLMRealm.mm
@@ -399,7 +399,7 @@ static NSArray *s_objectDescriptors = nil;
 
 - (void)sendNotifications {
     // call this realms notification blocks
-    for (RLMNotificationToken *token in _notificationHandlers) {
+    for (RLMNotificationToken *token in [_notificationHandlers copy]) {
         token.block(RLMRealmDidChangeNotification, self);
     }
 }


### PR DESCRIPTION
It is reasonable to remove an Realm notification token while the execution of an notification block:

``` objective-c
__weak typeof(self) weakSelf = self;
self->_token = [self->_realm addNotificationBlock:^(NSString *notification, RLMRealm *realm) {
    __strong typeof(weakSelf) strongSelf = weakSelf;
    [realm removeNotification:weakSelf->_token];
}];
[realm transactionWithBlock:^{
    // do something to update the realm
}];
```

However, this will cause a crash:

```
Collection <NSConcreteMapTable: 0x10e14de00> was mutated while being enumerated.
```

So `_notificationHandlers` is copied in case it is mutated while being enumerated.
