### PR TITLE
Add and remove indexes from existing columns during migrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ x.x.x Release notes (yyyy-MM-dd)
 * Sorting `RLMResults` is 2-5x faster (typically closer to 2x).
 * Refreshing `RLMRealm` after a write transaction which inserts or modifies
   strings or `NSData` is committed on another thread is significantly faster.
+* Indexes are now added and removed from existing properties during migrations,
+  rather than only when properties are first added.
 
 ### Bugfixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@ x.x.x Release notes (yyyy-MM-dd)
 * Sorting `RLMResults` is 2-5x faster (typically closer to 2x).
 * Refreshing `RLMRealm` after a write transaction which inserts or modifies
   strings or `NSData` is committed on another thread is significantly faster.
-* Indexes are now added and removed from existing properties during migrations,
-  rather than only when properties are first added.
+* Indexes are now added and removed from existing properties when a Realm file
+  is opened, rather than only when properties are first added.
 
 ### Bugfixes
 

--- a/Realm/RLMObjectStore.mm
+++ b/Realm/RLMObjectStore.mm
@@ -94,8 +94,7 @@ static void RLMRealmUpdateIndexes(RLMRealm *realm) {
     for (RLMObjectSchema *objectSchema in realm.schema.objectSchema) {
         realm::Table *table = objectSchema.table;
         for (RLMProperty *prop in objectSchema.properties) {
-            // FIXME: support other types
-            if (prop.type == RLMPropertyTypeString && prop.indexed != table->has_search_index(prop.column)) {
+            if (prop.indexed != table->has_search_index(prop.column)) {
                 if (!realm.inWriteTransaction) {
                     [realm beginWriteTransaction];
                     commitWriteTransaction = true;

--- a/Realm/RLMObjectStore.mm
+++ b/Realm/RLMObjectStore.mm
@@ -64,15 +64,6 @@ static void RLMVerifyAndAlignColumns(RLMObjectSchema *tableSchema, RLMObjectSche
                 [exceptionMessages addObject:[NSString stringWithFormat:@"Property '%@' has been made a primary key.", tableProp.name]];
             }
         }
-        // don't double-complain about indexedness changing due to pk changing
-        else if (tableProp.indexed != schemaProp.indexed) {
-            if (tableProp.indexed) {
-                [exceptionMessages addObject:[NSString stringWithFormat:@"Property '%@' is no longer indexed.", tableProp.name]];
-            }
-            else {
-                [exceptionMessages addObject:[NSString stringWithFormat:@"Property '%@' has had an index added.", tableProp.name]];
-            }
-        }
 
         // create new property with aligned column
         schemaProp.column = tableProp.column;
@@ -96,6 +87,34 @@ static void RLMVerifyAndAlignColumns(RLMObjectSchema *tableSchema, RLMObjectSche
     objectSchema.properties = properties;
 }
 
+// ensure all search indexes for all tables are up-to-date
+// does not need to be called from a write transaction
+static void RLMRealmUpdateIndexes(RLMRealm *realm) {
+    bool commitWriteTransaction = false;
+    for (RLMObjectSchema *objectSchema in realm.schema.objectSchema) {
+        realm::Table *table = objectSchema.table;
+        for (RLMProperty *prop in objectSchema.properties) {
+            // FIXME: support other types
+            if (prop.type == RLMPropertyTypeString && prop.indexed != table->has_search_index(prop.column)) {
+                if (!realm.inWriteTransaction) {
+                    [realm beginWriteTransaction];
+                    commitWriteTransaction = true;
+                }
+                if (prop.indexed) {
+                    table->add_search_index(prop.column);
+                }
+                else {
+                    table->remove_search_index(prop.column);
+                }
+            }
+        }
+    }
+
+    if (commitWriteTransaction) {
+        [realm commitWriteTransaction];
+    }
+}
+
 // create a column for a property in a table
 // NOTE: must be called from within write transaction
 static void RLMCreateColumn(RLMRealm *realm, realm::Table &table, RLMProperty *prop) {
@@ -107,18 +126,9 @@ static void RLMCreateColumn(RLMRealm *realm, realm::Table &table, RLMProperty *p
             prop.column = table.add_column_link(realm::DataType(prop.type), prop.name.UTF8String, *linkTable);
             break;
         }
-        default: {
+        default:
             prop.column = table.add_column(realm::DataType(prop.type), prop.name.UTF8String);
-            if (prop.indexed) {
-                // FIXME - support other types
-                if (prop.type != RLMPropertyTypeString) {
-                    NSLog(@"RLMPropertyAttributeIndexed only supported for 'NSString' properties");
-                }
-                else {
-                    table.add_search_index(prop.column);
-                }
-            }
-        }
+            break;
     }
 }
 
@@ -230,16 +240,6 @@ static bool RLMRealmCreateTables(RLMRealm *realm, RLMSchema *targetSchema, bool 
                 RLMCreateColumn(realm, *objectSchema.table, prop);
                 changed = true;
             }
-            // ensure search indexes for existing columns are up to date
-            else if (tableProp && prop.indexed != tableProp.indexed) {
-                if (prop.indexed) {
-                    objectSchema.table->add_search_index(tableProp.column);
-                }
-                else {
-                    objectSchema.table->remove_search_index(tableProp.column);
-                }
-                changed = true;
-            }
         }
 
         // remove extra columns
@@ -290,6 +290,7 @@ NSError *RLMUpdateRealmToSchemaVersion(RLMRealm *realm, NSUInteger newVersion, R
     // a write transaction
     if (!RLMMigrationRequired(realm, newVersion) && RLMRealmGetTables(realm, targetSchema)) {
         RLMRealmSetSchema(realm, targetSchema, true);
+        RLMRealmUpdateIndexes(realm);
         return nil;
     }
 
@@ -318,6 +319,7 @@ NSError *RLMUpdateRealmToSchemaVersion(RLMRealm *realm, NSUInteger newVersion, R
             }
 
             RLMRealmSetSchemaVersion(realm, newVersion);
+            RLMRealmUpdateIndexes(realm);
             changed = true;
         }
 


### PR DESCRIPTION
I'm not sure if it really needs to require a migration, but making it not require a migration would require some nontrivial refactoring.

Partially addresses #1735.

@jpsim @alazier 