### PR TITLE
use full logo URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Realm](logo.png)
+![Realm](https://github.com/realm/realm-cocoa/raw/master/logo.png)
 
 Realm is a mobile database that runs directly inside phones, tablets or wearables.
 This repository holds the source code for the iOS & OSX versions of Realm, for both Swift & Objective-C.


### PR DESCRIPTION
Otherwise, jazzy won't render the image because it's currently a relative link.