### PR TITLE
[RLMObjectStore] Allow properly updating linked objects with primary keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ x.x.x Release notes (yyyy-MM-dd)
   REALM_DISABLE_ENCRYPTION=YES in your application's environment variables to
   have requests to open an encrypted Realm treated as a request for an
   unencrypted Realm.
+* Linked objects are properly updated in `createOrUpdateInRealm:withValue:`.
 
 0.92.1 Release notes (2015-05-06)
 =============================================================

--- a/Realm/RLMAccessor.mm
+++ b/Realm/RLMAccessor.mm
@@ -210,6 +210,7 @@ static inline RLMObjectBase *RLMGetLink(unretained<RLMObjectBase> obj, NSUIntege
     NSUInteger index = obj->_row.get_link(colIndex);
     return RLMCreateObjectAccessor(obj->_realm, obj->_realm.schema[objectClassName], index);
 }
+
 static inline void RLMSetValue(unretained<RLMObjectBase> obj, NSUInteger colIndex,
                                unretained<RLMObjectBase> val, RLMCreationOptions options=0) {
     RLMVerifyInWriteTransaction(obj);
@@ -242,6 +243,7 @@ static inline RLMArray *RLMGetArray(unretained<RLMObjectBase> obj, NSUInteger co
                                                                 realm:obj->_realm];
     return ar;
 }
