### PR TITLE
Update packaging scripts for new Swift APIs

### DIFF
--- a/RealmSwift.xcodeproj/project.pbxproj
+++ b/RealmSwift.xcodeproj/project.pbxproj
@@ -580,7 +580,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "CONFIGURATION=$CONFIGURATION sh build.sh ios-dynamic\n";
+			shellScript = "if [[ ! -d \"dynamic_frameworks\" ]]; then\n  CONFIGURATION=$CONFIGURATION sh build.sh ios-dynamic\nfi\n";
 		};
 		295C17A41A7C55DA000E5F54 /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -593,7 +593,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "CONFIGURATION=$CONFIGURATION sh build.sh osx\n";
+			shellScript = "if [[ ! -d \"../osx/Realm.framework\" ]]; then\n  CONFIGURATION=$CONFIGURATION sh build.sh osx\nfi\n";
 		};
 		29A03F0F1A7C499C00C0D92E /* Embed Dynamic/Realm.framework */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -602,6 +602,7 @@
 			);
 			inputPaths = (
 				"build/DerivedData/Realm/Build/Products/$(CONFIGURATION)/Realm.framework",
+				../osx/Realm.framework,
 			);
 			name = "Embed Dynamic/Realm.framework";
 			outputPaths = (
@@ -609,7 +610,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "rm -rf \"${SCRIPT_OUTPUT_FILE_0}\"\nmkdir -p \"${SCRIPT_OUTPUT_FILE_0}\"\ncp -R \"${SCRIPT_INPUT_FILE_0}\" \"${SCRIPT_OUTPUT_FILE_0}/\"\n\ninstall_name_tool -id @rpath/RealmSwift.framework/Versions/A/Frameworks/Realm.framework/Realm \"${SCRIPT_OUTPUT_FILE_0}/Realm.framework/Realm\"\ninstall_name_tool -change @rpath/Realm.framework/Versions/A/Realm @rpath/RealmSwift.framework/Versions/A/Frameworks/Realm.framework/Realm \"${CONFIGURATION_BUILD_DIR}/${EXECUTABLE_PATH}\"";
+			shellScript = "if [[ ! -d \"dynamic_frameworks\" ]]; then\n  DYNAMIC_FRAMEWORK=\"${SCRIPT_INPUT_FILE_0}\"\nelse\n  DYNAMIC_FRAMEWORK=\"${SCRIPT_INPUT_FILE_1}\"\nfi\n\nrm -rf \"${SCRIPT_OUTPUT_FILE_0}\"\nmkdir -p \"${SCRIPT_OUTPUT_FILE_0}\"\ncp -R \"${DYNAMIC_FRAMEWORK}\" \"${SCRIPT_OUTPUT_FILE_0}/\"\n\ninstall_name_tool -id @rpath/RealmSwift.framework/Versions/A/Frameworks/Realm.framework/Realm \"${SCRIPT_OUTPUT_FILE_0}/Realm.framework/Realm\"\ninstall_name_tool -change @rpath/Realm.framework/Versions/A/Realm @rpath/RealmSwift.framework/Versions/A/Frameworks/Realm.framework/Realm \"${CONFIGURATION_BUILD_DIR}/${EXECUTABLE_PATH}\"";
 		};
 		29E3C6C31A718C5A00B62C1D /* Embed Dynamic/Realm.framework */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -618,6 +619,7 @@
 			);
 			inputPaths = (
 				"build/DerivedData/Realm/Build/Products/$(CONFIGURATION)-$(PLATFORM_NAME)-dynamic/Realm.framework",
+				"dynamic_frameworks/$(PLATFORM_NAME)/Realm.framework",
 			);
 			name = "Embed Dynamic/Realm.framework";
 			outputPaths = (
@@ -625,7 +627,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "rm -rf \"${SCRIPT_OUTPUT_FILE_0}\"\nmkdir -p \"${SCRIPT_OUTPUT_FILE_0}\"\ncp -R \"${SCRIPT_INPUT_FILE_0}\" \"${SCRIPT_OUTPUT_FILE_0}/\"\n\ninstall_name_tool -id @rpath/RealmSwift.framework/Frameworks/Realm.framework/Realm \"${SCRIPT_OUTPUT_FILE_0}/Realm.framework/Realm\"\ninstall_name_tool -change @rpath/Realm.framework/Realm @rpath/RealmSwift.framework/Frameworks/Realm.framework/Realm \"${CONFIGURATION_BUILD_DIR}/${EXECUTABLE_PATH}\"";
+			shellScript = "if [[ ! -d \"dynamic_frameworks\" ]]; then\n  DYNAMIC_FRAMEWORK=\"${SCRIPT_INPUT_FILE_0}\"\nelse\n  DYNAMIC_FRAMEWORK=\"${SCRIPT_INPUT_FILE_1}\"\nfi\n\nrm -rf \"${SCRIPT_OUTPUT_FILE_0}\"\nmkdir -p \"${SCRIPT_OUTPUT_FILE_0}\"\ncp -R \"${DYNAMIC_FRAMEWORK}\" \"${SCRIPT_OUTPUT_FILE_0}/\"\n\ninstall_name_tool -id @rpath/RealmSwift.framework/Frameworks/Realm.framework/Realm \"${SCRIPT_OUTPUT_FILE_0}/Realm.framework/Realm\"\ninstall_name_tool -change @rpath/Realm.framework/Realm @rpath/RealmSwift.framework/Frameworks/Realm.framework/Realm \"${CONFIGURATION_BUILD_DIR}/${EXECUTABLE_PATH}\"";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -791,7 +793,10 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_SEARCH_PATHS = "build/DerivedData/Realm/Build/Products/$(CONFIGURATION)";
+				FRAMEWORK_SEARCH_PATHS = (
+					"build/DerivedData/Realm/Build/Products/$(CONFIGURATION)",
+					../osx,
+				);
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"$(inherited)",
 					"REALM_SWIFT=1",
@@ -818,7 +823,10 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_SEARCH_PATHS = "build/DerivedData/Realm/Build/Products/$(CONFIGURATION)";
+				FRAMEWORK_SEARCH_PATHS = (
+					"build/DerivedData/Realm/Build/Products/$(CONFIGURATION)",
+					../osx,
+				);
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"$(inherited)",
 					"REALM_SWIFT=1",
@@ -905,7 +913,10 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_SEARCH_PATHS = "build/DerivedData/Realm/Build/Products/$(CONFIGURATION)-$(PLATFORM_NAME)-dynamic";
+				FRAMEWORK_SEARCH_PATHS = (
+					"build/DerivedData/Realm/Build/Products/$(CONFIGURATION)-$(PLATFORM_NAME)-dynamic",
+					"dynamic_frameworks/$(PLATFORM_NAME)",
+				);
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"$(inherited)",
 					"REALM_SWIFT=1",
@@ -933,7 +944,10 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_SEARCH_PATHS = "build/DerivedData/Realm/Build/Products/$(CONFIGURATION)-$(PLATFORM_NAME)-dynamic";
+				FRAMEWORK_SEARCH_PATHS = (
+					"build/DerivedData/Realm/Build/Products/$(CONFIGURATION)-$(PLATFORM_NAME)-dynamic",
+					"dynamic_frameworks/$(PLATFORM_NAME)",
+				);
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"$(inherited)",
 					"REALM_SWIFT=1",

--- a/RealmSwift.xcodeproj/project.pbxproj
+++ b/RealmSwift.xcodeproj/project.pbxproj
@@ -796,7 +796,7 @@
 					"$(inherited)",
 					"REALM_SWIFT=1",
 				);
