### PR TITLE
Update the type check used for aggregate operators to work correctly …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ x.x.x Release notes (yyyy-MM-dd)
 
 ### Bugfixes
 
-* Using a Swift subclass of Realm.Object in an aggregate operator of a predicate
+* Swift: Using a subclass of `Realm.Object` in an aggregate operator of a predicate
   no longer throws a spurious type error.
 
 0.92.2 Release notes (2015-05-08)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ x.x.x Release notes (yyyy-MM-dd)
 
 ### Bugfixes
 
-* Swift: Using a subclass of `Realm.Object` in an aggregate operator of a predicate
+* Swift: Using a subclass of `RealmSwift.Object` in an aggregate operator of a predicate
   no longer throws a spurious type error.
 
 0.92.2 Release notes (2015-05-08)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+x.x.x Release notes (yyyy-MM-dd)
+=============================================================
+
+### API breaking changes
+
+* None.
+
+### Enhancements
+
+* None.
+
+### Bugfixes
+
+* Using a Swift subclass of Realm.Object in an aggregate operator of a predicate
+  no longer throws a spurious type error.
+
 0.92.2 Release notes (2015-05-08)
 =============================================================
 

--- a/Realm/RLMQueryUtil.mm
+++ b/Realm/RLMQueryUtil.mm
@@ -411,7 +411,7 @@ RLMProperty *get_property_from_key_path(RLMSchema *schema, RLMObjectSchema *desc
 
 void validate_property_value(RLMProperty *prop, id value, NSString *err, RLMObjectSchema *objectSchema, NSString *keyPath) {
     if (prop.type == RLMPropertyTypeArray) {
-        RLMPrecondition([RLMDynamicCast<RLMObject>(value).objectSchema.className isEqualToString:prop.objectClassName],
+        RLMPrecondition([RLMObjectBaseObjectSchema(RLMDynamicCast<RLMObjectBase>(value)).className isEqualToString:prop.objectClassName],
                         @"Invalid value", err, prop.objectClassName, keyPath, objectSchema.className, value);
     }
     else {

--- a/RealmSwift/Tests/ResultsTests.swift
+++ b/RealmSwift/Tests/ResultsTests.swift
@@ -264,6 +264,13 @@ class ResultsTests: TestCase {
 
         XCTAssertEqual(str, "12")
     }
+
+    func testArrayAggregateWithSwiftObjectDoesntThrow() {
+        let results = getAggregateableResults()
+
+        // Should not throw a type error.
+        results.filter("ANY stringListCol == %@", SwiftStringObject())
+    }
 }
 
 class ResultsFromTableTests: ResultsTests {

--- a/RealmSwift/Tests/SwiftTestObjects.swift
+++ b/RealmSwift/Tests/SwiftTestObjects.swift
@@ -88,6 +88,7 @@ class SwiftAggregateObject: Object {
     dynamic var boolCol = false
     dynamic var dateCol = NSDate()
     dynamic var trueCol = true
+    dynamic var stringListCol = List<SwiftStringObject>()
 }
 
 class SwiftAllIntSizesObject: Object {


### PR DESCRIPTION
…for Swift classes.

Swift classes derive from Realm.Object rather than RLMObject, so we need to work with the common
superclass, RLMObjectBase, when performing the type check.

Fixes #1901.

/cc @segiddins @jpsim @tgoyne 