### PR TITLE
Get the version in a way that actually works with Xcode 5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 * Fix error about not being able to persist property 'hash' with incompatible
   type when building for devices with Xcode 6.
+* Fix spurious notifications of new versions of Realm.
 
 0.85.0 Release notes (2014-09-15)
 =============================================================

--- a/Realm-Xcode6.xcodeproj/project.pbxproj
+++ b/Realm-Xcode6.xcodeproj/project.pbxproj
@@ -773,6 +773,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = E856D1E8195614A400FB2FCF /* Build configuration list for PBXNativeTarget "iOS" */;
 			buildPhases = (
+				3F69DF9E19CA0DF900607109 /* Get Version Number */,
 				E856D1EE1956151D00FB2FCF /* Download Core */,
 				E856D1D0195614A300FB2FCF /* Sources */,
 				E856D1D2195614A300FB2FCF /* Headers */,
@@ -956,6 +957,22 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		3F69DF9E19CA0DF900607109 /* Get Version Number */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(SRCROOT)/Realm/Realm-Info.plist",
+			);
+			name = "Get Version Number";
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/RLMVersion.h",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "echo \"#define REALM_VERSION @\\\"$(sh build.sh get-version)\\\"\" > ${DERIVED_FILE_DIR}/RLMVersion.h";
+		};
 		E81A1FB71955FCE700FDED82 /* Download Core */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -1315,8 +1332,8 @@
 				);
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
-					"/Applications/Xcode6-Beta2.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include",
 					core/include,
+					"$(DERIVED_FILE_DIR)",
 				);
 				INFOPLIST_FILE = "Realm/Realm-Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
@@ -1342,8 +1359,8 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
-					"/Applications/Xcode6-Beta2.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include",
 					core/include,
+					"$(DERIVED_FILE_DIR)",
 				);
 				INFOPLIST_FILE = "Realm/Realm-Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";

--- a/Realm.podspec
+++ b/Realm.podspec
@@ -21,7 +21,7 @@ Pod::Spec.new do |s|
   s.documentation_url       = "http://realm.io/docs/cocoa/#{s.version}"
   s.license                 = { :type => 'Apache 2.0', :file => 'LICENSE' }
 
-  s.compiler_flags          = "-DTIGHTDB_HAVE_CONFIG -DREALM_SWIFT=0 -DREALM_VERSION='\"#{s.version}\"'"
+  s.compiler_flags          = "-DTIGHTDB_HAVE_CONFIG -DREALM_SWIFT=0 -DREALM_VERSION='@\"#{s.version}\"'"
   s.prepare_command         = 'sh build.sh cocoapods-setup'
   s.private_header_files    = 'include-ios/**/*.hpp', 'include-osx/**/*.hpp', '**/*_Private.h'
   s.source_files            = 'Realm/*.{m,mm}', 'core/**/*.{h,hpp}'

--- a/Realm.xcodeproj/project.pbxproj
+++ b/Realm.xcodeproj/project.pbxproj
@@ -562,6 +562,7 @@
 			buildConfigurationList = 02C415211921B0C400F858D9 /* Build configuration list for PBXNativeTarget "iOS Library" */;
 			buildPhases = (
 				022C8BF719428A8F00BCDB9D /* Download Core */,
+				3F2DB62C19CA1083000AF071 /* Get Version Number */,
 				02C415011921B0C300F858D9 /* Sources */,
 				02C415021921B0C300F858D9 /* Frameworks */,
 				02C4154A1921BE3F00F858D9 /* Headers */,
@@ -696,6 +697,22 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "sh build.sh download-core";
+		};
+		3F2DB62C19CA1083000AF071 /* Get Version Number */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(SRCROOT)/Realm/Realm-Info.plist",
+			);
+			name = "Get Version Number";
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/RLMVersion.h",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "echo \"#define REALM_VERSION @\\\"$(sh build.sh get-version)\\\"\" > ${DERIVED_FILE_DIR}/RLMVersion.h";
 		};
 		421A994E1933648E00F5E4D4 /* Build Framework */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -1014,7 +1031,10 @@
 				GCC_WARN_UNDECLARED_SELECTOR = YES;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
