### PR TITLE
[Examples/Obj-C] Fixed date format and set time zone offset such that the JSON strings are now parsed correctly.

### DIFF
--- a/examples/osx/objc/JSONImport/main.m
+++ b/examples/osx/objc/JSONImport/main.m
@@ -37,7 +37,8 @@ int main(int argc, const char * argv[])
 
         NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
         dateFormatter.locale = [NSLocale localeWithLocaleIdentifier:@"en_US_POSIX"];
-        dateFormatter.dateFormat = @"MMMM dd, YYYY";
+        dateFormatter.dateFormat = @"MMMM dd, yyyy";
+        dateFormatter.timeZone = [NSTimeZone timeZoneForSecondsFromGMT:0];
 
         RLMRealm *realm = [RLMRealm defaultRealm];
         [realm beginWriteTransaction];


### PR DESCRIPTION
The format YYYY is used for Year (in "Week of Year" based calendars), whereas yyyy is the "normal" calendar year ([doc](https://developer.apple.com/library/mac/documentation/Cocoa/Conceptual/DataFormatting/Articles/dfDateFormatting10_4.html#//apple_ref/doc/uid/TP40002369-SW13)). Along with setting the time zone offset to 0, the example now correctly parses "September 23, 1926" to an NSDate of 1926-09-23 00:00:00 +0000, instead of 1925-12-19 23:00:00 +0000.