### PR TITLE
Update to core 0.89.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ x.x.x Release notes (yyyy-MM-dd)
 ### Enhancements
 
 * Swift: Made `Object.init()` a required initializer.
+* `RLMObject`, `RLMResults`, `Object` and `Results` can now be safely
+  deallocated (but still not used) from any thread.
+* Improved performance of most simple queries.
 
 ### Bugfixes
 

--- a/Realm/RLMArrayLinkView.mm
+++ b/Realm/RLMArrayLinkView.mm
@@ -257,11 +257,10 @@ static inline void RLMValidateObjectClass(__unsafe_unretained RLMObjectBase *con
     std::vector<bool> order;
     RLMGetColumnIndices(_realm.schema[_objectClassName], properties, columns, order);
 
-    realm::TableView const &tv = _backingLinkView->get_sorted_view(move(columns), move(order));
     auto query = std::make_unique<realm::Query>(_backingLinkView->get_target_table().where(_backingLinkView));
     return [RLMResults resultsWithObjectClassName:self.objectClassName
                                                  query:move(query)
-                                                  view:tv
+                                                  view:_backingLinkView->get_sorted_view(move(columns), move(order))
                                                  realm:_realm];
 
 }

--- a/Realm/RLMArray_Private.hpp
+++ b/Realm/RLMArray_Private.hpp
@@ -71,7 +71,7 @@ namespace realm {
 
 + (instancetype)resultsWithObjectClassName:(NSString *)objectClassName
                                      query:(std::unique_ptr<realm::Query>)query
-                                      view:(realm::TableView)view
+                                      view:(realm::TableView &&)view
                                      realm:(RLMRealm *)realm;
 - (void)deleteObjectsFromRealm;
 @end

--- a/Realm/RLMObjectBase.mm
+++ b/Realm/RLMObjectBase.mm
@@ -181,12 +181,6 @@ const NSUInteger RLMDescriptionMaxDepth = 5;
     }
 }
 
-- (void)dealloc {
-    if (_realm && !self.isInvalidated) {
-        RLMCheckThread(_realm);
-    }
-}
-
 + (BOOL)shouldPersistToRealm {
     return RLMIsObjectSubclass(self);
 }

--- a/Realm/RLMResults.mm
+++ b/Realm/RLMResults.mm
@@ -72,12 +72,12 @@
 
 + (instancetype)resultsWithObjectClassName:(NSString *)objectClassName
                                      query:(std::unique_ptr<realm::Query>)query
-                                      view:(realm::TableView)view
+                                      view:(realm::TableView &&)view
                                      realm:(RLMRealm *)realm {
     RLMResults *ar = [[RLMResults alloc] initPrivate];
     ar->_objectClassName = objectClassName;
     ar->_viewCreated = YES;
-    ar->_backingView = move(view);
+    ar->_backingView = std::move(view);
     ar->_backingQuery = move(query);
     ar->_realm = realm;
     ar->_objectSchema = realm.schema[objectClassName];

--- a/build.sh
+++ b/build.sh
@@ -14,7 +14,7 @@ set -o pipefail
 set -e
 
 # You can override the version of the core library
-: ${REALM_CORE_VERSION:=0.89.3} # set to "current" to always use the current build
+: ${REALM_CORE_VERSION:=0.89.4} # set to "current" to always use the current build
 
 # You can override the xcmode used
 : ${XCMODE:=xcodebuild} # must be one of: xcodebuild (default), xcpretty, xctool


### PR DESCRIPTION
Performance test failures are expected since updating baselines would be a big waste of time when https://github.com/realm/realm-cocoa/pull/1956 updates them again.

Closes #1953 and #1893.