### PR TITLE
Generate unique object IDs for objects in the RealmSwift Xcode project.

### DIFF
--- a/RealmSwift.xcodeproj/project.pbxproj
+++ b/RealmSwift.xcodeproj/project.pbxproj
@@ -32,7 +32,7 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
-		0201B2741A54C68C004CFB6F /* libc++.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 023B19F71A423BD20067FB81 /* libc++.dylib */; };
+		0201B2741A54C68C004CFB6F /* libc++.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 554A51C33FAED0A637EBFEBF /* libc++.dylib */; };
 		0201B2951A54C78A004CFB6F /* RealmSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0201B27B1A54C68C004CFB6F /* RealmSwift.framework */; };
 		020F63C21A8037AE007CB52E /* Aliases.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020F63B91A8037AE007CB52E /* Aliases.swift */; };
 		020F63C31A8037AE007CB52E /* Aliases.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020F63B91A8037AE007CB52E /* Aliases.swift */; };
@@ -71,7 +71,7 @@
 		020F63FA1A8037DC007CB52E /* TestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020F63DD1A8037DC007CB52E /* TestCase.swift */; };
 		020F63FB1A8037DC007CB52E /* TestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 020F63DD1A8037DC007CB52E /* TestCase.swift */; };
 		020F63FE1A803895007CB52E /* RealmSwift.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 023B19A81A4234380067FB81 /* RealmSwift.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		023B19F81A423BD20067FB81 /* libc++.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 023B19F71A423BD20067FB81 /* libc++.dylib */; };
+		023B19F81A423BD20067FB81 /* libc++.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 554A51C33FAED0A637EBFEBF /* libc++.dylib */; };
 		0253CDAC1AAE667000AF9E6C /* TestUtils.mm in Sources */ = {isa = PBXBuildFile; fileRef = C0D8E1321A8196EE0077C784 /* TestUtils.mm */; };
 		02616BD51A817FC8009919CB /* MigrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02616BD41A817FC8009919CB /* MigrationTests.swift */; };
 		02616BD61A817FC8009919CB /* MigrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02616BD41A817FC8009919CB /* MigrationTests.swift */; };
@@ -110,7 +110,7 @@
 		C0E04FA41AB235D800DCC8C0 /* ObjectSchemaInitializationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0253CD9A1AA0016300AF9E6C /* ObjectSchemaInitializationTests.swift */; };
 		C0E04FA51AB235D900DCC8C0 /* ObjectSchemaInitializationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0253CD9A1AA0016300AF9E6C /* ObjectSchemaInitializationTests.swift */; };
 		C0E04FA61AB235E000DCC8C0 /* SortDescriptorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D8E12E1A81749D0077C784 /* SortDescriptorTests.swift */; };
-		C0E04FD11AB2367300DCC8C0 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = E8839B2D19E31FD90047B1A8 /* main.m */; };
+		C0E04FD11AB2367300DCC8C0 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 554A51CE3FAED0A637EBFEBF /* main.m */; };
 		C0FE465C1A9BE7A6006E0539 /* ObjectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0FE465B1A9BE7A6006E0539 /* ObjectTests.swift */; };
 		C0FE465D1A9BE7A6006E0539 /* ObjectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0FE465B1A9BE7A6006E0539 /* ObjectTests.swift */; };
 		C0FE465E1A9BE7A6006E0539 /* ObjectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0FE465B1A9BE7A6006E0539 /* ObjectTests.swift */; };
@@ -120,35 +120,35 @@
 /* Begin PBXContainerItemProxy section */
 		0201B2981A54C7BD004CFB6F /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = E8D89B8F1955FC6D00CF2B9A /* Project object */;
+			containerPortal = 554A51D03FAED0A637EBFEBF /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = 0201B2661A54C68C004CFB6F;
 			remoteInfo = "RealmSwift OSX";
 		};
 		026B0F001A780521005E26C8 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = E8D89B8F1955FC6D00CF2B9A /* Project object */;
+			containerPortal = 554A51D03FAED0A637EBFEBF /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = 026B0EFB1A780414005E26C8;
 			remoteInfo = Realm;
 		};
 		02B8228E1A532125007F28A5 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = E8D89B8F1955FC6D00CF2B9A /* Project object */;
