### PR TITLE
Support per-Realm migration blocks and schema versions per Realm #1336

### DIFF
--- a/Realm/RLMRealm.h
+++ b/Realm/RLMRealm.h
@@ -511,8 +511,22 @@ typedef void (^RLMMigrationBlock)(RLMMigration *migration, NSUInteger oldSchemaV
 
  @param version     The current schema version.
  @param block       The block which migrates the Realm to the current version.
+ @param realmPath   The path of the Realm to migrate.
  @return            The error that occurred while applying the migration, if any.
 
+ @see               RLMMigration
+ */
++ (void)setSchemaVersion:(NSUInteger)version withMigrationBlock:(RLMMigrationBlock)block realmPath:(NSString *)path;;
+
+/**
+ Specify a schema version and an associated migration block for default realm
+ 
+ As `setSchemaVersion:withMigrationBlock:realmPath`, but for default realm path.
+ 
+ @param version     The current schema version.
+ @param block       The block which migrates the Realm to the current version.
+ @return            The error that occurred while applying the migration, if any.
+ 
  @see               RLMMigration
  */
 + (void)setSchemaVersion:(NSUInteger)version withMigrationBlock:(RLMMigrationBlock)block;

--- a/Realm/RLMRealm_Private.hpp
+++ b/Realm/RLMRealm_Private.hpp
@@ -32,6 +32,8 @@ extern "C" {
     BOOL _inWriteTransaction;
     mach_port_t _threadID;
 }
+@property (nonatomic, copy) RLMMigrationBlock migrationBlock;
+@property (nonatomic) NSUInteger currentSchemaVersion;
 @property (nonatomic, readonly) BOOL inWriteTransaction;
 @property (nonatomic, readonly) BOOL dynamic;
 @property (nonatomic, readonly, getter=getOrCreateGroup) tightdb::Group *group;

--- a/Realm/Tests/MigrationTests.mm
+++ b/Realm/Tests/MigrationTests.mm
@@ -120,7 +120,7 @@ extern "C" {
             NSString *stringObj = [NSString stringWithFormat:@"%@", intObj];
             XCTAssertNoThrow(newObject[@"stringCol"] = stringObj, @"Should be able to set stringCol");
         }];
-    }];
+    } realmPath:RLMTestRealmPath()];
     [RLMRealm migrateRealmAtPath:RLMTestRealmPath()];
 
     // verify migration
@@ -129,7 +129,7 @@ extern "C" {
     XCTAssertEqual(mig1.intCol, 2, @"Int column should have value 2");
     XCTAssertEqualObjects(mig1.stringCol, @"2", @"String column should be populated");
 
-    [RLMRealm setSchemaVersion:0 withMigrationBlock:nil];
+    [RLMRealm setSchemaVersion:0 withMigrationBlock:nil realmPath:RLMTestRealmPath()];
     XCTAssertThrows([RLMRealm migrateRealmAtPath:RLMTestRealmPath()]);
 }
 
@@ -156,7 +156,7 @@ extern "C" {
             XCTAssertNoThrow(oldObject[@"deletedCol"], @"Deleted column should be accessible on old object.");
             XCTAssertThrows(newObject[@"deletedCol"], @"Deleted column should not be accessible on new object.");
         }];
-    }];
+    } realmPath:RLMTestRealmPath()];
     [RLMRealm migrateRealmAtPath:RLMTestRealmPath()];
 
     // verify migration
@@ -192,7 +192,7 @@ extern "C" {
     [RLMRealm setSchemaVersion:1 withMigrationBlock:^(RLMMigration *migration, NSUInteger oldSchemaVersion) {
         XCTAssertEqual(oldSchemaVersion, 0U, @"Initial schema version should be 0");
         [migration enumerateObjects:MigrationObject.className block:migrateObjectBlock];
-    }];
+    } realmPath:RLMTestRealmPath()];
     [RLMRealm migrateRealmAtPath:RLMTestRealmPath()];
 
     // verify migration
@@ -226,7 +226,7 @@ extern "C" {
             XCTAssert([intObj isKindOfClass:NSNumber.class], @"Old stringCol should be int");
             newObject[@"stringCol"] = intObj.stringValue;
         }];
-    }];
+    } realmPath:RLMTestRealmPath()];
     [RLMRealm migrateRealmAtPath:RLMTestRealmPath()];
 
     // verify migration
