### PR TITLE
Don't call migration blocks when first initializing a Realm file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,14 @@
 x.xx.x Release notes (yyyy-MM-dd)
 =============================================================
 
+### API breaking changes
+
+* Migration blocks are no longer called when a Realm file is first created.
+
 ### Enhancements
 
 * `Int8` properties defined in Swift are now treated as integers, rather than
   booleans.
-
-### Bugfixes
-
-* Migration blocks are no longer called when a Realm file is first created.
 
 0.91.3 Release notes (2015-04-17)
 =============================================================
@@ -20,6 +20,8 @@ x.xx.x Release notes (yyyy-MM-dd)
 
 0.91.2 Release notes (2015-04-16)
 =============================================================
+
+* Migration blocks are no longer called when a Realm file is first created.
 
 ### Enhancements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ x.xx.x Release notes (yyyy-MM-dd)
 * `Int8` properties defined in Swift are now treated as integers, rather than
   booleans.
 
+### Bugfixes
+
+* Migration blocks are no longer called when a Realm file is first created.
+
 0.91.3 Release notes (2015-04-17)
 =============================================================
 
@@ -30,11 +34,6 @@ x.xx.x Release notes (yyyy-MM-dd)
 
 * `+[RLMSchema dynamicSchemaForRealm:]` now respects search indexes.
 * `+[RLMProperty isEqualToProperty:]` now checks for equal `indexed` properties.
-* Setting indexed string properties to strings with embedded NUL bytes now
-  throws an exception rather than crashing deep within the core library.
-* Fix incorrect results when querying an indexed property on an RLMArray.
-* Fix corruption of string indexes when an object is deleted when there are
-  duplicate values for the indexed property.
 
 0.91.1 Release notes (2015-03-12)
 =============================================================

--- a/Realm/Tests/MigrationTests.mm
+++ b/Realm/Tests/MigrationTests.mm
@@ -91,7 +91,7 @@
 
 - (void)testSchemaVersion {
     [RLMRealm setDefaultRealmSchemaVersion:1 withMigrationBlock:^(__unused RLMMigration *migration,
-                                                      __unused NSUInteger oldSchemaVersion) {
+                                                                  __unused NSUInteger oldSchemaVersion) {
     }];
 
     RLMRealm *defaultRealm = [RLMRealm defaultRealm];
@@ -106,7 +106,8 @@
 
     XCTAssertEqual(0U, [RLMRealm schemaVersionAtPath:RLMRealm.defaultRealmPath encryptionKey:nil error:nil]);
     [RLMRealm setDefaultRealmSchemaVersion:1 withMigrationBlock:^(__unused RLMMigration *migration,
-                                                                  __unused NSUInteger oldSchemaVersion) {
+                                                                  NSUInteger oldSchemaVersion) {
+        XCTAssertEqual(0U, oldSchemaVersion);
     }];
 
     RLMRealm *realm = [RLMRealm defaultRealm];
@@ -132,7 +133,8 @@
 
     __block bool migrationComplete = false;
     [RLMRealm setSchemaVersion:2 forRealmAtPath:RLMTestRealmPath() withMigrationBlock:^(__unused RLMMigration *migration,
-                                                                                        __unused NSUInteger oldSchemaVersion) {
+                                                                                        NSUInteger oldSchemaVersion) {
+        XCTAssertEqual(0U, oldSchemaVersion);
         migrationComplete = true;
     }];
     RLMRealm *anotherRealm = [RLMRealm realmWithPath:RLMTestRealmPath()];
@@ -766,6 +768,15 @@
 
     // implicit migration
     XCTAssertEqualObjects(@"otherString", [StringObject.allObjects.firstObject stringCol]);
+}
+
+- (void)testMigrationBlockNotCalledForIntialRealmCreation {
+    [RLMRealm setSchemaVersion:1
+                forRealmAtPath:RLMTestRealmPath()
+            withMigrationBlock:^(__unused RLMMigration *migration, __unused NSUInteger oldSchemaVersion) {
+                XCTFail(@"Migration block should not have been called");
+            }];
+    XCTAssertNoThrow([self realmWithTestPath]);
 }
 
 @end

--- a/RealmSwift/Tests/MigrationTests.swift
+++ b/RealmSwift/Tests/MigrationTests.swift
@@ -186,19 +186,11 @@ class MigrationTests: TestCase {
             self.assertThrows(migration.create("NoSuchObject", value: []))
         })
 
-        XCTAssertEqual(Realm().objects(SwiftStringObject).count, 3)
-
-        var i = 0
-        for obj in Realm().objects(SwiftStringObject) {
-            if i == 2 {
-                // last object has default value of empty string
-                XCTAssertEqual("", obj.stringCol)
-            }
-            else {
-                XCTAssertEqual("string", obj.stringCol)
-            }
-            ++i
-        }
+        let objects = Realm().objects(SwiftStringObject)
+        XCTAssertEqual(objects.count, 3)
+        XCTAssertEqual(objects[0].stringCol, "string")
+        XCTAssertEqual(objects[1].stringCol, "string")
+        XCTAssertEqual(objects[2].stringCol, "")
     }
 
     func testDelete() {


### PR DESCRIPTION
It doesn't really make sense to do so since there's nothing to migrate, and the old version is an undocumented value that makes checking schema versions awkward. See #1737.

@alazier 