### PR TITLE
Improve error reporting when trying to index unindexable properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,8 @@ x.x.x Release notes (yyyy-MM-dd)
 * Swift: Made `SortDescriptor` conform to the `Equatable` and
   `StringLiteralConvertible` protocols.
 * Int primary keys are once again automatically indexed.
-* Improve error reporting when indexing is request for a property that can't be
-  indexed.
+* Improve error reporting when attempting to mark a property of a type that
+  cannot be indexed as indexed.
 
 ### Bugfixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ x.x.x Release notes (yyyy-MM-dd)
 * Swift: Made `SortDescriptor` conform to the `Equatable` and
   `StringLiteralConvertible` protocols.
 * Int primary keys are once again automatically indexed.
+* Improve error reporting when indexing is request for a property that can't be
+  indexed.
 
 ### Bugfixes
 

--- a/Realm/Tests/SchemaTests.mm
+++ b/Realm/Tests/SchemaTests.mm
@@ -64,7 +64,6 @@ RLM_ARRAY_TYPE(SchemaTestClassSecondChild)
 @implementation SchemaTestClassLink
 @end
 
-
 @interface SchemaTestClassWithSingleDuplicatePropertyBase : FakeObject
 @property NSString *string;
 @end
@@ -96,6 +95,15 @@ RLM_ARRAY_TYPE(SchemaTestClassSecondChild)
 @implementation SchemaTestClassWithMultipleDuplicateProperties
 @dynamic string;
 @dynamic integer;
+@end
+
+@interface UnindexableProperty : FakeObject
+@property double unindexable;
+@end
+@implementation UnindexableProperty
++ (NSArray *)indexedProperties {
+    return @[@"unindexable"];
+}
 @end
 
 
@@ -398,6 +406,14 @@ RLM_ARRAY_TYPE(SchemaTestClassSecondChild)
 
 - (void)testClassWithInvalidPrimaryKey {
     XCTAssertThrows([RLMObjectSchema schemaForObjectClass:InvalidPrimaryKeyType.class]);
+}
+
+- (void)testClassWithUnindexableProperty {
+    RLMObjectSchema *objectSchema = [RLMObjectSchema schemaForObjectClass:UnindexableProperty.class];
+    RLMSchema *schema = [[RLMSchema alloc] init];
+    schema.objectSchema = @[objectSchema];
+    RLMAssertThrowsWithReasonMatching([self realmWithTestPathAndSchema:schema],
+                                      @".*UnindexableProperty\\.unindexable.*double.*");
 }
 
 @end


### PR DESCRIPTION
Rollback the write transaction and throw an obj-c exception with a useful error message rather than just letting the c++ exception bubble out.

Closes #1997.