### PR TITLE
Use rangeOfString: instead containsString:

### DIFF
--- a/Realm/RLMQueryUtil.mm
+++ b/Realm/RLMQueryUtil.mm
@@ -656,7 +656,7 @@ void update_query_with_predicate(NSPredicate *predicate, RLMSchema *schema,
 
 RLMProperty *RLMValidatedPropertyForSort(RLMObjectSchema *schema, NSString *propName) {
     // validate
-    RLMPrecondition(![propName containsString:@"."], @"Invalid sort property", @"Cannot sort on '%@': sorting on key paths is not supported.", propName);
+    RLMPrecondition([propName rangeOfString:@"."].location == NSNotFound, @"Invalid sort property", @"Cannot sort on '%@': sorting on key paths is not supported.", propName);
     RLMProperty *prop = schema[propName];
     RLMPrecondition(prop, @"Invalid sort property", @"Cannot sort on property '%@' on object of type '%@': property not found.", propName, schema.className);
 


### PR DESCRIPTION
Ralated: https://github.com/realm/realm-cocoa/issues/1894

Use `rangeOfString:` instead `containsString:` for support iOS 7 because `containsString:` was introduced in iOS 8. 

Could you please review @segiddins @bdash?