### PR TITLE
Get the accessor class name from the schema rather than the className method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+0.86.1 Release notes (2014-10-03)
+=============================================================
+
+### Bugfixes
+
+* Fix a bug which would sometimes result in subclassing RLMObject subclasses
+  not working.
+
 0.86.0 Release notes (2014-10-03)
 =============================================================
 

--- a/Realm/RLMAccessor.mm
+++ b/Realm/RLMAccessor.mm
@@ -555,8 +555,7 @@ static Class RLMCreateAccessorClass(Class objectClass,
     }
     
     // create and register proxy class which derives from object class
-    NSString *objectClassName = [objectClass className];
-    NSString *accessorClassName = [accessorClassPrefix stringByAppendingString:objectClassName];
+    NSString *accessorClassName = [accessorClassPrefix stringByAppendingString:schema.className];
     Class accClass = objc_getClass(accessorClassName.UTF8String);
     if (!accClass) {
         accClass = objc_allocateClassPair(objectClass, accessorClassName.UTF8String, 0);


### PR DESCRIPTION
Calling [objectClass className] returns the parent class's class name rather than the current class's if the parent class is initialized before the child, and the order that they're initialized depends on what order a dictionary happens to be enumerated.

@jpsim 
