### PR TITLE
Add writeEncryptedCopyToPath:key:error:

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ x.x.x Release notes (yyyy-MM-dd)
 
 ### Enhancements
 
-* None.
+* Add ``-[RLMRealm writeEncryptedCopyToPath:key:error:]``.
 
 ### Bugfixes
 

--- a/Realm/RLMRealm.h
+++ b/Realm/RLMRealm.h
@@ -353,6 +353,21 @@ typedef void(^RLMNotificationBlock)(NSString *notification, RLMRealm *realm);
 - (BOOL)writeCopyToPath:(NSString *)path error:(NSError **)error;
 
 /**
+ Write an encrypted and compacted copy of the RLMRealm to the given path.
+
+ The destination file cannot already exist.
+
+ Note that if this is called from within a write transaction it writes the
+ *current* data, and not data when the last write transaction was committed.
+
+ @param path Path to save the Realm to.
+ @param key 64-byte encryption key to encrypt the new file with
+ @param error On input, a pointer to an error object. If an error occurs, this pointer is set to an actual error object containing the error information. You may specify nil for this parameter if you do not want the error information.
+ @return YES if the realm was copied successfully. Returns NO if an error occurred.
+*/
+- (BOOL)writeEncryptedCopyToPath:(NSString *)path key:(NSData *)key error:(NSError **)error;
+
+/**
  Invalidate all RLMObjects and RLMResults read from this Realm.
 
  An RLMRealm holds a read lock on the version of the data accessed by it, so

--- a/Realm/RLMRealm.mm
+++ b/Realm/RLMRealm.mm
@@ -851,11 +851,11 @@ static void CheckReadWrite(RLMRealm *realm, NSString *msg=@"Cannot write to a re
     return (RLMObject *)RLMCreateObjectInRealmWithValue(self, className, object, RLMCreationOptionsNone);
 }
 
-- (BOOL)writeCopyToPath:(NSString *)path error:(NSError **)error {
+- (BOOL)writeCopyToPath:(NSString *)path key:(NSData *)key error:(NSError **)error {
     BOOL success = YES;
 
     try {
-        self.group->write(path.UTF8String);
+        self.group->write(path.UTF8String, static_cast<const char *>(key.bytes));
     }
     catch (File::PermissionDenied &ex) {
         success = NO;
@@ -883,6 +883,18 @@ static void CheckReadWrite(RLMRealm *realm, NSString *msg=@"Cannot write to a re
     }
 
     return success;
+}
+
+- (BOOL)writeCopyToPath:(NSString *)path error:(NSError **)error {
+    return [self writeCopyToPath:path key:nil error:error];
+}
+
+- (BOOL)writeEncryptedCopyToPath:(NSString *)path key:(NSData *)key error:(NSError **)error {
+    if (!key) {
+        @throw [NSException exceptionWithName:@"RLMException" reason:@"Encryption key must not be nil" userInfo:nil];
+    }
+
+    return [self writeCopyToPath:path key:key error:error];
 }
 
 @end


### PR DESCRIPTION
This makes it possible to change the encryption key of an existing Realm file as follows:

    // RLMRealm instances are autoreleased and we must ensure the old file is
    // closed before we try to overwrite it
    @autoreleasepool {
        // Write a copy with the new encryption key
        [RLMRealm.defaultRealm writeEncryptedCopyToPath:@"/tmp/out.realm"
                                                    key:newKey
                                                  error:&error];
    }
    // Overwrite the original file with the new copy
    [NSFileManager.defaultManager moveItemAtPath:@"/tmp/out.realm"
                                          toPath:RLMRealm.defaultRealmPath
                                           error:&error];
    // Update the encryption key to use for the default Realm (if using the key caching)
    [RLMRealm setEncryptionKey:newKey forRealmsAtPath:RLMRealm.defaultRealmPath];

    // Open the new file
    RLMRealm *realm = [RLMRealm defaultRealm];

@alazier 