### PR TITLE
Make the performance tests a bit more useful

### DIFF
--- a/Realm.xcodeproj/project.pbxproj
+++ b/Realm.xcodeproj/project.pbxproj
@@ -26,7 +26,6 @@
 		02B8EF5A19E601D80045A93D /* RLMResults.h in Headers */ = {isa = PBXBuildFile; fileRef = 02B8EF5819E601D80045A93D /* RLMResults.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		02B8EF5C19E7048D0045A93D /* RLMCollection.h in Headers */ = {isa = PBXBuildFile; fileRef = 02B8EF5B19E7048D0045A93D /* RLMCollection.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		02B8EF5D19E7048D0045A93D /* RLMCollection.h in Headers */ = {isa = PBXBuildFile; fileRef = 02B8EF5B19E7048D0045A93D /* RLMCollection.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		3F04EA2F1992BEE400C2CE2E /* PerformanceTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 3F04EA2D1992BEE400C2CE2E /* PerformanceTests.m */; };
 		3F20DA2219BE1EA6007DE308 /* RLMUpdateChecker.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 3F20DA2019BE1EA6007DE308 /* RLMUpdateChecker.hpp */; };
 		3F20DA2319BE1EA6007DE308 /* RLMUpdateChecker.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 3F20DA2019BE1EA6007DE308 /* RLMUpdateChecker.hpp */; };
 		3F20DA2419BE1EA6007DE308 /* RLMUpdateChecker.mm in Sources */ = {isa = PBXBuildFile; fileRef = 3F20DA2119BE1EA6007DE308 /* RLMUpdateChecker.mm */; };
@@ -972,7 +971,6 @@
 				3FDE338D19C39A87003B7DBA /* RLMSupport.swift in Sources */,
 				E856D21A195615A900FB2FCF /* ObjectInterfaceTests.m in Sources */,
 				E856D21B195615A900FB2FCF /* ObjectTests.m in Sources */,
-				3F04EA2F1992BEE400C2CE2E /* PerformanceTests.m in Sources */,
 				E856D21C195615A900FB2FCF /* PropertyTypeTest.mm in Sources */,
 				E856D21D195615A900FB2FCF /* QueryTests.m in Sources */,
 				E856D21E195615A900FB2FCF /* RealmTests.mm in Sources */,

--- a/Realm/Tests/PerformanceTests.m
+++ b/Realm/Tests/PerformanceTests.m
@@ -8,50 +8,27 @@
 
 #import "RLMTestCase.h"
 
+@interface IndexedStringObject : RLMObject
+@property NSString *stringCol;
+@end
+
+@implementation IndexedStringObject
++ (RLMPropertyAttributes)attributesForProperty:(__unused NSString *)propertyName
+{
+    return RLMPropertyAttributeIndexed;
+}
+@end
+
 @interface PerformanceTests : RLMTestCase
 @end
 
 @implementation PerformanceTests
 
