### PR TITLE
[Proposal] Redesign in-memory realms

### DIFF
--- a/Realm/RLMRealm.h
+++ b/Realm/RLMRealm.h
@@ -60,7 +60,8 @@
  dispatch queues. You must get a separate RLMRealm instance for each thread and queue.
 
  @param path        Path to the file you want the data saved in.
- @param readonly    BOOL indicating if this Realm is readonly (must use for readonly files)
+ @param readonly    Whether to open the file in read-only mode. Cannot be mixed
+                    with opening the same file in read-write mode at the same time.
  @param error       Pass-by-reference for errors.
 
  @return An RLMRealm instance.
@@ -68,23 +69,63 @@
 + (instancetype)realmWithPath:(NSString *)path readOnly:(BOOL)readonly error:(NSError **)error;
 
 /**
- Make the default Realm in-memory only
+ Create a new in-memory Realm.
 
- By default, the default Realm is persisted to disk unless this method is called.
+ Unlike regular Realms, in-memory Realms are not persisted to disk. As a result,
+ this method always returns an entirely new Realm each time it is called and you
+ must explicitly hold a reference to it.
 
- @warning This must be called before any Realm instances are obtained (otherwise throws).
+ In-memory Realms can be used for testing, efficiently querying data sets, or
+ for sharing state between threads.
+
+ This function throws an exception if an error occurs while creating the Realm.
+
+ @warning   RLMRealm instances can only be used on the thread on which they were
+            created. When using an in-memory Realm on multiple threads or on
+            dispatch queues, call -realmForCurrentThread on an existing RLMRealm
+            instance to get an instance which can be used on the current thread.
  */
-+ (void)useInMemoryDefaultRealm;
++ (instancetype)memoryRealm;
 
 /**
- Path to the file where this Realm is persisted.
+ Create a new in-memory Realm.
+
+ Unlike regular Realms, in-memory Realms are not persisted to disk. As a result,
+ this method always returns an entirely new Realm each time it is called and you
+ must explicitly hold a reference to it.
+
+ In-memory Realms can be used for testing, efficiently querying data sets, or
+ for sharing state between threads.
+
+ @warning   RLMRealm instances can only be used on the thread on which they were
+            created. When using an in-memory Realm on multiple threads or on
+            dispatch queues, call -realmForCurrentThread on an existing RLMRealm
+            instance to get an instance which can be used on the current thread.
+ */
++ (instancetype)memoryRealmWithError:(NSError **)error;
+
+/**
+ Obtains an RLMRealm instance which can be used on the current thread.
+
+ This method is the only method which can be called on RLMRealm instances from
+ threads other than the one on which they were created. If the receiver was
+ created on the current thread it simply returns the receiver; otherwise it
+ returns a different RLMRealm insteance for the same file or backing memory
+ store.
+
+ As with the other RLMRealm creation methods, this will return the same RLMRealm
+ instance each time it is called for persisted realms, and new instances each
+ time for in-memory realms.
+ */
+- (instancetype)realmForCurrentThread;
+
+/**
+ Path to the file where this Realm is persisted, or nil for in-memory realms.
  */
 @property (nonatomic, readonly) NSString *path;
 
 /**
  Indicates if this Realm is read only
-
- @return    Boolean value indicating if this RLMRealm instance is readonly.
  */
 @property (nonatomic, readonly, getter = isReadOnly) BOOL readOnly;
 

--- a/Realm/Tests/RealmTests.m
+++ b/Realm/Tests/RealmTests.m
@@ -367,28 +367,6 @@
  }
  */
 
-- (void)testRealmInMemory
-{
-    RLMRealm *realmWithFile = [RLMRealm defaultRealm];
-    [realmWithFile beginWriteTransaction];
-    [StringObject createInRealm:realmWithFile withObject:@[@"a"]];
-    [realmWithFile commitWriteTransaction];
-    XCTAssertThrows([RLMRealm useInMemoryDefaultRealm], @"Realm instances already created");
-}
-
-- (void)testRealmInMemory2
-{
-    [RLMRealm useInMemoryDefaultRealm];
-    
-    RLMRealm *realmInMemory = [RLMRealm defaultRealm];
-    [realmInMemory beginWriteTransaction];
-    [StringObject createInRealm:realmInMemory withObject:@[@"a"]];
-    [StringObject createInRealm:realmInMemory withObject:@[@"b"]];
-    [StringObject createInRealm:realmInMemory withObject:@[@"c"]];
-    XCTAssertEqual([StringObject objectsInRealm:realmInMemory withPredicate:nil].count, (NSUInteger)3, @"Expecting 3 objects");
-    [realmInMemory commitWriteTransaction];
-}
-
 - (void)testRealmFileAccess
 {
     XCTAssertThrows([RLMRealm realmWithPath:nil], @"nil path");


### PR DESCRIPTION
The current design doesn't really work due to that the idea behind the default realm is that users don't need to pass around references to it, but an in-memory realm ceases to exist as soon as there's no RLMRealms referencing it. This new design abandons the idea of switching the default realm to in-memory, and instead lets the user create in-memory realms directly.

This adds two methods (plus variants of each with a NSError out parameter): +[RLMRealm createMemoryRealm] and -[RLMRealm realmForCurrentThread]. The former unconditionally creates an in-memory realm with an automatically generated backing path (i.e. a _different_ realm is created each time, with no caching). The latter returns the receiver if called on the correct thread, or a new RLMRealm instance with the same backing realm as the receiver if not (or a cached RLMRealm instance for persisted realms).

-[RLMRealm realmForCurrentThread] is needed due to that +[RLMRealm realmWithPath:] can't automatically detect that it's being given the path to an in-memory realm. We could make +[RLMRealm memoryRealmAtPath:] public, but that still makes it somewhat annoying to write a function which is passed a RLMRealm as a parameter (which may be either persisted or in-memory) and then dispatches to a background thread. Instead, -[RLMRealm path] returns nil so that the user is not mislead into thinking they can use realmWithPath: (and also just because in-memory realms having a path is an implementation detail that could confuse some users).

Once interprocess realm sharing is working, memoryRealmAtPath: should be made public and documented as being specifically for sharing realms between processes.

The documentation currently does not recommend using realmForCurrentThread for persisted realms. It has the potential to be more efficient than +[RLMRealm realmWithPath:] due to not needing any locks, but it has the downside of sometimes keeping the RLMRealm alive longer, and thus keeping its read transaction open. I also think that the style used in some of our tests of shadowing the main thread's realm object within the dispatched block may be less error prone than using a different name for the background realm.

The actual implementation of in-memory realms in this commit should be considered nothing more than a sanity check of the design.
