### PR TITLE
Fix copying RLMObjects between Realms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 * `-isEqual:` now uses the default `NSObject` implementation unless a primary key
   is specified for an RLMObject. When a primary key is specified, `-isEqual:` calls 
   `-isEqualToObject:` and a corresponding implementation for `-hash` is also implemented.
+* Fix adding RLMObjects persisted in one Realm to another Realm
 
 0.84.0 Release notes (2014-08-28)
 =============================================================

--- a/Realm/RLMAccessor.h
+++ b/Realm/RLMAccessor.h
@@ -16,8 +16,10 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-#import <Foundation/Foundation.h>
 #import "RLMRealm.h"
+
+#import <Foundation/Foundation.h>
+#import <tightdb/row.hpp>
 
 //
 // Accessors Class Creation/Caching
@@ -35,7 +37,7 @@ void RLMDynamicValidatedSet(RLMObject *obj, NSString *propName, id val);
 id RLMDynamicGet(RLMObject *obj, NSString *propName);
 
 // by property/column
-void RLMDynamicSet(RLMObject *obj, RLMProperty *prop, id val, bool enforceUnique, bool tryUpdate);
+void RLMDynamicSet(RLMRealm *realm, tightdb::Row &row, RLMProperty *prop, id val, bool enforceUnique, bool tryUpdate);
 
 //
 // Class modification

--- a/Realm/RLMArrayLinkView.mm
+++ b/Realm/RLMArrayLinkView.mm
@@ -38,6 +38,7 @@
     RLMArrayLinkView *ar = [[RLMArrayLinkView alloc] initViewWithObjectClassName:objectClassName];
     ar->_backingLinkView = view;
     ar->_realm = realm;
+
     return ar;
 }
 


### PR DESCRIPTION
This requires waiting to update the row accessor on the RLMObject until after all of the values have been copied, as otherwise the old values can't be read. Rather than requiring a temporary RLMObject, refactor the setters to take a Realm and a Row separately.

@alazier 
