### PR TITLE
Have +[RLMObjectSchema schemaForObjectClass:] throw an exception when…

### DIFF
--- a/Realm/RLMObjectSchema.mm
+++ b/Realm/RLMObjectSchema.mm
@@ -99,7 +99,18 @@
     schema.properties = props;
 
     // verify that we didn't add any properties twice due to inheritance
-    assert(props.count == [NSSet setWithArray:[props valueForKey:@"name"]].count);
+    if (props.count != [NSSet setWithArray:[props valueForKey:@"name"]].count) {
+        NSCountedSet *countedPropertyNames = [NSCountedSet setWithArray:[props valueForKey:@"name"]];
+        NSSet *duplicatePropertyNames = [countedPropertyNames filteredSetUsingPredicate:[NSPredicate predicateWithBlock:^BOOL(id object, NSDictionary *) {
+            return [countedPropertyNames countForObject:object] > 1;
+        }]];
+
+        if (duplicatePropertyNames.count == 1) {
+            @throw RLMException([NSString stringWithFormat:@"Property '%@' is declared multiple times in the class hierarchy of '%@'", duplicatePropertyNames.allObjects.firstObject, className]);
+        } else {
+            @throw RLMException([NSString stringWithFormat:@"Object '%@' has properties that are declared multiple times in its class hierarchy: '%@'", className, [duplicatePropertyNames.allObjects componentsJoinedByString:@"', '"]]);
+        }
+    }
 
     if (NSString *primaryKey = [objectClass primaryKey]) {
         for (RLMProperty *prop in schema.properties) {

--- a/Realm/Tests/RLMTestObjects.h
+++ b/Realm/Tests/RLMTestObjects.h
@@ -254,4 +254,7 @@ RLM_ARRAY_TYPE(CircleObject);
 @property (readonly) int readOnlyPropertyMadeReadWriteInClassExtension;
 @end
 
+#pragma mark FakeObject
 
+@interface FakeObject : NSObject
+@end

--- a/Realm/Tests/RLMTestObjects.m
+++ b/Realm/Tests/RLMTestObjects.m
@@ -150,3 +150,11 @@
     return nil;
 }
 @end
+
+#pragma mark FakeObject
+
+@implementation FakeObject
++ (NSArray *)ignoredProperties { return nil; }
++ (NSArray *)indexedProperties { return nil; }
++ (NSString *)primaryKey { return nil; }
+@end

--- a/Realm/Tests/SchemaTests.mm
+++ b/Realm/Tests/SchemaTests.mm
@@ -64,6 +64,27 @@ RLM_ARRAY_TYPE(SchemaTestClassSecondChild)
 @implementation SchemaTestClassLink
 @end
 
+// Inherit from NSObject rather than RLMObject to prevent the duplicate property from causing every
+// test to blow up.
+@interface SchemaTestClassWithDuplicatePropertyBase : NSObject
+@property NSString *string;
+@end
+
+// Implement the portions of RLMObject's interface that +[RLMObjectSchema schemaForObjectClass:] uses.
+@implementation SchemaTestClassWithDuplicatePropertyBase
++ (NSArray *)ignoredProperties { return nil; }
++ (NSArray *)indexedProperties { return nil; }
+@end
+
+@interface SchemaTestClassWithDuplicateProperty : SchemaTestClassWithDuplicatePropertyBase
+@property NSString *string;
+@end
+
+@implementation SchemaTestClassWithDuplicateProperty
+@dynamic string;
+@end
+
+
 @interface SchemaTests : RLMTestCase
 @end
 
@@ -344,6 +365,11 @@ RLM_ARRAY_TYPE(SchemaTestClassSecondChild)
                                               @"\t\t}\n"
                                               @"\t}\n"
                                               @"}");
+}
+
+- (void)testClassWithDuplicateProperties
+{
+    XCTAssertThrows([RLMObjectSchema schemaForObjectClass:SchemaTestClassWithDuplicateProperty.class]);
 }
 
 @end

--- a/Realm/Tests/SchemaTests.mm
+++ b/Realm/Tests/SchemaTests.mm
@@ -64,24 +64,38 @@ RLM_ARRAY_TYPE(SchemaTestClassSecondChild)
 @implementation SchemaTestClassLink
 @end
 
-// Inherit from NSObject rather than RLMObject to prevent the duplicate property from causing every
-// test to blow up.
-@interface SchemaTestClassWithDuplicatePropertyBase : NSObject
+
+@interface SchemaTestClassWithSingleDuplicatePropertyBase : FakeObject
 @property NSString *string;
 @end
 
-// Implement the portions of RLMObject's interface that +[RLMObjectSchema schemaForObjectClass:] uses.
-@implementation SchemaTestClassWithDuplicatePropertyBase
-+ (NSArray *)ignoredProperties { return nil; }
-+ (NSArray *)indexedProperties { return nil; }
+@implementation SchemaTestClassWithSingleDuplicatePropertyBase
 @end
 
-@interface SchemaTestClassWithDuplicateProperty : SchemaTestClassWithDuplicatePropertyBase
+@interface SchemaTestClassWithSingleDuplicateProperty : SchemaTestClassWithSingleDuplicatePropertyBase
 @property NSString *string;
 @end
 
-@implementation SchemaTestClassWithDuplicateProperty
+@implementation SchemaTestClassWithSingleDuplicateProperty
 @dynamic string;
+@end
+
+@interface SchemaTestClassWithMultipleDuplicatePropertiesBase : FakeObject
+@property NSString *string;
+@property int integer;
+@end
+
+@implementation SchemaTestClassWithMultipleDuplicatePropertiesBase
+@end
+
+@interface SchemaTestClassWithMultipleDuplicateProperties : SchemaTestClassWithMultipleDuplicatePropertiesBase
+@property NSString *string;
+@property int integer;
+@end
+
+@implementation SchemaTestClassWithMultipleDuplicateProperties
+@dynamic string;
+@dynamic integer;
 @end
 
 
@@ -369,7 +383,8 @@ RLM_ARRAY_TYPE(SchemaTestClassSecondChild)
 
 - (void)testClassWithDuplicateProperties
 {
-    XCTAssertThrows([RLMObjectSchema schemaForObjectClass:SchemaTestClassWithDuplicateProperty.class]);
+    XCTAssertThrows([RLMObjectSchema schemaForObjectClass:SchemaTestClassWithSingleDuplicateProperty.class]);
+    XCTAssertThrows([RLMObjectSchema schemaForObjectClass:SchemaTestClassWithMultipleDuplicateProperties.class]);
 }
 
 @end


### PR DESCRIPTION
… it sees the same property name multiple times for one class.

Fixes #1844.

/cc @segiddins @jpsim @tgoyne 
