### PR TITLE
Fix unsafe uses of __unsafe_unretained

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ x.x.x Release notes (yyyy-MM-dd)
 * An exception will now be thrown when calling `-beginWriteTransaction` from within a notification
   triggered by calling `-beginWriteTransaction` elsewhere.
 * When calling `delete:` we now verify that the object being deleted is persisted in the target Realm.
+* Fix crash when calling `createOrUpdate:inRealm` with nested linked objects.
 
 0.90.6 Release notes (2015-02-20)
 =============================================================

--- a/Realm/RLMAccessor.mm
+++ b/Realm/RLMAccessor.mm
@@ -30,7 +30,7 @@
 #import <objc/runtime.h>
 
 // verify attached
-static inline void RLMVerifyAttached(__unsafe_unretained RLMObjectBase *obj) {
+static inline void RLMVerifyAttached(__unsafe_unretained RLMObjectBase *const obj) {
     if (!obj->_row.is_attached()) {
         @throw RLMException(@"Object has been deleted or invalidated.");
     }
@@ -38,7 +38,7 @@ static inline void RLMVerifyAttached(__unsafe_unretained RLMObjectBase *obj) {
 }
 
 // verify writable
-static inline void RLMVerifyInWriteTransaction(__unsafe_unretained RLMObjectBase *obj) {
+static inline void RLMVerifyInWriteTransaction(__unsafe_unretained RLMObjectBase *const obj) {
     // first verify is attached
     RLMVerifyAttached(obj);
 
@@ -48,15 +48,15 @@ static inline void RLMVerifyInWriteTransaction(__unsafe_unretained RLMObjectBase
 }
 
 // long getter/setter
-static inline long long RLMGetLong(__unsafe_unretained RLMObjectBase *obj, NSUInteger colIndex) {
+static inline long long RLMGetLong(__unsafe_unretained RLMObjectBase *const obj, NSUInteger colIndex) {
     RLMVerifyAttached(obj);
     return obj->_row.get_int(colIndex);
 }
-static inline void RLMSetValue(__unsafe_unretained RLMObjectBase *obj, NSUInteger colIndex, long long val) {
+static inline void RLMSetValue(__unsafe_unretained RLMObjectBase *const obj, NSUInteger colIndex, long long val) {
     RLMVerifyInWriteTransaction(obj);
     obj->_row.set_int(colIndex, val);
 }
-static inline void RLMSetValueUnique(__unsafe_unretained RLMObjectBase *obj, NSUInteger colIndex, NSString *propName, long long val) {
+static inline void RLMSetValueUnique(__unsafe_unretained RLMObjectBase *const obj, NSUInteger colIndex, NSString *propName, long long val) {
     RLMVerifyInWriteTransaction(obj);
     size_t row = obj->_row.get_table()->find_first_int(colIndex, val);
     if (row == obj->_row.get_index()) {
@@ -70,41 +70,41 @@ static inline void RLMSetValueUnique(__unsafe_unretained RLMObjectBase *obj, NSU
 }
 
 // float getter/setter
-static inline float RLMGetFloat(__unsafe_unretained RLMObjectBase *obj, NSUInteger colIndex) {
+static inline float RLMGetFloat(__unsafe_unretained RLMObjectBase *const obj, NSUInteger colIndex) {
     RLMVerifyAttached(obj);
     return obj->_row.get_float(colIndex);
 }
-static inline void RLMSetValue(__unsafe_unretained RLMObjectBase *obj, NSUInteger colIndex, float val) {
+static inline void RLMSetValue(__unsafe_unretained RLMObjectBase *const obj, NSUInteger colIndex, float val) {
     RLMVerifyInWriteTransaction(obj);
     obj->_row.set_float(colIndex, val);
 }
 
 // double getter/setter
-static inline double RLMGetDouble(__unsafe_unretained RLMObjectBase *obj, NSUInteger colIndex) {
+static inline double RLMGetDouble(__unsafe_unretained RLMObjectBase *const obj, NSUInteger colIndex) {
     RLMVerifyAttached(obj);
     return obj->_row.get_double(colIndex);
 }
-static inline void RLMSetValue(__unsafe_unretained RLMObjectBase *obj, NSUInteger colIndex, double val) {
+static inline void RLMSetValue(__unsafe_unretained RLMObjectBase *const obj, NSUInteger colIndex, double val) {
     RLMVerifyInWriteTransaction(obj);
     obj->_row.set_double(colIndex, val);
 }
 
 // bool getter/setter
-static inline bool RLMGetBool(__unsafe_unretained RLMObjectBase *obj, NSUInteger colIndex) {
+static inline bool RLMGetBool(__unsafe_unretained RLMObjectBase *const obj, NSUInteger colIndex) {
     RLMVerifyAttached(obj);
     return obj->_row.get_bool(colIndex);
 }
-static inline void RLMSetValue(__unsafe_unretained RLMObjectBase *obj, NSUInteger colIndex, bool val) {
+static inline void RLMSetValue(__unsafe_unretained RLMObjectBase *const obj, NSUInteger colIndex, bool val) {
     RLMVerifyInWriteTransaction(obj);
     obj->_row.set_bool(colIndex, val);
 }
 
 // string getter/setter
-static inline NSString *RLMGetString(__unsafe_unretained RLMObjectBase *obj, NSUInteger colIndex) {
+static inline NSString *RLMGetString(__unsafe_unretained RLMObjectBase *const obj, NSUInteger colIndex) {
     RLMVerifyAttached(obj);
     return RLMStringDataToNSString(obj->_row.get_string(colIndex));
 }
-static inline void RLMSetValue(__unsafe_unretained RLMObjectBase *obj, NSUInteger colIndex, __unsafe_unretained NSString *val) {
+static inline void RLMSetValue(__unsafe_unretained RLMObjectBase *const obj, NSUInteger colIndex, __unsafe_unretained NSString *const val) {
     RLMVerifyInWriteTransaction(obj);
     try {
         obj->_row.set_string(colIndex, RLMStringDataWithNSString(val));
@@ -113,8 +113,8 @@ static inline void RLMSetValue(__unsafe_unretained RLMObjectBase *obj, NSUIntege
         @throw RLMException(e);
     }
 }
-static inline void RLMSetValueUnique(__unsafe_unretained RLMObjectBase *obj, NSUInteger colIndex, NSString *propName,
-                                      __unsafe_unretained NSString *val) {
+static inline void RLMSetValueUnique(__unsafe_unretained RLMObjectBase *const obj, NSUInteger colIndex, NSString *propName,
+                                     __unsafe_unretained NSString *const val) {
     RLMVerifyInWriteTransaction(obj);
     tightdb::StringData str = RLMStringDataWithNSString(val);
     size_t row = obj->_row.get_table()->find_first_string(colIndex, str);
@@ -134,24 +134,24 @@ static inline void RLMSetValueUnique(__unsafe_unretained RLMObjectBase *obj, NSU
 }
 
 // date getter/setter
-static inline NSDate *RLMGetDate(__unsafe_unretained RLMObjectBase *obj, NSUInteger colIndex) {
+static inline NSDate *RLMGetDate(__unsafe_unretained RLMObjectBase *const obj, NSUInteger colIndex) {
     RLMVerifyAttached(obj);
     tightdb::DateTime dt = obj->_row.get_datetime(colIndex);
     return [NSDate dateWithTimeIntervalSince1970:dt.get_datetime()];
 }
-static inline void RLMSetValue(__unsafe_unretained RLMObjectBase *obj, NSUInteger colIndex, __unsafe_unretained NSDate *date) {
+static inline void RLMSetValue(__unsafe_unretained RLMObjectBase *const obj, NSUInteger colIndex, __unsafe_unretained NSDate *const date) {
     RLMVerifyInWriteTransaction(obj);
     std::time_t time = date.timeIntervalSince1970;
     obj->_row.set_datetime(colIndex, tightdb::DateTime(time));
 }
 
 // data getter/setter
-static inline NSData *RLMGetData(__unsafe_unretained RLMObjectBase *obj, NSUInteger colIndex) {
+static inline NSData *RLMGetData(__unsafe_unretained RLMObjectBase *const obj, NSUInteger colIndex) {
     RLMVerifyAttached(obj);
     tightdb::BinaryData data = obj->_row.get_binary(colIndex);
     return [NSData dataWithBytes:data.data() length:data.size()];
 }
-static inline void RLMSetValue(__unsafe_unretained RLMObjectBase *obj, NSUInteger colIndex, __unsafe_unretained NSData *data) {
+static inline void RLMSetValue(__unsafe_unretained RLMObjectBase *const obj, NSUInteger colIndex, __unsafe_unretained NSData *const data) {
     RLMVerifyInWriteTransaction(obj);
 
     try {
@@ -162,8 +162,8 @@ static inline void RLMSetValue(__unsafe_unretained RLMObjectBase *obj, NSUIntege
     }
 }
 
-static inline size_t RLMAddLinkedObject(__unsafe_unretained RLMObjectBase *link,
-                                        __unsafe_unretained RLMRealm *realm,
+static inline size_t RLMAddLinkedObject(RLMObjectBase *link,
+                                        __unsafe_unretained RLMRealm *const realm,
                                         RLMCreationOptions options) {
     if (link.isInvalidated) {
         @throw RLMException(@"Adding a deleted or invalidated object to a Realm is not permitted");
@@ -184,7 +184,7 @@ static inline size_t RLMAddLinkedObject(__unsafe_unretained RLMObjectBase *link,
 }
 
 // link getter/setter
-static inline RLMObjectBase *RLMGetLink(__unsafe_unretained RLMObjectBase *obj, NSUInteger colIndex, __unsafe_unretained NSString *objectClassName) {
+static inline RLMObjectBase *RLMGetLink(__unsafe_unretained RLMObjectBase *const obj, NSUInteger colIndex, __unsafe_unretained NSString *const objectClassName) {
     RLMVerifyAttached(obj);
 
     if (obj->_row.is_null_link(colIndex)) {
@@ -193,8 +193,8 @@ static inline RLMObjectBase *RLMGetLink(__unsafe_unretained RLMObjectBase *obj, 
     NSUInteger index = obj->_row.get_link(colIndex);
     return RLMCreateObjectAccessor(obj.realm, obj.realm.schema[objectClassName], index);
 }
-static inline void RLMSetValue(__unsafe_unretained RLMObjectBase *obj, NSUInteger colIndex,
-                               __unsafe_unretained RLMObjectBase *val, RLMCreationOptions options=0) {
+static inline void RLMSetValue(__unsafe_unretained RLMObjectBase *const obj, NSUInteger colIndex,
+                               __unsafe_unretained RLMObjectBase *const val, RLMCreationOptions options=0) {
     RLMVerifyInWriteTransaction(obj);
 
     if (!val || (id)val == NSNull.null) {
@@ -214,7 +214,7 @@ static inline void RLMSetValue(__unsafe_unretained RLMObjectBase *obj, NSUIntege
 }
 
 // array getter/setter
-static inline RLMArray *RLMGetArray(__unsafe_unretained RLMObjectBase *obj, NSUInteger colIndex, __unsafe_unretained NSString *objectClassName) {
+static inline RLMArray *RLMGetArray(__unsafe_unretained RLMObjectBase *const obj, NSUInteger colIndex, __unsafe_unretained NSString *const objectClassName) {
     RLMVerifyAttached(obj);
 
     tightdb::LinkViewRef linkView = obj->_row.get_linklist(colIndex);
@@ -223,7 +223,7 @@ static inline RLMArray *RLMGetArray(__unsafe_unretained RLMObjectBase *obj, NSUI
                                                                 realm:obj.realm];
     return ar;
 }
-static inline void RLMSetValue(__unsafe_unretained RLMObjectBase *obj, NSUInteger colIndex,
+static inline void RLMSetValue(__unsafe_unretained RLMObjectBase *const obj, NSUInteger colIndex,
                                __unsafe_unretained id<NSFastEnumeration> val,
                                RLMCreationOptions options=0) {
     RLMVerifyInWriteTransaction(obj);
@@ -240,7 +240,7 @@ static inline void RLMSetValue(__unsafe_unretained RLMObjectBase *obj, NSUIntege
 }
 
 // any getter/setter
-static inline id RLMGetAnyProperty(__unsafe_unretained RLMObjectBase *obj, NSUInteger col_ndx) {
+static inline id RLMGetAnyProperty(__unsafe_unretained RLMObjectBase *const obj, NSUInteger col_ndx) {
     RLMVerifyAttached(obj);
 
     tightdb::Mixed mixed = obj->_row.get_mixed(col_ndx);
@@ -273,7 +273,7 @@ static inline id RLMGetAnyProperty(__unsafe_unretained RLMObjectBase *obj, NSUIn
         }
     }
 }
-static inline void RLMSetValue(__unsafe_unretained RLMObjectBase *obj, NSUInteger col_ndx, __unsafe_unretained id val) {
+static inline void RLMSetValue(__unsafe_unretained RLMObjectBase *const obj, NSUInteger col_ndx, __unsafe_unretained id val) {
     RLMVerifyInWriteTransaction(obj);
 
     // FIXME - enable when Any supports links
@@ -321,56 +321,56 @@ static IMP RLMAccessorGetter(RLMProperty *prop, char accessorCode, NSString *obj
     NSUInteger colIndex = prop.column;
     switch (accessorCode) {
         case 's':
-            return imp_implementationWithBlock(^(__unsafe_unretained RLMObjectBase *obj) {
+            return imp_implementationWithBlock(^(__unsafe_unretained RLMObjectBase *const obj) {
                 return (short)RLMGetLong(obj, colIndex);
             });
         case 'i':
-            return imp_implementationWithBlock(^(__unsafe_unretained RLMObjectBase *obj) {
+            return imp_implementationWithBlock(^(__unsafe_unretained RLMObjectBase *const obj) {
                 return (int)RLMGetLong(obj, colIndex);
             });
         case 'q':
-            return imp_implementationWithBlock(^(__unsafe_unretained RLMObjectBase *obj) {
+            return imp_implementationWithBlock(^(__unsafe_unretained RLMObjectBase *const obj) {
                 return RLMGetLong(obj, colIndex);
             });
         case 'l':
-            return imp_implementationWithBlock(^(__unsafe_unretained RLMObjectBase *obj) {
+            return imp_implementationWithBlock(^(__unsafe_unretained RLMObjectBase *const obj) {
                 return (long)RLMGetLong(obj, colIndex);
             });
         case 'f':
-            return imp_implementationWithBlock(^(__unsafe_unretained RLMObjectBase *obj) {
+            return imp_implementationWithBlock(^(__unsafe_unretained RLMObjectBase *const obj) {
                 return RLMGetFloat(obj, colIndex);
             });
         case 'd':
-            return imp_implementationWithBlock(^(__unsafe_unretained RLMObjectBase *obj) {
+            return imp_implementationWithBlock(^(__unsafe_unretained RLMObjectBase *const obj) {
                 return RLMGetDouble(obj, colIndex);
             });
         case 'B':
         case 'c':
-            return imp_implementationWithBlock(^(__unsafe_unretained RLMObjectBase *obj) {
+            return imp_implementationWithBlock(^(__unsafe_unretained RLMObjectBase *const obj) {
                 return RLMGetBool(obj, colIndex);
             });
         case 'S':
-            return imp_implementationWithBlock(^(__unsafe_unretained RLMObjectBase *obj) {
+            return imp_implementationWithBlock(^(__unsafe_unretained RLMObjectBase *const obj) {
                 return RLMGetString(obj, colIndex);
             });
         case 'a':
-            return imp_implementationWithBlock(^(__unsafe_unretained RLMObjectBase *obj) {
+            return imp_implementationWithBlock(^(__unsafe_unretained RLMObjectBase *const obj) {
                 return RLMGetDate(obj, colIndex);
             });
         case 'e':
-            return imp_implementationWithBlock(^(__unsafe_unretained RLMObjectBase *obj) {
+            return imp_implementationWithBlock(^(__unsafe_unretained RLMObjectBase *const obj) {
                 return RLMGetData(obj, colIndex);
             });
         case 'k':
-            return imp_implementationWithBlock(^id(__unsafe_unretained RLMObjectBase *obj) {
+            return imp_implementationWithBlock(^id(__unsafe_unretained RLMObjectBase *const obj) {
                 return RLMGetLink(obj, colIndex, objectClassName);
             });
         case 't':
-            return imp_implementationWithBlock(^(__unsafe_unretained RLMObjectBase *obj) {
+            return imp_implementationWithBlock(^(__unsafe_unretained RLMObjectBase *const obj) {
                 return RLMGetArray(obj, colIndex, objectClassName);
             });
         case '@':
-            return imp_implementationWithBlock(^(__unsafe_unretained RLMObjectBase *obj) {
+            return imp_implementationWithBlock(^(__unsafe_unretained RLMObjectBase *const obj) {
                 return RLMGetAnyProperty(obj, colIndex);
             });
         default:
@@ -385,7 +385,7 @@ static IMP RLMMakeSetter(NSUInteger colIndex, bool isPrimary) {
             @throw RLMException(@"Primary key can't be changed after an object is inserted.");
         });
     }
-    return imp_implementationWithBlock(^(__unsafe_unretained RLMObjectBase *obj, ArgType val) {
+    return imp_implementationWithBlock(^(__unsafe_unretained RLMObjectBase *const obj, ArgType val) {
         RLMSetValue(obj, colIndex, static_cast<StorageType>(val));
     });
 }
@@ -613,7 +613,7 @@ void RLMDynamicValidatedSet(RLMObjectBase *obj, NSString *propName, id val) {
     RLMDynamicSet(obj, prop, val, prop.isPrimary ? RLMCreationOptionsEnforceUnique : 0);
 }
 
-void RLMDynamicSet(__unsafe_unretained RLMObjectBase *obj, __unsafe_unretained RLMProperty *prop,
+void RLMDynamicSet(__unsafe_unretained RLMObjectBase *const obj, __unsafe_unretained RLMProperty *const prop,
                    __unsafe_unretained id val, RLMCreationOptions options) {
     NSUInteger col = prop.column;
     switch (accessorCodeForType(prop.objcType, prop.type)) {
@@ -666,7 +666,7 @@ void RLMDynamicSet(__unsafe_unretained RLMObjectBase *obj, __unsafe_unretained R
     }
 }
 
-id RLMDynamicGet(__unsafe_unretained RLMObjectBase *obj, __unsafe_unretained NSString *propName) {
+id RLMDynamicGet(__unsafe_unretained RLMObjectBase *const obj, __unsafe_unretained NSString *const propName) {
     RLMProperty *prop = obj.objectSchema[propName];
     if (!prop) {
         @throw RLMException(@"Invalid property name",

--- a/Realm/RLMArrayLinkView.mm
+++ b/Realm/RLMArrayLinkView.mm
@@ -50,13 +50,13 @@
 //
 // validation helpers
 //
-static inline void RLMLinkViewArrayValidateAttached(__unsafe_unretained RLMArrayLinkView *ar) {
+static inline void RLMLinkViewArrayValidateAttached(__unsafe_unretained RLMArrayLinkView *const ar) {
     if (!ar->_backingLinkView->is_attached()) {
         @throw RLMException(@"RLMArray is no longer valid");
     }
     RLMCheckThread(ar->_realm);
 }
-static inline void RLMLinkViewArrayValidateInWriteTransaction(__unsafe_unretained RLMArrayLinkView *ar) {
+static inline void RLMLinkViewArrayValidateInWriteTransaction(__unsafe_unretained RLMArrayLinkView *const ar) {
     // first verify attached
     RLMLinkViewArrayValidateAttached(ar);
 
@@ -64,7 +64,7 @@ static inline void RLMLinkViewArrayValidateInWriteTransaction(__unsafe_unretaine
         @throw RLMException(@"Can't mutate a persisted array outside of a write transaction.");
     }
 }
-static inline void RLMValidateObjectClass(__unsafe_unretained RLMObject *obj, __unsafe_unretained NSString *expected) {
+static inline void RLMValidateObjectClass(__unsafe_unretained RLMObject *const obj, __unsafe_unretained NSString *const expected) {
     NSString *objectClassName = obj.objectSchema.className;
     if (![objectClassName isEqualToString:expected]) {
         @throw RLMException(@"Attempting to insert wrong object type", @{@"expected class" : expected, @"actual class" : objectClassName});

--- a/Realm/RLMObjectBase.mm
+++ b/Realm/RLMObjectBase.mm
@@ -81,8 +81,8 @@
     return self;
 }
 
-- (instancetype)initWithRealm:(__unsafe_unretained RLMRealm *)realm
-                       schema:(__unsafe_unretained RLMObjectSchema *)schema
+- (instancetype)initWithRealm:(__unsafe_unretained RLMRealm *const)realm
+                       schema:(__unsafe_unretained RLMObjectSchema *const)schema
                 defaultValues:(BOOL)useDefaults {
     self = [super init];
     if (self) {

--- a/Realm/RLMObjectStore.h
+++ b/Realm/RLMObjectStore.h
@@ -95,8 +95,8 @@ RLMObjectBase *RLMCreateObjectInRealmWithValue(RLMRealm *realm, NSString *classN
 //
 
 // Create accessors
-RLMObjectBase *RLMCreateObjectAccessor(__unsafe_unretained RLMRealm *realm,
-                                       __unsafe_unretained RLMObjectSchema *objectSchema,
+RLMObjectBase *RLMCreateObjectAccessor(__unsafe_unretained RLMRealm *const realm,
+                                       __unsafe_unretained RLMObjectSchema *const objectSchema,
                                        NSUInteger index);
 
 

--- a/Realm/RLMObjectStore.mm
+++ b/Realm/RLMObjectStore.mm
@@ -589,9 +589,9 @@ id RLMGetObject(RLMRealm *realm, NSString *objectClassName, id key) {
 }
 
 // Create accessor and register with realm
-RLMObjectBase *RLMCreateObjectAccessor(__unsafe_unretained RLMRealm *realm,
-                                   	   __unsafe_unretained RLMObjectSchema *objectSchema,
-                                  	   NSUInteger index) {
+RLMObjectBase *RLMCreateObjectAccessor(__unsafe_unretained RLMRealm *const realm,
+                                       __unsafe_unretained RLMObjectSchema *const objectSchema,
+                                       NSUInteger index) {
     RLMObjectBase *accessor = [[objectSchema.accessorClass alloc] initWithRealm:realm schema:objectSchema defaultValues:NO];
     accessor->_row = (*objectSchema.table)[index];
     RLMInitializeSwiftListAccessor(accessor);

--- a/Realm/RLMObject_Private.h
+++ b/Realm/RLMObject_Private.h
@@ -28,8 +28,8 @@
     __unsafe_unretained RLMObjectSchema *_objectSchema;
 }
 
-- (instancetype)initWithRealm:(__unsafe_unretained RLMRealm *)realm
-                       schema:(__unsafe_unretained RLMObjectSchema *)schema
+- (instancetype)initWithRealm:(__unsafe_unretained RLMRealm *const)realm
+                       schema:(__unsafe_unretained RLMObjectSchema *const)schema
                 defaultValues:(BOOL)useDefaults;
 - (instancetype)initWithObject:(id)object schema:(RLMSchema *)schema;
 

--- a/Realm/RLMRealm_Private.hpp
+++ b/Realm/RLMRealm_Private.hpp
@@ -32,7 +32,7 @@ namespace tightdb {
 @end
 
 // throw an exception if the realm is being used from the wrong thread
-static inline void RLMCheckThread(__unsafe_unretained RLMRealm *realm) {
+static inline void RLMCheckThread(__unsafe_unretained RLMRealm *const realm) {
     if (realm->_threadID != pthread_mach_thread_np(pthread_self())) {
         @throw RLMException(@"Realm accessed from incorrect thread");
     }

--- a/Realm/RLMResults.mm
+++ b/Realm/RLMResults.mm
@@ -86,7 +86,7 @@
 //
 // validation helper
 //
-static inline void RLMResultsValidateAttached(__unsafe_unretained RLMResults *ar) {
+static inline void RLMResultsValidateAttached(__unsafe_unretained RLMResults *const ar) {
     if (ar->_viewCreated) {
         // verify view is attached and up to date
         if (!ar->_backingView.is_attached()) {
@@ -104,12 +104,12 @@ static inline void RLMResultsValidateAttached(__unsafe_unretained RLMResults *ar
     }
     // otherwise we're backed by a table and don't need to update anything
 }
-static inline void RLMResultsValidate(__unsafe_unretained RLMResults *ar) {
+static inline void RLMResultsValidate(__unsafe_unretained RLMResults *const ar) {
     RLMResultsValidateAttached(ar);
     RLMCheckThread(ar->_realm);
 }
 
-static inline void RLMResultsValidateInWriteTransaction(__unsafe_unretained RLMResults *ar) {
+static inline void RLMResultsValidateInWriteTransaction(__unsafe_unretained RLMResults *const ar) {
     // first verify attached
     RLMResultsValidate(ar);
 


### PR DESCRIPTION
Fix a place where a newly created object was being assigned to a __uu pointer, and make all __uu pointers const to ensure that the same thing isn't being done elsewhere.

@alazier 