### PR TITLE
Don't allow NUL bytes in indexed strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+x.x.x Release notes (yyyy-MM-dd)
+=============================================================
+
+### API breaking changes
+
+* None.
+
+### Enhancements
+
+* None.
+
+### Bugfixes
+
+* Don't allow setting indexed properties to strings with embedded nulls.
+
 0.91.1 Release notes (2015-03-12)
 =============================================================
 

--- a/Realm/RLMProperty.mm
+++ b/Realm/RLMProperty.mm
@@ -307,6 +307,7 @@
 - (BOOL)isEqualToProperty:(RLMProperty *)property {
     return _type == property->_type
         && _isPrimary == property->_isPrimary
+        && _indexed == property->_indexed // FIXME: maybe remove this when string indexes stop needing special logic in the setter
         && [_name isEqualToString:property->_name]
         && (_objectClassName == property->_objectClassName  || [_objectClassName isEqualToString:property->_objectClassName]);
 }

--- a/Realm/Tests/ObjectTests.m
+++ b/Realm/Tests/ObjectTests.m
@@ -1009,6 +1009,9 @@ RLM_ARRAY_TYPE(PrimaryIntObject);
     IndexedObject *io = [IndexedObject createInDefaultRealmWithObject:@[@"", @0]];
     XCTAssertThrows(io.name = @"a\0b");
     XCTAssertThrows(([IndexedObject createInDefaultRealmWithObject:@[@"a\0b", @0]]));
+    io = [[IndexedObject alloc] init];
+    io.name = @"a\0b";
+    XCTAssertThrows([realm addObject:io]);
     [realm cancelWriteTransaction];
 }
 
@@ -1018,6 +1021,12 @@ RLM_ARRAY_TYPE(PrimaryIntObject);
     [realm beginWriteTransaction];
     StringObject *so = [StringObject createInDefaultRealmWithObject:@[@""]];
     XCTAssertNoThrow(so.stringCol = @"a\0b");
+    XCTAssertEqual(3U, so.stringCol.length);
+    XCTAssertEqualObjects(@"a\0b", so.stringCol);
+
+    so = [[StringObject alloc] init];
+    so.stringCol = @"a\0b";
+    XCTAssertNoThrow([realm addObject:so]);
     XCTAssertEqual(3U, so.stringCol.length);
     XCTAssertEqualObjects(@"a\0b", so.stringCol);
     [realm cancelWriteTransaction];

--- a/Realm/Tests/ObjectTests.m
+++ b/Realm/Tests/ObjectTests.m
@@ -1002,6 +1002,27 @@ RLM_ARRAY_TYPE(PrimaryIntObject);
     XCTAssertFalse(ageProperty.indexed, @"non-indexed property shouldn't have an index");
 }
 
+- (void)testIndexedPropertyRejectsNullBytesInString
+{
+    RLMRealm *realm = RLMRealm.defaultRealm;
+    [realm beginWriteTransaction];
+    IndexedObject *io = [IndexedObject createInDefaultRealmWithObject:@[@"", @0]];
+    XCTAssertThrows(io.name = @"a\0b");
+    XCTAssertThrows(([IndexedObject createInDefaultRealmWithObject:@[@"a\0b", @0]]));
+    [realm cancelWriteTransaction];
+}
+
+- (void)testNullBytesWorkInUnindexedString
+{
+    RLMRealm *realm = RLMRealm.defaultRealm;
+    [realm beginWriteTransaction];
+    StringObject *so = [StringObject createInDefaultRealmWithObject:@[@""]];
+    XCTAssertNoThrow(so.stringCol = @"a\0b");
+    XCTAssertEqual(3U, so.stringCol.length);
+    XCTAssertEqualObjects(@"a\0b", so.stringCol);
+    [realm cancelWriteTransaction];
+}
+
 - (void)testRetainedRealmObjectUnknownKey
 {
     IntObject *obj = [[IntObject alloc] init];


### PR DESCRIPTION
Might be enough to allow us to continue to index primary keys by default if we're confident that embedded nulls are the only problem, and even if we do make it opt-in we need this check until string indexes are fixed.

@alazier 