### PR TITLE
[Swift] Throw when RLMObject subclass is nested in *any* Swift declaration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ x.x.x Release notes (yyyy-MM-dd)
 * Fix crash when calling `createOrUpdate:inRealm` with nested linked objects.
 * Use the key from `+[RLMRealm setEncryptionKey:forRealmsAtPath:]` in
   `-writeCopyToPath:error:` and `+migrateRealmAtPath:`.
+* Improved error message when an `RLMObject` subclass is defined nested within
+  another Swift declaration.
 
 0.90.6 Release notes (2015-02-20)
 =============================================================

--- a/Realm/RLMSchema.mm
+++ b/Realm/RLMSchema.mm
@@ -109,10 +109,10 @@ static NSMutableDictionary *s_localNameToClass;
         }
         // NSStringFromClass demangles the names for top-level Swift classes
         // but not for nested classes. _T indicates it's a Swift symbol, t
-        // indicates it's a type, and CC indicates it's a class within a
-        // class (further nesting will add more Cs)
-        else if ([className hasPrefix:@"_TtCC"]) {
-            @throw RLMException(@"RLMObject subclasses cannot be nested within other classes");
+        // indicates it's a type, and C indicates it's a class.
+        else if ([className hasPrefix:@"_TtC"]) {
+            NSString *message = [NSString stringWithFormat:@"RLMObject subclasses cannot be nested within other declarations. Please move %@ to global scope.", className];
+            @throw RLMException(message);
         }
         else {
             s_localNameToClass[className] = cls;


### PR DESCRIPTION
Fixes #1577. /cc @tgoyne 