### PR TITLE
[Podspec] Fix private header definition for using frameworks with CocoaPods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,9 @@ Realm.framework
 # sh build.sh build-cocoa
 bin
 
+# sh build.sh cocoapods-setup
+/include
+
 # sh build.sh docs
 /docs/output
 

--- a/Realm.podspec
+++ b/Realm.podspec
@@ -38,5 +38,6 @@ Pod::Spec.new do |s|
 
   s.subspec 'Headers' do |s|
     s.source_files          = 'include/**/*.h'
+    s.private_header_files  = '**/*.hpp', '**/*_Private.h', '**/*_Dynamic.h', 'include/tightdb/**/*.h'
   end
 end

--- a/Realm.podspec
+++ b/Realm.podspec
@@ -21,9 +21,11 @@ Pod::Spec.new do |s|
   s.documentation_url       = "http://realm.io/docs/cocoa/#{s.version}"
   s.license                 = { :type => 'Apache 2.0', :file => 'LICENSE' }
 
+  private_header_files = '**/*.hpp', '**/*_Private.h', '**/*_Dynamic.h', 'include/tightdb/**/*.h'.freeze
+
   s.compiler_flags          = "-DTIGHTDB_HAVE_CONFIG -DREALM_SWIFT=0 -DREALM_VERSION='@\"#{s.version}\"'"
   s.prepare_command         = 'sh build.sh cocoapods-setup'
-  s.private_header_files    = '**/*.hpp', '**/*_Private.h', '**/*_Dynamic.h', 'include/tightdb/**/*.h'
+  s.private_header_files    = private_header_files
   s.source_files            = 'Realm/*.{h,m,mm,hpp}', 'include/**/*.hpp'
   s.header_mappings_dir     = 'include'
   s.xcconfig                = { 'CLANG_CXX_LANGUAGE_STANDARD' => 'compiler-default',
@@ -38,6 +40,6 @@ Pod::Spec.new do |s|
 
   s.subspec 'Headers' do |s|
     s.source_files          = 'include/**/*.h'
-    s.private_header_files  = '**/*.hpp', '**/*_Private.h', '**/*_Dynamic.h', 'include/tightdb/**/*.h'
+    s.private_header_files  = private_header_files
   end
 end

--- a/build.sh
+++ b/build.sh
@@ -447,8 +447,9 @@ case "$COMMAND" in
 
         # CocoaPods doesn't support multiple header_mappings_dir, so combine
         # both sets of headers into a single directory
+        rm -rf include
         mv core/include include
-        mkdir include/Realm
+        mkdir -p include/Realm
         cp Realm/*.h include/Realm
         touch include/Realm/RLMPlatform.h
         ;;


### PR DESCRIPTION
Otherwise private headers will be imported from the umbrella header, which will cause that the framework can't be build.
Fixes #1280.