### PR TITLE
[WIP] Implement the string predicates for link queries

### DIFF
--- a/Realm-Xcode6.xcodeproj/project.pbxproj
+++ b/Realm-Xcode6.xcodeproj/project.pbxproj
@@ -1481,7 +1481,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
@@ -1534,7 +1534,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;

--- a/Realm/Tests/QueryTests.m
+++ b/Realm/Tests/QueryTests.m
@@ -641,15 +641,11 @@
     XCTAssertEqual(1U, [StringObject objectsWhere:@"stringCol BEGINSWITH[c] 'a'"].count);
     XCTAssertEqual(1U, [StringObject objectsWhere:@"stringCol BEGINSWITH[c] 'A'"].count);
 
-#if 0 // FIXME: enable when support is added
     XCTAssertEqual(1U, [AllTypesObject objectsWhere:@"objectCol.stringCol BEGINSWITH 'a'"].count);
     XCTAssertEqual(0U, [AllTypesObject objectsWhere:@"objectCol.stringCol BEGINSWITH 'c'"].count);
     XCTAssertEqual(0U, [AllTypesObject objectsWhere:@"objectCol.stringCol BEGINSWITH 'A'"].count);
     XCTAssertEqual(1U, [AllTypesObject objectsWhere:@"objectCol.stringCol BEGINSWITH[c] 'a'"].count);
     XCTAssertEqual(1U, [AllTypesObject objectsWhere:@"objectCol.stringCol BEGINSWITH[c] 'A'"].count);
-#else
-    XCTAssertThrows([AllTypesObject objectsWhere:@"objectCol.stringCol BEGINSWITH 'a'"]);
-#endif
 }
 
 - (void)testStringEndsWith
@@ -671,15 +667,11 @@
     XCTAssertEqual(1U, [StringObject objectsWhere:@"stringCol ENDSWITH[c] 'c'"].count);
     XCTAssertEqual(1U, [StringObject objectsWhere:@"stringCol ENDSWITH[c] 'C'"].count);
 
-#if 0 // FIXME: enable when support is added
     XCTAssertEqual(1U, [AllTypesObject objectsWhere:@"objectCol.stringCol ENDSWITH 'c'"].count);
     XCTAssertEqual(0U, [AllTypesObject objectsWhere:@"objectCol.stringCol ENDSWITH 'a'"].count);
     XCTAssertEqual(0U, [AllTypesObject objectsWhere:@"objectCol.stringCol ENDSWITH 'C'"].count);
     XCTAssertEqual(1U, [AllTypesObject objectsWhere:@"objectCol.stringCol ENDSWITH[c] 'c'"].count);
     XCTAssertEqual(1U, [AllTypesObject objectsWhere:@"objectCol.stringCol ENDSWITH[c] 'C'"].count);
-#else
-    XCTAssertThrows([AllTypesObject objectsWhere:@"objectCol.stringCol ENDSWITH 'c'"]);
-#endif
 }
 
 - (void)testStringContains
@@ -705,15 +697,11 @@
     XCTAssertEqual(1U, [StringObject objectsWhere:@"stringCol CONTAINS[c] 'c'"].count);
     XCTAssertEqual(1U, [StringObject objectsWhere:@"stringCol CONTAINS[c] 'C'"].count);
 
-#if 0 // FIXME: enable when support is added
     XCTAssertEqual(0U, [AllTypesObject objectsWhere:@"objectCol.stringCol CONTAINS 'd'"].count);
     XCTAssertEqual(1U, [AllTypesObject objectsWhere:@"objectCol.stringCol CONTAINS 'c'"].count);
     XCTAssertEqual(0U, [AllTypesObject objectsWhere:@"objectCol.stringCol CONTAINS 'C'"].count);
     XCTAssertEqual(1U, [AllTypesObject objectsWhere:@"objectCol.stringCol CONTAINS[c] 'c'"].count);
     XCTAssertEqual(1U, [AllTypesObject objectsWhere:@"objectCol.stringCol CONTAINS[c] 'C'"].count);