-				INFOPLIST_FILE = "Realm/Realm-Info.plist";
+				INFOPLIST_FILE = "RealmSwift/RealmSwift-Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MTL_ENABLE_DEBUG_INFO = YES;
@@ -823,7 +823,7 @@
 					"$(inherited)",
 					"REALM_SWIFT=1",
 				);
-				INFOPLIST_FILE = "Realm/Realm-Info.plist";
+				INFOPLIST_FILE = "RealmSwift/RealmSwift-Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MTL_ENABLE_DEBUG_INFO = NO;
@@ -850,7 +850,7 @@
 					"$(inherited)",
 					core/include,
 				);
-				INFOPLIST_FILE = "Realm/Tests/RealmTests-Info.plist";
+				INFOPLIST_FILE = "RealmSwift/Tests/RealmSwiftTests-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/../Frameworks";
 				METAL_ENABLE_DEBUG_INFO = YES;
@@ -880,7 +880,7 @@
 					"$(inherited)",
 					core/include,
 				);
-				INFOPLIST_FILE = "Realm/Tests/RealmTests-Info.plist";
+				INFOPLIST_FILE = "RealmSwift/Tests/RealmSwiftTests-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/../Frameworks";
 				METAL_ENABLE_DEBUG_INFO = NO;
@@ -910,7 +910,7 @@
 					"$(inherited)",
 					"REALM_SWIFT=1",
 				);
