### PR TITLE
small tweaks to changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,8 @@
 
 ### API breaking changes
 
-* Building `Realm.xcodeproj` requires Xcode 6 (Beta 5 & later). It is still possible to 
-  build Realm in Xcode 5 from CocoaPods. `Realm.framework` can still be used in Xcode 5 projects.
+* Xcode 6 is now supported from the main Xcode project `Realm.xcodeproj`.
+  Xcode 5 is no longer supported.
 
 ### Enhancements
 


### PR DESCRIPTION
Specifically the line about Xcode 6 could have been misinterpreted to mean that users couldn't use Realm in their Xcode 5 projects. @tgoyne @alazier 
