### PR TITLE
Remove all objects optimization

### DIFF
--- a/Realm/RLMArray.mm
+++ b/Realm/RLMArray.mm
@@ -83,7 +83,8 @@
     }
 }
 
-- (void)removeAllObjects {
+- (void)removeAllObjects
+{
     [_backingArray removeAllObjects];
 }
 

--- a/Realm/RLMArray.mm
+++ b/Realm/RLMArray.mm
@@ -84,9 +84,7 @@
 }
 
 - (void)removeAllObjects {
-    while (self.count) {
-        [self removeLastObject];
-    }
+    [_backingArray removeAllObjects];
 }
 
 - (id)objectAtIndexedSubscript:(NSUInteger)index {


### PR DESCRIPTION
It appears that the implementation of many `RLMArray` methods such as `objectAtIndex:`  and `removeObjectAtIndex:` simply call those methods on the underlying `NSMutableArray`, but I noticed `RLMArray`'s implementation of `removeAllObjects` didn't take advantage of this and instead calls a series of methods essentially iterating through the array and removing the last object until it's empty. I *presume* calling `NSMutableArray`'s  `removeAllObjects` directly, rather than the loop/if-statement/method-calls, would be more efficient, unless I'm missing something?