### PR TITLE
[RLMProperty] Re-add isEqualToProperty:

### DIFF
--- a/Realm.xcodeproj/project.pbxproj
+++ b/Realm.xcodeproj/project.pbxproj
@@ -117,7 +117,7 @@
 		3F6B896619EF3C06004E8EA8 /* RLMSwiftSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 3FE79FF719BA6A5900780C9A /* RLMSwiftSupport.h */; };
 		3F6B896819EF3C06004E8EA8 /* RLMPlatform.h in Headers */ = {isa = PBXBuildFile; fileRef = 024E6093198B2D51002FA042 /* RLMPlatform.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		3F6B896919EF3C06004E8EA8 /* RLMProperty.h in Headers */ = {isa = PBXBuildFile; fileRef = E81A1F761955FC9300FDED82 /* RLMProperty.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		3F6B896A19EF3C06004E8EA8 /* RLMProperty_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = E81A1F751955FC9300FDED82 /* RLMProperty_Private.h */; };
+		3F6B896A19EF3C06004E8EA8 /* RLMProperty_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = E81A1F751955FC9300FDED82 /* RLMProperty_Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		3F6B896B19EF3C06004E8EA8 /* RLMQueryUtil.hpp in Headers */ = {isa = PBXBuildFile; fileRef = E81A1F781955FC9300FDED82 /* RLMQueryUtil.hpp */; };
 		3F6B896C19EF3C06004E8EA8 /* RLMRealm.h in Headers */ = {isa = PBXBuildFile; fileRef = E81A1F7B1955FC9300FDED82 /* RLMRealm.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		3F6B896D19EF3C06004E8EA8 /* RLMRealm_Dynamic.h in Headers */ = {isa = PBXBuildFile; fileRef = E8951F01196C96DE00D6461C /* RLMRealm_Dynamic.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -201,7 +201,7 @@
 		E81A1F9A1955FC9300FDED82 /* RLMObjectSchema.h in Headers */ = {isa = PBXBuildFile; fileRef = E81A1F711955FC9300FDED82 /* RLMObjectSchema.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		E81A1F9B1955FC9300FDED82 /* RLMObjectSchema.mm in Sources */ = {isa = PBXBuildFile; fileRef = E81A1F721955FC9300FDED82 /* RLMObjectSchema.mm */; };
 		E81A1F9E1955FC9300FDED82 /* RLMObjectStore.mm in Sources */ = {isa = PBXBuildFile; fileRef = E81A1F741955FC9300FDED82 /* RLMObjectStore.mm */; };
-		E81A1FA01955FC9300FDED82 /* RLMProperty_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = E81A1F751955FC9300FDED82 /* RLMProperty_Private.h */; };
+		E81A1FA01955FC9300FDED82 /* RLMProperty_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = E81A1F751955FC9300FDED82 /* RLMProperty_Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E81A1FA11955FC9300FDED82 /* RLMProperty.h in Headers */ = {isa = PBXBuildFile; fileRef = E81A1F761955FC9300FDED82 /* RLMProperty.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		E81A1FA21955FC9300FDED82 /* RLMProperty.mm in Sources */ = {isa = PBXBuildFile; fileRef = E81A1F771955FC9300FDED82 /* RLMProperty.mm */; };
 		E81A1FA41955FC9300FDED82 /* RLMQueryUtil.hpp in Headers */ = {isa = PBXBuildFile; fileRef = E81A1F781955FC9300FDED82 /* RLMQueryUtil.hpp */; };
@@ -245,7 +245,7 @@
 		E856D2001956154C00FB2FCF /* RLMObjectSchema.h in Headers */ = {isa = PBXBuildFile; fileRef = E81A1F711955FC9300FDED82 /* RLMObjectSchema.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		E856D2011956154C00FB2FCF /* RLMObjectSchema.mm in Sources */ = {isa = PBXBuildFile; fileRef = E81A1F721955FC9300FDED82 /* RLMObjectSchema.mm */; };
 		E856D2031956154C00FB2FCF /* RLMObjectStore.mm in Sources */ = {isa = PBXBuildFile; fileRef = E81A1F741955FC9300FDED82 /* RLMObjectStore.mm */; };
-		E856D2041956154C00FB2FCF /* RLMProperty_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = E81A1F751955FC9300FDED82 /* RLMProperty_Private.h */; };
+		E856D2041956154C00FB2FCF /* RLMProperty_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = E81A1F751955FC9300FDED82 /* RLMProperty_Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E856D2051956154C00FB2FCF /* RLMProperty.h in Headers */ = {isa = PBXBuildFile; fileRef = E81A1F761955FC9300FDED82 /* RLMProperty.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		E856D2061956154C00FB2FCF /* RLMProperty.mm in Sources */ = {isa = PBXBuildFile; fileRef = E81A1F771955FC9300FDED82 /* RLMProperty.mm */; };
 		E856D2071956154C00FB2FCF /* RLMQueryUtil.hpp in Headers */ = {isa = PBXBuildFile; fileRef = E81A1F781955FC9300FDED82 /* RLMQueryUtil.hpp */; };
@@ -831,9 +831,9 @@
 				E81A1F951955FC9300FDED82 /* RLMObject_Private.h in Headers */,
 				E81A1FA11955FC9300FDED82 /* RLMProperty.h in Headers */,
 				29FA58801A7ACE7700A222E5 /* RLMObjectSchema_Private.h in Headers */,
-				E81A1FA01955FC9300FDED82 /* RLMProperty_Private.h in Headers */,
 				0207AB7F195DF9FB007EFB12 /* RLMMigration_Private.h in Headers */,
 				E81A1FA41955FC9300FDED82 /* RLMQueryUtil.hpp in Headers */,
+				E81A1FA01955FC9300FDED82 /* RLMProperty_Private.h in Headers */,
 				E81A1FA81955FC9300FDED82 /* RLMRealm.h in Headers */,
 				E81A1FA71955FC9300FDED82 /* RLMRealm_Private.hpp in Headers */,
 				02B8EF5919E601D80045A93D /* RLMResults.h in Headers */,

--- a/Realm.xcodeproj/project.pbxproj
+++ b/Realm.xcodeproj/project.pbxproj
@@ -177,6 +177,10 @@
 		3FDE338D19C39A87003B7DBA /* RLMSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = E88C36FF19745E5500C9963D /* RLMSupport.swift */; };
 		3FE79FF819BA6A5900780C9A /* RLMSwiftSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 3FE79FF719BA6A5900780C9A /* RLMSwiftSupport.h */; };
 		3FE79FF919BA6A5900780C9A /* RLMSwiftSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 3FE79FF719BA6A5900780C9A /* RLMSwiftSupport.h */; };
+		C0269E231A801FE70036E048 /* RLMPropertyTests.m in Sources */ = {isa = PBXBuildFile; fileRef = C0269E221A801FE70036E048 /* RLMPropertyTests.m */; };
+		C0269E241A801FE70036E048 /* RLMPropertyTests.m in Sources */ = {isa = PBXBuildFile; fileRef = C0269E221A801FE70036E048 /* RLMPropertyTests.m */; };
+		C0269E251A801FE70036E048 /* RLMPropertyTests.m in Sources */ = {isa = PBXBuildFile; fileRef = C0269E221A801FE70036E048 /* RLMPropertyTests.m */; };
+		C0269E261A801FE70036E048 /* RLMPropertyTests.m in Sources */ = {isa = PBXBuildFile; fileRef = C0269E221A801FE70036E048 /* RLMPropertyTests.m */; };
 		C0FE75C11A79B60800326886 /* RLMUtilTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = C0FE75C01A79B60800326886 /* RLMUtilTests.mm */; };
 		C0FE75C21A79B60800326886 /* RLMUtilTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = C0FE75C01A79B60800326886 /* RLMUtilTests.mm */; };
 		C0FE75C31A79B60800326886 /* RLMUtilTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = C0FE75C01A79B60800326886 /* RLMUtilTests.mm */; };
