### PR TITLE
Remove the Swift- prefix from the new test objects and files

### DIFF
--- a/RealmSwift.xcodeproj/project.pbxproj
+++ b/RealmSwift.xcodeproj/project.pbxproj
@@ -58,15 +58,15 @@
 		020F63E11A8037DC007CB52E /* ResultsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020F63D51A8037DC007CB52E /* ResultsTests.swift */; };
 		020F63E21A8037DC007CB52E /* ResultsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020F63D51A8037DC007CB52E /* ResultsTests.swift */; };
 		020F63E31A8037DC007CB52E /* ResultsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020F63D51A8037DC007CB52E /* ResultsTests.swift */; };
-		020F63E71A8037DC007CB52E /* SwiftLinkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020F63D71A8037DC007CB52E /* SwiftLinkTests.swift */; };
-		020F63E81A8037DC007CB52E /* SwiftLinkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020F63D71A8037DC007CB52E /* SwiftLinkTests.swift */; };
-		020F63E91A8037DC007CB52E /* SwiftLinkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020F63D71A8037DC007CB52E /* SwiftLinkTests.swift */; };
-		020F63F31A8037DC007CB52E /* SwiftTestObjects.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020F63DB1A8037DC007CB52E /* SwiftTestObjects.swift */; };
-		020F63F41A8037DC007CB52E /* SwiftTestObjects.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020F63DB1A8037DC007CB52E /* SwiftTestObjects.swift */; };
-		020F63F51A8037DC007CB52E /* SwiftTestObjects.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020F63DB1A8037DC007CB52E /* SwiftTestObjects.swift */; };
-		020F63F61A8037DC007CB52E /* SwiftUnicodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020F63DC1A8037DC007CB52E /* SwiftUnicodeTests.swift */; };
-		020F63F71A8037DC007CB52E /* SwiftUnicodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020F63DC1A8037DC007CB52E /* SwiftUnicodeTests.swift */; };
-		020F63F81A8037DC007CB52E /* SwiftUnicodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020F63DC1A8037DC007CB52E /* SwiftUnicodeTests.swift */; };
+		020F63E71A8037DC007CB52E /* LinkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020F63D71A8037DC007CB52E /* LinkTests.swift */; };
+		020F63E81A8037DC007CB52E /* LinkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020F63D71A8037DC007CB52E /* LinkTests.swift */; };
+		020F63E91A8037DC007CB52E /* LinkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020F63D71A8037DC007CB52E /* LinkTests.swift */; };
+		020F63F31A8037DC007CB52E /* TestObjects.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020F63DB1A8037DC007CB52E /* TestObjects.swift */; };
+		020F63F41A8037DC007CB52E /* TestObjects.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020F63DB1A8037DC007CB52E /* TestObjects.swift */; };
+		020F63F51A8037DC007CB52E /* TestObjects.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020F63DB1A8037DC007CB52E /* TestObjects.swift */; };
+		020F63F61A8037DC007CB52E /* UnicodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020F63DC1A8037DC007CB52E /* UnicodeTests.swift */; };
+		020F63F71A8037DC007CB52E /* UnicodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020F63DC1A8037DC007CB52E /* UnicodeTests.swift */; };
+		020F63F81A8037DC007CB52E /* UnicodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020F63DC1A8037DC007CB52E /* UnicodeTests.swift */; };
 		020F63F91A8037DC007CB52E /* TestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020F63DD1A8037DC007CB52E /* TestCase.swift */; };
 		020F63FA1A8037DC007CB52E /* TestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020F63DD1A8037DC007CB52E /* TestCase.swift */; };
 		020F63FB1A8037DC007CB52E /* TestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020F63DD1A8037DC007CB52E /* TestCase.swift */; };
@@ -200,22 +200,22 @@
 		020F63BF1A8037AE007CB52E /* Realm.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Realm.swift; path = RealmSwift/Realm.swift; sourceTree = SOURCE_ROOT; };
 		020F63C01A8037AE007CB52E /* Results.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Results.swift; path = RealmSwift/Results.swift; sourceTree = SOURCE_ROOT; };
 		020F63C11A8037AE007CB52E /* Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Schema.swift; path = RealmSwift/Schema.swift; sourceTree = SOURCE_ROOT; };
-		020F63D41A8037DC007CB52E /* ListTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ListTests.swift; path = RealmSwift/Tests/ListTests.swift; sourceTree = SOURCE_ROOT; };
+		020F63D41A8037DC007CB52E /* ListTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; name = ListTests.swift; path = RealmSwift/Tests/ListTests.swift; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		020F63D51A8037DC007CB52E /* ResultsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ResultsTests.swift; path = RealmSwift/Tests/ResultsTests.swift; sourceTree = SOURCE_ROOT; };
-		020F63D71A8037DC007CB52E /* SwiftLinkTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SwiftLinkTests.swift; path = RealmSwift/Tests/SwiftLinkTests.swift; sourceTree = SOURCE_ROOT; };
-		020F63DB1A8037DC007CB52E /* SwiftTestObjects.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SwiftTestObjects.swift; path = RealmSwift/Tests/SwiftTestObjects.swift; sourceTree = SOURCE_ROOT; };
-		020F63DC1A8037DC007CB52E /* SwiftUnicodeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SwiftUnicodeTests.swift; path = RealmSwift/Tests/SwiftUnicodeTests.swift; sourceTree = SOURCE_ROOT; };
+		020F63D71A8037DC007CB52E /* LinkTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; name = LinkTests.swift; path = RealmSwift/Tests/LinkTests.swift; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
+		020F63DB1A8037DC007CB52E /* TestObjects.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TestObjects.swift; path = RealmSwift/Tests/TestObjects.swift; sourceTree = SOURCE_ROOT; };
+		020F63DC1A8037DC007CB52E /* UnicodeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = UnicodeTests.swift; path = RealmSwift/Tests/UnicodeTests.swift; sourceTree = SOURCE_ROOT; };
 		020F63DD1A8037DC007CB52E /* TestCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TestCase.swift; path = RealmSwift/Tests/TestCase.swift; sourceTree = SOURCE_ROOT; };
 		023B19A81A4234380067FB81 /* RealmSwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = RealmSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		023B19F71A423BD20067FB81 /* libc++.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = "libc++.dylib"; path = "usr/lib/libc++.dylib"; sourceTree = SDKROOT; };
 		0253CD981AA0016300AF9E6C /* ObjectAccessorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ObjectAccessorTests.swift; path = RealmSwift/Tests/ObjectAccessorTests.swift; sourceTree = SOURCE_ROOT; };
-		0253CD991AA0016300AF9E6C /* ObjectCreationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ObjectCreationTests.swift; path = RealmSwift/Tests/ObjectCreationTests.swift; sourceTree = SOURCE_ROOT; };
-		0253CD9A1AA0016300AF9E6C /* ObjectSchemaInitializationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ObjectSchemaInitializationTests.swift; path = RealmSwift/Tests/ObjectSchemaInitializationTests.swift; sourceTree = SOURCE_ROOT; };
-		02616BD41A817FC8009919CB /* MigrationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = MigrationTests.swift; path = RealmSwift/Tests/MigrationTests.swift; sourceTree = SOURCE_ROOT; };
+		0253CD991AA0016300AF9E6C /* ObjectCreationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; name = ObjectCreationTests.swift; path = RealmSwift/Tests/ObjectCreationTests.swift; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
+		0253CD9A1AA0016300AF9E6C /* ObjectSchemaInitializationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; name = ObjectSchemaInitializationTests.swift; path = RealmSwift/Tests/ObjectSchemaInitializationTests.swift; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
+		02616BD41A817FC8009919CB /* MigrationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; name = MigrationTests.swift; path = RealmSwift/Tests/MigrationTests.swift; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		02B822821A532100007F28A5 /* RealmSwift iOS Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "RealmSwift iOS Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		3F8DCA5719930F550008BD7F /* iOS Device Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "iOS Device Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		C0027B061AAF6FBC00F013A2 /* SchemaTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SchemaTests.swift; path = RealmSwift/Tests/SchemaTests.swift; sourceTree = SOURCE_ROOT; };
-		C0027B0A1AAF736700F013A2 /* ObjectSchemaTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ObjectSchemaTests.swift; path = RealmSwift/Tests/ObjectSchemaTests.swift; sourceTree = SOURCE_ROOT; };
+		C0027B0A1AAF736700F013A2 /* ObjectSchemaTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; name = ObjectSchemaTests.swift; path = RealmSwift/Tests/ObjectSchemaTests.swift; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		C0240C2A1A84090000858BFA /* RealmTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = RealmTests.swift; path = RealmSwift/Tests/RealmTests.swift; sourceTree = SOURCE_ROOT; };
 		C04DAEBD1A8E7FBD008A9623 /* Util.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Util.swift; path = RealmSwift/Util.swift; sourceTree = SOURCE_ROOT; };
 		C081AEB11AAF865C00BA3E31 /* PropertyTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = PropertyTests.swift; path = RealmSwift/Tests/PropertyTests.swift; sourceTree = SOURCE_ROOT; };
@@ -304,10 +304,10 @@
 			isa = PBXGroup;
 			children = (
 				3F8DCA5719930F550008BD7F /* iOS Device Tests.xctest */,
-				023B19A81A4234380067FB81 /* RealmSwift.framework */,
 				02B822821A532100007F28A5 /* RealmSwift iOS Tests.xctest */,
-				0201B27B1A54C68C004CFB6F /* RealmSwift.framework */,
 				0201B2921A54C697004CFB6F /* RealmSwift OSX Tests.xctest */,
+				023B19A81A4234380067FB81 /* RealmSwift.framework */,
+				0201B27B1A54C68C004CFB6F /* RealmSwift.framework */,
 				C0E04FAB1AB2366200DCC8C0 /* TestHost.app */,
 			);
 			name = Products;
