### PR TITLE
Parallelize the pull request test running

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -631,6 +631,7 @@ EOF
         ;;
 
     *)
+        echo "Unknown command '$COMMAND'"
         usage
         exit 1
         ;;

--- a/build.sh
+++ b/build.sh
@@ -334,8 +334,8 @@ case "$COMMAND" in
 
     "verify-osx")
         CONFIGURATION="$CONFIGURATION" sh build.sh test-osx
-        CONFIGURATION="$CONFIGURATION" sh build.sh test-browse
-        CONFIGURATION="$CONFIGURATION" sh build.sh examples-os
+        CONFIGURATION="$CONFIGURATION" sh build.sh test-browser
+        CONFIGURATION="$CONFIGURATION" sh build.sh examples-osx
 
         (
             cd examples/osx/objc/build/DerivedData/RealmExamples/Build/Products/$CONFIGURATION

--- a/build.sh
+++ b/build.sh
@@ -257,6 +257,9 @@ case "$COMMAND" in
 
     "osx")
         xcrealm "-scheme OSX -configuration $CONFIGURATION"
+        rm -rf build/osx
+        mkdir build/osx
+        cp -R build/DerivedData/Realm/Build/Products/$CONFIGURATION/Realm.framework build/osx
         exit 0
         ;;
 

--- a/build.sh
+++ b/build.sh
@@ -344,6 +344,7 @@ case "$COMMAND" in
         exit 0
         ;;
 
+    # FIXME: make no-op in al-swift
     "verify-ios")
         CONFIGURATION="$CONFIGURATION" sh build.sh test-ios
         CONFIGURATION="$CONFIGURATION" sh build.sh examples-ios
@@ -357,6 +358,23 @@ case "$COMMAND" in
 
     "verify-docs")
         sh scripts/build-docs.sh
+        exit 0
+        ;;
+
+    # FIXME: make not no-ops in al-swift
+    "verify-ios-static")
+        exit 0
+        ;;
+
+    "verify-ios-dynamic")
+        exit 0
+        ;;
+
+    "verify-ios-swift")
+        exit 0
+        ;;
+
+    "verify-osx-swift")
         exit 0
         ;;
 

--- a/build.sh
+++ b/build.sh
@@ -296,18 +296,43 @@ case "$COMMAND" in
         exit 0
         ;;
 
+    ######################################
+    # Full verification
+    ######################################
     "verify")
-        sh build.sh docs
-        sh build.sh test-all "$XCMODE"
-        sh build.sh examples "$XCMODE"
-        sh build.sh browser "$XCMODE"
-        sh build.sh test-browser "$XCMODE"
+        sh build.sh verify-docs
+        sh build.sh verify-osx
+        sh build.sh verify-osx-debug
+        sh build.sh verify-ios
+        sh build.sh verify-ios-debug
+        sh build.sh verify-ios-device
+        ;;
+
+    "verify-osx")
+        CONFIGURATION="$CONFIGURATION" sh build.sh test-osx "$XCMODE"
+        CONFIGURATION="$CONFIGURATION" sh build.sh test-browser "$XCMODE"
+        CONFIGURATION="$CONFIGURATION" sh build.sh examples-osx "$XCMODE"
 
         (
-            cd examples/osx/objc/build/DerivedData/RealmExamples/Build/Products/Release
+            cd examples/osx/objc/build/DerivedData/RealmExamples/Build/Products/$CONFIGURATION
             DYLD_FRAMEWORK_PATH=. ./JSONImport
         ) || exit 1
+        exit 0
+        ;;
 
+    "verify-ios")
+        CONFIGURATION="$CONFIGURATION" sh build.sh test-ios "$XCMODE"
+        CONFIGURATION="$CONFIGURATION" sh build.sh examples-ios "$XCMODE"
+        exit 0
+        ;;
+
+    "verify-ios-device")
+        CONFIGURATION="$CONFIGURATION" sh build.sh test-ios-devices "$XCMODE"
+        exit 0
+        ;;
+
+    "verify-docs")
+        sh scripts/build-docs.sh
         exit 0
         ;;
 
@@ -323,22 +348,29 @@ case "$COMMAND" in
     # Examples
     ######################################
     "examples")
