### PR TITLE
Optimize stuff to offset speed hit from threadsafe accessor detaching

### DIFF
--- a/Realm.xcodeproj/xcshareddata/xcbaselines/3F8DCA5619930F550008BD7F.xcbaseline/7F8339ED-0034-40BF-9189-6C569D2814B7.plist
+++ b/Realm.xcodeproj/xcshareddata/xcbaselines/3F8DCA5619930F550008BD7F.xcbaseline/7F8339ED-0034-40BF-9189-6C569D2814B7.plist
@@ -21,7 +21,7 @@
 				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>0.08</real>
+					<real>0.37</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Local Baseline</string>
 				</dict>
@@ -31,7 +31,7 @@
 				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>0.06</real>
+					<real>0.32</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Local Baseline</string>
 				</dict>
@@ -41,7 +41,7 @@
 				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>0.02</real>
+					<real>0.29</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Local Baseline</string>
 				</dict>
@@ -51,7 +51,7 @@
 				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>0.04</real>
+					<real>0.29</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Local Baseline</string>
 				</dict>
@@ -61,7 +61,17 @@
 				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>0.08</real>
+					<real>0.41</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+				</dict>
+			</dict>
+			<key>testDeleteAll</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>0.1</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Local Baseline</string>
 				</dict>
@@ -71,7 +81,7 @@
 				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>0.05</real>
+					<real>0.07</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Local Baseline</string>
 				</dict>
@@ -81,7 +91,7 @@
 				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>0.08</real>
+					<real>0.09</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Local Baseline</string>
 				</dict>
@@ -91,7 +101,7 @@
 				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>0.05</real>
+					<real>0.07</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Local Baseline</string>
 				</dict>
@@ -101,7 +111,7 @@
 				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>0.07</real>
+					<real>0.09</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Local Baseline</string>
 				</dict>
@@ -121,7 +131,7 @@
 				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>0.07</real>
+					<real>0.09</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Local Baseline</string>
 				</dict>
@@ -141,7 +151,7 @@
 				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>0.26</real>
+					<real>0.18</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Local Baseline</string>
 				</dict>
@@ -151,7 +161,7 @@
 				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>0.17</real>
+					<real>0.15</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Local Baseline</string>
 				</dict>
@@ -161,7 +171,7 @@
 				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>0.22</real>
+					<real>0.24</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Local Baseline</string>
 				</dict>
@@ -171,7 +181,7 @@
 				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>0.16</real>
+					<real>0.15</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Local Baseline</string>
 				</dict>
@@ -181,7 +191,7 @@
 				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>0.04</real>
+					<real>0.06</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Local Baseline</string>
 				</dict>
@@ -191,7 +201,7 @@
 				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>0.47</real>
+					<real>0.5</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Local Baseline</string>
 				</dict>
@@ -201,7 +211,7 @@
 				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>0.04</real>
+					<real>0.15</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Local Baseline</string>
 				</dict>
@@ -216,22 +226,12 @@
 					<string>Local Baseline</string>
 				</dict>
 			</dict>
-			<key>testDeleteAll</key>
-			<dict>
-				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
-				<dict>
-					<key>baselineAverage</key>
-					<real>0.02</real>
-					<key>baselineIntegrationDisplayName</key>
-					<string>Local Baseline</string>
-				</dict>
-			</dict>
 			<key>testRealmCreationCached</key>
 			<dict>
 				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>0.43</real>
+					<real>0.49</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Local Baseline</string>
 				</dict>
@@ -241,7 +241,7 @@
 				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>0.05</real>
+					<real>0.02</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Local Baseline</string>
 				</dict>
@@ -251,7 +251,7 @@
 				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>0.19</real>
+					<real>0.18</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Local Baseline</string>
 				</dict>

--- a/Realm/RLMAccessor.mm
+++ b/Realm/RLMAccessor.mm
@@ -647,7 +647,8 @@ void RLMDynamicValidatedSet(RLMObjectBase *obj, NSString *propName, id val) {
     RLMDynamicSet(obj, prop, val, prop.isPrimary ? RLMCreationOptionsEnforceUnique : 0);
 }
 