-- (void)testArrayValidation {
-    // Create all of the objects outside the timed loop to reduce noise
-    NSMutableArray *arrays = [NSMutableArray arrayWithCapacity:10];
-    for (int i = 0; i < 10; ++i) {
-        NSMutableArray *subarray = [NSMutableArray arrayWithCapacity:1000];
-        for (int j = 0; j < 1000; ++j) {
-            StringObject *obj = [[StringObject alloc] init];
-            obj.stringCol = @"a";
-            [subarray addObject:obj];
-        }
-        [arrays addObject:subarray];
-    }
-
-    [self measureBlock:^{
-        ArrayPropertyObject *arrObj = [[ArrayPropertyObject alloc] init];
-        arrObj[@"array"] = [arrays lastObject];
-        [arrays removeLastObject];
-    }];
-}
-
-- (void)testInsertSingle {
-    [self measureBlock:^{
-        RLMRealm *realm = self.realmWithTestPath;
-        for (int i = 0; i < 100; ++i) {
-            [realm beginWriteTransaction];
-            StringObject *obj = [[StringObject alloc] init];
-            obj.stringCol = @"a";
-            [realm addObject:obj];
-            [realm commitWriteTransaction];
-        }
-        [self tearDown];
-    }];
-}
-
 - (void)testInsertMultiple {
     [self measureBlock:^{
         RLMRealm *realm = self.realmWithTestPath;
         [realm beginWriteTransaction];
-        for (int i = 0; i < 100; ++i) {
+        for (int i = 0; i < 5000; ++i) {
             StringObject *obj = [[StringObject alloc] init];
             obj.stringCol = @"a";
             [realm addObject:obj];
@@ -64,7 +41,7 @@
 - (void)testInsertSingleLiteral {
     [self measureBlock:^{
         RLMRealm *realm = self.realmWithTestPath;
-        for (int i = 0; i < 100; ++i) {
+        for (int i = 0; i < 500; ++i) {
             [realm beginWriteTransaction];
             [StringObject createInRealm:realm withObject:@[@"a"]];
             [realm commitWriteTransaction];
@@ -77,7 +54,7 @@
     [self measureBlock:^{
         RLMRealm *realm = self.realmWithTestPath;
         [realm beginWriteTransaction];
-        for (int i = 0; i < 100; ++i) {
+        for (int i = 0; i < 5000; ++i) {
             [StringObject createInRealm:realm withObject:@[@"a"]];
         }
         [realm commitWriteTransaction];
@@ -85,10 +62,10 @@
     }];
 }
 
-- (RLMRealm *)createStringObjects {
+- (RLMRealm *)createStringObjects:(int)factor {
     RLMRealm *realm = self.realmWithTestPath;
     [realm beginWriteTransaction];
-    for (int i = 0; i < 1000; ++i) {
+    for (int i = 0; i < 1000 * factor; ++i) {
         [StringObject createInRealm:realm withObject:@[@"a"]];
         [StringObject createInRealm:realm withObject:@[@"b"]];
     }
@@ -98,15 +75,15 @@
 }
 
 - (void)testCountWhereQuery {
-    RLMRealm *realm = [self createStringObjects];
+    RLMRealm *realm = [self createStringObjects:50];
     [self measureBlock:^{
         RLMResults *array = [StringObject objectsInRealm:realm where:@"stringCol = 'a'"];
         [array count];
     }];
 }
 
-- (void)testCountWhereTable {
-    RLMRealm *realm = [self createStringObjects];
+- (void)testCountWhereTableView {
+    RLMRealm *realm = [self createStringObjects:50];
     [self measureBlock:^{
         RLMResults *array = [StringObject objectsInRealm:realm where:@"stringCol = 'a'"];
         [array firstObject]; // Force materialization of backing table view
@@ -114,17 +91,8 @@
     }];
 }
 
-- (void)testCountWhereTablePrematerialized {
-    RLMRealm *realm = [self createStringObjects];
-    RLMResults *results = [StringObject objectsInRealm:realm where:@"stringCol = 'a'"];
-    [results firstObject]; // Force materialization of backing table view
-    [self measureBlock:^{
-        [results count];
-    }];
-}
-
 - (void)testEnumerateAndAccessQuery {
-    RLMRealm *realm = [self createStringObjects];
+    RLMRealm *realm = [self createStringObjects:5];
 
     [self measureBlock:^{
         for (StringObject *so in [StringObject objectsInRealm:realm where:@"stringCol = 'a'"]) {
@@ -134,7 +102,7 @@
 }
 
 - (void)testEnumerateAndAccessAll {
-    RLMRealm *realm = [self createStringObjects];
+    RLMRealm *realm = [self createStringObjects:5];
 
     [self measureBlock:^{
         for (StringObject *so in [StringObject allObjectsInRealm:realm]) {
@@ -143,12 +111,24 @@
     }];
 }
 
+- (void)testEnumerateAndAccessAllSlow {
+    RLMRealm *realm = [self createStringObjects:5];
+
+    [self measureBlock:^{
+        RLMResults *all = [StringObject allObjectsInRealm:realm];
+        for (NSUInteger i = 0; i < all.count; ++i) {
+            (void)[all[i] stringCol];
+
+        }
+    }];
+}
+
 - (void)testEnumerateAndAccessArrayProperty {
-    RLMRealm *realm = [self createStringObjects];
+    RLMRealm *realm = [self createStringObjects:5];
 
     [realm beginWriteTransaction];
     ArrayPropertyObject *apo = [ArrayPropertyObject createInRealm:realm
-                                                       withObject:@[@"name", [StringObject allObjects], @[]]];
+                                                       withObject:@[@"name", [StringObject allObjectsInRealm:realm], @[]]];
     [realm commitWriteTransaction];
 
     [self measureBlock:^{
@@ -158,8 +138,24 @@
     }];
 }
 
+- (void)testEnumerateAndAccessArrayPropertySlow {
+    RLMRealm *realm = [self createStringObjects:5];
+
+    [realm beginWriteTransaction];
+    ArrayPropertyObject *apo = [ArrayPropertyObject createInRealm:realm
+                                                       withObject:@[@"name", [StringObject allObjectsInRealm:realm], @[]]];
+    [realm commitWriteTransaction];
+
+    [self measureBlock:^{
+        RLMArray *array = apo.array;
+        for (NSUInteger i = 0; i < array.count; ++i) {
+            (void)[array[i] stringCol];
+        }
+    }];
+}
+
 - (void)testEnumerateAndMutate {
-    RLMRealm *realm = [self createStringObjects];
+    RLMRealm *realm = [self createStringObjects:1];
 
     [self measureBlock:^{
         [realm beginWriteTransaction];
@@ -178,6 +174,111 @@
         for (int i = 0; i < 100; ++i) {
             [AllTypesObject objectsInRealm:realm withPredicate:predicate];
         }
+    }];
+}
+
+- (void)testQueryDeletion {
+    RLMRealm *realm = self.realmWithTestPath;
+
+    [self measureMetrics:self.class.defaultPerformanceMetrics automaticallyStartMeasuring:NO forBlock:^{
+        [realm beginWriteTransaction];
+        for (int i = 0; i < 5000; ++i) {
+            [StringObject createInRealm:realm withObject:@[@"a"]];
+        }
+        [realm commitWriteTransaction];
+
+        [self startMeasuring];
+        [realm beginWriteTransaction];
+        [realm deleteObjects:[StringObject allObjectsInRealm:realm]];
+        [realm commitWriteTransaction];
+        [self stopMeasuring];
+    }];
+}
+
+- (void)testManualDeletion {
+    RLMRealm *realm = self.realmWithTestPath;
+
+    [self measureMetrics:self.class.defaultPerformanceMetrics automaticallyStartMeasuring:NO forBlock:^{
+        [realm beginWriteTransaction];
+        for (int i = 0; i < 5000; ++i) {
+            [StringObject createInRealm:realm withObject:@[@"a"]];
+        }
+        [realm commitWriteTransaction];
+
+        NSMutableArray *objects = [NSMutableArray arrayWithCapacity:5000];
+        for (StringObject *obj in [StringObject allObjectsInRealm:realm]) {
+            [objects addObject:obj];
+        }
+
+        [self startMeasuring];
+        [realm beginWriteTransaction];
+        [realm deleteObjects:objects];
+        [realm commitWriteTransaction];
+        [self stopMeasuring];
+    }];
+}
+
+- (void)testUnIndexedStringLookup {
+    RLMRealm *realm = self.realmWithTestPath;
+    [realm beginWriteTransaction];
+    for (int i = 0; i < 1000; ++i) {
+        [StringObject createInRealm:realm withObject:@[@(i).stringValue]];
+    }
+    [realm commitWriteTransaction];
+
+    [self measureBlock:^{
+        for (int i = 0; i < 1000; ++i) {
+            [[StringObject objectsInRealm:realm where:@"stringCol = %@", @(i).stringValue] firstObject];
+        }
+    }];
+}
+
+- (void)testIndexedStringLookup {
+    RLMRealm *realm = self.realmWithTestPath;
+    [realm beginWriteTransaction];
+    for (int i = 0; i < 1000; ++i) {
+        [IndexedStringObject createInRealm:realm withObject:@[@(i).stringValue]];
+    }
+    [realm commitWriteTransaction];
+
+    [self measureBlock:^{
+        for (int i = 0; i < 1000; ++i) {
+            [[IndexedStringObject objectsInRealm:realm where:@"stringCol = %@", @(i).stringValue] firstObject];
+        }
+    }];
+}
+
+- (void)testLargeINQuery {
+    RLMRealm *realm = self.realmWithTestPath;
+    [realm beginWriteTransaction];
+    NSMutableArray *ids = [NSMutableArray arrayWithCapacity:1000];
+    for (int i = 0; i < 2000; ++i) {
+        [IntObject createInRealm:realm withObject:@[@(i)]];
+        if (i % 2) {
+            [ids addObject:@(i)];
+        }
+    }
+    [realm commitWriteTransaction];
+
+    [self measureBlock:^{
+        (void)[[IntObject objectsInRealm:realm where:@"intCol IN %@", ids] firstObject];
+    }];
+}
+
+- (void)testRealmCreation {
+    [self realmWithTestPath]; // ensure a cached realm for the path
+
+    dispatch_queue_t queue = dispatch_queue_create("test queue", 0);
+    [self measureBlock:^{
+        for (int i = 0; i < 250; ++i) {
+            dispatch_async(queue, ^{
+                @autoreleasepool {
+                    [self realmWithTestPath];
+                }
+            });
+        }
+
+        dispatch_sync(queue, ^{});
     }];
 }
 


### PR DESCRIPTION
- Remove some that weren't testing anything interesting.
- Adjust the amount of work done in each test to get the standard deviations for all of the tests under 5%.
- Only run the performance tests in the iOS Device Tests target as the speed in the simulator isn't very interesting and they take a while to run.
- Add a few new tests.

This gets the performance tests to a state where adding a baseline for the device plugged into the CI machine and having it complain when performance regresses too much might be practical. Main thing left to figure out is how to go about _updating_ the baseline after making a change that should modify performance.
