### PR TITLE
Fix cannot retrieve keychain item in release build.

### DIFF
--- a/examples/ios/swift-next/Encryption/ViewController.swift
+++ b/examples/ios/swift-next/Encryption/ViewController.swift
@@ -102,6 +102,8 @@ class ViewController: UIViewController {
             kSecReturnData: true
         ]
 
+        // To avoid Swift optimization bug, should use withUnsafeMutablePointer() function to retrieve the keychain item
+        // See also: http://stackoverflow.com/questions/24145838/querying-ios-keychain-using-swift/27721328#27721328
         var dataTypeRef: AnyObject?
         var status = withUnsafeMutablePointer(&dataTypeRef) { SecItemCopyMatching(query, UnsafeMutablePointer($0)) }
         if status == errSecSuccess {

--- a/examples/ios/swift-next/Encryption/ViewController.swift
+++ b/examples/ios/swift-next/Encryption/ViewController.swift
@@ -102,10 +102,10 @@ class ViewController: UIViewController {
             kSecReturnData: true
         ]
 
-        var dataTypeRef: Unmanaged<AnyObject>?
-        var status = SecItemCopyMatching(query, &dataTypeRef)
+        var dataTypeRef: AnyObject?
+        var status = withUnsafeMutablePointer(&dataTypeRef) { SecItemCopyMatching(query, UnsafeMutablePointer($0)) }
         if status == errSecSuccess {
-            return dataTypeRef?.takeUnretainedValue() as NSData
+            return dataTypeRef as NSData
         }
 
         // No pre-existing key from this application, so generate a new one

--- a/examples/ios/swift/Encryption/ViewController.swift
+++ b/examples/ios/swift/Encryption/ViewController.swift
@@ -98,10 +98,10 @@ class ViewController: UIViewController {
             kSecReturnData: true
         ]
 
-        var dataTypeRef: Unmanaged<AnyObject>?
-        var status = SecItemCopyMatching(query, &dataTypeRef)
+        var dataTypeRef: AnyObject?
+        var status = withUnsafeMutablePointer(&dataTypeRef) { SecItemCopyMatching(query, UnsafeMutablePointer($0)) }
         if status == errSecSuccess {
-            return dataTypeRef?.takeUnretainedValue() as NSData
+            return dataTypeRef as NSData
         }
 
         // No pre-existing key from this application, so generate a new one

--- a/examples/ios/swift/Encryption/ViewController.swift
+++ b/examples/ios/swift/Encryption/ViewController.swift
@@ -98,6 +98,8 @@ class ViewController: UIViewController {
             kSecReturnData: true
         ]
 
+        // To avoid Swift optimization bug, should use withUnsafeMutablePointer() function to retrieve the keychain item
+        // See also: http://stackoverflow.com/questions/24145838/querying-ios-keychain-using-swift/27721328#27721328
         var dataTypeRef: AnyObject?
         var status = withUnsafeMutablePointer(&dataTypeRef) { SecItemCopyMatching(query, UnsafeMutablePointer($0)) }
         if status == errSecSuccess {


### PR DESCRIPTION
The Keychain API `SecItemCopyMatching()` with `Unmanaged#takeUnretainedValue()` cannot retrieve the value correctly in Release build (to be precise, fastest/smallest optimization [Os]).
`SecItemCopyMatching()` with `Unmanaged#takeUnretainedValue()` always return `nil` in release build. Maybe it's swift bug.


So this example project always crashes to cast nil value if build with release configuration.

```swift
return dataTypeRef?.takeUnretainedValue() as NSData // Crashes this line to cast nil value
```


To fix this issue use `withUnsafeMutablePointer()` function instead `takeUnretainedValue()`.


See also http://stackoverflow.com/questions/24145838/querying-ios-keychain-using-swift/27721328#27721328


Could you please review @alazier @jpsim ?


Version: Xcode 6.2, realm-cocoa 0.91.1 and master
