### PR TITLE
Enable indexing string primary keys

### DIFF
--- a/Realm/RLMObject.h
+++ b/Realm/RLMObject.h
@@ -237,6 +237,7 @@
  Implement to designate a property as the primary key for an RLMObject subclass. Only properties of
  type RLMPropertyTypeString and RLMPropertyTypeInt can be designated as the primary key. Primary key 
  properties enforce uniqueness for each value whenever the property is set which incurs some overhead.
+ Indexes are created automatically for string primary key properties.
 
  @return    Name of the property designated as the primary key.
  */

--- a/Realm/RLMObjectSchema.mm
+++ b/Realm/RLMObjectSchema.mm
@@ -89,8 +89,10 @@
     if (NSString *primaryKey = [objectClass primaryKey]) {
         for (RLMProperty *prop in schema.properties) {
             if ([primaryKey isEqualToString:prop.name]) {
-                // FIXME - re-enable when we have core suppport
-                //attr = attr | RLMPropertyAttributeIndexed;
+                 // FIXME - enable for ints when we have core suppport
+                if (prop.type == RLMPropertyTypeString) {
+                    prop.attributes |= RLMPropertyAttributeIndexed;
+                }
                 schema.primaryKeyProperty = prop;
                 break;
             }

--- a/Realm/RLMProperty_Private.h
+++ b/Realm/RLMProperty_Private.h
@@ -34,6 +34,7 @@
 // private setters
 @property (nonatomic, assign) NSUInteger column;
 @property (nonatomic, readwrite, assign) RLMPropertyType type;
+@property (nonatomic, readwrite) RLMPropertyAttributes attributes;
 
 // private properties
 @property (nonatomic, copy) NSString *objcRawType;


### PR DESCRIPTION
Indexed columns appear to work correctly with core 0.82.3.

Depends on #887.

@alazier 
