### PR TITLE
Roll back the write transaction on schema init if nothing changed

### DIFF
--- a/Realm/RLMObjectStore.hpp
+++ b/Realm/RLMObjectStore.hpp
@@ -38,11 +38,6 @@ NSError *RLMUpdateRealmToSchemaVersion(RLMRealm *realm, NSUInteger version, RLMS
 // caches table accessors on each objectSchema
 void RLMRealmSetSchema(RLMRealm *realm, RLMSchema *targetSchema, bool verifyAndAlignColumns);
 
-// sets a realm's schema to a copy of targetSchema and creates/updates tables
-// if update existing is true, updates existing tables, otherwise validates existing tables
-// NOTE: must be called from within write transaction
-void RLMRealmCreateTables(RLMRealm *realm, RLMSchema *targetSchema, bool updateExisting);
-
 // create or get cached accessors for the given schema
 void RLMRealmCreateAccessors(RLMSchema *schema);
 

--- a/Realm/RLMSchema.mm
+++ b/Realm/RLMSchema.mm
@@ -193,11 +193,13 @@ NSString *RLMRealmPrimaryKeyForObjectClass(RLMRealm *realm, NSString *objectClas
     return RLMStringDataToNSString(table->get_string(c_primaryKeyPropertyNameColumnIndex, row));
 }
 
-void RLMRealmCreateMetadataTables(RLMRealm *realm) {
+bool RLMRealmCreateMetadataTables(RLMRealm *realm) {
+    bool changed = false;
     tightdb::TableRef table = realm.group->get_or_add_table(c_primaryKeyTableName);
     if (table->get_column_count() == 0) {
         table->add_column(tightdb::type_String, c_primaryKeyObjectClassColumnName);
         table->add_column(tightdb::type_String, c_primaryKeyPropertyNameColumnName);
+        changed = true;
     }
 
     table = realm.group->get_or_add_table(c_metadataTableName);
@@ -207,7 +209,10 @@ void RLMRealmCreateMetadataTables(RLMRealm *realm) {
         // set initial version
         table->add_empty_row();
         table->set_int(c_versionColumnIndex, 0, RLMNotVersioned);
+        changed = true;
     }
+
+    return changed;
 }
 
 void RLMRealmSetPrimaryKeyForObjectClass(RLMRealm *realm, NSString *objectClass, NSString *primaryKey) {

--- a/Realm/RLMSchema_Private.h
+++ b/Realm/RLMSchema_Private.h
@@ -51,7 +51,8 @@ inline NSString *RLMTableNameForClass(NSString *className) {
 
 // create any metadata tables that don't already exist
 // must be in write transaction to set
-void RLMRealmCreateMetadataTables(RLMRealm *realm);
+// returns true if it actually did anything
+bool RLMRealmCreateMetadataTables(RLMRealm *realm);
 
 NSUInteger RLMRealmSchemaVersion(RLMRealm *realm);
 


### PR DESCRIPTION
Eliminates spurious change notifications when opening a Realm flle in multiple processes.