### PR TITLE
Fixed an issue where the default realm file could sometimes not be created on OS X. Reverts 54da5a.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ x.x.x Release notes (yyyy-MM-dd)
   in a database created using an older versions (0.86.3 and earlier).
 * Throw an exception when passing an array containing a
   non-RLMObject to -[RLMRealm addObjects:].
+* Fixed an issue where the default realm file could sometimes not be created on OS X.
 
 
 0.87.0 Release notes (2014-10-21)

--- a/Realm/RLMRealm.mm
+++ b/Realm/RLMRealm.mm
@@ -252,7 +252,7 @@ NSString * const c_defaultRealmFileName = @"default.realm";
         path = [path stringByAppendingPathComponent:identifier];
 
         // create directory
-        [[NSFileManager defaultManager] createDirectoryAtPath:path
+        [[NSFileManager defaultManager] createDirectoryAtPath:[path stringByDeletingLastPathComponent]
                                   withIntermediateDirectories:YES
                                                    attributes:nil
                                                         error:nil];


### PR DESCRIPTION
@astigsen just ran into this issue /cc @tgoyne @alazier 