-        sh build.sh clean
-
-        cd examples
-        xc "-project ios/objc/RealmExamples.xcodeproj -scheme Simple -configuration $CONFIGURATION build ${CODESIGN_PARAMS}"
-        xc "-project ios/objc/RealmExamples.xcodeproj -scheme TableView -configuration $CONFIGURATION build ${CODESIGN_PARAMS}"
-        xc "-project ios/objc/RealmExamples.xcodeproj -scheme Migration -configuration $CONFIGURATION build ${CODESIGN_PARAMS}"
-        xc "-project ios/objc/RealmExamples.xcodeproj -scheme Backlink -configuration $CONFIGURATION build ${CODESIGN_PARAMS}"
-        xc "-project ios/objc/RealmExamples.xcodeproj -scheme GroupedTableView -configuration $CONFIGURATION build ${CODESIGN_PARAMS}"
-        xc "-project osx/objc/RealmExamples.xcodeproj -scheme JSONImport -configuration $CONFIGURATION build ${CODESIGN_PARAMS}"
-        xc "-project ios/swift/RealmExamples.xcodeproj -scheme Simple -configuration $CONFIGURATION build ${CODESIGN_PARAMS}"
-        xc "-project ios/swift/RealmExamples.xcodeproj -scheme TableView -configuration $CONFIGURATION build ${CODESIGN_PARAMS}"
-        xc "-project ios/swift/RealmExamples.xcodeproj -scheme Migration -configuration $CONFIGURATION build ${CODESIGN_PARAMS}"
-        xc "-project ios/swift/RealmExamples.xcodeproj -scheme Encryption -configuration $CONFIGURATION build ${CODESIGN_PARAMS}"
-        xc "-project ios/swift/RealmExamples.xcodeproj -scheme Backlink -configuration $CONFIGURATION build ${CODESIGN_PARAMS}"
-        xc "-project ios/swift/RealmExamples.xcodeproj -scheme GroupedTableView -configuration $CONFIGURATION build ${CODESIGN_PARAMS}"
+        CONFIGURATION="$CONFIGURATION" sh build.sh clean
+        CONFIGURATION="$CONFIGURATION" sh build.sh examples-ios
+        CONFIGURATION="$CONFIGURATION" sh build.sh examples-osx
         exit 0
+        ;;
+
+    "examples-ios")
+        xc "-project examples/ios/objc/RealmExamples.xcodeproj -scheme Simple -configuration $CONFIGURATION build ${CODESIGN_PARAMS}"
+        xc "-project examples/ios/objc/RealmExamples.xcodeproj -scheme TableView -configuration $CONFIGURATION build ${CODESIGN_PARAMS}"
+        xc "-project examples/ios/objc/RealmExamples.xcodeproj -scheme Migration -configuration $CONFIGURATION build ${CODESIGN_PARAMS}"
+        xc "-project examples/ios/objc/RealmExamples.xcodeproj -scheme Backlink -configuration $CONFIGURATION build ${CODESIGN_PARAMS}"
+        xc "-project examples/ios/objc/RealmExamples.xcodeproj -scheme GroupedTableView -configuration $CONFIGURATION build ${CODESIGN_PARAMS}"
+        xc "-project examples/ios/swift/RealmExamples.xcodeproj -scheme Simple -configuration $CONFIGURATION build ${CODESIGN_PARAMS}"
+        xc "-project examples/ios/swift/RealmExamples.xcodeproj -scheme TableView -configuration $CONFIGURATION build ${CODESIGN_PARAMS}"
+        xc "-project examples/ios/swift/RealmExamples.xcodeproj -scheme Migration -configuration $CONFIGURATION build ${CODESIGN_PARAMS}"
+        xc "-project examples/ios/swift/RealmExamples.xcodeproj -scheme Encryption -configuration $CONFIGURATION build ${CODESIGN_PARAMS}"
+        xc "-project examples/ios/swift/RealmExamples.xcodeproj -scheme Backlink -configuration $CONFIGURATION build ${CODESIGN_PARAMS}"
+        xc "-project examples/ios/swift/RealmExamples.xcodeproj -scheme GroupedTableView -configuration $CONFIGURATION build ${CODESIGN_PARAMS}"
+        exit 0
+        ;;
+
+    "examples-osx")
+        xc "-project examples/osx/objc/RealmExamples.xcodeproj -scheme JSONImport -configuration ${CONFIGURATION} build ${CODESIGN_PARAMS}"
         ;;
 
     ######################################