+
 static inline void RLMSetValue(unretained<RLMObjectBase> obj, NSUInteger colIndex,
                                unretained<id><NSFastEnumeration> val,
                                RLMCreationOptions options=0) {

--- a/Realm/RLMObjectStore.h
+++ b/Realm/RLMObjectStore.h
@@ -89,7 +89,6 @@ id RLMGetObject(RLMRealm *realm, NSString *objectClassName, id key);
 // create object from array or dictionary
 RLMObjectBase *RLMCreateObjectInRealmWithValue(RLMRealm *realm, NSString *className, id value, RLMCreationOptions options);
 
-
 //
 // Accessor Creation
 //

--- a/Realm/RLMObjectStore.mm
+++ b/Realm/RLMObjectStore.mm
@@ -465,7 +465,6 @@ void RLMAddObjectToRealm(RLMObjectBase *object, RLMRealm *realm, RLMCreationOpti
     RLMInitializeSwiftListAccessor(object);
 }
 
-
 RLMObjectBase *RLMCreateObjectInRealmWithValue(RLMRealm *realm, NSString *className, id value, RLMCreationOptions options) {
     if (options & RLMCreationOptionsUpdateOrCreate && RLMIsObjectSubclass([value class])) {
         RLMObjectBase *obj = value;
@@ -485,7 +484,7 @@ RLMObjectBase *RLMCreateObjectInRealmWithValue(RLMRealm *realm, NSString *classN
 
     // validate values, create row, and populate
     if (NSArray *array = RLMDynamicCast<NSArray>(value)) {
-        array = RLMValidatedArrayForObjectSchema(value, objectSchema, schema);
+        array = RLMValidatedArrayForObjectSchema(value, objectSchema, schema, realm);
 
         // get or create our accessor
         bool created;
@@ -510,7 +509,7 @@ RLMObjectBase *RLMCreateObjectInRealmWithValue(RLMRealm *realm, NSString *classN
         object->_row = (*objectSchema.table)[RLMCreateOrGetRowForObject(objectSchema, primaryGetter, options, created)];
 
         // assume dictionary or object with kvc properties
-        NSDictionary *dict = RLMValidatedDictionaryForObjectSchema(value, objectSchema, schema, !created);
+        NSDictionary *dict = RLMValidatedDictionaryForObjectSchema(value, objectSchema, schema, !created, realm);
 
         // populate
         for (RLMProperty *prop in objectSchema.properties) {

--- a/Realm/RLMUtil.hpp
+++ b/Realm/RLMUtil.hpp
@@ -56,11 +56,11 @@ BOOL RLMIsObjectValidForProperty(id obj, RLMProperty *prop);
 // returns a validated object for an input object
 // creates new objects for child objects and array literals as necessary
 // throws if passed in literals are not compatible with prop
-id RLMValidatedObjectForProperty(id obj, RLMProperty *prop, RLMSchema *schema);
+id RLMValidatedObjectForProperty(id obj, RLMProperty *prop, RLMSchema *schema, RLMRealm *realm);
 
 // throws if the values in array are not valid for the given schema
 // returns array with allocated child objects
-NSArray *RLMValidatedArrayForObjectSchema(NSArray *array, RLMObjectSchema *objectSchema, RLMSchema *schema);
+NSArray *RLMValidatedArrayForObjectSchema(NSArray *array, RLMObjectSchema *objectSchema, RLMSchema *schema, RLMRealm *realm = nil);
 
 // gets default values for the given schema (+defaultPropertyValues)
 // merges with native property defaults if Swift class
@@ -70,7 +70,7 @@ NSDictionary *RLMDefaultValuesForObjectSchema(RLMObjectSchema *objectSchema);
 // inserts default values for missing properties when allowMissing is false
 // throws for missing properties when allowMissing is false
 // returns dictionary with default values and allocates child objects when applicable
-NSDictionary *RLMValidatedDictionaryForObjectSchema(id value, RLMObjectSchema *objectSchema, RLMSchema *schema, bool allowMissing = false);
+NSDictionary *RLMValidatedDictionaryForObjectSchema(id value, RLMObjectSchema *objectSchema, RLMSchema *schema, bool allowMissing = false, RLMRealm *realm = nil);
 
 NSArray *RLMCollectionValueForKey(NSString *key, RLMRealm *realm, RLMObjectSchema *objectSchema, size_t count, size_t (^indexGenerator)(size_t index));
 

--- a/Realm/RLMUtil.mm
+++ b/Realm/RLMUtil.mm
@@ -166,20 +166,29 @@ BOOL RLMIsObjectValidForProperty(id obj, RLMProperty *property) {
     @throw RLMException(@"Invalid RLMPropertyType specified");
 }
 
-id RLMValidatedObjectForProperty(id obj, RLMProperty *prop, RLMSchema *schema) {
+static inline id RLMValidatedRealmObject(id obj, RLMSchema *schema, RLMObjectSchema *objectSchema, RLMRealm *realm) {
+    if (realm) {
+        return RLMCreateObjectInRealmWithValue(realm, objectSchema.className, obj, RLMCreationOptionsAllowCopy | RLMCreationOptionsUpdateOrCreate);
+    }
+    else {
+        return [[objectSchema.objectClass alloc] initWithValue:obj schema:schema];
+    }
+}
+
+id RLMValidatedObjectForProperty(id obj, RLMProperty *prop, RLMSchema *schema, RLMRealm *realm) {
     if (!RLMIsObjectValidForProperty(obj, prop)) {
         // check for object or array literals
         if (prop.type == RLMPropertyTypeObject) {
             // for object create and try to initialize with obj
             RLMObjectSchema *objSchema = schema[prop.objectClassName];
-            return [[objSchema.objectClass alloc] initWithValue:obj schema:schema];
+            return RLMValidatedRealmObject(obj, schema, objSchema, realm);
         }
         else if (prop.type == RLMPropertyTypeArray && [obj conformsToProtocol:@protocol(NSFastEnumeration)]) {
             // for arrays, create objects for each literal object and return new array
             RLMObjectSchema *objSchema = schema[prop.objectClassName];
             RLMArray *objects = [[RLMArray alloc] initWithObjectClassName: objSchema.className standalone:YES];
             for (id el in obj) {
-                [objects addObject:[[objSchema.objectClass alloc] initWithValue:el schema:schema]];
+                [objects addObject:RLMValidatedRealmObject(el, schema, objSchema, realm)];
             }
             return objects;
         }
@@ -212,7 +221,7 @@ NSDictionary *RLMDefaultValuesForObjectSchema(RLMObjectSchema *objectSchema) {
     return defaults;
 }
 
-NSDictionary *RLMValidatedDictionaryForObjectSchema(id value, RLMObjectSchema *objectSchema, RLMSchema *schema, bool allowMissing) {
+NSDictionary *RLMValidatedDictionaryForObjectSchema(id value, RLMObjectSchema *objectSchema, RLMSchema *schema, bool allowMissing, RLMRealm *realm) {
     NSArray *properties = objectSchema.properties;
     NSMutableDictionary *outDict = [NSMutableDictionary dictionaryWithCapacity:properties.count];
     NSDictionary *defaultValues = nil;
@@ -232,13 +241,13 @@ NSDictionary *RLMValidatedDictionaryForObjectSchema(id value, RLMObjectSchema *o
             if (!obj) {
                 obj = NSNull.null;
             }
-            outDict[prop.name] = RLMValidatedObjectForProperty(obj, prop, schema);
+            outDict[prop.name] = RLMValidatedObjectForProperty(obj, prop, schema, realm);
         }
     }
     return outDict;
 }
 
-NSArray *RLMValidatedArrayForObjectSchema(NSArray *array, RLMObjectSchema *objectSchema, RLMSchema *schema) {
+NSArray *RLMValidatedArrayForObjectSchema(NSArray *array, RLMObjectSchema *objectSchema, RLMSchema *schema, RLMRealm *realm) {
     NSArray *props = objectSchema.properties;
     if (array.count != props.count) {
         @throw RLMException(@"Invalid array input. Number of array elements does not match number of properties.");
@@ -247,7 +256,7 @@ NSArray *RLMValidatedArrayForObjectSchema(NSArray *array, RLMObjectSchema *objec
     // validate all values
     NSMutableArray *outArray = [NSMutableArray arrayWithCapacity:props.count];
     for (NSUInteger i = 0; i < array.count; i++) {
-        [outArray addObject:RLMValidatedObjectForProperty(array[i], props[i], schema)];
+        [outArray addObject:RLMValidatedObjectForProperty(array[i], props[i], schema, realm)];
     }
     return outArray;
 };

--- a/Realm/Tests/ObjectTests.m
+++ b/Realm/Tests/ObjectTests.m
@@ -989,32 +989,6 @@ RLM_ARRAY_TYPE(PrimaryEmployeeObject);
     [realm commitWriteTransaction];
 }
 
-//- (void)testCreateInRealmWithCircularObject
-//{
-//    RLMRealm *realm = [self realmWithTestPath];
-//
-//    CircleObject *object = [[CircleObject alloc] init];
-//    object.data = @"data";
-//    object.next = [[CircleObject alloc] initWithValue:@[@"other data", object]];
-//
-//    [realm beginWriteTransaction];
-//    [CircleObject createInRealm:realm withValue:object];
-//    [realm commitWriteTransaction];
-//}
-
-//- (void)testInitCircularObject
-//{
-//    RLMRealm *realm = [self realmWithTestPath];
-//
-//    NSMutableDictionary *value = [NSMutableDictionary dictionaryWithObject:@"data" forKey:@"data"];
-//    value[@"next"] = @{@"data": @"other data", @"next": value};
-//
-//    [realm beginWriteTransaction];
-//    CircleObject *standalone = [[CircleObject alloc] initWithValue:value];
-//    [realm commitWriteTransaction];
-//    XCTAssertEqual(standalone.next.next, standalone);
-//}
-
 - (void)testObjectDescription
 {
     RLMRealm *realm = [RLMRealm defaultRealm];

--- a/RealmSwift/Tests/ObjectCreationTests.swift
+++ b/RealmSwift/Tests/ObjectCreationTests.swift
@@ -261,7 +261,7 @@ class ObjectCreationTests: TestCase {
         XCTAssertEqual(stringObjects.count, 1)
         let persistedObject = object.object!
 
-        XCTAssertEqual(persistedObject.intCol, 12)
+        XCTAssertEqual(persistedObject.intCol, 11)
         XCTAssertNil(standalone.realm) // the standalone object should be copied, rather than added, to the realm
         XCTAssertEqual(object.object!, persistedObject)
         XCTAssertEqual(object.objects.first!, persistedObject)

--- a/RealmSwift/Tests/ObjectCreationTests.swift
+++ b/RealmSwift/Tests/ObjectCreationTests.swift
@@ -254,14 +254,14 @@ class ObjectCreationTests: TestCase {
     func testUpdateWithNestedObjects() {
         let standalone = SwiftPrimaryStringObject(value: ["primary", 11])
         Realm().beginWrite()
-        let object = Realm().create(SwiftLinkToPrimaryStringObject.self, value: ["otherPrimary", standalone, [["primary", 12]]], update: true)
+        let object = Realm().create(SwiftLinkToPrimaryStringObject.self, value: ["otherPrimary", ["primary", 12], [["primary", 12]]], update: true)
         Realm().commitWrite()
 
         let stringObjects = Realm().objects(SwiftPrimaryStringObject)
         XCTAssertEqual(stringObjects.count, 1)
         let persistedObject = object.object!
 
-        XCTAssertEqual(persistedObject.intCol, 11)
+        XCTAssertEqual(persistedObject.intCol, 12)
         XCTAssertNil(standalone.realm) // the standalone object should be copied, rather than added, to the realm
         XCTAssertEqual(object.object!, persistedObject)
         XCTAssertEqual(object.objects.first!, persistedObject)


### PR DESCRIPTION
Closes #1362.
Successor to https://github.com/realm/realm-cocoa/pull/1810, but with out the cyclical object graph support.

Basically, this PR fixes the issue by fetching a persisted object when trying to update a link in `createOrUpdate`

\c @tgoyne @jpsim @bdash 