### PR TITLE
Disable debugging encrypted realms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,11 @@ x.x.x Release notes (yyyy-MM-dd)
 
 ### Bugfixes
 
-* None.
+* Prevent debugging of an application using an encrypted Realm to work around
+  frequent LLDB hangs. Until the underlying issue is addressed you may set
+  REALM_DISABLE_ENCRYPTION=YES in your application's environment variables to
+  have requests to open an encrypted Realm treated as a request for an
+  unencrypted Realm.
 
 0.92.0 Release notes (2015-05-05)
 =============================================================

--- a/Realm.xcodeproj/project.pbxproj
+++ b/Realm.xcodeproj/project.pbxproj
@@ -17,10 +17,10 @@
 		0207AB88195DFA15007EFB12 /* MigrationTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 0207AB85195DFA15007EFB12 /* MigrationTests.mm */; };
 		0207AB89195DFA15007EFB12 /* SchemaTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 0207AB86195DFA15007EFB12 /* SchemaTests.mm */; };
 		0207AB8A195DFA15007EFB12 /* SchemaTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 0207AB86195DFA15007EFB12 /* SchemaTests.mm */; };
-		021A88321AAFB5C800EEAC84 /* EncryptionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 021A882F1AAFB5BE00EEAC84 /* EncryptionTests.m */; };
-		021A88331AAFB5C900EEAC84 /* EncryptionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 021A882F1AAFB5BE00EEAC84 /* EncryptionTests.m */; };
-		021A88341AAFB5CA00EEAC84 /* EncryptionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 021A882F1AAFB5BE00EEAC84 /* EncryptionTests.m */; };
-		021A88351AAFB5CB00EEAC84 /* EncryptionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 021A882F1AAFB5BE00EEAC84 /* EncryptionTests.m */; };
+		021A88321AAFB5C800EEAC84 /* EncryptionTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 021A882F1AAFB5BE00EEAC84 /* EncryptionTests.mm */; };
+		021A88331AAFB5C900EEAC84 /* EncryptionTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 021A882F1AAFB5BE00EEAC84 /* EncryptionTests.mm */; };
+		021A88341AAFB5CA00EEAC84 /* EncryptionTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 021A882F1AAFB5BE00EEAC84 /* EncryptionTests.mm */; };
+		021A88351AAFB5CB00EEAC84 /* EncryptionTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 021A882F1AAFB5BE00EEAC84 /* EncryptionTests.mm */; };
 		021A88361AAFB5CD00EEAC84 /* ObjectSchemaTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 021A88301AAFB5BE00EEAC84 /* ObjectSchemaTests.m */; };
 		021A88371AAFB5CE00EEAC84 /* ObjectSchemaTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 021A88301AAFB5BE00EEAC84 /* ObjectSchemaTests.m */; };
 		021A88381AAFB5CF00EEAC84 /* ObjectSchemaTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 021A88301AAFB5BE00EEAC84 /* ObjectSchemaTests.m */; };
@@ -398,7 +398,7 @@
 		0207AB85195DFA15007EFB12 /* MigrationTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MigrationTests.mm; sourceTree = "<group>"; };
 		0207AB86195DFA15007EFB12 /* SchemaTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = SchemaTests.mm; sourceTree = "<group>"; };
 		0217D7B819CD0ACD00DE5C32 /* Swift-Tests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Swift-Tests-Bridging-Header.h"; sourceTree = "<group>"; };
-		021A882F1AAFB5BE00EEAC84 /* EncryptionTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = EncryptionTests.m; sourceTree = "<group>"; };
+		021A882F1AAFB5BE00EEAC84 /* EncryptionTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = EncryptionTests.mm; sourceTree = "<group>"; };
 		021A88301AAFB5BE00EEAC84 /* ObjectSchemaTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ObjectSchemaTests.m; sourceTree = "<group>"; };
 		021A88311AAFB5BE00EEAC84 /* UtilTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = UtilTests.mm; sourceTree = "<group>"; };
 		0237B5421A856F06004ACD57 /* RLMArray_Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RLMArray_Private.h; sourceTree = "<group>"; };
@@ -600,7 +600,7 @@
 			isa = PBXGroup;
 			children = (
 				027A4D291AB1012500AA46F9 /* InterprocessTests.m */,
-				021A882F1AAFB5BE00EEAC84 /* EncryptionTests.m */,
+				021A882F1AAFB5BE00EEAC84 /* EncryptionTests.mm */,
 				021A88301AAFB5BE00EEAC84 /* ObjectSchemaTests.m */,
 				021A88311AAFB5BE00EEAC84 /* UtilTests.mm */,
 				02AFB4611A80343600E11938 /* PropertyTests.m */,
