### PR TITLE
[RLMUtil] Only try to import RLMVersion.h if REALM_VERSION is undefined.

### DIFF
--- a/Realm/RLMUtil.mm
+++ b/Realm/RLMUtil.mm
@@ -23,8 +23,11 @@
 #import "RLMObject_Private.h"
 #import "RLMProperty_Private.h"
 #import "RLMSwiftSupport.h"
-#import "RLMVersion.h"
 #import "RLMSchema_Private.h"
+
+#if !defined(REALM_VERSION)
+#import "RLMVersion.h"
+#endif
 
 static inline bool nsnumber_is_like_integer(NSNumber *obj)
 {


### PR DESCRIPTION
Fixes building with CocoaPods.

Verified this fixes things with `pod lib lint`.

\c @tgoyne @mrackwitz 