### PR TITLE
Fix crash in RLMSuperSet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 * Preserve the sort order when querying a sorted `RLMResults`.
 * Fixed an issue with migrations where if a Realm file is deleted after a Realm is initialized,
   the newly created Realm can be initialized with an incorrect schema version.
+* Fix crash in `RLMSuperSet` when assigning to a `RLMArray` property on a standalone object.
 
 0.86.3 Release notes (2014-10-09)
 =============================================================

--- a/Realm/RLMAccessor.mm
+++ b/Realm/RLMAccessor.mm
@@ -417,7 +417,7 @@ static id RLMSuperGet(RLMObject *obj, NSString *propName) {
 
 // call setter for superclass for property at colIndex
 static void RLMSuperSet(RLMObject *obj, NSString *propName, id val) {
-    typedef id (*setter_type)(RLMObject *, SEL, RLMArray *ar);
+    typedef void (*setter_type)(RLMObject *, SEL, RLMArray *ar);
     RLMProperty *prop = obj.objectSchema[propName];
     Class superClass = class_getSuperclass(obj.class);
     setter_type superSetter = (setter_type)[superClass instanceMethodForSelector:prop.setterSel];


### PR DESCRIPTION
Setters return void, not id.

Closes #1033 and #1038.

@alazier 
