### PR TITLE
Speed up creating RLMRealm instances on background threads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@
 * Updating to core library version 0.85.0.
 * Implement `objectsWhere:` and `objectsWithPredicate:` for array properties.
 * Add `cancelWriteTransaction` to revert all changes made in a write transaction and end the transaction.
+* Make creating `RLMRealm` instances on background threads when an instance
+  exists on another thread take a fifth of the time.
 
 ### Bugfixes
 

--- a/Realm/RLMObjectSchema.mm
+++ b/Realm/RLMObjectSchema.mm
@@ -48,7 +48,7 @@
 
 // create property map when setting property array
 -(void)setProperties:(NSArray *)properties {
-    NSMutableDictionary *map = [NSMutableDictionary dictionaryWithCapacity:_properties.count];
+    NSMutableDictionary *map = [NSMutableDictionary dictionaryWithCapacity:properties.count];
     for (RLMProperty *prop in properties) {
         map[prop.name] = prop;
     }
@@ -213,10 +213,15 @@
 
 - (id)copyWithZone:(NSZone *)zone {
     RLMObjectSchema *schema = [[RLMObjectSchema allocWithZone:zone] init];
-    schema.properties = self.properties;
-    schema.objectClass = self.objectClass;
-    schema.className = self.className;
-    schema.primaryKeyProperty = schema[_primaryKeyProperty.name];
+    schema->_properties = _properties;
+    schema->_propertiesByName = _propertiesByName;
+    schema->_objectClass = _objectClass;
+    schema->_className = _className;
+    schema->_objectClass = _objectClass;
+    schema->_accessorClass = _accessorClass;
+    schema->_standaloneClass = _standaloneClass;
+    schema.primaryKeyProperty = _primaryKeyProperty;
+    // _table not copied as it's tightdb::Group-specific
     return schema;
 }
 

--- a/Realm/RLMObjectStore.mm
+++ b/Realm/RLMObjectStore.mm
@@ -113,13 +113,13 @@ void RLMRealmSetSchema(RLMRealm *realm, RLMSchema *targetSchema, bool verify) {
     for (RLMObjectSchema *objectSchema in realm.schema.objectSchema) {
         // read-only realms may be missing tables entirely
         objectSchema->_table = RLMTableForObjectClass(realm, objectSchema.className);
-        if (objectSchema->_table) {
+        if (objectSchema->_table && verify) {
             RLMObjectSchema *tableSchema = [RLMObjectSchema schemaFromTableForClassName:objectSchema.className realm:realm];
-            if (verify) {
-                RLMVerifyAndAlignColumns(tableSchema, objectSchema);
-            }
+            RLMVerifyAndAlignColumns(tableSchema, objectSchema);
         }
-        objectSchema.accessorClass = RLMAccessorClassForObjectClass(objectSchema.objectClass, objectSchema);
+        if (!objectSchema.accessorClass) {
+            objectSchema.accessorClass = RLMAccessorClassForObjectClass(objectSchema.objectClass, objectSchema);
+        }
     }
 }
 

--- a/Realm/RLMRealm.mm
+++ b/Realm/RLMRealm.mm
@@ -362,8 +362,8 @@ NSString * const c_defaultRealmFileName = @"default.realm";
                 // advance read in case another instance initialized the schema
                 LangBindHelper::advance_read(*realm->_sharedGroup, *realm->_writeLogs);
 
-                // if we have a cached realm on another thread, copy and verify without a transaction
-                RLMRealmSetSchema(realm, [realms[0] schema]);
+                // if we have a cached realm on another thread, copy without a transaction
+                RLMRealmSetSchema(realm, [realms[0] schema], false);
             }
             else {
                 // if we are the first realm at this path, set/align schema or perform migration if needed


### PR DESCRIPTION
Cuts the init time when there's a cached RLMRealm for a different thread from 3ms to 1.2ms.

Most of the remaining runtime is spent on validating that the table schema matches the object schema, which can probably be skipped, but not touching that file to avoid conflicts with other stuff in progress.

@alazier 