@@ -249,7 +249,7 @@ extern "C" {
     [realm commitWriteTransaction];
 
     // apply migration
-    [RLMRealm setSchemaVersion:1 withMigrationBlock:^(__unused RLMMigration *migration, __unused NSUInteger oldSchemaVersion) {}];
+    [RLMRealm setSchemaVersion:1 withMigrationBlock:^(__unused RLMMigration *migration, __unused NSUInteger oldSchemaVersion) {} realmPath:RLMTestRealmPath()];
     XCTAssertThrows([RLMRealm migrateRealmAtPath:RLMTestRealmPath()],
                     @"Migration should throw due to duplicate primary keys)");
 
@@ -258,7 +258,7 @@ extern "C" {
         [migration enumerateObjects:@"MigrationPrimaryKeyObject" block:^(__unused RLMObject *oldObject, RLMObject *newObject) {
             newObject[@"intCol"] = @(objectID++);
         }];
-    }];
+    } realmPath:RLMTestRealmPath()];
     [RLMRealm migrateRealmAtPath:RLMTestRealmPath()];
 }
 
@@ -280,7 +280,7 @@ extern "C" {
         [migration enumerateObjects:@"MigrationStringPrimaryKeyObject" block:^(__unused RLMObject *oldObject, RLMObject *newObject) {
             newObject[@"stringCol"] = [[NSUUID UUID] UUIDString];
         }];
-    }];
+    } realmPath:RLMTestRealmPath()];
     [RLMRealm migrateRealmAtPath:RLMTestRealmPath()];
 }
 
@@ -321,7 +321,7 @@ extern "C" {
     [realm commitWriteTransaction];
 
     // apply bad migration
-    [RLMRealm setSchemaVersion:1 withMigrationBlock:^(__unused RLMMigration *migration, __unused NSUInteger oldSchemaVersion) {}];
+    [RLMRealm setSchemaVersion:1 withMigrationBlock:^(__unused RLMMigration *migration, __unused NSUInteger oldSchemaVersion) {} realmPath:RLMTestRealmPath()];
     XCTAssertThrows([RLMRealm migrateRealmAtPath:RLMTestRealmPath()], @"Migration should throw due to duplicate primary keys)");
 
     // apply good migration
@@ -338,7 +338,7 @@ extern "C" {
            }
         }];
         XCTAssertEqual(true, duplicateDeleted);
-    }];
+    } realmPath:RLMTestRealmPath()];
     [RLMRealm migrateRealmAtPath:RLMTestRealmPath()];
 
     // make sure deletion occurred
@@ -361,7 +361,7 @@ extern "C" {
     }
 
     // fail to apply migration
-    [RLMRealm setSchemaVersion:1 withMigrationBlock:^(__unused RLMMigration *migration, __unused NSUInteger oldSchemaVersion) {}];
+    [RLMRealm setSchemaVersion:1 withMigrationBlock:^(__unused RLMMigration *migration, __unused NSUInteger oldSchemaVersion) {} realmPath:RLMTestRealmPath()];
     XCTAssertThrows([RLMRealm migrateRealmAtPath:RLMTestRealmPath()], @"Migration should throw due to duplicate primary keys)");
 
     // should still be able to open with pre-migration schema
@@ -410,7 +410,7 @@ extern "C" {
             newObject[@"stringCol"] = @"";
         }];
         migrationApplied = true;
-    }];
+    } realmPath:RLMTestRealmPath()];
 
     // migration should be applied when opening realm
     [RLMRealm realmWithPath:RLMTestRealmPath()];
@@ -422,7 +422,7 @@ extern "C" {
     XCTAssertEqual(false, migrationApplied);
 
     // test version cant go down
-    [RLMRealm setSchemaVersion:0 withMigrationBlock:^(__unused RLMMigration *migration, __unused NSUInteger oldSchemaVersion) {}];
+    [RLMRealm setSchemaVersion:0 withMigrationBlock:^(__unused RLMMigration *migration, __unused NSUInteger oldSchemaVersion) {} realmPath:RLMTestRealmPath()];
     XCTAssertThrows([RLMRealm migrateRealmAtPath:RLMTestRealmPath()]);
 }
 


### PR DESCRIPTION
Add api to perform file-based realm migrations:

    + (void)setSchemaVersion:(NSUInteger)version withMigrationBlock:(RLMMigrationBlock)block realmPath:(NSString *)path;

This is required when working with realms in separate environment. All tests passes, example updated. Pull introduces minimal changes to public api.

Closes #1336.