--- a/build.sh
+++ b/build.sh
@@ -31,25 +31,25 @@ cat <<EOF
 Usage: sh $0 command [argument]
 
 command:
-  download-core:           downloads core library (binary version)
-  clean:                   clean up/remove all generated files
-  build: [settings]        builds iOS and OS X frameworks
-  ios: [settings]          builds iOS frameworks
-  ios-dynamic: [settings]  builds iOS dynamic frameworks
-  ios-static: [settings]   builds a fat iOS static framework
-  osx: [settings]          builds OS X framework
-  test-ios: [settings]     tests iOS framework
-  test-ios-devices:        tests iOS on all attached iOS devices
-  test-osx: [settings]     tests OSX framework
-  test: [settings]         tests iOS and OS X frameworks
-  test-all: [settings]     tests iOS and OS X frameworks with debug and release configurations
-  examples: [settings]     builds all examples in examples/
-  browser: [settings]      builds the Realm Browser OSX app
-  test-browser: [settings] tests the Realm Browser OSX app
-  verify: [settings]       cleans, removes docs/output/, then runs docs, test-all, examples & browser
-  docs:                    builds docs in docs/output
-  get-version:             get the current version
-  set-version version:     set the version
+  download-core:               downloads core library (binary version)
+  clean:                       clean up/remove all generated files
+  build [settings]:            builds iOS and OS X frameworks
+  ios [settings]:              builds iOS frameworks
+  ios-dynamic [settings]:      builds iOS dynamic frameworks
+  ios-static [settings]:       builds a fat iOS static framework
+  osx [settings]:              builds OS X framework
+  test-ios [settings]:         tests iOS framework
+  test-ios-devices [settings]: tests iOS on all attached iOS devices
+  test-osx [settings]:         tests OSX framework
+  test [settings]:             tests iOS and OS X frameworks
+  test-all [settings]:         tests iOS and OS X frameworks with debug and release configurations
+  examples [settings]:         builds all examples in examples/
+  browser [settings]:          builds the Realm Browser OSX app
+  test-browser [settings]:     tests the Realm Browser OSX app
+  verify [settings]:           cleans, removes docs/output/, then runs docs, test-all, examples & browser
+  docs:                        builds docs in docs/output
+  get-version:                 get the current version
+  set-version version:         set the version
 
 argument:
   version: version in the x.y.z format

--- a/build.sh
+++ b/build.sh
@@ -333,9 +333,9 @@ case "$COMMAND" in
         ;;
 
     "verify-osx")
-        CONFIGURATION="$CONFIGURATION" sh build.sh test-osx
-        CONFIGURATION="$CONFIGURATION" sh build.sh test-browser
-        CONFIGURATION="$CONFIGURATION" sh build.sh examples-osx
+        sh build.sh test-osx
+        sh build.sh test-browser
+        sh build.sh examples-osx
 
         (
             cd examples/osx/objc/build/DerivedData/RealmExamples/Build/Products/$CONFIGURATION
@@ -346,13 +346,13 @@ case "$COMMAND" in
 
     # FIXME: make no-op in al-swift
     "verify-ios")
-        CONFIGURATION="$CONFIGURATION" sh build.sh test-ios
-        CONFIGURATION="$CONFIGURATION" sh build.sh examples-ios
+        sh build.sh test-ios
+        sh build.sh examples-ios
         exit 0
         ;;
 
     "verify-ios-device")
-        CONFIGURATION="$CONFIGURATION" sh build.sh test-ios-devices
+        sh build.sh test-ios-devices
         exit 0
         ;;
 
@@ -390,9 +390,9 @@ case "$COMMAND" in
     # Examples
     ######################################
     "examples")
-        CONFIGURATION="$CONFIGURATION" sh build.sh clean
-        CONFIGURATION="$CONFIGURATION" sh build.sh examples-ios
-        CONFIGURATION="$CONFIGURATION" sh build.sh examples-osx
+        sh build.sh clean
+        sh build.sh examples-ios
+        sh build.sh examples-osx
         exit 0
         ;;
 

