### PR TITLE
Use $TMPDIR instead of direct access to /tmp.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -160,7 +160,7 @@ fi
 
 download_core() {
     echo "Downloading dependency: core ${REALM_CORE_VERSION}"
-    TMP_DIR="/tmp/core_bin"
+    TMP_DIR="$TMPDIR/core_bin"
     mkdir -p "${TMP_DIR}"
     CORE_TMP_ZIP="${TMP_DIR}/core-${REALM_CORE_VERSION}.zip.tmp"
     CORE_ZIP="${TMP_DIR}/core-${REALM_CORE_VERSION}.zip"
@@ -511,7 +511,7 @@ case "$COMMAND" in
         ;;
 
     "package-release")
-        TEMPDIR=$(mktemp -d /tmp/realm-release-package.XXXX)
+        TEMPDIR=$(mktemp -d $TMPDIR/realm-release-package.XXXX)
 
         cd tightdb_objc
         VERSION=$(sh build.sh get-version)


### PR DESCRIPTION
It is generally not a good practice to use /tmp on OS X, because it is a shared directory - $TMPDIR points to a user-specific directory instead.