-				INFOPLIST_FILE = "Realm/Realm-Info.plist";
+				INFOPLIST_FILE = "RealmSwift/RealmSwift-Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
@@ -938,7 +938,7 @@
 					"$(inherited)",
 					"REALM_SWIFT=1",
 				);
-				INFOPLIST_FILE = "Realm/Realm-Info.plist";
+				INFOPLIST_FILE = "RealmSwift/RealmSwift-Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
@@ -984,7 +984,7 @@
 					"$(inherited)",
 					core/include,
 				);
-				INFOPLIST_FILE = "Realm/Tests/RealmTests-Info.plist";
+				INFOPLIST_FILE = "RealmSwift/Tests/RealmSwiftTests-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				METAL_ENABLE_DEBUG_INFO = YES;
@@ -1018,7 +1018,7 @@
 					"$(inherited)",
 					core/include,
 				);
-				INFOPLIST_FILE = "Realm/Tests/RealmTests-Info.plist";
+				INFOPLIST_FILE = "RealmSwift/Tests/RealmSwiftTests-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				METAL_ENABLE_DEBUG_INFO = NO;
@@ -1067,7 +1067,7 @@
 					"DEBUG=1",
 					"$(inherited)",
 				);
-				INFOPLIST_FILE = "Realm/Tests/RealmTests-Info.plist";
+				INFOPLIST_FILE = "RealmSwift/Tests/RealmSwiftTests-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MTL_ENABLE_DEBUG_INFO = YES;
@@ -1094,7 +1094,7 @@
 					"$(inherited)",
 					"$(CONFIGURATION_BUILD_DIR)/RealmSwift.framework/Frameworks",
 				);
-				INFOPLIST_FILE = "Realm/Tests/RealmTests-Info.plist";
+				INFOPLIST_FILE = "RealmSwift/Tests/RealmSwiftTests-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MTL_ENABLE_DEBUG_INFO = NO;

--- a/RealmSwift/RealmSwift-Info.plist
+++ b/RealmSwift/RealmSwift-Info.plist
@@ -1,0 +1,1 @@
+../Realm/Realm-Info.plist

--- a/RealmSwift/Tests/RealmSwiftTests-Info.plist
+++ b/RealmSwift/Tests/RealmSwiftTests-Info.plist
@@ -1,0 +1,1 @@
+../../Realm/Tests/RealmTests-Info.plist

--- a/build.sh
+++ b/build.sh
@@ -40,9 +40,7 @@ command:
   build:                builds all iOS  and OS X frameworks
   ios-static:           builds fat iOS static framework
   ios-dynamic:          builds iOS dynamic frameworks
-  ios-dynamic-fat:      builds fat iOS dynamic framework
   ios-swift:            builds RealmSwift frameworks for iOS
-  ios-swift-fat:        builds fat RealmSwift framework for iOS
   osx:                  builds OS X framework
   osx-swift:            builds RealmSwift framework for OS X
   test:                 tests all iOS and OS X frameworks
@@ -288,28 +286,18 @@ case "$COMMAND" in
     "ios-dynamic")
         xcrealm "-scheme 'iOS Dynamic' -configuration $CONFIGURATION build -sdk iphoneos"
         xcrealm "-scheme 'iOS Dynamic' -configuration $CONFIGURATION build -sdk iphonesimulator ONLY_ACTIVE_ARCH=NO"
-        exit 0
-        ;;
-
-    "ios-dynamic-fat")
-	build_combined "iOS Dynamic" "$CONFIGURATION" Realm -dynamic
 	exit 0
 	;;
 
     "ios-swift")
-        xcrealmswift "-scheme 'RealmSwift iOS' -configuration $CONFIGURATION build -sdk iphoneos"
-        xcrealmswift "-scheme 'RealmSwift iOS' -configuration $CONFIGURATION build -sdk iphonesimulator ONLY_ACTIVE_ARCH=NO"
-        exit 0
-        ;;
-
-    "ios-swift-fat")
-	build_combined "RealmSwift iOS" "$CONFIGURATION" RealmSwift
+	xcrealmswift "-scheme 'RealmSwift iOS' -configuration $CONFIGURATION build -sdk iphoneos"
+	xcrealmswift "-scheme 'RealmSwift iOS' -configuration $CONFIGURATION build -sdk iphonesimulator ONLY_ACTIVE_ARCH=NO"
 	exit 0
 	;;
 
     "osx")
