### PR TITLE
Avoid an unnecessary write transaction when opening Realms

### DIFF
--- a/Realm.xcodeproj/xcshareddata/xcbaselines/3F8DCA5619930F550008BD7F.xcbaseline/7F8339ED-0034-40BF-9189-6C569D2814B7.plist
+++ b/Realm.xcodeproj/xcshareddata/xcbaselines/3F8DCA5619930F550008BD7F.xcbaseline/7F8339ED-0034-40BF-9189-6C569D2814B7.plist
@@ -166,7 +166,7 @@
 					<string>Local Baseline</string>
 				</dict>
 			</dict>
-			<key>testRealmCreation</key>
+			<key>testRealmCreationCached</key>
 			<dict>
 				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
 				<dict>

--- a/Realm/RLMSchema.mm
+++ b/Realm/RLMSchema.mm
@@ -194,6 +194,10 @@ NSString *RLMRealmPrimaryKeyForObjectClass(RLMRealm *realm, NSString *objectClas
     return RLMStringDataToNSString(table->get_string(c_primaryKeyPropertyNameColumnIndex, row));
 }
 
+bool RLMRealmHasMetadataTables(RLMRealm *realm) {
+    return realm.group->get_table(c_primaryKeyTableName) && realm.group->get_table(c_metadataTableName);
+}
+
 bool RLMRealmCreateMetadataTables(RLMRealm *realm) {
     bool changed = false;
     tightdb::TableRef table = realm.group->get_or_add_table(c_primaryKeyTableName);

--- a/Realm/RLMSchema_Private.h
+++ b/Realm/RLMSchema_Private.h
@@ -55,6 +55,10 @@ inline NSString *RLMTableNameForClass(NSString *className) {
 // Realm schema metadata
 //
 
+
+// check if the realm already has all metadata tbales
+bool RLMRealmHasMetadataTables(RLMRealm *realm);
+
 // create any metadata tables that don't already exist
 // must be in write transaction to set
 // returns true if it actually did anything

--- a/Realm/Tests/PerformanceTests.m
+++ b/Realm/Tests/PerformanceTests.m
@@ -324,20 +324,31 @@ static RLMRealm *s_smallRealm, *s_mediumRealm, *s_largeRealm;
     }];
 }
 
-- (void)testRealmCreation {
-    [self realmWithTestPath]; // ensure a cached realm for the path
-
+- (void)testRealmCreationCached {
+    __block RLMRealm *realm;
     dispatch_queue_t queue = dispatch_queue_create("test queue", 0);
+    dispatch_async(queue, ^{
+        realm = [self realmWithTestPath]; // ensure a cached realm for the path
+    });
+    dispatch_sync(queue, ^{});
+
     [self measureBlock:^{
         for (int i = 0; i < 250; ++i) {
-            dispatch_async(queue, ^{
-                @autoreleasepool {
-                    [self realmWithTestPath];
-                }
-            });
+            @autoreleasepool {
+                [self realmWithTestPath];
+            }
         }
+    }];
+    [realm path];
+}
 
-        dispatch_sync(queue, ^{});
+- (void)testRealmCreationUncached {
+    [self measureBlock:^{
+        for (int i = 0; i < 50; ++i) {
+            @autoreleasepool {
+                [self realmWithTestPath];
+            }
+        }
     }];
 }
 


### PR DESCRIPTION
Check if any writing actually needs to be done before starting the write transaction, and skip it when possible. Mostly only relevant for the multi-process case, where this makes it so that a write transaction in one process doesn't block other processes from opening the file.

@alazier 