### PR TITLE
Fix failing `test-package-release` command on case sensitive filesystem

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -633,7 +633,7 @@ case "$COMMAND" in
         mkdir -p ${TEMPDIR}/realm-cocoa-${VERSION}/osx
         mkdir -p ${TEMPDIR}/realm-cocoa-${VERSION}/ios
         mkdir -p ${TEMPDIR}/realm-cocoa-${VERSION}/browser
-        mkdir -p ${TEMPDIR}/realm-cocoa-${VERSION}/swift
+        mkdir -p ${TEMPDIR}/realm-cocoa-${VERSION}/Swift
 
         (
             cd ${TEMPDIR}/realm-cocoa-${VERSION}/osx
@@ -652,7 +652,7 @@ case "$COMMAND" in
 
         (
             if [[ $PACKAGE_REALM_SWIFT == true ]]; then
-              cd ${TEMPDIR}/realm-cocoa-${VERSION}/swift
+              cd ${TEMPDIR}/realm-cocoa-${VERSION}/Swift
               unzip ${WORKSPACE}/realm-swift-source.zip
             fi
         )
@@ -661,7 +661,7 @@ case "$COMMAND" in
             cd ${WORKSPACE}/tightdb_objc
             cp -R plugin ${TEMPDIR}/realm-cocoa-${VERSION}
             cp LICENSE ${TEMPDIR}/realm-cocoa-${VERSION}/LICENSE.txt
-            cp Realm/Swift/RLMSupport.swift ${TEMPDIR}/realm-cocoa-${VERSION}/swift/
+            cp Realm/Swift/RLMSupport.swift ${TEMPDIR}/realm-cocoa-${VERSION}/Swift/
         )
 
         (


### PR DESCRIPTION
`sh build.sh test-package-release` command fails on case sensitive filesystem.

Because the command calls subcommand `package-release`, then copy `RLMSupport.swift` file to `realm-cocoa-${VERSION}/swift/` directory at line 664 of build.sh, like below:

```
cp Realm/Swift/RLMSupport.swift ${TEMPDIR}/realm-cocoa-${VERSION}/swift/
```

Then called another subcommand `package-test-examples`, this will build all static iOS examples.
But the project assumes `RLMSupport.swift` file in the `Swift` directory ("S" is uppercase), then build fails due to the following error.

```
CompileSwiftSources normal arm64 com.apple.xcode.tools.swift.compiler
    cd /Users/katsumi/Desktop/Realm/realm-cocoa/work/realm-cocoa-0.91.1/examples/ios/swift
    export PATH="/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/usr/bin:/Applications/Xcode.app/Contents/Developer/usr/bin:/usr/local/bin:/usr/bin:/bin:/usr/libexec:/usr/local/bin:/usr/bin:/bin:/usr/libexec:/usr/local/bin:/usr/bin:/bin:/usr/libexec:/usr/local/heroku/bin:/Users/katsumi/.nodebrew/current/bin:/Users/katsumi/.pyenv/shims:/Users/katsumi/.rbenv/shims:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/opt/X11/bin"
    /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swiftc -target arm64-apple-ios7.0 -module-name Simple -O -sdk /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS8.2.sdk -g -module-cache-path /Users/katsumi/Desktop/Realm/realm-cocoa/work/realm-cocoa-0.91.1/examples/ios/swift/build/DerivedData/ModuleCache -I /Users/katsumi/Desktop/Realm/realm-cocoa/work/realm-cocoa-0.91.1/examples/ios/swift/build/DerivedData/RealmExamples/Build/Products/Release-iphoneos -F /Users/katsumi/Desktop/Realm/realm-cocoa/work/realm-cocoa-0.91.1/examples/ios/swift/build/DerivedData/RealmExamples/Build/Products/Release-iphoneos -F /Users/katsumi/Desktop/Realm/realm-cocoa/work/realm-cocoa-0.91.1/examples/ios/swift/../../../ios -c -j8 /Users/katsumi/Desktop/Realm/realm-cocoa/work/realm-cocoa-0.91.1/examples/ios/swift/Simple/AppDelegate.swift /Users/katsumi/Desktop/Realm/realm-cocoa/work/realm-cocoa-0.91.1/Swift/RLMSupport.swift -output-file-map /Users/katsumi/Desktop/Realm/realm-cocoa/work/realm-cocoa-0.91.1/examples/ios/swift/build/DerivedData/RealmExamples/Build/Intermediates/RealmExamples.build/Release-iphoneos/Simple.build/Objects-normal/arm64/Simple-OutputFileMap.json -parseable-output -serialize-diagnostics -emit-dependencies -emit-module -emit-module-path /Users/katsumi/Desktop/Realm/realm-cocoa/work/realm-cocoa-0.91.1/examples/ios/swift/build/DerivedData/RealmExamples/Build/Intermediates/RealmExamples.build/Release-iphoneos/Simple.build/Objects-normal/arm64/Simple.swiftmodule -Xcc -I/Users/katsumi/Desktop/Realm/realm-cocoa/work/realm-cocoa-0.91.1/examples/ios/swift/build/DerivedData/RealmExamples/Build/Intermediates/RealmExamples.build/Release-iphoneos/Simple.build/swift-overrides.hmap -Xcc -iquote -Xcc /Users/katsumi/Desktop/Realm/realm-cocoa/work/realm-cocoa-0.91.1/examples/ios/swift/build/DerivedData/RealmExamples/Build/Intermediates/RealmExamples.build/Release-iphoneos/Simple.build/Simple-generated-files.hmap -Xcc -I/Users/katsumi/Desktop/Realm/realm-cocoa/work/realm-cocoa-0.91.1/examples/ios/swift/build/DerivedData/RealmExamples/Build/Intermediates/RealmExamples.build/Release-iphoneos/Simple.build/Simple-own-target-headers.hmap -Xcc -I/Users/katsumi/Desktop/Realm/realm-cocoa/work/realm-cocoa-0.91.1/examples/ios/swift/build/DerivedData/RealmExamples/Build/Intermediates/RealmExamples.build/Release-iphoneos/Simple.build/Simple-all-target-headers.hmap -Xcc -iquote -Xcc /Users/katsumi/Desktop/Realm/realm-cocoa/work/realm-cocoa-0.91.1/examples/ios/swift/build/DerivedData/RealmExamples/Build/Intermediates/RealmExamples.build/Release-iphoneos/Simple.build/Simple-project-headers.hmap -Xcc -I/Users/katsumi/Desktop/Realm/realm-cocoa/work/realm-cocoa-0.91.1/examples/ios/swift/build/DerivedData/RealmExamples/Build/Products/Release-iphoneos/include -Xcc -I/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include -Xcc -I/Users/katsumi/Desktop/Realm/realm-cocoa/work/realm-cocoa-0.91.1/examples/ios/swift/build/DerivedData/RealmExamples/Build/Intermediates/RealmExamples.build/Release-iphoneos/Simple.build/DerivedSources/arm64 -Xcc -I/Users/katsumi/Desktop/Realm/realm-cocoa/work/realm-cocoa-0.91.1/examples/ios/swift/build/DerivedData/RealmExamples/Build/Intermediates/RealmExamples.build/Release-iphoneos/Simple.build/DerivedSources -emit-objc-header -emit-objc-header-path /Users/katsumi/Desktop/Realm/realm-cocoa/work/realm-cocoa-0.91.1/examples/ios/swift/build/DerivedData/RealmExamples/Build/Intermediates/RealmExamples.build/Release-iphoneos/Simple.build/Objects-normal/arm64/Simple-Swift.h
<unknown>:0: error: no such file or directory: '/Users/katsumi/Desktop/Realm/realm-cocoa/work/realm-cocoa-0.91.1/Swift/RLMSupport.swift'
Command /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swiftc failed with exit code 1
```

This PR fixes the build error caused by case-sensitivity.