### PR TITLE
Fix a crash in CFRunLoopSourceInvalidate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,14 @@
-Master Release notes
+0.91.1 Release notes (2015-03-12)
 =============================================================
 
 ### Enhancements
 
 * The browser will automatically refresh when the Realm has been modified
   from another process.
+
+### Bugfixes
+
+* Fix a crash in CFRunLoopSourceInvalidate.
 
 0.91.0 Release notes (2015-03-10)
 =============================================================

--- a/Realm/RLMRealmUtil.mm
+++ b/Realm/RLMRealmUtil.mm
@@ -227,7 +227,6 @@ public:
 
     CFRunLoopSourceRef signal = CFRunLoopSourceCreate(kCFAllocatorDefault, 0, &ctx);
     CFRunLoopAddSource(_runLoop, signal, kCFRunLoopDefaultMode);
-    CFRelease(signal); // the runloop retains the signal
 
     // Set up the kqueue
     // EVFILT_READ indicates that we care about data being available to read
@@ -256,6 +255,7 @@ public:
         // and someone committed a write transaction
         if (event.ident == (uint32_t)_shutdownReadFd) {
             CFRunLoopSourceInvalidate(signal);
+            CFRelease(signal);
             CFRelease(_runLoop);
             return;
         }

--- a/Realm/Tests/RealmTests.mm
+++ b/Realm/Tests/RealmTests.mm
@@ -1158,4 +1158,22 @@ extern "C" {
     }
 }
 
+- (void)testHoldRealmAfterSourceThreadIsDestroyed {
+    __block RLMRealm *realm;
+
+    // Using an NSThread to ensure the thread (and thus runloop) is actually destroyed
+    NSThread *thread = [[NSThread alloc] initWithTarget:self selector:@selector(runBlock:) object:^{
+        realm = [RLMRealm defaultRealm];
+    }];
+    [thread start];
+    while (!thread.isFinished)
+        usleep(100);
+
+    [realm path]; // ensure ARC releases the object after the thread has finished
+}
+
+- (void)runBlock:(void (^)())block {
+    block();
+}
+
 @end


### PR DESCRIPTION
It turns out that the documentation's recommendation to release run loop sources immediate after adding them to the run loop is a rather bad idea, as the run loop releases its sources when it's shut down, so we'd crash if the kqueue waiter outlived the source thread.

The test forces this to happen by holding on to the RLMRealm after the thread dies, but it can happen inconsistently without that.

@alazier 