### PR TITLE
updated location of built Realm.framework for rubymotion example

### DIFF
--- a/examples/ios/rubymotion/Simple/Rakefile
+++ b/examples/ios/rubymotion/Simple/Rakefile
@@ -11,6 +11,6 @@ end
 Motion::Project::App.setup do |app|
   # Use `rake config' to see complete project settings.
   app.name = 'RealmRubyMotionSimpleExample'
-  app.vendor_project '../../../../build/Release/Realm.framework', :static, :products => ['Realm'], :force_load => false
-  app.vendor_project 'models', :static, :cflags => '-F ../../../../../build/Release/'
+  app.vendor_project '../../../../build/ios/Realm.framework', :static, :products => ['Realm']
+  app.vendor_project 'models', :static, :cflags => '-F ../../../../../build/ios/'
 end


### PR DESCRIPTION
We neglected to update the location of `Realm.framework` in the rubymotion example. However, the example no longer works, saying it can't find the `i386` version of the framework, even though `lipo` confirms it's in there.

![image](https://cloud.githubusercontent.com/assets/474794/4510483/e6195bb2-4b2a-11e4-8efe-9a9444693234.png)

I'm hoping @alloy can swoop in and shed some light on this.
