### PR TITLE
Cache dynamic realms

### DIFF
--- a/Realm/Tests/MigrationTests.mm
+++ b/Realm/Tests/MigrationTests.mm
@@ -98,17 +98,19 @@ extern "C" {
     RLMObjectSchema *objectSchema = [RLMObjectSchema schemaForObjectClass:MigrationObject.class];
     objectSchema.properties = @[objectSchema.properties[0]];
 
-    // create realm with old schema and populate
-    RLMRealm *realm = [self realmWithSingleObject:objectSchema];
-    [realm beginWriteTransaction];
-    [realm createObject:MigrationObject.className withObject:@[@1]];
-    [realm createObject:MigrationObject.className withObject:@[@2]];
-    [realm commitWriteTransaction];
+    @autoreleasepool {
+        // create realm with old schema and populate
+        RLMRealm *realm = [self realmWithSingleObject:objectSchema];
+        [realm beginWriteTransaction];
+        [realm createObject:MigrationObject.className withObject:@[@1]];
+        [realm createObject:MigrationObject.className withObject:@[@2]];
+        [realm commitWriteTransaction];
+    }
 
     // open realm with new schema before migration to test migration is necessary
     objectSchema = [RLMObjectSchema schemaForObjectClass:MigrationObject.class];
     XCTAssertThrows([self realmWithTestPath], @"Migration should be required");
-    
+
     // apply migration
     [RLMRealm setSchemaVersion:1 withMigrationBlock:^(RLMMigration *migration, NSUInteger oldSchemaVersion) {
         XCTAssertEqual(oldSchemaVersion, 0U, @"Initial schema version should be 0");
@@ -124,10 +126,12 @@ extern "C" {
     [RLMRealm migrateRealmAtPath:RLMTestRealmPath()];
 
     // verify migration
-    realm = [self realmWithTestPath];
-    MigrationObject *mig1 = [MigrationObject allObjectsInRealm:realm][1];
-    XCTAssertEqual(mig1.intCol, 2, @"Int column should have value 2");
-    XCTAssertEqualObjects(mig1.stringCol, @"2", @"String column should be populated");
+    @autoreleasepool {
+        RLMRealm *realm = [self realmWithTestPath];
+        MigrationObject *mig1 = [MigrationObject allObjectsInRealm:realm][1];
+        XCTAssertEqual(mig1.intCol, 2, @"Int column should have value 2");
+        XCTAssertEqualObjects(mig1.stringCol, @"2", @"String column should be populated");
+    }
 
     [RLMRealm setSchemaVersion:0 withMigrationBlock:nil];
     XCTAssertThrows([RLMRealm migrateRealmAtPath:RLMTestRealmPath()]);
@@ -142,11 +146,13 @@ extern "C" {
     objectSchema.properties = [objectSchema.properties arrayByAddingObject:thirdProperty];
 
     // create realm with old schema and populate
-    RLMRealm *realm = [self realmWithSingleObject:objectSchema];
-    [realm beginWriteTransaction];
-    [realm createObject:MigrationObject.className withObject:@[@1, @"1", @YES]];
-    [realm createObject:MigrationObject.className withObject:@[@2, @"2", @NO]];
-    [realm commitWriteTransaction];
+    @autoreleasepool {
+        RLMRealm *realm = [self realmWithSingleObject:objectSchema];
+        [realm beginWriteTransaction];
+        [realm createObject:MigrationObject.className withObject:@[@1, @"1", @YES]];
+        [realm createObject:MigrationObject.className withObject:@[@2, @"2", @NO]];
+        [realm commitWriteTransaction];
+    }
 
     // apply migration
     [RLMRealm setSchemaVersion:1 withMigrationBlock:^(RLMMigration *migration, NSUInteger oldSchemaVersion) {
@@ -160,7 +166,7 @@ extern "C" {
     [RLMRealm migrateRealmAtPath:RLMTestRealmPath()];
 
     // verify migration
-    realm = [self realmWithTestPath];
+    RLMRealm *realm = [self realmWithTestPath];
     MigrationObject *mig1 = [MigrationObject allObjectsInRealm:realm][1];
     XCTAssertThrows(mig1[@"deletedCol"], @"Deleted column should no longer be accessible.");
 }
@@ -172,11 +178,13 @@ extern "C" {
     objectSchema.properties = @[oldInt, objectSchema.properties[1]];
 
     // create realm with old schema and populate
-    RLMRealm *realm = [self realmWithSingleObject:objectSchema];
-    [realm beginWriteTransaction];
-    [realm createObject:MigrationObject.className withObject:@[@1, @"1"]];
-    [realm createObject:MigrationObject.className withObject:@[@1, @"2"]];
-    [realm commitWriteTransaction];
+    @autoreleasepool {
+        RLMRealm *realm = [self realmWithSingleObject:objectSchema];
+        [realm beginWriteTransaction];
+        [realm createObject:MigrationObject.className withObject:@[@1, @"1"]];
+        [realm createObject:MigrationObject.className withObject:@[@1, @"2"]];
+        [realm commitWriteTransaction];
+    }
 
     // object migration object
     void (^migrateObjectBlock)(RLMObject *, RLMObject *) = ^(RLMObject *oldObject, RLMObject *newObject) {
@@ -196,7 +204,7 @@ extern "C" {
     [RLMRealm migrateRealmAtPath:RLMTestRealmPath()];
 
     // verify migration
-    realm = [self realmWithTestPath];
+    RLMRealm *realm = [self realmWithTestPath];
     MigrationObject *mig1 = [MigrationObject allObjectsInRealm:realm][1];
     XCTAssertThrows(mig1[@"oldIntCol"], @"Deleted column should no longer be accessible.");
     XCTAssertEqual(0U, [mig1.objectSchema.properties[0] column]);
@@ -211,11 +219,13 @@ extern "C" {
     stringCol.objcType = 'i';
 
     // create realm with old schema and populate
-    RLMRealm *realm = [self realmWithSingleObject:objectSchema];
-    [realm beginWriteTransaction];
-    [realm createObject:MigrationObject.className withObject:@[@1, @1]];
-    [realm createObject:MigrationObject.className withObject:@[@2, @2]];
-    [realm commitWriteTransaction];
+    @autoreleasepool {
+        RLMRealm *realm = [self realmWithSingleObject:objectSchema];
+        [realm beginWriteTransaction];
+        [realm createObject:MigrationObject.className withObject:@[@1, @1]];
+        [realm createObject:MigrationObject.className withObject:@[@2, @2]];
+        [realm commitWriteTransaction];
+    }
 
     // apply migration
     [RLMRealm setSchemaVersion:1 withMigrationBlock:^(RLMMigration *migration, NSUInteger oldSchemaVersion) {
@@ -230,7 +240,7 @@ extern "C" {
     [RLMRealm migrateRealmAtPath:RLMTestRealmPath()];
 
     // verify migration
-    realm = [self realmWithTestPath];
+    RLMRealm *realm = [self realmWithTestPath];
     MigrationObject *mig1 = [MigrationObject allObjectsInRealm:realm][1];
     XCTAssertEqualObjects(mig1[@"stringCol"], @"2", @"stringCol should be string after migration.");
 }
@@ -242,11 +252,13 @@ extern "C" {
     objectSchema.primaryKeyProperty = nil;
 
     // create realm with old schema and populate
-    RLMRealm *realm = [self realmWithSingleObject:objectSchema];
-    [realm beginWriteTransaction];
-    [realm createObject:MigrationPrimaryKeyObject.className withObject:@[@1]];
-    [realm createObject:MigrationPrimaryKeyObject.className withObject:@[@1]];
-    [realm commitWriteTransaction];
+    @autoreleasepool {
+        RLMRealm *realm = [self realmWithSingleObject:objectSchema];
+        [realm beginWriteTransaction];
+        [realm createObject:MigrationPrimaryKeyObject.className withObject:@[@1]];
+        [realm createObject:MigrationPrimaryKeyObject.className withObject:@[@1]];
+        [realm commitWriteTransaction];
+    }
 
     // apply migration
     [RLMRealm setSchemaVersion:1 withMigrationBlock:^(__unused RLMMigration *migration, __unused NSUInteger oldSchemaVersion) {}];
@@ -269,11 +281,13 @@ extern "C" {
     objectSchema.primaryKeyProperty = nil;
 
     // create realm with old schema and populate
-    RLMRealm *realm = [self realmWithSingleObject:objectSchema];
-    [realm beginWriteTransaction];
-    [realm createObject:MigrationStringPrimaryKeyObject.className withObject:@[@"1"]];
-    [realm createObject:MigrationStringPrimaryKeyObject.className withObject:@[@"2"]];
-    [realm commitWriteTransaction];
+    @autoreleasepool {
+        RLMRealm *realm = [self realmWithSingleObject:objectSchema];
+        [realm beginWriteTransaction];
+        [realm createObject:MigrationStringPrimaryKeyObject.className withObject:@[@"1"]];
+        [realm createObject:MigrationStringPrimaryKeyObject.className withObject:@[@"2"]];
+        [realm commitWriteTransaction];
+    }
 
     // apply migration
     [RLMRealm setSchemaVersion:1 withMigrationBlock:^(__unused RLMMigration *migration, __unused NSUInteger oldSchemaVersion) {
@@ -292,11 +306,13 @@ extern "C" {
     objectSchema.primaryKeyProperty.attributes = 0;
 
     // create realm with old schema and populate
-    RLMRealm *realm = [self realmWithSingleObject:objectSchema];
-    [realm beginWriteTransaction];
-    [realm createObject:MigrationStringPrimaryKeyObject.className withObject:@[@"1"]];
-    [realm createObject:MigrationStringPrimaryKeyObject.className withObject:@[@"2"]];
-    [realm commitWriteTransaction];
+    @autoreleasepool {
+        RLMRealm *realm = [self realmWithSingleObject:objectSchema];
+        [realm beginWriteTransaction];
+        [realm createObject:MigrationStringPrimaryKeyObject.className withObject:@[@"1"]];
+        [realm createObject:MigrationStringPrimaryKeyObject.className withObject:@[@"2"]];
+        [realm commitWriteTransaction];
+    }
 
     // apply migration
     [RLMRealm setSchemaVersion:1 withMigrationBlock:^(__unused RLMMigration *migration, __unused NSUInteger oldSchemaVersion) {
@@ -314,11 +330,13 @@ extern "C" {
     objectSchema.primaryKeyProperty = nil;
 
     // create realm with old schema and populate
-    RLMRealm *realm = [self realmWithSingleObject:objectSchema];
-    [realm beginWriteTransaction];
-    [realm createObject:MigrationPrimaryKeyObject.className withObject:@[@1]];
-    [realm createObject:MigrationPrimaryKeyObject.className withObject:@[@1]];
-    [realm commitWriteTransaction];
+    @autoreleasepool {
+        RLMRealm *realm = [self realmWithSingleObject:objectSchema];
+        [realm beginWriteTransaction];
+        [realm createObject:MigrationPrimaryKeyObject.className withObject:@[@1]];
+        [realm createObject:MigrationPrimaryKeyObject.className withObject:@[@1]];
+        [realm commitWriteTransaction];
+    }
 
     // apply bad migration
     [RLMRealm setSchemaVersion:1 withMigrationBlock:^(__unused RLMMigration *migration, __unused NSUInteger oldSchemaVersion) {}];
@@ -413,7 +431,7 @@ extern "C" {
     }];
 
     // migration should be applied when opening realm
-    [RLMRealm realmWithPath:RLMTestRealmPath()];
+    @autoreleasepool { [RLMRealm realmWithPath:RLMTestRealmPath()]; }
     XCTAssertEqual(true, migrationApplied);
 
     // applying migration at same version is no-op


### PR DESCRIPTION
Mostly just to make dynamic realms more like normal realms, but also lets us check for a few more invalid things.

Test changes are all just to avoid having the same file open multiple times with different schemas on the same thread.

@alazier 