### PR TITLE
Automatically ignore readonly properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,13 @@
 ### Enhancements
 
 * Speed up inserting objects with `addObject:` by ~20%.
+* `readonly` properties are automatically ignored rather than having to be
+  added to `ignoredProperties`.
 
 ### Bugfixes
+
+* Fix error about not being able to persist property 'hash' with incompatible
+  type when building for devices with Xcode 6.
 
 0.85.0 Release notes (2014-09-15)
 =============================================================

--- a/Realm/RLMObjectSchema.mm
+++ b/Realm/RLMObjectSchema.mm
@@ -126,15 +126,20 @@
         }
 
         RLMPropertyAttributes atts = [objectClass attributesForProperty:propertyName];
+        RLMProperty *prop = nil;
         if (isSwiftClass) {
-            [propArray addObject:[[RLMProperty alloc] initSwiftPropertyWithName:propertyName
-                                                                     attributes:atts
-                                                                       property:props[i]
-                                                                       instance:swiftObjectInstance]];
+            prop = [[RLMProperty alloc] initSwiftPropertyWithName:propertyName
+                                                       attributes:atts
+                                                         property:props[i]
+                                                         instance:swiftObjectInstance];
         }
         else {
-            [propArray addObject:[[RLMProperty alloc] initWithName:propertyName attributes:atts property:props[i]]];
+            prop = [[RLMProperty alloc] initWithName:propertyName attributes:atts property:props[i]];
         }
+
+        if (prop) {
+            [propArray addObject:prop];
+         }
     }
     free(props);
 

--- a/Realm/Tests/ObjectTests.m
+++ b/Realm/Tests/ObjectTests.m
@@ -133,6 +133,10 @@ RLM_ARRAY_TYPE(PrimaryIntObject);
 }
 @end
 
+@interface ReadOnlyPropertyObject ()
+@property (readwrite) int readOnlyPropertyMadeReadWriteInClassExtension;
+@end
+
 #pragma mark - Private
 
 @interface RLMRealm ()
@@ -551,6 +555,20 @@ RLM_ARRAY_TYPE(PrimaryIntObject);
     
     XCTAssertEqualObjects(obj2.name, obj.name, @"persisted property should be the same");
     XCTAssertNil(obj2.url, @"ignored property should be nil when getting from realm");
+}
+
+- (void)testReadOnlyPropertiesImplicitlyIgnored
+{
+    RLMRealm *realm = [RLMRealm defaultRealm];
+
+    [realm beginWriteTransaction];
+    ReadOnlyPropertyObject *obj = [[ReadOnlyPropertyObject alloc] init];
+    obj.readOnlyPropertyMadeReadWriteInClassExtension = 5;
+    [realm addObject:obj];
+    [realm commitWriteTransaction];
+
+    obj = [[ReadOnlyPropertyObject allObjectsInRealm:realm] firstObject];
+    XCTAssertEqual(5, obj.readOnlyPropertyMadeReadWriteInClassExtension);
 }
 
 - (void)testCreateInRealmValidationForDictionary

--- a/Realm/Tests/RLMTestObjects.h
+++ b/Realm/Tests/RLMTestObjects.h
@@ -245,10 +245,14 @@ RLM_ARRAY_TYPE(CircleObject);
 
 @end
 
-
 @interface PrimaryStringObject : RLMObject
 @property NSString *stringCol;
 @property int intCol;
+@end
+
+@interface ReadOnlyPropertyObject : RLMObject
+@property (readonly) NSNumber *readOnlyUnsupportedProperty;
+@property (readonly) int readOnlyPropertyMadeReadWriteInClassExtension;
 @end
 
 

--- a/Realm/Tests/RLMTestObjects.m
+++ b/Realm/Tests/RLMTestObjects.m
@@ -133,3 +133,13 @@
     return @"stringCol";
 }
 @end
+
+@interface ReadOnlyPropertyObject ()
+@property (readwrite) int readOnlyPropertyMadeReadWriteInClassExtension;
+@end
+
+@implementation ReadOnlyPropertyObject
+- (NSNumber *)readOnlyUnsupportedProperty {
+    return nil;
+}
+@end


### PR DESCRIPTION
Readonly properties aren't persistable, so making the user explicitly ignore them is annoying. Also works around NSObject having some properties that used to be methods in the non-simulator iOS 8.0 SDK.

Fixes #905.

@alazier 
