### PR TITLE
[Podspec] update podspec for 0.92.0

### DIFF
--- a/Realm.podspec
+++ b/Realm.podspec
@@ -1,24 +1,19 @@
 Pod::Spec.new do |s|
   s.name                    = 'Realm'
   s.version                 = `sh build.sh get-version`
-  s.summary                 = 'Realm is a modern data framework & database for iOS & OSX.'
+  s.summary                 = 'Realm is a modern data framework & database for iOS & OS X.'
   s.description             = <<-DESC
-                              Realm is a modern data framework & database for iOS & OSX. You can use it purely in memory — or persist to disk with extraordinary performance.
+                              The Realm database, for Objective-C.
 
-                              Realm’s data structures look like NSObjects and NSArrays, but provide additional features such as: querying, relationships & graphs, thread safety, and more.
-
-                              Realm is not built on SQLite. Instead, a custom C++ core is used to provide memory-efficient access to your data by using Realm objects, which usually consume less RAM than native objects. The core also provides an optional persistence layer that can automatically save and retrieve your objects from disk.
-
-                              Realm offers extraordinary performance compared to SQLite and other persistence solutions. It has been in development since 2011 and powers an app with over 1 million
-                              daily active users at a major mobile game company.
+                              Realm is a mobile database: a replacement for Core Data & SQLite. You can use it on iOS & OS X. Realm is not an ORM on top SQLite: instead it uses its own persistence engine, built for simplicity (& speed). Learn more and get help at https://realm.io
                               DESC
-  s.homepage                = "http://realm.io"
-  s.source                  = { :git => 'https://github.com/Realm/realm-cocoa.git', :tag => "v#{s.version}" }
+  s.homepage                = "https://realm.io"
+  s.source                  = { :git => 'https://github.com/realm/realm-cocoa.git', :tag => "v#{s.version}" }
   s.author                  = { 'Realm' => 'help@realm.io' }
   s.library                 = 'c++'
   s.requires_arc            = true
   s.social_media_url        = 'https://twitter.com/realm'
-  s.documentation_url       = "http://realm.io/docs/cocoa/#{s.version}"
+  s.documentation_url       = "https://realm.io/docs/objc/#{s.version}"
   s.license                 = { :type => 'Apache 2.0', :file => 'LICENSE' }
 
   public_header_files = 'include/Realm/RLMArray.h',


### PR DESCRIPTION
This is needed to push 0.92.0 to trunk because the `documentation_url` needs to point to `https://realm.io/docs/objc/#{s.version}`. /cc @segiddins 