### PR TITLE
Eliminate duplicated copies of the header files

### DIFF
--- a/Realm.podspec
+++ b/Realm.podspec
@@ -23,24 +23,20 @@ Pod::Spec.new do |s|
 
   s.compiler_flags          = "-DTIGHTDB_HAVE_CONFIG -DREALM_SWIFT=0 -DREALM_VERSION='@\"#{s.version}\"'"
   s.prepare_command         = 'sh build.sh cocoapods-setup'
-  s.private_header_files    = 'include-ios/**/*.hpp', 'include-osx/**/*.hpp', '**/*_Private.h'
-  s.source_files            = 'Realm/*.{m,mm}', 'core/**/*.{h,hpp}'
+  s.private_header_files    = '**/*.hpp', '**/*_Private.h', '**/*_Dynamic.h', 'include/tightdb/**/*.h'
+  s.source_files            = 'Realm/*.{h,m,mm,hpp}', 'include/**/*.hpp'
+  s.header_mappings_dir     = 'include'
   s.xcconfig                = { 'CLANG_CXX_LANGUAGE_STANDARD' => 'compiler-default',
                                 'OTHER_CPLUSPLUSFLAGS' => '-std=c++1y $(inherited)' }
   s.preserve_paths          = %w(build.sh)
 
   s.ios.deployment_target   = '6.0'
   s.ios.vendored_library    = 'core/libtightdb-ios.a'
-  s.ios.header_mappings_dir = 'include-ios'
-  s.ios.source_files        = 'include-ios/**/*.hpp'
 
   s.osx.deployment_target   = '10.8'
   s.osx.vendored_library    = 'core/libtightdb.a'
-  s.osx.header_mappings_dir = 'include-osx'
-  s.osx.source_files        = 'include-osx/**/*.hpp'
 
   s.subspec 'Headers' do |s|
-    s.ios.source_files        = 'include-ios/**/*.h'
-    s.osx.source_files        = 'include-osx/**/*.h'
+    s.source_files          = 'include/**/*.h'
   end
 end

--- a/build.sh
+++ b/build.sh
@@ -445,19 +445,12 @@ case "$COMMAND" in
         mv $(readlink tmp) core
         rm tmp
 
-        rm -r include-ios
-        mkdir include-ios
-        cp -R core/include/* include-ios
-        mkdir include-ios/Realm
-        cp Realm/*.{h,hpp} include-ios/Realm
-        cp Realm/ios/*.h include-ios/Realm
-
-        rm -r include-osx
-        mkdir include-osx
-        cp -R core/include/* include-osx
-        mkdir include-osx/Realm
-        cp Realm/*.{h,hpp} include-osx/Realm
-        cp Realm/osx/*.h include-osx/Realm
+        # CocoaPods doesn't support multiple header_mappings_dir, so combine
+        # both sets of headers into a single directory
+        mv core/include include
+        mkdir include/Realm
+        cp Realm/*.h include/Realm
+        touch include/Realm/RLMPlatform.h
         ;;
 
     ######################################


### PR DESCRIPTION
The podspec was creating two full copies of the includes for the sake of RLMPlatform.h, but the platform checking is unnecessary with CocoaPods, and having duplicated headers breaks #import's duplicate checking when header maps are enabled (which CocoaPods requires) and both the OS X and iOS versions are used.

Closes #1303.