### PR TITLE
Only run Realm update checker if min required iOS version is >= iOS 7.0

### DIFF
--- a/Realm/RLMUpdateChecker.mm
+++ b/Realm/RLMUpdateChecker.mm
@@ -26,7 +26,7 @@
 
 void RLMCheckForUpdates() {
 #if TARGET_IPHONE_SIMULATOR
-    if (getenv("REALM_DISABLE_UPDATE_CHECKER") || ![[NSUserDefaults class] instancesRespondToSelector:@selector(initWithSuiteName:)]) {
+    if (getenv("REALM_DISABLE_UPDATE_CHECKER") || ![NSUserDefaults instancesRespondToSelector:@selector(initWithSuiteName:)]) {
         return;
     }
 


### PR DESCRIPTION
This will allow users to include Realm in iOS app projects targeting iOS 6.x ([see user group discussion](https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!msg/realm-cocoa/BPEsG53khI0/NsLuFplLukoJ)).

@tgoyne @alazier 
