### PR TITLE
Add tests for RLMArray delete methods

### DIFF
--- a/Realm/Tests/ArrayPropertyTests.m
+++ b/Realm/Tests/ArrayPropertyTests.m
@@ -234,7 +234,7 @@
     XCTAssertEqualObjects(array.array[0], stringObj1, @"Objects should be equal");
     XCTAssertEqualObjects(array.array[1], stringObj2, @"Objects should be equal");
     XCTAssertEqualObjects(array.array[2], stringObj3, @"Objects should be equal");
-    XCTAssertEqual(array.array.count, 3U, @"Should have three elements in string array");
+    XCTAssertEqual(array.array.count, 3U, @"Should have 3 elements in string array");
 
     XCTAssertEqualObjects(array.intArray[0], intObj1, @"Objects should be equal");
     XCTAssertEqualObjects(array.intArray[1], intObj2, @"Objects should be equal");
@@ -257,7 +257,7 @@
     XCTAssertEqual(array.array.count, 0U, @"Should have 0 elements in string array");
 
     [array.intArray removeAllObjects];
-    XCTAssertEqual(array.intArray.count, 0U, @"Should have 0 elements in string array");
+    XCTAssertEqual(array.intArray.count, 0U, @"Should have 0 elements in int array");
 }
 
 - (void)testIndexOfObject

--- a/Realm/Tests/ArrayPropertyTests.m
+++ b/Realm/Tests/ArrayPropertyTests.m
@@ -207,6 +207,59 @@
     __unused ArrayPropertyObject *obj = [[ArrayPropertyObject alloc] initWithObject:@[@"n", @[], @[[[IntObject alloc] initWithObject:@[@1]]]]];
 }
 
+- (void)testDeleteObjectInStandaloneArray {
+    ArrayPropertyObject *array = [[ArrayPropertyObject alloc] init];
+    array.name = @"name";
+
+    StringObject *stringObj1 = [[StringObject alloc] init];
+    stringObj1.stringCol = @"a";
+    StringObject *stringObj2 = [[StringObject alloc] init];
+    stringObj2.stringCol = @"b";
+    StringObject *stringObj3 = [[StringObject alloc] init];
+    stringObj3.stringCol = @"c";
+    [array.array addObject:stringObj1];
+    [array.array addObject:stringObj2];
+    [array.array addObject:stringObj3];
+
+    IntObject *intObj1 = [[IntObject alloc] init];
+    intObj1.intCol = 0;
+    IntObject *intObj2 = [[IntObject alloc] init];
+    intObj2.intCol = 1;
+    IntObject *intObj3 = [[IntObject alloc] init];
+    intObj3.intCol = 2;
+    [array.intArray addObject:intObj1];
+    [array.intArray addObject:intObj2];
+    [array.intArray addObject:intObj3];
+
+    XCTAssertEqualObjects(array.array[0], stringObj1, @"Objects should be equal");
+    XCTAssertEqualObjects(array.array[1], stringObj2, @"Objects should be equal");
+    XCTAssertEqualObjects(array.array[2], stringObj3, @"Objects should be equal");
+    XCTAssertEqual(array.array.count, 3U, @"Should have three elements in string array");
+
+    XCTAssertEqualObjects(array.intArray[0], intObj1, @"Objects should be equal");
+    XCTAssertEqualObjects(array.intArray[1], intObj2, @"Objects should be equal");
+    XCTAssertEqualObjects(array.intArray[2], intObj3, @"Objects should be equal");
+    XCTAssertEqual(array.intArray.count, 3U, @"Should have 3 elements in int array");
+
+    [array.array removeLastObject];
+
+    XCTAssertEqualObjects(array.array[0], stringObj1, @"Objects should be equal");
+    XCTAssertEqualObjects(array.array[1], stringObj2, @"Objects should be equal");
+    XCTAssertEqual(array.array.count, 2U, @"Should have 2 elements in string array");
+
+    [array.array removeLastObject];
+
+    XCTAssertEqualObjects(array.array[0], stringObj1, @"Objects should be equal");
+    XCTAssertEqual(array.array.count, 1U, @"Should have 1 elements in string array");
+
+    [array.array removeLastObject];
+
+    XCTAssertEqual(array.array.count, 0U, @"Should have 0 elements in string array");
+
+    [array.intArray removeAllObjects];
+    XCTAssertEqual(array.intArray.count, 0U, @"Should have 0 elements in string array");
+}
+
 - (void)testIndexOfObject
 {
     RLMRealm *realm = [RLMRealm defaultRealm];


### PR DESCRIPTION
Add 2 tests for `RLMArray#removeLastObject` and `RLMArray#removeAllObjects `.

Because there are no tests for the standalone array object's delete methods, although there are tests for array object after persistence.

I found that `removeLastObject ` and `removeAllObjects` in methods of RLMArray are not covered by the unit tests. There are some test cases that calls same name methods, but they are for the array after persistence (not for stand alone objet, they does not call RLMArray's methods).

Code coverage of RLMArray.mm increased (+6.5%) from 83.7 to 89.2% when merged this PR.

Could you please review? @jpsim @segiddins @alazier