### PR TITLE
Remove in-memory Realms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+0.87.0 Release notes (YYYY-MM-DD)
+=============================================================
+
+### API breaking changes
+
+* In-memory Realms have been removed. They will be re-added once they can
+  support use from multiple threads.
+
+### Enhancements
+
+### Bugfixes
+
 0.86.2 Release notes (2014-10-06)
 =============================================================
 

--- a/Realm/RLMRealm.h
+++ b/Realm/RLMRealm.h
@@ -94,24 +94,6 @@
 + (instancetype)realmWithPath:(NSString *)path readOnly:(BOOL)readonly error:(NSError **)error;
 
 /**
- Make the default Realm in-memory only.
-
- The default Realm is persisted to disk unless this method is called.
-
- Because in-memory Realms are not persisted, you must be sure to hold on to a
- reference to the `RLMRealm` object returned from this for as long as you want
- the data to last. Realm's internal cache of `RLMRealm`s will not keep the
- in-memory Realm alive across cycles of the run loop, so without a strong
- reference to the `RLMRealm` a new Realm will be created each time. Note that
- `RLMObject`s and `RLMArray`s that refer to objects persisted in a Realm have a
- strong reference to the relevant `RLMRealm`, as do `RLMNotifcationToken`s.
-
- @warning This must be called before any Realm instances are obtained. An
- exception will be thrown if a persisted default Realm already exists.
- */
-+ (void)useInMemoryDefaultRealm;
-
-/**
  Path to the file where this Realm is persisted.
  */
 @property (nonatomic, readonly) NSString *path;

--- a/Realm/RLMRealm.mm
+++ b/Realm/RLMRealm.mm
@@ -122,7 +122,6 @@ inline void clearRealmCache() {
     }
 }
 
-BOOL s_useInMemoryDefaultRealm = NO;
 NSString *s_defaultRealmPath = nil;
 NSArray *s_objectDescriptors = nil;
 
@@ -176,10 +175,6 @@ NSString * const c_defaultRealmFileName = @"default.realm";
             if (readonly) {
                 _readGroup = make_unique<Group>(path.UTF8String);
                 _group = _readGroup.get();
-            }
-            else if (s_useInMemoryDefaultRealm && [path isEqualToString:[RLMRealm defaultRealmPath]]) { // Only for default realm
-                _sharedGroup = make_unique<SharedGroup>(path.UTF8String, false, SharedGroup::durability_MemOnly);
-                _group = &const_cast<Group&>(_sharedGroup->begin_read());
             }
             else {
                 _writeLogs.reset(tightdb::getWriteLogs(path.UTF8String));
@@ -250,16 +245,6 @@ NSString * const c_defaultRealmFileName = @"default.realm";
 + (instancetype)defaultRealm
 {
     return [RLMRealm realmWithPath:[RLMRealm defaultRealmPath] readOnly:NO error:nil];
-}
-
-+ (void)useInMemoryDefaultRealm
-{
-    @synchronized(s_realmsPerPath) {
-        if (realmsAtPath([RLMRealm defaultRealmPath]).count) {
-            @throw [NSException exceptionWithName:@"RLMException" reason:@"Can only set default realm to use in Memory before creating or getting a default RLMRealm instance" userInfo:nil];
-        }
-    }
-    s_useInMemoryDefaultRealm = YES;
 }
 
 + (instancetype)realmWithPath:(NSString *)path

--- a/Realm/Tests/RealmTests.mm
+++ b/Realm/Tests/RealmTests.mm
@@ -445,28 +445,6 @@
     XCTAssertTrue(notificationFired);
 }
 
-- (void)testRealmInMemory
-{
-    RLMRealm *realmWithFile = [RLMRealm defaultRealm];
-    [realmWithFile beginWriteTransaction];
-    [StringObject createInRealm:realmWithFile withObject:@[@"a"]];
-    [realmWithFile commitWriteTransaction];
-    XCTAssertThrows([RLMRealm useInMemoryDefaultRealm], @"Realm instances already created");
-}
-
-- (void)testRealmInMemory2
-{
-    [RLMRealm useInMemoryDefaultRealm];
-
-    RLMRealm *realmInMemory = [RLMRealm defaultRealm];
-    [realmInMemory beginWriteTransaction];
-    [StringObject createInRealm:realmInMemory withObject:@[@"a"]];
-    [StringObject createInRealm:realmInMemory withObject:@[@"b"]];
-    [StringObject createInRealm:realmInMemory withObject:@[@"c"]];
-    XCTAssertEqual([StringObject objectsInRealm:realmInMemory withPredicate:nil].count, (NSUInteger)3, @"Expecting 3 objects");
-    [realmInMemory commitWriteTransaction];
-}
-
 - (void)testRealmFileAccess
 {
     XCTAssertThrows([RLMRealm realmWithPath:nil], @"nil path");


### PR DESCRIPTION
Until we get support for replication with in-memory Realms they're just a trap for the user that are very difficult to use usefully.
