### PR TITLE
Add tests for schema init with inheritance

### DIFF
--- a/Realm/Tests/RLMTestCase.h
+++ b/Realm/Tests/RLMTestCase.h
@@ -36,4 +36,6 @@ NSString *RLMRealmPathForFile(NSString *);
 - (RLMRealm *)realmWithTestPathAndSchema:(RLMSchema *)schema;
 - (RLMRealm *)dynamicRealmWithTestPathAndSchema:(RLMSchema *)schema;
 
++ (void)deleteFiles;
+
 @end

--- a/Realm/Tests/RLMTestCase.m
+++ b/Realm/Tests/RLMTestCase.m
@@ -82,7 +82,10 @@ static void RLMDeleteRealmFilesAtPath(NSString *path) {
 + (void)tearDown
 {
     [super tearDown];
+    [self deleteFiles];
+}
 
++ (void)deleteFiles {
     // Clear cache
     [RLMRealm clearRealmCache];
     


### PR DESCRIPTION
Tries to test the schema initialization with every permutation of orderings for the relevant classes. I failed to find a way to reproduce any of the issues reported post-0.86.3, but this does at least fail without the fixes in both 0.86.1 and 0.86.3, both of which previously had no regression tests.

@alazier 
