### PR TITLE
Updated example projects to work with Swift 1.2

### DIFF
--- a/examples/ios/swift/Backlink/AppDelegate.swift
+++ b/examples/ios/swift/Backlink/AppDelegate.swift
@@ -25,7 +25,7 @@ class Dog: RLMObject {
     var owners: [Person] {
         // Realm doesn't persist this property because it only has a getter defined
         // Define "owners" as the inverse relationship to Person.dogs
-        return linkingObjectsOfClass("Person", forProperty: "dogs") as [Person]
+        return linkingObjectsOfClass("Person", forProperty: "dogs") as! [Person]
     }
 }
 
@@ -39,7 +39,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     var window: UIWindow?
 
-    func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: NSDictionary?) -> Bool {
+    func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
 
         self.window = UIWindow(frame: UIScreen.mainScreen().bounds)
         self.window!.rootViewController = UIViewController()
@@ -56,7 +56,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Log all dogs and their owners using the "owners" inverse relationship
         let allDogs = Dog.allObjects()
         for dog in allDogs {
-            let dog = dog as Dog
+            let dog = dog as! Dog
             let ownerNames = dog.owners.map { $0.name }
             println("\(dog.name) has \(ownerNames.count) owners (\(ownerNames))")
         }

--- a/examples/ios/swift/Encryption/AppDelegate.swift
+++ b/examples/ios/swift/Encryption/AppDelegate.swift
@@ -20,12 +20,13 @@ import UIKit
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
-    var window: UIWindow!
+   
+    var window: UIWindow?
 
-    func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: NSDictionary?) -> Bool {
+    func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
         self.window = UIWindow(frame: UIScreen.mainScreen().bounds)
-        self.window.rootViewController = ViewController()
-        self.window.makeKeyAndVisible()
+        self.window!.rootViewController = ViewController()
+        self.window!.makeKeyAndVisible()
 
         return true
     }

--- a/examples/ios/swift/Encryption/ViewController.swift
+++ b/examples/ios/swift/Encryption/ViewController.swift
@@ -77,7 +77,7 @@ class ViewController: UIViewController {
             let realm = RLMRealm(path: RLMRealm.defaultRealmPath(),
                 encryptionKey: self.getKey(), readOnly: false, error: nil)
 
-            self.log("Saved object: \((EncryptionObject.allObjectsInRealm(realm).firstObject()! as EncryptionObject).stringProp)")
+            self.log("Saved object: \((EncryptionObject.allObjectsInRealm(realm).firstObject()! as! EncryptionObject).stringProp)")
         }
     }
 
