### PR TITLE
Fix accessor creation when the first Realm opened is read-only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+x.x.x Release notes (yyyy-MM-dd)
+=============================================================
+
+### API breaking changes
+
+* None.
+
+### Enhancements
+
+* None.
+
+### Bugfixes
+
+* Fix incorrect column type assertions when the first Realm file opened is a
+  read-only file that is missing tables.
+
 0.90.1 Release notes (2015-01-22)
 =============================================================
 

--- a/Realm/RLMObjectStore.hpp
+++ b/Realm/RLMObjectStore.hpp
@@ -41,6 +41,8 @@ void RLMRealmSetSchema(RLMRealm *realm, RLMSchema *targetSchema, bool verifyAndA
 // create or get cached accessors for the given schema
 void RLMRealmCreateAccessors(RLMSchema *schema);
 
+// Clear the cache of created accessor classes
+void RLMClearAccessorCache();
 
 //
 // Options for object creation

--- a/Realm/RLMObjectStore.mm
+++ b/Realm/RLMObjectStore.mm
@@ -113,10 +113,10 @@ static void RLMCreateColumn(RLMRealm *realm, tightdb::Table &table, RLMProperty 
     }
 }
 
-void RLMRealmCreateAccessors(RLMSchema *schema) {
-    // Schema used to created generated accessors
-    static NSMutableArray * const s_accessorSchema = [NSMutableArray new];
+// Schema used to created generated accessors
+static NSMutableArray * const s_accessorSchema = [NSMutableArray new];
 
+void RLMRealmCreateAccessors(RLMSchema *schema) {
     // create accessors for non-dynamic realms
     RLMSchema *matchingSchema = nil;
     for (RLMSchema *accessorSchema in s_accessorSchema) {
@@ -135,12 +135,18 @@ void RLMRealmCreateAccessors(RLMSchema *schema) {
     else {
         // create accessors and cache in s_accessorSchema
         for (RLMObjectSchema *objectSchema in schema.objectSchema) {
-            NSString *prefix = [NSString stringWithFormat:@"RLMAccessor_v%lu_",
-                                (unsigned long)s_accessorSchema.count];
-            objectSchema.accessorClass = RLMAccessorClassForObjectClass(objectSchema.objectClass, objectSchema, prefix);
+            if (objectSchema.table) {
+                NSString *prefix = [NSString stringWithFormat:@"RLMAccessor_v%lu_",
+                                    (unsigned long)s_accessorSchema.count];
+                objectSchema.accessorClass = RLMAccessorClassForObjectClass(objectSchema.objectClass, objectSchema, prefix);
+            }
         }
         [s_accessorSchema addObject:[schema copy]];
     }
+}
+
+void RLMClearAccessorCache() {
+    [s_accessorSchema removeAllObjects];
 }
 
 void RLMRealmSetSchema(RLMRealm *realm, RLMSchema *targetSchema, bool verify) {

--- a/Realm/RLMProperty.mm
+++ b/Realm/RLMProperty.mm
@@ -314,8 +314,11 @@
 
 
 -(BOOL)isEqualToProperty:(RLMProperty *)prop {
-    return [_name isEqualToString:prop.name] && _type == prop.type && prop.isPrimary == _isPrimary &&
-           (_objectClassName == nil || [_objectClassName isEqualToString:prop.objectClassName]);
+    return _type == prop->_type
+        && _isPrimary == prop->_isPrimary
+        && _column == prop->_column
+        && [_name isEqualToString:prop->_name]
+        && (_objectClassName == prop->_objectClassName  || [_objectClassName isEqualToString:prop->_objectClassName]);
 }
 
 - (BOOL)isEqual:(id)object {


### PR DESCRIPTION
When a read-only Realm is missing tables, we can't read the column order from the table, so we were creating accessors where every property was using column 0, and then reusing those accessors for Realms opened later which do have the tables. This fixes the problem by explicitly checking `_column` in `isEqualToProperty:` rather than relying on the order of the properties in the array, and as an optimization skips creating the accessors for missing tables.

Fixes https://secure.helpscout.net/conversation/67013100/364/ and hopefully the other reports of column type mismatches.

@alazier 