### PR TITLE
Reuse existing persisted objects passed to createInRealm:withObject:

### DIFF
--- a/Realm/Tests/ArrayPropertyTests.m
+++ b/Realm/Tests/ArrayPropertyTests.m
@@ -20,10 +20,6 @@
 
 #import <libkern/OSAtomic.h>
 
-@interface DogArrayObject : RLMObject
-@property RLMArray<DogObject> *dogs;
-@end
-
 @implementation DogArrayObject
 @end
 

--- a/Realm/Tests/RLMTestObjects.h
+++ b/Realm/Tests/RLMTestObjects.h
@@ -142,6 +142,11 @@ RLM_ARRAY_TYPE(EmployeeObject)
 
 RLM_ARRAY_TYPE(DogObject)
 
+@interface DogArrayObject : RLMObject
+@property RLMArray<DogObject> *dogs;
+@end
+
+
 #pragma mark OwnerObject
 
 @interface OwnerObject : RLMObject


### PR DESCRIPTION
Link to the existing objects in the Realm if they're of the correct type and in the Realm, and copy them otherwise.

I'm not totally convinced this is the right behavior, but I spent a depressingly long time trying to figure out why some tests I wrote weren't working before I realized that I was expecting this behavior rather than it linking to copies of the objects passed in the literal.

Either way there needs to be tests, as changing this didn't break any of the existing tests...

@alazier @jpsim 
