### PR TITLE
Make RLMResults always iterate over contents at start of iteration

### DIFF
--- a/Realm/RLMResults.mm
+++ b/Realm/RLMResults.mm
@@ -145,6 +145,13 @@ static inline void RLMResultsValidateInWriteTransaction(__unsafe_unretained RLMR
     }
     else {
         items = (__bridge id)(void *)state->extra[0];
+        NSUInteger size = items->size;
+        for (NSUInteger i = 0; i < size; i++) {
+            if ([self indexOfObject:items->array[0]] == NSNotFound) {
+                state->state--;
+                state->extra[1]--;
+            }
+        }
         [items resize:len];
     }
 
@@ -166,7 +173,7 @@ static inline void RLMResultsValidateInWriteTransaction(__unsafe_unretained RLMR
 
     state->itemsPtr = buffer;
     state->state = index;
-    state->mutationsPtr = state->extra+1;
+    state->mutationsPtr = &state->extra[2];
     
     return batchCount;
 }

--- a/Realm/Tests/ArrayTests.m
+++ b/Realm/Tests/ArrayTests.m
@@ -41,13 +41,13 @@
     NSDate *dateMaxInput = [dateMinInput dateByAddingTimeInterval:1000];
     
     [AggregateObject createInRealm:realm withObject:@[@10, @1.2f, @0.0, @YES, dateMinInput]];
-    [AggregateObject createInRealm:realm withObject:@[@10, @0.0f, @2.5, @NO, dateMaxInput]];
+    [AggregateObject createInRealm:realm withObject:@[@10, @0.0f, @2.5, @NO,  dateMaxInput]];
     [AggregateObject createInRealm:realm withObject:@[@10, @1.2f, @0.0, @YES, dateMinInput]];
-    [AggregateObject createInRealm:realm withObject:@[@10, @0.0f, @2.5, @NO, dateMaxInput]];
+    [AggregateObject createInRealm:realm withObject:@[@10, @0.0f, @2.5, @NO,  dateMaxInput]];
     [AggregateObject createInRealm:realm withObject:@[@10, @1.2f, @0.0, @YES, dateMinInput]];
-    [AggregateObject createInRealm:realm withObject:@[@10, @0.0f, @2.5, @NO, dateMaxInput]];
+    [AggregateObject createInRealm:realm withObject:@[@10, @0.0f, @2.5, @NO,  dateMaxInput]];
     [AggregateObject createInRealm:realm withObject:@[@10, @1.2f, @0.0, @YES, dateMinInput]];
-    [AggregateObject createInRealm:realm withObject:@[@10, @0.0f, @2.5, @NO, dateMaxInput]];
+    [AggregateObject createInRealm:realm withObject:@[@10, @0.0f, @2.5, @NO,  dateMaxInput]];
     [AggregateObject createInRealm:realm withObject:@[@10, @1.2f, @0.0, @YES, dateMinInput]];
     [AggregateObject createInRealm:realm withObject:@[@10, @1.2f, @0.0, @YES, dateMinInput]];
     [AggregateObject createInRealm:realm withObject:@[@10, @1.2f, @0.0, @YES, dateMinInput]];
@@ -91,6 +91,18 @@
         }
     }
     XCTAssertNil(objects[0], @"Object should have been released");
+
+    count = 0;
+    [realm beginWriteTransaction];
+    for (AggregateObject *ao in result) {
+        XCTAssertNotNil(ao, @"Object is not nil and accessible");
+        ao.intCol = 200;
+        count++;
+    }
+    [realm commitWriteTransaction];
+
+    XCTAssertEqual(count, 18, @"should have enumerated 18 objects");
+    XCTAssertEqual(result.count, (NSUInteger)0, @"0 objects left");
 }
 
 - (void)testObjectAggregate


### PR DESCRIPTION
Currently, `RLMResults` can silently change while you are iterating through it, if you change something about an object that makes it no longer fit the query. This causes the loop to only apply to every other object in the results (which is very confusing and difficult to debug).

This commit causes the array to always iterate through the objects that were in the results array at the start of the iteration, even if some of the objects leave the array in the meantime. After the iteration, the results array is the correct (possibly changed) value. It does perform slightly slower than the previous implementation, but I would rather this behavior and slightly slower performance.

**Warnings**: This implementation is still vulnerable to objects being changed in any way other than being removed. It is also vulnerable to the temporary array being released early, is noted in [Mike Ash's discussion of `NSFastEnumeration`](https://www.mikeash.com/pyblog/friday-qa-2010-04-16-implementing-fast-enumeration.html). (Neither of these vulnerabilities is new in this commit, just noting them for posterity.)
