### PR TITLE
Moved installation of file templates from privileged script to a new build phase

### DIFF
--- a/plugin/RealmPlugin.xcodeproj/project.pbxproj
+++ b/plugin/RealmPlugin.xcodeproj/project.pbxproj
@@ -168,8 +168,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 2263AAC919B0A1E6007240D9 /* Build configuration list for PBXNativeTarget "RealmPlugin" */;
 			buildPhases = (
-				C9DDD59B1A3A94F900292DD2 /* Install File Templates */,
-				22B78EF819B0A3AF00968525 /* Install Class Templates */,
+				22B78EF819B0A3AF00968525 /* Install Templates */,
 				3F527BDF1A16C34300CA8B97 /* Install LLDB Script */,
 				2263AAB219B0A1E6007240D9 /* Sources */,
 				2263AAB319B0A1E6007240D9 /* Frameworks */,
@@ -223,14 +222,14 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		22B78EF819B0A3AF00968525 /* Install Class Templates */ = {
+		22B78EF819B0A3AF00968525 /* Install Templates */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Install Class Templates";
+			name = "Install Templates";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -250,20 +249,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "python rlm_lldb.py";
-		};
-		C9DDD59B1A3A94F900292DD2 /* Install File Templates */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Install File Templates";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "# User File Templates\n\ncd Templates\n\nFILE_TEMPLATES_DIR=\"$HOME/Library/Developer/Xcode/Templates/File Templates/Realm\"\nmkdir -p \"$FILE_TEMPLATES_DIR\"\n\nfor dir in \"file_templates/*/\"\ndo\ncp -R ${dir%*/} \"$FILE_TEMPLATES_DIR\"\ndone";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/plugin/Templates/install_templates.sh
+++ b/plugin/Templates/install_templates.sh
@@ -1,6 +1,16 @@
 #!/bin/sh
 PATH=/bin:/usr/bin:/usr/libexec
 
+# User File Templates
+
+FILE_TEMPLATES_DIR="$HOME/Library/Developer/Xcode/Templates/File Templates/Realm"
+sudo -u $USER mkdir -p "$FILE_TEMPLATES_DIR"
+
+for dir in "file_templates/*/"
+do
+  sudo -u $USER cp -R ${dir%*/} "$FILE_TEMPLATES_DIR"
+done
+
 # Class Templates
 
 XCODE_DIR=$(xcode-select -p)


### PR DESCRIPTION
The installation of the plugin currently installs the templates into both the system Developer directory and the users ~/Library/Developer/Xcode/Templates directory using a script which is run as root.  This means that the templates added to the users Templates directory are owned by root and don't have permissions for the user to modify/delete the files.

I have added a new build phase which copies the file templates to the users directory without root privileges so that they are owned by the user.  The class templates are still installed by the privileged script.

You may want to implement this in a different way so feel free to do this in a different way.  However, I don't believe it is correct to place files in a home directory that the user can't remove.
