### PR TITLE
Fix json import example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ x.x.x Release notes (yyyy-MM-dd)
 * Throw an exception if the number of items in a RLMResults or RLMArray changes
   while it's being fast-enumerated.
 * Also encrypt the temporary files used when encryption is enabled for a Realm.
+* Fixed crash in JSONImport example on OS X with non-en_US locale.
 
 0.89.2 Release notes (2015-01-02)
 =============================================================

--- a/examples/osx/objc/JSONImport/main.m
+++ b/examples/osx/objc/JSONImport/main.m
@@ -36,6 +36,7 @@ int main(int argc, const char * argv[])
         }
 
         NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
+        dateFormatter.locale = [NSLocale localeWithLocaleIdentifier:@"en_US_POSIX"];
         dateFormatter.dateFormat = @"MMMM dd, YYYY";
 
         RLMRealm *realm = [RLMRealm defaultRealm];


### PR DESCRIPTION
Fixed crash in JSONImport example on OS X with non-en_US locale.