-void RLMDynamicSet(__unsafe_unretained RLMObjectBase *const obj, __unsafe_unretained RLMProperty *const prop,
+void RLMDynamicSet(__unsafe_unretained RLMObjectBase *const obj,
+                   __unsafe_unretained RLMProperty *const prop,
                    __unsafe_unretained id val, RLMCreationOptions options) {
     NSUInteger col = prop.column;
     switch (accessorCodeForType(prop.objcType, prop.type)) {

--- a/Realm/RLMObjectBase.mm
+++ b/Realm/RLMObjectBase.mm
@@ -35,7 +35,7 @@ const NSUInteger RLMDescriptionMaxDepth = 5;
 // standalone init
 - (instancetype)init {
     if (RLMSchema.sharedSchema) {
-        RLMObjectSchema *objectSchema = [self.class sharedSchema];
+        __unsafe_unretained RLMObjectSchema *objectSchema = [self.class sharedSchema];
         self = [self initWithRealm:nil schema:objectSchema];
 
         // set default values

--- a/Realm/RLMObjectBase.mm
+++ b/Realm/RLMObjectBase.mm
@@ -35,7 +35,7 @@ const NSUInteger RLMDescriptionMaxDepth = 5;
 // standalone init
 - (instancetype)init {
     if (RLMSchema.sharedSchema) {
-        __unsafe_unretained RLMObjectSchema *objectSchema = [self.class sharedSchema];
+        __unsafe_unretained RLMObjectSchema *const objectSchema = [self.class sharedSchema];
         self = [self initWithRealm:nil schema:objectSchema];
 
         // set default values

--- a/Realm/RLMObjectStore.h
+++ b/Realm/RLMObjectStore.h
@@ -98,6 +98,7 @@ RLMObjectBase *RLMCreateObjectAccessor(RLMRealm *realm,
                                        RLMObjectSchema *objectSchema,
                                        NSUInteger index);
 
+// switch List<> properties from being backed by standalone RLMArrays to RLMArrayLinkView
 void RLMInitializeSwiftListAccessor(RLMObjectBase *object);
 
 #ifdef __cplusplus

--- a/Realm/RLMObjectStore.h
+++ b/Realm/RLMObjectStore.h
@@ -81,13 +81,13 @@ void RLMDeleteObjectFromRealm(RLMObjectBase *object, RLMRealm *realm);
 void RLMDeleteAllObjectsFromRealm(RLMRealm *realm);
 
 // get objects of a given class
-RLMResults *RLMGetObjects(RLMRealm *realm, NSString *objectClassName, NSPredicate *predicate);
+RLMResults *RLMGetObjects(RLMRealm *realm, NSString *objectClassName, NSPredicate *predicate) NS_RETURNS_RETAINED;
 
 // get an object with the given primary key
-id RLMGetObject(RLMRealm *realm, NSString *objectClassName, id key);
+id RLMGetObject(RLMRealm *realm, NSString *objectClassName, id key) NS_RETURNS_RETAINED;
 
 // create object from array or dictionary
-RLMObjectBase *RLMCreateObjectInRealmWithValue(RLMRealm *realm, NSString *className, id value, RLMCreationOptions options);
+RLMObjectBase *RLMCreateObjectInRealmWithValue(RLMRealm *realm, NSString *className, id value, RLMCreationOptions options) NS_RETURNS_RETAINED;
 
 //
 // Accessor Creation
@@ -96,7 +96,7 @@ RLMObjectBase *RLMCreateObjectInRealmWithValue(RLMRealm *realm, NSString *classN
 // Create accessors
 RLMObjectBase *RLMCreateObjectAccessor(RLMRealm *realm,
                                        RLMObjectSchema *objectSchema,
-                                       NSUInteger index);
+                                       NSUInteger index) NS_RETURNS_RETAINED;
 
 // switch List<> properties from being backed by standalone RLMArrays to RLMArrayLinkView
 void RLMInitializeSwiftListAccessor(RLMObjectBase *object);

--- a/Realm/RLMObjectStore.mm
+++ b/Realm/RLMObjectStore.mm
@@ -32,8 +32,6 @@
 
 #import <objc/message.h>
 
-extern "C" {
-
 static void RLMVerifyAndAlignColumns(RLMObjectSchema *tableSchema, RLMObjectSchema *objectSchema) {
     NSMutableArray *properties = [NSMutableArray arrayWithCapacity:objectSchema.properties.count];
     NSMutableArray *exceptionMessages = [NSMutableArray array];
@@ -365,8 +363,6 @@ void RLMInitializeSwiftListAccessor(__unsafe_unretained RLMObjectBase *const obj
     }
 }
 
-} // extern "C" {
-
 template<typename F>
 static inline NSUInteger RLMCreateOrGetRowForObject(RLMObjectSchema *schema, F primaryValueGetter, RLMCreationOptions options, bool &created) {
     // try to get existing row if updating
@@ -396,8 +392,6 @@ static inline NSUInteger RLMCreateOrGetRowForObject(RLMObjectSchema *schema, F p
     // get accessor
     return rowIndex;
 }
-
-extern "C" {
 
 void RLMAddObjectToRealm(RLMObjectBase *object, RLMRealm *realm, RLMCreationOptions options) {
     RLMVerifyInWriteTransaction(realm);
@@ -628,5 +622,3 @@ RLMObjectBase *RLMCreateObjectAccessor(__unsafe_unretained RLMRealm *const realm
     RLMInitializeSwiftListAccessor(accessor);
     return accessor;
 }
-
-} // extern "C" {

--- a/Realm/RLMObjectStore.mm
+++ b/Realm/RLMObjectStore.mm
@@ -335,7 +335,7 @@ NSError *RLMUpdateRealmToSchemaVersion(RLMRealm *realm, NSUInteger newVersion, R
     return nil;
 }
 
-static inline void RLMVerifyInWriteTransaction(RLMRealm *realm) {
+static inline void RLMVerifyInWriteTransaction(__unsafe_unretained RLMRealm *const realm) {
     // if realm is not writable throw
     if (!realm.inWriteTransaction) {
         @throw RLMException(@"Can only add, remove, or create objects in a Realm in a write transaction - call beginWriteTransaction on an RLMRealm instance first.");
@@ -364,7 +364,10 @@ void RLMInitializeSwiftListAccessor(__unsafe_unretained RLMObjectBase *const obj
 }
 
 template<typename F>
-static inline NSUInteger RLMCreateOrGetRowForObject(RLMObjectSchema *schema, F primaryValueGetter, RLMCreationOptions options, bool &created) {
+static inline NSUInteger RLMCreateOrGetRowForObject(__unsafe_unretained RLMObjectSchema *const schema,
+                                                    F&& primaryValueGetter,
+                                                    RLMCreationOptions options,
+                                                    bool &created) {
     // try to get existing row if updating
     size_t rowIndex = realm::not_found;
     realm::Table &table = *schema.table;
@@ -393,7 +396,9 @@ static inline NSUInteger RLMCreateOrGetRowForObject(RLMObjectSchema *schema, F p
     return rowIndex;
 }
 
-void RLMAddObjectToRealm(RLMObjectBase *object, RLMRealm *realm, RLMCreationOptions options) {
+void RLMAddObjectToRealm(__unsafe_unretained RLMObjectBase *const object,
+                         __unsafe_unretained RLMRealm *const realm,
+                         RLMCreationOptions options) {
     RLMVerifyInWriteTransaction(realm);
 
     // verify that object is standalone
@@ -417,7 +422,7 @@ void RLMAddObjectToRealm(RLMObjectBase *object, RLMRealm *realm, RLMCreationOpti
 
     // get or create row
     bool created;
-    auto primaryGetter = [=](RLMProperty *p) { return [object valueForKey:p.getterName]; };
+    auto primaryGetter = [=](__unsafe_unretained RLMProperty *p) { return [object valueForKey:p.getterName]; };
     object->_row = (*schema.table)[RLMCreateOrGetRowForObject(schema, primaryGetter, options, created)];
 
     // populate all properties
@@ -522,7 +527,8 @@ RLMObjectBase *RLMCreateObjectInRealmWithValue(RLMRealm *realm, NSString *classN
     return object;
 }
 
-void RLMDeleteObjectFromRealm(RLMObjectBase *object, RLMRealm *realm) {
+void RLMDeleteObjectFromRealm(__unsafe_unretained RLMObjectBase *const object,
+                              __unsafe_unretained RLMRealm *const realm) {
     if (realm != object->_realm) {
         @throw RLMException(@"Can only delete an object from the Realm it belongs to.");
     }

--- a/Realm/RLMObjectStore.mm
+++ b/Realm/RLMObjectStore.mm
@@ -422,7 +422,9 @@ void RLMAddObjectToRealm(__unsafe_unretained RLMObjectBase *const object,
 
     // get or create row
     bool created;
-    auto primaryGetter = [=](__unsafe_unretained RLMProperty *p) { return [object valueForKey:p.getterName]; };
+    auto primaryGetter = [=](__unsafe_unretained RLMProperty *const p) {
+        return [object valueForKey:p.getterName];
+    };
     object->_row = (*schema.table)[RLMCreateOrGetRowForObject(schema, primaryGetter, options, created)];
 
     // populate all properties

--- a/Realm/RLMQueryUtil.mm
+++ b/Realm/RLMQueryUtil.mm
@@ -316,7 +316,7 @@ void add_constraint_to_query(realm::Query &query, RLMPropertyType type,
                              NSComparisonPredicateOptions predicateOptions,
                              std::vector<NSUInteger> linkColumns, NSUInteger idx, id value)
 {
-    realm::Table *(^table)() = ^{
+    auto table = [&] {
         realm::TableRef& tbl = query.get_table();
         for (NSUInteger col : linkColumns) {
             tbl->link(col); // mutates m_link_chain on table
@@ -370,11 +370,12 @@ RLMProperty *get_property_from_key_path(RLMSchema *schema, RLMObjectSchema *desc
                                         NSString *keyPath, std::vector<NSUInteger> &indexes, bool isAny)
 {
     RLMProperty *prop = nil;
-    NSArray *paths = [keyPath componentsSeparatedByString:@"."];
-    indexes.reserve(paths.count - 1);
 
     NSString *prevPath = nil;
-    for (NSString *path in paths) {
+    NSUInteger start = 0, length = keyPath.length, end = NSNotFound;
+    do {
+        end = [keyPath rangeOfString:@"." options:0 range:{start, length - start}].location;
+        NSString *path = [keyPath substringWithRange:{start, end == NSNotFound ? length - start : end - start}];
         if (prop) {
             RLMPrecondition(prop.type == RLMPropertyTypeObject || prop.type == RLMPropertyTypeArray,
                             @"Invalid value", @"Property '%@' is not a link in object of type '%@'", prevPath, desc.className);
@@ -404,12 +405,17 @@ RLMProperty *get_property_from_key_path(RLMSchema *schema, RLMObjectSchema *desc
             desc = schema[prop.objectClassName];
         }
         prevPath = path;
-    }
+        start = end + 1;
+    } while (end != NSNotFound);
 
     return prop;
 }
 
-void validate_property_value(RLMProperty *prop, id value, NSString *err, RLMObjectSchema *objectSchema, NSString *keyPath) {
+void validate_property_value(__unsafe_unretained RLMProperty *prop,
+                             __unsafe_unretained id value,
+                             __unsafe_unretained NSString *err,
+                             __unsafe_unretained RLMObjectSchema *objectSchema,
+                             __unsafe_unretained NSString *keyPath) {
     if (prop.type == RLMPropertyTypeArray) {
         RLMPrecondition([RLMObjectBaseObjectSchema(RLMDynamicCast<RLMObjectBase>(value)).className isEqualToString:prop.objectClassName],
                         @"Invalid value", err, prop.objectClassName, keyPath, objectSchema.className, value);
@@ -554,7 +560,7 @@ void update_query_with_column_expression(RLMObjectSchema *scheme, Query &query,
 }
 
 void update_query_with_predicate(NSPredicate *predicate, RLMSchema *schema,
-                                 RLMObjectSchema *objectSchema, realm::Query & query)
+                                 RLMObjectSchema *objectSchema, realm::Query &query)
 {
     // Compound predicates.
     if ([predicate isMemberOfClass:[NSCompoundPredicate class]]) {
@@ -577,7 +583,7 @@ void update_query_with_predicate(NSPredicate *predicate, RLMSchema *schema,
 
             case NSOrPredicateType: {
                 // Add all of the subpredicates with ors inbetween.
-                process_or_group(query, comp.subpredicates, [&](NSPredicate *subp) {
+                process_or_group(query, comp.subpredicates, [&](__unsafe_unretained NSPredicate *const subp) {
                     update_query_with_predicate(subp, schema, objectSchema, query);
                 });
                 break;

--- a/Realm/RLMQueryUtil.mm
+++ b/Realm/RLMQueryUtil.mm
@@ -411,11 +411,11 @@ RLMProperty *get_property_from_key_path(RLMSchema *schema, RLMObjectSchema *desc
     return prop;
 }
 
-void validate_property_value(__unsafe_unretained RLMProperty *prop,
-                             __unsafe_unretained id value,
-                             __unsafe_unretained NSString *err,
-                             __unsafe_unretained RLMObjectSchema *objectSchema,
-                             __unsafe_unretained NSString *keyPath) {
+void validate_property_value(__unsafe_unretained RLMProperty *const prop,
+                             __unsafe_unretained id const value,
+                             __unsafe_unretained NSString *const err,
+                             __unsafe_unretained RLMObjectSchema *const objectSchema,
+                             __unsafe_unretained NSString *const keyPath) {
     if (prop.type == RLMPropertyTypeArray) {
         RLMPrecondition([RLMObjectBaseObjectSchema(RLMDynamicCast<RLMObjectBase>(value)).className isEqualToString:prop.objectClassName],
                         @"Invalid value", err, prop.objectClassName, keyPath, objectSchema.className, value);

--- a/Realm/RLMRealm.mm
+++ b/Realm/RLMRealm.mm
@@ -710,7 +710,7 @@ static void CheckReadWrite(RLMRealm *realm, NSString *msg=@"Cannot write to a re
     }
 }
 
-- (void)addObject:(RLMObject *)object {
+- (void)addObject:(__unsafe_unretained RLMObject *const)object {
     RLMAddObjectToRealm(object, self, RLMCreationOptionsNone);
 }
 

--- a/Realm/RLMSchema.mm
+++ b/Realm/RLMSchema.mm
@@ -56,7 +56,7 @@ static NSMutableDictionary *s_localNameToClass;
     return _objectSchemaByName[className];
 }
 
-- (RLMObjectSchema *)objectForKeyedSubscript:(id <NSCopying>)className {
+- (RLMObjectSchema *)objectForKeyedSubscript:(__unsafe_unretained id<NSCopying> const)className {
     RLMObjectSchema *schema = _objectSchemaByName[className];
     if (!schema) {
         NSString *message = [NSString stringWithFormat:@"Object type '%@' not persisted in Realm", className];

--- a/Realm/RLMUtil.hpp
+++ b/Realm/RLMUtil.hpp
@@ -118,7 +118,7 @@ static inline NSString * RLMStringDataToNSString(realm::StringData stringData) {
                                   encoding:NSUTF8StringEncoding];
 }
 
-static inline realm::StringData RLMStringDataWithNSString(__unsafe_unretained NSString *string) {
+static inline realm::StringData RLMStringDataWithNSString(__unsafe_unretained NSString *const string) {
     static_assert(sizeof(size_t) >= sizeof(NSUInteger),
                   "Need runtime overflow check for NSUInteger to size_t conversion");
     return realm::StringData(string.UTF8String,
@@ -126,6 +126,6 @@ static inline realm::StringData RLMStringDataWithNSString(__unsafe_unretained NS
 }
 
 // Binary convertion utilities
-static inline realm::BinaryData RLMBinaryDataForNSData(__unsafe_unretained NSData *data) {
+static inline realm::BinaryData RLMBinaryDataForNSData(__unsafe_unretained NSData *const data) {
     return realm::BinaryData(static_cast<const char *>(data.bytes), data.length);
 }

--- a/Realm/RLMUtil.hpp
+++ b/Realm/RLMUtil.hpp
@@ -118,7 +118,7 @@ static inline NSString * RLMStringDataToNSString(realm::StringData stringData) {
                                   encoding:NSUTF8StringEncoding];
 }
 
-static inline realm::StringData RLMStringDataWithNSString(NSString *string) {
+static inline realm::StringData RLMStringDataWithNSString(__unsafe_unretained NSString *string) {
     static_assert(sizeof(size_t) >= sizeof(NSUInteger),
                   "Need runtime overflow check for NSUInteger to size_t conversion");
     return realm::StringData(string.UTF8String,
@@ -126,6 +126,6 @@ static inline realm::StringData RLMStringDataWithNSString(NSString *string) {
 }
 
 // Binary convertion utilities
-static inline realm::BinaryData RLMBinaryDataForNSData(NSData *data) {
+static inline realm::BinaryData RLMBinaryDataForNSData(__unsafe_unretained NSData *data) {
     return realm::BinaryData(static_cast<const char *>(data.bytes), data.length);
 }

--- a/Realm/RLMUtil.mm
+++ b/Realm/RLMUtil.mm
@@ -33,21 +33,20 @@
 #import "RLMVersion.h"
 #endif
 
-static inline bool nsnumber_is_like_integer(NSNumber *obj)
+static inline bool nsnumber_is_like_integer(__unsafe_unretained NSNumber *const obj)
 {
-    const char *data_type = [obj objCType];
-    // FIXME: Performance optimization - don't use strcmp, use first char in data_type.
-    return (strcmp(data_type, @encode(short)) == 0 ||
-            strcmp(data_type, @encode(int)) == 0 ||
-            strcmp(data_type, @encode(long)) ==  0 ||
-            strcmp(data_type, @encode(long long)) == 0 ||
-            strcmp(data_type, @encode(unsigned short)) == 0 ||
-            strcmp(data_type, @encode(unsigned int)) == 0 ||
-            strcmp(data_type, @encode(unsigned long)) == 0 ||
-            strcmp(data_type, @encode(unsigned long long)) == 0);
+    char data_type = [obj objCType][0];
+    return data_type == *@encode(short) ||
+           data_type == *@encode(int) ||
+           data_type == *@encode(long) ||
+           data_type == *@encode(long long) ||
+           data_type == *@encode(unsigned short) ||
+           data_type == *@encode(unsigned int) ||
+           data_type == *@encode(unsigned long) ||
+           data_type == *@encode(unsigned long long);
 }
 
-static inline bool nsnumber_is_like_bool(NSNumber *obj)
+static inline bool nsnumber_is_like_bool(__unsafe_unretained NSNumber *const obj)
 {
     // @encode(BOOL) is 'B' on iOS 64 and 'c'
     // objcType is always 'c'. Therefore compare to "c".
@@ -63,40 +62,38 @@ static inline bool nsnumber_is_like_bool(NSNumber *obj)
     return false;
 }
 
-static inline bool nsnumber_is_like_float(NSNumber *obj)
+static inline bool nsnumber_is_like_float(__unsafe_unretained NSNumber *const obj)
 {
-    const char *data_type = [obj objCType];
-    // FIXME: Performance optimization - don't use strcmp, use first char in data_type.
-    return (strcmp(data_type, @encode(float)) == 0 ||
-            strcmp(data_type, @encode(short)) == 0 ||
-            strcmp(data_type, @encode(int)) == 0 ||
-            strcmp(data_type, @encode(long)) ==  0 ||
-            strcmp(data_type, @encode(long long)) == 0 ||
-            strcmp(data_type, @encode(unsigned short)) == 0 ||
-            strcmp(data_type, @encode(unsigned int)) == 0 ||
-            strcmp(data_type, @encode(unsigned long)) == 0 ||
-            strcmp(data_type, @encode(unsigned long long)) == 0 ||
-            // A double is like float if it fits within float bounds
-            (strcmp(data_type, @encode(double)) == 0 && ABS([obj doubleValue]) <= FLT_MAX));
+    char data_type = [obj objCType][0];
+    return data_type == *@encode(float) ||
+           data_type == *@encode(short) ||
+           data_type == *@encode(int) ||
+           data_type == *@encode(long) ||
+           data_type == *@encode(long long) ||
+           data_type == *@encode(unsigned short) ||
+           data_type == *@encode(unsigned int) ||
+           data_type == *@encode(unsigned long) ||
+           data_type == *@encode(unsigned long long) ||
+           // A double is like float if it fits within float bounds
+           (data_type == *@encode(double) && ABS([obj doubleValue]) <= FLT_MAX);
 }
 
-static inline bool nsnumber_is_like_double(NSNumber *obj)
+static inline bool nsnumber_is_like_double(__unsafe_unretained NSNumber *const obj)
 {
-    const char *data_type = [obj objCType];
-    // FIXME: Performance optimization - don't use strcmp, use first char in data_type.
-    return (strcmp(data_type, @encode(double)) == 0 ||
-            strcmp(data_type, @encode(float)) == 0 ||
-            strcmp(data_type, @encode(short)) == 0 ||
-            strcmp(data_type, @encode(int)) == 0 ||
-            strcmp(data_type, @encode(long)) ==  0 ||
-            strcmp(data_type, @encode(long long)) == 0 ||
-            strcmp(data_type, @encode(unsigned short)) == 0 ||
-            strcmp(data_type, @encode(unsigned int)) == 0 ||
-            strcmp(data_type, @encode(unsigned long)) == 0 ||
-            strcmp(data_type, @encode(unsigned long long)) == 0);
+    char data_type = [obj objCType][0];
+    return data_type == *@encode(double) ||
+           data_type == *@encode(float) ||
+           data_type == *@encode(short) ||
+           data_type == *@encode(int) ||
+           data_type == *@encode(long) ||
+           data_type == *@encode(long long) ||
+           data_type == *@encode(unsigned short) ||
+           data_type == *@encode(unsigned int) ||
+           data_type == *@encode(unsigned long) ||
+           data_type == *@encode(unsigned long long);
 }
 
-static inline bool object_has_valid_type(id obj)
+static inline bool object_has_valid_type(__unsafe_unretained id const obj)
 {
     return ([obj isKindOfClass:[NSString class]] ||
             [obj isKindOfClass:[NSNumber class]] ||
@@ -104,7 +101,8 @@ static inline bool object_has_valid_type(id obj)
             [obj isKindOfClass:[NSData class]]);
 }
 
-BOOL RLMIsObjectValidForProperty(id obj, RLMProperty *property) {
+BOOL RLMIsObjectValidForProperty(__unsafe_unretained id const obj,
+                                 __unsafe_unretained RLMProperty *const property) {
     switch (property.type) {
         case RLMPropertyTypeString:
             return [obj isKindOfClass:[NSString class]];
@@ -200,7 +198,7 @@ id RLMValidatedObjectForProperty(id obj, RLMProperty *prop, RLMSchema *schema, R
     return obj;
 }
 
-NSDictionary *RLMDefaultValuesForObjectSchema(RLMObjectSchema *objectSchema) {
+NSDictionary *RLMDefaultValuesForObjectSchema(__unsafe_unretained RLMObjectSchema *const objectSchema) {
     if (!objectSchema.isSwiftClass) {
         return [objectSchema.objectClass defaultPropertyValues];
     }

--- a/Realm/Tests/PerformanceTests.m
+++ b/Realm/Tests/PerformanceTests.m
@@ -69,8 +69,9 @@ static RLMRealm *s_smallRealm, *s_mediumRealm, *s_largeRealm;
 }
 
 - (void)testInsertMultiple {
-    [self measureBlock:^{
+    [self measureMetrics:self.class.defaultPerformanceMetrics automaticallyStartMeasuring:NO forBlock:^{
         RLMRealm *realm = self.realmWithTestPath;
+        [self startMeasuring];
         [realm beginWriteTransaction];
         for (int i = 0; i < 5000; ++i) {
             StringObject *obj = [[StringObject alloc] init];
@@ -78,6 +79,7 @@ static RLMRealm *s_smallRealm, *s_mediumRealm, *s_largeRealm;
             [realm addObject:obj];
         }
         [realm commitWriteTransaction];
+        [self stopMeasuring];
         [self tearDown];
     }];
 }

--- a/Realm/Tests/PerformanceTests.m
+++ b/Realm/Tests/PerformanceTests.m
@@ -118,17 +118,21 @@ static RLMRealm *s_smallRealm, *s_mediumRealm, *s_largeRealm;
 - (void)testCountWhereQuery {
     RLMRealm *realm = [self getStringObjects:50];
     [self measureBlock:^{
-        RLMResults *array = [StringObject objectsInRealm:realm where:@"stringCol = 'a'"];
-        [array count];
+        for (int i = 0; i < 50; ++i) {
+            RLMResults *array = [StringObject objectsInRealm:realm where:@"stringCol = 'a'"];
+            [array count];
+        }
     }];
 }
 
 - (void)testCountWhereTableView {
     RLMRealm *realm = [self getStringObjects:50];
     [self measureBlock:^{
-        RLMResults *array = [StringObject objectsInRealm:realm where:@"stringCol = 'a'"];
-        [array firstObject]; // Force materialization of backing table view
-        [array count];
+        for (int i = 0; i < 10; ++i) {
+            RLMResults *array = [StringObject objectsInRealm:realm where:@"stringCol = 'a'"];
+            [array firstObject]; // Force materialization of backing table view
+            [array count];
+        }
     }];
 }
 
@@ -224,7 +228,7 @@ static RLMRealm *s_smallRealm, *s_mediumRealm, *s_largeRealm;
     NSPredicate *predicate = [NSPredicate predicateWithFormat:@"boolCol = false and (intCol = 5 or floatCol = 1.0) and objectCol = nil and longCol != 7 and stringCol IN {'a', 'b', 'c'}"];
 
     [self measureBlock:^{
-        for (int i = 0; i < 100; ++i) {
+        for (int i = 0; i < 500; ++i) {
             [AllTypesObject objectsInRealm:realm withPredicate:predicate];
         }
     }];
@@ -232,7 +236,7 @@ static RLMRealm *s_smallRealm, *s_mediumRealm, *s_largeRealm;
 
 - (void)testDeleteAll {
     [self measureMetrics:self.class.defaultPerformanceMetrics automaticallyStartMeasuring:NO forBlock:^{
-        RLMRealm *realm = [self getStringObjects:5];
+        RLMRealm *realm = [self getStringObjects:50];
 
         [self startMeasuring];
         [realm beginWriteTransaction];
@@ -304,8 +308,8 @@ static RLMRealm *s_smallRealm, *s_mediumRealm, *s_largeRealm;
 - (void)testLargeINQuery {
     RLMRealm *realm = self.realmWithTestPath;
     [realm beginWriteTransaction];
-    NSMutableArray *ids = [NSMutableArray arrayWithCapacity:1000];
-    for (int i = 0; i < 2000; ++i) {
+    NSMutableArray *ids = [NSMutableArray arrayWithCapacity:3000];
+    for (int i = 0; i < 3000; ++i) {
         [IntObject createInRealm:realm withValue:@[@(i)]];
         if (i % 2) {
             [ids addObject:@(i)];
@@ -321,7 +325,7 @@ static RLMRealm *s_smallRealm, *s_mediumRealm, *s_largeRealm;
 - (void)testSortingAllObjects {
     RLMRealm *realm = self.realmWithTestPath;
     [realm beginWriteTransaction];
-    for (int i = 0; i < 2000; ++i) {
+    for (int i = 0; i < 3000; ++i) {
         [IntObject createInRealm:realm withValue:@[@(arc4random())]];
     }
     [realm commitWriteTransaction];
@@ -385,7 +389,7 @@ static RLMRealm *s_smallRealm, *s_mediumRealm, *s_largeRealm;
 
         RLMNotificationToken *token = [realm addNotificationBlock:^(__unused NSString *note, __unused RLMRealm *realm) { }];
         [self startMeasuring];
-        while (obj.intCol < 100) {
+        while (obj.intCol < 500) {
             [realm transactionWithBlock:^{
                 obj.intCol++;
             }];
@@ -396,7 +400,7 @@ static RLMRealm *s_smallRealm, *s_mediumRealm, *s_largeRealm;
 }
 
 - (void)testCommitWriteTransactionWithCrossThreadNotification {
-    const int stopValue = 100;
+    const int stopValue = 500;
 
     [self measureMetrics:self.class.defaultPerformanceMetrics automaticallyStartMeasuring:NO forBlock:^{
         RLMRealm *realm = [RLMRealm inMemoryRealmWithIdentifier:@"test"];
@@ -436,7 +440,7 @@ static RLMRealm *s_smallRealm, *s_mediumRealm, *s_largeRealm;
 }
 
 - (void)testCrossThreadSyncLatency {
-    const int stopValue = 100;
+    const int stopValue = 500;
 
     [self measureMetrics:self.class.defaultPerformanceMetrics automaticallyStartMeasuring:NO forBlock:^{
         RLMRealm *realm = [RLMRealm inMemoryRealmWithIdentifier:@"test"];

--- a/RealmSwift.xcodeproj/xcshareddata/xcbaselines/554A51C73FAED0A637EBFEBF.xcbaseline/6890B8D9-CE81-403E-8EF6-B95A367D65B5.plist
+++ b/RealmSwift.xcodeproj/xcshareddata/xcbaselines/554A51C73FAED0A637EBFEBF.xcbaseline/6890B8D9-CE81-403E-8EF6-B95A367D65B5.plist
@@ -16,22 +16,12 @@
 					<string>Local Baseline</string>
 				</dict>
 			</dict>
-			<key>testCommitWriteTransactionWithCrossThreadNotification()</key>
-			<dict>
-				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
-				<dict>
-					<key>baselineAverage</key>
-					<real>0.08</real>
-					<key>baselineIntegrationDisplayName</key>
-					<string>Local Baseline</string>
-				</dict>
-			</dict>
 			<key>testCommitWriteTransactionWithLocalNotification()</key>
 			<dict>
 				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>0.07</real>
+					<real>0.06</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Local Baseline</string>
 				</dict>
@@ -41,7 +31,7 @@
 				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>0.01</real>
+					<real>0.29</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Local Baseline</string>
 				</dict>
@@ -51,7 +41,7 @@
 				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>0.04</real>
+					<real>1.34</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Local Baseline</string>
 				</dict>
@@ -71,7 +61,7 @@
 				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>0</real>
+					<real>0.05</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Local Baseline</string>
 				</dict>
@@ -81,7 +71,7 @@
 				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>0.19</real>
+					<real>0.13</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Local Baseline</string>
 				</dict>
@@ -91,7 +81,7 @@
 				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>0.17</real>
+					<real>0.15</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Local Baseline</string>
 				</dict>
@@ -101,7 +91,7 @@
 				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>0.21</real>
+					<real>0.14</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Local Baseline</string>
 				</dict>
@@ -111,7 +101,7 @@
 				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>0.18</real>
+					<real>0.17</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Local Baseline</string>
 				</dict>
@@ -121,7 +111,7 @@
 				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>0.11</real>
+					<real>0.07</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Local Baseline</string>
 				</dict>
@@ -131,7 +121,7 @@
 				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>0.25</real>
+					<real>0.21</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Local Baseline</string>
 				</dict>
@@ -141,7 +131,7 @@
 				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>0.5</real>
+					<real>0.11</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Local Baseline</string>
 				</dict>
@@ -151,7 +141,7 @@
 				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>0.4</real>
+					<real>0.24</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Local Baseline</string>
 				</dict>
@@ -161,7 +151,7 @@
 				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>0.29</real>
+					<real>0.25</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Local Baseline</string>
 				</dict>
@@ -171,7 +161,17 @@
 				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>0.91</real>
+					<real>0.37</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+				</dict>
+			</dict>
+			<key>testInsertSingleLiteral()</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>0.12</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Local Baseline</string>
 				</dict>
@@ -181,7 +181,7 @@
 				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>0.05</real>
+					<real>0.06</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Local Baseline</string>
 				</dict>
@@ -191,7 +191,7 @@
 				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>0.8</real>
+					<real>0.48</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Local Baseline</string>
 				</dict>
@@ -201,7 +201,7 @@
 				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>0.05</real>
+					<real>0.17</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Local Baseline</string>
 				</dict>
@@ -211,7 +211,7 @@
 				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>0.09</real>
+					<real>0.9</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Local Baseline</string>
 				</dict>
@@ -221,7 +221,7 @@
 				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>0.42</real>
+					<real>0.44</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Local Baseline</string>
 				</dict>
@@ -231,7 +231,7 @@
 				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>0.06</real>
+					<real>0.02</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Local Baseline</string>
 				</dict>
@@ -241,7 +241,7 @@
 				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>0.39</real>
+					<real>0.23</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Local Baseline</string>
 				</dict>

--- a/RealmSwift.xcodeproj/xcshareddata/xcbaselines/554A51C73FAED0A637EBFEBF.xcbaseline/Info.plist
+++ b/RealmSwift.xcodeproj/xcshareddata/xcbaselines/554A51C73FAED0A637EBFEBF.xcbaseline/Info.plist
@@ -4,7 +4,7 @@
 <dict>
 	<key>runDestinationsByUUID</key>
 	<dict>
-		<key>7F8339ED-0034-40BF-9189-6C569D2814B7</key>
+		<key>6890B8D9-CE81-403E-8EF6-B95A367D65B5</key>
 		<dict>
 			<key>targetArchitecture</key>
 			<string>armv7s</string>
@@ -12,18 +12,6 @@
 			<dict>
 				<key>modelCode</key>
 				<string>iPhone5,1</string>
-				<key>platformIdentifier</key>
-				<string>com.apple.platform.iphoneos</string>
-			</dict>
-		</dict>
-		<key>E15E6DC2-362A-47E4-8E27-83A9497D3A20</key>
-		<dict>
-			<key>targetArchitecture</key>
-			<string>arm64</string>
-			<key>targetDevice</key>
-			<dict>
-				<key>modelCode</key>
-				<string>iPhone7,2</string>
 				<key>platformIdentifier</key>
 				<string>com.apple.platform.iphoneos</string>
 			</dict>

--- a/RealmSwift/Migration.swift
+++ b/RealmSwift/Migration.swift
@@ -220,7 +220,10 @@ private func accessorMigrationBlock(migrationBlock: MigrationBlock) -> RLMMigrat
     return { migration, oldVersion in
         // set all accessor classes to MigrationObject
         for objectSchema in migration.oldSchema.objectSchema {
-            (objectSchema as! RLMObjectSchema).accessorClass = MigrationObject.self
+            if let objectSchema = objectSchema as? RLMObjectSchema {
+                objectSchema.accessorClass = MigrationObject.self
+                objectSchema.isSwiftClass = true // not set automatically for schemas from the Realm file
+            }
         }
         for objectSchema in migration.newSchema.objectSchema {
             (objectSchema as! RLMObjectSchema).accessorClass = MigrationObject.self

--- a/RealmSwift/Migration.swift
+++ b/RealmSwift/Migration.swift
@@ -222,11 +222,16 @@ private func accessorMigrationBlock(migrationBlock: MigrationBlock) -> RLMMigrat
         for objectSchema in migration.oldSchema.objectSchema {
             if let objectSchema = objectSchema as? RLMObjectSchema {
                 objectSchema.accessorClass = MigrationObject.self
-                objectSchema.isSwiftClass = true // not set automatically for schemas from the Realm file
+                // isSwiftClass is always `false` for object schema generated
+                // from the table, but we need to pretend it's from a swift class
+                // (even if it isn't) for the accessors to be initialized correctly.
+                objectSchema.isSwiftClass = true
             }
         }
         for objectSchema in migration.newSchema.objectSchema {
-            (objectSchema as! RLMObjectSchema).accessorClass = MigrationObject.self
+            if let objectSchema = objectSchema as? RLMObjectSchema {
+                objectSchema.accessorClass = MigrationObject.self
+            }
         }
 
         // run migration

--- a/RealmSwift/Tests/PerformanceTests.swift
+++ b/RealmSwift/Tests/PerformanceTests.swift
@@ -128,17 +128,21 @@ class SwiftPerformanceTests: TestCase {
     func testCountWhereQuery() {
         let realm = copyRealmToTestPath(largeRealm)
         measureBlock {
-            let results = realm.objects(SwiftStringObject).filter("stringCol = 'a'")
-            _ = results.count
+            for i in 0..<50 {
+                let results = realm.objects(SwiftStringObject).filter("stringCol = 'a'")
+                _ = results.count
+            }
         }
     }
 
     func testCountWhereTableView() {
-        let realm = copyRealmToTestPath(largeRealm)
+        let realm = copyRealmToTestPath(mediumRealm)
         measureBlock {
-            let results = realm.objects(SwiftStringObject).filter("stringCol = 'a'")
-            _ = results.first
-            _ = results.count
+            for i in 0..<50 {
+                let results = realm.objects(SwiftStringObject).filter("stringCol = 'a'")
+                _ = results.first
+                _ = results.count
+            }
         }
     }
 
@@ -224,7 +228,7 @@ class SwiftPerformanceTests: TestCase {
         let predicate = NSPredicate(format: "boolCol = false and (intCol = 5 or floatCol = 1.0) and objectCol = nil and doubleCol != 7.0 and stringCol IN {'a', 'b', 'c'}")
 
         measureBlock {
-            for _ in 0..<100 {
+            for _ in 0..<500 {
                 _ = realm.objects(SwiftObject).filter(predicate)
             }
         }
@@ -232,7 +236,7 @@ class SwiftPerformanceTests: TestCase {
 
     func testDeleteAll() {
         inMeasureBlock {
-            let realm = self.copyRealmToTestPath(mediumRealm)
+            let realm = self.copyRealmToTestPath(largeRealm)
             self.startMeasuring()
             realm.write {
                 realm.delete(realm.objects(SwiftStringObject))
@@ -296,7 +300,7 @@ class SwiftPerformanceTests: TestCase {
         let realm = realmWithTestPath()
         realm.beginWrite()
         var ids = [Int]()
-        for i in 0..<2000 {
+        for i in 0..<3000 {
             realm.create(SwiftIntObject.self, value: [i])
             if i % 2 != 0 {
                 ids.append(i)
@@ -311,7 +315,7 @@ class SwiftPerformanceTests: TestCase {
     func testSortingAllObjects() {
         let realm = realmWithTestPath()
         realm.write {
-            for _ in 0..<2000 {
+            for _ in 0..<3000 {
                 let randomNumber = Int(arc4random_uniform(UInt32(INT_MAX)))
                 realm.create(SwiftIntObject.self, value: [randomNumber])
             }


### PR DESCRIPTION
https://github.com/realm/realm-core/pull/826 makes everything way slower, so I took a stab at optimizing things to make the net change more reasonable. Net change on the perf tests with changes exceeding the standard deviation (numbers are percent slower than baseline, negative is faster):

Test Name | Standard Deviation | Threadsafe detaching | Optimized threadsafe detaching
----------|--------------------|----------------------|--------------------------------
EnumerateAndAccessAll | 2.9% | 31.2% | 15%
EnumerateAndAccessAllSlow | 1.06% | 17.8% | -3.1%
EnumerateAndAccessArrayProperty | 0.599% | 26.5% | 6.4%
EnumerateAndAccessArrayPropertySlow | 1.38% | 17.6% | -2.9%
EnumerateAndAccessQuery | 8.69% | 34.3% | 22%
EnumerateAndMutateAll | 1.2% | 25.2% | -1.3%
EnumerateAndMutateQuery | 1.8% | -1.1% | -8.3%
IndexedStringLookup | 0.48% | 1.49% | -8.1%
InsertMultiple | 6.72% | 9.74% | -19%
InsertMultipleLiteral | 3.24% | 8.24% | -11%
InsertSingleLiteral | 2.79% | -0.74% | -25%
LargeINQuery | 0.344% | 0.602% | -11%
ManualDeletion | 21.8% | 0% | -22%
QueryConstruction | 8.5% | 4.9% | -12%
QueryDeletion | 0.739% | 5.54% | -25%
UnIndexedStringLookup | 0.839% | 2.19% | -8.2%

The remaining big loser is fast enumerating and reading from realm objects, since those tests are basically 100% creating and destroying accessors.
