### PR TITLE
[RubyMotion] Specify the Realm framework as a framework instead.

### DIFF
--- a/examples/ios/rubymotion/Simple/Rakefile
+++ b/examples/ios/rubymotion/Simple/Rakefile
@@ -11,6 +11,6 @@ end
 Motion::Project::App.setup do |app|
   # Use `rake config' to see complete project settings.
   app.name = 'RealmRubyMotionSimpleExample'
-  app.vendor_project '../../../../build/ios/Realm.framework', :static, :products => ['Realm'], :force_load => false
+  app.external_frameworks << '../../../../build/ios/Realm.framework'
   app.vendor_project 'models', :static, :cflags => '-F ../../../../../build/ios/'
 end


### PR DESCRIPTION
(NOTE: I never sign CLAs, so you’ll probably have to manually apply this fix, which I give you total permission for. The fix is so short that it can reasonably be assumed to be under fair-use and it’s not even any code, just proper configuration.)

Fixes #981.

This will still link the objects in the static archive (the fake
framework) into the application binary, but it will also setup the
frameworks search path during the application linking phase so that
`Realm.framework` can be found.

This last part is important, because the `models` static library, which
is built with clang modules enabled (the default), will contain a linker
load flag that tells the linker to also load `Realm.framework` when
linking the `models` static library and if at that time (the application
linking phase) `Realm.framework` cannot be found in any frameworks
search paths, an unhelpful error like the following will be raised:

```
ld: framework not found Realm for architecture i386
```

The linker load flag (`LC_LINKER_OPTION`) that gets added to the
`models` static library and that triggers the loading of
`Realm.framework` is the following:

```
otool -l models/build-iPhoneSimulator/libmodels.a
…
Load command 10
     cmd LC_LINKER_OPTION
 cmdsize 32
   count 2
  string #1 -framework
  string #2 Realm
…
```
