### PR TITLE
Add OS X tests for doing things with multiple processes

### DIFF
--- a/Realm.xcodeproj/project.pbxproj
+++ b/Realm.xcodeproj/project.pbxproj
@@ -178,6 +178,8 @@
 		3FB4FA1E19F5D2740020D53B /* SwiftPropertyTypeTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26F3CA681986CC86004623E1 /* SwiftPropertyTypeTest.swift */; };
 		3FB4FA1F19F5D2740020D53B /* SwiftRealmTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E81A1FD01955FE0100FDED82 /* SwiftRealmTests.swift */; };
 		3FB4FA2019F5D2740020D53B /* SwiftUnicodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E891759A197A1B600068ACC6 /* SwiftUnicodeTests.swift */; };
+		3FBB3C271A84456D00582589 /* RLMMultiProcessTestCase.m in Sources */ = {isa = PBXBuildFile; fileRef = 3FBB3C261A84456D00582589 /* RLMMultiProcessTestCase.m */; };
+		3FBB3C2A1A8964C600582589 /* InterprocessTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 3FBB3C291A8964C600582589 /* InterprocessTests.m */; };
 		3FDCFEB619F6A8D3005E414A /* RLMSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = E88C36FF19745E5500C9963D /* RLMSupport.swift */; };
 		3FDE338C19C37E4C003B7DBA /* RLMSwiftSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 3F452EC519C2279800AFC154 /* RLMSwiftSupport.m */; };
 		3FDE338D19C39A87003B7DBA /* RLMSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = E88C36FF19745E5500C9963D /* RLMSupport.swift */; };
@@ -409,6 +411,9 @@
 		3F7668F71A6D96C50058F4F1 /* RLMRealmUtil.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = RLMRealmUtil.mm; sourceTree = "<group>"; };
 		3F7792361A60A646004E4CA6 /* ResultsTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ResultsTests.m; sourceTree = "<group>"; };
 		3F8DCA5719930F550008BD7F /* iOS Device Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "iOS Device Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		3FBB3C251A84456D00582589 /* RLMMultiProcessTestCase.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RLMMultiProcessTestCase.h; sourceTree = "<group>"; };
+		3FBB3C261A84456D00582589 /* RLMMultiProcessTestCase.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RLMMultiProcessTestCase.m; sourceTree = "<group>"; };
+		3FBB3C291A8964C600582589 /* InterprocessTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = InterprocessTests.m; sourceTree = "<group>"; };
 		3FE79FF719BA6A5900780C9A /* RLMSwiftSupport.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RLMSwiftSupport.h; sourceTree = "<group>"; };
 		C0269E221A801FE70036E048 /* RLMPropertyTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RLMPropertyTests.m; sourceTree = "<group>"; };
 		C0FE75C01A79B60800326886 /* RLMUtilTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = RLMUtilTests.mm; sourceTree = "<group>"; };
@@ -587,6 +592,7 @@
 				E81A1FB81955FE0100FDED82 /* ArrayPropertyTests.m */,
 				E81A1FBA1955FE0100FDED82 /* DynamicTests.m */,
 				E81A1FBB1955FE0100FDED82 /* EnumeratorTests.m */,
+				3FBB3C291A8964C600582589 /* InterprocessTests.m */,
 				E81A1FBC1955FE0100FDED82 /* LinkTests.m */,
 				0207AB85195DFA15007EFB12 /* MigrationTests.mm */,
 				E81A1FBD1955FE0100FDED82 /* MixedTests.m */,
@@ -597,6 +603,8 @@
 				E81A1FC11955FE0100FDED82 /* QueryTests.m */,
 				E81A1FC31955FE0100FDED82 /* RealmTests.mm */,
 				3F7792361A60A646004E4CA6 /* ResultsTests.m */,
+				3FBB3C251A84456D00582589 /* RLMMultiProcessTestCase.h */,
+				3FBB3C261A84456D00582589 /* RLMMultiProcessTestCase.m */,
 				E8A543AD195C9C9E00990A20 /* RLMPredicateUtil.h */,
 				E8A543AE195C9C9E00990A20 /* RLMPredicateUtil.m */,
 				E81A1FC41955FE0100FDED82 /* RLMTestCase.h */,
