### PR TITLE
Fix warning in testDataObjectDescription

### DIFF
--- a/Realm/Tests/ObjectTests.m
+++ b/Realm/Tests/ObjectTests.m
@@ -975,8 +975,8 @@ RLM_ARRAY_TYPE(PrimaryIntObject);
     [realm commitWriteTransaction];
 
     DataObject *obj = [DataObject allObjectsInRealm:realm].firstObject;
-    XCTAssertNotEqual(NSNotFound, [obj.description rangeOfString:@"200 total bytes"].location);
-    XCTAssertNotEqual(NSNotFound, [obj.description rangeOfString:@"2 total bytes"].location);
+    XCTAssertTrue([obj.description rangeOfString:@"200 total bytes"].location != NSNotFound);
+    XCTAssertTrue([obj.description rangeOfString:@"2 total bytes"].location != NSNotFound);
 }
 
 - (void)testDeletedObjectDescription


### PR DESCRIPTION
It should be used XCTAssertTrue() instead of XCTAssertNotEqual() when
we confirm the result of rangeOfString, I think because of warning. It
compares int value(NSNotFound) with unsigned int(location property),
ofcourse it's no problem just silence compiler warnings.