### PR TITLE
added test to confirm that Swift RLMObject properties with no setter defined are ignored by Realm

### DIFF
--- a/Realm/Tests/Swift/SwiftRealmTests.swift
+++ b/Realm/Tests/Swift/SwiftRealmTests.swift
@@ -108,8 +108,10 @@ class SwiftRealmTests: SwiftTestCase {
 
         let objects = SwiftIgnoredPropertiesObject.allObjectsInRealm(realm)
         XCTAssertEqual(objects.count, UInt(1), "There should be 1 object of type SwiftIgnoredPropertiesObject")
-        XCTAssertNil((objects[0] as SwiftIgnoredPropertiesObject).runtimeProperty, "Ignored property should be nil")
-        XCTAssertEqual((objects[0] as SwiftIgnoredPropertiesObject).name, "@fz", "Value of the name column doesn't match the assigned one.")
+        let retrievedObject = objects[0] as SwiftIgnoredPropertiesObject
+        XCTAssertNil(retrievedObject.runtimeProperty, "Ignored property should be nil")
+        XCTAssertEqual(retrievedObject.name, "@fz", "Value of the name column doesn't match the assigned one.")
+        XCTAssertEqual(retrievedObject.objectSchema.properties.count, 2, "Only 'name' and 'age' properties should be detected by Realm")
     }
 
     func testUpdatingSortedArrayAfterBackgroundUpdate() {

--- a/Realm/Tests/Swift/SwiftTestObjects.swift
+++ b/Realm/Tests/Swift/SwiftTestObjects.swift
@@ -107,11 +107,11 @@ class SwiftIgnoredPropertiesObject: RLMObject {
     dynamic var name = ""
     dynamic var age = 0
     dynamic var runtimeProperty: AnyObject?
-    
+    dynamic var readOnlyProperty: Int { return 0 }
+
     override class func ignoredProperties() -> [AnyObject]! {
         return ["runtimeProperty"]
     }
-
 }
 
 class SwiftPrimaryStringObject: RLMObject {


### PR DESCRIPTION
@tgoyne @alazier. Inspired by #1110.
