### PR TITLE
Add transaction block helper for default Realm

### DIFF
--- a/Realm/RLMRealm.h
+++ b/Realm/RLMRealm.h
@@ -300,6 +300,11 @@ typedef void(^RLMNotificationBlock)(NSString *notification, RLMRealm *realm);
 - (void)transactionWithBlock:(void(^)(void))block;
 
 /**
+ Helper to perform a block within a write transaction in the default Realm.
+ */
++ (void)transactionInDefaultRealmWithBlock:(void(^)(RLMRealm *))block;
+
+/**
  Update an `RLMRealm` and outstanding objects to point to the most recent data for this `RLMRealm`.
 
  @return    Whether the realm had any updates. Note that this may return YES even if no data has actually changed.

--- a/Realm/RLMRealm.mm
+++ b/Realm/RLMRealm.mm
@@ -545,6 +545,16 @@ static void CheckReadWrite(RLMRealm *realm, NSString *msg=@"Cannot write to a re
     }
 }
 
++ (void)transactionInDefaultRealmWithBlock:(void(^)(RLMRealm *))block
+{
+    RLMRealm *defaultRealm = [self defaultRealm];
+    [defaultRealm beginWriteTransaction];
+    block(defaultRealm);
+    if (defaultRealm->_inWriteTransaction) {
+        [defaultRealm commitWriteTransaction];
+    }
+}
+
 - (void)cancelWriteTransaction {
     CheckReadWrite(self);
     RLMCheckThread(self);

--- a/Realm/Tests/RealmTests.mm
+++ b/Realm/Tests/RealmTests.mm
@@ -345,6 +345,15 @@ extern "C" {
     XCTAssertEqualObjects([objects.firstObject stringCol], @"b", @"Expecting column to be 'b'");
 }
 
+- (void)testDefaultRealmTransactionBlock {
+    [RLMRealm transactionInDefaultRealmWithBlock:^(RLMRealm *realm) {
+        [StringObject createInRealm:realm withObject:@[@"f"]];
+    }];
+    RLMResults *objects = [StringObject allObjects];
+    XCTAssertEqual(objects.count, 1U, @"Expecting 1 object");
+    XCTAssertEqualObjects([objects.firstObject stringCol], @"f", @"Expecting column to be 'f'");
+}
+
 - (void)testAutorefreshAfterBackgroundUpdate {
     RLMRealm *realm = [self realmWithTestPath];
 


### PR DESCRIPTION
This hopefully addresses #1498.

Passing the realm as an argument in `-transactionWithBlock:` would break a great deal of code without making a separate method with a different signature. It also seemed unnecessary since the receiver is likely readily available for capturing in the block. 