### PR TITLE
Restore initWithObjectClassName to the public headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+0.91.3 Release notes (2015-04-17)
+=============================================================
+
+### Bugfixes
+
+* Fix `Extra argument 'objectClassName' in call` errors when building via
+  CocoaPods.
+
 0.91.2 Release notes (2015-04-16)
 =============================================================
 

--- a/Realm/RLMArray.h
+++ b/Realm/RLMArray.h
@@ -300,3 +300,7 @@
 
 @end
 
+@interface RLMArray (Swift)
+// for use only in Swift class definitions
+- (instancetype)initWithObjectClassName:(NSString *)objectClassName;
+@end

--- a/Realm/Swift/RLMSupport.swift
+++ b/Realm/Swift/RLMSupport.swift
@@ -17,7 +17,6 @@
 ////////////////////////////////////////////////////////////////////////////
 
 import Realm
-import Realm.Private
 
 extension RLMObject {
     // Swift query convenience functions


### PR DESCRIPTION
The podspec doesn't create `Realm.Private` yet, so trying to import it in RLMSupport.swift doesn't work very well.

Fixes #1765.

@jpsim @segiddins 