-#else
-    XCTAssertThrows([AllTypesObject objectsWhere:@"objectCol.stringCol CONTAINS 'c'"]);
-#endif
 }
 
 - (void)testStringEquality
@@ -726,27 +714,24 @@
     [realm commitWriteTransaction];
 
     XCTAssertEqual(1U, [StringObject objectsWhere:@"stringCol == 'abc'"].count);
-    XCTAssertEqual(1U, [StringObject objectsWhere:@"stringCol != 'def'"].count);
+    XCTAssertEqual(1U, [StringObject objectsWhere:@"stringCol != 'ABC'"].count);
     XCTAssertEqual(1U, [StringObject objectsWhere:@"stringCol ==[c] 'abc'"].count);
     XCTAssertEqual(1U, [StringObject objectsWhere:@"stringCol ==[c] 'ABC'"].count);
 
     XCTAssertEqual(0U, [StringObject objectsWhere:@"stringCol != 'abc'"].count);
     XCTAssertEqual(0U, [StringObject objectsWhere:@"stringCol == 'def'"].count);
     XCTAssertEqual(0U, [StringObject objectsWhere:@"stringCol == 'ABC'"].count);
+    XCTAssertEqual(0U, [StringObject objectsWhere:@"stringCol !=[c] 'ABC'"].count);
 
     XCTAssertEqual(1U, [AllTypesObject objectsWhere:@"objectCol.stringCol == 'abc'"].count);
-    XCTAssertEqual(1U, [AllTypesObject objectsWhere:@"objectCol.stringCol != 'def'"].count);
-
-#if 0 // FIXME: enable when support is added
+    XCTAssertEqual(1U, [AllTypesObject objectsWhere:@"objectCol.stringCol != 'ABC'"].count);
     XCTAssertEqual(1U, [AllTypesObject objectsWhere:@"objectCol.stringCol ==[c] 'abc'"].count);
     XCTAssertEqual(1U, [AllTypesObject objectsWhere:@"objectCol.stringCol ==[c] 'ABC'"].count);
-#else
-    XCTAssertThrows([AllTypesObject objectsWhere:@"objectCol.stringCol ==[c] 'abc'"]);
-#endif
 
     XCTAssertEqual(0U, [AllTypesObject objectsWhere:@"objectCol.stringCol != 'abc'"].count);
     XCTAssertEqual(0U, [AllTypesObject objectsWhere:@"objectCol.stringCol == 'def'"].count);
     XCTAssertEqual(0U, [AllTypesObject objectsWhere:@"objectCol.stringCol == 'ABC'"].count);
+    XCTAssertEqual(0U, [AllTypesObject objectsWhere:@"objectCol.stringCol !=[c] 'ABC'"].count);
 }
 
 - (void)testStringIN
@@ -765,12 +750,8 @@
     XCTAssertEqual(0U, [StringObject objectsWhere:@"stringCol IN {'ABC'}"].count);
 
     XCTAssertEqual(1U, [AllTypesObject objectsWhere:@"objectCol.stringCol IN {'abc'}"].count);
-#if 0 // FIXME: enable when support is added
     XCTAssertEqual(1U, [AllTypesObject objectsWhere:@"objectCol.stringCol IN[c] {'abc'}"].count);
     XCTAssertEqual(1U, [AllTypesObject objectsWhere:@"objectCol.stringCol IN[c] {'ABC'}"].count);
-#else
-    XCTAssertThrows([AllTypesObject objectsWhere:@"objectCol.stringCol INc] {'abc'}"]);
-#endif
     XCTAssertEqual(0U, [AllTypesObject objectsWhere:@"objectCol.stringCol IN {'def'}"].count);
     XCTAssertEqual(0U, [AllTypesObject objectsWhere:@"objectCol.stringCol IN {'ABC'}"].count);
 }


### PR DESCRIPTION
This is pretty gross at the moment, but I thought I'd throw it up for comments on if this is even a reasonable thing to be doing at all. This adds implementations of the various string predicates currently not supported by the newer query expressions and manually builds query objects using them. Since it uses NSString's transformation methods it'd also make it easy to add support for NSDiacriticInsensitivePredicateOption.

@alazier @rrrlasse 
