### PR TITLE
Use a named pipe for interprocess notifications

### DIFF
--- a/Realm/RLMProperty.mm
+++ b/Realm/RLMProperty.mm
@@ -39,7 +39,6 @@
         _objectClassName = objectClassName;
         _indexed = indexed;
         [self setObjcCodeFromType];
-        [self updateAccessors];
     }
 
     return self;

--- a/Realm/RLMRealm.mm
+++ b/Realm/RLMRealm.mm
@@ -398,7 +398,7 @@ static id RLMAutorelease(id value) {
     }
 
     if (!readonly) {
-        RLMStartListeningForChanges(realm);
+        realm.notifier = [[RLMWeakNotifier alloc] initWithRealm:realm];
     }
 
     return RLMAutorelease(realm);
@@ -520,7 +520,7 @@ static void CheckReadWrite(RLMRealm *realm, NSString *msg=@"Cannot write to a re
             _inWriteTransaction = NO;
 
             // notify other realm instances of changes
-            RLMNotifyOtherRealms(self);
+            [self.notifier notifyOtherRealms];
 
             // send local notification
             [self sendNotifications:RLMRealmDidChangeNotification];
@@ -586,7 +586,7 @@ static void CheckReadWrite(RLMRealm *realm, NSString *msg=@"Cannot write to a re
               "pending changes have been rolled back. Make sure to retain a reference to the "
               "RLMRealm for the duration of the write transaction.");
     }
-    RLMStopListeningForChanges(self);
+    [_notifier stop];
 }
 
 - (void)handleExternalCommit {

--- a/Realm/RLMRealm.mm
+++ b/Realm/RLMRealm.mm
@@ -398,7 +398,10 @@ static id RLMAutorelease(id value) {
     }
 
     if (!readonly) {
-        realm.notifier = [[RLMNotifier alloc] initWithRealm:realm];
+        realm.notifier = [[RLMNotifier alloc] initWithRealm:realm error:outError];
+        if (!realm.notifier) {
+            return nil;
+        }
     }
 
     return RLMAutorelease(realm);

--- a/Realm/RLMRealm.mm
+++ b/Realm/RLMRealm.mm
@@ -398,7 +398,7 @@ static id RLMAutorelease(id value) {
     }
 
     if (!readonly) {
-        realm.notifier = [[RLMWeakNotifier alloc] initWithRealm:realm];
+        realm.notifier = [[RLMNotifier alloc] initWithRealm:realm];
     }
 
     return RLMAutorelease(realm);

--- a/Realm/RLMRealmUtil.h
+++ b/Realm/RLMRealmUtil.h
@@ -29,8 +29,12 @@ RLMRealm *RLMGetAnyCachedRealmForPath(NSString *path);
 // Clear the weak cache of Realms
 void RLMClearRealmCache();
 
-void RLMStartListeningForChanges(RLMRealm *realm);
-void RLMStopListeningForChanges(RLMRealm *realm);
-// notify all of the Realms other than `notifyingRealm` at the same path as
-// `notifyingRealm` that a commit has occurred
-void RLMNotifyOtherRealms(RLMRealm *notifyingRealm);
+@interface RLMWeakNotifier : NSObject
+// listens to changes to the realm's file and notifies it when they occur
+// does not retain the Realm
+- (instancetype)initWithRealm:(RLMRealm *)realm;
+// stop listening for changes
+- (void)stop;
+// notify other Realm instances for the same path that a change has occurred
+- (void)notifyOtherRealms;
+@end

--- a/Realm/RLMRealmUtil.h
+++ b/Realm/RLMRealmUtil.h
@@ -32,7 +32,7 @@ void RLMClearRealmCache();
 @interface RLMNotifier : NSObject
 // listens to changes to the realm's file and notifies it when they occur
 // does not retain the Realm
-- (instancetype)initWithRealm:(RLMRealm *)realm;
+- (instancetype)initWithRealm:(RLMRealm *)realm error:(NSError **)error;
 // stop listening for changes
 - (void)stop;
 // notify other Realm instances for the same path that a change has occurred

--- a/Realm/RLMRealmUtil.h
+++ b/Realm/RLMRealmUtil.h
@@ -29,7 +29,7 @@ RLMRealm *RLMGetAnyCachedRealmForPath(NSString *path);
 // Clear the weak cache of Realms
 void RLMClearRealmCache();
 
-@interface RLMWeakNotifier : NSObject
+@interface RLMNotifier : NSObject
 // listens to changes to the realm's file and notifies it when they occur
 // does not retain the Realm
 - (instancetype)initWithRealm:(RLMRealm *)realm;

--- a/Realm/RLMRealmUtil.mm
+++ b/Realm/RLMRealmUtil.mm
@@ -57,7 +57,7 @@ void RLMClearRealmCache() {
     }
 }
 