@@ -101,7 +101,7 @@ class ViewController: UIViewController {
         var dataTypeRef: Unmanaged<AnyObject>?
         var status = SecItemCopyMatching(query, &dataTypeRef)
         if status == errSecSuccess {
-            return dataTypeRef?.takeUnretainedValue() as NSData
+            return dataTypeRef?.takeUnretainedValue() as! NSData
         }
 
         // No pre-existing key from this application, so generate a new one

--- a/examples/ios/swift/GroupedTableView/AppDelegate.swift
+++ b/examples/ios/swift/GroupedTableView/AppDelegate.swift
@@ -23,7 +23,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     var window: UIWindow?
 
-    func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: NSDictionary?) -> Bool {
+    func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
         self.window = UIWindow(frame: UIScreen.mainScreen().bounds)
         self.window!.rootViewController = UINavigationController(rootViewController: TableViewController(style: .Plain))
         self.window!.makeKeyAndVisible()

--- a/examples/ios/swift/GroupedTableView/TableViewController.swift
+++ b/examples/ios/swift/GroupedTableView/TableViewController.swift
@@ -84,7 +84,7 @@ class TableViewController: UITableViewController {
     }
 
     override func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexPath) -> UITableViewCell {
-        let cell = tableView.dequeueReusableCellWithIdentifier("cell", forIndexPath: indexPath) as Cell
+        let cell = tableView.dequeueReusableCellWithIdentifier("cell", forIndexPath: indexPath) as! Cell
 
         let object = objectForIndexPath(indexPath)!
         cell.textLabel?.text = object.title

--- a/examples/ios/swift/Migration/AppDelegate.swift
+++ b/examples/ios/swift/Migration/AppDelegate.swift
@@ -52,7 +52,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     var window: UIWindow?
 
-    func application(application: UIApplication!, didFinishLaunchingWithOptions launchOptions: NSDictionary!) -> Bool {
+    func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
         self.window = UIWindow(frame: UIScreen.mainScreen().bounds)
         self.window!.rootViewController = UIViewController()
         self.window!.makeKeyAndVisible()
@@ -73,8 +73,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                 migration.enumerateObjects(Person.className()) { oldObject, newObject in
                     if oldSchemaVersion < 1 {
                         // combine name fields into a single field
-                        let firstName = oldObject["firstName"] as String
-                        let lastName = oldObject["lastName"] as String
+                        let firstName = oldObject["firstName"] as! String
+                        let lastName = oldObject["lastName"] as! String
                         newObject["fullName"] = "\(firstName) \(lastName)"
                     }
                 }
@@ -82,7 +82,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             if oldSchemaVersion < 2 {
                 migration.enumerateObjects(Person.className()) { oldObject, newObject in
                     // give JP a dog
-                    if newObject["fullName"] as String == "JP McDonald" {
+                    if newObject["fullName"] as! String == "JP McDonald" {
                         let jpsDog = Pet(object: ["Jimbo", "dog"])
                         newObject["pets"].addObject(jpsDog)
                     }

--- a/examples/ios/swift/Simple/AppDelegate.swift
+++ b/examples/ios/swift/Simple/AppDelegate.swift
@@ -34,7 +34,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     var window: UIWindow?
 
-    func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: NSDictionary?) -> Bool {
+    func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
 
         self.window = UIWindow(frame: UIScreen.mainScreen().bounds)
         self.window!.rootViewController = UIViewController()

--- a/examples/ios/swift/TableView/AppDelegate.swift
+++ b/examples/ios/swift/TableView/AppDelegate.swift
@@ -23,7 +23,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     var window: UIWindow?
 
-    func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: NSDictionary?) -> Bool {
+    func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
         self.window = UIWindow(frame: UIScreen.mainScreen().bounds)
         self.window!.rootViewController = UINavigationController(rootViewController: TableViewController(style: .Plain))
         self.window!.makeKeyAndVisible()

--- a/examples/ios/swift/TableView/TableViewController.swift
+++ b/examples/ios/swift/TableView/TableViewController.swift
@@ -69,9 +69,9 @@ class TableViewController: UITableViewController {
     }
 
     override func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexPath) -> UITableViewCell {
-        let cell = tableView.dequeueReusableCellWithIdentifier("cell", forIndexPath: indexPath) as Cell
+        let cell = tableView.dequeueReusableCellWithIdentifier("cell", forIndexPath: indexPath) as! Cell
 
-        let object = array[UInt(indexPath.row)] as DemoObject
+        let object = array[UInt(indexPath.row)] as! DemoObject
         cell.textLabel?.text = object.title
         cell.detailTextLabel?.text = object.date.description
 
@@ -82,7 +82,7 @@ class TableViewController: UITableViewController {
         if editingStyle == .Delete {
             let realm = RLMRealm.defaultRealm()
             realm.beginWriteTransaction()
-            realm.deleteObject(array[UInt(indexPath.row)] as RLMObject)
+            realm.deleteObject(array[UInt(indexPath.row)] as! RLMObject)
             realm.commitWriteTransaction()
         }
     }


### PR DESCRIPTION
The examples stopped working for the new Swift version, a couple of small changes:
- cast with `as!` instead of `as` to force downcast
- changed the signature of the `application:didFinishLaunchingWithOptions` method
- also, changed some optionals to follow the same style in all examples.