### PR TITLE
RealmSwift.podspec

### DIFF
--- a/Realm.podspec
+++ b/Realm.podspec
@@ -38,7 +38,7 @@ Pod::Spec.new do |s|
   s.header_mappings_dir     = 'include'
   s.xcconfig                = { 'CLANG_CXX_LANGUAGE_STANDARD' => 'compiler-default',
                                 'OTHER_CPLUSPLUSFLAGS' => '-std=c++1y $(inherited)' }
-  s.preserve_paths          = %w(build.sh)
+  s.preserve_paths          = %w(build.sh Realm/*.{h,hpp})
 
   s.ios.deployment_target   = '7.0'
   s.ios.vendored_library    = 'core/librealm-ios.a'

--- a/Realm.podspec
+++ b/Realm.podspec
@@ -38,7 +38,7 @@ Pod::Spec.new do |s|
   s.header_mappings_dir     = 'include'
   s.xcconfig                = { 'CLANG_CXX_LANGUAGE_STANDARD' => 'compiler-default',
                                 'OTHER_CPLUSPLUSFLAGS' => '-std=c++1y $(inherited)' }
-  s.preserve_paths          = %w(build.sh Realm/*.{h,hpp})
+  s.preserve_paths          = %w(build.sh)
 
   s.ios.deployment_target   = '7.0'
   s.ios.vendored_library    = 'core/librealm-ios.a'

--- a/Realm.podspec
+++ b/Realm.podspec
@@ -4,7 +4,7 @@ Pod::Spec.new do |s|
   s.version                 = `sh build.sh get-version`
   s.summary                 = 'Realm is a modern data framework & database for iOS & OS X.'
   s.description             = <<-DESC
-                              The Realm database, for Objective-C.
+                              The Realm database, for Objective-C. (If you want to use Realm from Swift, see the “RealmSwift” pod.)
 
                               Realm is a mobile database: a replacement for Core Data & SQLite. You can use it on iOS & OS X. Realm is not an ORM on top SQLite: instead it uses its own persistence engine, built for simplicity (& speed). Learn more and get help at https://realm.io
                               DESC

--- a/Realm.podspec
+++ b/Realm.podspec
@@ -49,6 +49,6 @@ Pod::Spec.new do |s|
   s.subspec 'Headers' do |s|
     s.source_files          = 'include/**/*.{h,hpp}'
     s.public_header_files   = public_header_files
-    s.private_header_files  = 'include/Realm/*{ListBase,ObjectStore,Private,Dynamic}.h'
+    s.private_header_files  = 'include/Realm/*{RealmUtil,ListBase,ObjectStore,Private,Dynamic}.h'
   end
 end

--- a/Realm.podspec
+++ b/Realm.podspec
@@ -1,5 +1,6 @@
 Pod::Spec.new do |s|
   s.name                    = 'Realm'
+  s.module_map              = 'Realm/module.modulemap'
   s.version                 = `sh build.sh get-version`
   s.summary                 = 'Realm is a modern data framework & database for iOS & OS X.'
   s.description             = <<-DESC
@@ -16,25 +17,24 @@ Pod::Spec.new do |s|
   s.documentation_url       = "https://realm.io/docs/objc/#{s.version}"
   s.license                 = { :type => 'Apache 2.0', :file => 'LICENSE' }
 
-  public_header_files = 'include/Realm/RLMArray.h',
-                        'include/Realm/RLMCollection.h',
-                        'include/Realm/RLMConstants.h',
-                        'include/Realm/RLMListBase.h',
-                        'include/Realm/RLMMigration.h',
-                        'include/Realm/RLMObject.h',
-                        'include/Realm/RLMObjectBase.h',
-                        'include/Realm/RLMObjectSchema.h',
-                        'include/Realm/RLMPlatform.h',
-                        'include/Realm/RLMProperty.h',
-                        'include/Realm/RLMRealm.h',
-                        'include/Realm/RLMResults.h',
-                        'include/Realm/RLMSchema.h',
-                        'include/Realm/Realm.h'
+  public_header_files       = 'include/Realm/RLMArray.h',
+                              'include/Realm/RLMCollection.h',
+                              'include/Realm/RLMConstants.h',
+                              'include/Realm/RLMListBase.h',
+                              'include/Realm/RLMMigration.h',
+                              'include/Realm/RLMObject.h',
+                              'include/Realm/RLMObjectBase.h',
+                              'include/Realm/RLMObjectSchema.h',
+                              'include/Realm/RLMPlatform.h',
+                              'include/Realm/RLMProperty.h',
+                              'include/Realm/RLMRealm.h',
+                              'include/Realm/RLMResults.h',
+                              'include/Realm/RLMSchema.h',
+                              'include/Realm/Realm.h'
 
   s.compiler_flags          = "-DREALM_HAVE_CONFIG -DREALM_COCOA_VERSION='@\"#{s.version}\"'"
   s.prepare_command         = 'sh build.sh cocoapods-setup'
-  s.public_header_files     = public_header_files
-  s.source_files            = 'Realm/*.{h,m,mm,hpp}', 'include/**/*.hpp'
+  s.source_files            = 'Realm/*.{m,mm}'
   s.header_mappings_dir     = 'include'
   s.xcconfig                = { 'CLANG_CXX_LANGUAGE_STANDARD' => 'compiler-default',
                                 'OTHER_CPLUSPLUSFLAGS' => '-std=c++1y $(inherited)' }
@@ -47,7 +47,8 @@ Pod::Spec.new do |s|
   s.osx.vendored_library    = 'core/librealm.a'
 
   s.subspec 'Headers' do |s|
-    s.source_files          = 'include/**/*.h'
+    s.source_files          = 'include/**/*.{h,hpp}'
     s.public_header_files   = public_header_files
+    s.private_header_files  = 'include/Realm/*{ListBase,ObjectStore,Private,Dynamic}.h'
   end
 end

--- a/Realm.podspec
+++ b/Realm.podspec
@@ -1,6 +1,5 @@
 Pod::Spec.new do |s|
   s.name                    = 'Realm'
-  s.module_map              = 'Realm/module.modulemap'
   s.version                 = `sh build.sh get-version`
   s.summary                 = 'Realm is a modern data framework & database for iOS & OS X.'
   s.description             = <<-DESC
@@ -32,6 +31,7 @@ Pod::Spec.new do |s|
                               'include/Realm/RLMSchema.h',
                               'include/Realm/Realm.h'
 
+  s.module_map              = 'Realm/module.modulemap'
   s.compiler_flags          = "-DREALM_HAVE_CONFIG -DREALM_COCOA_VERSION='@\"#{s.version}\"'"
   s.prepare_command         = 'sh build.sh cocoapods-setup'
   s.source_files            = 'Realm/*.{m,mm}'

--- a/Realm/RLMArray.mm
+++ b/Realm/RLMArray.mm
@@ -18,7 +18,6 @@
 
 #import "RLMArray_Private.hpp"
 
-#import "RLMObject.h"
 #import "RLMObject_Private.h"
 #import "RLMObjectStore.h"
 #import "RLMObjectSchema.h"

--- a/Realm/RLMArray_Private.hpp
+++ b/Realm/RLMArray_Private.hpp
@@ -17,7 +17,7 @@
 ////////////////////////////////////////////////////////////////////////////
 
 #import "RLMArray_Private.h"
-#import "RLMResults.h"
+#import <Realm/RLMResults.h>
 
 #import <memory>
 

--- a/RealmSwift.podspec
+++ b/RealmSwift.podspec
@@ -1,0 +1,28 @@
+Pod::Spec.new do |s|
+  s.name                    = 'RealmSwift'
+  s.version                 = `sh build.sh get-version`
+  s.summary                 = 'Realm is a modern data framework & database for iOS & OSX.'
+  s.description             = <<-DESC
+                              Realm is a modern data framework & database for iOS & OSX. You can use it purely in memory — or persist to disk with extraordinary performance.
+
+                              Realm’s data structures look like NSObjects and NSArrays, but provide additional features such as: querying, relationships & graphs, thread safety, and more.
+
+                              Realm is not built on SQLite. Instead, a custom C++ core is used to provide memory-efficient access to your data by using Realm objects, which usually consume less RAM than native objects. The core also provides an optional persistence layer that can automatically save and retrieve your objects from disk.
+
+                              Realm offers extraordinary performance compared to SQLite and other persistence solutions. It has been in development since 2011 and powers an app with over 1 million
+                              daily active users at a major mobile game company.
+                              DESC
+  s.homepage                = "http://realm.io"
+  s.source                  = { :git => 'https://github.com/Realm/realm-cocoa.git', :tag => "v#{s.version}" }
+  s.author                  = { 'Realm' => 'help@realm.io' }
+  s.requires_arc            = true
+  s.social_media_url        = 'https://twitter.com/realm'
+  s.documentation_url       = "http://realm.io/docs/cocoa/#{s.version}"
+  s.license                 = { :type => 'Apache 2.0', :file => 'LICENSE' }
+
+  s.dependency 'Realm', "= #{s.version}"
+  s.source_files = 'RealmSwift/*.swift'
+
+  s.ios.deployment_target   = '8.0'
+  s.osx.deployment_target   = '10.8'
+end

--- a/RealmSwift.podspec
+++ b/RealmSwift.podspec
@@ -24,5 +24,5 @@ Pod::Spec.new do |s|
   s.source_files = 'RealmSwift/*.swift'
 
   s.ios.deployment_target   = '8.0'
-  s.osx.deployment_target   = '10.8'
+  s.osx.deployment_target   = '10.9'
 end

--- a/RealmSwift.podspec
+++ b/RealmSwift.podspec
@@ -3,14 +3,9 @@ Pod::Spec.new do |s|
   s.version                 = `sh build.sh get-version`
   s.summary                 = 'Realm is a modern data framework & database for iOS & OSX.'
   s.description             = <<-DESC
-                              Realm is a modern data framework & database for iOS & OSX. You can use it purely in memory — or persist to disk with extraordinary performance.
+                              The Realm database, for Swift. (If you want to use Realm from Objective-C, see the “Realm” pod.)
 
-                              Realm’s data structures look like NSObjects and NSArrays, but provide additional features such as: querying, relationships & graphs, thread safety, and more.
-
-                              Realm is not built on SQLite. Instead, a custom C++ core is used to provide memory-efficient access to your data by using Realm objects, which usually consume less RAM than native objects. The core also provides an optional persistence layer that can automatically save and retrieve your objects from disk.
-
-                              Realm offers extraordinary performance compared to SQLite and other persistence solutions. It has been in development since 2011 and powers an app with over 1 million
-                              daily active users at a major mobile game company.
+                              Realm is a mobile database: a replacement for Core Data & SQLite. You can use it on iOS & OS X. Realm is not an ORM on top SQLite: instead it uses its own persistence engine, built for simplicity (& speed). Learn more and get help at https://realm.io
                               DESC
   s.homepage                = "http://realm.io"
   s.source                  = { :git => 'https://github.com/Realm/realm-cocoa.git', :tag => "v#{s.version}" }

--- a/RealmSwift.podspec
+++ b/RealmSwift.podspec
@@ -18,6 +18,8 @@ Pod::Spec.new do |s|
   s.dependency 'Realm', "= #{s.version}"
   s.source_files = 'RealmSwift/*.swift'
 
+  s.preserve_paths          = %w(build.sh)
+
   s.ios.deployment_target   = '8.0'
   s.osx.deployment_target   = '10.9'
 end

--- a/RealmSwift.podspec
+++ b/RealmSwift.podspec
@@ -1,18 +1,18 @@
 Pod::Spec.new do |s|
   s.name                    = 'RealmSwift'
   s.version                 = `sh build.sh get-version`
-  s.summary                 = 'Realm is a modern data framework & database for iOS & OSX.'
+  s.summary                 = 'Realm is a modern data framework & database for iOS & OS X.'
   s.description             = <<-DESC
                               The Realm database, for Swift. (If you want to use Realm from Objective-C, see the “Realm” pod.)
 
                               Realm is a mobile database: a replacement for Core Data & SQLite. You can use it on iOS & OS X. Realm is not an ORM on top SQLite: instead it uses its own persistence engine, built for simplicity (& speed). Learn more and get help at https://realm.io
                               DESC
-  s.homepage                = "http://realm.io"
-  s.source                  = { :git => 'https://github.com/Realm/realm-cocoa.git', :tag => "v#{s.version}" }
+  s.homepage                = "https://realm.io"
+  s.source                  = { :git => 'https://github.com/realm/realm-cocoa.git', :tag => "v#{s.version}" }
   s.author                  = { 'Realm' => 'help@realm.io' }
   s.requires_arc            = true
   s.social_media_url        = 'https://twitter.com/realm'
-  s.documentation_url       = "http://realm.io/docs/cocoa/#{s.version}"
+  s.documentation_url       = "https://realm.io/docs/swift/#{s.version}"
   s.license                 = { :type => 'Apache 2.0', :file => 'LICENSE' }
 
   s.dependency 'Realm', "= #{s.version}"

--- a/build.sh
+++ b/build.sh
@@ -531,7 +531,7 @@ case "$COMMAND" in
         rm -rf include
         mv core/include include
         mkdir -p include/Realm
-        cp Realm/*.h include/Realm
+        cp Realm/*.{h,hpp} include/Realm
         touch include/Realm/RLMPlatform.h
         ;;
 

--- a/build.sh
+++ b/build.sh
@@ -521,10 +521,12 @@ case "$COMMAND" in
     "cocoapods-setup")
         sh build.sh download-core
 
-        # CocoaPods seems to not like symlinks
-        mv core tmp
-        mv $(readlink tmp) core
-        rm tmp
+        # CocoaPods doesn't support symlinks
+        if [ -L core ]; then
+            mv core core-tmp
+            mv $(readlink core-tmp) core
+            rm core-tmp
+        fi
 
         # CocoaPods doesn't support multiple header_mappings_dir, so combine
         # both sets of headers into a single directory

--- a/build.sh
+++ b/build.sh
@@ -531,7 +531,7 @@ case "$COMMAND" in
         # CocoaPods doesn't support multiple header_mappings_dir, so combine
         # both sets of headers into a single directory
         rm -rf include
-        mv core/include include
+        cp -R core/include include
         mkdir -p include/Realm
         cp Realm/*.{h,hpp} include/Realm
         touch include/Realm/RLMPlatform.h


### PR DESCRIPTION
This closes #1705 and supersedes #1510.
This is blocked by the (full public) release of CocoaPods/CocoaPods#3420.

#### Local Testing

:warning: Those instructions are only thought for development on Realm. Please wait until the release of RealmSwift before trying to consume the podspec.

```shell
# Preconditions
cd realm-cocoa
git fetch
git checkout mr-swift-podspec

# `pod --version` ~> 0.37.0.beta.1
gem install --pre cocoapods

# Setup a local private repo
mkdir -p ~/.cocoapods/bare-repos
git init --bare ~/.cocoapods/bare-repos/realm-private
pod repo add realm-private ~/.cocoapods/bare-repos/realm-private

# Change the source of Realm.podspec to point to this branch
# otherwise the changes in build.sh wouldn’t be applied
sed -ie "s/:tag => \"v#{s.version}/:branch => \"mr-swift-podspec/" Realm.podspec

# Nuke the CocoaPods downloader cache
rm -rf ~/Library/Caches/CocoaPods/**/Realm

# Push Realm.podspec with modulemap to private local repo
pod ipc spec Realm.podspec > Realm.podspec.json
pod repo push --verbose realm-private Realm.podspec.json --allow-warnings

# Lint RealmSwift.podspec
pod ipc spec RealmSwift.podspec > RealmSwift.podspec.json
pod spec lint --verbose RealmSwift.podspec.json --sources=realm-private
```