@@ -1206,7 +1206,7 @@
 				026B0F101A780680005E26C8 /* ObjectInterfaceTests.m in Sources */,
 				02AFB4691A80343600E11938 /* ResultsTests.m in Sources */,
 				026B0F111A780680005E26C8 /* ObjectTests.m in Sources */,
-				021A88341AAFB5CA00EEAC84 /* EncryptionTests.m in Sources */,
+				021A88341AAFB5CA00EEAC84 /* EncryptionTests.mm in Sources */,
 				026B0F121A780680005E26C8 /* PropertyTypeTest.mm in Sources */,
 				026B0F131A780680005E26C8 /* QueryTests.m in Sources */,
 				026B0F141A780680005E26C8 /* RealmTests.mm in Sources */,
@@ -1270,7 +1270,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				021A88351AAFB5CB00EEAC84 /* EncryptionTests.m in Sources */,
+				021A88351AAFB5CB00EEAC84 /* EncryptionTests.mm in Sources */,
 				02AFB4661A80343600E11938 /* PropertyTests.m in Sources */,
 				3F8DCA6419930F8E0008BD7F /* ArrayPropertyTests.m in Sources */,
 				3F8DCA6919930F960008BD7F /* DynamicTests.m in Sources */,
@@ -1335,7 +1335,7 @@
 				E856D21A195615A900FB2FCF /* ObjectInterfaceTests.m in Sources */,
 				02AFB4681A80343600E11938 /* ResultsTests.m in Sources */,
 				E856D21B195615A900FB2FCF /* ObjectTests.m in Sources */,
-				021A88331AAFB5C900EEAC84 /* EncryptionTests.m in Sources */,
+				021A88331AAFB5C900EEAC84 /* EncryptionTests.mm in Sources */,
 				E856D21C195615A900FB2FCF /* PropertyTypeTest.mm in Sources */,
 				E856D21D195615A900FB2FCF /* QueryTests.m in Sources */,
 				E856D21E195615A900FB2FCF /* RealmTests.mm in Sources */,
@@ -1402,7 +1402,7 @@
 				027A4D2D1AB1012500AA46F9 /* RLMMultiProcessTestCase.m in Sources */,
 				02AFB4671A80343600E11938 /* ResultsTests.m in Sources */,
 				E81A1FE31955FE0100FDED82 /* ObjectTests.m in Sources */,
-				021A88321AAFB5C800EEAC84 /* EncryptionTests.m in Sources */,
+				021A88321AAFB5C800EEAC84 /* EncryptionTests.mm in Sources */,
 				E81A1FE51955FE0100FDED82 /* PropertyTypeTest.mm in Sources */,
 				E81A1FE71955FE0100FDED82 /* QueryTests.m in Sources */,
 				E81A1FEB1955FE0100FDED82 /* RealmTests.mm in Sources */,

--- a/Realm/RLMRealm.h
+++ b/Realm/RLMRealm.h
@@ -102,7 +102,9 @@
  Encrypted Realms currently cannot be opened while lldb is attached to the
  process since lldb often hangs in this situation. See issue #1625 for
  further discussion. Attempting to open an encrypted Realm with lldb attached
- will result in an EXC_BAD_ACCESS.
+ will result in an EXC_BAD_ACCESS. Running your application with
+ REALM_DISABLE_ENCRYPTION=YES set in your environment will result in Realm
+ treating requests to open an encrypted Realm as requesting an unencrypted Realm.
 
  @param path        Path to the file you want the data saved in.
  @param key         64-byte key to use to encrypt the data.

--- a/Realm/RLMRealm.h
+++ b/Realm/RLMRealm.h
@@ -99,6 +99,11 @@
  The on-disk storage for encrypted Realms are encrypted using AES256+HMAC-SHA2,
  but otherwise they behave like normal persisted Realms.
 
+ Encrypted Realms currently cannot be opened while lldb is attached to the
+ process since lldb often hangs in this situation. See issue #1625 for
+ further discussion. Attempting to open an encrypted Realm with lldb attached
+ will result in an EXC_BAD_ACCESS.
+
  @param path        Path to the file you want the data saved in.
  @param key         64-byte key to use to encrypt the data.
  @param readonly    BOOL indicating if this Realm is read-only (must use for read-only files)