+			containerPortal = 554A51D03FAED0A637EBFEBF /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = 023B19A71A4234380067FB81;
 			remoteInfo = "RealmSwift iOS";
 		};
 		295C17A81A7C5627000E5F54 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = E8D89B8F1955FC6D00CF2B9A /* Project object */;
+			containerPortal = 554A51D03FAED0A637EBFEBF /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = 295C17A31A7C55DA000E5F54;
 			remoteInfo = "Realm OSX";
 		};
 		C0E04FD21AB2367A00DCC8C0 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = E8D89B8F1955FC6D00CF2B9A /* Project object */;
+			containerPortal = 554A51D03FAED0A637EBFEBF /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = C0E04FAA1AB2366200DCC8C0;
 			remoteInfo = TestHost;
@@ -220,13 +220,13 @@
 		020F63DC1A8037DC007CB52E /* SwiftUnicodeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SwiftUnicodeTests.swift; path = RealmSwift/Tests/SwiftUnicodeTests.swift; sourceTree = SOURCE_ROOT; };
 		020F63DD1A8037DC007CB52E /* TestCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TestCase.swift; path = RealmSwift/Tests/TestCase.swift; sourceTree = SOURCE_ROOT; };
 		023B19A81A4234380067FB81 /* RealmSwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = RealmSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		023B19F71A423BD20067FB81 /* libc++.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = "libc++.dylib"; path = "usr/lib/libc++.dylib"; sourceTree = SDKROOT; };
+		554A51C33FAED0A637EBFEBF /* libc++.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = "libc++.dylib"; path = "usr/lib/libc++.dylib"; sourceTree = SDKROOT; };
 		0253CD981AA0016300AF9E6C /* ObjectAccessorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ObjectAccessorTests.swift; path = RealmSwift/Tests/ObjectAccessorTests.swift; sourceTree = SOURCE_ROOT; };
 		0253CD991AA0016300AF9E6C /* ObjectCreationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ObjectCreationTests.swift; path = RealmSwift/Tests/ObjectCreationTests.swift; sourceTree = SOURCE_ROOT; };
 		0253CD9A1AA0016300AF9E6C /* ObjectSchemaInitializationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ObjectSchemaInitializationTests.swift; path = RealmSwift/Tests/ObjectSchemaInitializationTests.swift; sourceTree = SOURCE_ROOT; };
 		02616BD41A817FC8009919CB /* MigrationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = MigrationTests.swift; path = RealmSwift/Tests/MigrationTests.swift; sourceTree = SOURCE_ROOT; };
 		02B822821A532100007F28A5 /* RealmSwift iOS Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "RealmSwift iOS Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
-		3F8DCA5719930F550008BD7F /* iOS Device Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "iOS Device Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		554A51C83FAED0A637EBFEBF /* iOS Device Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "iOS Device Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		C0027B061AAF6FBC00F013A2 /* SchemaTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SchemaTests.swift; path = RealmSwift/Tests/SchemaTests.swift; sourceTree = SOURCE_ROOT; };
 		C0027B0A1AAF736700F013A2 /* ObjectSchemaTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ObjectSchemaTests.swift; path = RealmSwift/Tests/ObjectSchemaTests.swift; sourceTree = SOURCE_ROOT; };
 		C0240C2A1A84090000858BFA /* RealmTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = RealmTests.swift; path = RealmSwift/Tests/RealmTests.swift; sourceTree = SOURCE_ROOT; };
@@ -240,9 +240,9 @@
 		C0D8E1391A819B430077C784 /* RealmSwiftTests-BridgingHeader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "RealmSwiftTests-BridgingHeader.h"; path = "RealmSwift/Tests/RealmSwiftTests-BridgingHeader.h"; sourceTree = SOURCE_ROOT; };
 		C0E04FAB1AB2366200DCC8C0 /* TestHost.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TestHost.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C0FE465B1A9BE7A6006E0539 /* ObjectTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ObjectTests.swift; path = RealmSwift/Tests/ObjectTests.swift; sourceTree = SOURCE_ROOT; };
-		E81A1FC21955FE0100FDED82 /* RealmTests-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "RealmTests-Info.plist"; sourceTree = "<group>"; };
-		E8839B2C19E31FD90047B1A8 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = Realm/Tests/TestHost/Info.plist; sourceTree = SOURCE_ROOT; };
-		E8839B2D19E31FD90047B1A8 /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = main.m; path = Realm/Tests/TestHost/main.m; sourceTree = SOURCE_ROOT; };
+		554A51CC3FAED0A637EBFEBF /* RealmTests-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "RealmTests-Info.plist"; sourceTree = "<group>"; };
+		554A51CD3FAED0A637EBFEBF /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = Realm/Tests/TestHost/Info.plist; sourceTree = SOURCE_ROOT; };
+		554A51CE3FAED0A637EBFEBF /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = main.m; path = Realm/Tests/TestHost/main.m; sourceTree = SOURCE_ROOT; };
 		E8DF380F1AF7185B00BC914F /* strip-frameworks.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; name = "strip-frameworks.sh"; path = "scripts/strip-frameworks.sh"; sourceTree = SOURCE_ROOT; };
 /* End PBXFileReference section */
 
