### PR TITLE
[Swift][List] Removed unused List.init(_ rlmArray:) initializer

### DIFF
--- a/RealmSwift/List.swift
+++ b/RealmSwift/List.swift
@@ -72,10 +72,6 @@ public final class List<T: Object>: ListBase {
         super.init(array: RLMArray(objectClassName: T.className()))
     }
 
-    internal init(_ rlmArray: RLMArray) {
-        super.init(array: rlmArray)
-    }
-
     // MARK: Index Retrieval
 
     /**


### PR DESCRIPTION
/cc @tgoyne @segiddins @bdash turns out we weren't using this, as detected by @kishikawakatsumi's SwiftCov tool :smile:.