@@ -1361,6 +1369,7 @@
 				E81A1FD51955FE0100FDED82 /* ArrayPropertyTests.m in Sources */,
 				E81A1FD91955FE0100FDED82 /* DynamicTests.m in Sources */,
 				E81A1FDB1955FE0100FDED82 /* EnumeratorTests.m in Sources */,
+				3FBB3C2A1A8964C600582589 /* InterprocessTests.m in Sources */,
 				E81A1FDD1955FE0100FDED82 /* LinkTests.m in Sources */,
 				0207AB87195DFA15007EFB12 /* MigrationTests.mm in Sources */,
 				E81A1FDF1955FE0100FDED82 /* MixedTests.m in Sources */,
@@ -1371,6 +1380,7 @@
 				E81A1FE71955FE0100FDED82 /* QueryTests.m in Sources */,
 				E81A1FEB1955FE0100FDED82 /* RealmTests.mm in Sources */,
 				3F7792371A60A646004E4CA6 /* ResultsTests.m in Sources */,
+				3FBB3C271A84456D00582589 /* RLMMultiProcessTestCase.m in Sources */,
 				E8A5DEED1968E520006A50F6 /* RLMPredicateUtil.m in Sources */,
 				3FDCFEB619F6A8D3005E414A /* RLMSupport.swift in Sources */,
 				E81A1FEE1955FE0100FDED82 /* RLMTestCase.m in Sources */,

