### PR TITLE
[BUG] Sorting a sorted RLMArray

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@
 * Support setting model properties starting with the letter 'z'
 * Fixed crashes that could result from switching between Debug and Relase
   builds of Realm.
+* Fixing incorrect result when sorting a sorted RLMArray.
+
 
 0.83.0 Release notes (2014-08-13)
 =============================================================

--- a/Realm/RLMArrayTableView.mm
+++ b/Realm/RLMArrayTableView.mm
@@ -206,8 +206,7 @@ static inline void RLMArrayTableViewValidateInWriteTransaction(RLMArrayTableView
 {
     RLMArrayTableViewValidate(self);
 
-    tightdb::Query query = _backingView.get_parent().where();
-    query.tableview(_backingView);
+    tightdb::Query query = _backingView.get_parent().where(&(_backingView));
     
     // apply order
     RLMArrayTableView *ar = [RLMArrayTableView arrayWithObjectClassName:self.objectClassName

--- a/Realm/Tests/ArrayPropertyTests.m
+++ b/Realm/Tests/ArrayPropertyTests.m
@@ -290,4 +290,43 @@
     OSSpinLockLock(&spinlock);
 }
 
+void sortingSortedView(id self, BOOL asc1, BOOL asc2) {
+    int N = 5;
+    RLMRealm *realm = [RLMRealm defaultRealm];
+    [realm beginWriteTransaction];
+    for(int i=0; i<N; i++) {
+        EmployeeObject *eo = [[EmployeeObject alloc] init];
+        eo.age = i;
+        eo.name = [NSString stringWithFormat:@"%10d", i];
+        [realm addObject:eo];
+    }
+    [realm commitWriteTransaction];
+
+    RLMArray *sortedAge = [[EmployeeObject allObjectsInRealm:realm] arraySortedByProperty:@"age" ascending:asc1];
+    RLMArray *sortedName = [sortedAge arraySortedByProperty:@"name" ascending:asc2];
+    XCTAssertEqual(sortedAge.count, (unsigned long)N);
+    XCTAssertEqual(sortedName.count, (unsigned long)N);
+}
+
+- (void)testSortingSortedView1
+{
+    sortingSortedView(self, TRUE, TRUE);
+}
+
+-(void)testSortingSortedView2
+{
+    sortingSortedView(self, TRUE, FALSE);
+}
+
+-(void)testSortingSortedView3
+{
+    sortingSortedView(self, FALSE, TRUE);
+}
+
+-(void)testSortingSortedView4
+{
+    sortingSortedView(self, FALSE, TRUE);
+}
+
+
 @end


### PR DESCRIPTION
Core's `Query::tableview` method should not be used as it does not support sorting a sorted view. 

See also https://github.com/willmoore/RealmTest for original bug report.

@alazier @tgoyne @jpsim 
