### PR TITLE
Improve the exception message when comparing a linked property to another property (unsupported)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ x.x.x Release notes (yyyy-MM-dd)
 
 ### Enhancements
 
-* None.
+* Improve the exception message when comparing a linked property to another
+  property (unsupported).
 
 ### Bugfixes
 

--- a/Realm/RLMQueryUtil.mm
+++ b/Realm/RLMQueryUtil.mm
@@ -463,6 +463,12 @@ Query column_expression(NSComparisonPredicateOptions operatorType,
 
 void update_query_with_column_expression(RLMObjectSchema *scheme, Query &query, NSString *leftColumnName, NSString *rightColumnName, NSComparisonPredicateOptions predicateOptions)
 {
+    // Comparing two linked keypaths is unsupported.
+    RLMPrecondition([leftColumnName componentsSeparatedByString:@"."].count == 1 &&
+                    [rightColumnName componentsSeparatedByString:@"."].count == 1,
+                    @"Invalid predicate",
+                    @"Linked properties cannot be compared to other properties");
+
     // Validate object types
     NSUInteger leftIndex = RLMValidatedColumnIndex(scheme, leftColumnName);
     RLMPropertyType leftType = [scheme[leftColumnName] type];

--- a/Realm/Tests/QueryTests.m
+++ b/Realm/Tests/QueryTests.m
@@ -451,6 +451,10 @@
 
     // ALL
     XCTAssertThrows([realm objects:className where:@"ALL intCol > 5"], @"ALL int > constant");
+
+    // Linked Column Comparison
+    XCTAssertThrows([realm objects:AllTypesObject.className where:@"objectCol.stringCol == stringCol"],
+                    @"can't compare linked columns to other columns");
 }
 
 - (void)testPredicateMisuse


### PR DESCRIPTION
Fixes #1286.