### PR TITLE
Improvements to RLMObject create* methods when argument is an RLMObject

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,18 @@ x.x.x Release notes (yyyy-MM-dd)
 
 ### Enhancements
 
-* None.
+* Calling `createInDefaultRealmWithObject:`, `createInRealm:withObject:`,
+  `createOrUpdateInDefaultRealmWithObject:` or `createOrUpdateInRealm:withObject:`
+  is a no-op if the argument is an RLMObject of the same type as the receiver
+  and is already backed by the target realm.
 
 ### Bugfixes
 
 * Fix incorrect column type assertions when the first Realm file opened is a
   read-only file that is missing tables.
 * Throw an exception when adding an invalidated or deleted object as a link.
+* Throw an exception when calling `createOrUpdateInRealm:withObject:` when the
+  receiver has no primary key defined.
 
 0.90.1 Release notes (2015-01-22)
 =============================================================

--- a/Realm/RLMObject.h
+++ b/Realm/RLMObject.h
@@ -156,7 +156,7 @@
  is returned. Otherwise this creates and populates a new instance of this object in the default Realm.
  
  If nested objects are included in the argument, `createOrUpdateInDefaultRealmWithObject:` will be
- called on them.
+ called on them if have a primary key (`createInDefaultRealmWithObject:` otherwise).
  
  This is a no-op if the argument is an RLMObject of the same type already backed by the target realm.
 
@@ -179,7 +179,7 @@
  is returned. Otherwise this creates and populates a new instance of this object in the provided Realm.
  
  If nested objects are included in the argument, `createOrUpdateInRealm:withObject:` will be
- called on them.
+ called on them if have a primary key (`createInRealm:withObject:` otherwise).
 
  This is a no-op if the argument is an RLMObject of the same type already backed by the target realm.
 

--- a/Realm/RLMObject.h
+++ b/Realm/RLMObject.h
@@ -112,6 +112,9 @@
 
  Creates an instance of this object and adds it to the default Realm populating
  the object with the given object.
+ 
+ If nested objects are included in the argument, `createInDefaultRealmWithObject:` will be called
+ on them.
 
  @param object  The object used to populate the object. This can be any key/value coding compliant
                 object, or a JSON object such as those returned from the methods in NSJSONSerialization, or
@@ -129,6 +132,9 @@
  
  Creates an instance of this object and adds it to the given Realm populating
  the object with the given object.
+ 
+ If nested objects are included in the argument, `createInRealm:withObject:` will be called
+ on them.
  
  @param realm   The Realm in which this object is persisted.
  @param object  The object used to populate the object. This can be any key/value coding compliant
@@ -148,6 +154,11 @@
  This method can only be called on object types with a primary key defined. If there is already
  an object with the same primary key value in the default RLMRealm its values are updated and the object
  is returned. Otherwise this creates and populates a new instance of this object in the default Realm.
+ 
+ If nested objects are included in the argument, `createOrUpdateInDefaultRealmWithObject:` will be
+ called on them.
+ 
+ This is a no-op if the argument is an RLMObject of the same type already backed by the target realm.
 
  @param object  The object used to populate the object. This can be any key/value coding compliant
                 object, or a JSON object such as those returned from the methods in NSJSONSerialization, or
@@ -166,6 +177,11 @@
  This method can only be called on object types with a primary key defined. If there is already
  an object with the same primary key value in the provided RLMRealm its values are updated and the object
  is returned. Otherwise this creates and populates a new instance of this object in the provided Realm.
+ 
+ If nested objects are included in the argument, `createOrUpdateInRealm:withObject:` will be
+ called on them.
+
+ This is a no-op if the argument is an RLMObject of the same type already backed by the target realm.
 
  @param realm   The Realm in which this object is persisted.
  @param object  The object used to populate the object. This can be any key/value coding compliant

--- a/Realm/RLMObject.mm
+++ b/Realm/RLMObject.mm
@@ -53,17 +53,16 @@
 }
 
 + (instancetype)createOrUpdateInDefaultRealmWithObject:(id)object {
+    return [self createOrUpdateInRealm:[RLMRealm defaultRealm] withObject:object];
+}
+
++ (instancetype)createOrUpdateInRealm:(RLMRealm *)realm withObject:(id)value {
     // verify primary key
     RLMObjectSchema *schema = [self sharedSchema];
     if (!schema.primaryKeyProperty) {
         NSString *reason = [NSString stringWithFormat:@"'%@' does not have a primary key and can not be updated", schema.className];
         @throw [NSException exceptionWithName:@"RLMExecption" reason:reason userInfo:nil];
     }
-
-    return (RLMObject *)RLMCreateObjectInRealmWithValue([RLMRealm defaultRealm], [self className], object, RLMCreationOptionsUpdateOrCreate | RLMCreationOptionsAllowCopy);
-}
-
-+ (instancetype)createOrUpdateInRealm:(RLMRealm *)realm withObject:(id)value {
     return (RLMObject *)RLMCreateObjectInRealmWithValue(realm, [self className], value, RLMCreationOptionsUpdateOrCreate | RLMCreationOptionsAllowCopy);
 }
 

