### PR TITLE
Have RLMNotifier create a dedicated thread to listen for notifications…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+x.x.x Release notes (yyyy-MM-dd)
+=============================================================
+
+### API breaking changes
+
+* None.
+
+### Enhancements
+
+* None.
+
+### Bugfixes
+
+* The interprocess notification mechanism no longer uses dispatch worker threads, preventing it from
+  starving other GCD clients of the opportunity to execute blocks when dozens of Realms are open at once.
+
 0.92.3 Release notes (2015-05-13)
 =============================================================
 

--- a/Realm/RLMRealmUtil.mm
+++ b/Realm/RLMRealmUtil.mm
@@ -209,14 +209,14 @@ public:
         _shutdownReadFd = pipeFd[0];
         _shutdownWriteFd = pipeFd[1];
 
-        dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
-            [self listen];
-        });
+        [NSThread detachNewThreadSelector:@selector(listen) toTarget:self withObject:nil];
     }
     return self;
 }
 
 - (void)listen {
+    [NSThread currentThread].name = @"RLMRealm notification listener";
+
     // Create the runloop source
     CFRunLoopSourceContext ctx{};
     ctx.info = (__bridge void *)self;

--- a/Realm/Tests/RealmTests.mm
+++ b/Realm/Tests/RealmTests.mm
@@ -1240,6 +1240,22 @@ extern "C" {
     XCTAssertGreaterThan(fileSizeBefore, fileSizeAfter);
 }
 
+- (void)testCanCreate100RealmsWithoutBreakingGCD
+{
+    NSMutableArray *realms = [NSMutableArray array];
+    for (int i = 0; i < 100; ++i) {
+        NSString *realmFileName = [NSString stringWithFormat:@"test.%d.realm", i];
+        RLMRealm *realm = [RLMRealm realmWithPath:RLMRealmPathForFile(realmFileName)];
+        [realms addObject:realm];
+    }
+
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Block dispatched to concurrent queue should be executed"];
+    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+        [expectation fulfill];
+    });
+    [self waitForExpectationsWithTimeout:1 handler:nil];
+}
+
 - (void)runBlock:(void (^)())block {
     block();
 }


### PR DESCRIPTION
… rather than doing so on a global concurrent queue.

There is a relatively low cap on the number of worker threads that can
service the global concurrent queues. Using a dedicated thread to listen
for notifications avoids tying up a worker thread for the lifetime of
each RLMRealm instance, which prevents starving other GCD clients when a
large number of RLMRealm instances are live.

Addresses an issue mentioned in #1970.