### PR TITLE
Rollback on schema validation errors rather than committing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ x.x.x Release notes (yyyy-MM-dd)
 ### Bugfixes
 
 * Merge native Swift default property values with defaultPropertyValues().
+* Don't leave the database schema partially updated when opening a realm fails
+  due to a migration being needed.
 
 
 0.88.0 Release notes (2014-12-02)

--- a/Realm/RLMRealm.mm
+++ b/Realm/RLMRealm.mm
@@ -131,15 +131,18 @@ void createTablesInTransaction(RLMRealm *realm, RLMSchema *targetSchema) {
     [realm beginWriteTransaction];
 
     @try {
+        RLMRealmCreateMetadataTables(realm);
         if (RLMRealmSchemaVersion(realm) == RLMNotVersioned) {
             RLMRealmSetSchemaVersion(realm, s_currentSchemaVersion);
         }
         RLMRealmCreateTables(realm, targetSchema, false);
     }
-    @finally {
-        // FIXME: should rollback on exceptions rather than commit once that's implemented
-        [realm commitWriteTransaction];
+    @catch (NSException *) {
+        [realm cancelWriteTransaction];
+        @throw;
     }
+
+    [realm commitWriteTransaction];
 }
 
 } // anonymous namespace

--- a/Realm/RLMSchema_Private.h
+++ b/Realm/RLMSchema_Private.h
@@ -48,6 +48,11 @@ inline NSString *RLMTableNameForClass(NSString *className) {
 //
 // Realm schema metadata
 //
+
+// create any metadata tables that don't already exist
+// must be in write transaction to set
+void RLMRealmCreateMetadataTables(RLMRealm *realm);
+
 NSUInteger RLMRealmSchemaVersion(RLMRealm *realm);
 
 // must be in write transaction to set


### PR DESCRIPTION
Was almost trivial, but rolling back transactions breaks if you create tables after creating link columns so I had to pull the creation of the primary key table to before the columns are updated.

@alazier 
