### PR TITLE
Improve error reporting for incompatible lock files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ x.x.x Release notes (yyyy-MM-dd)
   write transaction with changes were committed without the main thread
   RLMRealm getting a chance to refresh.
 * Fixed incomplete results when querying for non-null relationships.
+* Improve the error message when a Realm file is opened in multiple processes
+  at once.
 
 0.89.2 Release notes (2015-01-02)
 =============================================================

--- a/Realm/RLMConstants.h
+++ b/Realm/RLMConstants.h
@@ -167,12 +167,10 @@ typedef NS_ENUM(NSInteger, RLMError) {
     RLMErrorFileExists            = 4,
     /** Returned by RLMRealm if no_create was specified and the file was not found when the realm is opened. */
     RLMErrorFileNotFound          = 5,
-    /** Returned by RLMRealm if a stale .lock file is present when the realm is opened. */
-    RLMErrorStaleLockFile         = 6,
-    /** Returned by RLMRealm if the database file is deleted while there are open realms,
-        and subsequent attempts to open realms will try to join an already
-        active shared scheme, but fail due to the missing database file. */
-    RLMErrorLockFileButNoData     = 7
+    /** Returned by RLMRealm if the database file is currently open in another
+        process which cannot share with the current process due to an
+        architecture mismatch. */
+    RLMErrorIncompatibleLockFile  = 8,
 };
 
 // Schema version used for unitialized Realms


### PR DESCRIPTION
Adds a better error message that tries to explain what's wrong.

@alazier @jpsim 