### PR TITLE
Objects with custom getter names can now be used to initialize other objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ x.x.x Release notes (yyyy-MM-dd)
 * Merge native Swift default property values with defaultPropertyValues().
 * Don't leave the database schema partially updated when opening a realm fails
   due to a migration being needed.
+* Fixed issue where objects with custom getter names couldn't be used to
+  initialize other objects.
 
 
 0.88.0 Release notes (2014-12-02)

--- a/Realm/RLMUtil.mm
+++ b/Realm/RLMUtil.mm
@@ -23,7 +23,7 @@
 #import "RLMArray_Private.hpp"
 #import "RLMObject.h"
 #import "RLMObjectSchema_Private.hpp"
-#import "RLMProperty.h"
+#import "RLMProperty_Private.h"
 #import "RLMSwiftSupport.h"
 
 static inline bool nsnumber_is_like_integer(NSNumber *obj)
@@ -198,7 +198,7 @@ NSDictionary *RLMValidatedDictionaryForObjectSchema(id value, RLMObjectSchema *o
     NSMutableDictionary *outDict = [NSMutableDictionary dictionaryWithCapacity:properties.count];
     BOOL isDict = [value isKindOfClass:NSDictionary.class];
     for (RLMProperty *prop in properties) {
-        id obj = (isDict || [value respondsToSelector:NSSelectorFromString(prop.name)]) ? [value valueForKey:prop.name] : nil;
+        id obj = (isDict || [value respondsToSelector:prop.getterSel]) ? [value valueForKey:prop.getterName] : nil;
 
         // get default for nil object
         if (!obj && !allowMissing) {

--- a/Realm/Tests/ObjectInterfaceTests.m
+++ b/Realm/Tests/ObjectInterfaceTests.m
@@ -57,6 +57,22 @@
     XCTAssertEqual((int)objectFromRealm.age, (int)99, @"age property should be 99");
 }
 
+- (void)testCustomAccessorsWithCreateOrUpdate
+{
+    RLMRealm *realm = [RLMRealm defaultRealm];
+
+    [realm beginWriteTransaction];
+    CustomAccessorsObject *caStandalone = [[CustomAccessorsObject alloc] init];
+    caStandalone.name = @"name";
+    caStandalone.age = 99;
+    [CustomAccessorsObject createOrUpdateInRealm:realm withObject:caStandalone];
+    [realm commitWriteTransaction];
+
+    CustomAccessorsObject *objectFromRealm = [CustomAccessorsObject allObjects][0];
+    XCTAssertEqualObjects(objectFromRealm.name, @"name", @"name property should be name.");
+    XCTAssertEqual(objectFromRealm.age, 99, @"age property should be 99");
+}
+
 - (void)testClassExtension
 {
     RLMRealm *realm = [RLMRealm defaultRealm];


### PR DESCRIPTION
Fixes #1228. Thanks @FredericRuaudel! @tgoyne @alazier 
