### PR TITLE
Only check for cached RLMRealms when using the shared schema

### DIFF
--- a/Realm/RLMRealm.mm
+++ b/Realm/RLMRealm.mm
@@ -319,7 +319,11 @@ NSString * const c_defaultRealmFileName = @"default.realm";
     }
 
     // try to reuse existing realm first
-    __autoreleasing RLMRealm *realm = cachedRealm(path);
+    __autoreleasing RLMRealm *realm = nil;
+    if (!dynamic && !customSchema) {
+        realm = cachedRealm(path);
+    }
+
     if (realm) {
         // if already opened with different read permissions then throw
         if (realm->_readOnly != readonly) {


### PR DESCRIPTION
Dynamic realms aren't cached, so looking in the cache for a dynamic realm is at best a waste of time, and could give the wrong thing in sufficiently weird circumstances.

@alazier 