@@ -398,6 +402,7 @@
 		3F7792361A60A646004E4CA6 /* ResultsTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ResultsTests.m; sourceTree = "<group>"; };
 		3F8DCA5719930F550008BD7F /* iOS Device Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "iOS Device Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		3FE79FF719BA6A5900780C9A /* RLMSwiftSupport.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RLMSwiftSupport.h; sourceTree = "<group>"; };
+		C0269E221A801FE70036E048 /* RLMPropertyTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RLMPropertyTests.m; sourceTree = "<group>"; };
 		C0FE75C01A79B60800326886 /* RLMUtilTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = RLMUtilTests.mm; sourceTree = "<group>"; };
 		E81A1F621955FC9300FDED82 /* Realm-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "Realm-Info.plist"; sourceTree = "<group>"; };
 		E81A1F631955FC9300FDED82 /* RLMAccessor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RLMAccessor.h; sourceTree = "<group>"; };
@@ -594,6 +599,7 @@
 				E81A1FD11955FE0100FDED82 /* TransactionTests.m */,
 				E8917597197A1B350068ACC6 /* UnicodeTests.m */,
 				C0FE75C01A79B60800326886 /* RLMUtilTests.mm */,
+				C0269E221A801FE70036E048 /* RLMPropertyTests.m */,
 			);
 			name = "Objective-C";
 			sourceTree = "<group>";
