### PR TITLE
Fix issues with building/packaging RealmBrowser.app with build.sh

### DIFF
--- a/tools/RealmBrowser/RealmBrowser.xcodeproj/project.pbxproj
+++ b/tools/RealmBrowser/RealmBrowser.xcodeproj/project.pbxproj
@@ -754,7 +754,7 @@
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)",
-					"/Users/jp/realm/code/realm-cocoa/build/DerivedData/Realm/Build/Products/Release",
+					"../../build/DerivedData/Realm/Build/Products/Release",
 				);
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "RealmBrowser/RealmBrowser-Prefix.pch";
@@ -778,7 +778,7 @@
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)",
-					"/Users/jp/realm/code/realm-cocoa/build/DerivedData/Realm/Build/Products/Release",
+					"../../build/DerivedData/Realm/Build/Products/Release",
 				);
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "RealmBrowser/RealmBrowser-Prefix.pch";


### PR DESCRIPTION
Instead of using `Realm.xcodeproj` as a subproject to `RealmBrowser.xcodeproj`, use the same approach as examples ("Realm" aggregate build phase that runs `sh build.sh osx` only if the framework isn't built).

Also copy `Realm.framework` into the resulting app bundle so the browser app is self-contained.

@tgoyne @alazier @GreatApe 
