### PR TITLE
Remove unused variable

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -176,9 +176,6 @@ fi
 # Variables
 ######################################
 
-# Xcode sets this variable - set to current directory if running standalone
-: ${SRCROOT:$(pwd)}
-
 download_core() {
     echo "Downloading dependency: core ${REALM_CORE_VERSION}"
     TMP_DIR="$TMPDIR/core_bin"


### PR DESCRIPTION
$SRCROOT isn't being set correctly, but it's not actually used anywhere or exported to subshells so just remove it.

@jpsim 