### PR TITLE
Allow key paths on either side of operators in cases where it clearly makes sense

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ x.x.x Release notes (yyyy-MM-dd)
 
 * Objects are no longer copied into standalone objects during object creation. This fixes an issue where
   nested objects with a primary key are sometimes duplicated rather than updated.
+* Comparison predicates with a constant on the left of the operator and key path on the right now give
+  correct results. An exception is now thrown for predicates that do not yet support this ordering.
 
 0.93.0 Release notes (2015-05-27)
 =============================================================

--- a/Realm/RLMQueryUtil.mm
+++ b/Realm/RLMQueryUtil.mm
@@ -347,6 +347,8 @@ void add_link_constraint_to_query(realm::Query & query,
 }
 
 void add_link_constraint_to_query(realm::Query& query, NSPredicateOperatorType operatorType, RLMObject *obj, NSUInteger column) {
+    // Link constraints only support the equal-to and not-equal-to operators. The order of operands
+    // is not important for those comaprisons so we can delegate to the other implementation.
     add_link_constraint_to_query(query, operatorType, column, obj);
 }
 

--- a/Realm/RLMQueryUtil.mm
+++ b/Realm/RLMQueryUtil.mm
@@ -348,7 +348,7 @@ void add_link_constraint_to_query(realm::Query & query,
 
 void add_link_constraint_to_query(realm::Query& query, NSPredicateOperatorType operatorType, RLMObject *obj, NSUInteger column) {
     // Link constraints only support the equal-to and not-equal-to operators. The order of operands
-    // is not important for those comaprisons so we can delegate to the other implementation.
+    // is not important for those comparisons so we can delegate to the other implementation.
     add_link_constraint_to_query(query, operatorType, column, obj);
 }
 

--- a/Realm/RLMQueryUtil.mm
+++ b/Realm/RLMQueryUtil.mm
@@ -90,6 +90,42 @@ struct FalseExpression : realm::Expression {
     const Table* get_table() override { return nullptr; }
 };
 
+NSString *operatorName(NSPredicateOperatorType operatorType)
+{
+    switch (operatorType) {
+        case NSLessThanPredicateOperatorType:
+            return @"<";
+        case NSLessThanOrEqualToPredicateOperatorType:
+            return @"<=";
+        case NSGreaterThanPredicateOperatorType:
+            return @">";
+        case NSGreaterThanOrEqualToPredicateOperatorType:
+            return @">=";
+        case NSEqualToPredicateOperatorType:
+            return @"==";
+        case NSNotEqualToPredicateOperatorType:
+            return @"!=";
+        case NSMatchesPredicateOperatorType:
+            return @"MATCHES";
+        case NSLikePredicateOperatorType:
+            return @"LIKE";
+        case NSBeginsWithPredicateOperatorType:
+            return @"BEGINSWITH";
+        case NSEndsWithPredicateOperatorType:
+            return @"ENDSWITH";
+        case NSInPredicateOperatorType:
+            return @"IN";
+        case NSContainsPredicateOperatorType:
+            return @"CONTAINS";
+        case NSBetweenPredicateOperatorType:
+            return @"BETWEENS";
+        case NSCustomSelectorPredicateOperatorType:
+            return @"custom selector";
+    }
+
+    return [NSString stringWithFormat:@"unknown operator %lu", (unsigned long)operatorType];
+}
+
 // add a clause for numeric constraints based on operator type
 template <typename A, typename B>
 void add_numeric_constraint_to_query(realm::Query& query,
@@ -119,7 +155,7 @@ void add_numeric_constraint_to_query(realm::Query& query,
             break;
         default:
             @throw RLMPredicateException(@"Invalid operator type",
-                                         @"Operator type %lu not supported for type %@", (unsigned long)operatorType, RLMTypeToString(datatype));
+                                         @"Operator '%@' not supported for type %@", operatorName(operatorType), RLMTypeToString(datatype));
     }
 }
 
@@ -134,7 +170,7 @@ void add_bool_constraint_to_query(realm::Query &query, NSPredicateOperatorType o
             break;
         default:
             @throw RLMPredicateException(@"Invalid operator type",
-                                         @"Operator type %lu not supported for bool type", (unsigned long)operatorType);
+                                         @"Operator '%@' not supported for bool type", operatorName(operatorType));
     }
 }
 
@@ -167,7 +203,7 @@ void add_string_constraint_to_query(realm::Query &query,
             break;
         default:
             @throw RLMPredicateException(@"Invalid operator type",
-                                         @"Operator type %lu not supported for string type", (unsigned long)operatorType);
+                                         @"Operator '%@' not supported for string type", operatorName(operatorType));
     }
 }
 
@@ -183,8 +219,8 @@ void add_string_constraint_to_query(realm::Query& query,
             break;
         default:
             @throw RLMPredicateException(@"Invalid operator type",
-                                         @"Operator type %lu is not supported for string type with key path on right side of operator",
-                                         (unsigned long)operatorType);
+                                         @"Operator '%@' is not supported for string type with key path on right side of operator",
+                                         operatorName(operatorType));
     }
 }
 
@@ -275,7 +311,7 @@ void add_binary_constraint_to_query(realm::Query & query,
             break;
         default:
             @throw RLMPredicateException(@"Invalid operator type",
-                                         @"Operator type %lu not supported for binary type", (unsigned long)operatorType);
+                                         @"Operator '%@' not supported for binary type", operatorName(operatorType));
     }
 }
 
@@ -287,8 +323,8 @@ void add_binary_constraint_to_query(realm::Query& query, NSPredicateOperatorType
             break;
         default:
             @throw RLMPredicateException(@"Invalid operator type",
-                                         @"Operator type %lu is not supported binary type with key path on right side of operator",
-                                         (unsigned long)operatorType);
+                                         @"Operator '%@' is not supported for binary type with key path on right side of operator",
+                                         operatorName(operatorType));
     }
 }
 
@@ -644,7 +680,7 @@ void update_query_with_column_expression(RLMObjectSchema *scheme, Query &query,
                     break;
                 default:
                     @throw RLMPredicateException(@"Invalid operator type",
-                                                 @"Operator type %lu not supported for string type", (unsigned long)type);
+                                                 @"Operator '%@' not supported for string type", operatorName(type));
             }
             break;
         }

--- a/Realm/Tests/QueryTests.m
+++ b/Realm/Tests/QueryTests.m
@@ -1711,11 +1711,11 @@
     XCTAssertEqual(6U, [QueryObject objectsWhere:@"'a' != string2"].count);
 
     RLMAssertThrowsWithReasonMatching([QueryObject objectsWhere:@"'Realm' CONTAINS string1"].count,
-                                      @"Operator type 99 is not supported .* right side");
+                                      @"Operator 'CONTAINS' is not supported .* right side");
     RLMAssertThrowsWithReasonMatching([QueryObject objectsWhere:@"'Amazon' BEGINSWITH string2"].count,
-                                      @"Operator type 8 is not supported .* right side");
+                                      @"Operator 'BEGINSWITH' is not supported .* right side");
     RLMAssertThrowsWithReasonMatching([QueryObject objectsWhere:@"'Tuba' ENDSWITH string1"].count,
-                                      @"Operator type 9 is not supported .* right side");
+                                      @"Operator 'ENDSWITH' is not supported .* right side");
 }
 
 @end


### PR DESCRIPTION
This takes care of the basic cases of the key path being on the right hand side of the operator. There are some operators that this does not yet support (e.g., 'foo' CONTAINS stringKeyPath). It may require improvements in core to support them.

I'd appreciate feedback on whether anyone can see a nicer approach than using templates like I've done in this approach.

Fixes #1990.