-        xcrealm "-scheme OSX -configuration $CONFIGURATION"
-        rm -rf build/osx
+	xcrealm "-scheme OSX -configuration $CONFIGURATION"
+	rm -rf build/osx
         mkdir build/osx
         cp -R build/DerivedData/Realm/Build/Products/$CONFIGURATION/Realm.framework build/osx
         exit 0

--- a/build.sh
+++ b/build.sh
@@ -286,18 +286,18 @@ case "$COMMAND" in
     "ios-dynamic")
         xcrealm "-scheme 'iOS Dynamic' -configuration $CONFIGURATION build -sdk iphoneos"
         xcrealm "-scheme 'iOS Dynamic' -configuration $CONFIGURATION build -sdk iphonesimulator ONLY_ACTIVE_ARCH=NO"
-	exit 0
-	;;
+        exit 0
+        ;;
 
     "ios-swift")
-	xcrealmswift "-scheme 'RealmSwift iOS' -configuration $CONFIGURATION build -sdk iphoneos"
-	xcrealmswift "-scheme 'RealmSwift iOS' -configuration $CONFIGURATION build -sdk iphonesimulator ONLY_ACTIVE_ARCH=NO"
-	exit 0
-	;;
+        xcrealmswift "-scheme 'RealmSwift iOS' -configuration $CONFIGURATION build -sdk iphoneos"
+        xcrealmswift "-scheme 'RealmSwift iOS' -configuration $CONFIGURATION build -sdk iphonesimulator ONLY_ACTIVE_ARCH=NO"
+        exit 0
+        ;;
 
     "osx")
-	xcrealm "-scheme OSX -configuration $CONFIGURATION"
-	rm -rf build/osx
+        xcrealm "-scheme OSX -configuration $CONFIGURATION"
+        rm -rf build/osx
         mkdir build/osx
         cp -R build/DerivedData/Realm/Build/Products/$CONFIGURATION/Realm.framework build/osx
         exit 0
@@ -568,10 +568,10 @@ case "$COMMAND" in
     "package-examples")
         cd tightdb_objc
         ./scripts/package_examples.rb
-	if [[ $PACKAGE_REALM_SWIFT == false ]]; then
-	    rm -rf examples/ios/swift-next
-	fi
-	zip --symlinks -r realm-examples.zip examples
+        if [[ $PACKAGE_REALM_SWIFT == false ]]; then
+          rm -rf examples/ios/swift-next
+        fi
+        zip --symlinks -r realm-examples.zip examples
         ;;
 
     "package-test-examples")
@@ -580,23 +580,23 @@ case "$COMMAND" in
 
         cp $0 realm-cocoa-${VERSION}
         cd realm-cocoa-${VERSION}
-	if [[ $PACKAGE_REALM_SWIFT == false ]]; then
-	  sh build.sh examples-ios
-	  sh build.sh examples-osx
-	else
-	  sh build.sh examples
-	fi
+        if [[ $PACKAGE_REALM_SWIFT == false ]]; then
+          sh build.sh examples-ios
+          sh build.sh examples-osx
+        else
+          sh build.sh examples
+        fi
         cd ..
-	rm -rf realm-cocoa-${VERSION}
+        rm -rf realm-cocoa-${VERSION}
         ;;
 
     "package-ios-static")
         cd tightdb_objc
-	sh build.sh test-ios-static
-	sh build.sh ios-static
+        sh build.sh test-ios-static
+        sh build.sh ios-static
 
         cd build/ios
-	zip --symlinks -r realm-framework-ios.zip Realm.framework
+        zip --symlinks -r realm-framework-ios.zip Realm.framework
         ;;
 
     "package-osx")
@@ -608,16 +608,16 @@ case "$COMMAND" in
         ;;
 
     "package-swift-source")
