### PR TITLE
Test that, in migrations, arrays yield DynamicObjects

### DIFF
--- a/Realm/Tests/MigrationTests.mm
+++ b/Realm/Tests/MigrationTests.mm
@@ -752,6 +752,7 @@
     @autoreleasepool {
         [[RLMRealm defaultRealm] transactionWithBlock:^{
             [StringObject createInDefaultRealmWithValue:@[@"string"]];
+            [ArrayPropertyObject createInDefaultRealmWithValue:@[@"array", @[@[@"string"]], @[@[@1]]]];
         }];
     }
 
@@ -763,6 +764,13 @@
                                 XCTAssertEqualObjects([oldObject valueForKey:@"realm"], oldObject.realm);
                                 XCTAssertThrows([oldObject valueForKey:@"noSuchKey"]);
                                 XCTAssertThrows([newObject setValue:@1 forKey:@"noSuchKey"]);
+                            }];
+
+                            [migration enumerateObjects:ArrayPropertyObject.className block:^(RLMObject *oldObject, RLMObject *newObject) {
+                                XCTAssertEqual(RLMDynamicObject.class, newObject.class);
+                                XCTAssertEqual(RLMDynamicObject.class, oldObject.class);
+                                XCTAssertEqual(RLMDynamicObject.class, [[oldObject[@"array"] firstObject] class]);
+                                XCTAssertEqual(RLMDynamicObject.class, [[newObject[@"array"] firstObject] class]);
                             }];
                         }];
 

--- a/RealmSwift/Tests/MigrationTests.swift
+++ b/RealmSwift/Tests/MigrationTests.swift
@@ -171,6 +171,23 @@ class MigrationTests: TestCase {
                 XCTAssertEqual(count, 1)
             })
         }
+
+        autoreleasepool {
+            Realm().write {
+                Realm().create(SwiftArrayPropertyObject.self, value: ["string", [["array"]], [[2]]])
+            }
+        }
+
+        autoreleasepool {
+            self.migrateAndTestRealm(Realm.defaultPath, schemaVersion: 3, block: { migration, oldSchemaVersion in
+                migration.enumerate("SwiftArrayPropertyObject") { oldObject, newObject in
+                    XCTAssertTrue(oldObject! as AnyObject is MigrationObject)
+                    XCTAssertTrue(newObject! as AnyObject is MigrationObject)
+                    XCTAssertTrue(oldObject!["array"]! is List<MigrationObject>)
+                    XCTAssertTrue(oldObject!["array"]! is List<MigrationObject>)
+                }
+            })
+        }
     }
 
     func testCreate() {


### PR DESCRIPTION
Closes #1331.

\c @jpsim 