-@implementation RLMWeakNotifier {
+@implementation RLMNotifier {
     __weak RLMRealm *_realm;
     int _notifyFd;
     int _shutdownFd;
@@ -92,7 +92,7 @@ static void checkError(int ret) {
         CFRunLoopSourceContext ctx{};
         ctx.info = (__bridge void *)self;
         ctx.perform = [](void *info) {
-            RLMWeakNotifier *notifier = (__bridge RLMWeakNotifier *)info;
+            RLMNotifier *notifier = (__bridge RLMNotifier *)info;
             if (RLMRealm *realm = notifier->_realm) {
                 [realm handleExternalCommit];
             }

--- a/Realm/RLMRealmUtil.mm
+++ b/Realm/RLMRealmUtil.mm
@@ -187,7 +187,10 @@ public:
 
         // Make writing to the pipe return -1 when the pipe's buffer is full
         // rather than blocking until there's space available
-        fcntl(_notifyFd, F_SETFL, O_NONBLOCK);
+        ret = fcntl(_notifyFd, F_SETFL, O_NONBLOCK);
+        if (ret == -1) {
+            return handleError(errno, error);
+        }
 
         // Create the anonymous pipe
         int pipeFd[2];

--- a/Realm/RLMRealmUtil.mm
+++ b/Realm/RLMRealmUtil.mm
@@ -57,12 +57,15 @@ void RLMClearRealmCache() {
     }
 }
 
-static void checkError(int ret) {
+// Convert 'return -1 and set errno' error reporting to exception throws
+static int checkError(int ret) {
     if (ret < 0 && errno != EEXIST) {
         @throw RLMException(@(strerror(errno)));
     }
+    return ret;
 }
 
+// Write a byte to a pipe to notify anyone waiting for data on the pipe
 static void notifyFd(int fd) {
     while (true) {
         char c = 0;
@@ -70,40 +73,105 @@ static void notifyFd(int fd) {
         if (ret == 1) {
             break;
         }
-        assert(ret == -1 && errno == EAGAIN);
 
-        // pipe is full so read some data from it to make space
+        // If the pipe's buffer is full, we need to read some of the old data in
+        // it to make space. We don't just read in the code waiting for
+        // notifications so that we can notify multiple waiters with a single
+        // write.
+        assert(ret == -1 && errno == EAGAIN);
         char buff[1024];
         read(fd, buff, sizeof buff);
     }
 }
 
+namespace {
+// A RAII holder for a file descriptor which automatically closes the wrapped fd
+// when it's deallocated
+class FdHolder {
+    int fd = -1;
+    void close() {
+        if (fd != -1) {
+            ::close(fd);
+        }
+        fd = -1;
+    }
+
+public:
+    ~FdHolder() { close(); }
+    operator int() const { return fd; }
+    FdHolder& operator=(int newFd) {
+        close();
+        fd = newFd;
+        return *this;
+    }
+};
+}
+
+// Inter-thread and inter-process notifications of changes are done using a
+// named pipe in the filesystem next to the Realm file. Everyone who wants to be
+// notified of commits waits for data to become available on the pipe, and anyone
+// who commits a write transaction writes data to the pipe after releasing the
+// write lock. Note that no one ever actually *reads* from the pipe: the data
+// actually written is meaningless, and trying to read from a pipe from multiple
+// processes at once is fraught with race conditions.
+
+// When a RLMRealm instance is created, we add a CFRunLoopSource to the current
+// thread's runloop. On each cycle of the run loop, the run loop checks each of
+// its sources for work to do, which in the case of CFRunLoopSource is just
+// checking if CFRunLoopSourceSignal has been called since the last time it ran,
+// and if so invokes the function pointer supplied when the source is created,
+// which in our case just invokes `[realm handleExternalChange]`.
+
+// Listening for external changes is done using kqueue() on a background thread.
+// kqueue() lets us efficiently wait until the amount of data which can be read
+// from one or more file descriptors has changed, and tells us which of the file
+// descriptors it was that changed. We use this to wait on both the shared named
+// pipe, and a local anonymous pipe. When data is written to the named pipe, we
+// signal the runloop source and wake up the target runloop, and when data is
+// written to the anonymous pipe the background thread removes the runloop
+// source from the runloop and and shuts down.
+
 @implementation RLMNotifier {
+    // Realm to notify of changes
     __weak RLMRealm *_realm;
-    int _notifyFd;
-    int _shutdownFd;
+    // Runloop which notifications are delivered on
+    CFRunLoopRef _runLoop;
+    CFRunLoopSourceRef _signal;
+
+    // Read-write file descriptor for the named pipe which is waited on for
+    // changes and written to when a commit is made
+    FdHolder _notifyFd;
+    // File descriptor for the kqueue
+    FdHolder _kq;
+    // The two ends of an anonymous pipe used to notify the kqueue() thread that
+    // it should be shut down.
+    FdHolder _shutdownReadFd;
+    FdHolder _shutdownWriteFd;
 }
 
 - (instancetype)initWithRealm:(RLMRealm *)realm {
     self = [super init];
     if (self) {
         _realm = realm;
+        _runLoop = CFRunLoopGetCurrent();
+        _kq = checkError(kqueue());
 
         const char *path = [realm.path stringByAppendingString:@".note"].UTF8String;
-        checkError(mkfifo(path, 0600));
 
-        checkError(_notifyFd = open(path, O_RDWR));
-        // return -1 if pipe is full rather than blocking
+        // Create and open the named pipe
+        checkError(mkfifo(path, 0600));
+        _notifyFd = checkError(open(path, O_RDWR));
+        // Make writing to the pipe return -1 when the pipe's buffer is full
+        // rather than blocking until there's space available
         fcntl(_notifyFd, F_SETFL, O_NONBLOCK);
 
+        // Create the anonymous pipe
         int pipeFd[2];
         checkError(pipe(pipeFd));
-        _shutdownFd = pipeFd[1];
+        _shutdownReadFd = pipeFd[0];
+        _shutdownWriteFd = pipeFd[1];
 
-        CFRunLoopRef runLoop = CFRunLoopGetCurrent();
-
-        // Add a source to the current runloop that we'll signal every time
-        // there's a commit
+        // Create the runloop source
         CFRunLoopSourceContext ctx{};
         ctx.info = (__bridge void *)self;
         ctx.perform = [](void *info) {
@@ -112,54 +180,58 @@ static void notifyFd(int fd) {
                 [realm handleExternalCommit];
             }
         };
-        CFRunLoopSourceRef signal = CFRunLoopSourceCreate(0, 0, &ctx);
-        CFRunLoopAddSource(runLoop, signal, kCFRunLoopDefaultMode);
-        CFRelease(signal); // the runloop retains the signal
 
-        int kq = kqueue();
-        checkError(kq);
+        _signal = CFRunLoopSourceCreate(kCFAllocatorDefault, 0, &ctx);
+        CFRunLoopAddSource(_runLoop, _signal, kCFRunLoopDefaultMode);
+        CFRelease(_signal); // the runloop retains the signal
 
-        dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), [=] {
-            // Set up the kqueue to wait for data to become available to read
-            // on either the fifo shared with other processes or the pipe used
-            // to signal shutdowns
-            struct kevent ke[2];
-            EV_SET(&ke[0], _notifyFd, EVFILT_READ, EV_ADD | EV_CLEAR, 0, 0, 0);
-            EV_SET(&ke[1], pipeFd[0], EVFILT_READ, EV_ADD | EV_CLEAR, 0, 0, 0);
-            kevent(kq, ke, 2, nullptr, 0, nullptr);
-
-            while (true) {
-                struct kevent ev;
-                // Wait until there's more data available on either of the fds.
-                // EV_CLEAR makes it only return each event once, so we don't
-                // need to actually read from the fifo (which is good, as it
-                // means that a single write can wake up everyone waiting on the fifo)
-                int ret = kevent(kq, nullptr, 0, &ev, 1, nullptr);
-                if (ret <= 0) {
-                    continue;
-                }
-
-                if (ev.ident == (uint32_t)pipeFd[0]) {
-                    // Someone called -stop, so tear everything down and exit
-                    CFRunLoopSourceInvalidate(signal);
-                    close(_notifyFd);
-                    close(pipeFd[0]);
-                    close(pipeFd[1]);
-                    close(kq);
-                    return;
-                }
-
-                CFRunLoopSourceSignal(signal);
-                CFRunLoopWakeUp(runLoop);
-            }
-        });
+        [self listen];
     }
     return self;
 }
 
+- (void)listen {
+    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+        // Set up the kqueue
+        // EVFILT_READ indicates that we care about data being available to read
+        // on the given file descriptor.
+        // EV_CLEAR makes it wait for the amount of data available to be read to
+        // change rather than just returning when there is any data to read.
+        struct kevent ke[2];
+        EV_SET(&ke[0], _notifyFd, EVFILT_READ, EV_ADD | EV_CLEAR, 0, 0, 0);
+        EV_SET(&ke[1], _shutdownReadFd, EVFILT_READ, EV_ADD | EV_CLEAR, 0, 0, 0);
+        kevent(_kq, ke, 2, nullptr, 0, nullptr);
+
+        while (true) {
+            struct kevent event;
+            // Wait for data to become on either fd
+            // Return code is number of bytes available or -1 on error
+            int ret = kevent(_kq, nullptr, 0, &event, 1, nullptr);
+            assert(ret >= 0);
+            if (ret == 0) {
+                // Spurious wakeup; just wait again
+                continue;
+            }
+
+            // Check which file descriptor had activity: if it's the shutdown
+            // pipe, then someone called -stop; otherwise it's the named pipe
+            // and someone committed a write transaction
+            if (event.ident == (uint32_t)_shutdownReadFd) {
+                CFRunLoopSourceInvalidate(_signal);
+                return;
+            }
+
+            CFRunLoopSourceSignal(_signal);
+            // Signalling the source makes it run the next time the runloop gets
+            // to it, but doesn't make the runloop start if it's currently idle
+            // waiting for events
+            CFRunLoopWakeUp(_runLoop);
+        }
+    });
+}
+
 - (void)stop {
-    // wake up the kqueue
-    notifyFd(_shutdownFd);
+    notifyFd(_shutdownWriteFd);
 }
 
 - (void)notifyOtherRealms {

--- a/Realm/RLMRealm_Private.h
+++ b/Realm/RLMRealm_Private.h
@@ -18,7 +18,7 @@
 
 #import <Realm/RLMRealm.h>
 
-@class RLMWeakNotifier;
+@class RLMNotifier;
 
 // RLMRealm private members
 @interface RLMRealm () {
@@ -30,7 +30,7 @@
 @property (nonatomic, readonly) BOOL inWriteTransaction;
 @property (nonatomic, readonly) BOOL dynamic;
 @property (nonatomic, readwrite) RLMSchema *schema;
-@property (nonatomic, strong) RLMWeakNotifier *notifier;
+@property (nonatomic, strong) RLMNotifier *notifier;
 
 + (void)resetRealmState;
 

--- a/Realm/RLMRealm_Private.h
+++ b/Realm/RLMRealm_Private.h
@@ -18,6 +18,8 @@
 
 #import <Realm/RLMRealm.h>
 
+@class RLMWeakNotifier;
+
 // RLMRealm private members
 @interface RLMRealm () {
     @public
@@ -28,6 +30,7 @@
 @property (nonatomic, readonly) BOOL inWriteTransaction;
 @property (nonatomic, readonly) BOOL dynamic;
 @property (nonatomic, readwrite) RLMSchema *schema;
+@property (nonatomic, strong) RLMWeakNotifier *notifier;
 
 + (void)resetRealmState;
 

--- a/Realm/RLMSchema.mm
+++ b/Realm/RLMSchema.mm
@@ -65,16 +65,9 @@ static NSMutableDictionary *s_localNameToClass;
     return schema;
 }
 
-- (id)init {
-    self = [super init];
-    if (self) {
-        _objectSchemaByName = [NSMutableDictionary dictionary];
-    }
-    return self;
-}
-
 - (void)setObjectSchema:(NSArray *)objectSchema {
     _objectSchema = objectSchema;
+    _objectSchemaByName = [NSMutableDictionary dictionaryWithCapacity:objectSchema.count];
     for (RLMObjectSchema *object in objectSchema) {
         [(NSMutableDictionary *)_objectSchemaByName setObject:object forKey:object.className];
     }

--- a/Realm/RLMSchema_Private.h
+++ b/Realm/RLMSchema_Private.h
@@ -39,14 +39,14 @@ extern const char * const c_primaryKeyTableName;
 extern const char * const c_versionColumnName;
 extern const size_t c_versionColumnIndex;
 
-inline NSString *RLMClassForTableName(NSString *tableName) {
+static inline NSString *RLMClassForTableName(NSString *tableName) {
     if ([tableName hasPrefix:c_objectTableNamePrefix]) {
         return [tableName substringFromIndex:6];
     }
     return nil;
 }
 
-inline NSString *RLMTableNameForClass(NSString *className) {
+static inline NSString *RLMTableNameForClass(NSString *className) {
     return [c_objectTableNamePrefix stringByAppendingString:className];
 }
 

--- a/Realm/Tests/RLMMultiProcessTestCase.h
+++ b/Realm/Tests/RLMMultiProcessTestCase.h
@@ -25,6 +25,8 @@
 // spawn a child process running the current test and wait for it complete
 // returns the return code of the process
 - (int)runChildAndWait;
+
+- (NSTask *)childTask;
 @end
 
 #define RLMRunChildAndWait() \

--- a/Realm/Tests/RLMMultiProcessTestCase.m
+++ b/Realm/Tests/RLMMultiProcessTestCase.m
@@ -73,18 +73,24 @@
     }
 }
 
-- (int)runChildAndWait {
+- (NSTask *)childTask {
     NSString *testName = [NSString stringWithFormat:@"%@/%@", self.className, self.testName];
     NSMutableDictionary *env = [NSProcessInfo.processInfo.environment mutableCopy];
     env[@"RLMProcessIsChild"] = @"true";
-
-    NSPipe *outputPipe = [NSPipe pipe];
-    NSFileHandle *handle = outputPipe.fileHandleForReading;
 
     NSTask *task = [[NSTask alloc] init];
     task.launchPath = self.xctestPath;
     task.arguments = @[@"-XCTest", testName, self.testsPath];
     task.environment = env;
+    task.standardError = nil;
+    return task;
+}
+
+- (int)runChildAndWait {
+    NSPipe *outputPipe = [NSPipe pipe];
+    NSFileHandle *handle = outputPipe.fileHandleForReading;
+
+    NSTask *task = [self childTask];
     task.standardError = outputPipe;
     [task launch];
 

--- a/Realm/Tests/RLMTestCase.m
+++ b/Realm/Tests/RLMTestCase.m
@@ -47,21 +47,21 @@ NSString *RLMTestRealmPath() {
     return RLMRealmPathForFile(@"test.realm");
 }
 
-static NSString *RLMLockPath(NSString *path) {
-    return [path stringByAppendingString:@".lock"];
-}
-
-static void RLMDeleteRealmFilesAtPath(NSString *path) {
+static void deleteOrThrow(NSString *path) {
     NSError *error;
-    if (![[NSFileManager defaultManager] removeItemAtPath:path error:&error] ||
-        ![[NSFileManager defaultManager] removeItemAtPath:RLMLockPath(path) error:&error] ||
-        ![[NSFileManager defaultManager] removeItemAtPath:[path stringByAppendingString:@".note"] error:&error]) {
+    if (![[NSFileManager defaultManager] removeItemAtPath:path error:&error]) {
         if (error.code != NSFileNoSuchFileError) {
             @throw [NSException exceptionWithName:@"RLMTestException"
                                            reason:[@"Unable to delete realm: " stringByAppendingString:error.description]
                                          userInfo:nil];
         }
     }
+}
+
+static void RLMDeleteRealmFilesAtPath(NSString *path) {
+    deleteOrThrow(path);
+    deleteOrThrow([path stringByAppendingString:@".lock"]);
+    deleteOrThrow([path stringByAppendingString:@".note"]);
 }
 
 NSData *RLMGenerateKey() {

--- a/Realm/Tests/RLMTestCase.m
+++ b/Realm/Tests/RLMTestCase.m
@@ -31,22 +31,16 @@
 
 NSString *RLMRealmPathForFile(NSString *fileName) {
 #if TARGET_OS_IPHONE
-    NSArray *paths = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES);
-    NSString *documentsDirectory = [paths objectAtIndex:0];
-    return [documentsDirectory stringByAppendingPathComponent:fileName];
-#else
-    return fileName;
-#endif
-}
-
-NSString *RLMDefaultRealmPath() {
-#if TARGET_OS_IPHONE
     NSString *path = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES)[0];
 #else
     NSString *path = NSSearchPathForDirectoriesInDomains(NSApplicationSupportDirectory, NSUserDomainMask, YES)[0];
     path = [path stringByAppendingPathComponent:[[[NSBundle mainBundle] executablePath] lastPathComponent]];
 #endif
-    return [path stringByAppendingPathComponent:@"default.realm"];
+    return [path stringByAppendingPathComponent:fileName];
+}
+
+NSString *RLMDefaultRealmPath() {
+    return RLMRealmPathForFile(@"default.realm");
 }
 
 NSString *RLMTestRealmPath() {

--- a/Realm/Tests/RLMTestCase.m
+++ b/Realm/Tests/RLMTestCase.m
@@ -58,14 +58,15 @@ static NSString *RLMLockPath(NSString *path) {
 }
 
 static void RLMDeleteRealmFilesAtPath(NSString *path) {
-    [[NSFileManager defaultManager] removeItemAtPath:path error:nil];
-    if ([[NSFileManager defaultManager] fileExistsAtPath:path]) {
-        @throw [NSException exceptionWithName:@"RLMTestException" reason:@"Unable to delete realm" userInfo:nil];
-    }
-
-    [[NSFileManager defaultManager] removeItemAtPath:RLMLockPath(path) error:nil];
-    if ([[NSFileManager defaultManager] fileExistsAtPath:RLMLockPath(path)]) {
-        @throw [NSException exceptionWithName:@"RLMTestException" reason:@"Unable to delete realm" userInfo:nil];
+    NSError *error;
+    if (![[NSFileManager defaultManager] removeItemAtPath:path error:&error] ||
+        ![[NSFileManager defaultManager] removeItemAtPath:RLMLockPath(path) error:&error] ||
+        ![[NSFileManager defaultManager] removeItemAtPath:[path stringByAppendingString:@".note"] error:&error]) {
+        if (error.code != NSFileNoSuchFileError) {
+            @throw [NSException exceptionWithName:@"RLMTestException"
+                                           reason:[@"Unable to delete realm: " stringByAppendingString:error.description]
+                                         userInfo:nil];
+        }
     }
 }
 

--- a/Realm/Tests/RealmTests.mm
+++ b/Realm/Tests/RealmTests.mm
@@ -1150,4 +1150,12 @@ extern "C" {
     XCTAssertThrows([RLMRealm setEncryptionKey:[[NSMutableData alloc] initWithLength:64] forRealmsAtPath:path]);
 }
 
+- (void)testNotificationPipeBufferOverfull {
+    RLMRealm *realm = [RLMRealm inMemoryRealmWithIdentifier:@"test"];
+    // pipes have a 8 KB buffer on OS X, so verify we don't block after 8192 commits
+    for (int i = 0; i < 9000; ++i) {
+        [realm transactionWithBlock:^{}];
+    }
+}
+
 @end

--- a/Realm/Tests/RealmTests.mm
+++ b/Realm/Tests/RealmTests.mm
@@ -943,6 +943,7 @@ extern "C" {
     dog.age = 10;
     XCTAssertNoThrow([realm addObjects:@[dog]], @"should allow RLMObject in array");
     XCTAssertEqual(1U, [[DogObject allObjectsInRealm:realm] count]);
+    [realm cancelWriteTransaction];
 }
 
 - (void)testWriteCopyOfRealm


### PR DESCRIPTION
Basic idea here is to just create a named pipe, wait for data to become available on it in a background thread (and trigger notifications when it does), and then write a byte to it after each commit. kqueue is used to wait on both the named pipe and an anonymous pipe used locally to tell the waiting thread to exit.

Doing the notifications entirely in the binding turned out to not really be any more complex than using `wait_for_change()` was since eliminating the `SharedGroup` on the background thread makes shutdown and cleanup a lot simpler.

@alazier 