### PR TITLE
[RLMArray] call addOrUpdateObject if an object has a primary key in -[RLMArray addObject:]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+x.x.x Release notes (yyyy-MM-dd)
+=============================================================
+
+### API breaking changes
+
+* None.
+
+### Enhancements
+
+* `-[RLMArray addObject:]`, `-[RLMArray addObjects:]`, `List.append(_:)` and
+  `List.extend(_:)` now supports passing in unpersisted objects with primary
+  key values already contained in the target Realm.
+
+### Bugfixes
+
+* None.
+
 0.92.4 Release notes (2015-05-22)
 =============================================================
 

--- a/Realm/RLMArrayLinkView.mm
+++ b/Realm/RLMArrayLinkView.mm
@@ -142,7 +142,11 @@ static inline void RLMValidateObjectClass(__unsafe_unretained RLMObjectBase *con
     RLMValidateObjectClass(object, self.objectClassName);
 
     if (object->_realm != self.realm) {
-        [self.realm addObject:object];
+        if (object.objectSchema.primaryKeyProperty != nil) {
+            [self.realm addOrUpdateObject:object];
+        } else {
+            [self.realm addObject:object];
+        }
     }
     _backingLinkView->add(object->_row.get_index());
 }

--- a/Realm/Tests/ArrayPropertyTests.m
+++ b/Realm/Tests/ArrayPropertyTests.m
@@ -21,6 +21,13 @@
 @implementation DogArrayObject
 @end
 
+RLM_ARRAY_TYPE(PrimaryStringObject)
+@interface ArrayOfPrimaryStringObject : RLMObject
+@property RLMArray<PrimaryStringObject> *array;
+@end
+@implementation ArrayOfPrimaryStringObject
+@end
+
 @interface ArrayPropertyTests : RLMTestCase
 @end
 
@@ -53,6 +60,22 @@
     for (RLMObject *obj in array.array) {
         XCTAssertTrue(obj.description.length, @"Object should have description");
     }
+}
+
+- (void)testAddObjectPrimaryKey
+{
+    RLMRealm *realm = self.realmWithTestPath;
+    [realm beginWriteTransaction];
+    PrimaryStringObject *primaryString = [PrimaryStringObject createInRealm:realm withValue:@[@"a", @0]];
+    ArrayOfPrimaryStringObject *array = [ArrayOfPrimaryStringObject createInRealm:realm withValue:@[@[]]];
+    [array.array addObject:primaryString];
+    XCTAssertEqual([array.array count], 1U);
+    PrimaryStringObject *modifiedPrimaryString = [[PrimaryStringObject alloc] initWithValue:primaryString];
+    [array.array removeAllObjects];
+    XCTAssertEqual([array.array count], 0U);
+    [array.array addObject:modifiedPrimaryString];
+    XCTAssertEqual([array.array count], 1U);
+    [realm commitWriteTransaction];
 }
 
 -(void)testModifyDetatchedArray {


### PR DESCRIPTION
Prompted by #1999. I couldn't think of a reason why we shouldn't be doing this, and that functionality hasn't changed since originally introducing it (before primary keys were even supported).

/cc @tgoyne @bdash @segiddins 