### PR TITLE
Fix grouped queries on allObjects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 * Fix for RLMObject being treated as a model object class and showing up in the browser.
 * Fix compilation from the podspec.
+* Fix for crash when calling `objectsWhere:` with grouping in the query on `allObjects`.
 
 0.90.0 Release notes (2015-01-21)
 =============================================================

--- a/Realm/RLMResults.mm
+++ b/Realm/RLMResults.mm
@@ -527,7 +527,7 @@ static NSNumber *averageOfProperty(TableType const& table, RLMRealm *realm, NSSt
 }
 
 - (std::unique_ptr<Query>)cloneQuery {
-    return std::make_unique<tightdb::Query>(_table->where());
+    return std::make_unique<tightdb::Query>(_table->where(), tightdb::Query::TCopyExpressionTag{});
 }
 
 - (NSUInteger)indexInSource:(NSUInteger)index {

--- a/Realm/Tests/QueryTests.m
+++ b/Realm/Tests/QueryTests.m
@@ -128,6 +128,11 @@
     XCTAssertEqual(betweenResults.count, 2U, @"Should equal 2");
     betweenResults = [AllTypesObject objectsWhere:@"doubleCol BETWEEN {3.0, 7.0}"];
     XCTAssertEqual(betweenResults.count, 2U, @"Should equal 2");
+
+    betweenResults = [AllTypesObject.allObjects objectsWhere:@"intCol BETWEEN {2, 3}"];
+    XCTAssertEqual(betweenResults.count, 2U, @"Should equal 2");
+    betweenResults = [AllTypesObject.allObjects objectsWhere:@"doubleCol BETWEEN {3.0, 7.0}"];
+    XCTAssertEqual(betweenResults.count, 2U, @"Should equal 2");
 }
 
 - (void)testQueryWithDates


### PR DESCRIPTION
Shallow copies of empty queries give an invalid Query, so make a "deep" copy.

Closes #1394.

@alazier 