### PR TITLE
Re-enable automatically indexing int primary keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ x.x.x Release notes (yyyy-MM-dd)
   and `List.filter(_:...)`.
 * Swift: Made `SortDescriptor` conform to the `Equatable` and
   `StringLiteralConvertible` protocols.
+* Int primary keys are once again automatically indexed.
 
 ### Bugfixes
 

--- a/Realm/RLMObject.h
+++ b/Realm/RLMObject.h
@@ -220,7 +220,7 @@
 
 /**
  Return an array of property names for properties which should be indexed. Only supported
- for string properties.
+ for string and int properties.
  @return    NSArray of property names.
  */
 + (NSArray *)indexedProperties;
@@ -236,7 +236,7 @@
  Implement to designate a property as the primary key for an RLMObject subclass. Only properties of
  type RLMPropertyTypeString and RLMPropertyTypeInt can be designated as the primary key. Primary key 
  properties enforce uniqueness for each value whenever the property is set which incurs some overhead.
- Indexes are created automatically for string primary key properties.
+ Indexes are created automatically for primary key properties.
 
  @return    Name of the property designated as the primary key.
  */

--- a/Realm/RLMObjectSchema.mm
+++ b/Realm/RLMObjectSchema.mm
@@ -115,10 +115,7 @@
     if (NSString *primaryKey = [objectClass primaryKey]) {
         for (RLMProperty *prop in schema.properties) {
             if ([primaryKey isEqualToString:prop.name]) {
-                 // FIXME - enable for ints when we have core suppport
-                if (prop.type == RLMPropertyTypeString) {
-                    prop.indexed = YES;
-                }
+                prop.indexed = YES;
                 schema.primaryKeyProperty = prop;
                 break;
             }

--- a/Realm/Tests/MigrationTests.mm
+++ b/Realm/Tests/MigrationTests.mm
@@ -499,12 +499,12 @@
 }
 
 - (void)testDuplicatePrimaryKeyMigration {
-    // make string an int
+    // make the pk non-primary so that we can add duplicate values
     RLMObjectSchema *objectSchema = [RLMObjectSchema schemaForObjectClass:MigrationPrimaryKeyObject.class];
     objectSchema.primaryKeyProperty.isPrimary = NO;
     objectSchema.primaryKeyProperty = nil;
 
-    // create realm with old schema and populate
+    // populate with values that will be invalid when the property is made primary
     RLMRealm *realm = [self realmWithSingleObject:objectSchema];
     [realm beginWriteTransaction];
     [realm createObject:MigrationPrimaryKeyObject.className withValue:@[@1]];
@@ -517,7 +517,7 @@
             withMigrationBlock:^(__unused RLMMigration *migration, __unused NSUInteger oldSchemaVersion) {}];
     XCTAssertThrows([RLMRealm migrateRealmAtPath:RLMTestRealmPath()], @"Migration should throw due to duplicate primary keys)");
 
-    // apply good migration
+    // apply good migration that deletes duplicates
     [RLMRealm setSchemaVersion:1
                 forRealmAtPath:RLMTestRealmPath()
             withMigrationBlock:^(RLMMigration *migration, __unused NSUInteger oldSchemaVersion) {

--- a/Realm/Tests/MigrationTests.mm
+++ b/Realm/Tests/MigrationTests.mm
@@ -466,7 +466,6 @@
     [RLMRealm migrateRealmAtPath:RLMTestRealmPath()];
 }
 
-#if 0 // FIXME: re-enable when int indexing is enabled
 - (void)testIntPrimaryKeyNoIndexMigration {
     // make string an int
     RLMObjectSchema *objectSchema = [RLMObjectSchema schemaForObjectClass:MigrationPrimaryKeyObject.class];
@@ -498,7 +497,6 @@
     XCTAssertEqual(1, [objects[0] intCol]);
     XCTAssertEqual(2, [objects[1] intCol]);
 }
-#endif
 
 - (void)testDuplicatePrimaryKeyMigration {
     // make string an int

--- a/Realm/Tests/SchemaTests.mm
+++ b/Realm/Tests/SchemaTests.mm
@@ -99,6 +99,15 @@ RLM_ARRAY_TYPE(SchemaTestClassSecondChild)
 @end
 
 
+@interface InvalidPrimaryKeyType : FakeObject
+@property double primaryKey;
+@end
+@implementation InvalidPrimaryKeyType
++ (NSString *)primaryKey {
+    return @"primaryKey";
+}
+@end
+
 @interface SchemaTests : RLMTestCase
 @end
 
@@ -385,6 +394,10 @@ RLM_ARRAY_TYPE(SchemaTestClassSecondChild)
 {
     RLMAssertThrowsWithReasonMatching([RLMObjectSchema schemaForObjectClass:SchemaTestClassWithSingleDuplicateProperty.class], @"'string' .* multiple times .* 'SchemaTestClassWithSingleDuplicateProperty'");
     RLMAssertThrowsWithReasonMatching([RLMObjectSchema schemaForObjectClass:SchemaTestClassWithMultipleDuplicateProperties.class], @"'SchemaTestClassWithMultipleDuplicateProperties' .* declared multiple times");
+}
+
+- (void)testClassWithInvalidPrimaryKey {
+    XCTAssertThrows([RLMObjectSchema schemaForObjectClass:InvalidPrimaryKeyType.class]);
 }
 
 @end

--- a/RealmSwift/Object.swift
+++ b/RealmSwift/Object.swift
@@ -110,7 +110,7 @@ public class Object: RLMObjectBase, Equatable, Printable {
     Override to designate a property as the primary key for an `Object` subclass. Only properties of
     type String and Int can be designated as the primary key. Primary key
     properties enforce uniqueness for each value whenever the property is set which incurs some overhead.
-    Indexes are created automatically for string primary key properties.
+    Indexes are created automatically for primary key properties.
     :returns: Name of the property designated as the primary key, or `nil` if the model has no primary key.
     */
     public class func primaryKey() -> String? { return nil }
@@ -125,7 +125,7 @@ public class Object: RLMObjectBase, Equatable, Printable {
 
     /**
     Return an array of property names for properties which should be indexed. Only supported
-    for string properties.
+    for string and int properties.
     :returns: `Array` of property names to index.
     */
     public class func indexedProperties() -> [String] { return [] }


### PR DESCRIPTION
It turns out that we've been unintentionally allowing indexing int properties since 0.92.0 due to missing error checking, so just go ahead and make it explicitly supported.