### PR TITLE
Avoid using private implementation details in the Swift tests

### DIFF
--- a/RealmSwift/Tests/ListTests.swift
+++ b/RealmSwift/Tests/ListTests.swift
@@ -39,15 +39,13 @@ class ListTests: TestCase {
         arrayObject = createArray()
         array = arrayObject.array
 
-        autoreleasepool {
-            let realm = self.realmWithTestPath()
-            realm.write {
-                realm.add(self.str1)
-                realm.add(self.str2)
-            }
-
-            realm.beginWrite()
+        let realm = self.realmWithTestPath()
+        realm.write {
+            realm.add(self.str1)
+            realm.add(self.str2)
         }
+
+        realm.beginWrite()
     }
 
     override func tearDown() {

--- a/RealmSwift/Tests/ListTests.swift
+++ b/RealmSwift/Tests/ListTests.swift
@@ -39,13 +39,15 @@ class ListTests: TestCase {
         arrayObject = createArray()
         array = arrayObject.array
 
-        let realm = realmWithTestPath()
-        realm.write {
-            realm.add(self.str1)
-            realm.add(self.str2)
-        }
+        autoreleasepool {
+            let realm = self.realmWithTestPath()
+            realm.write {
+                realm.add(self.str1)
+                realm.add(self.str2)
+            }
 
-        realm.beginWrite()
+            realm.beginWrite()
+        }
     }
 
     override func tearDown() {

--- a/RealmSwift/Tests/ObjectSchemaTests.swift
+++ b/RealmSwift/Tests/ObjectSchemaTests.swift
@@ -24,7 +24,9 @@ class ObjectSchemaTests: TestCase {
 
     override func setUp() {
         super.setUp()
-        objectSchema = Realm().schema["SwiftObject"]
+        autoreleasepool {
+            self.objectSchema = Realm().schema["SwiftObject"]
+        }
     }
 
     func testProperties() {

--- a/RealmSwift/Tests/PerformanceTests.swift
+++ b/RealmSwift/Tests/PerformanceTests.swift
@@ -38,9 +38,11 @@ private var largeRealm: Realm!
 class SwiftPerformanceTests: TestCase {
     override class func setUp() {
         super.setUp()
-        smallRealm = createStringObjects(1)
-        mediumRealm = createStringObjects(5)
-        largeRealm = createStringObjects(50)
+        autoreleasepool {
+            smallRealm = createStringObjects(1)
+            mediumRealm = createStringObjects(5)
+            largeRealm = createStringObjects(50)
+        }
     }
 
     override class func tearDown() {

--- a/RealmSwift/Tests/PropertyTests.swift
+++ b/RealmSwift/Tests/PropertyTests.swift
@@ -26,10 +26,12 @@ class PropertyTests: TestCase {
 
     override func setUp() {
         super.setUp()
-        let schema = Realm().schema
-        primitiveProperty = schema["SwiftObject"]!["intCol"]!
-        linkProperty = schema["SwiftOptionalObject"]!["optObjectCol"]!
-        primaryProperty = schema["SwiftPrimaryStringObject"]!["stringCol"]!
+        autoreleasepool {
+            let schema = Realm().schema
+            self.primitiveProperty = schema["SwiftObject"]!["intCol"]!
+            self.linkProperty = schema["SwiftOptionalObject"]!["optObjectCol"]!
+            self.primaryProperty = schema["SwiftPrimaryStringObject"]!["stringCol"]!
+        }
     }
 
     func testName() {

--- a/RealmSwift/Tests/RealmTests.swift
+++ b/RealmSwift/Tests/RealmTests.swift
@@ -23,16 +23,19 @@ import Foundation
 class RealmTests: TestCase {
     override func setUp() {
         super.setUp()
-        realmWithTestPath().write {
-            self.realmWithTestPath().create(SwiftStringObject.self, value: ["1"])
-            self.realmWithTestPath().create(SwiftStringObject.self, value: ["2"])
-            self.realmWithTestPath().create(SwiftStringObject.self, value: ["3"])
-        }
 
-        Realm().write {
-            Realm().create(SwiftIntObject.self, value: [100])
-            Realm().create(SwiftIntObject.self, value: [200])
-            Realm().create(SwiftIntObject.self, value: [300])
+        autoreleasepool {
+            self.realmWithTestPath().write {
+                self.realmWithTestPath().create(SwiftStringObject.self, value: ["1"])
+                self.realmWithTestPath().create(SwiftStringObject.self, value: ["2"])
+                self.realmWithTestPath().create(SwiftStringObject.self, value: ["3"])
+            }
+
+            Realm().write {
+                Realm().create(SwiftIntObject.self, value: [100])
+                Realm().create(SwiftIntObject.self, value: [200])
+                Realm().create(SwiftIntObject.self, value: [300])
+            }
         }
     }
 

--- a/RealmSwift/Tests/ResultsTests.swift
+++ b/RealmSwift/Tests/ResultsTests.swift
@@ -70,14 +70,12 @@ class ResultsTests: TestCase {
         str2 = SwiftStringObject()
         str2.stringCol = "2"
 
-        autoreleasepool {
-            let realm = self.realmWithTestPath()
-            realm.beginWrite()
-            realm.add(self.str1)
-            realm.add(self.str2)
+        let realm = self.realmWithTestPath()
+        realm.beginWrite()
+        realm.add(self.str1)
+        realm.add(self.str2)
 
-            self.results = self.getResults()
-        }
+        self.results = self.getResults()
     }
 
     override func tearDown() {

--- a/RealmSwift/Tests/ResultsTests.swift
+++ b/RealmSwift/Tests/ResultsTests.swift
@@ -70,12 +70,14 @@ class ResultsTests: TestCase {
         str2 = SwiftStringObject()
         str2.stringCol = "2"
 
-        let realm = realmWithTestPath()
-        realm.beginWrite()
-        realm.add(str1)
-        realm.add(str2)
+        autoreleasepool {
+            let realm = self.realmWithTestPath()
+            realm.beginWrite()
+            realm.add(self.str1)
+            realm.add(self.str2)
 
-        results = getResults()
+            self.results = self.getResults()
+        }
     }
 
     override func tearDown() {

--- a/RealmSwift/Tests/SchemaTests.swift
+++ b/RealmSwift/Tests/SchemaTests.swift
@@ -24,7 +24,9 @@ class SchemaTests: TestCase {
 
     override func setUp() {
         super.setUp()
-        schema = Realm().schema
+        autoreleasepool {
+            self.schema = Realm().schema
+        }
     }
     
     func testObjectSchema() {

--- a/RealmSwift/Tests/SortDescriptorTests.swift
+++ b/RealmSwift/Tests/SortDescriptorTests.swift
@@ -21,13 +21,8 @@ import RealmSwift
 
 class SortDescriptorTests: TestCase {
 
-    var sortDescriptor: SortDescriptor!
+    let sortDescriptor = SortDescriptor(property: "property")
 
-    override func setUp() {
-        super.setUp()
-        sortDescriptor = SortDescriptor(property: "property")
-    }
-    
     func testAscendingDefaultsToTrue() {
         XCTAssertTrue(sortDescriptor.ascending)
     }

--- a/RealmSwift/Tests/TestCase.swift
+++ b/RealmSwift/Tests/TestCase.swift
@@ -16,13 +16,13 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-import XCTest
-import RealmSwift
+import Foundation
 import Realm
 import Realm.Private
-import Foundation
+import RealmSwift
+import XCTest
 
-class TestCase: XCTestCase {
+class TestCase: RLMAutoreleasePoolTestCase {
     var exceptionThrown = false
 
     func realmWithTestPath() -> Realm {
@@ -33,18 +33,8 @@ class TestCase: XCTestCase {
         Realm.defaultPath = realmPathForFile("\(realmFilePrefix()).default.realm")
         NSFileManager.defaultManager().createDirectoryAtPath(realmPathForFile(""), withIntermediateDirectories: true, attributes: nil, error: nil)
 
-        internalImplementation().setNumberOfTestIterations(1)
         exceptionThrown = false
-
-        autoreleasepool {
-            self.setUp()
-        }
-        autoreleasepool {
-            self.invocation.invoke()
-        }
-        autoreleasepool {
-            self.tearDown()
-        }
+        super.invokeTest()
 
         if exceptionThrown {
             RLMDeallocateRealm(Realm.defaultPath)

--- a/RealmSwift/Tests/TestUtils.h
+++ b/RealmSwift/Tests/TestUtils.h
@@ -19,9 +19,9 @@
 #import <Foundation/Foundation.h>
 #import <XCTest/XCTestCase.h>
 
-@interface XCTestCase ()
-- (instancetype)internalImplementation;
-- (void)setNumberOfTestIterations:(NSUInteger)num;
+// An XCTestCase that invokes each test in an autorelease pool
+// Works around a swift 1.1 limitation where `super` can't be used in a block
+@interface RLMAutoreleasePoolTestCase : XCTestCase
 @end
 
 FOUNDATION_EXTERN void RLMAssertThrows(XCTestCase *self, dispatch_block_t block, NSString *message, NSString *fileName, NSUInteger lineNumber);

--- a/RealmSwift/Tests/TestUtils.mm
+++ b/RealmSwift/Tests/TestUtils.mm
@@ -20,7 +20,14 @@
 
 #import <Realm/Realm.h>
 #import <Realm/RLMRealmUtil.h>
-#import <XCTest/XCTestCase.h>
+
+@implementation RLMAutoreleasePoolTestCase
+- (void)invokeTest {
+    @autoreleasepool {
+        [super invokeTest];
+    }
+}
+@end
 
 void RLMAssertThrows(XCTestCase *self, dispatch_block_t block, NSString *message, NSString *fileName, NSUInteger lineNumber) {
     BOOL didThrow = NO;


### PR DESCRIPTION
Explicitly wrap things creating Realms in `setUp` methods in `autoreleasepool` blocks to avoid the need to wrap all calls to `setUp` explicitly, and then just call `super.invokeTest()` in an autorelease pool rather than trying to replicate all of the work it does. Requires an obj-c helper to work around not being able to use `super` in a block in swift 1.1.

@segiddins @jpsim 