### PR TITLE
[RLMObjectBase] Don't crash when calling isEqual: against a non-RLMObject...

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ x.x.x Release notes (yyyy-MM-dd)
 * Fix crash when calling `createOrUpdate:inRealm` with nested linked objects.
 * Use the key from `+[RLMRealm setEncryptionKey:forRealmsAtPath:]` in
   `-writeCopyToPath:error:` and `+migrateRealmAtPath:`.
+* Comparing an RLMObject to a non-RLMObject using `-[RLMObject isEqual:]` or
+  `-isEqualToObject:` now returns NO instead of crashing.
 * Improved error message when an `RLMObject` subclass is defined nested within
   another Swift declaration.
 * Fix crash when the process is terminated by the OS on iOS while encrypted realms are open.

--- a/Realm/RLMObjectBase.mm
+++ b/Realm/RLMObjectBase.mm
@@ -256,12 +256,12 @@
 }
 
 - (BOOL)isEqual:(id)object {
-    if (_objectSchema.primaryKeyProperty) {
-        return [self isEqualToObject:object];
+    if (RLMObjectBase *other = RLMDynamicCast<RLMObjectBase>(object)) {
+	if (_objectSchema.primaryKeyProperty) {
+	    return [self isEqualToObject:other];
+	}
     }
-    else {
-        return [super isEqual:object];
-    }
+    return [super isEqual:object];
 }
 
 - (NSUInteger)hash {

--- a/Realm/RLMObjectBase.mm
+++ b/Realm/RLMObjectBase.mm
@@ -257,9 +257,9 @@
 
 - (BOOL)isEqual:(id)object {
     if (RLMObjectBase *other = RLMDynamicCast<RLMObjectBase>(object)) {
-	if (_objectSchema.primaryKeyProperty) {
-	    return [self isEqualToObject:other];
-	}
+        if (_objectSchema.primaryKeyProperty) {
+            return [self isEqualToObject:other];
+        }
     }
     return [super isEqual:object];
 }

--- a/Realm/Tests/ObjectTests.m
+++ b/Realm/Tests/ObjectTests.m
@@ -1032,6 +1032,8 @@ RLM_ARRAY_TYPE(PrimaryIntObject);
     RLMRealm *realm = [RLMRealm defaultRealm];
     RLMRealm *otherRealm = [self realmWithTestPath];
 
+    XCTAssertFalse([obj isEqual:[NSObject new]], @"Comparing an RLMObject to a non-RLMObject should be false.");
+    XCTAssertFalse([obj isEqualToObject:(RLMObject *)[NSObject new]], @"Comparing an RLMObject to a non-RLMObject should be false.");
     XCTAssertTrue([obj isEqual:obj], @"Same instance.");
     XCTAssertTrue([obj isEqualToObject:obj], @"Same instance.");
     XCTAssertFalse([obj isEqualToObject:otherObj], @"Comparison outside of realm.");


### PR DESCRIPTION
Closes #1547.

\c @alazier @tgoyne 