-				HEADER_SEARCH_PATHS = "$(SRCROOT)/core/include";
+				HEADER_SEARCH_PATHS = (
+					"$(SRCROOT)/core/include",
+					"$(DERIVED_FILE_DIR)",
+				);
 				INFOPLIST_FILE = "Realm/Realm-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
 				LIBRARY_SEARCH_PATHS = "$(SRCROOT)/core";
@@ -1046,7 +1066,10 @@
 				GCC_WARN_UNDECLARED_SELECTOR = YES;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
-				HEADER_SEARCH_PATHS = "$(SRCROOT)/core/include";
+				HEADER_SEARCH_PATHS = (
+					"$(SRCROOT)/core/include",
+					"$(DERIVED_FILE_DIR)",
+				);
 				INFOPLIST_FILE = "Realm/Realm-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
 				LIBRARY_SEARCH_PATHS = "$(SRCROOT)/core";
@@ -1311,7 +1334,10 @@
 				GCC_WARN_UNDECLARED_SELECTOR = YES;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
-				HEADER_SEARCH_PATHS = "$(SRCROOT)/core/include";
+				HEADER_SEARCH_PATHS = (
+					"$(SRCROOT)/core/include",
+					"$(DERIVED_FILE_DIR)",
+				);
 				INFOPLIST_FILE = "Realm/Realm-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
 				LIBRARY_SEARCH_PATHS = "$(SRCROOT)/core";

--- a/Realm/RLMUpdateChecker.mm
+++ b/Realm/RLMUpdateChecker.mm
@@ -20,6 +20,10 @@
 
 #import "RLMRealm.h"
 
+#if TARGET_IPHONE_SIMULATOR && !defined(REALM_VERSION)
+#import "RLMVersion.h"
+#endif
+
 void RLMCheckForUpdates() {
 #if TARGET_IPHONE_SIMULATOR
     if (getenv("REALM_DISABLE_UPDATE_CHECKER")) {
@@ -33,13 +37,6 @@ void RLMCheckForUpdates() {
         return;
     }
 
-#ifdef REALM_VERSION
-    NSString *version = @REALM_VERSION;
-#else
-    NSBundle *bundle = [NSBundle bundleForClass:[RLMRealm class]];
-    NSString *version = [bundle objectForInfoDictionaryKey:(NSString *)kCFBundleVersionKey];
-#endif
-
     auto handler = ^(NSData *data, __unused NSURLResponse *response, NSError *error) {
         if (error) {
             NSLog(@"Failed to check for updates to Realm: %@", error);
@@ -47,14 +44,14 @@ void RLMCheckForUpdates() {
         }
 
         NSString *latestVersion = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
-        if (![version isEqualToString:latestVersion]) {
+        if (![REALM_VERSION isEqualToString:latestVersion]) {
             NSLog(@"Version %@ of Realm is now available: http://static.realm.io/downloads/cocoa/latest", latestVersion);
         }
 
         [settings setDouble:NSDate.timeIntervalSinceReferenceDate forKey:@"Last Update Check"];
     };
 
-    NSString *url = [NSString stringWithFormat:@"http://static.realm.io/update/cocoa?%@", version];
+    NSString *url = [NSString stringWithFormat:@"http://static.realm.io/update/cocoa?%@", REALM_VERSION];
     [[NSURLSession.sharedSession dataTaskWithURL:[NSURL URLWithString:url] completionHandler:handler] resume];
 #endif
 }


### PR DESCRIPTION
Getting the version number from the plist only works when Realm is built as a dynamic framework, as otherwise our plist doesn't actually end up in the final executable at all. As our release builds are currently built with Xcode 5 and thus not dynamic frameworks, this resulted in Realm reporting that an update was available on every check.

@alazier 
