### PR TITLE
Improve the exception messages when sorting on an invalid column name

### DIFF
--- a/Realm/RLMQueryUtil.mm
+++ b/Realm/RLMQueryUtil.mm
@@ -656,6 +656,7 @@ void update_query_with_predicate(NSPredicate *predicate, RLMSchema *schema,
 
 RLMProperty *RLMValidatedPropertyForSort(RLMObjectSchema *schema, NSString *propName) {
     // validate
+    RLMPrecondition(![propName containsString:@"."], @"Invalid sort property", @"Sorting on key paths is not supported.");
     RLMProperty *prop = schema[propName];
     RLMPrecondition(prop, @"Invalid sort property", @"Property named '%@' not found on object of type '%@'.", propName, schema.className);
 

--- a/Realm/RLMQueryUtil.mm
+++ b/Realm/RLMQueryUtil.mm
@@ -656,9 +656,9 @@ void update_query_with_predicate(NSPredicate *predicate, RLMSchema *schema,
 
 RLMProperty *RLMValidatedPropertyForSort(RLMObjectSchema *schema, NSString *propName) {
     // validate
-    RLMPrecondition(![propName containsString:@"."], @"Invalid sort property", @"Sorting on key paths is not supported.");
+    RLMPrecondition(![propName containsString:@"."], @"Invalid sort property", @"Cannot sort on '%@': sorting on key paths is not supported.", propName);
     RLMProperty *prop = schema[propName];
-    RLMPrecondition(prop, @"Invalid sort property", @"Property named '%@' not found on object of type '%@'.", propName, schema.className);
+    RLMPrecondition(prop, @"Invalid sort property", @"Cannot sort on property '%@' on object of type '%@': property not found.", propName, schema.className);
 
     switch (prop.type) {
         case RLMPropertyTypeBool:
@@ -671,7 +671,7 @@ RLMProperty *RLMValidatedPropertyForSort(RLMObjectSchema *schema, NSString *prop
 
         default:
             @throw RLMPredicateException(@"Invalid sort property type",
-                                         @"Sorting is only supported on Bool, Date, Double, Float, Integer, and String properties.");
+                                         @"Cannot sort on property '%@' on object of type '%@': sorting is only supported on bool, date, double, float, integer, and string properties, but property is of type %@.", propName, schema.className, RLMTypeToString(prop.type));
     }
     return prop;
 }

--- a/Realm/RLMQueryUtil.mm
+++ b/Realm/RLMQueryUtil.mm
@@ -650,14 +650,14 @@ void update_query_with_predicate(NSPredicate *predicate, RLMSchema *schema,
     else {
         // invalid predicate type
         @throw RLMPredicateException(@"Invalid predicate",
-                                     @"Only support compound, comparison and constant predicates");
+                                     @"Only support compound, comparison, and constant predicates");
     }
 }
 
 RLMProperty *RLMValidatedPropertyForSort(RLMObjectSchema *schema, NSString *propName) {
     // validate
     RLMProperty *prop = schema[propName];
-    RLMPrecondition(prop, @"Invalid sort column", @"Column named '%@' not found.", prop);
+    RLMPrecondition(prop, @"Invalid sort property", @"Property named '%@' not found on object of type '%@'.", propName, schema.className);
 
     switch (prop.type) {
         case RLMPropertyTypeBool:
@@ -669,8 +669,8 @@ RLMProperty *RLMValidatedPropertyForSort(RLMObjectSchema *schema, NSString *prop
             break;
 
         default:
-            @throw RLMPredicateException(@"Invalid sort column type",
-                                         @"Sorting is only supported on Bool, Date, Double, Float, Integer and String columns.");
+            @throw RLMPredicateException(@"Invalid sort property type",
+                                         @"Sorting is only supported on Bool, Date, Double, Float, Integer, and String properties.");
     }
     return prop;
 }

--- a/Realm/Tests/QueryTests.m
+++ b/Realm/Tests/QueryTests.m
@@ -294,6 +294,10 @@
     // sort invalid name
     RLMAssertThrowsWithReasonMatching([[AllTypesObject allObjects] sortedResultsUsingProperty:@"invalidCol" ascending:YES], @"'invalidCol' not found .* 'AllTypesObject'");
     XCTAssertThrows([arrayOfAll.array sortedResultsUsingProperty:@"invalidCol" ascending:NO]);
+
+    // sort on key path
+    RLMAssertThrowsWithReasonMatching([[AllTypesObject allObjects] sortedResultsUsingProperty:@"key.path" ascending:YES], @"key paths is not supported");
+    XCTAssertThrows([arrayOfAll.array sortedResultsUsingProperty:@"key.path" ascending:NO]);
 }
 
 - (void)testSortByMultipleColumns {

--- a/Realm/Tests/QueryTests.m
+++ b/Realm/Tests/QueryTests.m
@@ -286,13 +286,11 @@
     [self verifySort:realm column:@"stringCol" ascending:NO expected:@"cc"];
     
     // sort by mixed column
-    XCTAssertThrows([[AllTypesObject allObjects] sortedResultsUsingProperty:@"mixedCol" ascending:YES],
-                    @"Sort on mixed col not supported");
-    XCTAssertThrows([arrayOfAll.array sortedResultsUsingProperty:@"mixedCol" ascending:NO],
-                    @"Sort on mixed col not supported");
+    RLMAssertThrowsWithReasonMatching([[AllTypesObject allObjects] sortedResultsUsingProperty:@"mixedCol" ascending:YES], @"'mixedCol' .* 'AllTypesObject': sorting is only supported .* type any");
+    XCTAssertThrows([arrayOfAll.array sortedResultsUsingProperty:@"mixedCol" ascending:NO]);
     
     // sort invalid name
-    RLMAssertThrowsWithReasonMatching([[AllTypesObject allObjects] sortedResultsUsingProperty:@"invalidCol" ascending:YES], @"'invalidCol' not found .* 'AllTypesObject'");
+    RLMAssertThrowsWithReasonMatching([[AllTypesObject allObjects] sortedResultsUsingProperty:@"invalidCol" ascending:YES], @"'invalidCol'.* 'AllTypesObject'.* not found");
     XCTAssertThrows([arrayOfAll.array sortedResultsUsingProperty:@"invalidCol" ascending:NO]);
 
     // sort on key path

--- a/Realm/Tests/QueryTests.m
+++ b/Realm/Tests/QueryTests.m
@@ -292,10 +292,8 @@
                     @"Sort on mixed col not supported");
     
     // sort invalid name
-    XCTAssertThrows([[AllTypesObject allObjects] sortedResultsUsingProperty:@"invalidCol" ascending:YES],
-                    @"Sort on invalid col not supported");
-    XCTAssertThrows([arrayOfAll.array sortedResultsUsingProperty:@"invalidCol" ascending:NO],
-                    @"Sort on invalid col not supported");
+    RLMAssertThrowsWithReasonMatching([[AllTypesObject allObjects] sortedResultsUsingProperty:@"invalidCol" ascending:YES], @"'invalidCol' not found .* 'AllTypesObject'");
+    XCTAssertThrows([arrayOfAll.array sortedResultsUsingProperty:@"invalidCol" ascending:NO]);
 }
 
 - (void)testSortByMultipleColumns {

--- a/Realm/Tests/RLMAssertions.h
+++ b/Realm/Tests/RLMAssertions.h
@@ -47,3 +47,9 @@
         _XCTRegisterFailure(self, [_XCTFailureDescription(_XCTAssertion_True, 0, @#expression @" (EXPR_STRING) matches " @#regexString) stringByReplacingOccurrencesOfString:@"EXPR_STRING" withString:string ?: @"<nil>"], format); \
     } \
 })
+
+#define RLMAssertThrowsWithReasonMatching(expression, regex, ...) \
+({ \
+    NSException *exception = RLMAssertThrows(expression, __VA_ARGS__); \
+    RLMAssertMatches(exception.reason, regex, __VA_ARGS__); \
+})


### PR DESCRIPTION
Improve the exception message when sorting on an invalid column name, and introduce an explicit exception indicating that sorting on key paths is not supported.

Fixes #1861.

/cc @segiddins @jpsim 