### PR TITLE
Support setting model properties starting with the letter 'z'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * Handle object cycles in -[RLMObject description] and -[RLMArray description].
 * Lowered the deployment target for the Xcode 6 projects and Swift examples to
   iOS 7.0, as they didn't actually require 8.0.
+* Support setting model properties starting with the letter 'z'
 
 0.83.0 Release notes (2014-08-13)
 =============================================================

--- a/Realm/RLMProperty.m
+++ b/Realm/RLMProperty.m
@@ -64,9 +64,9 @@
         _getterName = _name;
     }
     if (!_setterName) {
-        // Objective-C setters only capitalize the first letter of the property name if it falls between 'A' and 'z'
+        // Objective-C setters only capitalize the first letter of the property name if it falls between 'a' and 'z'
         int asciiCode = [_name characterAtIndex:0];
-        BOOL shouldUppercase = asciiCode > 'A' && asciiCode < 'z';
+        BOOL shouldUppercase = asciiCode >= 'a' && asciiCode <= 'z';
         NSString *firstChar = [_name substringToIndex:1];
         firstChar = shouldUppercase ? firstChar.uppercaseString : firstChar;
         _setterName = [NSString stringWithFormat:@"set%@%@:", firstChar, [_name substringFromIndex:1]];


### PR DESCRIPTION
Fixes #809.

@alazier @tgoyne 
