### PR TITLE
Fix errors when rearranging properties in model classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@
 
 ### Bugfixes
 
+* Fix exceptions when trying to set `RLMObject` properties after rearranging
+  the properties in a `RLMObject` subclass.
+
 0.86.3 Release notes (2014-10-09)
 =============================================================
 

--- a/Realm/RLMObjectStore.mm
+++ b/Realm/RLMObjectStore.mm
@@ -39,9 +39,11 @@ static void RLMVerifyAndAlignColumns(RLMObjectSchema *tableSchema, RLMObjectSche
                                      userInfo:nil];
     }
 
+    NSMutableArray *properties = [NSMutableArray arrayWithCapacity:objectSchema.properties.count];
+
     // check to see if properties are the same
-    for (RLMProperty *schemaProp in objectSchema.properties) {
-        RLMProperty *tableProp = tableSchema[schemaProp.name];
+    for (RLMProperty *tableProp in tableSchema.properties) {
+        RLMProperty *schemaProp = objectSchema[tableProp.name];
         if (![tableProp.name isEqualToString:schemaProp.name]) {
             @throw [NSException exceptionWithName:@"RLMException"
                                            reason:@"Existing property does not match interface - migration required"
@@ -73,7 +75,11 @@ static void RLMVerifyAndAlignColumns(RLMObjectSchema *tableSchema, RLMObjectSche
 
         // align
         schemaProp.column = tableProp.column;
+        [properties addObject:schemaProp];
     }
+
+    // ensure the order of the properties matches the column order in the table
+    objectSchema.properties = properties;
 }
 
 // create a column for a property in a table

--- a/Realm/Tests/MigrationTests.mm
+++ b/Realm/Tests/MigrationTests.mm
@@ -159,7 +159,9 @@ extern "C" {
     // verify migration
     realm = [self realmWithTestPath];
     MigrationObject *mig1 = [MigrationObject allObjectsInRealm:realm][1];
-    XCTAssertThrows(mig1[@"deletedCol"], @"Deleted column should no longer be accessible.");
+    XCTAssertThrows(mig1[@"oldIntCol"], @"Deleted column should no longer be accessible.");
+    XCTAssertEqual(0U, [mig1.objectSchema.properties[0] column]);
+    XCTAssertEqual(1U, [mig1.objectSchema.properties[1] column]);
 }
 
 - (void)testChangePropertyType {
@@ -253,6 +255,31 @@ extern "C" {
         }];
         return oldSchemaVersion;
     }]);
+}
+
+- (void)testRearrangeProperties {
+    // create realm with the properties reversed
+    @autoreleasepool {
+        RLMSchema *schema = [[RLMSchema sharedSchema] copy];
+        RLMObjectSchema *objectSchema = schema[@"CircleObject"];
+        objectSchema.properties = @[objectSchema.properties[1], objectSchema.properties[0]];
+
+        RLMRealm *realm = [self realmWithTestPathAndSchema:schema];
+        [realm beginWriteTransaction];
+        [realm createObject:CircleObject.className withObject:@[NSNull.null, @"data"]];
+        [realm commitWriteTransaction];
+    }
+
+    // migration should not be requried
+    RLMRealm *realm = nil;
+    XCTAssertNoThrow(realm = [self realmWithTestPath]);
+
+    // accessors should work
+    CircleObject *obj = [[CircleObject allObjectsInRealm:realm] firstObject];
+    [realm beginWriteTransaction];
+    XCTAssertNoThrow(obj.data = @"new data");
+    XCTAssertNoThrow(obj.next = obj);
+    [realm commitWriteTransaction];
 }
 
 @end


### PR DESCRIPTION
Ensure that the order of properties in the object schema matches the order of columns, as the validation code for setting link properties assumes that they match.

@alazier 
