### PR TITLE
[RubyMotion] Specify the Realm framework as a framework instead.

### DIFF
--- a/examples/ios/rubymotion/Simple/Rakefile
+++ b/examples/ios/rubymotion/Simple/Rakefile
@@ -11,6 +11,6 @@ end
 Motion::Project::App.setup do |app|
   # Use `rake config' to see complete project settings.
   app.name = 'RealmRubyMotionSimpleExample'
-  app.vendor_project '../../../../build/ios/Realm.framework', :static, :products => ['Realm'], :force_load => false
+  app.external_frameworks << '../../../../build/ios/Realm.framework'
   app.vendor_project 'models', :static, :cflags => '-F ../../../../../build/ios/'
 end


### PR DESCRIPTION
Thanks to @alloy for this fix. I've confirmed it works locally. Original PR here #1037, but couldn't be merged directly because CLA.

Fixes #981.

![image](https://cloud.githubusercontent.com/assets/474794/4684107/3423529c-562d-11e4-8716-3069c86ae841.png)
