### PR TITLE
Clarified exception message when opening a realm with insufficient permissions

### DIFF
--- a/Realm/RLMRealm.mm
+++ b/Realm/RLMRealm.mm
@@ -247,7 +247,7 @@ NSString * const c_defaultRealmFileName = @"default.realm";
         }
         catch (File::PermissionDenied &ex) {
 	    NSString *mode = readonly ? @"read" : @"read-write";
-	    NSString *additionalMessage = [NSString stringWithFormat:@"Unable to open a realm at path %@. Please use a path where your app has %@ permissions.", path, mode];
+	    NSString *additionalMessage = [NSString stringWithFormat:@"Unable to open a realm at path '%@'. Please use a path where your app has %@ permissions.", path, mode];
 	    NSString *newMessage = [NSString stringWithFormat:@"%s\n%@", ex.what(), additionalMessage];
 	    ex = File::PermissionDenied(newMessage.UTF8String);
             *error = make_realm_error(RLMErrorFilePermissionDenied, ex);


### PR DESCRIPTION
Fixes https://app.asana.com/0/861870036984/17678329857532. @tgoyne @alazier there _must_ be a more concise way to do this.
