### PR TITLE
Allow per Realm schema versions and migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ x.x.x Release notes (yyyy-MM-dd)
 
 * Rename `-[RLMRealm encryptedRealmWithPath:key:readOnly:error:]` to
   `-[RLMRealm realmWithPath:encryptionKey:readOnly:error:]`.
+* `-[RLMRealm setSchemaVersion:withMigrationBlock]` is no longer global and must be called
+  for each individual Realm path used. You can now call `-[RLMRealm setDefaultRealmSchemaVersion:withMigrationBlock]` 
+  for the default Realm and `-[RLMRealm setSchemaVersion:forRealmAtPath:withMigrationBlock:]` for all others; 
 
 ### Enhancements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ x.x.x Release notes (yyyy-MM-dd)
   while it's being fast-enumerated.
 * Also encrypt the temporary files used when encryption is enabled for a Realm.
 * Fixed crash in JSONImport example on OS X with non-en_US locale.
+* Fix a crash when adding primary keys to older realm files with no primary
+  keys on any objects.
 
 0.89.2 Release notes (2015-01-02)
 =============================================================

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ x.x.x Release notes (yyyy-MM-dd)
 * Fixed crash in JSONImport example on OS X with non-en_US locale.
 * Fixed infinite loop when opening a Realm file in the Browser at the same time
   as it is open in a 32-bit simulator.
+* Fixed a crash when adding primary keys to older realm files with no primary
+  keys on any objects.
 
 0.89.2 Release notes (2015-01-02)
 =============================================================

--- a/Realm/RLMMigration_Private.h
+++ b/Realm/RLMMigration_Private.h
@@ -26,6 +26,6 @@
 
 - (instancetype)initWithRealm:(RLMRealm *)realm key:(NSData *)key error:(NSError **)error;
 
-- (void)migrateWithBlock:(RLMMigrationBlock)block version:(NSUInteger)newVersion;
+- (void)execute:(RLMMigrationBlock)block;
 
 @end

