### PR TITLE
[Results] `Results` now conforms to `CVarArgType`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+x.x.x Release notes (yyyy-MM-dd)
+=============================================================
+
+### API breaking changes
+
+* None.
+
+### Enhancements
+
+* Swift: `Results` now conforms to `CVarArgType` so it can
+  now be passed as an argument to `Results.filter(_:...)`
+  and `List.filter(_:...)`.
+
+### Bugfixes
+
+* None.
+
 0.92.4 Release notes (2015-05-22)
 =============================================================
 

--- a/RealmSwift/Results.swift
+++ b/RealmSwift/Results.swift
@@ -291,6 +291,6 @@ extension Results: CVarArgType {
     /// Transform `self` into a series of machine words that can be
     /// appropriately interpreted by C varargs
     public func encode() -> [Word] {
-        return (map(self, { $0 }) as NSArray).encode()
+        return rlmResults.encode()
     }
 }

--- a/RealmSwift/Results.swift
+++ b/RealmSwift/Results.swift
@@ -284,3 +284,13 @@ extension Results: CollectionType {
     /// endIndex is not a valid argument to subscript, and is always reachable from startIndex by zero or more applications of successor().
     public var endIndex: Int { return count }
 }
+
+// MARK: Variadic Arguments Support
+
+extension Results: CVarArgType {
+    /// Transform `self` into a series of machine words that can be
+    /// appropriately interpreted by C varargs
+    public func encode() -> [Word] {
+        return (map(self, { $0 }) as NSArray).encode()
+    }
+}

--- a/RealmSwift/Tests/ListTests.swift
+++ b/RealmSwift/Tests/ListTests.swift
@@ -29,7 +29,7 @@ class ListTests: TestCase {
         fatalError("abstract")
     }
 
-    func createArrayWithLinks() ->  SwiftListOfSwiftObject {
+    func createArrayWithLinks() -> SwiftListOfSwiftObject {
         fatalError("abstract")
     }
 
@@ -43,7 +43,7 @@ class ListTests: TestCase {
         arrayObject = createArray()
         array = arrayObject.array
 
-        let realm = self.realmWithTestPath()
+        let realm = realmWithTestPath()
         realm.write {
             realm.add(self.str1)
             realm.add(self.str2)
@@ -65,7 +65,7 @@ class ListTests: TestCase {
 
     override class func defaultTestSuite() -> XCTestSuite! {
         // Don't run tests for the base class
-        if self.isEqual(ListTests) {
+        if isEqual(ListTests) {
             return nil
         }
         return super.defaultTestSuite()
@@ -200,6 +200,32 @@ class ListTests: TestCase {
         array.append(str2)
         XCTAssertEqual(Int(1), array.filter("stringCol = '1'").count)
         XCTAssertEqual(Int(1), array.filter("stringCol = '2'").count)
+    }
+
+    func testFilterList() {
+        let innerArray = createArrayWithLinks()
+
+        if let realm = innerArray.realm {
+            realm.beginWrite()
+            innerArray.array.append(SwiftObject())
+            let outerArray = SwiftDoubleListOfSwiftObject()
+            realm.add(outerArray)
+            outerArray.array.append(innerArray)
+            realm.commitWrite()
+            XCTAssertEqual(Int(1), outerArray.array.filter("ANY array IN %@", innerArray.array).count)
+        }
+    }
+
+    func testFilterResults() {
+        let arrayObject = createArrayWithLinks()
+
+        if let realm = arrayObject.realm {
+            realm.beginWrite()
+            arrayObject.array.append(SwiftObject())
+            let subArray = arrayObject.array
+            realm.commitWrite()
+            XCTAssertEqual(Int(1), realm.objects(SwiftListOfSwiftObject).filter("ANY array IN %@", subArray).count)
+        }
     }
 
     func testFilterPredicate() {
@@ -468,7 +494,7 @@ class ListNewlyAddedTests: ListTests {
     override func createArray() -> SwiftArrayPropertyObject {
         let array = SwiftArrayPropertyObject()
         array.name = "name"
-        let realm = self.realmWithTestPath()
+        let realm = realmWithTestPath()
         realm.write { realm.add(array) }
 
         XCTAssertNotNil(array.realm)
@@ -487,7 +513,7 @@ class ListNewlyAddedTests: ListTests {
 
 class ListNewlyCreatedTests: ListTests {
     override func createArray() -> SwiftArrayPropertyObject {
-        let realm = self.realmWithTestPath()
+        let realm = realmWithTestPath()
         realm.beginWrite()
         let array = realm.create(SwiftArrayPropertyObject.self, value: ["name", [], []])
         realm.commitWrite()
@@ -509,7 +535,7 @@ class ListNewlyCreatedTests: ListTests {
 
 class ListRetrievedTests: ListTests {
     override func createArray() -> SwiftArrayPropertyObject {
-        let realm = self.realmWithTestPath()
+        let realm = realmWithTestPath()
         realm.beginWrite()
         realm.create(SwiftArrayPropertyObject.self, value: ["name", [], []])
         realm.commitWrite()

--- a/RealmSwift/Tests/ResultsTests.swift
+++ b/RealmSwift/Tests/ResultsTests.swift
@@ -179,6 +179,25 @@ class ResultsTests: TestCase {
         XCTAssertEqual(Int(0), results.filter("stringCol = %@", "3").count)
     }
 
+    func testFilterList() {
+        let outerArray = SwiftDoubleListOfSwiftObject()
+        let realm = realmWithTestPath()
+        let innerArray = SwiftListOfSwiftObject()
+        innerArray.array.append(SwiftObject())
+        outerArray.array.append(innerArray)
+        realm.add(outerArray)
+        XCTAssertEqual(Int(1), outerArray.array.filter("ANY array IN %@", realm.objects(SwiftObject)).count)
+    }
+
+    func testFilterResults() {
+        let array = SwiftListOfSwiftObject()
+        let realm = realmWithTestPath()
+        array.array.append(SwiftObject())
+        realm.add(array)
+        XCTAssertEqual(Int(1),
+            realm.objects(SwiftListOfSwiftObject).filter("ANY array IN %@", realm.objects(SwiftObject)).count)
+    }
+
     func testFilterPredicate() {
         let pred1 = NSPredicate(format: "stringCol = '1'")
         let pred2 = NSPredicate(format: "stringCol = '2'")

--- a/RealmSwift/Tests/SwiftTestObjects.swift
+++ b/RealmSwift/Tests/SwiftTestObjects.swift
@@ -114,6 +114,10 @@ class SwiftArrayPropertyObject: Object {
     let intArray = List<SwiftIntObject>()
 }
 
+class SwiftDoubleListOfSwiftObject: Object {
+    let array = List<SwiftListOfSwiftObject>()
+}
+
 class SwiftListOfSwiftObject: Object {
     let array = List<SwiftObject>()
 }


### PR DESCRIPTION
Fixes #1995. `List` already conforms to `CVarArgType` because it inherits from `NSObject`. /cc @tgoyne @bdash @segiddins 