### PR TITLE
Don't log update checker errors

### DIFF
--- a/Realm/RLMUpdateChecker.mm
+++ b/Realm/RLMUpdateChecker.mm
@@ -32,7 +32,6 @@ void RLMCheckForUpdates() {
 
     auto handler = ^(NSData *data, __unused NSURLResponse *response, NSError *error) {
         if (error) {
-            NSLog(@"Failed to check for updates to Realm: %@", error);
             return;
         }
 


### PR DESCRIPTION
They're annoying when there's no internet connection and unlikely to be useful to anyone.

@jpsim 
