### PR TITLE
[Docs] fixed OS X location of defaultRealmPath in docs

### DIFF
--- a/Realm/RLMRealm.h
+++ b/Realm/RLMRealm.h
@@ -188,7 +188,7 @@
 /**
  Returns the location of the default Realm as a string.
 
- `~/Application Support/{bundle ID}/default.realm` on OS X.
+ `~/Library/Application Support/{bundle ID}/default.realm` on OS X.
 
  `default.realm` in your application's documents directory on iOS.
 

--- a/RealmSwift/Realm.swift
+++ b/RealmSwift/Realm.swift
@@ -58,7 +58,7 @@ public final class Realm {
     /**
     The location of the default Realm as a string. Can be overridden.
 
-    `~/Application Support/{bundle ID}/default.realm` on OS X.
+    `~/Library/Application Support/{bundle ID}/default.realm` on OS X.
 
     `default.realm` in your application's documents directory on iOS.
 


### PR DESCRIPTION
As identified by https://twitter.com/ronaldmannak/status/604118705870479360. /cc @tgoyne @bdash @segiddins 