-	cd tightdb_objc
-	sh build.sh ios-dynamic
-	mkdir -p dynamic_frameworks/iphoneos dynamic_frameworks/iphonesimulator
-	cp -R build/DerivedData/Realm/Build/Products/Release-iphoneos-dynamic/Realm.framework dynamic_frameworks/iphoneos/Realm.framework/
-	cp -R build/DerivedData/Realm/Build/Products/Release-iphonesimulator-dynamic/Realm.framework dynamic_frameworks/iphonesimulator/Realm.framework/
-	rm RealmSwift/RealmSwift-Info.plist RealmSwift/Tests/RealmSwiftTests-Info.plist
-	cp Realm/Realm-Info.plist RealmSwift/RealmSwift-Info.plist
-	cp Realm/Tests/RealmTests-Info.plist RealmSwift/Tests/RealmSwiftTests-Info.plist
-	zip --symlinks -r realm-swift-source.zip RealmSwift.xcodeproj RealmSwift dynamic_frameworks
-	;;
+        cd tightdb_objc
+        sh build.sh ios-dynamic
+        mkdir -p dynamic_frameworks/iphoneos dynamic_frameworks/iphonesimulator
+        cp -R build/DerivedData/Realm/Build/Products/Release-iphoneos-dynamic/Realm.framework dynamic_frameworks/iphoneos/Realm.framework/
+        cp -R build/DerivedData/Realm/Build/Products/Release-iphonesimulator-dynamic/Realm.framework dynamic_frameworks/iphonesimulator/Realm.framework/
+        rm RealmSwift/RealmSwift-Info.plist RealmSwift/Tests/RealmSwiftTests-Info.plist
+        cp Realm/Realm-Info.plist RealmSwift/RealmSwift-Info.plist
+        cp Realm/Tests/RealmTests-Info.plist RealmSwift/Tests/RealmSwiftTests-Info.plist
+        zip --symlinks -r realm-swift-source.zip RealmSwift.xcodeproj RealmSwift dynamic_frameworks
+    ;;
 
     "package-release")
         TEMPDIR=$(mktemp -d $TMPDIR/realm-release-package.XXXX)
@@ -629,7 +629,7 @@ case "$COMMAND" in
         mkdir -p ${TEMPDIR}/realm-cocoa-${VERSION}/osx
         mkdir -p ${TEMPDIR}/realm-cocoa-${VERSION}/ios
         mkdir -p ${TEMPDIR}/realm-cocoa-${VERSION}/browser
-	mkdir -p ${TEMPDIR}/realm-cocoa-${VERSION}/swift
+        mkdir -p ${TEMPDIR}/realm-cocoa-${VERSION}/swift
 
         (
             cd ${TEMPDIR}/realm-cocoa-${VERSION}/osx
@@ -647,23 +647,23 @@ case "$COMMAND" in
         )
 
         (
-	    if [[ $PACKAGE_REALM_SWIFT == true ]]; then
-	      cd ${TEMPDIR}/realm-cocoa-${VERSION}/swift
-	      unzip ${WORKSPACE}/realm-swift-source.zip
-	    fi
+            if [[ $PACKAGE_REALM_SWIFT == true ]]; then
+              cd ${TEMPDIR}/realm-cocoa-${VERSION}/swift
+              unzip ${WORKSPACE}/realm-swift-source.zip
+            fi
         )
 
-	(
-	    cd ${WORKSPACE}/tightdb_objc
-	    cp -R plugin ${TEMPDIR}/realm-cocoa-${VERSION}
-	    cp LICENSE ${TEMPDIR}/realm-cocoa-${VERSION}/LICENSE.txt
-	    cp Realm/Swift/RLMSupport.swift ${TEMPDIR}/realm-cocoa-${VERSION}/swift/
-	)
+        (
+            cd ${WORKSPACE}/tightdb_objc
+            cp -R plugin ${TEMPDIR}/realm-cocoa-${VERSION}
+            cp LICENSE ${TEMPDIR}/realm-cocoa-${VERSION}/LICENSE.txt
+            cp Realm/Swift/RLMSupport.swift ${TEMPDIR}/realm-cocoa-${VERSION}/swift/
+        )
 
-	(
-	    cd ${TEMPDIR}/realm-cocoa-${VERSION}
-	    unzip ${WORKSPACE}/realm-examples.zip
-	)
+        (
+            cd ${TEMPDIR}/realm-cocoa-${VERSION}
+            unzip ${WORKSPACE}/realm-examples.zip
+        )
 
         cat > ${TEMPDIR}/realm-cocoa-${VERSION}/docs.webloc <<EOF
 <?xml version="1.0" encoding="UTF-8"?>
@@ -700,8 +700,8 @@ EOF
         cd $WORKSPACE
         git clone $REALM_SOURCE tightdb_objc
 
-	echo 'Packaging iOS static'
-	sh tightdb_objc/build.sh package-ios-static
+        echo 'Packaging iOS static'
+        sh tightdb_objc/build.sh package-ios-static
         cp tightdb_objc/build/ios/realm-framework-ios.zip .
 
         echo 'Packaging OS X'
@@ -718,28 +718,28 @@ EOF
         cd ../..
 
         sh tightdb_objc/build.sh package-examples
