### PR TITLE
Improve insertion performance a bit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+0.86.0 Release notes (YYYY-MM-DD)
+=============================================================
+
+### API breaking changes
+
+### Enhancements
+
+* Speed up inserting objects with `addObject:` by ~20%.
+
+### Bugfixes
+
 0.85.0 Release notes (2014-09-15)
 =============================================================
 

--- a/Realm/RLMAccessor.mm
+++ b/Realm/RLMAccessor.mm
@@ -398,9 +398,8 @@ static id RLMSuperGet(RLMObject *obj, NSString *propName) {
     typedef id (*getter_type)(RLMObject *, SEL);
     RLMProperty *prop = obj.objectSchema[propName];
     Class superClass = class_getSuperclass(obj.class);
-    SEL selector = NSSelectorFromString(prop.getterName);
-    getter_type superGetter = (getter_type)[superClass instanceMethodForSelector:selector];
-    return superGetter(obj, selector);
+    getter_type superGetter = (getter_type)[superClass instanceMethodForSelector:prop.getterSel];
+    return superGetter(obj, prop.getterSel);
 }
 
 // call setter for superclass for property at colIndex
@@ -408,9 +407,8 @@ static void RLMSuperSet(RLMObject *obj, NSString *propName, id val) {
     typedef id (*setter_type)(RLMObject *, SEL, RLMArray *ar);
     RLMProperty *prop = obj.objectSchema[propName];
     Class superClass = class_getSuperclass(obj.class);
-    SEL selector = NSSelectorFromString(prop.setterName);
-    setter_type superSetter = (setter_type)[superClass instanceMethodForSelector:selector];
-    superSetter(obj, selector, val);
+    setter_type superSetter = (setter_type)[superClass instanceMethodForSelector:prop.setterSel];
+    superSetter(obj, prop.setterSel, val);
 }
 
 // getter/setter for standalone
@@ -558,17 +556,15 @@ static Class RLMCreateAccessorClass(Class objectClass,
         RLMProperty *prop = schema.properties[propNum];
         char accessorCode = accessorCodeForType(prop.objcType, prop.type);
         if (getterGetter) {
-            SEL getterSel = NSSelectorFromString(prop.getterName);
             IMP getterImp = getterGetter(prop, accessorCode, prop.objectClassName);
             if (getterImp) {
-                class_replaceMethod(accClass, getterSel, getterImp, getterTypeStringForObjcCode(prop.objcType));
+                class_replaceMethod(accClass, prop.getterSel, getterImp, getterTypeStringForObjcCode(prop.objcType));
             }
         }
         if (setterGetter) {
-            SEL setterSel = NSSelectorFromString(prop.setterName);
             IMP setterImp = setterGetter(prop, accessorCode);
             if (setterImp) {
-                class_replaceMethod(accClass, setterSel, setterImp, setterTypeStringForObjcCode(prop.objcType));
+                class_replaceMethod(accClass, prop.setterSel, setterImp, setterTypeStringForObjcCode(prop.objcType));
             }
         }
     }

--- a/Realm/RLMObjectStore.mm
+++ b/Realm/RLMObjectStore.mm
@@ -293,7 +293,7 @@ void RLMAddObjectToRealm(RLMObject *object, RLMRealm *realm, bool update) {
     for (RLMProperty *prop in schema.properties) {
         // get object from ivar using key value coding
         id value = nil;
-        if ([object respondsToSelector:NSSelectorFromString(prop.getterName)]) {
+        if ([object respondsToSelector:prop.getterSel]) {
             value = [object valueForKey:prop.getterName];
         }
 

--- a/Realm/RLMProperty.m
+++ b/Realm/RLMProperty.m
@@ -55,6 +55,9 @@
         firstChar = shouldUppercase ? firstChar.uppercaseString : firstChar;
         _setterName = [NSString stringWithFormat:@"set%@%@:", firstChar, [_name substringFromIndex:1]];
     }
+
+    _getterSel = NSSelectorFromString(_getterName);
+    _setterSel = NSSelectorFromString(_setterName);
 }
 
 -(void)setObjcCodeFromType {

--- a/Realm/RLMProperty_Private.h
+++ b/Realm/RLMProperty_Private.h
@@ -42,6 +42,8 @@
 // getter and setter names
 @property (nonatomic, copy) NSString *getterName;
 @property (nonatomic, copy) NSString *setterName;
+@property (nonatomic) SEL getterSel;
+@property (nonatomic) SEL setterSel;
 @property (nonatomic, copy) NSString *objectClassName;
 @property (nonatomic, assign) BOOL isPrimary;
 


### PR DESCRIPTION
Cache the getter and setter selector on RLMProperty to avoid the NSSelectorFromString call. Speeds up adding objects via `addObject:` by  ~20%. Caching the setter selector doesn't help performance and is just done for symmetry.

@alazier 
