### PR TITLE
[RLMAccessor] Improve the exception message when trying to set a property with an object of the incorrect type.

### DIFF
--- a/Realm/RLMAccessor.mm
+++ b/Realm/RLMAccessor.mm
@@ -310,7 +310,7 @@ static inline void RLMSetValue(__unsafe_unretained RLMObjectBase *obj, NSUIntege
                 return;
         }
     }
-    @throw [NSException exceptionWithName:@"RLMException" reason:@"Inserting invalid object for RLMPropertyTypeAny property" userInfo:nil];
+    @throw [NSException exceptionWithName:@"RLMException" reason:[NSString stringWithFormat:@"Inserting invalid object of class %@ for an RLMPropertyTypeAny property (%@).", [val class], [obj.objectSchema.properties[col_ndx] name]] userInfo:nil];
 }
 
 // dynamic getter with column closure


### PR DESCRIPTION
Closes https://github.com/realm/realm-cocoa/issues/1369.

\c @alazier @tgoyne 