### PR TITLE
Eliminate a Query deep copy when constructing RLMArrayTableView

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * Updating to core library version 0.83.1.
 * Return "[deleted object]" rather than throwing an exception when
   `-description` is called on a deleted RLMObject.
+* Significantly improve performance of very large queries.
 
 ### Bugfixes
 

--- a/Realm/RLMArrayTableView.mm
+++ b/Realm/RLMArrayTableView.mm
@@ -31,14 +31,18 @@
 //
 // RLMArray implementation
 //
-@implementation RLMArrayTableView
+@implementation RLMArrayTableView {
+    std::unique_ptr<tightdb::Query> _backingQuery;
+    tightdb::TableView _backingView;
+    BOOL _viewCreated;
+}
 
 + (instancetype)arrayWithObjectClassName:(NSString *)objectClassName
-                                   query:(tightdb::Query &)query
+                                   query:(std::unique_ptr<tightdb::Query>)query
                                   realm:(RLMRealm *)realm {
     RLMArrayTableView *ar = [[RLMArrayTableView alloc] initViewWithObjectClassName:objectClassName];
     ar->_viewCreated = NO;
-    ar->_backingQuery = query;
+    ar->_backingQuery = move(query);
     ar->_realm = realm;
     return ar;
 }
@@ -63,7 +67,7 @@
 static inline void RLMArrayTableViewValidateAttached(RLMArrayTableView *ar) {
     if (!ar->_viewCreated) {
         // create backing view if needed
-        ar->_backingView = ar->_backingQuery.find_all();
+        ar->_backingView = ar->_backingQuery->find_all();
         ar->_viewCreated = YES;
     }
     else {
@@ -100,7 +104,7 @@ static inline void RLMArrayTableViewValidateInWriteTransaction(RLMArrayTableView
     }
     else {
         RLMCheckThread(_realm);
-        return _backingQuery.count();
+        return _backingQuery->count();
     }
 }
 
@@ -220,9 +224,9 @@ static inline void RLMArrayTableViewValidateInWriteTransaction(RLMArrayTableView
     RLMArrayTableViewValidate(self);
 
     // copy array and apply new predicate creating a new query and view
-    tightdb::Query query(_backingQuery, tightdb::Query::TCopyExpressionTag{});
-    RLMUpdateQueryWithPredicate(&query, predicate, _realm.schema, _realm.schema[self.objectClassName]);
-    return [RLMArrayTableView arrayWithObjectClassName:self.objectClassName query:query realm:_realm];
+    auto query = std::make_unique<tightdb::Query>(*_backingQuery, tightdb::Query::TCopyExpressionTag{});
+    RLMUpdateQueryWithPredicate(query.get(), predicate, _realm.schema, _realm.schema[self.objectClassName]);
+    return [RLMArrayTableView arrayWithObjectClassName:self.objectClassName query:move(query) realm:_realm];
 }
 
 - (RLMArray *)arraySortedByProperty:(NSString *)property ascending:(BOOL)ascending
@@ -230,9 +234,9 @@ static inline void RLMArrayTableViewValidateInWriteTransaction(RLMArrayTableView
     RLMArrayTableViewValidate(self);
 
     // apply order
-    tightdb::Query query(_backingQuery, tightdb::Query::TCopyExpressionTag{});
+    auto query = std::make_unique<tightdb::Query>(*_backingQuery, tightdb::Query::TCopyExpressionTag{});
     RLMArrayTableView *ar = [RLMArrayTableView arrayWithObjectClassName:self.objectClassName
-                                                                  query:query
+                                                                  query:move(query)
                                                                   realm:_realm];
     // attach new table view
     RLMArrayTableViewValidateAttached(ar);

--- a/Realm/RLMArray_Private.hpp
+++ b/Realm/RLMArray_Private.hpp
@@ -81,13 +81,9 @@
 //
 // TableView backed RLMArray subclass
 //
-@interface RLMArrayTableView : RLMArray {
-    tightdb::Query _backingQuery;
-    tightdb::TableView _backingView;
-    BOOL _viewCreated;
-}
+@interface RLMArrayTableView : RLMArray
 + (instancetype)arrayWithObjectClassName:(NSString *)objectClassName
-                                   query:(tightdb::Query &)query
+                                   query:(std::unique_ptr<tightdb::Query>)query
                                    realm:(RLMRealm *)realm;
 
 + (instancetype)arrayWithObjectClassName:(NSString *)objectClassName

--- a/Realm/RLMObjectStore.mm
+++ b/Realm/RLMObjectStore.mm
@@ -387,7 +387,9 @@ RLMArray *RLMGetObjects(RLMRealm *realm, NSString *objectClassName, NSPredicate 
     RLMUpdateQueryWithPredicate(&query, predicate, realm.schema, objectSchema);
     
     // create and populate array
-    __autoreleasing RLMArray * array = [RLMArrayTableView arrayWithObjectClassName:objectClassName query:query realm:realm];
+    __autoreleasing RLMArray * array = [RLMArrayTableView arrayWithObjectClassName:objectClassName
+                                                                             query:std::make_unique<Query>(query)
+                                                                             realm:realm];
     return array;
 }
 


### PR DESCRIPTION
Query doesn't support move-assignment and obj-c++ requires that C++ data members of obj-c classes be default-constructed, so heap-allocate queries to eliminate the copy assignment.

Makes queries bound by the Query construction/destruction time roughly twice as fast.

@alazier 
