### PR TITLE
Added support for bulk updates to RLMResults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ x.x.x Release notes (yyyy-MM-dd)
 
 ### Enhancements
 
+* Added support for bulk operations with `setValue:forKey:` to RLMResults.
 * The bowser will no longer show objects that have no persisted properties.
 
 ### Bugfixes

--- a/Realm/RLMResults.h
+++ b/Realm/RLMResults.h
@@ -225,6 +225,16 @@
 
 - (id)objectAtIndexedSubscript:(NSUInteger)index;
 
+/**
+ Bulk update values by invoking `setValue:forKey:` on each of the array's items using the specified `value` and `key`.
+ 
+ @warning This method can only be called during a write transaction.
+ 
+ @param value The object value.
+ @param key The name of the property.
+ */
+- (void)setValue:(id)value forKey:(NSString *)key;
+
 #pragma mark -
 
 /**---------------------------------------------------------------------------------------

--- a/Realm/Tests/RLMTestObjects.h
+++ b/Realm/Tests/RLMTestObjects.h
@@ -93,7 +93,7 @@ RLM_ARRAY_TYPE(IntObject)
 @property NSData       *binaryCol;
 @property NSDate       *dateCol;
 @property bool          cBoolCol;
-@property int64_t     longCol;
+@property int64_t       longCol;
 @property id            mixedCol;
 @property StringObject *objectCol;
 


### PR DESCRIPTION
Warning, rusty programmer ahead. Review carefully. I needed to de-stress a bit, so I implemented a fix for #1172

 This allows you to to bulk updates on query results, so you can nice one-liners like this:

```obj-c
[[Emails objectsWhere:@"unread = YES"] setValue:@NO forKey:"unread"];
```

@realm/cocoa 

