### PR TITLE
[RLMObject] Declare re-declared/inherited properties as @dynamic

### DIFF
--- a/Realm/RLMObject.mm
+++ b/Realm/RLMObject.mm
@@ -31,6 +31,9 @@
 // that).
 @implementation RLMObject
 
+// These properties are synthesized in RLMObjectBase
+@dynamic objectSchema, realm, invalidated;
+
 - (instancetype)init {
     return [super init];
 }


### PR DESCRIPTION
Gets rid of three new warnings under Xcode 6.3

\c @tgoyne 