### PR TITLE
[Podspec] Move headers to subspec only

### DIFF
--- a/Realm.podspec
+++ b/Realm.podspec
@@ -21,24 +21,9 @@ Pod::Spec.new do |s|
   s.documentation_url       = "http://realm.io/docs/cocoa/#{s.version}"
   s.license                 = { :type => 'Apache 2.0', :file => 'LICENSE' }
 
-  public_header_files = 'include/Realm/RLMArray.h',
-                        'include/Realm/RLMCollection.h',
-                        'include/Realm/RLMConstants.h',
-                        'include/Realm/RLMListBase.h',
-                        'include/Realm/RLMMigration.h',
-                        'include/Realm/RLMObject.h',
-                        'include/Realm/RLMObjectBase.h',
-                        'include/Realm/RLMObjectSchema.h',
-                        'include/Realm/RLMPlatform.h',
-                        'include/Realm/RLMProperty.h',
-                        'include/Realm/RLMRealm.h',
-                        'include/Realm/RLMResults.h',
-                        'include/Realm/RLMSchema.h',
-                        'include/Realm/Realm.h'
-
   s.compiler_flags          = "-DTIGHTDB_HAVE_CONFIG -DREALM_SWIFT=0 -DREALM_VERSION='@\"#{s.version}\"'"
   s.prepare_command         = 'sh build.sh cocoapods-setup'
-  s.public_header_files     = public_header_files
+  s.public_header_files     = []
   s.source_files            = 'Realm/*.{h,m,mm,hpp}', 'include/**/*.hpp'
   s.header_mappings_dir     = 'include'
   s.xcconfig                = { 'CLANG_CXX_LANGUAGE_STANDARD' => 'compiler-default',
@@ -53,6 +38,19 @@ Pod::Spec.new do |s|
 
   s.subspec 'Headers' do |s|
     s.source_files          = 'include/**/*.h'
-    s.public_header_files   = public_header_files
+    s.public_header_files   = 'include/Realm/RLMArray.h',
+                              'include/Realm/RLMCollection.h',
+                              'include/Realm/RLMConstants.h',
+                              'include/Realm/RLMListBase.h',
+                              'include/Realm/RLMMigration.h',
+                              'include/Realm/RLMObject.h',
+                              'include/Realm/RLMObjectBase.h',
+                              'include/Realm/RLMObjectSchema.h',
+                              'include/Realm/RLMPlatform.h',
+                              'include/Realm/RLMProperty.h',
+                              'include/Realm/RLMRealm.h',
+                              'include/Realm/RLMResults.h',
+                              'include/Realm/RLMSchema.h',
+                              'include/Realm/Realm.h'
   end
 end


### PR DESCRIPTION
Otherwise they will cause warnings with framework support of CocoaPods 0.36.0-beta1, because they would be added twice. This won't mean any changes for the user, as the `Header` subspec is included by default.