@@ -1171,6 +1177,7 @@
 				3F512D9F19F9A1F300746016 /* RLMPredicateUtil.m in Sources */,
 				02689E021A572DCA00C8AE9D /* RLMSupport.swift in Sources */,
 				3F512DA119F9A1F300746016 /* RLMTestCase.m in Sources */,
+				C0269E261A801FE70036E048 /* RLMPropertyTests.m in Sources */,
 				3F512DA219F9A1F300746016 /* RLMTestObjects.m in Sources */,
 				3F512DA319F9A1F300746016 /* SchemaTests.mm in Sources */,
 				3F512DA419F9A1F300746016 /* SwiftArrayPropertyTests.swift in Sources */,
@@ -1228,6 +1235,7 @@
 				3F8DCA6F19930F960008BD7F /* ObjectTests.m in Sources */,
 				3F8DCA7019930F960008BD7F /* PerformanceTests.m in Sources */,
 				3F8DCA7119930F960008BD7F /* PropertyTypeTest.mm in Sources */,
+				C0269E251A801FE70036E048 /* RLMPropertyTests.m in Sources */,
 				3F8DCA7219930F960008BD7F /* QueryTests.m in Sources */,
 				3F8DCA7319930F960008BD7F /* RealmTests.mm in Sources */,
 				3F7792391A60A646004E4CA6 /* ResultsTests.m in Sources */,
@@ -1286,6 +1294,7 @@
 				E8A5DEEE1968E521006A50F6 /* RLMPredicateUtil.m in Sources */,
 				3FDE338D19C39A87003B7DBA /* RLMSupport.swift in Sources */,
 				E856D21F195615B100FB2FCF /* RLMTestCase.m in Sources */,
+				C0269E241A801FE70036E048 /* RLMPropertyTests.m in Sources */,
 				028481CB19CCFC9C0097A416 /* RLMTestObjects.m in Sources */,
 				0207AB8A195DFA15007EFB12 /* SchemaTests.mm in Sources */,
 				3F8DCA7619930FCB0008BD7F /* SwiftArrayPropertyTests.swift in Sources */,
@@ -1349,6 +1358,7 @@
 				E8A5DEED1968E520006A50F6 /* RLMPredicateUtil.m in Sources */,
 				3FDCFEB619F6A8D3005E414A /* RLMSupport.swift in Sources */,
 				E81A1FEE1955FE0100FDED82 /* RLMTestCase.m in Sources */,