@@ -279,7 +279,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		3F8DCA5419930F550008BD7F /* Frameworks */ = {
+		554A51C63FAED0A637EBFEBF /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -296,29 +296,29 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		3F1A5E731992EB7400F45F4C /* TestHost */ = {
+		554A51C43FAED0A637EBFEBF /* TestHost */ = {
 			isa = PBXGroup;
 			children = (
-				E8839B2C19E31FD90047B1A8 /* Info.plist */,
-				E8839B2D19E31FD90047B1A8 /* main.m */,
+				554A51CD3FAED0A637EBFEBF /* Info.plist */,
+				554A51CE3FAED0A637EBFEBF /* main.m */,
 			);
 			name = TestHost;
 			path = ../../TestHost;
 			sourceTree = "<group>";
 		};
-		E8D89B8E1955FC6D00CF2B9A = {
+		554A51CF3FAED0A637EBFEBF = {
 			isa = PBXGroup;
 			children = (
-				E8D89B991955FC6D00CF2B9A /* Products */,
-				E8D89B9A1955FC6D00CF2B9A /* RealmSwift */,
-				E8D89BA71955FC6D00CF2B9A /* Tests */,
+				554A51D23FAED0A637EBFEBF /* Products */,
+				554A51D33FAED0A637EBFEBF /* RealmSwift */,
+				554A51D53FAED0A637EBFEBF /* Tests */,
 			);
 			sourceTree = "<group>";
 		};
-		E8D89B991955FC6D00CF2B9A /* Products */ = {
+		554A51D23FAED0A637EBFEBF /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				3F8DCA5719930F550008BD7F /* iOS Device Tests.xctest */,
+				554A51C83FAED0A637EBFEBF /* iOS Device Tests.xctest */,
 				023B19A81A4234380067FB81 /* RealmSwift.framework */,
 				02B822821A532100007F28A5 /* RealmSwift iOS Tests.xctest */,
 				0201B27B1A54C68C004CFB6F /* RealmSwift.framework */,
@@ -328,7 +328,7 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
-		E8D89B9A1955FC6D00CF2B9A /* RealmSwift */ = {
+		554A51D33FAED0A637EBFEBF /* RealmSwift */ = {
 			isa = PBXGroup;
 			children = (
 				020F63B91A8037AE007CB52E /* Aliases.swift */,
@@ -342,22 +342,22 @@
 				020F63C11A8037AE007CB52E /* Schema.swift */,
 				C0D8E12B1A8174090077C784 /* SortDescriptor.swift */,
 				C04DAEBD1A8E7FBD008A9623 /* Util.swift */,
-				E8D89B9B1955FC6D00CF2B9A /* Supporting Files */,
+				554A51D43FAED0A637EBFEBF /* Supporting Files */,
 			);
 			name = RealmSwift;
 			path = Realm;
 			sourceTree = "<group>";
 		};
-		E8D89B9B1955FC6D00CF2B9A /* Supporting Files */ = {
+		554A51D43FAED0A637EBFEBF /* Supporting Files */ = {
 			isa = PBXGroup;
 			children = (
 				E8DF380F1AF7185B00BC914F /* strip-frameworks.sh */,
-				023B19F71A423BD20067FB81 /* libc++.dylib */,
+				554A51C33FAED0A637EBFEBF /* libc++.dylib */,
 			);
 			name = "Supporting Files";
 			sourceTree = "<group>";
 		};
-		E8D89BA71955FC6D00CF2B9A /* Tests */ = {
+		554A51D53FAED0A637EBFEBF /* Tests */ = {
 			isa = PBXGroup;
 			children = (
 				020F63D41A8037DC007CB52E /* ListTests.swift */,
@@ -377,8 +377,8 @@
 				020F63DB1A8037DC007CB52E /* SwiftTestObjects.swift */,
 				020F63DC1A8037DC007CB52E /* SwiftUnicodeTests.swift */,
 				020F63DD1A8037DC007CB52E /* TestCase.swift */,
-				E8D89BA81955FC6D00CF2B9A /* Supporting Files */,
-				3F1A5E731992EB7400F45F4C /* TestHost */,
+				554A51D63FAED0A637EBFEBF /* Supporting Files */,
+				554A51C43FAED0A637EBFEBF /* TestHost */,
 				C0D8E1311A8196EE0077C784 /* TestUtils.h */,
 				C0D8E1321A8196EE0077C784 /* TestUtils.mm */,
 			);
@@ -386,10 +386,10 @@
 			path = Realm/Tests;
 			sourceTree = "<group>";
 		};
-		E8D89BA81955FC6D00CF2B9A /* Supporting Files */ = {
+		554A51D63FAED0A637EBFEBF /* Supporting Files */ = {
 			isa = PBXGroup;
 			children = (
-				E81A1FC21955FE0100FDED82 /* RealmTests-Info.plist */,
+				554A51CC3FAED0A637EBFEBF /* RealmTests-Info.plist */,
 				C0D8E1391A819B430077C784 /* RealmSwiftTests-BridgingHeader.h */,
 			);
 			name = "Supporting Files";
@@ -471,12 +471,12 @@
 			productReference = 02B822821A532100007F28A5 /* RealmSwift iOS Tests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
-		3F8DCA5619930F550008BD7F /* iOS Device Tests */ = {
+		554A51C73FAED0A637EBFEBF /* iOS Device Tests */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 3F8DCA5D19930F550008BD7F /* Build configuration list for PBXNativeTarget "iOS Device Tests" */;
+			buildConfigurationList = 554A51C93FAED0A637EBFEBF /* Build configuration list for PBXNativeTarget "iOS Device Tests" */;
 			buildPhases = (
-				3F8DCA5319930F550008BD7F /* Sources */,
-				3F8DCA5419930F550008BD7F /* Frameworks */,
+				554A51C53FAED0A637EBFEBF /* Sources */,
+				554A51C63FAED0A637EBFEBF /* Frameworks */,
 				020F63FD1A803885007CB52E /* CopyFiles */,
 			);
 			buildRules = (
@@ -486,7 +486,7 @@
 			);
 			name = "iOS Device Tests";
 			productName = "iOS Device Tests";
-			productReference = 3F8DCA5719930F550008BD7F /* iOS Device Tests.xctest */;
+			productReference = 554A51C83FAED0A637EBFEBF /* iOS Device Tests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
 		C0E04FAA1AB2366200DCC8C0 /* TestHost */ = {
@@ -509,7 +509,7 @@
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
-		E8D89B8F1955FC6D00CF2B9A /* Project object */ = {
+		554A51D03FAED0A637EBFEBF /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
 				CLASSPREFIX = RLM;
@@ -523,7 +523,7 @@
 					026B0EFB1A780414005E26C8 = {
 						CreatedOnToolsVersion = 6.1;
 					};
-					3F8DCA5619930F550008BD7F = {
+					554A51C73FAED0A637EBFEBF = {
 						CreatedOnToolsVersion = 6.0;
 						TestTargetID = C0E04FAA1AB2366200DCC8C0;
 					};
@@ -532,7 +532,7 @@
 					};
 				};
 			};
-			buildConfigurationList = E8D89B921955FC6D00CF2B9A /* Build configuration list for PBXProject "RealmSwift" */;
+			buildConfigurationList = 554A51D13FAED0A637EBFEBF /* Build configuration list for PBXProject "RealmSwift" */;
 			compatibilityVersion = "Xcode 3.2";
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
@@ -540,8 +540,8 @@
 				en,
 				Base,
 			);
-			mainGroup = E8D89B8E1955FC6D00CF2B9A;
-			productRefGroup = E8D89B991955FC6D00CF2B9A /* Products */;
+			mainGroup = 554A51CF3FAED0A637EBFEBF;
+			productRefGroup = 554A51D23FAED0A637EBFEBF /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
@@ -549,7 +549,7 @@
 				02B822551A532100007F28A5 /* RealmSwift iOS Tests */,
 				0201B2661A54C68C004CFB6F /* RealmSwift OSX */,
 				0201B27D1A54C697004CFB6F /* RealmSwift OSX Tests */,
-				3F8DCA5619930F550008BD7F /* iOS Device Tests */,
+				554A51C73FAED0A637EBFEBF /* iOS Device Tests */,
 				026B0EFB1A780414005E26C8 /* Realm iOS */,
 				295C17A31A7C55DA000E5F54 /* Realm OSX */,
 				C0E04FAA1AB2366200DCC8C0 /* TestHost */,
@@ -713,7 +713,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		3F8DCA5319930F550008BD7F /* Sources */ = {
+		554A51C53FAED0A637EBFEBF /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -1027,7 +1027,7 @@
 			};
 			name = Release;
 		};
-		3F8DCA5E19930F550008BD7F /* Debug */ = {
+		554A51CA3FAED0A637EBFEBF /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
@@ -1059,7 +1059,7 @@
 			};
 			name = Debug;
 		};
-		3F8DCA5F19930F550008BD7F /* Release */ = {
+		554A51CB3FAED0A637EBFEBF /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
@@ -1119,7 +1119,7 @@
 			};
 			name = Release;
 		};
-		E8D89BAC1955FC6D00CF2B9A /* Debug */ = {
+		554A51D73FAED0A637EBFEBF /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -1172,7 +1172,7 @@
 			};
 			name = Debug;
 		};
-		E8D89BAD1955FC6D00CF2B9A /* Release */ = {
+		554A51D83FAED0A637EBFEBF /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -1276,11 +1276,11 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		3F8DCA5D19930F550008BD7F /* Build configuration list for PBXNativeTarget "iOS Device Tests" */ = {
+		554A51C93FAED0A637EBFEBF /* Build configuration list for PBXNativeTarget "iOS Device Tests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				3F8DCA5E19930F550008BD7F /* Debug */,
-				3F8DCA5F19930F550008BD7F /* Release */,
+				554A51CA3FAED0A637EBFEBF /* Debug */,
+				554A51CB3FAED0A637EBFEBF /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
@@ -1294,16 +1294,16 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		E8D89B921955FC6D00CF2B9A /* Build configuration list for PBXProject "RealmSwift" */ = {
+		554A51D13FAED0A637EBFEBF /* Build configuration list for PBXProject "RealmSwift" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				E8D89BAC1955FC6D00CF2B9A /* Debug */,
-				E8D89BAD1955FC6D00CF2B9A /* Release */,
+				554A51D73FAED0A637EBFEBF /* Debug */,
+				554A51D83FAED0A637EBFEBF /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
 	};
-	rootObject = E8D89B8F1955FC6D00CF2B9A /* Project object */;
+	rootObject = 554A51D03FAED0A637EBFEBF /* Project object */;
 }


### PR DESCRIPTION
The RealmSwift Xcode project started life as a copy of the Realm Xcode project,
causing many objects to have the same object IDs. This causes Xcode to crash if
you attempt to add both Xcode projects to the same workspace.

/cc @segiddins @jpsim 