--- a/Realm/Tests/InterprocessTests.m
+++ b/Realm/Tests/InterprocessTests.m
@@ -1,0 +1,276 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2015 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+#import "RLMMultiProcessTestCase.h"
+
+@interface InterprocessTest : RLMMultiProcessTestCase
+@end
+
+@implementation InterprocessTest
+- (void)testCreateInitialRealmInChild {
+    if (self.isParent) {
+        RLMRunChildAndWait();
+        RLMRealm *realm = [RLMRealm defaultRealm];
+        XCTAssertEqual(1U, [IntObject allObjectsInRealm:realm].count);
+    }
+    else {
+        RLMRealm *realm = [RLMRealm defaultRealm];
+        [realm beginWriteTransaction];
+        [IntObject createInRealm:realm withObject:@[@0]];
+        [realm commitWriteTransaction];
+    }
+}
+
+- (void)testCreateInitialRealmInParent {
+    RLMRealm *realm = [RLMRealm defaultRealm];
+    if (self.isParent) {
+        [realm beginWriteTransaction];
+        [IntObject createInRealm:realm withObject:@[@0]];
+        [realm commitWriteTransaction];
+
+        RLMRunChildAndWait();
+    }
+    else {
+        XCTAssertEqual(1U, [IntObject allObjectsInRealm:realm].count);
+    }
+}
+
+- (void)testOpenInParentThenAddObjectInChild {
+    RLMRealm *realm = [RLMRealm defaultRealm];
+    XCTAssertEqual(0U, [IntObject allObjectsInRealm:realm].count);
+
+    if (self.isParent) {
+        RLMRunChildAndWait(); // runs the event loop
+        XCTAssertEqual(1U, [IntObject allObjectsInRealm:realm].count);
+    }
+    else {
+        [realm beginWriteTransaction];
+        [IntObject createInRealm:realm withObject:@[@0]];
+        [realm commitWriteTransaction];
+    }
+}
+
+- (void)testOpenInParentThenAddObjectInChildWithoutAutorefresh {
+    RLMRealm *realm = [RLMRealm defaultRealm];
+    realm.autorefresh = NO;
+    XCTAssertEqual(0U, [IntObject allObjectsInRealm:realm].count);
+
+    if (self.isParent) {
+        RLMRunChildAndWait();
+        XCTAssertEqual(0U, [IntObject allObjectsInRealm:realm].count);
+        [realm refresh];
+        XCTAssertEqual(1U, [IntObject allObjectsInRealm:realm].count);
+    }
+    else {
+        [realm beginWriteTransaction];
+        [IntObject createInRealm:realm withObject:@[@0]];
+        [realm commitWriteTransaction];
+    }
+}
+
+- (void)testOpenInParentThenAddObjectInChildWithNoChanceToAutorefresh {
+    RLMRealm *realm = [RLMRealm defaultRealm];
+    XCTAssertEqual(0U, [IntObject allObjectsInRealm:realm].count);
+
+    if (self.isParent) {
+        // Wait on a different thread so that this thread doesn't get the chance
+        // to autorefresh
+        dispatch_queue_t queue = dispatch_queue_create("background", 0);
+        dispatch_async(queue, ^{ RLMRunChildAndWait(); });
+        dispatch_sync(queue, ^{});
+
+        XCTAssertEqual(0U, [IntObject allObjectsInRealm:realm].count);
+        [realm refresh];
+        XCTAssertEqual(1U, [IntObject allObjectsInRealm:realm].count);
+    }
+    else {
+        [realm beginWriteTransaction];
+        [IntObject createInRealm:realm withObject:@[@0]];
+        [realm commitWriteTransaction];
+    }
+}
+
+- (void)testChangeInChildTriggersNotificationInParent {
+    RLMRealm *realm = [RLMRealm defaultRealm];
+    XCTAssertEqual(0U, [IntObject allObjectsInRealm:realm].count);
+
+    if (self.isParent) {
+        [self waitForNotification:RLMRealmDidChangeNotification realm:realm block:^{
+            RLMRunChildAndWait();
+        }];
+        XCTAssertEqual(1U, [IntObject allObjectsInRealm:realm].count);
+    }
+    else {
+        [realm beginWriteTransaction];
+        [IntObject createInRealm:realm withObject:@[@0]];
+        [realm commitWriteTransaction];
+    }
+}
+
+- (void)testBackgroundProcessDoesNotTriggerSpuriousNotifications {
+    RLMRealm *realm = [RLMRealm defaultRealm];
+    RLMNotificationToken *token = [realm addNotificationBlock:^(__unused NSString *notification, __unused RLMRealm *realm) {
+        XCTFail(@"Notification should not have been triggered");
+    }];
+
+    if (self.isParent) {
+        RLMRunChildAndWait();
+    }
+    else {
+        // Just a meaningless thing that reads from the realm
+        XCTAssertEqual(0U, [IntObject allObjectsInRealm:realm].count);
+    }
+
+    [realm removeNotification:token];
+}
+
+- (void)testShareInMemoryRealm {
+    RLMRealm *realm = [RLMRealm inMemoryRealmWithIdentifier:@"test"];
+    XCTAssertEqual(0U, [IntObject allObjectsInRealm:realm].count);
+
+    if (self.isParent) {
+        [self waitForNotification:RLMRealmDidChangeNotification realm:realm block:^{
+            RLMRunChildAndWait();
+        }];
+        XCTAssertEqual(1U, [IntObject allObjectsInRealm:realm].count);
+    }
+    else {
+        [realm beginWriteTransaction];
+        [IntObject createInRealm:realm withObject:@[@0]];
+        [realm commitWriteTransaction];
+    }
+}
+
+- (void)testBidirectionalCommunication {
+    const int stopValue = 100;
+
+    RLMRealm *realm = [RLMRealm inMemoryRealmWithIdentifier:@"test"];
+    [realm beginWriteTransaction];
+    IntObject *obj = [IntObject allObjectsInRealm:realm].firstObject;
+    if (!obj) {
+        obj = [IntObject createInRealm:realm withObject:@[@0]];
+        [realm commitWriteTransaction];
+    }
+    else {
+        [realm cancelWriteTransaction];
+    }
+
+    RLMNotificationToken *token = [realm addNotificationBlock:^(__unused NSString *note, __unused RLMRealm *realm) {
+        if (obj.intCol % 2 != self.isParent && obj.intCol < stopValue) {
+            [realm transactionWithBlock:^{
+                obj.intCol++;
+            }];
+        }
+    }];
+
+    if (self.isParent) {
+        dispatch_queue_t queue = dispatch_queue_create("background", 0);
+        dispatch_async(queue, ^{ RLMRunChildAndWait(); });
+        while (obj.intCol < stopValue) {
+            [[NSRunLoop currentRunLoop] runMode:NSDefaultRunLoopMode beforeDate:[NSDate distantFuture]];
+        }
+        dispatch_sync(queue, ^{});
+    }
+    else {
+        [realm transactionWithBlock:^{
+            obj.intCol++;
+        }];
+        while (obj.intCol < stopValue) {
+            [[NSRunLoop currentRunLoop] runMode:NSDefaultRunLoopMode beforeDate:[NSDate distantFuture]];
+        }
+    }
+
+    [realm removeNotification:token];
+}
+
+- (void)testManyWriters {
+    const int stopValue = 100;
+    const int workers = 10;
+    const RLMRealm *realm = RLMRealm.defaultRealm;
+
+    if (self.isParent) {
+        [realm beginWriteTransaction];
+        IntObject *obj = [IntObject createInDefaultRealmWithObject:@[@(-workers)]];
+        [realm commitWriteTransaction];
+
+        dispatch_queue_t queue = dispatch_queue_create("queue", DISPATCH_QUEUE_CONCURRENT);
+        for (int i = 0; i < workers; ++i) {
+            dispatch_async(queue, ^{ RLMRunChildAndWait(); });
+        }
+        dispatch_barrier_sync(queue, ^{});
+
+        [realm refresh];
+        XCTAssertEqual(stopValue, obj.intCol);
+        XCTAssertEqual(stopValue, [DoubleObject allObjects].count);
+        XCTAssertEqual(stopValue / 2 + 1, [[DoubleObject.allObjects minOfProperty:@"doubleCol"] intValue]);
+        return;
+    }
+
+    // Run the run loop until someone else makes a commit
+    dispatch_block_t waitForExternalChange = ^{
+        RLMNotificationToken *token = [realm addNotificationBlock:^(__unused NSString *note, __unused RLMRealm *realm) {
+            CFRunLoopStop(CFRunLoopGetCurrent());
+        }];
+        CFRunLoopRun();
+        [realm removeNotification:token];
+    };
+
+    IntObject *obj = [IntObject allObjects].firstObject;
+    int nextRun = -1;
+
+    // Wait for all of the workers to start up
+    while (obj.intCol < 0) {
+        if (nextRun == -1) {
+            [realm beginWriteTransaction];
+            ++obj.intCol;
+            [realm commitWriteTransaction];
+            nextRun = 0;
+        }
+        waitForExternalChange();
+    }
+
+    while (true) {
+        // Wait for someone else to run if it's not our turn yet
+        if (obj.intCol < nextRun && nextRun < 100) {
+            waitForExternalChange();
+            continue;
+        }
+
+        [realm beginWriteTransaction];
+        if (obj.intCol == stopValue) {
+            [realm commitWriteTransaction];
+            break;
+        }
+
+        ++obj.intCol;
+
+        // Do some stuff
+        [DoubleObject createInDefaultRealmWithObject:@[@(obj.intCol)]];
+        [DoubleObject createInDefaultRealmWithObject:@[@(obj.intCol)]];
+        RLMResults *min = [DoubleObject objectsWhere:@"doubleCol = %@", [DoubleObject.allObjects minOfProperty:@"doubleCol"]];
+        [realm deleteObject:min.firstObject];
+        [realm commitWriteTransaction];
+
+        // Wait for a random number of other workers to do some work to avoid
+        // having a strict order that processes run in and to avoid having a
+        // single process do everything
+        nextRun = obj.intCol + arc4random() % 10;
+    }
+}
+
+@end