--- a/examples/osx/objc/RealmExamples.xcodeproj/project.pbxproj
+++ b/examples/osx/objc/RealmExamples.xcodeproj/project.pbxproj
@@ -61,7 +61,7 @@
 		E823C34B19BA4A7600D2FF5F /* Person.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Person.m; sourceTree = "<group>"; };
 		E823C34C19BA4A7600D2FF5F /* persons.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = persons.json; sourceTree = "<group>"; };
 		E823C35219BA4B8600D2FF5F /* libc++.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = "libc++.dylib"; path = "usr/lib/libc++.dylib"; sourceTree = SDKROOT; };
-		E85A517019BA76B7006C63CB /* Realm.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Realm.framework; path = ../../../build/DerivedData/Realm/Build/Products/Release/Realm.framework; sourceTree = "<group>"; };
+		E85A517019BA76B7006C63CB /* Realm.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Realm.framework; path = ../../../build/osx/Realm.framework; sourceTree = "<group>"; };
 		E8F1E82019BA4A3800FAD64E /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 /* End PBXFileReference section */
 
@@ -260,7 +260,7 @@
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
-				FRAMEWORK_SEARCH_PATHS = ../../../build/DerivedData/Realm/Build/Products/Release;
+				FRAMEWORK_SEARCH_PATHS = ../../../build/osx;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
@@ -301,7 +301,7 @@
 				COPY_PHASE_STRIP = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_NS_ASSERTIONS = NO;
-				FRAMEWORK_SEARCH_PATHS = ../../../build/DerivedData/Realm/Build/Products/Release;
+				FRAMEWORK_SEARCH_PATHS = ../../../build/osx;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;

--- a/tools/RealmBrowser/RealmBrowser.xcodeproj/project.pbxproj
+++ b/tools/RealmBrowser/RealmBrowser.xcodeproj/project.pbxproj
@@ -197,7 +197,7 @@
 		84E35A4C196B021B007F0344 /* RLMArrayNavigationState.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RLMArrayNavigationState.m; path = Classes/RLMArrayNavigationState.m; sourceTree = "<group>"; };
 		E84EB8271A2FC38C00EB780E /* RLMTestObjects.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RLMTestObjects.h; sourceTree = "<group>"; };
 		E84EB8281A2FC38C00EB780E /* RLMTestObjects.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RLMTestObjects.m; sourceTree = "<group>"; };
-		E8E3D63D19E0729B00C67D13 /* Realm.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Realm.framework; path = ../../build/DerivedData/Realm/Build/Products/Release/Realm.framework; sourceTree = "<group>"; };
+		E8E3D63D19E0729B00C67D13 /* Realm.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Realm.framework; path = ../../build/osx/Realm.framework; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -776,7 +776,7 @@
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)",
-					../../build/DerivedData/Realm/Build/Products/Release,
+					../../build/osx,
 				);
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "RealmBrowser/RealmBrowser-Prefix.pch";
@@ -801,7 +801,7 @@
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)",
-					../../build/DerivedData/Realm/Build/Products/Release,
+					../../build/osx,
 				);
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "RealmBrowser/RealmBrowser-Prefix.pch";
@@ -826,7 +826,7 @@
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)",
-					../../build/DerivedData/Realm/Build/Products/Release,
+					../../build/osx/,
 				);
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "";
@@ -847,7 +847,7 @@
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)",
-					../../build/DerivedData/Realm/Build/Products/Release,
+					../../build/osx/,
 				);
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "";


### PR DESCRIPTION
This does a few things:

1. Refactors `build.sh` to make the `-debug` versions of commands just set a variable and call the normal version, to eliminate a bunch of duplication and to make it easier to programmatically call either the debug or release versions.
2. Splits `verify` into sub-tasks which each build `Realm.framework` in one configuration and then run all tests relevant to that framework.
3. Makes `build.sh osx` copy the built result to `build/osx` and switches the browser and examples to looking there, to make it easier to use the browser with a debug build of the framework.

https://ci.tightdb.com/job/cocoa_pr/ takes advantage of this to run each sub-task on a different slave in parallel. Net result is a reduction from 12-15 minutes to 5-6 minutes to run all of the tests and a slightly better UI for determining what exactly failed.