--- a/Realm/RLMObjectStore.hpp
+++ b/Realm/RLMObjectStore.hpp
@@ -24,9 +24,15 @@
 extern "C" {
 #endif
 
+
 //
 // Table modifications
 //
+
+// updates a Realm to a given target schema/version
+// creates tables as necessary
+// optionally runs migration block if schema is out of date
+NSError *RLMUpdateRealmToSchemaVersion(RLMRealm *realm, NSUInteger version, RLMSchema *targetSchema, NSError *(^migrationBlock)());
 
 // sets a realm's schema to a copy of targetSchema
 // caches table accessors on each objectSchema

--- a/Realm/RLMObjectStore.mm
+++ b/Realm/RLMObjectStore.mm
@@ -156,14 +156,9 @@ NSError *RLMUpdateRealmToSchemaVersion(RLMRealm *realm, NSUInteger newVersion, R
         NSUInteger oldVersion = RLMRealmSchemaVersion(realm);
 
         // validate versions
-        if (newVersion == RLMNotVersioned) {
-            @throw [NSException exceptionWithName:@"RLMException"
-                                           reason:@"No schema versions specified when initializing Realm"
-                                         userInfo:@{@"path" : realm.path}];
-        }
         if (oldVersion > newVersion && oldVersion != RLMNotVersioned) {
             @throw [NSException exceptionWithName:@"RLMException"
-                                           reason:@"Realm version is higher than the previous version"
+                                           reason:@"Version of Realm file on disk is higher than current schema version"
                                          userInfo:@{@"path" : realm.path}];
         }
 

--- a/Realm/RLMRealm.h
+++ b/Realm/RLMRealm.h
@@ -566,7 +566,7 @@ typedef void (^RLMMigrationBlock)(RLMMigration *migration, NSUInteger oldSchemaV
  @return            The error that occurred while applying the migration if any.
 
  @see               RLMMigration
- @see               setSchemaVersion:withMigrationBlock:
+ @see               setSchemaVersion:forRealmAtPath:withMigrationBlock:
  */
 + (NSError *)migrateRealmAtPath:(NSString *)realmPath;
 

--- a/Realm/RLMRealm.h
+++ b/Realm/RLMRealm.h
@@ -487,7 +487,7 @@ typedef void (^RLMMigrationBlock)(RLMMigration *migration, NSUInteger oldSchemaV
 
 /**
  Specify a schema version and an associated migration block which is applied when
- opening any Realm with and old schema version.
+ opening the default Realm with an old schema version.
 
  Before you can open an existing `RLMRealm` which has a different on-disk schema
  from the schema defined in your object interfaces you must provide a migration 
@@ -515,7 +515,20 @@ typedef void (^RLMMigrationBlock)(RLMMigration *migration, NSUInteger oldSchemaV
 
  @see               RLMMigration
  */
-+ (void)setSchemaVersion:(NSUInteger)version withMigrationBlock:(RLMMigrationBlock)block;
++ (void)setDefaultRealmSchemaVersion:(NSUInteger)version withMigrationBlock:(RLMMigrationBlock)block;
+
+/**
+ Specify a schema version and an associated migration block which is applied when
+ opening the Realm at realmPath with an old schema version.
+
+ @param version     The current schema version.
+ @param realmPath   The path at which this schema version and migration block is applied.
+ @param block       The block which migrates the Realm to the current version.
+ @return            The error that occurred while applying the migration, if any.
+
+ @see               RLMMigration
+ */
++ (void)setSchemaVersion:(NSUInteger)version forRealmAtPath:(NSString *)realmPath withMigrationBlock:(RLMMigrationBlock)block;
 
 /**
  Get the schema version for a Realm at a given path.

--- a/Realm/RLMRealm.mm
+++ b/Realm/RLMRealm.mm
@@ -68,23 +68,22 @@ using namespace std;
 using namespace tightdb;
 using namespace tightdb::util;
 
-namespace {
 
 // create NSException from c++ exception
-__attribute__((noreturn)) void throw_objc_exception(exception &ex) {
+static __attribute__((noreturn)) void throw_objc_exception(exception &ex) {
     NSString *errorMessage = [NSString stringWithUTF8String:ex.what()];
     @throw [NSException exceptionWithName:@"RLMException" reason:errorMessage userInfo:nil];
 }
 
 // create NSError from c++ exception
-NSError *make_realm_error(RLMError code, exception &ex) {
+static NSError *make_realm_error(RLMError code, exception &ex) {
     NSMutableDictionary *details = [NSMutableDictionary dictionary];
     [details setValue:[NSString stringWithUTF8String:ex.what()] forKey:NSLocalizedDescriptionKey];
     [details setValue:@(code) forKey:@"Error Code"];
     return [NSError errorWithDomain:@"io.realm" code:code userInfo:details];
 }
 
-void setOrThrowError(NSError *error, NSError **outError) {
+static void setOrThrowError(NSError *error, NSError **outError) {
     if (outError) {
         *outError = error;
     }
@@ -98,14 +97,14 @@ void setOrThrowError(NSError *error, NSError **outError) {
 //
 // Global encryption key cache and validation
 //
-NSMutableDictionary *s_keysPerPath;
-NSData *keyForPath(NSString *path) {
+static NSMutableDictionary *s_keysPerPath;
+static NSData *keyForPath(NSString *path) {
     @synchronized (s_keysPerPath) {
         return s_keysPerPath[path];
     }
 }
 
-void setKeyForPath(NSData *key, NSString *path) {
+static void setKeyForPath(NSData *key, NSString *path) {
     @synchronized (s_keysPerPath) {
         if (key) {
             s_keysPerPath[path] = key;
@@ -116,13 +115,13 @@ void setKeyForPath(NSData *key, NSString *path) {
     }
 }
 
-void clearKeyCache() {
+static void clearKeyCache() {
     @synchronized(s_keysPerPath) {
         s_keysPerPath = [NSMutableDictionary dictionary];
     }
 }
 
-bool isDebuggerAttached() {
+static bool isDebuggerAttached() {
     int name[] = {
         CTL_KERN,
         KERN_PROC,
@@ -141,7 +140,7 @@ bool isDebuggerAttached() {
     return (info.kp_proc.p_flag & P_TRACED) != 0;
 }
 
-void validateNotInDebugger() {
+static void validateNotInDebugger() {
     if (isDebuggerAttached()) {
         @throw [NSException exceptionWithName:@"RLMException"
                                        reason:@"Cannot open an encrypted Realm with a debugger attached to the process"
@@ -149,7 +148,7 @@ void validateNotInDebugger() {
     }
 }
 
-NSData *validatedKey(NSData *key) {
+static NSData *validatedKey(NSData *key) {
     if (key) {
         if ([key length] != 64) {
             @throw [NSException exceptionWithName:@"RLMException"
@@ -163,20 +162,20 @@ NSData *validatedKey(NSData *key) {
 //
 // Global RLMRealm instance cache
 //
-NSMutableDictionary *s_realmsPerPath;
+static NSMutableDictionary *s_realmsPerPath;
 
 // FIXME: In the following 3 functions, we should be identifying files by the inode,device number pair
 //  rather than by the path (since the path is not a reliable identifier). This requires additional support
 //  from the core library though, because the inode,device number pair needs to be taken from the open file
 //  (to avoid race conditions).
-RLMRealm *cachedRealm(NSString *path) {
+static RLMRealm *cachedRealm(NSString *path) {
     mach_port_t threadID = pthread_mach_thread_np(pthread_self());
     @synchronized(s_realmsPerPath) {
         return [s_realmsPerPath[path] objectForKey:@(threadID)];
     }
 }
 
-void cacheRealm(RLMRealm *realm, NSString *path) {
+static void cacheRealm(RLMRealm *realm, NSString *path) {
     mach_port_t threadID = pthread_mach_thread_np(pthread_self());
     @synchronized(s_realmsPerPath) {
         if (!s_realmsPerPath[path]) {
@@ -186,13 +185,13 @@ void cacheRealm(RLMRealm *realm, NSString *path) {
     }
 }
 
-NSArray *realmsAtPath(NSString *path) {
+static NSArray *realmsAtPath(NSString *path) {
     @synchronized(s_realmsPerPath) {
         return [s_realmsPerPath[path] objectEnumerator].allObjects;
     }
 }
 
-void clearRealmCache() {
+static void clearRealmCache() {
     @synchronized(s_realmsPerPath) {
         for (NSMapTable *map in s_realmsPerPath.allValues) {
             [map removeAllObjects];
@@ -203,14 +202,38 @@ void clearRealmCache() {
 
 
 //
+// Schema version and migration blocks
+//
+static NSMutableDictionary *s_migrationBlocks;
+static NSMutableDictionary *s_schemaVersions;
+
+static NSUInteger schemaVersionForPath(NSString *path) {
+    @synchronized(s_migrationBlocks) {
+        NSNumber *version = s_schemaVersions[path];
+        if (version) {
+            return [version unsignedIntegerValue];
+        }
+        return 0;
+    }
+}
+
+static RLMMigrationBlock migrationBlockForPath(NSString *path) {
+    @synchronized(s_migrationBlocks) {
+        return s_migrationBlocks[path];
+    }
+}
+
+static void clearMigrationCache() {
+    @synchronized(s_migrationBlocks) {
+        s_migrationBlocks = [NSMutableDictionary new];
+        s_schemaVersions = [NSMutableDictionary new];
+    }
+}
+
+//
 // Global realm state
 //
 static NSString *s_defaultRealmPath = nil;
-static RLMMigrationBlock s_migrationBlock;
-static NSUInteger s_currentSchemaVersion = 0;
-
-} // anonymous namespace
-
 
 NSString * const c_defaultRealmFileName = @"default.realm";
 
@@ -245,9 +268,8 @@ NSString * const c_defaultRealmFileName = @"default.realm";
     // set up global realm cache
     RLMCheckForUpdates();
 
-    // initilize realm and key caches
-    clearRealmCache();
-    clearKeyCache();
+    // reset global state
+    [RLMRealm resetRealmState];
 }
 
 - (instancetype)initWithPath:(NSString *)path key:(NSData *)key readOnly:(BOOL)readonly inMemory:(BOOL)inMemory dynamic:(BOOL)dynamic error:(NSError **)outError {
@@ -451,6 +473,14 @@ static id RLMAutorelease(id value) {
         return nil;
     }
 
+    RLMSchema *targetSchema = RLMSchema.sharedSchema;
+    if (customSchema) {
+        targetSchema = customSchema;
+    }
+    else if (dynamic) {
+        targetSchema = [RLMSchema dynamicSchemaFromRealm:realm];
+    }
+
     // we need to protect the realm cache and accessors cache
     @synchronized(s_realmsPerPath) {
         // create tables, set schema, and create accessors when needed
@@ -460,7 +490,7 @@ static id RLMAutorelease(id value) {
                                                reason:@"Cannot open an uninitialized realm in read-only mode"
                                              userInfo:nil];
             }
-            RLMRealmSetSchema(realm, [RLMSchema sharedSchema], true);
+            RLMRealmSetSchema(realm, targetSchema, true);
             RLMRealmCreateAccessors(realm.schema);
         }
         else {
@@ -472,8 +502,7 @@ static id RLMAutorelease(id value) {
             }
             else {
                 // if we are the first realm at this path, set/align schema or perform migration if needed
-                RLMSchema *targetSchema = customSchema ?: dynamic ? [RLMSchema dynamicSchemaFromRealm:realm] : RLMSchema.sharedSchema;
-                NSError *error = RLMUpdateRealmToSchemaVersion(realm, s_currentSchemaVersion, targetSchema, [realm migrationBlock:key]);
+                NSError *error = RLMUpdateRealmToSchemaVersion(realm, schemaVersionForPath(path), targetSchema, [realm migrationBlock:key]);
                 if (error) {
                     setOrThrowError(error, outError);
                     return nil;
@@ -495,7 +524,7 @@ static id RLMAutorelease(id value) {
 }
 
 - (NSError *(^)())migrationBlock:(NSData *)encryptionKey {
-    RLMMigrationBlock userBlock = s_migrationBlock;
+    RLMMigrationBlock userBlock = migrationBlockForPath(_path);
     if (userBlock) {
         return ^{
             NSError *error;
@@ -516,8 +545,7 @@ static id RLMAutorelease(id value) {
 }
 
 + (void)resetRealmState {
-    s_currentSchemaVersion = 0;
-    s_migrationBlock = NULL;
+    clearMigrationCache();
     clearRealmCache();
     clearKeyCache();
 }
@@ -812,9 +840,20 @@ static void CheckReadWrite(RLMRealm *realm, NSString *msg=@"Cannot write to a re
     return RLMGetObjects(self, objectClassName, predicate);
 }
 
-+ (void)setSchemaVersion:(NSUInteger)version withMigrationBlock:(RLMMigrationBlock)block {
-    s_currentSchemaVersion = version;
-    s_migrationBlock = block;
++ (void)setDefaultRealmSchemaVersion:(NSUInteger)version withMigrationBlock:(RLMMigrationBlock)block {
+    [RLMRealm setSchemaVersion:version forRealmAtPath:[RLMRealm defaultRealmPath] withMigrationBlock:block];
+}
+
++ (void)setSchemaVersion:(NSUInteger)version forRealmAtPath:(NSString *)realmPath withMigrationBlock:(RLMMigrationBlock)block {
+    @synchronized(s_migrationBlocks) {
+        if (block) {
+            s_migrationBlocks[realmPath] = block;
+        }
+        else {
+            [s_migrationBlocks removeObjectForKey:realmPath];
+        }
+        s_schemaVersions[realmPath] = @(version);
+    }
 }
 
 + (NSUInteger)schemaVersionAtPath:(NSString *)realmPath error:(NSError **)error {
@@ -854,7 +893,7 @@ static void CheckReadWrite(RLMRealm *realm, NSString *msg=@"Cannot write to a re
     if (error)
         return error;
 
-    return RLMUpdateRealmToSchemaVersion(realm, s_currentSchemaVersion, RLMSchema.sharedSchema, [realm migrationBlock:key]);
+    return RLMUpdateRealmToSchemaVersion(realm, schemaVersionForPath(realmPath), RLMSchema.sharedSchema, [realm migrationBlock:key]);
 }
 
 - (RLMObject *)createObject:(NSString *)className withObject:(id)object {

--- a/Realm/RLMSchema.mm
+++ b/Realm/RLMSchema.mm
@@ -26,14 +26,14 @@
 #import <objc/runtime.h>
 
 NSString * const c_objectTableNamePrefix = @"class_";
-const char *c_metadataTableName = "metadata";
-const char *c_versionColumnName = "version";
+const char * const c_metadataTableName = "metadata";
+const char * const c_versionColumnName = "version";
 const size_t c_versionColumnIndex = 0;
 
-const char *c_primaryKeyTableName = "pk";
-const char *c_primaryKeyObjectClassColumnName = "pk_table";
+const char * const c_primaryKeyTableName = "pk";
+const char * const c_primaryKeyObjectClassColumnName = "pk_table";
 const size_t c_primaryKeyObjectClassColumnIndex =  0;
-const char *c_primaryKeyPropertyNameColumnName = "pk_property";
+const char * const c_primaryKeyPropertyNameColumnName = "pk_property";
 const size_t c_primaryKeyPropertyNameColumnIndex =  1;
 
 const NSUInteger RLMNotVersioned = (NSUInteger)-1;

--- a/Realm/RLMSchema_Private.h
+++ b/Realm/RLMSchema_Private.h
@@ -28,8 +28,9 @@
 //            of the typename (the rest of the name after class)
 //  metadata - table used for realm metadata storage
 extern NSString * const c_objectTableNamePrefix;
-extern const char *c_metadataTableName;
-extern const char *c_versionColumnName;
+extern const char * const c_metadataTableName;
+extern const char * const c_primaryKeyTableName;
+extern const char * const c_versionColumnName;
 extern const size_t c_versionColumnIndex;
 
 inline NSString *RLMClassForTableName(NSString *tableName) {

--- a/Realm/Tests/RealmTests.mm
+++ b/Realm/Tests/RealmTests.mm
@@ -21,6 +21,10 @@
 #import "RLMObjectSchema_Private.hpp"
 #import "RLMRealm_Dynamic.h"
 
+extern "C" {
+#import "RLMSchema_Private.h"
+}
+
 #import <libkern/OSAtomic.h>
 
 @interface RLMRealm ()
@@ -594,6 +598,7 @@
 
         [realm beginWriteTransaction];
         [realm createObject:StringObject.className withObject:@[@"a"]];
+        RLMRealmSetSchemaVersion(realm, 0);
         [realm commitWriteTransaction];
     }
 

--- a/examples/ios/objc/Migration/AppDelegate.m
+++ b/examples/ios/objc/Migration/AppDelegate.m
@@ -48,7 +48,7 @@
     // define a migration block
     // you can define this inline, but we will reuse this to migrate realm files from multiple versions
     // to the most current version of our data model
-    [RLMRealm setSchemaVersion:3 withMigrationBlock:^(RLMMigration *migration, NSUInteger oldSchemaVersion) {
+    RLMMigrationBlock migrationBlock = ^(RLMMigration *migration, NSUInteger oldSchemaVersion) {
         if (oldSchemaVersion < 1) {
             [migration enumerateObjects:Person.className block:^(RLMObject *oldObject, RLMObject *newObject) {
                 if (oldSchemaVersion < 1) {
@@ -75,7 +75,10 @@
             }];
         }
         NSLog(@"Migration complete.");
-    }];
+    };
+
+    // set the schema verion and migration block for the defualt realm
+    [RLMRealm setDefaultRealmSchemaVersion:3 withMigrationBlock:migrationBlock];
 
     // now that we have called `setSchemaVersion:withMigrationBlock` opening an outdated Realm will automatically
     // perform the migration and opening the Realm will succeed
@@ -95,6 +98,10 @@
     [[NSFileManager defaultManager] copyItemAtPath:v1Path toPath:realmv1Path error:nil];
     [[NSFileManager defaultManager] removeItemAtPath:realmv2Path error:nil];
     [[NSFileManager defaultManager] copyItemAtPath:v2Path toPath:realmv2Path error:nil];
+
+    // set schemave versions and migration blocks form Realms at each path
+    [RLMRealm setSchemaVersion:3 forRealmAtPath:realmv1Path withMigrationBlock:migrationBlock];
+    [RLMRealm setSchemaVersion:3 forRealmAtPath:realmv2Path withMigrationBlock:migrationBlock];
 
     // manully migration v1Path, v2Path is migrated implicitly on access
     [RLMRealm migrateRealmAtPath:realmv1Path];

--- a/examples/ios/swift/Migration/AppDelegate.swift
+++ b/examples/ios/swift/Migration/AppDelegate.swift
@@ -90,7 +90,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             }
             println("Migration complete.")
         }
-        RLMRealm.setSchemaVersion(3, withMigrationBlock: migrationBlock)
+        RLMRealm.setDefaultRealmSchemaVersion(3, withMigrationBlock: migrationBlock)
 
         // print out all migrated objects in the default realm
         // migration is performed implicitly on Realm access
@@ -108,6 +108,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         NSFileManager.defaultManager().copyItemAtPath(v1Path, toPath: realmv1Path, error: nil)
         NSFileManager.defaultManager().removeItemAtPath(realmv2Path, error: nil)
         NSFileManager.defaultManager().copyItemAtPath(v2Path, toPath: realmv2Path, error: nil)
+
+        // set the schema version and migration blocks for our custom path realms
+        RLMRealm.setSchemaVersion(3, forRealmAtPath: realmv1Path, withMigrationBlock: migrationBlock)
+        RLMRealm.setSchemaVersion(3, forRealmAtPath: realmv2Path, withMigrationBlock: migrationBlock)
 
         // migrate realms at realmv1Path manually, realmv2Path is migrated automatically on access
         RLMRealm.migrateRealmAtPath(realmv1Path)

--- a/tools/RealmBrowser/RealmBrowser/Classes/RLMRealmNode.m
+++ b/tools/RealmBrowser/RealmBrowser/Classes/RLMRealmNode.m
@@ -43,15 +43,21 @@
 
 - (BOOL)connect:(NSError **)error
 {
-    _realm = [RLMRealm realmWithPath:_url
-                                 key:nil
-                            readOnly:NO
-                            inMemory:NO
-                             dynamic:YES
-                              schema:nil
-                               error:error];
-    
-    if (*error != nil) {
+    // set the schema version of the realm we are about to open to its current version
+    NSUInteger version = [RLMRealm schemaVersionAtPath:_url encryptionKey:nil error:error];
+
+    if (!*error) {
+        [RLMRealm setSchemaVersion:version forRealmAtPath:_url withMigrationBlock:nil];
+        _realm = [RLMRealm realmWithPath:_url
+                                     key:nil
+                                readOnly:NO
+                                inMemory:NO
+                                 dynamic:YES
+                                  schema:nil
+                                   error:error];
+    }
+
+    if (*error) {
         NSLog(@"Realm was opened with error: %@", *error);
     }
     else {

--- a/tools/RealmBrowser/RealmBrowser/Classes/RLMRealmNode.m
+++ b/tools/RealmBrowser/RealmBrowser/Classes/RLMRealmNode.m
@@ -43,20 +43,13 @@
 
 - (BOOL)connect:(NSError **)error
 {
-    // set the schema version of the realm we are about to open to its current version
-    NSUInteger version = [RLMRealm schemaVersionAtPath:_url encryptionKey:nil error:error];
-
-    if (!*error) {
-        [RLMRealm setSchemaVersion:version forRealmAtPath:_url withMigrationBlock:nil];
-        _realm = [RLMRealm realmWithPath:_url
-                                     key:nil
-                                readOnly:NO
-                                inMemory:NO
-                                 dynamic:YES
-                                  schema:nil
-                                   error:error];
-    }
-
+    _realm = [RLMRealm realmWithPath:_url
+                                 key:nil
+                            readOnly:NO
+                            inMemory:NO
+                             dynamic:YES
+                              schema:nil
+                               error:error];
     if (*error) {
         NSLog(@"Realm was opened with error: %@", *error);
     }


### PR DESCRIPTION
Also cleans up the logic for migration and checking/updating schema version.

Closes #1336, #1326 
Replaces #1340, #1335  

@tgoyne 