--- a/Realm/Tests/InterprocessTests.m
+++ b/Realm/Tests/InterprocessTests.m
@@ -273,4 +273,18 @@
     }
 }
 
+- (void)testRecoverAfterCrash {
+    if (self.isParent) {
+        [self runChildAndWait];
+        RLMRealm *realm = RLMRealm.defaultRealm;
+        [realm beginWriteTransaction];
+        [realm commitWriteTransaction];
+    }
+    else {
+        RLMRealm *realm = RLMRealm.defaultRealm;
+        [realm beginWriteTransaction];
+        abort();
+    }
+}
+
 @end

--- a/Realm/Tests/RLMMultiProcessTestCase.h
+++ b/Realm/Tests/RLMMultiProcessTestCase.h
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////
 //
-// Copyright 2014 Realm Inc.
+// Copyright 2015 Realm Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,26 +16,16 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-#import <XCTest/XCTest.h>
-#import "RLMTestObjects.h"
+#import "RLMTestCase.h"
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-NSString *RLMTestRealmPath(void);
-NSString *RLMDefaultRealmPath(void);
-NSString *RLMRealmPathForFile(NSString *);
-#ifdef __cplusplus
-}
-#endif
+@interface RLMMultiProcessTestCase : RLMTestCase
+// if true, this is running the main test process
+@property (nonatomic, readonly) bool isParent;
 
