### PR TITLE
Refactor schema init and fix a crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ x.x.x Release notes (yyyy-MM-dd)
   while it's being fast-enumerated.
 * Also encrypt the temporary files used when encryption is enabled for a Realm.
 * Fixed crash in JSONImport example on OS X with non-en_US locale.
+* Fix a crash when adding primary keys to older realm files with no primary
+  keys on any objects.
 
 0.89.2 Release notes (2015-01-02)
 =============================================================

--- a/Realm/RLMSchema.mm
+++ b/Realm/RLMSchema.mm
@@ -26,14 +26,14 @@
 #import <objc/runtime.h>
 
 NSString * const c_objectTableNamePrefix = @"class_";
-const char *c_metadataTableName = "metadata";
-const char *c_versionColumnName = "version";
+const char * const c_metadataTableName = "metadata";
+const char * const c_versionColumnName = "version";
 const size_t c_versionColumnIndex = 0;
 
-const char *c_primaryKeyTableName = "pk";
-const char *c_primaryKeyObjectClassColumnName = "pk_table";
+const char * const c_primaryKeyTableName = "pk";
+const char * const c_primaryKeyObjectClassColumnName = "pk_table";
 const size_t c_primaryKeyObjectClassColumnIndex =  0;
-const char *c_primaryKeyPropertyNameColumnName = "pk_property";
+const char * const c_primaryKeyPropertyNameColumnName = "pk_property";
 const size_t c_primaryKeyPropertyNameColumnIndex =  1;
 
 const NSUInteger RLMNotVersioned = (NSUInteger)-1;

--- a/Realm/RLMSchema_Private.h
+++ b/Realm/RLMSchema_Private.h
@@ -28,8 +28,9 @@
 //            of the typename (the rest of the name after class)
 //  metadata - table used for realm metadata storage
 extern NSString * const c_objectTableNamePrefix;
-extern const char *c_metadataTableName;
-extern const char *c_versionColumnName;
+extern const char * const c_metadataTableName;
+extern const char * const c_primaryKeyTableName;
+extern const char * const c_versionColumnName;
 extern const size_t c_versionColumnIndex;
 
 inline NSString *RLMClassForTableName(NSString *tableName) {

--- a/Realm/Tests/RealmTests.mm
+++ b/Realm/Tests/RealmTests.mm
@@ -21,6 +21,10 @@
 #import "RLMObjectSchema_Private.hpp"
 #import "RLMRealm_Dynamic.h"
 
+extern "C" {
+#import "RLMSchema_Private.h"
+}
+
 #import <libkern/OSAtomic.h>
 
 @interface RLMRealm ()
@@ -594,6 +598,7 @@
 
         [realm beginWriteTransaction];
         [realm createObject:StringObject.className withObject:@[@"a"]];
+        RLMRealmSetSchemaVersion(realm, 0);
         [realm commitWriteTransaction];
     }
 


### PR DESCRIPTION
Pull more of the schema version checking and updating stuff into one place to hopefully make it easier to follow and make explicit and implicit migrations do the exact same thing. Fixes a crash due to RLMRealmCreateMetadataTables not being called when implicitly migrating an existing realm file from being we unconditionally created the primary key table.

This also makes creating a brand new Realm file with a custom schema not set the schema version to the static schema version, since doing so didn't really make any sense.

@alazier 