### PR TITLE
Don't require indexes when using primary keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 0.91.1 Release notes (2015-03-12)
 =============================================================
 
+### API breaking changes
+
+* Search indexes are no longer automatically created for string primary key properties.
+
 ### Enhancements
 
 * The browser will automatically refresh when the Realm has been modified

--- a/Realm/RLMObjectSchema.mm
+++ b/Realm/RLMObjectSchema.mm
@@ -118,10 +118,6 @@
     if (NSString *primaryKey = [objectClass primaryKey]) {
         for (RLMProperty *prop in schema.properties) {
             if ([primaryKey isEqualToString:prop.name]) {
-                 // FIXME - enable for ints when we have core suppport
-                if (prop.type == RLMPropertyTypeString) {
-                    prop.indexed = YES;
-                }
                 schema.primaryKeyProperty = prop;
                 break;
             }

--- a/Realm/Tests/ObjectSchemaTests.m
+++ b/Realm/Tests/ObjectSchemaTests.m
@@ -31,7 +31,7 @@
                                                     @"\tstringCol {\n"
                                                     @"\t\ttype = string;\n"
                                                     @"\t\tobjectClassName = (null);\n"
-                                                    @"\t\tindexed = YES;\n"
+                                                    @"\t\tindexed = NO;\n"
                                                     @"\t\tisPrimary = YES;\n"
                                                     @"\t}\n"
                                                     @"\tintCol {\n"


### PR DESCRIPTION
This removes the automatic creation of indexes for primary string properties.

@tgoyne 