-@interface RLMTestCase : XCTestCase
-
-- (RLMRealm *)realmWithTestPath;
-- (RLMRealm *)realmWithTestPathAndSchema:(RLMSchema *)schema;
-
-- (void)deleteFiles;
-
-- (void)waitForNotification:(NSString *)expectedNote realm:(RLMRealm *)realm block:(dispatch_block_t)block;
-
+// spawn a child process running the current test and wait for it complete
+// returns the return code of the process
+- (int)runChildAndWait;
 @end
+
+#define RLMRunChildAndWait() \
+    XCTAssertEqual(0, [self runChildAndWait], @"Tests in child process failed")

--- a/Realm/Tests/RLMMultiProcessTestCase.m
+++ b/Realm/Tests/RLMMultiProcessTestCase.m
@@ -1,0 +1,119 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2015 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+#import "RLMMultiProcessTestCase.h"
+
+@interface RLMMultiProcessTestCase ()
+@property (nonatomic) bool isParent;
+@property (nonatomic, strong) NSString *testName;
+
+@property (nonatomic, strong) NSString *xctestPath;
+@property (nonatomic, strong) NSString *testsPath;
+@end
+
+@implementation RLMMultiProcessTestCase
+// Override all of the methods for creating a XCTestCase object to capture the current test name
++ (id)testCaseWithInvocation:(NSInvocation *)invocation {
+    RLMMultiProcessTestCase *testCase = [super testCaseWithInvocation:invocation];
+    testCase.testName = NSStringFromSelector(invocation.selector);
+    return testCase;
+}
+
+- (id)initWithInvocation:(NSInvocation *)invocation {
+    self = [super initWithInvocation:invocation];
+    if (self) {
+        self.testName = NSStringFromSelector(invocation.selector);
+    }
+    return self;
+}
+
++ (id)testCaseWithSelector:(SEL)selector {
+    RLMMultiProcessTestCase *testCase = [super testCaseWithSelector:selector];
+    testCase.testName = NSStringFromSelector(selector);
+    return testCase;
+}
+
+- (id)initWithSelector:(SEL)selector {
+    self = [super initWithSelector:selector];
+    if (self) {
+        self.testName = NSStringFromSelector(selector);
+    }
+    return self;
+}
+
+- (void)setUp {
+    self.isParent = !getenv("RLMProcessIsChild");
+
+    NSProcessInfo *info = NSProcessInfo.processInfo;
+    self.xctestPath = info.arguments[0];
+    self.testsPath = [info.arguments lastObject];
+
+    [super setUp];
+}
+
+- (void)deleteFiles {
+    // Only the parent should delete files in setUp/tearDown
+    if (self.isParent) {
+        [super deleteFiles];
+    }
+}
+
+- (int)runChildAndWait {
+    NSString *testName = [NSString stringWithFormat:@"%@/%@", self.className, self.testName];
+    NSMutableDictionary *env = [NSProcessInfo.processInfo.environment mutableCopy];
+    env[@"RLMProcessIsChild"] = @"true";
+
+    NSPipe *outputPipe = [NSPipe pipe];
+    NSFileHandle *handle = outputPipe.fileHandleForReading;
+
+    NSTask *task = [[NSTask alloc] init];
+    task.launchPath = self.xctestPath;
+    task.arguments = @[@"-XCTest", testName, self.testsPath];
+    task.environment = env;
+    task.standardError = outputPipe;
+    [task launch];
+
+    NSFileHandle *err = [NSFileHandle fileHandleWithStandardError];
+    NSData *delimiter = [@"\n" dataUsingEncoding:NSUTF8StringEncoding];
+    NSMutableData *buffer = [NSMutableData data];
+
+    // Filter the output from the child process to reduce xctest noise
+    while (true) {
+        NSUInteger newline = [buffer rangeOfData:delimiter options:0 range:NSMakeRange(0, buffer.length)].location;
+        if (newline != NSNotFound) {
+            // Skip lines starting with "Test Case", "Test Suite" and "     Executed"
+            const void *b = buffer.bytes;
+            if (newline < 13 || (memcmp(b, "Test Suite", 10) && memcmp(b, "Test Case", 9) && memcmp(b, "     Executed", 13))) {
+                [err writeData:[[NSData alloc] initWithBytesNoCopy:buffer.mutableBytes length:newline + 1 freeWhenDone:NO]];
+            }
+            [buffer replaceBytesInRange:NSMakeRange(0, newline + 1) withBytes:NULL length:0];
+        }
+
+        @autoreleasepool {
+            NSData *next = [handle availableData];
+            if (!next.length)
+                break;
+            [buffer appendData:next];
+        }
+    }
+
+    [task waitUntilExit];
+
+    return task.terminationStatus;
+}
+@end