+				C0269E231A801FE70036E048 /* RLMPropertyTests.m in Sources */,
 				028481EF19CD032C0097A416 /* RLMTestObjects.m in Sources */,
 				0207AB89195DFA15007EFB12 /* SchemaTests.mm in Sources */,
 				3FB4FA1819F5D2740020D53B /* SwiftArrayPropertyTests.swift in Sources */,

--- a/Realm/RLMProperty.h
+++ b/Realm/RLMProperty.h
@@ -53,4 +53,9 @@
  */
 @property (nonatomic, readonly, copy) NSString *objectClassName;
 
+/**
+ Returns YES if property objects are equal.
+ */
+- (BOOL)isEqualToProperty:(RLMProperty *)property;
+
 @end

--- a/Realm/RLMProperty.mm
+++ b/Realm/RLMProperty.mm
@@ -304,4 +304,11 @@
     return prop;
 }
 
+- (BOOL)isEqualToProperty:(RLMProperty *)property {
+    return _type == property->_type
+        && _isPrimary == property->_isPrimary
+        && [_name isEqualToString:property->_name]
+        && (_objectClassName == property->_objectClassName  || [_objectClassName isEqualToString:property->_objectClassName]);
+}
+
 @end

--- a/Realm/RLMProperty_Private.h
+++ b/Realm/RLMProperty_Private.h
@@ -16,7 +16,7 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-#import "RLMProperty.h"
+#import <Realm/RLMProperty.h>
 #import <objc/runtime.h>
 
 @class RLMObjectBase;

--- a/Realm/Tests/RLMPropertyTests.m
+++ b/Realm/Tests/RLMPropertyTests.m
@@ -1,0 +1,43 @@
+//
+//  RLMPropertyTests.m
+//  Realm
+//
+//  Created by Samuel Giddins on 2/2/15.
+//  Copyright (c) 2015 Realm. All rights reserved.
+//
+
+#import "RLMTestCase.h"
+
+#import <objc/runtime.h>
+#import "RLMProperty_Private.h"
+
+@interface RLMPropertyTests : RLMTestCase
+
+@end
+
+@implementation RLMPropertyTests
+
+- (void)testTwoPropertiesAreEqual {
+    const char *name = "intCol";
+    objc_property_t objcProperty1 = class_getProperty(AllTypesObject.class, name);
+    RLMProperty *property1 = [[RLMProperty alloc] initWithName:@(name) indexed:YES property:objcProperty1];
+
+    objc_property_t objcProperty2 = class_getProperty(IntObject.class, name);
+    RLMProperty *property2 = [[RLMProperty alloc] initWithName:@(name) indexed:YES property:objcProperty2];
+
+    XCTAssertTrue([property1 isEqualToProperty:property2]);
+}
+
+- (void)testTwoPropertiesAreUnequal {
+    const char *name = "stringCol";
+    objc_property_t objcProperty1 = class_getProperty(AllTypesObject.class, name);
+    RLMProperty *property1 = [[RLMProperty alloc] initWithName:@(name) indexed:YES property:objcProperty1];
+
+    name = "intCol";
+    objc_property_t objcProperty2 = class_getProperty(IntObject.class, name);
+    RLMProperty *property2 = [[RLMProperty alloc] initWithName:@(name) indexed:YES property:objcProperty2];
+
+    XCTAssertFalse([property1 isEqualToProperty:property2]);
+}
+
+@end

--- a/Realm/module.modulemap
+++ b/Realm/module.modulemap
@@ -14,5 +14,6 @@ framework module Realm {
         header "RLMObjectSchema_Private.h"
         header "RLMMigration_Private.h"
         header "RLMResults_Private.h"
+        header "RLMProperty_Private.h"
     }
 }


### PR DESCRIPTION
Restores the user-facing `isEqualToProperty:` method

\c @alazier @tgoyne 