### PR TITLE
[WIP] Cache linked objects for persisted objects

### DIFF
--- a/Realm/RLMAccessor.mm
+++ b/Realm/RLMAccessor.mm
@@ -64,6 +64,43 @@ static inline void RLMVerifyInWriteTransaction(__unsafe_unretained RLMObjectBase
     }
 }
 
+template<typename FunctionType>
+static FunctionType RLMGetImpForSelector(Class cls, SEL selector) {
+    return reinterpret_cast<FunctionType>(method_getImplementation(class_getInstanceMethod(cls, selector)));
+}
+
+// Helper for calling superclass methods outside the context of a method
+template<typename T>
+class RLMSuperImpl {
+public:
+    RLMSuperImpl() { }
+
+    RLMSuperImpl(__unsafe_unretained RLMProperty *const prop, Class superClass)
+    : getterSel(prop.getterSel)
+    , getter(RLMGetImpForSelector<T (*)(id, SEL)>(superClass, getterSel))
+    , setterSel(prop.setterSel)
+    , setter(RLMGetImpForSelector<void (*)(id, SEL, T)>(superClass, setterSel))
+    {
+    }
+
+
+    T get(__unsafe_unretained id const obj) const {
+        return getter ? getter(obj, getterSel) : T{};
+    }
+
+    void set(__unsafe_unretained id const obj, const T value) const {
+        if (setter) {
+            setter(obj, setterSel, value);
+        }
+    }
+
+private:
+    SEL getterSel;
+    T (*getter)(id, SEL) = nullptr;
+    SEL setterSel;
+    void (*setter)(id, SEL, T) = nullptr;
+};
+
 // long getter/setter
 static inline long long RLMGetLong(__unsafe_unretained RLMObjectBase *const obj, NSUInteger colIndex) {
     RLMVerifyAttached(obj);
@@ -214,22 +251,37 @@ static inline RLMObjectBase *RLMGetLinkedObjectForValue(__unsafe_unretained RLMR
 }
 
 // link getter/setter
-static inline RLMObjectBase *RLMGetLink(__unsafe_unretained RLMObjectBase *const obj, NSUInteger colIndex, __unsafe_unretained NSString *const objectClassName) {
-    RLMVerifyAttached(obj);
-
-    if (obj->_row.is_null_link(colIndex)) {
+static inline RLMObjectBase *RLMGetLink(__unsafe_unretained RLMObjectBase *const obj,
+                                        NSUInteger colIndex,
+                                        __unsafe_unretained NSString *const objectClassName,
+                                        RLMSuperImpl<id> const& super) {
+    Row const& row = obj->_row;
+    __unsafe_unretained RLMObjectBase *value = super.get(obj);
+    if (row.is_null_link(colIndex)) {
+        if (value) {
+            super.set(obj, nil);
+        }
         return nil;
     }
-    NSUInteger index = obj->_row.get_link(colIndex);
-    return RLMCreateObjectAccessor(obj->_realm, obj->_realm.schema[objectClassName], index);
+
+    if (value && row.get_index() == value->_row.get_index()) {
+        return value;
+    }
+
+    __unsafe_unretained RLMRealm *realm = obj->_realm;
+    id newValue = RLMCreateObjectAccessor(realm, realm.schema[objectClassName], row.get_link(colIndex));
+    super.set(obj, newValue);
+    return newValue;
 }
 
 static inline void RLMSetValue(__unsafe_unretained RLMObjectBase *const obj, NSUInteger colIndex,
-                               __unsafe_unretained RLMObjectBase *const val) {
+                               __unsafe_unretained RLMObjectBase *const val,
+                               RLMSuperImpl<id> const& super) {
     RLMVerifyInWriteTransaction(obj);
 
     if (!val) {
         obj->_row.nullify_link(colIndex);
+        super.set(obj, nil);
     }
     else {
         // make sure it is the correct type
@@ -240,8 +292,10 @@ static inline void RLMSetValue(__unsafe_unretained RLMObjectBase *const obj, NSU
                                 valSchema.className, [objSchema.properties[colIndex] objectClassName]];
             @throw RLMException(reason);
         }
+
         RLMObjectBase *link = RLMGetLinkedObjectForValue(obj->_realm, valSchema.className, val, RLMCreationOptionsPromoteStandalone);
         obj->_row.set_link(colIndex, link->_row.get_index());
+        super.set(obj, link);
     }
 }
 
@@ -250,10 +304,9 @@ static inline RLMArray *RLMGetArray(__unsafe_unretained RLMObjectBase *const obj
     RLMVerifyAttached(obj);
 
     realm::LinkViewRef linkView = obj->_row.get_linklist(colIndex);
-    RLMArrayLinkView *ar = [RLMArrayLinkView arrayWithObjectClassName:objectClassName
-                                                                 view:linkView
-                                                                realm:obj->_realm];
-    return ar;
+    return [RLMArrayLinkView arrayWithObjectClassName:objectClassName
+                                                 view:linkView
+                                                realm:obj->_realm];
 }
 
 static inline void RLMSetValue(__unsafe_unretained RLMObjectBase *const obj, NSUInteger colIndex,
@@ -265,7 +318,7 @@ static inline void RLMSetValue(__unsafe_unretained RLMObjectBase *const obj, NSU
     // FIXME: make sure delete rules don't purge objects
     linkView->clear();
     for (RLMObjectBase *link in array) {
-        RLMObjectBase * addedLink = RLMGetLinkedObjectForValue(obj->_realm, link->_objectSchema.className, link, RLMCreationOptionsPromoteStandalone);
+        RLMObjectBase *addedLink = RLMGetLinkedObjectForValue(obj->_realm, link->_objectSchema.className, link, RLMCreationOptionsPromoteStandalone);
         linkView->add(addedLink->_row.get_index());
     }
 }
@@ -289,9 +342,7 @@ static inline id RLMGetAnyProperty(__unsafe_unretained RLMObjectBase *const obj,
         case RLMPropertyTypeDate:
             return [NSDate dateWithTimeIntervalSince1970:mixed.get_datetime().get_datetime()];
         case RLMPropertyTypeData: {
-            realm::BinaryData bd = mixed.get_binary();
-            NSData *d = [NSData dataWithBytes:bd.data() length:bd.size()];
-            return d;
+            return RLMBinaryDataToNSData(mixed.get_binary());
         }
         case RLMPropertyTypeArray:
             @throw [NSException exceptionWithName:@"RLMNotImplementedException"
@@ -348,7 +399,7 @@ static inline void RLMSetValue(__unsafe_unretained RLMObjectBase *const obj, NSU
 }
 
 // dynamic getter with column closure
-static IMP RLMAccessorGetter(RLMProperty *prop, RLMAccessorCode accessorCode, NSString *objectClassName) {
+static IMP RLMAccessorGetter(RLMProperty *prop, RLMAccessorCode accessorCode, Class superClass) {
     NSUInteger colIndex = prop.column;
     switch (accessorCode) {
         case RLMAccessorCodeByte:
@@ -395,14 +446,20 @@ static IMP RLMAccessorGetter(RLMProperty *prop, RLMAccessorCode accessorCode, NS
             return imp_implementationWithBlock(^(__unsafe_unretained RLMObjectBase *const obj) {
                 return RLMGetData(obj, colIndex);
             });
-        case RLMAccessorCodeLink:
+        case RLMAccessorCodeLink: {
+            NSString *objectClassName = prop.objectClassName;
+            RLMSuperImpl<id> super(prop, superClass);
+
             return imp_implementationWithBlock(^id(__unsafe_unretained RLMObjectBase *const obj) {
-                return RLMGetLink(obj, colIndex, objectClassName);
+                return RLMGetLink(obj, colIndex, objectClassName, super);
             });
-        case RLMAccessorCodeArray:
+        }
+        case RLMAccessorCodeArray: {
+            NSString *objectClassName = prop.objectClassName;
             return imp_implementationWithBlock(^(__unsafe_unretained RLMObjectBase *const obj) {
                 return RLMGetArray(obj, colIndex, objectClassName);
             });
+        }
         case RLMAccessorCodeAny:
             return imp_implementationWithBlock(^(__unsafe_unretained RLMObjectBase *const obj) {
                 return RLMGetAnyProperty(obj, colIndex);
@@ -411,8 +468,9 @@ static IMP RLMAccessorGetter(RLMProperty *prop, RLMAccessorCode accessorCode, NS
 }
 
 template<typename ArgType, typename StorageType=ArgType>
-static IMP RLMMakeSetter(NSUInteger colIndex, bool isPrimary) {
-    if (isPrimary) {
+static IMP RLMMakeSetter(RLMProperty *prop) {
+    NSUInteger colIndex = prop.column;
+    if (prop.isPrimary) {
         return imp_implementationWithBlock(^(__unused RLMObjectBase *obj, __unused ArgType val) {
             @throw RLMException(@"Primary key can't be changed after an object is inserted.");
         });
@@ -422,73 +480,66 @@ static IMP RLMMakeSetter(NSUInteger colIndex, bool isPrimary) {
     });
 }
 
-// dynamic setter with column closure
-static IMP RLMAccessorSetter(RLMProperty *prop, RLMAccessorCode accessorCode) {
+template<typename T>
+static IMP RLMMakeSetter(RLMProperty *prop, Class parentClass) {
     NSUInteger colIndex = prop.column;
+    RLMSuperImpl<id> super(prop, parentClass);
+    return imp_implementationWithBlock(^(__unsafe_unretained RLMObjectBase *const obj, T val) {
+        RLMSetValue(obj, colIndex, val, super);
+    });
+}
+
+// dynamic setter with column closure
+static IMP RLMAccessorSetter(RLMProperty *prop, RLMAccessorCode accessorCode, Class parentClass) {
     switch (accessorCode) {
-        case RLMAccessorCodeByte: return RLMMakeSetter<char, long long>(colIndex, prop.isPrimary);
-        case RLMAccessorCodeShort: return RLMMakeSetter<short, long long>(colIndex, prop.isPrimary);
-        case RLMAccessorCodeInt: return RLMMakeSetter<int, long long>(colIndex, prop.isPrimary);
-        case RLMAccessorCodeLong: return RLMMakeSetter<long, long long>(colIndex, prop.isPrimary);
-        case RLMAccessorCodeLongLong: return RLMMakeSetter<long long>(colIndex, prop.isPrimary);
-        case RLMAccessorCodeFloat: return RLMMakeSetter<float>(colIndex, prop.isPrimary);
-        case RLMAccessorCodeDouble: return RLMMakeSetter<double>(colIndex, prop.isPrimary);
-        case RLMAccessorCodeBool: return RLMMakeSetter<BOOL>(colIndex, prop.isPrimary);
-        case RLMAccessorCodeString: return RLMMakeSetter<NSString *>(colIndex, prop.isPrimary);
-        case RLMAccessorCodeDate: return RLMMakeSetter<NSDate *>(colIndex, prop.isPrimary);
-        case RLMAccessorCodeData: return RLMMakeSetter<NSData *>(colIndex, prop.isPrimary);
-        case RLMAccessorCodeLink: return RLMMakeSetter<RLMObjectBase *>(colIndex, prop.isPrimary);
-        case RLMAccessorCodeArray: return RLMMakeSetter<RLMArray *>(colIndex, prop.isPrimary);
-        case RLMAccessorCodeAny: return RLMMakeSetter<id>(colIndex, prop.isPrimary);
+        case RLMAccessorCodeByte:     return RLMMakeSetter<char, long long>(prop);
+        case RLMAccessorCodeShort:    return RLMMakeSetter<short, long long>(prop);
+        case RLMAccessorCodeInt:      return RLMMakeSetter<int, long long>(prop);
+        case RLMAccessorCodeLong:     return RLMMakeSetter<long, long long>(prop);
+        case RLMAccessorCodeLongLong: return RLMMakeSetter<long long>(prop);
+        case RLMAccessorCodeFloat:    return RLMMakeSetter<float>(prop);
+        case RLMAccessorCodeDouble:   return RLMMakeSetter<double>(prop);
+        case RLMAccessorCodeBool:     return RLMMakeSetter<BOOL>(prop);
+        case RLMAccessorCodeString:   return RLMMakeSetter<NSString *>(prop);
+        case RLMAccessorCodeDate:     return RLMMakeSetter<NSDate *>(prop);
+        case RLMAccessorCodeData:     return RLMMakeSetter<NSData *>(prop);
+        case RLMAccessorCodeLink:     return RLMMakeSetter<RLMObjectBase *>(prop, parentClass);
+        case RLMAccessorCodeArray:    return RLMMakeSetter<RLMArray *>(prop);
+        case RLMAccessorCodeAny:      return RLMMakeSetter<id>(prop);
     }
 }
 
-// call getter for superclass for property at colIndex
-static id RLMSuperGet(RLMObjectBase *obj, NSString *propName) {
-    typedef id (*getter_type)(RLMObjectBase *, SEL);
-    RLMProperty *prop = obj->_objectSchema[propName];
-    Class superClass = class_getSuperclass(obj.class);
-    getter_type superGetter = (getter_type)[superClass instanceMethodForSelector:prop.getterSel];
-    return superGetter(obj, prop.getterSel);
-}
-
-// call setter for superclass for property at colIndex
-static void RLMSuperSet(RLMObjectBase *obj, NSString *propName, id val) {
-    typedef void (*setter_type)(RLMObjectBase *, SEL, RLMArray *ar);
-    RLMProperty *prop = obj->_objectSchema[propName];
-    Class superClass = class_getSuperclass(obj.class);
-    setter_type superSetter = (setter_type)[superClass instanceMethodForSelector:prop.setterSel];
-    superSetter(obj, prop.setterSel, val);
-}
-
 // getter/setter for standalone
-static IMP RLMAccessorStandaloneGetter(RLMProperty *prop, RLMAccessorCode accessorCode, NSString *objectClassName) {
+static IMP RLMAccessorStandaloneGetter(RLMProperty *prop, RLMAccessorCode accessorCode, Class superClass) {
     // only override getters for RLMArray properties
     if (accessorCode == RLMAccessorCodeArray) {
-        NSString *propName = prop.name;
+        NSString *objectClassName = prop.objectClassName;
+        RLMSuperImpl<id> super(prop, superClass);
+
         return imp_implementationWithBlock(^(RLMObjectBase *obj) {
-            id val = RLMSuperGet(obj, propName);
+            id val = super.get(obj);
             if (!val) {
                 val = [[RLMArray alloc] initWithObjectClassName:objectClassName standalone:YES];
-                RLMSuperSet(obj, propName, val);
+                super.set(obj, val);
             }
             return val;
         });
     }
     return nil;
 }
-static IMP RLMAccessorStandaloneSetter(RLMProperty *prop, RLMAccessorCode accessorCode) {
+static IMP RLMAccessorStandaloneSetter(RLMProperty *prop, RLMAccessorCode accessorCode, Class superClass) {
     // only override getters for RLMArray properties
     if (accessorCode == RLMAccessorCodeArray) {
-        NSString *propName = prop.name;
         NSString *objectClassName = prop.objectClassName;
+        RLMSuperImpl<id> super(prop, superClass);
+
         return imp_implementationWithBlock(^(RLMObjectBase *obj, id<NSFastEnumeration> ar) {
             // make copy when setting (as is the case for all other variants)
             RLMArray *standaloneAr = [[RLMArray alloc] initWithObjectClassName:objectClassName standalone:YES];
             if ((id)ar != NSNull.null) {
                 [standaloneAr addObjects:ar];
             }
-            RLMSuperSet(obj, propName, standaloneAr);
+            super.set(obj, standaloneAr);
         });
     }
     return nil;
@@ -590,8 +641,8 @@ void RLMReplaceSharedSchemaMethod(Class accessorClass, RLMObjectSchema *schema) 
 static Class RLMCreateAccessorClass(Class objectClass,
                                     RLMObjectSchema *schema,
                                     NSString *accessorClassPrefix,
-                                    IMP (*getterGetter)(RLMProperty *, RLMAccessorCode, NSString *),
-                                    IMP (*setterGetter)(RLMProperty *, RLMAccessorCode)) {
+                                    IMP (*getterGetter)(RLMProperty *, RLMAccessorCode, Class),
+                                    IMP (*setterGetter)(RLMProperty *, RLMAccessorCode, Class)) {
     // throw if no schema, prefix, or object class
     if (!objectClass || !schema || !accessorClassPrefix) {
         @throw RLMException(@"Missing arguments");
@@ -613,13 +664,13 @@ static Class RLMCreateAccessorClass(Class objectClass,
         RLMProperty *prop = schema.properties[propNum];
         RLMAccessorCode accessorCode = accessorCodeForType(prop.objcType, prop.type);
         if (prop.getterSel && getterGetter) {
-            IMP getterImp = getterGetter(prop, accessorCode, prop.objectClassName);
+            IMP getterImp = getterGetter(prop, accessorCode, objectClass);
             if (getterImp) {
                 class_replaceMethod(accClass, prop.getterSel, getterImp, getterTypeStringForObjcCode(prop.objcType));
             }
         }
         if (prop.setterSel && setterGetter) {
-            IMP setterImp = setterGetter(prop, accessorCode);
+            IMP setterImp = setterGetter(prop, accessorCode, objectClass);
             if (setterImp) {
                 class_replaceMethod(accClass, prop.setterSel, setterImp, setterTypeStringForObjcCode(prop.objcType));
             }
@@ -657,8 +708,10 @@ void RLMDynamicValidatedSet(RLMObjectBase *obj, NSString *propName, id val) {
     RLMDynamicSet(obj, prop, val, RLMCreationOptionsPromoteStandalone);
 }
 
-void RLMDynamicSet(__unsafe_unretained RLMObjectBase *const obj, __unsafe_unretained RLMProperty *const prop,
-                   __unsafe_unretained id const val, RLMCreationOptions creationOptions) {
+void RLMDynamicSet(__unsafe_unretained RLMObjectBase *const obj,
+                   __unsafe_unretained RLMProperty *const prop,
+                   __unsafe_unretained id const val,
+                   RLMCreationOptions creationOptions) {
     NSUInteger col = prop.column;
     switch (accessorCodeForType(prop.objcType, prop.type)) {
         case RLMAccessorCodeByte:
@@ -698,10 +751,10 @@ void RLMDynamicSet(__unsafe_unretained RLMObjectBase *const obj, __unsafe_unreta
             break;
         case RLMAccessorCodeLink: {
             if (!val || val == NSNull.null) {
-                RLMSetValue(obj, col, (RLMObjectBase *)nil);
+                RLMSetValue(obj, col, (RLMObjectBase *)nil, {});
             }
             else {
-                RLMSetValue(obj, col, RLMGetLinkedObjectForValue(obj->_realm, prop.objectClassName, val, creationOptions));
+                RLMSetValue(obj, col, RLMGetLinkedObjectForValue(obj->_realm, prop.objectClassName, val, creationOptions), {});
             }
             break;
         }
@@ -728,24 +781,24 @@ id RLMDynamicGet(__unsafe_unretained RLMObjectBase *obj, __unsafe_unretained NSS
     RLMProperty *prop = obj->_objectSchema[propName];
     if (!prop) {
         @throw RLMException(@"Invalid property name",
-                            @{@"Property name:" : propName ?: @"nil",
+                            @{@"Property name:": propName ?: @"nil",
                               @"Class name": obj->_objectSchema.className});
     }
     NSUInteger col = prop.column;
     switch (accessorCodeForType(prop.objcType, prop.type)) {
-        case RLMAccessorCodeByte: return @((char)RLMGetLong(obj, col));
-        case RLMAccessorCodeShort: return @((short)RLMGetLong(obj, col));
-        case RLMAccessorCodeInt: return @((int)RLMGetLong(obj, col));
-        case RLMAccessorCodeLong: return @((long)RLMGetLong(obj, col));
+        case RLMAccessorCodeByte:     return @((char)RLMGetLong(obj, col));
+        case RLMAccessorCodeShort:    return @((short)RLMGetLong(obj, col));
+        case RLMAccessorCodeInt:      return @((int)RLMGetLong(obj, col));
+        case RLMAccessorCodeLong:     return @((long)RLMGetLong(obj, col));
         case RLMAccessorCodeLongLong: return @(RLMGetLong(obj, col));
-        case RLMAccessorCodeFloat: return @(RLMGetFloat(obj, col));
-        case RLMAccessorCodeDouble: return @(RLMGetDouble(obj, col));
-        case RLMAccessorCodeBool: return @(RLMGetBool(obj, col));
-        case RLMAccessorCodeString: return RLMGetString(obj, col);
-        case RLMAccessorCodeDate: return RLMGetDate(obj, col);
-        case RLMAccessorCodeData: return RLMGetData(obj, col);
-        case RLMAccessorCodeLink: return RLMGetLink(obj, col, prop.objectClassName);
-        case RLMAccessorCodeArray: return RLMGetArray(obj, col, prop.objectClassName);
-        case RLMAccessorCodeAny: return RLMGetAnyProperty(obj, col);
+        case RLMAccessorCodeFloat:    return @(RLMGetFloat(obj, col));
+        case RLMAccessorCodeDouble:   return @(RLMGetDouble(obj, col));
+        case RLMAccessorCodeBool:     return @(RLMGetBool(obj, col));
+        case RLMAccessorCodeString:   return RLMGetString(obj, col);
+        case RLMAccessorCodeDate:     return RLMGetDate(obj, col);
+        case RLMAccessorCodeData:     return RLMGetData(obj, col);
+        case RLMAccessorCodeLink:     return RLMGetLink(obj, col, prop.objectClassName, {});
+        case RLMAccessorCodeArray:    return RLMGetArray(obj, col, prop.objectClassName);
+        case RLMAccessorCodeAny:      return RLMGetAnyProperty(obj, col);
     }
 }

--- a/Realm/RLMAccessor.mm
+++ b/Realm/RLMAccessor.mm
@@ -256,6 +256,7 @@ static inline RLMObjectBase *RLMGetLink(__unsafe_unretained RLMObjectBase *const
                                         NSUInteger colIndex,
                                         __unsafe_unretained NSString *const objectClassName,
                                         RLMSuperImpl const& super) {
+    RLMVerifyAttached(obj);
     Row const& row = obj->_row;
     __unsafe_unretained RLMObjectBase *value = super.get(obj);
     if (row.is_null_link(colIndex)) {
@@ -265,12 +266,13 @@ static inline RLMObjectBase *RLMGetLink(__unsafe_unretained RLMObjectBase *const
         return nil;
     }
 
-    if (value && row.get_index() == value->_row.get_index()) {
+    size_t dstRow = row.get_link(colIndex);
+    if (value && value->_row.get_index() == dstRow) {
         return value;
     }
 
     __unsafe_unretained RLMRealm *realm = obj->_realm;
-    id newValue = RLMCreateObjectAccessor(realm, realm.schema[objectClassName], row.get_link(colIndex));
+    id newValue = RLMCreateObjectAccessor(realm, realm.schema[objectClassName], dstRow);
     super.set(obj, newValue);
     return newValue;
 }

--- a/Realm/RLMAccessor.mm
+++ b/Realm/RLMAccessor.mm
@@ -546,12 +546,15 @@ static IMP RLMAccessorStandaloneSetter(RLMProperty *prop, RLMAccessorCode access
         RLMSuperImpl super(prop, superClass);
 
         return imp_implementationWithBlock(^(RLMObjectBase *obj, id<NSFastEnumeration> ar) {
-            // make copy when setting (as is the case for all other variants)
-            RLMArray *standaloneAr = [[RLMArray alloc] initWithObjectClassName:objectClassName standalone:YES];
-            if ((id)ar != NSNull.null) {
-                [standaloneAr addObjects:ar];
+            if (ar == nil || ar == (id)NSNull.null) {
+                super.set(obj, nil);
             }
-            super.set(obj, standaloneAr);
+            else {
+                // make copy when setting (as is the case for all other variants)
+                RLMArray *standaloneAr = [[RLMArray alloc] initWithObjectClassName:objectClassName standalone:YES];
+                [standaloneAr addObjects:ar];
+                super.set(obj, standaloneAr);
+            }
         });
     }
     return nil;

--- a/Realm/RLMUtil.hpp
+++ b/Realm/RLMUtil.hpp
@@ -115,6 +115,9 @@ static inline realm::StringData RLMStringDataWithNSString(__unsafe_unretained NS
 static inline realm::BinaryData RLMBinaryDataForNSData(__unsafe_unretained NSData *const data) {
     return realm::BinaryData(static_cast<const char *>(data.bytes), data.length);
 }
+static inline NSData *RLMBinaryDataToNSData(realm::BinaryData data) {
+    return [[NSData alloc] initWithBytes:data.data() length:data.size()];
+}
 
 static inline NSUInteger RLMConvertNotFound(size_t index) {
     return index == realm::not_found ? NSNotFound : index;


### PR DESCRIPTION
This is significantly incomplete, but I wanted to make sure no one had objections to the basic idea before I spend too much time on it.

For KVO support on keypaths, I need to keep the observed linked-to objects alive for as long as the source object (i.e. when observing `foo.bar.baz`, `foo.bar` needs to continue to exist as long as `foo` does (or until it's changed)). The simplest way to do this is to just store the linked-to object in the ivar for the link property, and update it if needed in the property getter.

Outside of KVO this also gives a bit of a performance improvement when the same property is read repeatedly, and might make ignored properties work more sensibly. Currently if you do `obj.link.ignoredProperty = 5` and then immediately read `obj.link.ignoredProperty`, you'll get 0 (or whatever the default is), because you get different objects each time you read from `link`. With this change it'll work correctly, but I'm worried that there could be confusion with the related case of two different accessors for the same row, where maybe a user would expect both accessors to return the same linked object?

Any thoughts on if this matters, or any other potential problems from this?

@jpsim @bdash @segiddins 