--- a/Realm/Tests/RLMMultiProcessTestCase.m
+++ b/Realm/Tests/RLMMultiProcessTestCase.m
@@ -94,11 +94,11 @@
 
     // Filter the output from the child process to reduce xctest noise
     while (true) {
-        NSUInteger newline = [buffer rangeOfData:delimiter options:0 range:NSMakeRange(0, buffer.length)].location;
-        if (newline != NSNotFound) {
+        NSUInteger newline;
+        while ((newline = [buffer rangeOfData:delimiter options:0 range:NSMakeRange(0, buffer.length)].location) != NSNotFound) {
             // Skip lines starting with "Test Case", "Test Suite" and "     Executed"
             const void *b = buffer.bytes;
-            if (newline < 13 || (memcmp(b, "Test Suite", 10) && memcmp(b, "Test Case", 9) && memcmp(b, "     Executed", 13))) {
+            if (newline < 17 || (memcmp(b, "Test Suite", 10) && memcmp(b, "Test Case", 9) && memcmp(b, "	 Executed 1 test", 17))) {
                 [err writeData:[[NSData alloc] initWithBytesNoCopy:buffer.mutableBytes length:newline + 1 freeWhenDone:NO]];
             }
             [buffer replaceBytesInRange:NSMakeRange(0, newline + 1) withBytes:NULL length:0];

--- a/Realm/Tests/RealmTests.mm
+++ b/Realm/Tests/RealmTests.mm
@@ -347,26 +347,6 @@ extern "C" {
     XCTAssertEqualObjects([objects.firstObject stringCol], @"b", @"Expecting column to be 'b'");
 }
 
-- (void)waitForNotification:(NSString *)expectedNote realm:(RLMRealm *)realm block:(dispatch_block_t)block {
-    XCTestExpectation *notificationFired = [self expectationWithDescription:@"notification fired"];
-    RLMNotificationToken *token = [realm addNotificationBlock:^(__unused NSString *note, RLMRealm *realm) {
-        XCTAssertNotNil(realm, @"Realm should not be nil");
-        if (note == expectedNote) {
-            [notificationFired fulfill];
-        }
-    }];
-
-    dispatch_queue_t queue = dispatch_queue_create("background", 0);
-    dispatch_async(queue, block);
-
-    [self waitForExpectationsWithTimeout:2.0 handler:nil];
-
-    // wait for queue to finish
-    dispatch_sync(queue, ^{});
-
-    [realm removeNotification:token];
-}
-
 - (void)testAutorefreshAfterBackgroundUpdate {
     RLMRealm *realm = [self realmWithTestPath];
 


### PR DESCRIPTION
Will fail on CI due to not using a core build with working wait_for_change().

Any suggestions for other things to test? It covers everything we test for multiple threads along with a few other things that came to mind and an attempt at a brute-force test, but it seems like there must be more that's testable.

@alazier 