### PR TITLE
Add the release packaging scripts to build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -567,7 +567,7 @@ EOF
 
         echo 'Packaging docs'
         sh tightdb_objc/build.sh package-docs
-        cp tightdb_objc/docs/output/0.84.0/realm-docs.tgz .
+        cp tightdb_objc/docs/output/*/realm-docs.tgz .
 
         echo 'Packaging examples'
         cd tightdb_objc/examples


### PR DESCRIPTION
This keeps the same release flow of Jenkins assembling tested artifacts into the final release package, and just moves the scripts for doing so into build.sh so that changes to the release packaging can be done via PRs. It also adds a test target which mimics the CI setup's assembly flow (but not any of the actual releasing parts) so that changes to the release tasks can be tested locally. Main goal of this is that #879 and #901 both need release packaging changes, and with the current setup it's hard to test those changes and synchronize them with when the PR is merged.

There should be only two functional changes from this: it doesn't generate the no-longer-used cocoapods package (since the podspec now builds from source), and a missing `--symlinks` was added to the examples zip creation that cuts the size of the final zip from 24MB to 14MB.

@alazier @emanuelez 