@@ -316,6 +316,7 @@
 		E8D89B9A1955FC6D00CF2B9A /* RealmSwift */ = {
 			isa = PBXGroup;
 			children = (
+				E8D89B9B1955FC6D00CF2B9A /* Supporting Files */,
 				020F63B91A8037AE007CB52E /* Aliases.swift */,
 				020F63BA1A8037AE007CB52E /* List.swift */,
 				020F63BB1A8037AE007CB52E /* Migration.swift */,
@@ -327,7 +328,6 @@
 				020F63C11A8037AE007CB52E /* Schema.swift */,
 				C0D8E12B1A8174090077C784 /* SortDescriptor.swift */,
 				C04DAEBD1A8E7FBD008A9623 /* Util.swift */,
-				E8D89B9B1955FC6D00CF2B9A /* Supporting Files */,
 			);
 			name = RealmSwift;
 			path = Realm;
@@ -344,26 +344,26 @@
 		E8D89BA71955FC6D00CF2B9A /* Tests */ = {
 			isa = PBXGroup;
 			children = (
+				E8D89BA81955FC6D00CF2B9A /* Supporting Files */,
+				3F1A5E731992EB7400F45F4C /* TestHost */,
+				020F63D71A8037DC007CB52E /* LinkTests.swift */,
 				020F63D41A8037DC007CB52E /* ListTests.swift */,
 				02616BD41A817FC8009919CB /* MigrationTests.swift */,
-				C0027B0A1AAF736700F013A2 /* ObjectSchemaTests.swift */,
-				C0FE465B1A9BE7A6006E0539 /* ObjectTests.swift */,
 				0253CD981AA0016300AF9E6C /* ObjectAccessorTests.swift */,
 				0253CD991AA0016300AF9E6C /* ObjectCreationTests.swift */,
 				0253CD9A1AA0016300AF9E6C /* ObjectSchemaInitializationTests.swift */,
+				C0027B0A1AAF736700F013A2 /* ObjectSchemaTests.swift */,
+				C0FE465B1A9BE7A6006E0539 /* ObjectTests.swift */,
 				C081AEB11AAF865C00BA3E31 /* PropertyTests.swift */,
 				C0240C2A1A84090000858BFA /* RealmTests.swift */,
 				020F63D51A8037DC007CB52E /* ResultsTests.swift */,
-				C0D8E12E1A81749D0077C784 /* SortDescriptorTests.swift */,
 				C0027B061AAF6FBC00F013A2 /* SchemaTests.swift */,
-				020F63D71A8037DC007CB52E /* SwiftLinkTests.swift */,
-				020F63DB1A8037DC007CB52E /* SwiftTestObjects.swift */,
-				020F63DC1A8037DC007CB52E /* SwiftUnicodeTests.swift */,
+				C0D8E12E1A81749D0077C784 /* SortDescriptorTests.swift */,
 				020F63DD1A8037DC007CB52E /* TestCase.swift */,
-				E8D89BA81955FC6D00CF2B9A /* Supporting Files */,
-				3F1A5E731992EB7400F45F4C /* TestHost */,
+				020F63DB1A8037DC007CB52E /* TestObjects.swift */,
 				C0D8E1311A8196EE0077C784 /* TestUtils.h */,
 				C0D8E1321A8196EE0077C784 /* TestUtils.mm */,
+				020F63DC1A8037DC007CB52E /* UnicodeTests.swift */,
 			);
 			name = Tests;
 			path = Realm/Tests;
@@ -372,8 +372,8 @@
 		E8D89BA81955FC6D00CF2B9A /* Supporting Files */ = {
 			isa = PBXGroup;
 			children = (
-				E81A1FC21955FE0100FDED82 /* RealmTests-Info.plist */,
 				C0D8E1391A819B430077C784 /* RealmSwiftTests-BridgingHeader.h */,
+				E81A1FC21955FE0100FDED82 /* RealmTests-Info.plist */,
 			);
 			name = "Supporting Files";
 			sourceTree = "<group>";
@@ -637,17 +637,17 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				020F63D31A8037AE007CB52E /* Schema.swift in Sources */,
-				020F63CD1A8037AE007CB52E /* Property.swift in Sources */,
 				020F63C31A8037AE007CB52E /* Aliases.swift in Sources */,
-				020F63D11A8037AE007CB52E /* Results.swift in Sources */,
-				C0D8E12D1A8174090077C784 /* SortDescriptor.swift in Sources */,
 				020F63C51A8037AE007CB52E /* List.swift in Sources */,
-				020F63CF1A8037AE007CB52E /* Realm.swift in Sources */,
+				020F63C71A8037AE007CB52E /* Migration.swift in Sources */,
 				020F63C91A8037AE007CB52E /* Object.swift in Sources */,
 				020F63CB1A8037AE007CB52E /* ObjectSchema.swift in Sources */,
+				020F63CD1A8037AE007CB52E /* Property.swift in Sources */,
+				020F63CF1A8037AE007CB52E /* Realm.swift in Sources */,
+				020F63D11A8037AE007CB52E /* Results.swift in Sources */,
+				020F63D31A8037AE007CB52E /* Schema.swift in Sources */,
+				C0D8E12D1A8174090077C784 /* SortDescriptor.swift in Sources */,
 				C04DAEBF1A8E7FBD008A9623 /* Util.swift in Sources */,
-				020F63C71A8037AE007CB52E /* Migration.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -655,24 +655,23 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				C0E04FA11AB235D400DCC8C0 /* ObjectCreationTests.swift in Sources */,
-				020F63F71A8037DC007CB52E /* SwiftUnicodeTests.swift in Sources */,
-				C0E04F9E1AB235CE00DCC8C0 /* ObjectAccessorTests.swift in Sources */,
-				020F63FA1A8037DC007CB52E /* TestCase.swift in Sources */,
-				020F63F41A8037DC007CB52E /* SwiftTestObjects.swift in Sources */,
-				C0E04F9B1AB20A1A00DCC8C0 /* ObjectCreationTests.swift in Sources */,
-				C0E04FA41AB235D800DCC8C0 /* ObjectSchemaInitializationTests.swift in Sources */,
-				C0D8E1301A81749D0077C784 /* SortDescriptorTests.swift in Sources */,
-				C0FE465D1A9BE7A6006E0539 /* ObjectTests.swift in Sources */,
-				C081AEB31AAF8FF900BA3E31 /* PropertyTests.swift in Sources */,
-				020F63E21A8037DC007CB52E /* ResultsTests.swift in Sources */,
-				C0240C2C1A84090000858BFA /* RealmTests.swift in Sources */,
-				C0027B0C1AAF736700F013A2 /* ObjectSchemaTests.swift in Sources */,
-				C0027B081AAF6FBC00F013A2 /* SchemaTests.swift in Sources */,
-				C0D8E1381A8199420077C784 /* TestUtils.mm in Sources */,
-				020F63E81A8037DC007CB52E /* SwiftLinkTests.swift in Sources */,
+				020F63E81A8037DC007CB52E /* LinkTests.swift in Sources */,
 				020F63DF1A8037DC007CB52E /* ListTests.swift in Sources */,
 				02616BD61A817FC8009919CB /* MigrationTests.swift in Sources */,
+				C0E04F9E1AB235CE00DCC8C0 /* ObjectAccessorTests.swift in Sources */,
+				C0E04FA11AB235D400DCC8C0 /* ObjectCreationTests.swift in Sources */,
+				C0E04FA41AB235D800DCC8C0 /* ObjectSchemaInitializationTests.swift in Sources */,
+				C0027B0C1AAF736700F013A2 /* ObjectSchemaTests.swift in Sources */,
+				C0FE465D1A9BE7A6006E0539 /* ObjectTests.swift in Sources */,
+				C081AEB31AAF8FF900BA3E31 /* PropertyTests.swift in Sources */,
+				C0240C2C1A84090000858BFA /* RealmTests.swift in Sources */,
+				020F63E21A8037DC007CB52E /* ResultsTests.swift in Sources */,
+				C0027B081AAF6FBC00F013A2 /* SchemaTests.swift in Sources */,
+				C0D8E1301A81749D0077C784 /* SortDescriptorTests.swift in Sources */,
+				020F63FA1A8037DC007CB52E /* TestCase.swift in Sources */,
+				020F63F41A8037DC007CB52E /* TestObjects.swift in Sources */,
+				C0D8E1381A8199420077C784 /* TestUtils.mm in Sources */,
+				020F63F71A8037DC007CB52E /* UnicodeTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -680,17 +679,17 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				020F63D21A8037AE007CB52E /* Schema.swift in Sources */,
-				020F63CC1A8037AE007CB52E /* Property.swift in Sources */,
 				020F63C21A8037AE007CB52E /* Aliases.swift in Sources */,
-				020F63D01A8037AE007CB52E /* Results.swift in Sources */,
-				C0D8E12C1A8174090077C784 /* SortDescriptor.swift in Sources */,
 				020F63C41A8037AE007CB52E /* List.swift in Sources */,
-				020F63CE1A8037AE007CB52E /* Realm.swift in Sources */,
+				020F63C61A8037AE007CB52E /* Migration.swift in Sources */,
 				020F63C81A8037AE007CB52E /* Object.swift in Sources */,
 				020F63CA1A8037AE007CB52E /* ObjectSchema.swift in Sources */,
+				020F63CC1A8037AE007CB52E /* Property.swift in Sources */,
+				020F63CE1A8037AE007CB52E /* Realm.swift in Sources */,
+				020F63D01A8037AE007CB52E /* Results.swift in Sources */,
+				020F63D21A8037AE007CB52E /* Schema.swift in Sources */,
+				C0D8E12C1A8174090077C784 /* SortDescriptor.swift in Sources */,
 				C04DAEBE1A8E7FBD008A9623 /* Util.swift in Sources */,
-				020F63C61A8037AE007CB52E /* Migration.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -698,24 +697,23 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				C0E04FA01AB235D200DCC8C0 /* ObjectCreationTests.swift in Sources */,
-				020F63F61A8037DC007CB52E /* SwiftUnicodeTests.swift in Sources */,
-				C0E04F9D1AB235CC00DCC8C0 /* ObjectAccessorTests.swift in Sources */,
-				020F63F91A8037DC007CB52E /* TestCase.swift in Sources */,
-				020F63F31A8037DC007CB52E /* SwiftTestObjects.swift in Sources */,
-				C0E04F9A1AB20A1900DCC8C0 /* ObjectCreationTests.swift in Sources */,
-				C0E04FA31AB235D700DCC8C0 /* ObjectSchemaInitializationTests.swift in Sources */,
-				C0D8E12F1A81749D0077C784 /* SortDescriptorTests.swift in Sources */,
-				C0FE465C1A9BE7A6006E0539 /* ObjectTests.swift in Sources */,
-				C081AEB21AAF865C00BA3E31 /* PropertyTests.swift in Sources */,
-				020F63E11A8037DC007CB52E /* ResultsTests.swift in Sources */,
-				C0240C2B1A84090000858BFA /* RealmTests.swift in Sources */,
-				C0027B0B1AAF736700F013A2 /* ObjectSchemaTests.swift in Sources */,
-				C0027B071AAF6FBC00F013A2 /* SchemaTests.swift in Sources */,
-				C0D8E1371A8199420077C784 /* TestUtils.mm in Sources */,
-				020F63E71A8037DC007CB52E /* SwiftLinkTests.swift in Sources */,
+				020F63E71A8037DC007CB52E /* LinkTests.swift in Sources */,
 				020F63DE1A8037DC007CB52E /* ListTests.swift in Sources */,
 				02616BD51A817FC8009919CB /* MigrationTests.swift in Sources */,
+				C0E04F9D1AB235CC00DCC8C0 /* ObjectAccessorTests.swift in Sources */,
+				C0E04FA01AB235D200DCC8C0 /* ObjectCreationTests.swift in Sources */,
+				C0E04FA31AB235D700DCC8C0 /* ObjectSchemaInitializationTests.swift in Sources */,
+				C0027B0B1AAF736700F013A2 /* ObjectSchemaTests.swift in Sources */,
+				C0FE465C1A9BE7A6006E0539 /* ObjectTests.swift in Sources */,
+				C081AEB21AAF865C00BA3E31 /* PropertyTests.swift in Sources */,
+				C0240C2B1A84090000858BFA /* RealmTests.swift in Sources */,
+				020F63E11A8037DC007CB52E /* ResultsTests.swift in Sources */,
+				C0027B071AAF6FBC00F013A2 /* SchemaTests.swift in Sources */,
+				C0D8E12F1A81749D0077C784 /* SortDescriptorTests.swift in Sources */,
+				020F63F91A8037DC007CB52E /* TestCase.swift in Sources */,
+				020F63F31A8037DC007CB52E /* TestObjects.swift in Sources */,
+				C0D8E1371A8199420077C784 /* TestUtils.mm in Sources */,
+				020F63F61A8037DC007CB52E /* UnicodeTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -723,24 +721,23 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				020F63F81A8037DC007CB52E /* SwiftUnicodeTests.swift in Sources */,
-				C0E04FA51AB235D900DCC8C0 /* ObjectSchemaInitializationTests.swift in Sources */,
-				C0E04FA61AB235E000DCC8C0 /* SortDescriptorTests.swift in Sources */,
-				C0E04F9F1AB235CE00DCC8C0 /* ObjectAccessorTests.swift in Sources */,
-				020F63FB1A8037DC007CB52E /* TestCase.swift in Sources */,
-				C0E04FA21AB235D400DCC8C0 /* ObjectCreationTests.swift in Sources */,
-				020F63F51A8037DC007CB52E /* SwiftTestObjects.swift in Sources */,
-				C081AEB41AAF8FFB00BA3E31 /* PropertyTests.swift in Sources */,
-				020F63E31A8037DC007CB52E /* ResultsTests.swift in Sources */,
-				C0240C2D1A84090000858BFA /* RealmTests.swift in Sources */,
-				C0027B0D1AAF736700F013A2 /* ObjectSchemaTests.swift in Sources */,
-				C0027B091AAF6FBC00F013A2 /* SchemaTests.swift in Sources */,
-				0253CDAC1AAE667000AF9E6C /* TestUtils.mm in Sources */,
-				020F63E91A8037DC007CB52E /* SwiftLinkTests.swift in Sources */,
+				020F63E91A8037DC007CB52E /* LinkTests.swift in Sources */,
 				020F63E01A8037DC007CB52E /* ListTests.swift in Sources */,
-				C0E04F9C1AB20A1B00DCC8C0 /* ObjectCreationTests.swift in Sources */,
-				C0FE465E1A9BE7A6006E0539 /* ObjectTests.swift in Sources */,
 				02616BD71A817FC8009919CB /* MigrationTests.swift in Sources */,
+				C0E04F9F1AB235CE00DCC8C0 /* ObjectAccessorTests.swift in Sources */,
+				C0E04FA21AB235D400DCC8C0 /* ObjectCreationTests.swift in Sources */,
+				C0E04FA51AB235D900DCC8C0 /* ObjectSchemaInitializationTests.swift in Sources */,
+				C0027B0D1AAF736700F013A2 /* ObjectSchemaTests.swift in Sources */,
+				C0FE465E1A9BE7A6006E0539 /* ObjectTests.swift in Sources */,
+				C081AEB41AAF8FFB00BA3E31 /* PropertyTests.swift in Sources */,
+				C0240C2D1A84090000858BFA /* RealmTests.swift in Sources */,
+				020F63E31A8037DC007CB52E /* ResultsTests.swift in Sources */,
+				C0027B091AAF6FBC00F013A2 /* SchemaTests.swift in Sources */,
+				C0E04FA61AB235E000DCC8C0 /* SortDescriptorTests.swift in Sources */,
+				020F63FB1A8037DC007CB52E /* TestCase.swift in Sources */,
+				020F63F51A8037DC007CB52E /* TestObjects.swift in Sources */,
+				0253CDAC1AAE667000AF9E6C /* TestUtils.mm in Sources */,
+				020F63F81A8037DC007CB52E /* UnicodeTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/RealmSwift/Tests/LinkTests.swift
+++ b/RealmSwift/Tests/LinkTests.swift
@@ -19,20 +19,20 @@
 import XCTest
 import RealmSwift
 
-class SwiftLinkTests: TestCase {
+class LinkTests: TestCase {
 
     func testBasicLink() {
         let realm = realmWithTestPath()
 
-        let owner = SwiftOwnerObject()
+        let owner = OwnerObject()
         owner.name = "Tim"
-        owner.dog = SwiftDogObject()
+        owner.dog = DogObject()
         owner.dog.dogName = "Harvie"
 
         realm.write { realm.add(owner) }
 
-        let owners = realm.objects(SwiftOwnerObject.self)
-        let dogs = realm.objects(SwiftDogObject.self)
+        let owners = realm.objects(OwnerObject.self)
+        let dogs = realm.objects(DogObject.self)
         XCTAssertEqual(owners.count, Int(1), "Expecting 1 owner")
         XCTAssertEqual(dogs.count, Int(1), "Expecting 1 dog")
         XCTAssertEqual(owners[0].name, "Tim", "Tim is named Tim")
@@ -44,46 +44,46 @@ class SwiftLinkTests: TestCase {
     func testMultipleOwnerLink() {
         let realm = realmWithTestPath()
 
-        let owner = SwiftOwnerObject()
+        let owner = OwnerObject()
         owner.name = "Tim"
-        owner.dog = SwiftDogObject()
+        owner.dog = DogObject()
         owner.dog.dogName = "Harvie"
 
         realm.write { realm.add(owner) }
 
-        XCTAssertEqual(realm.objects(SwiftOwnerObject.self).count, Int(1), "Expecting 1 owner")
-        XCTAssertEqual(realm.objects(SwiftDogObject.self).count, Int(1), "Expecting 1 dog")
+        XCTAssertEqual(realm.objects(OwnerObject.self).count, Int(1), "Expecting 1 owner")
+        XCTAssertEqual(realm.objects(DogObject.self).count, Int(1), "Expecting 1 dog")
 
         realm.beginWrite()
-        let fiel = realm.create(SwiftOwnerObject.self, value: ["Fiel", NSNull()])
+        let fiel = realm.create(OwnerObject.self, value: ["Fiel", NSNull()])
         fiel.dog = owner.dog
         realm.commitWrite()
 
-        XCTAssertEqual(realm.objects(SwiftOwnerObject.self).count, Int(2), "Expecting 2 owners")
-        XCTAssertEqual(realm.objects(SwiftDogObject.self).count, Int(1), "Expecting 1 dog")
+        XCTAssertEqual(realm.objects(OwnerObject.self).count, Int(2), "Expecting 2 owners")
+        XCTAssertEqual(realm.objects(DogObject.self).count, Int(1), "Expecting 1 dog")
     }
 
     func testLinkRemoval() {
         let realm = realmWithTestPath()
 
-        let owner = SwiftOwnerObject()
+        let owner = OwnerObject()
         owner.name = "Tim"
-        owner.dog = SwiftDogObject()
+        owner.dog = DogObject()
         owner.dog.dogName = "Harvie"
 
         realm.write { realm.add(owner) }
 
-        XCTAssertEqual(realm.objects(SwiftOwnerObject.self).count, Int(1), "Expecting 1 owner")
-        XCTAssertEqual(realm.objects(SwiftDogObject.self).count, Int(1), "Expecting 1 dog")
+        XCTAssertEqual(realm.objects(OwnerObject.self).count, Int(1), "Expecting 1 owner")
+        XCTAssertEqual(realm.objects(DogObject.self).count, Int(1), "Expecting 1 dog")
 
         realm.write { realm.delete(owner.dog) }
 
         XCTAssertNil(owner.dog, "Dog should be nullified when deleted")
 
         // refresh owner and check
-        let owner2 = realm.objects(SwiftOwnerObject.self).first!
+        let owner2 = realm.objects(OwnerObject.self).first!
         XCTAssertNotNil(owner, "Should have 1 owner")
         XCTAssertNil(owner.dog, "Dog should be nullified when deleted")
-        XCTAssertEqual(realm.objects(SwiftDogObject.self).count, Int(0), "Expecting 0 dogs")
+        XCTAssertEqual(realm.objects(DogObject.self).count, Int(0), "Expecting 0 dogs")
     }
 }

--- a/RealmSwift/Tests/ListTests.swift
+++ b/RealmSwift/Tests/ListTests.swift
@@ -20,21 +20,21 @@ import XCTest
 import RealmSwift
 
 class ListTests: TestCase {
-    var str1: SwiftStringObject!
-    var str2: SwiftStringObject!
-    var arrayObject: SwiftArrayPropertyObject!
-    var array: List<SwiftStringObject>!
+    var str1: StringObject!
+    var str2: StringObject!
+    var arrayObject: ArrayPropertyObject!
+    var array: List<StringObject>!
 
-    func createArray() -> SwiftArrayPropertyObject {
+    func createArray() -> ArrayPropertyObject {
         fatalError("abstract")
     }
 
     override func setUp() {
         super.setUp()
 
-        str1 = SwiftStringObject()
+        str1 = StringObject()
         str1.stringCol = "1"
-        str2 = SwiftStringObject()
+        str2 = StringObject()
         str2.stringCol = "2"
         arrayObject = createArray()
         array = arrayObject.array
@@ -205,24 +205,24 @@ class ListTests: TestCase {
     }
 
     func testSortWithDescriptors() {
-        let object = realmWithTestPath().create(SwiftAggregateObjectList.self, value: [[]])
+        let object = realmWithTestPath().create(AggregateObjectList.self, value: [[]])
         let array = object.list
 
-        let obj1 = SwiftAggregateObject()
+        let obj1 = AggregateObject()
         obj1.intCol = 1
         obj1.floatCol = 1.1
         obj1.doubleCol = 1.11
         obj1.dateCol = NSDate(timeIntervalSince1970: 1)
         obj1.boolCol = false
 
-        let obj2 = SwiftAggregateObject()
+        let obj2 = AggregateObject()
         obj2.intCol = 2
         obj2.floatCol = 2.2
         obj2.doubleCol = 2.22
         obj2.dateCol = NSDate(timeIntervalSince1970: 2)
         obj2.boolCol = false
 
-        let obj3 = SwiftAggregateObject()
+        let obj3 = AggregateObject()
         obj3.intCol = 3
         obj3.floatCol = 2.2
         obj3.doubleCol = 2.22
@@ -275,7 +275,7 @@ class ListTests: TestCase {
     }
 
     func testAppendResults() {
-        array.extend(realmWithTestPath().objects(SwiftStringObject))
+        array.extend(realmWithTestPath().objects(StringObject))
         XCTAssertEqual(Int(2), array.count)
         XCTAssertEqual(str1, array[0])
         XCTAssertEqual(str2, array[1])
@@ -353,7 +353,7 @@ class ListTests: TestCase {
         if let realm = array.realm {
             array.extend([str1, str2])
 
-            let otherArray = realm.objects(SwiftArrayPropertyObject).first!.array
+            let otherArray = realm.objects(ArrayPropertyObject).first!.array
             XCTAssertEqual(Int(2), otherArray.count)
         }
     }
@@ -361,10 +361,10 @@ class ListTests: TestCase {
     func testPopulateEmptyArray() {
         XCTAssertEqual(array.count, 0, "Should start with no array elements.")
 
-        let obj = SwiftStringObject()
+        let obj = StringObject()
         obj.stringCol = "a"
         array.append(obj)
-        array.append(realmWithTestPath().create(SwiftStringObject.self, value: ["b"]))
+        array.append(realmWithTestPath().create(StringObject.self, value: ["b"]))
         array.append(obj)
 
         XCTAssertEqual(array.count, 3)
@@ -380,8 +380,8 @@ class ListTests: TestCase {
 }
 
 class ListStandaloneTests: ListTests {
-    override func createArray() -> SwiftArrayPropertyObject {
-        let array = SwiftArrayPropertyObject()
+    override func createArray() -> ArrayPropertyObject {
+        let array = ArrayPropertyObject()
         XCTAssertNil(array.realm)
         return array
     }
@@ -426,8 +426,8 @@ class ListStandaloneTests: ListTests {
 }
 
 class ListNewlyAddedTests: ListTests {
-    override func createArray() -> SwiftArrayPropertyObject {
-        let array = SwiftArrayPropertyObject()
+    override func createArray() -> ArrayPropertyObject {
+        let array = ArrayPropertyObject()
         array.name = "name"
         let realm = self.realmWithTestPath()
         realm.write { realm.add(array) }
@@ -438,10 +438,10 @@ class ListNewlyAddedTests: ListTests {
 }
 
 class ListNewlyCreatedTests: ListTests {
-    override func createArray() -> SwiftArrayPropertyObject {
+    override func createArray() -> ArrayPropertyObject {
         let realm = self.realmWithTestPath()
         realm.beginWrite()
-        let array = realm.create(SwiftArrayPropertyObject.self, value: ["name", [], []])
+        let array = realm.create(ArrayPropertyObject.self, value: ["name", [], []])
         realm.commitWrite()
 
         XCTAssertNotNil(array.realm)
@@ -450,12 +450,12 @@ class ListNewlyCreatedTests: ListTests {
 }
 
 class ListRetrievedTests: ListTests {
-    override func createArray() -> SwiftArrayPropertyObject {
+    override func createArray() -> ArrayPropertyObject {
         let realm = self.realmWithTestPath()
         realm.beginWrite()
-        realm.create(SwiftArrayPropertyObject.self, value: ["name", [], []])
+        realm.create(ArrayPropertyObject.self, value: ["name", [], []])
         realm.commitWrite()
-        let array = realm.objects(SwiftArrayPropertyObject).first!
+        let array = realm.objects(ArrayPropertyObject).first!
 
         XCTAssertNotNil(array.realm)
         return array

--- a/RealmSwift/Tests/MigrationTests.swift
+++ b/RealmSwift/Tests/MigrationTests.swift
@@ -119,7 +119,7 @@ class MigrationTests: TestCase {
     func testMigrationProperties() {
         let prop = RLMProperty(name: "stringCol", type: RLMPropertyType.Int, objectClassName: nil, indexed: false)
         autoreleasepool { () -> () in
-            realmWithSingleClassProperties(Realm.defaultPath, "SwiftStringObject", [prop])
+            realmWithSingleClassProperties(Realm.defaultPath, "StringObject", [prop])
             return
         }
 
@@ -127,16 +127,16 @@ class MigrationTests: TestCase {
             XCTAssertEqual(migration.oldSchema.objectSchema.count, 1)
             XCTAssertGreaterThan(migration.newSchema.objectSchema.count, 1)
             XCTAssertEqual(migration.oldSchema.objectSchema[0].properties.count, 1)
-            XCTAssertEqual(migration.newSchema["SwiftStringObject"]!.properties.count, 1)
-            XCTAssertEqual(migration.oldSchema["SwiftStringObject"]!.properties[0].type, PropertyType.Int)
-            XCTAssertEqual(migration.newSchema["SwiftStringObject"]!["stringCol"]!.type, PropertyType.String)
+            XCTAssertEqual(migration.newSchema["StringObject"]!.properties.count, 1)
+            XCTAssertEqual(migration.oldSchema["StringObject"]!.properties[0].type, PropertyType.Int)
+            XCTAssertEqual(migration.newSchema["StringObject"]!["stringCol"]!.type, PropertyType.String)
         })
     }
 
     func testEnumerate() {
         autoreleasepool {
             self.migrateAndTestRealm(Realm.defaultPath, block: { migration, oldSchemaVersion in
-                migration.enumerate("SwiftStringObject", { oldObj, newObj in
+                migration.enumerate("StringObject", { oldObj, newObj in
                     XCTFail("No objects to enumerate")
                 })
 
@@ -147,7 +147,7 @@ class MigrationTests: TestCase {
         autoreleasepool {
             // add object
             Realm().write {
-                Realm().create(SwiftStringObject.self, value: ["string"])
+                Realm().create(StringObject.self, value: ["string"])
                 return
             }
         }
@@ -155,9 +155,9 @@ class MigrationTests: TestCase {
         autoreleasepool {
             self.migrateAndTestRealm(Realm.defaultPath, schemaVersion: 2, block: { migration, oldSchemaVersion in
                 var count = 0
-                migration.enumerate("SwiftStringObject", { oldObj, newObj in
-                    XCTAssertEqual(newObj!.objectSchema.className, "SwiftStringObject")
-                    XCTAssertEqual(oldObj!.objectSchema.className, "SwiftStringObject")
+                migration.enumerate("StringObject", { oldObj, newObj in
+                    XCTAssertEqual(newObj!.objectSchema.className, "StringObject")
+                    XCTAssertEqual(oldObj!.objectSchema.className, "StringObject")
                     XCTAssertEqual(newObj!["stringCol"] as String, "string")
                     XCTAssertEqual(oldObj!["stringCol"] as String, "string")
                     self.assertThrows(oldObj!["noSuchCol"] as String)
@@ -171,14 +171,14 @@ class MigrationTests: TestCase {
 
     func testCreate() {
         migrateAndTestRealm(Realm.defaultPath, block: { migration, oldSchemaVersion in
-            migration.create("SwiftStringObject", value: ["string"])
-            migration.create("SwiftStringObject", value: ["stringCol": "string"])
-            migration.create("SwiftStringObject")
+            migration.create("StringObject", value: ["string"])
+            migration.create("StringObject", value: ["stringCol": "string"])
+            migration.create("StringObject")
 
             self.assertThrows(migration.create("NoSuchObject", value: []))
 
             var count = 0
-            migration.enumerate("SwiftStringObject", { oldObj, newObj in
+            migration.enumerate("StringObject", { oldObj, newObj in
                 if count == 0 {
                     // first object has default value of empty string
                     XCTAssertEqual(newObj!["stringCol"] as String, "")
@@ -192,21 +192,21 @@ class MigrationTests: TestCase {
             XCTAssertEqual(count, 3)
         })
 
-        XCTAssertEqual(Realm().objects(SwiftStringObject.self).count, 3)
+        XCTAssertEqual(Realm().objects(StringObject.self).count, 3)
     }
 
     func testDelete() {
         autoreleasepool { () -> () in
             Realm().write {
-                Realm().create(SwiftStringObject.self, value: ["string1"])
-                Realm().create(SwiftStringObject.self, value: ["string2"])
+                Realm().create(StringObject.self, value: ["string1"])
+                Realm().create(StringObject.self, value: ["string2"])
                 return
             }
         }
 
         self.migrateAndTestRealm(Realm.defaultPath, block: { migration, oldSchemaVersion in
             var deleted = false;
-            migration.enumerate("SwiftStringObject", { oldObj, newObj in
+            migration.enumerate("StringObject", { oldObj, newObj in
                 if deleted == false {
                     migration.delete(newObj!)
                     deleted = true
@@ -214,17 +214,17 @@ class MigrationTests: TestCase {
             })
         })
 
-        XCTAssertEqual(Realm().objects(SwiftStringObject.self).count, 1)
+        XCTAssertEqual(Realm().objects(StringObject.self).count, 1)
     }
 
     // test getting/setting all property types
     func testMigrationObject() {
         autoreleasepool {
             Realm().write {
-                var object = SwiftObject()
+                var object = AllTypesObject()
                 object.boolCol = true
-                object.objectCol = SwiftBoolObject(value: [true])
-                object.arrayCol.append(SwiftBoolObject(value: [false]))
+                object.objectCol = BoolObject(value: [true])
+                object.arrayCol.append(BoolObject(value: [false]))
                 Realm().add(object)
                 return
             }
@@ -232,7 +232,7 @@ class MigrationTests: TestCase {
 
         self.migrateAndTestRealm(Realm.defaultPath, block: { migration, oldSchemaVersion in
             var enumerated = false
-            migration.enumerate("SwiftObject", { oldObj, newObj in
+            migration.enumerate("AllTypesObject", { oldObj, newObj in
                 XCTAssertEqual(oldObj!["boolCol"] as Bool, true)
                 XCTAssertEqual(newObj!["boolCol"] as Bool, true)
                 XCTAssertEqual(oldObj!["intCol"] as Int, 123)
@@ -250,7 +250,7 @@ class MigrationTests: TestCase {
                 XCTAssertEqual(oldObj!["dateCol"] as NSDate, dateCol)
                 XCTAssertEqual(newObj!["dateCol"] as NSDate, dateCol)
 
-                // FIXME - test that casting to SwiftBoolObject throws
+                // FIXME - test that casting to BoolObject throws
                 XCTAssertEqual((oldObj!["objectCol"] as MigrationObject)["boolCol"] as Bool, true)
                 XCTAssertEqual((newObj!["objectCol"] as MigrationObject)["boolCol"] as Bool, true)
 
@@ -270,9 +270,9 @@ class MigrationTests: TestCase {
                 var list = newObj!["arrayCol"] as List<MigrationObject>
                 list[0]["boolCol"] = true
                 list.append(newObj!["objectCol"] as MigrationObject)
-                list.append(migration.create(SwiftBoolObject.className(), value: [true]))
+                list.append(migration.create(BoolObject.className(), value: [true]))
 
-                newObj!["objectCol"] = SwiftBoolObject(value: [false])
+                newObj!["objectCol"] = BoolObject(value: [false])
 
                 enumerated = true
             })
@@ -283,7 +283,7 @@ class MigrationTests: TestCase {
         Realm().refresh()
 
         // check edited values
-        let object = Realm().objects(SwiftObject.self).first!
+        let object = Realm().objects(AllTypesObject.self).first!
         XCTAssertEqual(object.boolCol, false)
         XCTAssertEqual(object.intCol, 1)
         XCTAssertEqual(object.floatCol, 1.0 as Float)
@@ -297,7 +297,7 @@ class MigrationTests: TestCase {
         XCTAssertEqual(object.arrayCol[2].boolCol, true)
 
         // make sure we added new bool objects as object property and in the list
-        XCTAssertEqual(Realm().objects(SwiftBoolObject).count, 4)
+        XCTAssertEqual(Realm().objects(BoolObject).count, 4)
     }
 }
 

--- a/RealmSwift/Tests/ObjectAccessorTests.swift
+++ b/RealmSwift/Tests/ObjectAccessorTests.swift
@@ -21,7 +21,7 @@ import RealmSwift
 import Foundation
 
 class ObjectAccessorTests: TestCase {
-    func setAndTestAllProperties(object: SwiftObject) {
+    func setAndTestAllProperties(object: AllTypesObject) {
         object.boolCol = true
         XCTAssertEqual(object.boolCol, true)
         object.boolCol = false
@@ -62,19 +62,19 @@ class ObjectAccessorTests: TestCase {
         object.dateCol = date
         XCTAssertEqual(object.dateCol, date)
 
-        object.objectCol = SwiftBoolObject(value: [true])
+        object.objectCol = BoolObject(value: [true])
         XCTAssertEqual(object.objectCol.boolCol, true)
     }
 
     func testStandaloneAccessors() {
-        let object = SwiftObject()
+        let object = AllTypesObject()
         setAndTestAllProperties(object)
     }
 
     func testPersistedAccessors() {
-        let object = SwiftObject()
+        let object = AllTypesObject()
         Realm().beginWrite()
-        Realm().create(SwiftObject.self)
+        Realm().create(AllTypesObject.self)
         setAndTestAllProperties(object)
         Realm().commitWrite()
     }
@@ -87,7 +87,7 @@ class ObjectAccessorTests: TestCase {
         // 1 << 40 doesn't auto-promote to Int64 on 32-bit platforms
         let v64 = Int64(1) << 40
         realm.write {
-            let obj = SwiftAllIntSizesObject()
+            let obj = AllIntSizesObject()
 
             obj.int16 = v16
             XCTAssertEqual(obj.int16, v16)
@@ -99,7 +99,7 @@ class ObjectAccessorTests: TestCase {
             realm.add(obj)
         }
 
-        let obj = realm.objects(SwiftAllIntSizesObject.self).first!
+        let obj = realm.objects(AllIntSizesObject.self).first!
         XCTAssertEqual(obj.int16, v16)
         XCTAssertEqual(obj.int32, v32)
         XCTAssertEqual(obj.int64, v64)
@@ -114,12 +114,12 @@ class ObjectAccessorTests: TestCase {
         let realm = realmWithTestPath()
 
         realm.beginWrite()
-        realm.create(SwiftIntObject.self, value: [longNumber])
-        realm.create(SwiftIntObject.self, value: [intNumber])
-        realm.create(SwiftIntObject.self, value: [negativeLongNumber])
+        realm.create(IntObject.self, value: [longNumber])
+        realm.create(IntObject.self, value: [intNumber])
+        realm.create(IntObject.self, value: [negativeLongNumber])
         realm.commitWrite()
 
-        let objects = realm.objects(SwiftIntObject.self)
+        let objects = realm.objects(IntObject.self)
         XCTAssertEqual(objects.count, Int(3), "3 rows expected")
         XCTAssertEqual(objects[0].intCol, longNumber, "2 ^ 34 expected")
         XCTAssertEqual(objects[1].intCol, intNumber, "2 ^ 31 - 1 expected")

--- a/RealmSwift/Tests/ObjectCreationTests.swift
+++ b/RealmSwift/Tests/ObjectCreationTests.swift
@@ -25,11 +25,11 @@ class ObjectCreationTests: TestCase {
     // MARK: Init tests
     func testInitWithDefaults() {
         // test all properties are defaults
-        let object = SwiftObject()
+        let object = AllTypesObject()
         XCTAssertNil(object.realm)
 
         // test defaults values
-        verifySwiftObjectWithDictionaryLiteral(object, dictionary: SwiftObject.defaultValues(), boolObjectValue: false, boolObjectListValues: [])
+        verifyAllTypesObjectWithDictionaryLiteral(object, dictionary: AllTypesObject.defaultValues(), boolObjectValue: false, boolObjectListValues: [])
 
         // test realm properties are nil for standalone
         XCTAssertNil(object.realm)
@@ -47,38 +47,38 @@ class ObjectCreationTests: TestCase {
             "stringCol": "b" as NSString,
             "binaryCol": "b".dataUsingEncoding(NSUTF8StringEncoding)! as NSData,
             "dateCol": NSDate(timeIntervalSince1970: 2) as NSDate,
-            "objectCol": SwiftBoolObject(value: [true]) as AnyObject,
-            "arrayCol": [SwiftBoolObject(value: [true]), SwiftBoolObject()]  as AnyObject
+            "objectCol": BoolObject(value: [true]) as AnyObject,
+            "arrayCol": [BoolObject(value: [true]), BoolObject()]  as AnyObject
            ]
 
         // test with valid dictionary literals
-        let props = Realm().schema["SwiftObject"]!.properties
+        let props = Realm().schema["AllTypesObject"]!.properties
         for propNum in 0..<props.count {
-            for validValue in validValuesForSwiftObjectType(props[propNum].type) {
+            for validValue in validValuesForAllTypesObjectType(props[propNum].type) {
                 // update dict with valid value and init
                 var values = baselineValues
                 values[props[propNum].name] = validValue
-                let object = SwiftObject(value: values)
-                verifySwiftObjectWithDictionaryLiteral(object, dictionary: values, boolObjectValue: true, boolObjectListValues: [true, false])
+                let object = AllTypesObject(value: values)
+                verifyAllTypesObjectWithDictionaryLiteral(object, dictionary: values, boolObjectValue: true, boolObjectListValues: [true, false])
             }
         }
 
         // test with invalid dictionary literals
         for propNum in 0..<props.count {
-            for invalidValue in invalidValuesForSwiftObjectType(props[propNum].type) {
+            for invalidValue in invalidValuesForAllTypesObjectType(props[propNum].type) {
                 // update dict with invalid value and init
                 var values = baselineValues
                 values[props[propNum].name] = invalidValue
-                assertThrows(SwiftObject(value: values), "Invalid property value")
+                assertThrows(AllTypesObject(value: values), "Invalid property value")
             }
         }
     }
 
     func testInitWithDefaultsAndDictionary() {
         // test with dictionary with mix of default and one specified value
-        let object = SwiftObject(value: ["intCol": 200])
-        let valueDict = defaultSwiftObjectValuesWithReplacements(["intCol": 200])
-        verifySwiftObjectWithDictionaryLiteral(object, dictionary: valueDict, boolObjectValue: false, boolObjectListValues: [])
+        let object = AllTypesObject(value: ["intCol": 200])
+        let valueDict = defaultAllTypesObjectValuesWithReplacements(["intCol": 200])
+        verifyAllTypesObjectWithDictionaryLiteral(object, dictionary: valueDict, boolObjectValue: false, boolObjectListValues: [])
     }
 
     func testInitWithArray() {
@@ -86,51 +86,51 @@ class ObjectCreationTests: TestCase {
         let baselineValues = [true, 1, 1.1, 11.1, "b", "b".dataUsingEncoding(NSUTF8StringEncoding)! as NSData, NSDate(timeIntervalSince1970: 2) as NSDate, ["boolCol": true], [[true], [false]]] as [AnyObject]
 
         // test with valid dictionary literals
-        let props = Realm().schema["SwiftObject"]!.properties
+        let props = Realm().schema["AllTypesObject"]!.properties
         for propNum in 0..<props.count {
-            for validValue in validValuesForSwiftObjectType(props[propNum].type) {
+            for validValue in validValuesForAllTypesObjectType(props[propNum].type) {
                 // update dict with valid value and init
                 var values = baselineValues
                 values[propNum] = validValue
-                let object = SwiftObject(value: values)
-                verifySwiftObjectWithArrayLiteral(object, array: values, boolObjectValue: true, boolObjectListValues: [true, false])
+                let object = AllTypesObject(value: values)
+                verifyAllTypesObjectWithArrayLiteral(object, array: values, boolObjectValue: true, boolObjectListValues: [true, false])
             }
         }
 
         // test with invalid dictionary literals
         for propNum in 0..<props.count {
-            for invalidValue in invalidValuesForSwiftObjectType(props[propNum].type) {
+            for invalidValue in invalidValuesForAllTypesObjectType(props[propNum].type) {
                 // update dict with invalid value and init
                 var values = baselineValues
                 values[propNum] = invalidValue
-                assertThrows(SwiftObject(value: values), "Invalid property value")
+                assertThrows(AllTypesObject(value: values), "Invalid property value")
             }
         }
     }
 
     func testInitWithKVCObject() {
         // test with kvc object
-        let objectWithInt = SwiftObject(value: ["intCol": 200])
-        let objectWithKVCObject = SwiftObject(value: objectWithInt)
-        let valueDict = defaultSwiftObjectValuesWithReplacements(["intCol": 200])
-        verifySwiftObjectWithDictionaryLiteral(objectWithKVCObject, dictionary: valueDict, boolObjectValue: false, boolObjectListValues: [])
+        let objectWithInt = AllTypesObject(value: ["intCol": 200])
+        let objectWithKVCObject = AllTypesObject(value: objectWithInt)
+        let valueDict = defaultAllTypesObjectValuesWithReplacements(["intCol": 200])
+        verifyAllTypesObjectWithDictionaryLiteral(objectWithKVCObject, dictionary: valueDict, boolObjectValue: false, boolObjectListValues: [])
     }
 
     // MARK: Creation tests
 
     func testCreateWithDefaults() {
         let realm = Realm()
-        assertThrows(realm.create(SwiftObject.self), "Must be in write transaction")
+        assertThrows(realm.create(AllTypesObject.self), "Must be in write transaction")
 
-        var object: SwiftObject!
-        let objects = realm.objects(SwiftObject)
+        var object: AllTypesObject!
+        let objects = realm.objects(AllTypesObject)
         XCTAssertEqual(0, objects.count)
         realm.write {
             // test create with all defaults
-            object = realm.create(SwiftObject.self)
+            object = realm.create(AllTypesObject.self)
             return
         }
-        verifySwiftObjectWithDictionaryLiteral(object, dictionary: SwiftObject.defaultValues(), boolObjectValue: false, boolObjectListValues: [])
+        verifyAllTypesObjectWithDictionaryLiteral(object, dictionary: AllTypesObject.defaultValues(), boolObjectValue: false, boolObjectListValues: [])
 
         // test realm properties are populated correctly
         XCTAssertEqual(object.realm!, realm)
@@ -148,33 +148,33 @@ class ObjectCreationTests: TestCase {
                 "stringCol": "b" as NSString,
                 "binaryCol": "b".dataUsingEncoding(NSUTF8StringEncoding)! as NSData,
                 "dateCol": NSDate(timeIntervalSince1970: 2) as NSDate,
-                "objectCol": SwiftBoolObject(value: [true]) as AnyObject,
-                "arrayCol": [SwiftBoolObject(value: [true]), SwiftBoolObject()]  as AnyObject
+                "objectCol": BoolObject(value: [true]) as AnyObject,
+                "arrayCol": [BoolObject(value: [true]), BoolObject()]  as AnyObject
             ]
 
         // test with valid dictionary literals
-        let props = Realm().schema["SwiftObject"]!.properties
+        let props = Realm().schema["AllTypesObject"]!.properties
         for propNum in 0..<props.count {
-            for validValue in validValuesForSwiftObjectType(props[propNum].type) {
+            for validValue in validValuesForAllTypesObjectType(props[propNum].type) {
                 // update dict with valid value and init
                 var values = baselineValues
                 values[props[propNum].name] = validValue
                 Realm().beginWrite()
-                let object = Realm().create(SwiftObject.self, value: values)
-                verifySwiftObjectWithDictionaryLiteral(object, dictionary: values, boolObjectValue: true, boolObjectListValues: [true, false])
+                let object = Realm().create(AllTypesObject.self, value: values)
+                verifyAllTypesObjectWithDictionaryLiteral(object, dictionary: values, boolObjectValue: true, boolObjectListValues: [true, false])
                 Realm().commitWrite()
-                verifySwiftObjectWithDictionaryLiteral(object, dictionary: values, boolObjectValue: true, boolObjectListValues: [true, false])
+                verifyAllTypesObjectWithDictionaryLiteral(object, dictionary: values, boolObjectValue: true, boolObjectListValues: [true, false])
             }
         }
 
         // test with invalid dictionary literals
         for propNum in 0..<props.count {
-            for invalidValue in invalidValuesForSwiftObjectType(props[propNum].type) {
+            for invalidValue in invalidValuesForAllTypesObjectType(props[propNum].type) {
                 // update dict with invalid value and init
                 var values = baselineValues
                 values[props[propNum].name] = invalidValue
                 Realm().beginWrite()
-                assertThrows(Realm().create(SwiftObject.self, value: values), "Invalid property value")
+                assertThrows(Realm().create(AllTypesObject.self, value: values), "Invalid property value")
                 Realm().cancelWrite()
             }
         }
@@ -184,11 +184,11 @@ class ObjectCreationTests: TestCase {
         // test with dictionary with mix of default and one specified value
         let realm = Realm()
         realm.beginWrite()
-        let objectWithInt = realm.create(SwiftObject.self, value: ["intCol": 200])
+        let objectWithInt = realm.create(AllTypesObject.self, value: ["intCol": 200])
         realm.commitWrite()
 
-        let valueDict = defaultSwiftObjectValuesWithReplacements(["intCol": 200])
-        verifySwiftObjectWithDictionaryLiteral(objectWithInt, dictionary: valueDict, boolObjectValue: false, boolObjectListValues: [])
+        let valueDict = defaultAllTypesObjectValuesWithReplacements(["intCol": 200])
+        verifyAllTypesObjectWithDictionaryLiteral(objectWithInt, dictionary: valueDict, boolObjectValue: false, boolObjectListValues: [])
     }
 
     func testCreateWithArray() {
@@ -196,29 +196,29 @@ class ObjectCreationTests: TestCase {
         let baselineValues = [true, 1, 1.1, 11.1, "b", "b".dataUsingEncoding(NSUTF8StringEncoding)! as NSData, NSDate(timeIntervalSince1970: 2) as NSDate, ["boolCol": true], [[true], [false]]] as [AnyObject]
 
         // test with valid dictionary literals
-        let props = Realm().schema["SwiftObject"]!.properties
+        let props = Realm().schema["AllTypesObject"]!.properties
         for propNum in 0..<props.count {
-            for validValue in validValuesForSwiftObjectType(props[propNum].type) {
+            for validValue in validValuesForAllTypesObjectType(props[propNum].type) {
                 // update dict with valid value and init
                 var values = baselineValues
                 values[propNum] = validValue
                 Realm().beginWrite()
-                let object = Realm().create(SwiftObject.self, value: values)
-                verifySwiftObjectWithArrayLiteral(object, array: values, boolObjectValue: true, boolObjectListValues: [true, false])
+                let object = Realm().create(AllTypesObject.self, value: values)
+                verifyAllTypesObjectWithArrayLiteral(object, array: values, boolObjectValue: true, boolObjectListValues: [true, false])
                 Realm().commitWrite()
-                verifySwiftObjectWithArrayLiteral(object, array: values, boolObjectValue: true, boolObjectListValues: [true, false])
+                verifyAllTypesObjectWithArrayLiteral(object, array: values, boolObjectValue: true, boolObjectListValues: [true, false])
             }
         }
 
         // test with invalid array literals
         for propNum in 0..<props.count {
-            for invalidValue in invalidValuesForSwiftObjectType(props[propNum].type) {
+            for invalidValue in invalidValuesForAllTypesObjectType(props[propNum].type) {
                 // update dict with invalid value and init
                 var values = baselineValues
                 values[propNum] = invalidValue
 
                 Realm().beginWrite()
-                assertThrows(Realm().create(SwiftObject.self, value: values), "Invalid property value '\(invalidValue)' for property number \(propNum)")
+                assertThrows(Realm().create(AllTypesObject.self, value: values), "Invalid property value '\(invalidValue)' for property number \(propNum)")
                 Realm().cancelWrite()
             }
         }
@@ -227,22 +227,22 @@ class ObjectCreationTests: TestCase {
     func testCreateWithKVCObject() {
         // test with kvc object
         Realm().beginWrite()
-        let objectWithInt = Realm().create(SwiftObject.self, value: ["intCol": 200])
-        let objectWithKVCObject = Realm().create(SwiftObject.self, value: objectWithInt)
-        let valueDict = defaultSwiftObjectValuesWithReplacements(["intCol": 200])
+        let objectWithInt = Realm().create(AllTypesObject.self, value: ["intCol": 200])
+        let objectWithKVCObject = Realm().create(AllTypesObject.self, value: objectWithInt)
+        let valueDict = defaultAllTypesObjectValuesWithReplacements(["intCol": 200])
         Realm().commitWrite()
 
-        verifySwiftObjectWithDictionaryLiteral(objectWithKVCObject, dictionary: valueDict, boolObjectValue: false, boolObjectListValues: [])
-        XCTAssertEqual(Realm().objects(SwiftObject).count, 2, "Object should have been copied")
+        verifyAllTypesObjectWithDictionaryLiteral(objectWithKVCObject, dictionary: valueDict, boolObjectValue: false, boolObjectListValues: [])
+        XCTAssertEqual(Realm().objects(AllTypesObject).count, 2, "Object should have been copied")
     }
 
     func testCreateWithNestedObjects() {
-        let standalone = SwiftPrimaryStringObject(value: ["primary", 11])
+        let standalone = PrimaryStringObject(value: ["primary", 11])
         Realm().beginWrite()
-        let objectWithNestedObjects = Realm().create(SwiftLinkToPrimaryStringObject.self, value: ["primary", ["primary", 11], [standalone]])
+        let objectWithNestedObjects = Realm().create(LinkToPrimaryStringObject.self, value: ["primary", ["primary", 11], [standalone]])
         Realm().commitWrite()
 
-        let stringObjects = Realm().objects(SwiftPrimaryStringObject)
+        let stringObjects = Realm().objects(PrimaryStringObject)
         XCTAssertEqual(stringObjects.count, 1)
         let persistedObject = stringObjects.first!
 
@@ -252,12 +252,12 @@ class ObjectCreationTests: TestCase {
     }
 
     func testUpdateWithNestedObjects() {
-        let standalone = SwiftPrimaryStringObject(value: ["primary", 11])
+        let standalone = PrimaryStringObject(value: ["primary", 11])
         Realm().beginWrite()
-        let object = Realm().create(SwiftLinkToPrimaryStringObject.self, value: ["otherPrimary", standalone, [["primary", 12]]], update: true)
+        let object = Realm().create(LinkToPrimaryStringObject.self, value: ["otherPrimary", standalone, [["primary", 12]]], update: true)
         Realm().commitWrite()
 
-        let stringObjects = Realm().objects(SwiftPrimaryStringObject)
+        let stringObjects = Realm().objects(PrimaryStringObject)
         XCTAssertEqual(stringObjects.count, 1)
         let persistedObject = object.object!
 
@@ -278,35 +278,35 @@ class ObjectCreationTests: TestCase {
 //            "stringCol": "b" as NSString,
 //            "binaryCol": "b".dataUsingEncoding(NSUTF8StringEncoding)! as NSData,
 //            "dateCol": NSDate(timeIntervalSince1970: 2) as NSDate,
-//            "objectCol": SwiftBoolObject(object: [true]) as AnyObject,
-//            "arrayCol": [SwiftBoolObject(object: [true]), SwiftBoolObject()]  as AnyObject,
+//            "objectCol": BoolObject(object: [true]) as AnyObject,
+//            "arrayCol": [BoolObject(object: [true]), BoolObject()]  as AnyObject,
 //        ]
 //
 //        realmWithTestPath().beginWrite()
-//        let otherRealmObject = realmWithTestPath().create(SwiftObject.self, value: values)
+//        let otherRealmObject = realmWithTestPath().create(AllTypesObject.self, value: values)
 //        realmWithTestPath().commitWrite()
 //
 //        Realm().beginWrite()
-//        let object = Realm().create(SwiftObject.self, value: otherRealmObject)
+//        let object = Realm().create(AllTypesObject.self, value: otherRealmObject)
 //        Realm().commitWrite()
 //
 //        XCTAssertNotEqual(otherRealmObject, object)
-//        verifySwiftObjectWithDictionaryLiteral(object, dictionary: values, boolObjectValue: true, boolObjectListValues: [true, false])
+//        verifyAllTypesObjectWithDictionaryLiteral(object, dictionary: values, boolObjectValue: true, boolObjectListValues: [true, false])
 //    }
 
     func testUpdateWithObjectsFromAnotherRealm() {
         realmWithTestPath().beginWrite()
-        let otherRealmObject = realmWithTestPath().create(SwiftLinkToPrimaryStringObject.self, value: ["primary", NSNull(), [["2", 2], ["4", 4]]])
+        let otherRealmObject = realmWithTestPath().create(LinkToPrimaryStringObject.self, value: ["primary", NSNull(), [["2", 2], ["4", 4]]])
         realmWithTestPath().commitWrite()
 
         Realm().beginWrite()
-        Realm().create(SwiftLinkToPrimaryStringObject.self, value: ["primary", ["10", 10], [["11", 11]]])
-        let object = Realm().create(SwiftLinkToPrimaryStringObject.self, value: otherRealmObject, update: true)
+        Realm().create(LinkToPrimaryStringObject.self, value: ["primary", ["10", 10], [["11", 11]]])
+        let object = Realm().create(LinkToPrimaryStringObject.self, value: otherRealmObject, update: true)
         Realm().commitWrite()
 
         XCTAssertNotEqual(otherRealmObject, object) // the object from the other realm should be copied into this realm
-        XCTAssertEqual(Realm().objects(SwiftLinkToPrimaryStringObject).count, 1)
-        XCTAssertEqual(Realm().objects(SwiftPrimaryStringObject).count, 4)
+        XCTAssertEqual(Realm().objects(LinkToPrimaryStringObject).count, 1)
+        XCTAssertEqual(Realm().objects(PrimaryStringObject).count, 4)
     }
 
     // test NSNull for object
@@ -320,11 +320,11 @@ class ObjectCreationTests: TestCase {
     // MARK: Add tests
     func testAddWithExisingNestedObjects() {
         Realm().beginWrite()
-        let existingObject = Realm().create(SwiftBoolObject)
+        let existingObject = Realm().create(BoolObject)
         Realm().commitWrite()
 
         Realm().beginWrite()
-        let object = SwiftObject(value: ["objectCol" : existingObject])
+        let object = AllTypesObject(value: ["objectCol" : existingObject])
         Realm().add(object)
         Realm().commitWrite()
 
@@ -334,11 +334,11 @@ class ObjectCreationTests: TestCase {
 
     func testAddAndUpdateWithExisingNestedObjects() {
         Realm().beginWrite()
-        let existingObject = Realm().create(SwiftPrimaryStringObject.self, value: ["primary", 1])
+        let existingObject = Realm().create(PrimaryStringObject.self, value: ["primary", 1])
         Realm().commitWrite()
 
         Realm().beginWrite()
-        let object = SwiftLinkToPrimaryStringObject(value: ["primary", ["primary", 2], []])
+        let object = LinkToPrimaryStringObject(value: ["primary", ["primary", 2], []])
         Realm().add(object, update: true)
         Realm().commitWrite()
 
@@ -348,7 +348,7 @@ class ObjectCreationTests: TestCase {
     }
 
     // MARK: Private utilities
-    private func verifySwiftObjectWithArrayLiteral(object: SwiftObject, array: [AnyObject], boolObjectValue: Bool, boolObjectListValues: [Bool]) {
+    private func verifyAllTypesObjectWithArrayLiteral(object: AllTypesObject, array: [AnyObject], boolObjectValue: Bool, boolObjectListValues: [Bool]) {
         XCTAssertEqual(object.boolCol, array[0] as Bool)
         XCTAssertEqual(object.intCol, array[1] as Int)
         XCTAssertEqual(object.floatCol, array[2] as Float)
@@ -363,7 +363,7 @@ class ObjectCreationTests: TestCase {
         }
     }
 
-    private func verifySwiftObjectWithDictionaryLiteral(object: SwiftObject, dictionary: [String:AnyObject], boolObjectValue: Bool, boolObjectListValues: [Bool]) {
+    private func verifyAllTypesObjectWithDictionaryLiteral(object: AllTypesObject, dictionary: [String:AnyObject], boolObjectValue: Bool, boolObjectListValues: [Bool]) {
         XCTAssertEqual(object.boolCol, dictionary["boolCol"] as Bool)
         XCTAssertEqual(object.intCol, dictionary["intCol"] as Int)
         XCTAssertEqual(object.floatCol, dictionary["floatCol"] as Float)
@@ -378,8 +378,8 @@ class ObjectCreationTests: TestCase {
         }
     }
 
-    private func defaultSwiftObjectValuesWithReplacements(replace: [String: AnyObject]) -> [String: AnyObject] {
-        var valueDict = SwiftObject.defaultValues()
+    private func defaultAllTypesObjectValuesWithReplacements(replace: [String: AnyObject]) -> [String: AnyObject] {
+        var valueDict = AllTypesObject.defaultValues()
         for (key, value) in replace {
             valueDict[key] = value
         }
@@ -387,9 +387,9 @@ class ObjectCreationTests: TestCase {
     }
 
     // return an array of valid values that can be used to initialize each type
-    private func validValuesForSwiftObjectType(type: PropertyType) -> [AnyObject] {
+    private func validValuesForAllTypesObjectType(type: PropertyType) -> [AnyObject] {
         Realm().beginWrite()
-        let persistedObject = Realm().create(SwiftBoolObject.self, value: [true])
+        let persistedObject = Realm().create(BoolObject.self, value: [true])
         Realm().commitWrite()
         switch type {
             case .Bool:     return [true, 0 as Int, 1 as Int]
@@ -399,16 +399,16 @@ class ObjectCreationTests: TestCase {
             case .String:   return ["b"]
             case .Data:     return ["b".dataUsingEncoding(NSUTF8StringEncoding, allowLossyConversion: false)! as NSData]
             case .Date:     return [NSDate(timeIntervalSince1970: 2) as AnyObject]
-            case .Object:   return [[true], ["boolCol": true], SwiftBoolObject(value: [true]), persistedObject]
-            case .Array:    return [[[true], [false]], [["boolCol": true], ["boolCol": false]], [SwiftBoolObject(value: [true]), SwiftBoolObject(value: [false])], [persistedObject, [false]]]
+            case .Object:   return [[true], ["boolCol": true], BoolObject(value: [true]), persistedObject]
+            case .Array:    return [[[true], [false]], [["boolCol": true], ["boolCol": false]], [BoolObject(value: [true]), BoolObject(value: [false])], [persistedObject, [false]]]
             case .Any:      XCTFail("not supported")
         }
         return []
     }
 
-    private func invalidValuesForSwiftObjectType(type: PropertyType) -> [AnyObject] {
+    private func invalidValuesForAllTypesObjectType(type: PropertyType) -> [AnyObject] {
         Realm().beginWrite()
-        let persistedObject = Realm().create(SwiftIntObject)
+        let persistedObject = Realm().create(IntObject)
         Realm().commitWrite()
         switch type {
             case .Bool:     return ["invalid", 2 as Int, 1.1 as Float, 11.1 as Double]
@@ -418,8 +418,8 @@ class ObjectCreationTests: TestCase {
             case .String:   return [0x197A71D, true, false]
             case .Data:     return ["invalid"]
             case .Date:     return ["invalid"]
-            case .Object:   return ["invalid", ["a"], ["boolCol": "a"], SwiftIntObject()]
-            case .Array:    return ["invalid", [["a"]], [["boolCol" : "a"]], [[SwiftIntObject()]], [[persistedObject]]]
+            case .Object:   return ["invalid", ["a"], ["boolCol": "a"], IntObject()]
+            case .Array:    return ["invalid", [["a"]], [["boolCol" : "a"]], [[IntObject()]], [[persistedObject]]]
             case .Any:      XCTFail("not supported")
         }
         return []

--- a/RealmSwift/Tests/ObjectSchemaTests.swift
+++ b/RealmSwift/Tests/ObjectSchemaTests.swift
@@ -24,7 +24,7 @@ class ObjectSchemaTests: TestCase {
 
     override func setUp() {
         super.setUp()
-        objectSchema = Realm().schema["SwiftObject"]
+        objectSchema = Realm().schema["AllTypesObject"]
     }
 
     func testProperties() {
@@ -34,16 +34,16 @@ class ObjectSchemaTests: TestCase {
 
     // Cannot name testClassName() because it interferes with the method on XCTest
     func testClassNameProperty() {
-        XCTAssertEqual(objectSchema.className, "SwiftObject")
+        XCTAssertEqual(objectSchema.className, "AllTypesObject")
     }
 
     func testPrimaryKeyProperty() {
         XCTAssertNil(objectSchema.primaryKeyProperty)
-        XCTAssertEqual(Realm().schema["SwiftPrimaryStringObject"]!.primaryKeyProperty!.name, "stringCol")
+        XCTAssertEqual(Realm().schema["PrimaryStringObject"]!.primaryKeyProperty!.name, "stringCol")
     }
 
     func testDescription() {
-        XCTAssertEqual(objectSchema.description, "SwiftObject {\n\tboolCol {\n\t\ttype = bool;\n\t\tobjectClassName = (null);\n\t\tindexed = NO;\n\t\tisPrimary = NO;\n\t}\n\tintCol {\n\t\ttype = int;\n\t\tobjectClassName = (null);\n\t\tindexed = NO;\n\t\tisPrimary = NO;\n\t}\n\tfloatCol {\n\t\ttype = float;\n\t\tobjectClassName = (null);\n\t\tindexed = NO;\n\t\tisPrimary = NO;\n\t}\n\tdoubleCol {\n\t\ttype = double;\n\t\tobjectClassName = (null);\n\t\tindexed = NO;\n\t\tisPrimary = NO;\n\t}\n\tstringCol {\n\t\ttype = string;\n\t\tobjectClassName = (null);\n\t\tindexed = NO;\n\t\tisPrimary = NO;\n\t}\n\tbinaryCol {\n\t\ttype = data;\n\t\tobjectClassName = (null);\n\t\tindexed = NO;\n\t\tisPrimary = NO;\n\t}\n\tdateCol {\n\t\ttype = date;\n\t\tobjectClassName = (null);\n\t\tindexed = NO;\n\t\tisPrimary = NO;\n\t}\n\tobjectCol {\n\t\ttype = object;\n\t\tobjectClassName = SwiftBoolObject;\n\t\tindexed = NO;\n\t\tisPrimary = NO;\n\t}\n\tarrayCol {\n\t\ttype = array;\n\t\tobjectClassName = SwiftBoolObject;\n\t\tindexed = NO;\n\t\tisPrimary = NO;\n\t}\n}")
+        XCTAssertEqual(objectSchema.description, "AllTypesObject {\n\tboolCol {\n\t\ttype = bool;\n\t\tobjectClassName = (null);\n\t\tindexed = NO;\n\t\tisPrimary = NO;\n\t}\n\tintCol {\n\t\ttype = int;\n\t\tobjectClassName = (null);\n\t\tindexed = NO;\n\t\tisPrimary = NO;\n\t}\n\tfloatCol {\n\t\ttype = float;\n\t\tobjectClassName = (null);\n\t\tindexed = NO;\n\t\tisPrimary = NO;\n\t}\n\tdoubleCol {\n\t\ttype = double;\n\t\tobjectClassName = (null);\n\t\tindexed = NO;\n\t\tisPrimary = NO;\n\t}\n\tstringCol {\n\t\ttype = string;\n\t\tobjectClassName = (null);\n\t\tindexed = NO;\n\t\tisPrimary = NO;\n\t}\n\tbinaryCol {\n\t\ttype = data;\n\t\tobjectClassName = (null);\n\t\tindexed = NO;\n\t\tisPrimary = NO;\n\t}\n\tdateCol {\n\t\ttype = date;\n\t\tobjectClassName = (null);\n\t\tindexed = NO;\n\t\tisPrimary = NO;\n\t}\n\tobjectCol {\n\t\ttype = object;\n\t\tobjectClassName = BoolObject;\n\t\tindexed = NO;\n\t\tisPrimary = NO;\n\t}\n\tarrayCol {\n\t\ttype = array;\n\t\tobjectClassName = BoolObject;\n\t\tindexed = NO;\n\t\tisPrimary = NO;\n\t}\n}")
     }
 
     func testSubscript() {
@@ -52,7 +52,7 @@ class ObjectSchemaTests: TestCase {
     }
 
     func testEquals() {
-        XCTAssert(objectSchema == Realm().schema["SwiftObject"]!)
-        XCTAssert(objectSchema != Realm().schema["SwiftStringObject"]!)
+        XCTAssert(objectSchema == Realm().schema["AllTypesObject"]!)
+        XCTAssert(objectSchema != Realm().schema["StringObject"]!)
     }
 }

--- a/RealmSwift/Tests/ObjectTests.swift
+++ b/RealmSwift/Tests/ObjectTests.swift
@@ -27,13 +27,13 @@ class ObjectTests: TestCase {
     // init(value:) tests are in ObjectCreationTests.swift
     
     func testRealm() {
-        let standalone = SwiftStringObject()
+        let standalone = StringObject()
         XCTAssertNil(standalone.realm)
 
         let realm = Realm()
-        var persisted: SwiftStringObject!
+        var persisted: StringObject!
         realm.write {
-            persisted = realm.create(SwiftStringObject.self, value: [:])
+            persisted = realm.create(StringObject.self, value: [:])
             XCTAssertNotNil(persisted.realm)
             XCTAssertEqual(realm, persisted.realm!)
         }
@@ -48,16 +48,16 @@ class ObjectTests: TestCase {
     }
 
     func testObjectSchema() {
-        let object = SwiftObject()
+        let object = AllTypesObject()
         let schema = object.objectSchema
         XCTAssert(schema as AnyObject is ObjectSchema)
         XCTAssert(schema.properties as AnyObject is [Property])
-        XCTAssertEqual(schema.className, "SwiftObject")
+        XCTAssertEqual(schema.className, "AllTypesObject")
         XCTAssertEqual(schema.properties.map { $0.name }, ["boolCol", "intCol", "floatCol", "doubleCol", "stringCol", "binaryCol", "dateCol", "objectCol", "arrayCol"])
     }
 
     func testInvalidated() {
-        let object = SwiftObject()
+        let object = AllTypesObject()
         XCTAssertFalse(object.invalidated)
 
         let realm = Realm()
@@ -74,51 +74,51 @@ class ObjectTests: TestCase {
     }
 
     func testDescription() {
-        let object = SwiftObject()
+        let object = AllTypesObject()
         let regex = NSRegularExpression(pattern: "RLMArray <0x[a-z0-9]+>", options: nil, error: nil)
         let rawDescription = object.description
         let description = regex!.stringByReplacingMatchesInString(rawDescription, options: nil, range: NSRange(location: 0, length: countElements(rawDescription)), withTemplate: "RLMArray <0x0>")
-        XCTAssertEqual(description, "SwiftObject {\n\tboolCol = 0;\n\tintCol = 123;\n\tfloatCol = 1.23;\n\tdoubleCol = 12.3;\n\tstringCol = a;\n\tbinaryCol = <61 — 1 total bytes>;\n\tdateCol = 1970-01-01 00:00:01 +0000;\n\tobjectCol = SwiftBoolObject {\n\t\tboolCol = 0;\n\t};\n\tarrayCol = RLMArray <0x0> (\n\t\n\t);\n}")
+        XCTAssertEqual(description, "AllTypesObject {\n\tboolCol = 0;\n\tintCol = 123;\n\tfloatCol = 1.23;\n\tdoubleCol = 12.3;\n\tstringCol = a;\n\tbinaryCol = <61 — 1 total bytes>;\n\tdateCol = 1970-01-01 00:00:01 +0000;\n\tobjectCol = BoolObject {\n\t\tboolCol = 0;\n\t};\n\tarrayCol = RLMArray <0x0> (\n\t\n\t);\n}")
     }
 
     func testPrimaryKey() {
         XCTAssertNil(Object.primaryKey(), "primary key should default to nil")
-        XCTAssertNil(SwiftStringObject.primaryKey())
-        XCTAssertNil(SwiftStringObject().objectSchema.primaryKeyProperty)
-        XCTAssertEqual(SwiftPrimaryStringObject.primaryKey(), "stringCol")
-        XCTAssertEqual(SwiftPrimaryStringObject().objectSchema.primaryKeyProperty!.name, "stringCol")
+        XCTAssertNil(StringObject.primaryKey())
+        XCTAssertNil(StringObject().objectSchema.primaryKeyProperty)
+        XCTAssertEqual(PrimaryStringObject.primaryKey(), "stringCol")
+        XCTAssertEqual(PrimaryStringObject().objectSchema.primaryKeyProperty!.name, "stringCol")
     }
 
     func testIgnoredProperties() {
         XCTAssertEqual(Object.ignoredProperties(), [], "ignored properties should default to []")
-        XCTAssertEqual(SwiftIgnoredPropertiesObject.ignoredProperties().count, 2)
-        XCTAssertNil(SwiftIgnoredPropertiesObject().objectSchema["runtimeProperty"])
+        XCTAssertEqual(IgnoredPropertiesObject.ignoredProperties().count, 2)
+        XCTAssertNil(IgnoredPropertiesObject().objectSchema["runtimeProperty"])
     }
 
     func testIndexedProperties() {
         XCTAssertEqual(Object.indexedProperties(), [], "indexed properties should default to []")
-        XCTAssertEqual(SwiftIndexedPropertiesObject.indexedProperties().count, 1)
-        XCTAssertTrue(SwiftIndexedPropertiesObject().objectSchema["stringCol"]!.indexed)
+        XCTAssertEqual(IndexedPropertiesObject.indexedProperties().count, 1)
+        XCTAssertTrue(IndexedPropertiesObject().objectSchema["stringCol"]!.indexed)
     }
 
     func testLinkingObjects() {
         let realm = Realm()
-        let object = SwiftEmployeeObject()
-        assertThrows(object.linkingObjects(SwiftCompanyObject.self, forProperty: "employees"))
+        let object = EmployeeObject()
+        assertThrows(object.linkingObjects(CompanyObject.self, forProperty: "employees"))
         realm.write {
             realm.add(object)
-            self.assertThrows(object.linkingObjects(SwiftCompanyObject.self, forProperty: "noSuchCol"))
-            XCTAssertEqual(0, object.linkingObjects(SwiftCompanyObject.self, forProperty: "employees").count)
+            self.assertThrows(object.linkingObjects(CompanyObject.self, forProperty: "noSuchCol"))
+            XCTAssertEqual(0, object.linkingObjects(CompanyObject.self, forProperty: "employees").count)
             for _ in 0..<10 {
-                realm.create(SwiftCompanyObject.self, value: [[object]])
+                realm.create(CompanyObject.self, value: [[object]])
             }
-            XCTAssertEqual(10, object.linkingObjects(SwiftCompanyObject.self, forProperty: "employees").count)
+            XCTAssertEqual(10, object.linkingObjects(CompanyObject.self, forProperty: "employees").count)
         }
-        XCTAssertEqual(10, object.linkingObjects(SwiftCompanyObject.self, forProperty: "employees").count)
+        XCTAssertEqual(10, object.linkingObjects(CompanyObject.self, forProperty: "employees").count)
     }
 
     func testValueForKey() {
-        let test: (SwiftObject) -> () = { object in
+        let test: (AllTypesObject) -> () = { object in
             XCTAssertEqual(object.valueForKey("boolCol") as Bool!, false)
             XCTAssertEqual(object.valueForKey("intCol") as Int!, 123)
             XCTAssertEqual(object.valueForKey("floatCol") as Float!, 1.23 as Float)
@@ -126,19 +126,19 @@ class ObjectTests: TestCase {
             XCTAssertEqual(object.valueForKey("stringCol") as String!, "a")
             XCTAssertEqual(object.valueForKey("binaryCol") as NSData, "a".dataUsingEncoding(NSUTF8StringEncoding)! as NSData)
             XCTAssertEqual(object.valueForKey("dateCol") as NSDate!, NSDate(timeIntervalSince1970: 1))
-            XCTAssertEqual((object.valueForKey("objectCol")! as SwiftBoolObject).boolCol, false)
-            XCTAssert(object.valueForKey("arrayCol")! is List<SwiftBoolObject>)
+            XCTAssertEqual((object.valueForKey("objectCol")! as BoolObject).boolCol, false)
+            XCTAssert(object.valueForKey("arrayCol")! is List<BoolObject>)
         }
 
-        test(SwiftObject())
+        test(AllTypesObject())
         Realm().write {
-            let persistedObject = Realm().create(SwiftObject.self, value: [:])
+            let persistedObject = Realm().create(AllTypesObject.self, value: [:])
             test(persistedObject)
         }
     }
 
     func testSetValueForKey() {
-        let test: (SwiftObject) -> () = { object in
+        let test: (AllTypesObject) -> () = { object in
             object.setValue(true, forKey: "boolCol")
             XCTAssertEqual(object.valueForKey("boolCol") as Bool!, true)
 
@@ -160,21 +160,21 @@ class ObjectTests: TestCase {
             object.setValue(NSDate(timeIntervalSince1970: 333), forKey: "dateCol")
             XCTAssertEqual(object.valueForKey("dateCol") as NSDate!, NSDate(timeIntervalSince1970: 333))
 
-            let boolObject = SwiftBoolObject(value: [true])
+            let boolObject = BoolObject(value: [true])
             object.setValue(boolObject, forKey: "objectCol")
-            XCTAssertEqual(object.valueForKey("objectCol") as SwiftBoolObject, boolObject)
-            XCTAssertEqual((object.valueForKey("objectCol")! as SwiftBoolObject).boolCol, true)
+            XCTAssertEqual(object.valueForKey("objectCol") as BoolObject, boolObject)
+            XCTAssertEqual((object.valueForKey("objectCol")! as BoolObject).boolCol, true)
 
-            let list = List<SwiftBoolObject>()
+            let list = List<BoolObject>()
             list.append(boolObject)
             object.setValue(list, forKey: "arrayCol")
-            XCTAssertEqual((object.valueForKey("arrayCol") as List<SwiftBoolObject>).count, 1)
-            XCTAssertEqual((object.valueForKey("arrayCol") as List<SwiftBoolObject>).first!, boolObject)
+            XCTAssertEqual((object.valueForKey("arrayCol") as List<BoolObject>).count, 1)
+            XCTAssertEqual((object.valueForKey("arrayCol") as List<BoolObject>).first!, boolObject)
         }
 
-        test(SwiftObject())
+        test(AllTypesObject())
         Realm().write {
-            let persistedObject = Realm().create(SwiftObject.self, value: [:])
+            let persistedObject = Realm().create(AllTypesObject.self, value: [:])
             test(persistedObject)
         }
     }

--- a/RealmSwift/Tests/PropertyTests.swift
+++ b/RealmSwift/Tests/PropertyTests.swift
@@ -27,9 +27,9 @@ class PropertyTests: TestCase {
     override func setUp() {
         super.setUp()
         let schema = Realm().schema
-        primitiveProperty = schema["SwiftObject"]!["intCol"]!
-        linkProperty = schema["SwiftOptionalObject"]!["optObjectCol"]!
-        primaryProperty = schema["SwiftPrimaryStringObject"]!["stringCol"]!
+        primitiveProperty = schema["AllTypesObject"]!["intCol"]!
+        linkProperty = schema["OptionalObject"]!["optObjectCol"]!
+        primaryProperty = schema["PrimaryStringObject"]!["stringCol"]!
     }
 
     func testName() {
@@ -52,12 +52,12 @@ class PropertyTests: TestCase {
 
     func testObjectClassName() {
         XCTAssertNil(primitiveProperty.objectClassName)
-        XCTAssertEqual(linkProperty.objectClassName!, "SwiftBoolObject")
+        XCTAssertEqual(linkProperty.objectClassName!, "BoolObject")
         XCTAssertNil(primaryProperty.objectClassName)
     }
 
     func testEquals() {
-        XCTAssert(primitiveProperty == Realm().schema["SwiftObject"]!["intCol"]!)
+        XCTAssert(primitiveProperty == Realm().schema["AllTypesObject"]!["intCol"]!)
         XCTAssert(primitiveProperty != linkProperty)
     }
 }

--- a/RealmSwift/Tests/RealmTests.swift
+++ b/RealmSwift/Tests/RealmTests.swift
@@ -24,15 +24,15 @@ class RealmTests: TestCase {
     override func setUp() {
         super.setUp()
         realmWithTestPath().write {
-            self.realmWithTestPath().create(SwiftStringObject.self, value: ["1"])
-            self.realmWithTestPath().create(SwiftStringObject.self, value: ["2"])
-            self.realmWithTestPath().create(SwiftStringObject.self, value: ["3"])
+            self.realmWithTestPath().create(StringObject.self, value: ["1"])
+            self.realmWithTestPath().create(StringObject.self, value: ["2"])
+            self.realmWithTestPath().create(StringObject.self, value: ["3"])
         }
 
         Realm().write {
-            Realm().create(SwiftIntObject.self, value: [100])
-            Realm().create(SwiftIntObject.self, value: [200])
-            Realm().create(SwiftIntObject.self, value: [300])
+            Realm().create(IntObject.self, value: [100])
+            Realm().create(IntObject.self, value: [200])
+            Realm().create(IntObject.self, value: [300])
         }
     }
 
@@ -47,7 +47,7 @@ class RealmTests: TestCase {
         }
         let readOnlyRealm = Realm(path: Realm.defaultPath, readOnly: true, error: nil)!
         XCTAssertEqual(true, readOnlyRealm.readOnly)
-        XCTAssertEqual(3, readOnlyRealm.objects(SwiftIntObject).count)
+        XCTAssertEqual(3, readOnlyRealm.objects(IntObject).count)
 
         assertThrows(Realm(), "Realm has different readOnly settings")
     }
@@ -55,7 +55,7 @@ class RealmTests: TestCase {
     func testSchema() {
         let schema = Realm().schema
         XCTAssert(schema as AnyObject is Schema)
-        XCTAssertEqual(1, schema.objectSchema.filter({ $0.className == "SwiftStringObject" }).count)
+        XCTAssertEqual(1, schema.objectSchema.filter({ $0.className == "StringObject" }).count)
     }
 
     func testDefaultPath() {
@@ -97,33 +97,33 @@ class RealmTests: TestCase {
         autoreleasepool {
             var realm = Realm(inMemoryIdentifier: "identifier")
             realm.write {
-                realm.create(SwiftIntObject.self, value: [1])
+                realm.create(IntObject.self, value: [1])
                 return
             }
         }
         var realm = Realm(inMemoryIdentifier: "identifier")
-        XCTAssertEqual(realm.objects(SwiftIntObject).count, 0)
+        XCTAssertEqual(realm.objects(IntObject).count, 0)
 
         realm.write {
-            realm.create(SwiftIntObject.self, value: [1])
-            XCTAssertEqual(realm.objects(SwiftIntObject).count, 1)
+            realm.create(IntObject.self, value: [1])
+            XCTAssertEqual(realm.objects(IntObject).count, 1)
 
-            Realm(inMemoryIdentifier: "identifier").create(SwiftIntObject.self, value: [1])
-            XCTAssertEqual(realm.objects(SwiftIntObject).count, 2)
+            Realm(inMemoryIdentifier: "identifier").create(IntObject.self, value: [1])
+            XCTAssertEqual(realm.objects(IntObject).count, 2)
         }
 
         var realm2 = Realm(inMemoryIdentifier: "identifier2")
-        XCTAssertEqual(realm2.objects(SwiftIntObject).count, 0)
+        XCTAssertEqual(realm2.objects(IntObject).count, 0)
     }
 
     func testWrite() {
         Realm().write {
             self.assertThrows(Realm().beginWrite())
             self.assertThrows(Realm().write { })
-            Realm().create(SwiftStringObject.self, value:["1"])
-            XCTAssertEqual(Realm().objects(SwiftStringObject).count, 1)
+            Realm().create(StringObject.self, value:["1"])
+            XCTAssertEqual(Realm().objects(StringObject).count, 1)
         }
-        XCTAssertEqual(Realm().objects(SwiftStringObject).count, 1)
+        XCTAssertEqual(Realm().objects(StringObject).count, 1)
     }
 
     func testBeginWrite() {
@@ -131,48 +131,48 @@ class RealmTests: TestCase {
         assertThrows(Realm().beginWrite())
         Realm().cancelWrite()
         Realm().beginWrite()
-        Realm().create(SwiftStringObject.self, value:["1"])
-        XCTAssertEqual(Realm().objects(SwiftStringObject).count, 1)
+        Realm().create(StringObject.self, value:["1"])
+        XCTAssertEqual(Realm().objects(StringObject).count, 1)
     }
 
     func testCommitWrite() {
         Realm().beginWrite()
-        Realm().create(SwiftStringObject.self, value:["1"])
+        Realm().create(StringObject.self, value:["1"])
         Realm().commitWrite()
-        XCTAssertEqual(Realm().objects(SwiftStringObject).count, 1)
+        XCTAssertEqual(Realm().objects(StringObject).count, 1)
         Realm().beginWrite()
     }
 
     func testCancelWrite() {
         assertThrows(Realm().cancelWrite())
         Realm().beginWrite()
-        Realm().create(SwiftStringObject.self, value:["1"])
+        Realm().create(StringObject.self, value:["1"])
         Realm().cancelWrite()
-        XCTAssertEqual(Realm().objects(SwiftStringObject).count, 0)
+        XCTAssertEqual(Realm().objects(StringObject).count, 0)
 
         Realm().write {
             self.assertThrows(self.realmWithTestPath().cancelWrite())
-            let object = Realm().create(SwiftStringObject)
+            let object = Realm().create(StringObject)
             Realm().cancelWrite()
             XCTAssertTrue(object.invalidated)
-            XCTAssertEqual(Realm().objects(SwiftStringObject).count, 0)
+            XCTAssertEqual(Realm().objects(StringObject).count, 0)
         }
-        XCTAssertEqual(Realm().objects(SwiftStringObject).count, 0)
+        XCTAssertEqual(Realm().objects(StringObject).count, 0)
     }
 
     func testAddSingleObject() {
         let realm = Realm()
-        assertThrows(realm.add(SwiftObject()))
-        XCTAssertEqual(0, realm.objects(SwiftObject).count)
-        var defaultRealmObject: SwiftObject!
+        assertThrows(realm.add(AllTypesObject()))
+        XCTAssertEqual(0, realm.objects(AllTypesObject).count)
+        var defaultRealmObject: AllTypesObject!
         realm.write {
-            defaultRealmObject = SwiftObject()
+            defaultRealmObject = AllTypesObject()
             realm.add(defaultRealmObject)
-            XCTAssertEqual(1, realm.objects(SwiftObject).count)
+            XCTAssertEqual(1, realm.objects(AllTypesObject).count)
             realm.add(defaultRealmObject)
-            XCTAssertEqual(1, realm.objects(SwiftObject).count)
+            XCTAssertEqual(1, realm.objects(AllTypesObject).count)
         }
-        XCTAssertEqual(1, realm.objects(SwiftObject).count)
+        XCTAssertEqual(1, realm.objects(AllTypesObject).count)
 
         let testRealm = realmWithTestPath()
         testRealm.write {
@@ -182,16 +182,16 @@ class RealmTests: TestCase {
 
     func testAddWithUpdateSingleObject() {
         let realm = Realm()
-        XCTAssertEqual(0, realm.objects(SwiftPrimaryStringObject).count)
-        var defaultRealmObject: SwiftPrimaryStringObject!
+        XCTAssertEqual(0, realm.objects(PrimaryStringObject).count)
+        var defaultRealmObject: PrimaryStringObject!
         realm.write {
-            defaultRealmObject = SwiftPrimaryStringObject()
+            defaultRealmObject = PrimaryStringObject()
             realm.add(defaultRealmObject, update: true)
-            XCTAssertEqual(1, realm.objects(SwiftPrimaryStringObject).count)
-            realm.add(SwiftPrimaryStringObject(), update: true)
-            XCTAssertEqual(1, realm.objects(SwiftPrimaryStringObject).count)
+            XCTAssertEqual(1, realm.objects(PrimaryStringObject).count)
+            realm.add(PrimaryStringObject(), update: true)
+            XCTAssertEqual(1, realm.objects(PrimaryStringObject).count)
         }
-        XCTAssertEqual(1, realm.objects(SwiftPrimaryStringObject).count)
+        XCTAssertEqual(1, realm.objects(PrimaryStringObject).count)
 
         let testRealm = realmWithTestPath()
         testRealm.write {
@@ -201,34 +201,34 @@ class RealmTests: TestCase {
 
     func testAddMultipleObjects() {
         let realm = Realm()
-        assertThrows(realm.add([SwiftObject(), SwiftObject()]))
-        XCTAssertEqual(0, realm.objects(SwiftObject).count)
+        assertThrows(realm.add([AllTypesObject(), AllTypesObject()]))
+        XCTAssertEqual(0, realm.objects(AllTypesObject).count)
         realm.write {
-            let objs = [SwiftObject(), SwiftObject()]
+            let objs = [AllTypesObject(), AllTypesObject()]
             realm.add(objs)
-            XCTAssertEqual(2, realm.objects(SwiftObject).count)
+            XCTAssertEqual(2, realm.objects(AllTypesObject).count)
         }
-        XCTAssertEqual(2, realm.objects(SwiftObject).count)
+        XCTAssertEqual(2, realm.objects(AllTypesObject).count)
 
         let testRealm = realmWithTestPath()
         testRealm.write {
-            self.assertThrows(testRealm.add(realm.objects(SwiftObject)))
+            self.assertThrows(testRealm.add(realm.objects(AllTypesObject)))
         }
     }
 
     func testAddWithUpdateMultipleObjects() {
         let realm = Realm()
-        XCTAssertEqual(0, realm.objects(SwiftPrimaryStringObject).count)
+        XCTAssertEqual(0, realm.objects(PrimaryStringObject).count)
         realm.write {
-            let objs = [SwiftPrimaryStringObject(), SwiftPrimaryStringObject()]
+            let objs = [PrimaryStringObject(), PrimaryStringObject()]
             realm.add(objs, update: true)
-            XCTAssertEqual(1, realm.objects(SwiftPrimaryStringObject).count)
+            XCTAssertEqual(1, realm.objects(PrimaryStringObject).count)
         }
-        XCTAssertEqual(1, realm.objects(SwiftPrimaryStringObject).count)
+        XCTAssertEqual(1, realm.objects(PrimaryStringObject).count)
 
         let testRealm = realmWithTestPath()
         testRealm.write {
-            self.assertThrows(testRealm.add(realm.objects(SwiftPrimaryStringObject), update: true))
+            self.assertThrows(testRealm.add(realm.objects(PrimaryStringObject), update: true))
         }
     }
 
@@ -236,20 +236,20 @@ class RealmTests: TestCase {
 
     func testDeleteSingleObject() {
         let realm = Realm()
-        XCTAssertEqual(0, realm.objects(SwiftObject).count)
-        assertThrows(realm.delete(SwiftObject()))
-        var defaultRealmObject: SwiftObject!
+        XCTAssertEqual(0, realm.objects(AllTypesObject).count)
+        assertThrows(realm.delete(AllTypesObject()))
+        var defaultRealmObject: AllTypesObject!
         realm.write {
-            defaultRealmObject = SwiftObject()
+            defaultRealmObject = AllTypesObject()
             self.assertThrows(realm.delete(defaultRealmObject))
-            XCTAssertEqual(0, realm.objects(SwiftObject).count)
+            XCTAssertEqual(0, realm.objects(AllTypesObject).count)
             realm.add(defaultRealmObject)
-            XCTAssertEqual(1, realm.objects(SwiftObject).count)
+            XCTAssertEqual(1, realm.objects(AllTypesObject).count)
             realm.delete(defaultRealmObject)
-            XCTAssertEqual(0, realm.objects(SwiftObject).count)
+            XCTAssertEqual(0, realm.objects(AllTypesObject).count)
         }
         assertThrows(realm.delete(defaultRealmObject))
-        XCTAssertEqual(0, realm.objects(SwiftObject).count)
+        XCTAssertEqual(0, realm.objects(AllTypesObject).count)
 
         let testRealm = realmWithTestPath()
         assertThrows(testRealm.delete(defaultRealmObject))
@@ -260,16 +260,16 @@ class RealmTests: TestCase {
 
     func testDeleteSequenceOfObjects() {
         let realm = Realm()
-        XCTAssertEqual(0, realm.objects(SwiftObject).count)
-        var objs: [SwiftObject]!
+        XCTAssertEqual(0, realm.objects(AllTypesObject).count)
+        var objs: [AllTypesObject]!
         realm.write {
-            objs = [SwiftObject(), SwiftObject()]
+            objs = [AllTypesObject(), AllTypesObject()]
             realm.add(objs)
-            XCTAssertEqual(2, realm.objects(SwiftObject).count)
+            XCTAssertEqual(2, realm.objects(AllTypesObject).count)
             realm.delete(objs)
-            XCTAssertEqual(0, realm.objects(SwiftObject).count)
+            XCTAssertEqual(0, realm.objects(AllTypesObject).count)
         }
-        XCTAssertEqual(0, realm.objects(SwiftObject).count)
+        XCTAssertEqual(0, realm.objects(AllTypesObject).count)
 
         let testRealm = realmWithTestPath()
         assertThrows(testRealm.delete(objs))
@@ -280,60 +280,60 @@ class RealmTests: TestCase {
 
     func testDeleteListOfObjects() {
         let realm = Realm()
-        XCTAssertEqual(0, realm.objects(SwiftCompanyObject).count)
+        XCTAssertEqual(0, realm.objects(CompanyObject).count)
         realm.write {
-            let obj = SwiftCompanyObject()
-            obj.employees.append(SwiftEmployeeObject())
+            let obj = CompanyObject()
+            obj.employees.append(EmployeeObject())
             realm.add(obj)
-            XCTAssertEqual(1, realm.objects(SwiftEmployeeObject).count)
+            XCTAssertEqual(1, realm.objects(EmployeeObject).count)
             realm.delete(obj.employees)
             XCTAssertEqual(0, obj.employees.count)
-            XCTAssertEqual(0, realm.objects(SwiftEmployeeObject).count)
+            XCTAssertEqual(0, realm.objects(EmployeeObject).count)
         }
-        XCTAssertEqual(0, realm.objects(SwiftEmployeeObject).count)
+        XCTAssertEqual(0, realm.objects(EmployeeObject).count)
     }
 
     func testDeleteResults() {
         let realm = Realm(path: testRealmPath())
-        XCTAssertEqual(0, realm.objects(SwiftCompanyObject).count)
+        XCTAssertEqual(0, realm.objects(CompanyObject).count)
         realm.write {
-            realm.add(SwiftIntObject(value: [1]))
-            realm.add(SwiftIntObject(value: [1]))
-            realm.add(SwiftIntObject(value: [2]))
-            XCTAssertEqual(3, realm.objects(SwiftIntObject).count)
-            realm.delete(realm.objects(SwiftIntObject).filter("intCol = 1"))
-            XCTAssertEqual(1, realm.objects(SwiftIntObject).count)
+            realm.add(IntObject(value: [1]))
+            realm.add(IntObject(value: [1]))
+            realm.add(IntObject(value: [2]))
+            XCTAssertEqual(3, realm.objects(IntObject).count)
+            realm.delete(realm.objects(IntObject).filter("intCol = 1"))
+            XCTAssertEqual(1, realm.objects(IntObject).count)
         }
-        XCTAssertEqual(1, realm.objects(SwiftIntObject).count)
+        XCTAssertEqual(1, realm.objects(IntObject).count)
     }
 
     func testDeleteAll() {
         let realm = Realm()
         realm.write {
-            realm.add(SwiftObject())
-            XCTAssertEqual(1, realm.objects(SwiftObject).count)
+            realm.add(AllTypesObject())
+            XCTAssertEqual(1, realm.objects(AllTypesObject).count)
             realm.deleteAll()
-            XCTAssertEqual(0, realm.objects(SwiftObject).count)
+            XCTAssertEqual(0, realm.objects(AllTypesObject).count)
         }
-        XCTAssertEqual(0, realm.objects(SwiftObject).count)
+        XCTAssertEqual(0, realm.objects(AllTypesObject).count)
     }
 
     func testObjects() {
-        XCTAssertEqual(0, Realm().objects(SwiftStringObject).count)
-        XCTAssertEqual(3, Realm().objects(SwiftIntObject).count)
-        XCTAssertEqual(3, Realm().objects(SwiftIntObject.self).count)
+        XCTAssertEqual(0, Realm().objects(StringObject).count)
+        XCTAssertEqual(3, Realm().objects(IntObject).count)
+        XCTAssertEqual(3, Realm().objects(IntObject.self).count)
         assertThrows(Realm().objects(Object))
     }
 
     func testObjectForPrimaryKey() {
         let realm = Realm()
         realm.write {
-            realm.create(SwiftPrimaryStringObject.self, value: ["a", 1])
-            realm.create(SwiftPrimaryStringObject.self, value: ["b", 2])
+            realm.create(PrimaryStringObject.self, value: ["a", 1])
+            realm.create(PrimaryStringObject.self, value: ["b", 2])
         }
 
-        XCTAssertNotNil(realm.objectForPrimaryKey(SwiftPrimaryStringObject.self, key: "a"))
-        XCTAssertNil(realm.objectForPrimaryKey(SwiftPrimaryStringObject.self, key: "z"))
+        XCTAssertNotNil(realm.objectForPrimaryKey(PrimaryStringObject.self, key: "a"))
+        XCTAssertNil(realm.objectForPrimaryKey(PrimaryStringObject.self, key: "z"))
     }
 
     func testAddNotificationBlock() {
@@ -377,7 +377,7 @@ class RealmTests: TestCase {
 
         dispatch_async(dispatch_queue_create("background", nil)) {
             Realm().write {
-                Realm().create(SwiftStringObject.self, value: ["string"])
+                Realm().create(StringObject.self, value: ["string"])
                 return
             }
         }
@@ -385,7 +385,7 @@ class RealmTests: TestCase {
         Realm().removeNotification(token)
 
         // get object
-        let results = Realm().objects(SwiftStringObject.self)
+        let results = Realm().objects(StringObject.self)
         XCTAssertEqual(results.count, Int(1), "There should be 1 object of type StringObject")
         XCTAssertEqual(results[0].stringCol, "string", "Value of first column should be 'string'")
     }
@@ -402,12 +402,12 @@ class RealmTests: TestCase {
             notificationFired.fulfill()
         }
 
-        let results = realm.objects(SwiftStringObject.self)
+        let results = realm.objects(StringObject.self)
         XCTAssertEqual(results.count, Int(0), "There should be 1 object of type StringObject")
 
         dispatch_async(dispatch_queue_create("background", nil)) {
             Realm().write {
-                Realm().create(SwiftStringObject.self, value: ["string"])
+                Realm().create(StringObject.self, value: ["string"])
                 return
             }
         }
@@ -425,7 +425,7 @@ class RealmTests: TestCase {
 
     func testInvalidate() {
         let realm = Realm()
-        let object = SwiftObject()
+        let object = AllTypesObject()
         realm.write {
             realm.add(object)
             return
@@ -434,23 +434,23 @@ class RealmTests: TestCase {
         XCTAssertEqual(object.invalidated, true)
 
         realm.write {
-            realm.add(SwiftObject())
+            realm.add(AllTypesObject())
             return
         }
-        XCTAssertEqual(realm.objects(SwiftObject).count, 2)
+        XCTAssertEqual(realm.objects(AllTypesObject).count, 2)
         XCTAssertEqual(object.invalidated, true)
     }
 
     func testWriteCopyToPath() {
         let realm = Realm()
         realm.write {
-            realm.add(SwiftObject())
+            realm.add(AllTypesObject())
         }
         let path = Realm.defaultPath.stringByDeletingLastPathComponent.stringByAppendingPathComponent("copy.realm")
         XCTAssertNil(realm.writeCopyToPath(path))
         autoreleasepool {
             let copy = Realm(path: path)
-            XCTAssertEqual(1, copy.objects(SwiftObject.self).count)
+            XCTAssertEqual(1, copy.objects(AllTypesObject.self).count)
         }
         NSFileManager.defaultManager().removeItemAtPath(path, error: nil)
     }

--- a/RealmSwift/Tests/ResultsTests.swift
+++ b/RealmSwift/Tests/ResultsTests.swift
@@ -19,39 +19,39 @@
 import XCTest
 import RealmSwift
 
-class SwiftAggregateObjectList: Object {
-    let list = List<SwiftAggregateObject>()
+class AggregateObjectList: Object {
+    let list = List<AggregateObject>()
 }
 
 class ResultsTests: TestCase {
-    var str1: SwiftStringObject!
-    var str2: SwiftStringObject!
-    var results: Results<SwiftStringObject>!
+    var str1: StringObject!
+    var str2: StringObject!
+    var results: Results<StringObject>!
 
-    func getResults() -> Results<SwiftStringObject> {
+    func getResults() -> Results<StringObject> {
         fatalError("abstract")
     }
 
-    func getAggregateableResults() -> Results<SwiftAggregateObject> {
+    func getAggregateableResults() -> Results<AggregateObject> {
         fatalError("abstract")
     }
 
-    func makeAggregateableObjects() -> [SwiftAggregateObject] {
-        let obj1 = SwiftAggregateObject()
+    func makeAggregateableObjects() -> [AggregateObject] {
+        let obj1 = AggregateObject()
         obj1.intCol = 1
         obj1.floatCol = 1.1
         obj1.doubleCol = 1.11
         obj1.dateCol = NSDate(timeIntervalSince1970: 1)
         obj1.boolCol = false
 
-        let obj2 = SwiftAggregateObject()
+        let obj2 = AggregateObject()
         obj2.intCol = 2
         obj2.floatCol = 2.2
         obj2.doubleCol = 2.22
         obj2.dateCol = NSDate(timeIntervalSince1970: 2)
         obj2.boolCol = false
 
-        let obj3 = SwiftAggregateObject()
+        let obj3 = AggregateObject()
         obj3.intCol = 3
         obj3.floatCol = 2.2
         obj3.doubleCol = 2.22
@@ -65,9 +65,9 @@ class ResultsTests: TestCase {
     override func setUp() {
         super.setUp()
 
-        str1 = SwiftStringObject()
+        str1 = StringObject()
         str1.stringCol = "1"
-        str2 = SwiftStringObject()
+        str2 = StringObject()
         str2.stringCol = "2"
 
         let realm = realmWithTestPath()
@@ -104,7 +104,7 @@ class ResultsTests: TestCase {
         let regex = NSRegularExpression(pattern: "RLMResults <0x[a-z0-9]+>", options: nil, error: nil)
         let rawDescription = results.description
         let description = regex!.stringByReplacingMatchesInString(rawDescription, options: nil, range: NSRange(location: 0, length: countElements(rawDescription)), withTemplate: "RLMResults <0x0>")
-        XCTAssertEqual(description, "RLMResults <0x0> (\n\t[0] SwiftStringObject {\n\t\tstringCol = 1;\n\t},\n\t[1] SwiftStringObject {\n\t\tstringCol = 2;\n\t}\n)")
+        XCTAssertEqual(description, "RLMResults <0x0> (\n\t[0] StringObject {\n\t\tstringCol = 1;\n\t},\n\t[1] StringObject {\n\t\tstringCol = 2;\n\t}\n)")
     }
 
     func testCount() {
@@ -255,35 +255,35 @@ class ResultsTests: TestCase {
 }
 
 class ResultsFromTableTests: ResultsTests {
-    override func getResults() -> Results<SwiftStringObject> {
-        return realmWithTestPath().objects(SwiftStringObject.self)
+    override func getResults() -> Results<StringObject> {
+        return realmWithTestPath().objects(StringObject.self)
     }
 
-    override func getAggregateableResults() -> Results<SwiftAggregateObject> {
+    override func getAggregateableResults() -> Results<AggregateObject> {
         makeAggregateableObjects()
-        return realmWithTestPath().objects(SwiftAggregateObject.self)
+        return realmWithTestPath().objects(AggregateObject.self)
     }
 }
 
 class ResultsFromTableViewTests: ResultsTests {
-    override func getResults() -> Results<SwiftStringObject> {
-        return realmWithTestPath().objects(SwiftStringObject.self).filter("stringCol != ''")
+    override func getResults() -> Results<StringObject> {
+        return realmWithTestPath().objects(StringObject.self).filter("stringCol != ''")
     }
 
-    override func getAggregateableResults() -> Results<SwiftAggregateObject> {
+    override func getAggregateableResults() -> Results<AggregateObject> {
         makeAggregateableObjects()
-        return realmWithTestPath().objects(SwiftAggregateObject.self).filter("trueCol == true")
+        return realmWithTestPath().objects(AggregateObject.self).filter("trueCol == true")
     }
 }
 
 class ResultsFromLinkViewTests: ResultsTests {
-    override func getResults() -> Results<SwiftStringObject> {
-        let array = realmWithTestPath().create(SwiftArrayPropertyObject.self, value: ["", [str1, str2], []])
+    override func getResults() -> Results<StringObject> {
+        let array = realmWithTestPath().create(ArrayPropertyObject.self, value: ["", [str1, str2], []])
         return array.array.filter("stringCol != ''") // i.e. all of them
     }
 
-    override func getAggregateableResults() -> Results<SwiftAggregateObject> {
-        let list = SwiftAggregateObjectList()
+    override func getAggregateableResults() -> Results<AggregateObject> {
+        let list = AggregateObjectList()
         realmWithTestPath().add(list)
         list.list.extend(makeAggregateableObjects())
         return list.list.filter("intCol != 0") // i.e. all of them

--- a/RealmSwift/Tests/SchemaTests.swift
+++ b/RealmSwift/Tests/SchemaTests.swift
@@ -37,7 +37,7 @@ class SchemaTests: TestCase {
     }
 
     func testSubscript() {
-        XCTAssertEqual(schema["SwiftObject"]!.className, "SwiftObject")
+        XCTAssertEqual(schema["AllTypesObject"]!.className, "AllTypesObject")
         XCTAssertNil(schema["NoSuchClass"])
     }
 

--- a/RealmSwift/Tests/TestObjects.swift
+++ b/RealmSwift/Tests/TestObjects.swift
@@ -19,19 +19,19 @@
 import Foundation
 import RealmSwift
 
-class SwiftStringObject: Object {
+class StringObject: Object {
     dynamic var stringCol = ""
 }
 
-class SwiftBoolObject: Object {
+class BoolObject: Object {
     dynamic var boolCol = false
 }
 
-class SwiftIntObject: Object {
+class IntObject: Object {
     dynamic var intCol = 0
 }
 
-class SwiftObject: Object {
+class AllTypesObject: Object {
     dynamic var boolCol = false
     dynamic var intCol = 123
     dynamic var floatCol = 1.23 as Float
@@ -39,8 +39,8 @@ class SwiftObject: Object {
     dynamic var stringCol = "a"
     dynamic var binaryCol = "a".dataUsingEncoding(NSUTF8StringEncoding)!
     dynamic var dateCol = NSDate(timeIntervalSince1970: 1)
-    dynamic var objectCol = SwiftBoolObject()
-    let arrayCol = List<SwiftBoolObject>()
+    dynamic var objectCol = BoolObject()
+    let arrayCol = List<BoolObject>()
 
     class func defaultValues() -> [String: AnyObject] {
         return  ["boolCol": false as AnyObject,
@@ -55,7 +55,7 @@ class SwiftObject: Object {
     }
 }
 
-class SwiftOptionalObject: Object {
+class OptionalObject: Object {
     // FIXME: Support all optional property types
 //    dynamic var optBoolCol: Bool?
 //    dynamic var optIntCol: Int?
@@ -64,20 +64,20 @@ class SwiftOptionalObject: Object {
 //    dynamic var optStringCol: String?
 //    dynamic var optBinaryCol: NSData?
 //    dynamic var optDateCol: NSDate?
-    dynamic var optObjectCol: SwiftBoolObject?
-//    let arrayCol = List<SwiftBoolObject>()
+    dynamic var optObjectCol: BoolObject?
+//    let arrayCol = List<BoolObject>()
 }
 
-class SwiftDogObject: Object {
+class DogObject: Object {
     dynamic var dogName = ""
 }
 
-class SwiftOwnerObject: Object {
+class OwnerObject: Object {
     dynamic var name = ""
-    dynamic var dog = SwiftDogObject()
+    dynamic var dog = DogObject()
 }
 
-class SwiftAggregateObject: Object {
+class AggregateObject: Object {
     dynamic var intCol = 0
     dynamic var floatCol = 0 as Float
     dynamic var doubleCol = 0.0
@@ -86,37 +86,37 @@ class SwiftAggregateObject: Object {
     dynamic var trueCol = true
 }
 
-class SwiftAllIntSizesObject: Object {
+class AllIntSizesObject: Object {
     dynamic var int16 : Int16 = 0
     dynamic var int32 : Int32 = 0
     dynamic var int64 : Int64 = 0
 }
 
-class SwiftEmployeeObject: Object {
+class EmployeeObject: Object {
     dynamic var name = ""
     dynamic var age = 0
     dynamic var hired = false
 }
 
-class SwiftCompanyObject: Object {
-    let employees = List<SwiftEmployeeObject>()
+class CompanyObject: Object {
+    let employees = List<EmployeeObject>()
 }
 
-class SwiftArrayPropertyObject: Object {
+class ArrayPropertyObject: Object {
     dynamic var name = ""
-    let array = List<SwiftStringObject>()
-    let intArray = List<SwiftIntObject>()
+    let array = List<StringObject>()
+    let intArray = List<IntObject>()
 }
 
-class SwiftArrayPropertySubclassObject: SwiftArrayPropertyObject {
-    let boolArray = List<SwiftBoolObject>()
+class ArrayPropertySubclassObject: ArrayPropertyObject {
+    let boolArray = List<BoolObject>()
 }
 
-class SwiftUTF8Object: Object {
+class UTF8Object: Object {
     dynamic var 柱колоéнǢкƱаم👍 = "值значен™👍☞⎠‱௹♣︎☐▼❒∑⨌⧭иеمرحبا"
 }
 
-class SwiftIgnoredPropertiesObject: Object {
+class IgnoredPropertiesObject: Object {
     dynamic var name = ""
     dynamic var age = 0
     dynamic var runtimeProperty: AnyObject?
@@ -128,17 +128,17 @@ class SwiftIgnoredPropertiesObject: Object {
     }
 }
 
-class SwiftLinkToPrimaryStringObject: Object {
+class LinkToPrimaryStringObject: Object {
     dynamic var pk = ""
-    dynamic var object: SwiftPrimaryStringObject?
-    let objects = List<SwiftPrimaryStringObject>()
+    dynamic var object: PrimaryStringObject?
+    let objects = List<PrimaryStringObject>()
 
     override class func primaryKey() -> String? {
         return "pk"
     }
 }
 
-class SwiftPrimaryStringObject: Object {
+class PrimaryStringObject: Object {
     dynamic var stringCol = ""
     dynamic var intCol = 0
 
@@ -147,7 +147,7 @@ class SwiftPrimaryStringObject: Object {
     }
 }
 
-class SwiftIndexedPropertiesObject: Object {
+class IndexedPropertiesObject: Object {
     dynamic var stringCol = ""
     dynamic var intCol = 0
 

--- a/RealmSwift/Tests/UnicodeTests.swift
+++ b/RealmSwift/Tests/UnicodeTests.swift
@@ -21,37 +21,37 @@ import RealmSwift
 
 let utf8TestString = "值значен™👍☞⎠‱௹♣︎☐▼❒∑⨌⧭иеمرحبا"
 
-class SwiftUnicodeTests: TestCase {
+class UnicodeTests: TestCase {
     func testUTF8StringContents() {
         let realm = realmWithTestPath()
 
         realm.write {
-            realm.create(SwiftStringObject.self, value: [utf8TestString])
+            realm.create(StringObject.self, value: [utf8TestString])
             return
         }
 
-        let obj1 = realm.objects(SwiftStringObject.self).first!
+        let obj1 = realm.objects(StringObject.self).first!
         XCTAssertEqual(obj1.stringCol, utf8TestString)
 
-        let obj2 = realm.objects(SwiftStringObject.self).filter("stringCol == %@", utf8TestString).first!
+        let obj2 = realm.objects(StringObject.self).filter("stringCol == %@", utf8TestString).first!
         XCTAssertEqual(obj1, obj2)
         XCTAssertEqual(obj2.stringCol, utf8TestString)
 
-        XCTAssertEqual(Int(0), realm.objects(SwiftStringObject.self).filter("stringCol != %@", utf8TestString).count)
+        XCTAssertEqual(Int(0), realm.objects(StringObject.self).filter("stringCol != %@", utf8TestString).count)
     }
 
     func testUTF8PropertyWithUTF8StringContents() {
         let realm = realmWithTestPath()
         realm.write {
-            realm.create(SwiftUTF8Object.self, value: [utf8TestString])
+            realm.create(UTF8Object.self, value: [utf8TestString])
             return
         }
 
-        let obj1 = realm.objects(SwiftUTF8Object.self).first!
+        let obj1 = realm.objects(UTF8Object.self).first!
         XCTAssertEqual(obj1.柱колоéнǢкƱаم👍, utf8TestString, "Storing and retrieving a string with UTF8 content should work")
 
         // Test fails because of rdar://17735684
-        let obj2 = realm.objects(SwiftUTF8Object.self).filter("%K == %@", "柱колоéнǢкƱаم👍", utf8TestString).first!
+        let obj2 = realm.objects(UTF8Object.self).filter("%K == %@", "柱колоéнǢкƱаم👍", utf8TestString).first!
         XCTAssertEqual(obj1, obj2, "Querying a realm searching for a string with UTF8 content should work")
     }
 }


### PR DESCRIPTION
Might happen to prevent the transient test failures due to not having multiple files named the same thing in different places, and makes the tests read better by eliminating some noise.