### PR TITLE
Roll back changes made when an exception is thrown during a migration.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ x.x.x Release notes (yyyy-MM-dd)
 
 ### Bugfixes
 
-* None.
+* Roll back changes made when an exception is thrown during a migration.
 
 0.89.2 Release notes (2015-01-02)
 =============================================================

--- a/Realm/RLMMigration.mm
+++ b/Realm/RLMMigration.mm
@@ -149,10 +149,13 @@
         // update new version
         RLMRealmSetSchemaVersion(_realm, newVersion);
     }
-    @finally {
-        // end transaction
-        [_realm commitWriteTransaction];
+    @catch (...) {
+        [_realm cancelWriteTransaction];
+        @throw;
     }
+
+    // end transaction
+    [_realm commitWriteTransaction];
 }
 
 -(RLMObject *)createObject:(NSString *)className withObject:(id)object {


### PR DESCRIPTION
Previously it just left things sorta half-migrated.

@alazier 