### PR TITLE
[Swift][Object] Made `Object.init()` a required initializer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ x.x.x Release notes (yyyy-MM-dd)
 
 ### Enhancements
 
-* None.
+* Swift: Made `Object.init()` a required initializer.
 
 ### Bugfixes
 

--- a/RealmSwift/Object.swift
+++ b/RealmSwift/Object.swift
@@ -63,7 +63,7 @@ public class Object: RLMObjectBase, Equatable, Printable {
 
     :see: Realm().add(_:)
     */
-    public override init() {
+    public required override init() {
         super.init()
     }
 

--- a/RealmSwift/Tests/ObjectCreationTests.swift
+++ b/RealmSwift/Tests/ObjectCreationTests.swift
@@ -116,6 +116,15 @@ class ObjectCreationTests: TestCase {
         verifySwiftObjectWithDictionaryLiteral(objectWithKVCObject, dictionary: valueDict, boolObjectValue: false, boolObjectListValues: [])
     }
 
+    func testGenericInit() {
+        func createObject<T: Object>() -> T {
+            return T()
+        }
+        let obj1: SwiftBoolObject = createObject()
+        let obj2 = SwiftBoolObject()
+        XCTAssertEqual(obj1.boolCol, obj2.boolCol, "object created via generic initializer should equal object created by calling initializer directly")
+    }
+
     // MARK: Creation tests
 
     func testCreateWithDefaults() {


### PR DESCRIPTION
Fixes #1916.

As far as I can tell, this doesn't negatively impact anything since convenience initializers can still be created for Object subclasses without having to override `init()`. /cc @tgoyne @segiddins @bdash