### PR TITLE
Add a check for the count changing during RLMResults fast enumeration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ x.x.x Release notes (yyyy-MM-dd)
 ### Bugfixes
 
 * Roll back changes made when an exception is thrown during a migration.
+* Throw an exception if the number of items in a RLMResults or RLMArray changes
+  while it's being fast-enumerated.
 
 0.89.2 Release notes (2015-01-02)
 =============================================================

--- a/Realm/RLMArrayLinkView.mm
+++ b/Realm/RLMArrayLinkView.mm
@@ -92,6 +92,13 @@ static inline void RLMValidateObjectClass(__unsafe_unretained RLMObject *obj, __
         state->extra[1] = _backingLinkView->size();
     }
     else {
+        // FIXME: mutationsPtr should be pointing to a value updated by core
+        // whenever the linkview is changed rather than doing this check
+        if (state->extra[1] != self.count) {
+            @throw [NSException exceptionWithName:@"RLMException"
+                                           reason:@"Collection was mutated while being enumerated."
+                                         userInfo:nil];
+        }
         items = (__bridge id)(void *)state->extra[0];
         [items resize:len];
     }

--- a/Realm/RLMResults.mm
+++ b/Realm/RLMResults.mm
@@ -144,6 +144,8 @@ static inline void RLMResultsValidateInWriteTransaction(__unsafe_unretained RLMR
         state->extra[1] = self.count;
     }
     else {
+        // FIXME: mutationsPtr should be pointing to a value updated by core
+        // whenever the results are changed rather than doing this check
         if (state->extra[1] != self.count) {
             @throw [NSException exceptionWithName:@"RLMException"
                                            reason:@"Collection was mutated while being enumerated."

--- a/Realm/RLMResults.mm
+++ b/Realm/RLMResults.mm
@@ -144,6 +144,11 @@ static inline void RLMResultsValidateInWriteTransaction(__unsafe_unretained RLMR
         state->extra[1] = self.count;
     }
     else {
+        if (state->extra[1] != self.count) {
+            @throw [NSException exceptionWithName:@"RLMException"
+                                           reason:@"Collection was mutated while being enumerated."
+                                         userInfo:nil];
+        }
         items = (__bridge id)(void *)state->extra[0];
         [items resize:len];
     }

--- a/Realm/Tests/ArrayTests.m
+++ b/Realm/Tests/ArrayTests.m
@@ -92,7 +92,7 @@
     }
     XCTAssertNil(objects[0], @"Object should have been released");
 
-    @try {
+    void (^mutateDuringEnumeration)() = ^{
         bool first = true;
         for (__unused AggregateObject *ao in result) {
             // Only insert the first time so we don't infinite loop if the check
@@ -104,12 +104,10 @@
                 first = false;
             }
         }
+    };
 
-        XCTFail(@"Adding an object during fast enumeration did not throw");
-    }
-    @catch (NSException *) {
-        // nothing to do here
-    }
+    XCTAssertThrows(mutateDuringEnumeration(),
+                    @"Adding an object during fast enumeration did not throw");
 }
 
 - (void)testObjectAggregate


### PR DESCRIPTION
Without this check we now get an assertion failure when the count goes down, as we'd read past the end of the TableView.

@alazier 