### PR TITLE
Feature/key path mapping transformation

### DIFF
--- a/Realm.xcodeproj/project.pbxproj
+++ b/Realm.xcodeproj/project.pbxproj
@@ -26,6 +26,15 @@
 		02B8EF5A19E601D80045A93D /* RLMResults.h in Headers */ = {isa = PBXBuildFile; fileRef = 02B8EF5819E601D80045A93D /* RLMResults.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		02B8EF5C19E7048D0045A93D /* RLMCollection.h in Headers */ = {isa = PBXBuildFile; fileRef = 02B8EF5B19E7048D0045A93D /* RLMCollection.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		02B8EF5D19E7048D0045A93D /* RLMCollection.h in Headers */ = {isa = PBXBuildFile; fileRef = 02B8EF5B19E7048D0045A93D /* RLMCollection.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2F08457E1A49E79A003868BE /* RLMTransformer.h in Headers */ = {isa = PBXBuildFile; fileRef = 2F08457C1A49E79A003868BE /* RLMTransformer.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2F08457F1A49E79A003868BE /* RLMTransformer.m in Sources */ = {isa = PBXBuildFile; fileRef = 2F08457D1A49E79A003868BE /* RLMTransformer.m */; };
+		2F0845801A49EC72003868BE /* RLMTransformer.h in Headers */ = {isa = PBXBuildFile; fileRef = 2F08457C1A49E79A003868BE /* RLMTransformer.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2F0845811A49EC73003868BE /* RLMTransformer.h in Headers */ = {isa = PBXBuildFile; fileRef = 2F08457C1A49E79A003868BE /* RLMTransformer.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2F0845821A49EC9D003868BE /* RLMTransformer.m in Sources */ = {isa = PBXBuildFile; fileRef = 2F08457D1A49E79A003868BE /* RLMTransformer.m */; };
+		2F0845831A49EC9E003868BE /* RLMTransformer.m in Sources */ = {isa = PBXBuildFile; fileRef = 2F08457D1A49E79A003868BE /* RLMTransformer.m */; };
+		2F38D28A1A4FA8E000C0D6DD /* RLMObjectTranslationProtocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 2F38D2891A4FA80000C0D6DD /* RLMObjectTranslationProtocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2F38D28B1A4FA8E000C0D6DD /* RLMObjectTranslationProtocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 2F38D2891A4FA80000C0D6DD /* RLMObjectTranslationProtocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2F38D28C1A4FA8E100C0D6DD /* RLMObjectTranslationProtocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 2F38D2891A4FA80000C0D6DD /* RLMObjectTranslationProtocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		3F20DA2219BE1EA6007DE308 /* RLMUpdateChecker.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 3F20DA2019BE1EA6007DE308 /* RLMUpdateChecker.hpp */; };
 		3F20DA2319BE1EA6007DE308 /* RLMUpdateChecker.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 3F20DA2019BE1EA6007DE308 /* RLMUpdateChecker.hpp */; };
 		3F20DA2419BE1EA6007DE308 /* RLMUpdateChecker.mm in Sources */ = {isa = PBXBuildFile; fileRef = 3F20DA2119BE1EA6007DE308 /* RLMUpdateChecker.mm */; };
@@ -355,6 +364,9 @@
 		02B8EF5819E601D80045A93D /* RLMResults.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RLMResults.h; sourceTree = "<group>"; };
 		02B8EF5B19E7048D0045A93D /* RLMCollection.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RLMCollection.h; sourceTree = "<group>"; };
 		26F3CA681986CC86004623E1 /* SwiftPropertyTypeTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwiftPropertyTypeTest.swift; sourceTree = "<group>"; };
+		2F08457C1A49E79A003868BE /* RLMTransformer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RLMTransformer.h; sourceTree = "<group>"; };
+		2F08457D1A49E79A003868BE /* RLMTransformer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RLMTransformer.m; sourceTree = "<group>"; };
+		2F38D2891A4FA80000C0D6DD /* RLMObjectTranslationProtocol.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RLMObjectTranslationProtocol.h; sourceTree = "<group>"; };
 		3F04EA2D1992BEE400C2CE2E /* PerformanceTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PerformanceTests.m; sourceTree = "<group>"; };
 		3F1A5E721992EB7400F45F4C /* TestHost.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TestHost.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		3F20DA2019BE1EA6007DE308 /* RLMUpdateChecker.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = RLMUpdateChecker.hpp; sourceTree = "<group>"; };
@@ -622,6 +634,7 @@
 				0207AB7C195DF9FB007EFB12 /* RLMMigration_Private.h */,
 				E81A1F6E1955FC9300FDED82 /* RLMObject.h */,
 				E81A1F6F1955FC9300FDED82 /* RLMObject.mm */,
+				2F38D2891A4FA80000C0D6DD /* RLMObjectTranslationProtocol.h */,
 				E81A1F6D1955FC9300FDED82 /* RLMObject_Private.h */,
 				E81A1F711955FC9300FDED82 /* RLMObjectSchema.h */,
 				E81A1F721955FC9300FDED82 /* RLMObjectSchema.mm */,
@@ -645,6 +658,8 @@
 				E8F8D907196CB89100475368 /* RLMSwiftHelpers.h */,
 				3FE79FF719BA6A5900780C9A /* RLMSwiftSupport.h */,
 				3F452EC519C2279800AFC154 /* RLMSwiftSupport.m */,
+				2F08457C1A49E79A003868BE /* RLMTransformer.h */,
+				2F08457D1A49E79A003868BE /* RLMTransformer.m */,
 				3F20DA2019BE1EA6007DE308 /* RLMUpdateChecker.hpp */,
 				3F20DA2119BE1EA6007DE308 /* RLMUpdateChecker.mm */,
 				E81A1F811955FC9300FDED82 /* RLMUtil.hpp */,
@@ -693,6 +708,7 @@
 				3F6B895A19EF3C06004E8EA8 /* RLMAccessor.h in Headers */,
 				3F6B895B19EF3C06004E8EA8 /* RLMArray.h in Headers */,
 				3F6B895D19EF3C06004E8EA8 /* RLMArray_Private.hpp in Headers */,
+				2F0845811A49EC73003868BE /* RLMTransformer.h in Headers */,
 				3F6B895C19EF3C06004E8EA8 /* RLMCollection.h in Headers */,
 				3F6B895E19EF3C06004E8EA8 /* RLMConstants.h in Headers */,
 				3F6B896019EF3C06004E8EA8 /* RLMMigration.h in Headers */,
@@ -701,6 +717,7 @@
 				3F6B896319EF3C06004E8EA8 /* RLMObject_Private.h in Headers */,
 				3F6B896419EF3C06004E8EA8 /* RLMObjectSchema.h in Headers */,
 				3F6B896519EF3C06004E8EA8 /* RLMObjectSchema_Private.hpp in Headers */,
+				2F38D28C1A4FA8E100C0D6DD /* RLMObjectTranslationProtocol.h in Headers */,
 				3F6B896719EF3C06004E8EA8 /* RLMObjectStore.hpp in Headers */,
 				3F6B896819EF3C06004E8EA8 /* RLMPlatform.h in Headers */,
 				3F6B896919EF3C06004E8EA8 /* RLMProperty.h in Headers */,
@@ -727,6 +744,7 @@
 				E856D1F21956154C00FB2FCF /* RLMAccessor.h in Headers */,
 				E856D1F51956154C00FB2FCF /* RLMArray.h in Headers */,
 				E856D1F41956154C00FB2FCF /* RLMArray_Private.hpp in Headers */,
+				2F0845801A49EC72003868BE /* RLMTransformer.h in Headers */,
 				02B8EF5D19E7048D0045A93D /* RLMCollection.h in Headers */,
 				E856D1FA1956154C00FB2FCF /* RLMConstants.h in Headers */,
 				0207AB82195DF9FB007EFB12 /* RLMMigration.h in Headers */,
@@ -735,6 +753,7 @@
 				E856D1FC1956154C00FB2FCF /* RLMObject_Private.h in Headers */,
 				E856D2001956154C00FB2FCF /* RLMObjectSchema.h in Headers */,
 				E856D1FF1956154C00FB2FCF /* RLMObjectSchema_Private.hpp in Headers */,
+				2F38D28B1A4FA8E000C0D6DD /* RLMObjectTranslationProtocol.h in Headers */,
 				E856D2021956154C00FB2FCF /* RLMObjectStore.hpp in Headers */,
 				024E6094198B2D51002FA042 /* RLMPlatform.h in Headers */,
 				E856D2051956154C00FB2FCF /* RLMProperty.h in Headers */,
@@ -761,6 +780,7 @@
 				E81A1F851955FC9300FDED82 /* RLMAccessor.h in Headers */,
 				E81A1F891955FC9300FDED82 /* RLMArray.h in Headers */,
 				E81A1F881955FC9300FDED82 /* RLMArray_Private.hpp in Headers */,
+				2F08457E1A49E79A003868BE /* RLMTransformer.h in Headers */,
 				02B8EF5C19E7048D0045A93D /* RLMCollection.h in Headers */,
 				E81A1F921955FC9300FDED82 /* RLMConstants.h in Headers */,
 				0207AB81195DF9FB007EFB12 /* RLMMigration.h in Headers */,
@@ -769,6 +789,7 @@
 				E81A1F951955FC9300FDED82 /* RLMObject_Private.h in Headers */,
 				E81A1F9A1955FC9300FDED82 /* RLMObjectSchema.h in Headers */,
 				E81A1F991955FC9300FDED82 /* RLMObjectSchema_Private.hpp in Headers */,
+				2F38D28A1A4FA8E000C0D6DD /* RLMObjectTranslationProtocol.h in Headers */,
 				E81A1F9D1955FC9300FDED82 /* RLMObjectStore.hpp in Headers */,
 				024E6097198B2D59002FA042 /* RLMPlatform.h in Headers */,
 				E81A1FA11955FC9300FDED82 /* RLMProperty.h in Headers */,
@@ -1159,6 +1180,7 @@
 				3F6B894E19EF3C06004E8EA8 /* RLMObjectSchema.mm in Sources */,
 				3F6B894F19EF3C06004E8EA8 /* RLMObjectStore.mm in Sources */,
 				3F6B895019EF3C06004E8EA8 /* RLMProperty.mm in Sources */,
+				2F0845831A49EC9E003868BE /* RLMTransformer.m in Sources */,
 				3F6B895119EF3C06004E8EA8 /* RLMQueryUtil.mm in Sources */,
 				3F6B895219EF3C06004E8EA8 /* RLMRealm.mm in Sources */,
 				3F6B894A19EF3C06004E8EA8 /* RLMResults.mm in Sources */,
@@ -1216,6 +1238,7 @@
 				3FDE338C19C37E4C003B7DBA /* RLMSwiftSupport.m in Sources */,
 				3F20DA2519BE1EA6007DE308 /* RLMUpdateChecker.mm in Sources */,
 				E856D2121956154C00FB2FCF /* RLMUtil.mm in Sources */,
+				2F0845821A49EC9D003868BE /* RLMTransformer.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1276,6 +1299,7 @@
 				3F452EC619C2279800AFC154 /* RLMSwiftSupport.m in Sources */,
 				3F20DA2419BE1EA6007DE308 /* RLMUpdateChecker.mm in Sources */,
 				E81A1FB11955FC9300FDED82 /* RLMUtil.mm in Sources */,
+				2F08457F1A49E79A003868BE /* RLMTransformer.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Realm/RLMObject.h
+++ b/Realm/RLMObject.h
@@ -253,17 +253,6 @@
 + (NSArray *)ignoredProperties;
 
 /**
- @brief Implement to specify how properties map to key paths in the initWithObject: attributes parameter.
- This dictionary is consulted if no attribute is found for a given property name. The dictionary can
- contain key path format mapping for cases where you need to collapse an object - e.g. property of
- firstName mapped to user.firstName.
- 
- @see [RLMObject initWithObject:]
- @return    NSDictionary specifying property key path mapping.
- */
-+ (NSDictionary *)objectPropertyKeyPathMapping;
-
-/**
  * @brief Implement to specify a default translation object that should be used when
  * creating new objects using the initWithObject: API. Translations define the mapping
  * and transformation logic applied to properties for the RLMObject being created.

--- a/Realm/RLMObject.h
+++ b/Realm/RLMObject.h
@@ -251,6 +251,16 @@
  */
 + (NSArray *)ignoredProperties;
 
+/**
+ @brief Implement to specify how properties map to key paths in the initWithObject: attributes parameter.
+ This dictionary is consulted if no attribute is found for a given property name. The dictionary can
+ contain key path format mapping for cases where you need to collapse an object - e.g. property of
+ firstName mapped to user.firstName.
+ 
+ @see [RLMObject initWithObject:]
+ @return    NSDictionary specifying property key path mapping.
+ */
++ (NSDictionary *)objectPropertyKeyPathMapping;
 
 /**---------------------------------------------------------------------------------------
  *  @name Getting & Querying Objects from the Default Realm

--- a/Realm/RLMObject.h
+++ b/Realm/RLMObject.h
@@ -18,6 +18,7 @@
 
 #import <Foundation/Foundation.h>
 #import <Realm/RLMConstants.h>
+#import "RLMObjectTranslationProtocol.h"
 
 @class RLMRealm;
 @class RLMResults;
@@ -261,6 +262,17 @@
  @return    NSDictionary specifying property key path mapping.
  */
 + (NSDictionary *)objectPropertyKeyPathMapping;
+
+/**
+ * @brief Implement to specify a default translation object that should be used when
+ * creating new objects using the initWithObject: API. Translations define the mapping
+ * and transformation logic applied to properties for the RLMObject being created.
+ 
+ * @return An object that conforms to RLMObjectTranslationProtocol
+ * @see [RLMObject initWithObject:]
+ * @see RLMObjectTranslationProtocol
+ */
++ (id<RLMObjectTranslationProtocol>)defaultTranslation;
 
 /**---------------------------------------------------------------------------------------
  *  @name Getting & Querying Objects from the Default Realm

--- a/Realm/RLMObject.mm
+++ b/Realm/RLMObject.mm
@@ -139,6 +139,11 @@
     return nil;
 }
 
+// default translation object
++ (id<RLMObjectTranslationProtocol>)defaultTranslation; {
+    return nil;
+}
+
 // default primaryKey implementation
 + (NSString *)primaryKey {
     return nil;

--- a/Realm/RLMObject.mm
+++ b/Realm/RLMObject.mm
@@ -134,11 +134,6 @@
     return nil;
 }
 
-// default object property key path mapping implementation
-+ (NSDictionary *)objectPropertyKeyPathMapping {
-    return nil;
-}
-
 // default translation object
 + (id<RLMObjectTranslationProtocol>)defaultTranslation; {
     return nil;

--- a/Realm/RLMObject.mm
+++ b/Realm/RLMObject.mm
@@ -134,6 +134,11 @@
     return nil;
 }
 
+// default object property key path mapping implementation
++ (NSDictionary *)objectPropertyKeyPathMapping {
+    return nil;
+}
+
 // default primaryKey implementation
 + (NSString *)primaryKey {
     return nil;

--- a/Realm/RLMObjectTranslationProtocol.h
+++ b/Realm/RLMObjectTranslationProtocol.h
@@ -1,0 +1,54 @@
+//
+//  RLMObjectTranslationProtocol.h
+//  Realm
+//
+//  Created by Nathan Jones on 12/27/14.
+//  Copyright (c) 2014 Realm. All rights reserved.
+//
+
+typedef NS_ENUM(NSInteger, RLMObjectTransformInput) {
+    RLMObjectTransformInputDefault = 0, // default is a mapped value
+    RLMObjectTransformInputMappedValue = RLMObjectTransformInputDefault,
+    RLMObjectTransformInputAttributes
+};
+
+/**
+ * @description This protocol defines how objects should be created
+ * from a given input source. You could use this when creating objects
+ * from the response of an API call where the response structure does
+ * not match the RLMObject property structure. This protocol also defines
+ * how input data is transformed during initialization. For example, you
+ * may need to format dates, or combine two remote attributes to form a
+ * single local property value.
+ 
+ * @see RLMTransformer
+ * @see [RLMObject defaultTranslation]
+ */
+@protocol RLMObjectTranslationProtocol <NSObject>
+@required
+
+/**
+ * @brief The mapped source for a given property from the input object
+ * @param property The current property being evaluated
+ * @return The key path within the source to map for the give property
+ */
+- (NSString *)sourceKeyPathMappingForProperty:(NSString *)property;
+
+/**
+ * @brief The input type expected for a given property
+ * @param property  The current property being evaluated
+ * @return An RLMObjectTransformInput value representing the
+ * type of data the corresponding transform expects
+ * @see transformObject:forProperty:
+ */
+- (RLMObjectTransformInput)transformInputForProperty:(NSString *)property;
+
+/**
+ * @brief Transform a given object for a given property
+ * @param object    The object that should be transformed
+ * @param property  The property for which the object is being transformed
+ * @return The transformed object
+ */
+- (id)transformObject:(id)object forProperty:(NSString *)property;
+
+@end

--- a/Realm/RLMObjectTranslationProtocol.h
+++ b/Realm/RLMObjectTranslationProtocol.h
@@ -1,10 +1,20 @@
+////////////////////////////////////////////////////////////////////////////
 //
-//  RLMObjectTranslationProtocol.h
-//  Realm
+// Copyright 2014 Realm Inc.
 //
-//  Created by Nathan Jones on 12/27/14.
-//  Copyright (c) 2014 Realm. All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
 
 typedef NS_ENUM(NSInteger, RLMObjectTransformInput) {
     RLMObjectTransformInputDefault = 0, // default is a mapped value

--- a/Realm/RLMTransformer.h
+++ b/Realm/RLMTransformer.h
@@ -1,0 +1,65 @@
+//
+//  RLMTransformer.h
+//  Realm
+//
+//  Created by Nathan Jones on 12/23/14.
+//  Copyright (c) 2014 Realm. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+typedef id (^RLMTransformBlock)(id object);
+
+/**
+ * This class provides a wrapper transforming an input using one of multiple
+ * transform options, such as a block or date formatter.
+ * Objects are created using the convenience methods below:
+ * @see transformerWithDateFormatter:
+ * @see transformerWithBlock:
+ */
+@interface RLMTransformer : NSObject
+
+/**
+ * @property dateFormatter
+ * @brief The NSDateFormatter set when the transformer was created and applied
+ * to the input of transformObject:.
+ */
+@property(nonatomic, copy, readonly) NSDateFormatter *dateFormatter;
+
+/**
+ * @property transformBlock
+ * @brief The transform block set when the transformer was created and applied
+ * to the input of transformObject:. The value is of type RLMTransformBlock
+ */
+@property(nonatomic, copy, readonly) RLMTransformBlock transformBlock;
+
+/**
+ * @brief Applies the transform set for this object to the input and returns
+ * the resulting object.
+ 
+ * @param object    The object that should be transformed.
+ * @return The transformed object.
+ */
+- (id)transformObject:(id)object;
+
+/**
+ * @brief Creates a date formatter based RLMTransformer object ready to use.
+ 
+ * @param formatter The date formatter that should be applied during transformation.
+ * @return An instance of RLMTransformer ready for use.
+ 
+ * @see transformObject:
+ */
++ (RLMTransformer *)transformerWithDateFormatter:(NSDateFormatter *)formatter;
+
+/**
+ * @brief Creates a block based RLMTransformer object ready to use.
+ 
+ * @param block The block that should be executed during transformation.
+ * @return  An instance of RLMTransformer ready for use.
+ 
+ * @see transformObject:
+ */
++ (RLMTransformer *)transformerWithBlock:(RLMTransformBlock)block;
+
+@end

--- a/Realm/RLMTransformer.h
+++ b/Realm/RLMTransformer.h
@@ -1,10 +1,20 @@
+////////////////////////////////////////////////////////////////////////////
 //
-//  RLMTransformer.h
-//  Realm
+// Copyright 2014 Realm Inc.
 //
-//  Created by Nathan Jones on 12/23/14.
-//  Copyright (c) 2014 Realm. All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
 
 #import <Foundation/Foundation.h>
 

--- a/Realm/RLMTransformer.m
+++ b/Realm/RLMTransformer.m
@@ -1,0 +1,46 @@
+//
+//  RLMTransformer.m
+//  Realm
+//
+//  Created by Nathan Jones on 12/23/14.
+//  Copyright (c) 2014 Realm. All rights reserved.
+//
+
+#import "RLMTransformer.h"
+
+@interface RLMTransformer ()
+
+@property(nonatomic, copy, readwrite) NSDateFormatter *dateFormatter;
+@property(nonatomic, copy, readwrite) RLMTransformBlock transformBlock;
+
+@end
+
+@implementation RLMTransformer
+
+- (id)transformObject:(id)object {
+    if (self.dateFormatter) {
+        return [self.dateFormatter dateFromString:object];
+    
+    } else if (self.transformBlock) {
+        return self.transformBlock(object);
+    
+    }
+    
+    return nil;
+}
+
++ (RLMTransformer *)transformerWithDateFormatter:(NSDateFormatter *)formatter {
+    RLMTransformer *transform = [RLMTransformer new];
+    transform.dateFormatter = formatter;
+    
+    return transform;
+}
+
++ (RLMTransformer *)transformerWithBlock:(RLMTransformBlock)block {
+    RLMTransformer *transform = [RLMTransformer new];
+    transform.transformBlock = block;
+    
+    return transform;
+}
+
+@end

--- a/Realm/RLMTransformer.m
+++ b/Realm/RLMTransformer.m
@@ -1,10 +1,20 @@
+////////////////////////////////////////////////////////////////////////////
 //
-//  RLMTransformer.m
-//  Realm
+// Copyright 2014 Realm Inc.
 //
-//  Created by Nathan Jones on 12/23/14.
-//  Copyright (c) 2014 Realm. All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
 
 #import "RLMTransformer.h"
 

--- a/Realm/RLMUtil.mm
+++ b/Realm/RLMUtil.mm
@@ -182,10 +182,17 @@ id RLMValidatedObjectForProperty(id obj, RLMProperty *prop, RLMSchema *schema) {
 NSDictionary *RLMValidatedDictionaryForObjectSchema(id value, RLMObjectSchema *objectSchema, RLMSchema *schema, bool allowMissing) {
     NSArray *properties = objectSchema.properties;
     NSDictionary *defaults = [objectSchema.objectClass defaultPropertyValues];
+    NSDictionary *keyMapping = [objectSchema.objectClass objectPropertyKeyPathMapping];
     NSMutableDictionary *outDict = [NSMutableDictionary dictionaryWithCapacity:properties.count];
     BOOL isDict = [value isKindOfClass:NSDictionary.class];
     for (RLMProperty *prop in properties) {
         id obj = (isDict || [value respondsToSelector:NSSelectorFromString(prop.name)]) ? [value valueForKey:prop.name] : nil;
+        
+        // get value under the mapped property
+        NSString *mappedProp = keyMapping[prop.name];
+        if (!obj) {
+            obj = (isDict || [value respondsToSelector:NSSelectorFromString(mappedProp)]) ? [value valueForKeyPath:mappedProp] : nil;
+        }
 
         // get default for nil object
         if (!obj && !allowMissing) {

--- a/Realm/Realm.h
+++ b/Realm/Realm.h
@@ -21,6 +21,8 @@
 #import <Realm/RLMArray.h>
 #import <Realm/RLMMigration.h>
 #import <Realm/RLMObject.h>
+#import <Realm/RLMObjectTranslationProtocol.h>
+#import <Realm/RLMTransformer.h>
 #import <Realm/RLMPlatform.h>
 #import <Realm/RLMRealm.h>
 #import <Realm/RLMResults.h>

--- a/Realm/Tests/ObjectTests.m
+++ b/Realm/Tests/ObjectTests.m
@@ -341,6 +341,13 @@ RLM_ARRAY_TYPE(PrimaryIntObject);
     XCTAssertThrows([[EmployeeObject alloc] initWithObject:nil], @"Not an array or dictionary");
 }
 
+- (void)testObjectInitWithKeyPathMapping {
+    NSDictionary *attrs = @{@"id": @"123",
+                            @"user": @{@"first": @"John",
+                                       @"last": @"Doe"}};
+    
+    XCTAssertNoThrow([[UserKeyPathObject alloc] initWithObject:attrs]);
+}
 
 - (void)testObjectSubscripting
 {

--- a/Realm/Tests/ObjectTests.m
+++ b/Realm/Tests/ObjectTests.m
@@ -341,12 +341,24 @@ RLM_ARRAY_TYPE(PrimaryIntObject);
     XCTAssertThrows([[EmployeeObject alloc] initWithObject:nil], @"Not an array or dictionary");
 }
 
-- (void)testObjectInitWithKeyPathMapping {
-    NSDictionary *attrs = @{@"id": @"123",
-                            @"user": @{@"first": @"John",
-                                       @"last": @"Doe"}};
+- (void)testObjectInitTranslation {
     
-    XCTAssertNoThrow([[UserKeyPathObject alloc] initWithObject:attrs]);
+    NSDictionary *attrs = @{@"userId": @"1234", // this is the actual property name
+                            @"id": @"9876",     // but, this is the field we want mapped
+                            @"user": @{@"prefix": @"Mr.",
+                                       @"first": @"John",
+                                       @"last": @"Doe"},
+                            @"started": @"2014-11-08T08:46:18-05:00",
+                            @"today": @"2014-12-20T08:46:18-05:00", // used solely to test expiration
+                            @"expirationDate": @"2014-12-30T08:46:18-05:00"};
+    
+    UserTranslationObject *user;
+    XCTAssertNoThrow(user = [[UserTranslationObject alloc] initWithObject:attrs]);
+    XCTAssert([user.greeting isEqualToString:@"Mr. Doe"]);
+    XCTAssert([user.first isEqualToString:@"John"]);
+    XCTAssert([user.last isEqualToString:@"Doe"]);
+    XCTAssert([user.userId isEqualToString:@"9876"]);
+    XCTAssertTrue(user.active);
 }
 
 - (void)testObjectSubscripting

--- a/Realm/Tests/RLMTestObjects.h
+++ b/Realm/Tests/RLMTestObjects.h
@@ -250,4 +250,9 @@ RLM_ARRAY_TYPE(CircleObject);
 @property (readonly) int readOnlyPropertyMadeReadWriteInClassExtension;
 @end
 
+#pragma mark KeyPathObject
 
+@interface UserKeyPathObject : RLMObject
+@property(nonatomic, strong) NSString *userId;
+@property(nonatomic, strong) NSString *firstName;
+@end

--- a/Realm/Tests/RLMTestObjects.h
+++ b/Realm/Tests/RLMTestObjects.h
@@ -250,9 +250,17 @@ RLM_ARRAY_TYPE(CircleObject);
 @property (readonly) int readOnlyPropertyMadeReadWriteInClassExtension;
 @end
 
-#pragma mark KeyPathObject
+#pragma mark UserTranslationObject
 
-@interface UserKeyPathObject : RLMObject
-@property(nonatomic, strong) NSString *userId;
-@property(nonatomic, strong) NSString *firstName;
+@interface UserTranslationObject : RLMObject
+@property(nonatomic, strong) NSString   *userId;
+@property(nonatomic, strong) NSString   *first;
+@property(nonatomic, strong) NSString   *last;
+@property(nonatomic, strong) NSString   *greeting;
+@property(nonatomic, strong) NSDate     *joined;
+@property(nonatomic, assign) BOOL       active;
 @end
+
+@interface UserAPITranslation : NSObject <RLMObjectTranslationProtocol>
+@end
+

--- a/Realm/Tests/RLMTestObjects.m
+++ b/Realm/Tests/RLMTestObjects.m
@@ -143,3 +143,10 @@
     return nil;
 }
 @end
+
+@implementation UserKeyPathObject
++ (NSDictionary *)objectPropertyKeyPathMapping {
+    return @{@"userId": @"id",
+             @"firstName": @"user.first"};
+}
+@end

--- a/Realm/Tests/RLMTestObjects.m
+++ b/Realm/Tests/RLMTestObjects.m
@@ -144,9 +144,93 @@
 }
 @end
 
-@implementation UserKeyPathObject
-+ (NSDictionary *)objectPropertyKeyPathMapping {
-    return @{@"userId": @"id",
-             @"firstName": @"user.first"};
+@implementation UserTranslationObject
++ (id<RLMObjectTranslationProtocol>)defaultTranslation {
+    return [UserAPITranslation new];
+}
+@end
+
+@interface UserAPITranslation()
+@property(nonatomic, strong) NSDictionary *mapping;
+@property(nonatomic, strong) NSDictionary *transforms;
+@end
+
+@implementation UserAPITranslation
+- (instancetype)init {
+    self = [super init];
+    
+    // Specify our property to attribute mapping
+    _mapping =  @{@"userId": @"id",
+                  @"first": @"user.first",
+                  @"last": @"user.last",
+                  @"joined": @"started"};
+    
+    // Specify our transforms
+    RLMTransformer *greetingTransformer = [RLMTransformer transformerWithBlock:^id(id attributes) {
+        if ([attributes isKindOfClass:NSDictionary.class]) {
+            NSString *prefix = [attributes valueForKeyPath:@"user.prefix"];
+            NSString *last = [attributes valueForKeyPath:@"user.last"];
+            return [NSString stringWithFormat:@"%@ %@", prefix, last];
+        }
+        return nil;
+    }];
+    
+    NSDateFormatter *dateFormatter = [NSDateFormatter new];
+    [dateFormatter setDateFormat:@"yyyy-MM-dd'T'HH:mm:ssZZZZ"];
+    RLMTransformer *joinedTransformer = [RLMTransformer transformerWithDateFormatter:dateFormatter];
+    
+    // Active transform - block set as local variable before creating transformer
+    RLMTransformBlock activeBlock = ^id(id attributes) {
+        if ([attributes isKindOfClass:NSDictionary.class]) {
+            
+            // Get the date from our payload
+            NSString *expirationDateString = attributes[@"expirationDate"];
+            NSString *todayDateString = attributes[@"today"];
+            
+            // Get the date objects
+            NSDateFormatter *formatter = [NSDateFormatter new];
+            [formatter setDateFormat:@"yyyy-MM-dd'T'HH:mm:ssZZZZ"];
+            NSDate *expiryDate = [formatter dateFromString:expirationDateString];
+            NSDate *today = [formatter dateFromString:todayDateString];
+            
+            // Expiration comparison
+            return @([expiryDate compare:today] == NSOrderedDescending);
+        }
+        return [NSNumber numberWithBool:NO];
+    };
+    RLMTransformer *activeTransformer = [RLMTransformer transformerWithBlock:activeBlock];
+    
+    _transforms = @{@"greeting": greetingTransformer,
+                    @"joined": joinedTransformer,
+                    @"active": activeTransformer};
+    
+    return self;
+}
+
+- (NSString *)sourceKeyPathMappingForProperty:(NSString *)property {
+    if ([self.mapping.allKeys containsObject:property]) {
+        return self.mapping[property];
+    }
+    
+    // by default, return the property name passed in
+    return property;
+}
+
+- (RLMObjectTransformInput)transformInputForProperty:(NSString *)property {
+    if ([property.lowercaseString isEqualToString:@"greeting"] || [property.lowercaseString isEqualToString:@"active"]) {
+        return RLMObjectTransformInputAttributes;
+    }
+    
+    return RLMObjectTransformInputDefault;
+}
+
+- (id)transformObject:(id)object forProperty:(NSString *)property {
+    RLMTransformer *transform = self.transforms[property];
+    if (transform) {
+        return [transform transformObject:object];
+    }
+    
+    // by default, return the original input
+    return object;
 }
 @end


### PR DESCRIPTION
Gents - this PR supersedes https://github.com/realm/realm-cocoa/pull/1074. It contains similar functionality, but I found myself needing some of the translation features that were mentioned in the comments for a project. I debated a few different patterns and settled on this. I'm obviously open to discussing things.

This PR does not solve the per-object translation. However, it sets the stage for it in a future PR. An additional initializer on `RLMObject` could be added (along with a read only property) to make this possible - e.g. `initWithTranslation:andObject:`. Currently, this would require that the instance or the translation property itself be passed to the utility function `RLMValidatedDictionaryForObjectSchema`. Noticing that you are making structural changes to that class, I think this requires more discussion before adding. 