### PR TITLE
Don't throw an exception when -description is called on a deleted object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 * `readonly` properties are automatically ignored rather than having to be
   added to `ignoredProperties`.
 * Updating to core library version 0.83.1.
+* Return "[deleted object]" rather than throwing an exception when
+  `-description` is called on a deleted RLMObject.
 
 ### Bugfixes
 

--- a/Realm/RLMObject.mm
+++ b/Realm/RLMObject.mm
@@ -208,6 +208,10 @@
 
 - (NSString *)description
 {
+    if (self.isDeletedFromRealm) {
+        return @"[deleted object]";
+    }
+
     return [self descriptionWithMaxDepth:5];
 }
 

--- a/Realm/Tests/ObjectTests.m
+++ b/Realm/Tests/ObjectTests.m
@@ -820,6 +820,18 @@ RLM_ARRAY_TYPE(PrimaryIntObject);
     XCTAssertNoThrow(obj.description);
 }
 
+- (void)testDeletedObjectDescription
+{
+    RLMRealm *realm = [RLMRealm defaultRealm];
+
+    [realm beginWriteTransaction];
+    EmployeeObject *obj = [EmployeeObject createInRealm:realm withObject:@[@"Peter", @30, @YES]];
+    [realm deleteObject:obj];
+    [realm commitWriteTransaction];
+
+    XCTAssertNoThrow(obj.description);
+}
+
 #pragma mark - Indexing Tests
 
 - (void)testIndex


### PR DESCRIPTION
Seems friendlier to just return a description indicating that the object is deleted instead.

Fix for #926