-	cp tightdb_objc/realm-examples.zip .
+        cp tightdb_objc/realm-examples.zip .
 
         echo 'Packaging browser'
         sh tightdb_objc/build.sh package-browser
 
-	echo 'Packaging Swift source'
-	(
-	    # Reset repo state
-	    cd tightdb_objc
-	    git reset --hard
-	    git clean -xdf
-	)
-	sh tightdb_objc/build.sh package-swift-source
-	cp tightdb_objc/realm-swift-source.zip .
+        echo 'Packaging Swift source'
+        (
+            # Reset repo state
+            cd tightdb_objc
+            git reset --hard
+            git clean -xdf
+        )
+        sh tightdb_objc/build.sh package-swift-source
+        cp tightdb_objc/realm-swift-source.zip .
 
         echo 'Building final release package'
-	(
-	    # Reset repo state
-	    cd tightdb_objc
-	    git reset --hard
-	    git clean -xdf
-	)
+        (
+            # Reset repo state
+            cd tightdb_objc
+            git reset --hard
+            git clean -xdf
+        )
         sh tightdb_objc/build.sh package-release
 
         echo 'Testing packaged examples'

--- a/build.sh
+++ b/build.sh
@@ -622,9 +622,12 @@ case "$COMMAND" in
     "package-swift-source")
 	cd tightdb_objc
 	sh build.sh ios-dynamic
-	mkdir -p dynamic_frameworks
-	cp -R build/DerivedData/Realm/Build/Products/Release-iphoneos-dynamic/Realm.framework dynamic_frameworks/iphoneos/
-	cp -R build/DerivedData/Realm/Build/Products/Release-iphonesimulator-dynamic/Realm.framework dynamic_frameworks/iphonesimulator/
+	mkdir -p dynamic_frameworks/iphoneos dynamic_frameworks/iphonesimulator
+	cp -R build/DerivedData/Realm/Build/Products/Release-iphoneos-dynamic/Realm.framework dynamic_frameworks/iphoneos/Realm.framework/
+	cp -R build/DerivedData/Realm/Build/Products/Release-iphonesimulator-dynamic/Realm.framework dynamic_frameworks/iphonesimulator/Realm.framework/
+	rm RealmSwift/RealmSwift-Info.plist RealmSwift/Tests/RealmSwiftTests-Info.plist
+	cp Realm/Realm-Info.plist RealmSwift/RealmSwift-Info.plist
+	cp Realm/Tests/RealmTests-Info.plist RealmSwift/Tests/RealmSwiftTests-Info.plist
 	zip --symlinks -r realm-swift-source.zip RealmSwift.xcodeproj RealmSwift dynamic_frameworks
 	;;
 

--- a/scripts/package_examples.rb
+++ b/scripts/package_examples.rb
@@ -17,7 +17,7 @@ def remove_target(project_path, target_name)
 
   project.save
 
-  FileUtils.rm(project_path + "/xcshareddata/xcschemes/" + target_name + ".xcscheme")
+  FileUtils.rm("#{project_path}/xcshareddata/xcschemes/#{target_name}.xcscheme", :force => true)
 end
 
 def remove_all_dependencies(project_path)
@@ -36,7 +36,7 @@ end
 # Script
 ##########################
 
-# Remove Realm target and dependency from both objc projects
+# Remove Realm target and dependency from all objc projects
 
 objc_examples = [
   "examples/ios/objc/RealmExamples.xcodeproj",
@@ -54,6 +54,20 @@ objc_examples.each do |example|
     file.puts contents.gsub("/build/ios", "/ios")
                       .gsub("Realm/Swift", "Swift")
                       .gsub("/build/osx", "/osx")
+  end
+end
+
+# Update location of RealmSwift.xcodeproj for all swift projects
+
+swift_examples = [
+  "examples/ios/swift-next/RealmExamples.xcodeproj"
+]
+
+swift_examples.each do |example|
+  filepath = File.join(example, "project.pbxproj")
+  contents = File.read(filepath)
+  File.open(filepath, "w") do |file|
+    file.puts contents.gsub("../../../RealmSwift.xcodeproj", "../../../swift/RealmSwift.xcodeproj")
   end
 end
 


### PR DESCRIPTION
Closes #1602.

- removed old Swift examples
- added source code to release package for building dynamic & swift frameworks
- added `ios-dynamic-fat` and `ios-swift-fat` targets to build.sh
- update build.sh usage

/cc @tgoyne @alazier @segiddins 