### PR TITLE
Remove magic number in RLMClassForTableName method

### DIFF
--- a/Realm/RLMSchema_Private.h
+++ b/Realm/RLMSchema_Private.h
@@ -35,7 +35,7 @@ extern const NSUInteger RLMNotVersioned;
 
 inline NSString *RLMClassForTableName(NSString *tableName) {
     if ([tableName hasPrefix:c_objectTableNamePrefix]) {
-        return [tableName substringFromIndex:6];
+        return [tableName substringFromIndex:c_objectTableNamePrefix.length];
     }
     return nil;
 }


### PR DESCRIPTION
I think this is more proper because c_objectTableNamePrefix is constants, So There is a possibility that the change. Sorry for being so fussy.
