### PR TITLE
clean up kvc support for lists

### DIFF
--- a/Realm/RLMListBase.h
+++ b/Realm/RLMListBase.h
@@ -22,7 +22,7 @@
 
 // A base class for Swift generic Lists to make it possible to interact with
 // them from obj-c
-@interface RLMListBase : NSObject
+@interface RLMListBase : NSObject<NSFastEnumeration>
 @property (nonatomic, strong) RLMArray *_rlmArray;
 
 - (instancetype)initWithArray:(RLMArray *)array;

--- a/Realm/RLMListBase.m
+++ b/Realm/RLMListBase.m
@@ -20,6 +20,7 @@
 #import <Realm/RLMArray.h>
 
 @implementation RLMListBase
+
 - (instancetype)initWithArray:(RLMArray *)array {
     self = [super init];
     if (self) {
@@ -31,4 +32,5 @@
 - (NSUInteger)countByEnumeratingWithState:(NSFastEnumerationState *)state objects:(id __unsafe_unretained [])buffer count:(NSUInteger)len {
     return [__rlmArray countByEnumeratingWithState:state objects:buffer count:len];
 }
+
 @end

--- a/Realm/RLMListBase.m
+++ b/Realm/RLMListBase.m
@@ -17,6 +17,7 @@
 ////////////////////////////////////////////////////////////////////////////
 
 #import "RLMListBase.h"
+#import <Realm/RLMArray.h>
 
 @implementation RLMListBase
 - (instancetype)initWithArray:(RLMArray *)array {
@@ -25,5 +26,9 @@
         __rlmArray = array;
     }
     return self;
+}
+
+- (NSUInteger)countByEnumeratingWithState:(NSFastEnumerationState *)state objects:(id __unsafe_unretained [])buffer count:(NSUInteger)len {
+    return [__rlmArray countByEnumeratingWithState:state objects:buffer count:len];
 }
 @end

--- a/RealmSwift/Object.swift
+++ b/RealmSwift/Object.swift
@@ -168,27 +168,35 @@ public class Object : RLMObjectBase, Equatable {
 
     // Get RLMArray values when getting array properties
     public override func valueForKey(key: String) -> AnyObject? {
-        if let prop = RLMObjectBaseObjectSchema(self)?[key] {
-            if prop.type == .Array {
-                let list = object_getIvar(self, prop.swiftListIvar) as RLMListBase
-                return list._rlmArray
-            }
+        if let list = listProperty(key) {
+            return list
         }
         return super.valueForKey(key)
     }
 
     // Support setting RLMArray values
     public override func setValue(value: AnyObject?, forKey: String) {
-        if let prop = RLMObjectBaseObjectSchema(self)?[forKey] {
-            if prop.type == .Array {
-                let list = object_getIvar(self, prop.swiftListIvar) as RLMListBase
-                if let value = value as? RLMArray {
-                    list._rlmArray = value
-                    return
-                }
+        if let list = listProperty(forKey) {
+            if let value = value as? RLMArray {
+                list._rlmArray = value
+                return
+            }
+            if let value = value as? RLMListBase {
+                list._rlmArray = value._rlmArray
+                return
             }
         }
         super.setValue(value, forKey: forKey)
+    }
+
+    // Helper for getting a list property for the given key
+    private func listProperty(forKey: String) -> RLMListBase? {
+        if let prop = RLMObjectBaseObjectSchema(self)?[forKey] {
+            if prop.type == .Array {
+                return object_getIvar(self, prop.swiftListIvar) as RLMListBase?
+            }
+        }
+        return nil
     }
 }
 

--- a/RealmSwift/Tests/RealmTests.swift
+++ b/RealmSwift/Tests/RealmTests.swift
@@ -478,4 +478,28 @@ class RealmTests: TestCase {
         }
         waitForExpectationsWithTimeout(2, handler: nil)
     }
+
+    func testInitStandaloneObjectWithObjectWithDefaultArrayProperty() {
+        let object = SwiftObject(object: [
+            "intCol": 200
+        ])
+
+        XCTAssertNil(object.realm)
+        XCTAssertEqual(object.stringCol, "a", "Should be initialized with default value")
+        XCTAssertEqual(object.intCol, 200, "Should be initialized with the passed-in value")
+        XCTAssertEqual(object.arrayCol.count, 0)
+        XCTAssertNil(object.arrayCol.realm)
+    }
+
+    func testInitStandaloneObjectWithObjectWithCustomArrayProperty() {
+        let object = SwiftObject(object: [
+            "arrayCol" : [[true]]
+            ])
+
+        XCTAssertNil(object.realm)
+        XCTAssertEqual(object.arrayCol.count, 1)
+        XCTAssertEqual(object.arrayCol.first!.boolCol, true)
+        XCTAssertNil(object.arrayCol.realm)
+    }
+
 }


### PR DESCRIPTION
@tgoyne @segiddins 

I think this addresses the concerns. valueForKey now returns a List. setValue supports both lists and RLMArrays. We only had to forward the fast enumeration method to make this work.