--- a/Realm/RLMRealm.mm
+++ b/Realm/RLMRealm.mm
@@ -29,9 +29,6 @@
 #import "RLMUpdateChecker.hpp"
 #import "RLMUtil.hpp"
 
-#include <sys/sysctl.h>
-#include <sys/types.h>
-
 #include <realm/commit_log.hpp>
 #include <realm/version.hpp>
 
@@ -88,28 +85,9 @@ static void clearKeyCache() {
     }
 }
 
-static bool isDebuggerAttached()
-{
-    int name[] = {
-        CTL_KERN,
-        KERN_PROC,
-        KERN_PROC_PID,
-        getpid()
-    };
-
-    struct kinfo_proc info;
-    size_t info_size = sizeof(info);
-    if (sysctl(name, sizeof(name)/sizeof(name[0]), &info, &info_size, NULL, 0) == -1) {
-        NSLog(@"sysctl() failed: %s", strerror(errno));
-        return false;
-    }
-
-    return (info.kp_proc.p_flag & P_TRACED) != 0;
-}
-
 static void validateNotInDebugger()
 {
-    if (isDebuggerAttached()) {
+    if (RLMIsDebuggerAttached()) {
         @throw RLMException(@"Cannot open an encrypted Realm with a debugger attached to the process");
     }
 }

--- a/Realm/RLMUtil.hpp
+++ b/Realm/RLMUtil.hpp
@@ -76,6 +76,8 @@ NSArray *RLMCollectionValueForKey(NSString *key, RLMRealm *realm, RLMObjectSchem
 
 void RLMCollectionSetValueForKey(id value, NSString *key, RLMRealm *realm, RLMObjectSchema *objectSchema, size_t count, size_t (^indexGenerator)(size_t index));
 
+BOOL RLMIsDebuggerAttached();
+
 // C version of isKindOfClass
 static inline BOOL RLMIsKindOfClass(Class class1, Class class2) {
     while (class1) {

--- a/Realm/Tests/EncryptionTests.mm
+++ b/Realm/Tests/EncryptionTests.mm
@@ -21,6 +21,7 @@
 #import "RLMObjectSchema_Private.h"
 #import "RLMRealm_Private.h"
 #import "RLMSchema_Private.h"
+#import "RLMUtil.hpp"
 
 @interface EncryptionTests : RLMTestCase
 @end
@@ -32,6 +33,21 @@
                      encryptionKey:key
                           readOnly:NO
                              error:nil];
+}
+
++ (XCTestSuite *)defaultTestSuite
+{
+    if (RLMIsDebuggerAttached()) {
+        XCTestSuite *suite = [XCTestSuite testSuiteWithName:self.className];
+        [suite addTest:[EncryptionTests testCaseWithSelector:@selector(encryptionTestsAreSkippedWhileDebuggerIsAttached)]];
+        return suite;
+    }
+
+    return [super defaultTestSuite];
+}
+
+- (void)encryptionTestsAreSkippedWhileDebuggerIsAttached
+{
 }
 
 #pragma mark - Key validation

--- a/Realm/Tests/EncryptionTests.mm
+++ b/Realm/Tests/EncryptionTests.mm
@@ -38,7 +38,7 @@
 + (XCTestSuite *)defaultTestSuite
 {
     if (RLMIsDebuggerAttached()) {
-        XCTestSuite *suite = [XCTestSuite testSuiteWithName:self.className];
+        XCTestSuite *suite = [XCTestSuite testSuiteWithName:NSStringFromClass(self)];
         [suite addTest:[EncryptionTests testCaseWithSelector:@selector(encryptionTestsAreSkippedWhileDebuggerIsAttached)]];
         return suite;
     }

--- a/build.sh
+++ b/build.sh
@@ -26,6 +26,8 @@ if ! [ -z "${JENKINS_HOME}" ]; then
     CODESIGN_PARAMS="CODE_SIGN_IDENTITY= CODE_SIGNING_REQUIRED=NO"
 fi
 
+export REALM_SKIP_DEBUGGER_CHECKS=YES
+
 usage() {
 cat <<EOF
 Usage: sh $0 command [argument]


### PR DESCRIPTION
Prevent debugging of an application using an encrypted Realm to work around
frequent LLDB hangs. Until the underlying issue is addressed you may set
REALM_DISABLE_ENCRYPTION=YES in your application's environment variables to
have requests to open an encrypted Realm treated as a request for an
unencrypted Realm.

Fixes #1625.

/cc @jpsim @tgoyne @segiddins 