### PR TITLE
Don't clear the realm cache after performing a migration

### DIFF
--- a/Realm/RLMRealm.mm
+++ b/Realm/RLMRealm.mm
@@ -735,8 +735,6 @@ static void CheckReadWrite(RLMRealm *realm, NSString *msg=@"Cannot write to a re
         }
     }
 
-    // clear cache for future callers
-    clearRealmCache();
     return nil;
 }
 

--- a/Realm/Tests/MigrationTests.mm
+++ b/Realm/Tests/MigrationTests.mm
@@ -445,5 +445,11 @@ extern "C" {
     }
 }
 
+- (void)testMigrationDoesNotEffectOtherPaths {
+    RLMRealm *defaultRealm = RLMRealm.defaultRealm;
+    [RLMRealm migrateRealmAtPath:RLMTestRealmPath()];
+    XCTAssertEqual(defaultRealm, RLMRealm.defaultRealm);
+}
+
 @end
 


### PR DESCRIPTION
AFAICT it's never needed (since RLMRealms with custom schema aren't cached, it shouldn't be possible to have a cached RLMRealm for a path that needs a migration), and removing completely unrelated paths from the cache is actively bad.

@alazier 
