### PR TITLE
Fixes for using IN on array properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 * Trying to add a persisted RLMObject to a different Realm now throws an
   exception rather than creating an uninitialized object.
 * Fix validation errors when using IN on array properties.
+* Fix errors when an IN clause has zero items.
 
 0.85.0 Release notes (2014-09-15)
 =============================================================

--- a/Realm/RLMQueryUtil.mm
+++ b/Realm/RLMQueryUtil.mm
@@ -307,6 +307,20 @@ void process_or_group(Query &query, id array, Func&& func) {
 
         func(item);
     }
+
+    if (first) {
+        // Queries can't be empty, so if there's zero things in the OR group
+        // validation will fail. Work around this by adding an expression which
+        // will never find any rows in a table.
+        // FIXME: this should be supported by core in some way
+        struct FalseExpression : tightdb::Expression {
+            size_t find_first(size_t, size_t) const override { return tightdb::not_found; }
+            void set_table() override {}
+            const Table* get_table() override { return nullptr; }
+        };
+        query.expression(new FalseExpression);
+    }
+
     query.end_group();
 }
 

--- a/Realm/Tests/QueryTests.m
+++ b/Realm/Tests/QueryTests.m
@@ -1477,4 +1477,22 @@
     XCTAssertThrows(([[AllTypesObject objectsWhere:@"objectCol.stringCol IN[c] %@", @[@"ABC"]] count]));
 }
 
+- (void)testArrayIn
+{
+
+    RLMRealm *realm = [RLMRealm defaultRealm];
+    [realm beginWriteTransaction];
+
+    ArrayPropertyObject *arr = [ArrayPropertyObject createInRealm:realm withObject:@[@"name", @[], @[]]];
+    [arr.array addObject:[StringObject createInRealm:realm withObject:@[@"value"]]];
+    [realm commitWriteTransaction];
+
+
+    XCTAssertEqual(0U, ([[ArrayPropertyObject objectsWhere:@"ANY array.stringCol IN %@", @[@"missing"]] count]));
+    XCTAssertEqual(1U, ([[ArrayPropertyObject objectsWhere:@"ANY array.stringCol IN %@", @[@"value"]] count]));
+
+    XCTAssertEqual(0U, ([[ArrayPropertyObject objectsWhere:@"ANY array IN %@", [StringObject objectsWhere:@"stringCol = 'missing'"]] count]));
+    XCTAssertEqual(1U, ([[ArrayPropertyObject objectsWhere:@"ANY array IN %@", [StringObject objectsWhere:@"stringCol = 'value'"]] count]));
+}
+
 @end


### PR DESCRIPTION
I'll create an Asana ticket for a nicer way to handle empty queries, since none of the ideas mentioned actually work (without lots and lots of dumb code to construct a never matching query for every possible column type), and I'm not totally sure what it should even look like. Current workaround isn't too ugly at least.

Fixes #950.

@alazier 
