### PR TITLE
Cannot retrieve relation objects in FastEnumeration

### DIFF
--- a/RealmSwift/List.swift
+++ b/RealmSwift/List.swift
@@ -309,9 +309,13 @@ extension List: ExtensibleCollectionType {
 
     /// Returns a `GeneratorOf<T>` that yields successive elements in the list.
     public func generate() -> GeneratorOf<T> {
-        let base = NSFastGenerator(_rlmArray)
+        var i: UInt = 0
         return GeneratorOf<T>() {
-            return base.next() as! T?
+            if (i >= self._rlmArray.count) {
+                return .None
+            } else {
+                return self._rlmArray[i++] as? T
+            }
         }
     }
 

--- a/RealmSwift/Results.swift
+++ b/RealmSwift/Results.swift
@@ -266,9 +266,13 @@ extension Results: CollectionType {
 
     /// Returns a `GeneratorOf<T>` that yields successive elements in the results.
     public func generate() -> GeneratorOf<T> {
-        let base = NSFastGenerator(rlmResults)
+        var i: UInt = 0
         return GeneratorOf<T>() {
-            return base.next() as! T?
+            if (i >= self.rlmResults.count) {
+                return .None
+            } else {
+                return self.rlmResults[i++] as? T
+            }
         }
     }
 

--- a/RealmSwift/Tests/ObjectAccessorTests.swift
+++ b/RealmSwift/Tests/ObjectAccessorTests.swift
@@ -165,4 +165,40 @@ class ObjectAccessorTests: TestCase {
 
         XCTAssertEqual(objects[0].longCol, updatedLongNumber, "After update: 2 ^ 33 expected")
     }
+
+    func testRelation() {
+        let realm = realmWithTestPath()
+
+        let object1 = SwiftObject()
+        let object2 = SwiftObject()
+
+        let trueObject = SwiftBoolObject()
+        trueObject.boolCol = true
+
+        let falseObject = SwiftBoolObject()
+        falseObject.boolCol = false
+
+        object1.arrayCol.append(trueObject)
+        object1.arrayCol.append(falseObject)
+
+        object2.arrayCol.append(trueObject)
+        object2.arrayCol.append(falseObject)
+
+        realm.write {
+            realm.add(object1)
+            realm.add(object2)
+        }
+
+        let objects = realm.objects(SwiftObject)
+
+        let firstObject = objects.first
+        XCTAssertEqual(2, firstObject!.arrayCol.count)
+
+        let lastObject = objects.last
+        XCTAssertEqual(2, lastObject!.arrayCol.count)
+
+        for obj in objects {
+            XCTAssertEqual(2, obj.arrayCol.count)
+        }
+    }
 }


### PR DESCRIPTION
Related: https://github.com/realm/realm-cocoa/issues/1876

In the loop using the FastEnumeration, it is not possible to obtain the relation objects correctly. 

**Environments:**
Realm-Cocoa 0.92.1 and master

iOS 8.3
iPhone 6 Plus
Xcode 6.3.1 (6D1002)

**Reproducible code:**
```swift
let dog1 = Dog()
dog1.name = "dog1"

let dog2 = Dog()
dog2.name = "dog2"

let person = Person()
person.name = "person1"
person.dogs.append(dog1)
person.dogs.append(dog2)

let realm = Realm()
realm.write { () -> Void in
    realm.add(person)
}

let people = realm.objects(Person)

// It is OK using first, last, or index access 
if let person = people.first {
    println("Count: \(person.dogs.count)") // 2 [OK]
}

// If using `for ... in` loop, failed to retrieve dogs objects 
for person in people {
    println("Count: \(person.dogs.count)") // 0 [NG]
}
```