--- a/Realm/RLMObjectStore.mm
+++ b/Realm/RLMObjectStore.mm
@@ -411,6 +411,13 @@ void RLMAddObjectToRealm(RLMObjectBase *object, RLMRealm *realm, RLMCreationOpti
 
 
 RLMObjectBase *RLMCreateObjectInRealmWithValue(RLMRealm *realm, NSString *className, id value, RLMCreationOptions options) {
+    if (RLMIsSubclass([value class], RLMObjectBase.class) &&
+        [[[(RLMObjectBase *)value class] className] isEqualToString:className] &&
+        [(RLMObjectBase *)value realm] == realm) {
+        // This is a no-op if value is an RLMObject of the same type already backed by the target realm.
+        return value;
+    }
+
     // verify writable
     RLMVerifyInWriteTransaction(realm);
 

--- a/Realm/Tests/ObjectInterfaceTests.m
+++ b/Realm/Tests/ObjectInterfaceTests.m
@@ -20,6 +20,18 @@
 
 #pragma mark - Test Objects
 
+@interface PrimaryKeyWithLinkObject : RLMObject
+@property NSString *primaryKey;
+@property StringObject *string;
+@end
+
+@implementation PrimaryKeyWithLinkObject
++ (NSString *)primaryKey
+{
+    return @"primaryKey";
+}
+@end
+
 #pragma mark - Tests
 
 @interface ObjectInterfaceTests : RLMTestCase
@@ -65,12 +77,22 @@
     CustomAccessorsObject *caStandalone = [[CustomAccessorsObject alloc] init];
     caStandalone.name = @"name";
     caStandalone.age = 99;
-    [CustomAccessorsObject createOrUpdateInRealm:realm withObject:caStandalone];
+    [CustomAccessorsObject createInRealm:realm withObject:caStandalone];
     [realm commitWriteTransaction];
 
     CustomAccessorsObject *objectFromRealm = [CustomAccessorsObject allObjects][0];
     XCTAssertEqualObjects(objectFromRealm.name, @"name", @"name property should be name.");
     XCTAssertEqual(objectFromRealm.age, 99, @"age property should be 99");
+}
+
+- (void)testCreateOrUpdateSameRealm
+{
+    RLMRealm *realm = self.realmWithTestPath;
+    [realm beginWriteTransaction];
+    PrimaryKeyWithLinkObject *object = [PrimaryKeyWithLinkObject createInRealm:realm withObject:@[@"", @[@""]]];
+    PrimaryKeyWithLinkObject *returnedObject = [PrimaryKeyWithLinkObject createOrUpdateInRealm:realm withObject:object];
+    XCTAssertEqual(object, returnedObject);
+    [realm commitWriteTransaction];
 }
 
 - (void)testClassExtension

--- a/Realm/Tests/ObjectTests.m
+++ b/Realm/Tests/ObjectTests.m
@@ -1154,8 +1154,9 @@ RLM_ARRAY_TYPE(PrimaryIntObject);
     XCTAssertEqual([objects count], 2U, @"Should have 2 objects");
     XCTAssertEqual([(PrimaryStringObject *)objects[0] intCol], 3, @"Value should be 3");
 
-    // upsert on non-primary key object shoudld throw
+    // upsert on non-primary key object should throw
     XCTAssertThrows([StringObject createOrUpdateInDefaultRealmWithObject:@[@"string"]]);
+    XCTAssertThrows([StringObject createOrUpdateInRealm:realm withObject:@[@"string"]]);
 
     [realm commitWriteTransaction];
 }


### PR DESCRIPTION
- `RLMCreateObjectInRealmWithValue()` is now a no-op if value is an RLMObject
  of the same type already backed by the target realm.
- Moved check for primary key from `createOrUpdateInDefaultRealmWithObject:` to
  `createOrUpdateInRealm:withObject:`

Fixes #1409. @alazier @tgoyne 