### PR TITLE
Avoid force unwrapping in the Swift examples

### DIFF
--- a/examples/ios/swift/Encryption/ViewController.swift
+++ b/examples/ios/swift/Encryption/ViewController.swift
@@ -90,10 +90,7 @@ class ViewController: UIViewController {
     func getKey() -> NSData {
         // Identifier for our keychain entry - should be unique for your application
         let keychainIdentifier = "io.Realm.EncryptionExampleKey"
-        let optionalKeychainIdentifierData = keychainIdentifier.dataUsingEncoding(NSUTF8StringEncoding, allowLossyConversion: false)
-
-        assert(optionalKeychainIdentifierData != nil)
-        let keychainIdentifierData = optionalKeychainIdentifierData!
+        let keychainIdentifierData = keychainIdentifier.dataUsingEncoding(NSUTF8StringEncoding, allowLossyConversion: false)!
 
         // First check in the keychain for an existing key
         var query: [NSString: AnyObject] = [

--- a/examples/ios/swift/Encryption/ViewController.swift
+++ b/examples/ios/swift/Encryption/ViewController.swift
@@ -27,16 +27,12 @@ class EncryptionObject: Object {
 }
 
 class ViewController: UIViewController {
-    var textView: UITextView!
+    let textView = UITextView(frame: UIScreen.mainScreen().applicationFrame)
 
     // Create a view to display output in
     override func loadView() {
-        let applicationFrame = UIScreen.mainScreen().applicationFrame
-        self.view = UIView(frame: applicationFrame)
-        self.view.backgroundColor = UIColor.whiteColor()
-
-        self.textView = UITextView(frame: applicationFrame)
-        self.view.addSubview(self.textView)
+        super.loadView()
+        view.addSubview(textView)
     }
 
     override func viewDidAppear(animated: Bool) {
@@ -46,7 +42,7 @@ class ViewController: UIViewController {
         // that we can try to reopen it with different keys
         autoreleasepool {
             if let realm = Realm(path: Realm.defaultPath, readOnly: false,
-                encryptionKey: self.getKey(), error: nil) {
+                encryptionKey: getKey(), error: nil) {
 
                 // Add an object
                 realm.write {
@@ -63,14 +59,14 @@ class ViewController: UIViewController {
             Realm(path: Realm.defaultPath, readOnly: false,
                 encryptionKey: "1234567890123456789012345678901234567890123456789012345678901234".dataUsingEncoding(NSUTF8StringEncoding, allowLossyConversion: false),
                 error: &error)
-            self.log("Open with wrong key: \(error)")
+            log("Open with wrong key: \(error)")
         }
 
         // Opening wihout supplying a key at all fails
         autoreleasepool {
             var error: NSError? = nil
             Realm(path: Realm.defaultPath, readOnly: false, error: &error)
-            self.log("Open with no key: \(error)")
+            log("Open with no key: \(error)")
         }
 
         // Reopening with the correct key works and can read the data
@@ -78,26 +74,31 @@ class ViewController: UIViewController {
             var error: NSError? = nil
             if let realm = Realm(path: Realm.defaultPath,
                 readOnly: false,
-                encryptionKey: self.getKey(),
+                encryptionKey: getKey(),
                 error: &error) {
-                self.log("Saved object: \((realm.objects(EncryptionObject).first!).stringProp)")
+                if let stringProp = realm.objects(EncryptionObject).first?.stringProp {
+                    log("Saved object: \(stringProp)")
+                }
             }
         }
     }
 
     func log(text: String) {
-        self.textView.text = self.textView.text + text + "\n\n"
+        textView.text = textView.text + text + "\n\n"
     }
 
     func getKey() -> NSData {
         // Identifier for our keychain entry - should be unique for your application
         let keychainIdentifier = "io.Realm.EncryptionExampleKey"
-        let keychainIdentifierData = keychainIdentifier.dataUsingEncoding(NSUTF8StringEncoding, allowLossyConversion: false)
+        let optionalKeychainIdentifierData = keychainIdentifier.dataUsingEncoding(NSUTF8StringEncoding, allowLossyConversion: false)
+
+        assert(optionalKeychainIdentifierData != nil)
+        let keychainIdentifierData = optionalKeychainIdentifierData!
 
         // First check in the keychain for an existing key
         var query: [NSString: AnyObject] = [
             kSecClass: kSecClassKey,
-            kSecAttrApplicationTag: keychainIdentifierData!,
+            kSecAttrApplicationTag: keychainIdentifierData,
             kSecAttrKeySizeInBits: 512,
             kSecReturnData: true
         ]
@@ -117,7 +118,7 @@ class ViewController: UIViewController {
         // Store the key in the keychain
         query = [
             kSecClass: kSecClassKey,
-            kSecAttrApplicationTag: keychainIdentifierData!,
+            kSecAttrApplicationTag: keychainIdentifierData,
             kSecAttrKeySizeInBits: 512,
             kSecValueData: keyData
         ]
@@ -125,6 +126,6 @@ class ViewController: UIViewController {
         status = SecItemAdd(query, nil)
         assert(status == errSecSuccess, "Failed to insert the new key in the keychain")
 
-        return keyData;
+        return keyData
     }
 }

--- a/examples/ios/swift/GroupedTableView/TableViewController.swift
+++ b/examples/ios/swift/GroupedTableView/TableViewController.swift
@@ -86,9 +86,9 @@ class TableViewController: UITableViewController {
     override func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCellWithIdentifier("cell", forIndexPath: indexPath) as! Cell
 
-        let object = objectForIndexPath(indexPath)!
-        cell.textLabel?.text = object.title
-        cell.detailTextLabel?.text = object.date.description
+        let object = objectForIndexPath(indexPath)
+        cell.textLabel?.text = object?.title
+        cell.detailTextLabel?.text = object?.date.description
 
         return cell
     }

--- a/examples/ios/swift/Migration/AppDelegate.swift
+++ b/examples/ios/swift/Migration/AppDelegate.swift
@@ -65,8 +65,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         let defaultPath = Realm.defaultPath
         let defaultParentPath = defaultPath.stringByDeletingLastPathComponent
 
-        let v0Path = bundlePath("default-v0.realm")
-        if let v0Path = v0Path {
+        if let v0Path = bundlePath("default-v0.realm") {
             NSFileManager.defaultManager().removeItemAtPath(defaultPath, error: nil)
             NSFileManager.defaultManager().copyItemAtPath(v0Path, toPath: defaultPath, error: nil)
         }
@@ -109,9 +108,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         //
         // Migrate a realms at a custom paths
         //
-        let v1Path = bundlePath("default-v1.realm")
-        let v2Path = bundlePath("default-v2.realm")
-        if let v1Path = v1Path, v2Path = v2Path {
+        if let v1Path = bundlePath("default-v1.realm"), v2Path = bundlePath("default-v2.realm") {
             let realmv1Path = defaultParentPath.stringByAppendingPathComponent("default-v1.realm")
             let realmv2Path = defaultParentPath.stringByAppendingPathComponent("default-v2.realm")
             setSchemaVersion(3, realmv1Path, migrationBlock)

--- a/examples/ios/swift/Migration/AppDelegate.swift
+++ b/examples/ios/swift/Migration/AppDelegate.swift
@@ -78,10 +78,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                 migration.enumerate(Person.className()) { oldObject, newObject in
                     if oldSchemaVersion < 1 {
                         // combine name fields into a single field
-                        let firstName = oldObject?["firstName"] as? String
-                        assert(firstName != nil)
-                        let lastName = oldObject?["lastName"] as? String
-                        assert(lastName != nil)
+                        let firstName = oldObject!["firstName"] as! String
+                        let lastName = oldObject!["lastName"] as! String
                         newObject?["fullName"] = "\(firstName) \(lastName)"
                     }
                 }


### PR DESCRIPTION
We shouldn't be recommending that users do this.

The times in which values must not be nil, I'm using asserts instead. /cc @segiddins @tgoyne 