### PR TITLE
[Swift] Made SortDescriptor conform to Equatable & StringLiteralConvertible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ x.x.x Release notes (yyyy-MM-dd)
 * Swift: `Results` now conforms to `CVarArgType` so it can
   now be passed as an argument to `Results.filter(_:...)`
   and `List.filter(_:...)`.
+* Swift: Made `SortDescriptor` conform to the `Equatable` and
+  `StringLiteralConvertible` protocols.
 
 ### Bugfixes
 

--- a/RealmSwift/SortDescriptor.swift
+++ b/RealmSwift/SortDescriptor.swift
@@ -70,3 +70,51 @@ extension SortDescriptor: Printable {
         return "SortDescriptor (property: \(property), direction: \(direction))"
     }
 }
+
+// MARK: Equatable
+
+extension SortDescriptor: Equatable {}
+
+/// Returns whether the two sort descriptors are equal.
+public func ==(lhs: SortDescriptor, rhs: SortDescriptor) -> Bool {
+    return lhs.property == rhs.property &&
+        lhs.ascending == lhs.ascending
+}
+
+// MARK: StringLiteralConvertible
+
+extension SortDescriptor: StringLiteralConvertible {
+
+    /// `StringLiteralType`. Required for `StringLiteralConvertible` conformance.
+    public typealias UnicodeScalarLiteralType = StringLiteralType
+
+    /// `StringLiteralType`. Required for `StringLiteralConvertible` conformance.
+    public typealias ExtendedGraphemeClusterLiteralType = StringLiteralType
+
+    /**
+    Creates a `SortDescriptor` from a `UnicodeScalarLiteralType`.
+
+    :param: unicodeScalarLiteral Property name literal.
+    */
+    public init(unicodeScalarLiteral value: UnicodeScalarLiteralType) {
+        self.init(property: value)
+    }
+
+    /**
+    Creates a `SortDescriptor` from an `ExtendedGraphemeClusterLiteralType`.
+
+    :param: extendedGraphemeClusterLiteral Property name literal.
+    */
+    public init(extendedGraphemeClusterLiteral value: ExtendedGraphemeClusterLiteralType) {
+        self.init(property: value)
+    }
+
+    /**
+    Creates a `SortDescriptor` from a `StringLiteralType`.
+
+    :param: stringLiteral Property name literal.
+    */
+    public init(stringLiteral value: StringLiteralType) {
+        self.init(property: value)
+    }
+}

--- a/RealmSwift/Tests/SortDescriptorTests.swift
+++ b/RealmSwift/Tests/SortDescriptorTests.swift
@@ -37,4 +37,9 @@ class SortDescriptorTests: TestCase {
     func testDescription() {
         XCTAssertEqual(sortDescriptor.description, "SortDescriptor (property: property, direction: ascending)")
     }
+
+    func testStringLiteralConvertible() {
+        let literalSortDescriptor: SortDescriptor = "property"
+        XCTAssertEqual(sortDescriptor, literalSortDescriptor, "SortDescriptor should conform to StringLiteralConvertible")
+    }
 }


### PR DESCRIPTION
This makes it much cleaner to sort by multiple properties:

```swift
// before
results.sorted([SortDescriptor(property: "a"), SortDescriptor(property: "b"), SortDescriptor(property: "c")])
// after
results.sorted(["a", "b", "c"])
```

/cc @tgoyne @segiddins @bdash 