### PR TITLE
[Docs] re-enable jazzy in build-docs.sh because it now supports Swift 1.2

### DIFF
--- a/scripts/build-docs.sh
+++ b/scripts/build-docs.sh
@@ -37,17 +37,14 @@ mkdir -p ${SRCROOT}/docs/output
 rm -rf ${SRCROOT}/docs/output/${realm_version}
 mv ${SRCROOT}/docs/html ${SRCROOT}/docs/output/${realm_version}
 
-# Disable jazzy until it supports Swift 1.2
-# 
-# ${jazzy} \
-#   --author Realm \
-#   --author_url "http://realm.io" \
-#   --clean \
-#   --github_url https://github.com/realm/realm-cocoa \
-#   --github-file-prefix https://github.com/realm/realm-cocoa/tree/v${realm_version} \
-#   --min-acl public \
-#   --module RealmSwift \
-#   --module-version ${realm_version} \
-#   --output "${SRCROOT}/docs/swift_output" \
-#   --root-url http://realm.io/docs/swift/api/ \
-#   --xcodebuild-arguments "-project,${SRCROOT}/RealmSwift.xcodeproj" \
+${jazzy} \
+  --author Realm \
+  --author_url "http://realm.io" \
+  --clean \
+  --github_url https://github.com/realm/realm-cocoa \
+  --github-file-prefix https://github.com/realm/realm-cocoa/tree/v${realm_version} \
+  --module RealmSwift \
+  --module-version ${realm_version} \
+  --output "${SRCROOT}/docs/swift_output" \
+  --root-url http://realm.io/docs/swift/api/ \
+  --xcodebuild-arguments "-project,${SRCROOT}/RealmSwift.xcodeproj,-dry-run" \


### PR DESCRIPTION
Jazzy 0.2.0 is installed on all CI workers.