### PR TITLE
Make RLMArray and RLMResults generic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ x.xx.x Release notes (yyyy-MM-dd)
 * Avoid evaluating results eagerly when filtering and sorting.
 * Add nullability annotations to the Objective-C API to provide enhanced compiler
   warnings and bridging to Swift.
+* Added `RLM_GENERIC_ARRAY(ObjectType)` macro to make `RLMArray`s use
+  Objective-C generics where available.
 
 ### Bugfixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,9 @@ x.xx.x Release notes (yyyy-MM-dd)
 * Avoid evaluating results eagerly when filtering and sorting.
 * Add nullability annotations to the Objective-C API to provide enhanced compiler
   warnings and bridging to Swift.
-* Added `RLM_GENERIC_ARRAY(ObjectType)` macro to make `RLMArray`s use
+* Add `RLM_GENERIC_ARRAY(ObjectType)` macro to make `RLMArray`s use
   Objective-C generics where available.
+* Make `RLMResult`s support being used as an Objective-C generic.
 
 ### Bugfixes
 

--- a/Realm/RLMArray.h
+++ b/Realm/RLMArray.h
@@ -22,7 +22,7 @@
 
 RLM_ASSUME_NONNULL_BEGIN
 
-@class RLMObject, RLMRealm, RLMResults;
+@class RLMObject, RLMRealm, RLMResults RLM_GENERIC_COLLECTION;
 
 /**
  
@@ -37,7 +37,7 @@ RLM_ASSUME_NONNULL_BEGIN
  lazily created when accessed, or can be obtained by querying a Realm.
  */
 
-@interface RLMArray : NSObject<RLMCollection, NSFastEnumeration>
+@interface RLMArray RLM_GENERIC_COLLECTION : NSObject<RLMCollection, NSFastEnumeration>
 
 /**---------------------------------------------------------------------------------------
  *  @name RLMArray Properties
@@ -78,7 +78,7 @@ RLM_ASSUME_NONNULL_BEGIN
  
  @return An RLMObject of the class contained by this RLMArray.
  */
-- (id)objectAtIndex:(NSUInteger)index;
+- (RLMObjectType)objectAtIndex:(NSUInteger)index;
 
 /**
  Returns the first object in the array.
@@ -87,7 +87,7 @@ RLM_ASSUME_NONNULL_BEGIN
  
  @return An RLMObject of the class contained by this RLMArray.
  */
-- (nullable id)firstObject;
+- (nullable RLMObjectType)firstObject;
 
 /**
  Returns the last object in the array.
@@ -96,7 +96,7 @@ RLM_ASSUME_NONNULL_BEGIN
 
  @return An RLMObject of the class contained by this RLMArray.
  */
-- (nullable id)lastObject;
+- (nullable RLMObjectType)lastObject;
 
 
 #pragma mark -
@@ -114,7 +114,7 @@ RLM_ASSUME_NONNULL_BEGIN
  
  @param object  An RLMObject of the class contained by this RLMArray.
  */
-- (void)addObject:(RLMObject *)object;
+- (void)addObject:(RLMObjectArgument)object;
 
 /**
  Adds an array of objects at the end of the array.
@@ -136,7 +136,7 @@ RLM_ASSUME_NONNULL_BEGIN
  @param anObject  An object (of the same type as returned from the objectClassName selector).
  @param index   The array index at which the object is inserted.
  */
-- (void)insertObject:(RLMObject *)anObject atIndex:(NSUInteger)index;
+- (void)insertObject:(RLMObjectArgument)anObject atIndex:(NSUInteger)index;
 
 /**
  Removes an object at a given index.
@@ -173,7 +173,7 @@ RLM_ASSUME_NONNULL_BEGIN
  @param index       The array index of the object to be replaced.
  @param anObject    An object (of the same type as returned from the objectClassName selector).
  */
-- (void)replaceObjectAtIndex:(NSUInteger)index withObject:(RLMObject *)anObject;
+- (void)replaceObjectAtIndex:(NSUInteger)index withObject:(RLMObjectArgument)anObject;
 
 
 #pragma mark -
@@ -190,7 +190,7 @@ RLM_ASSUME_NONNULL_BEGIN
  
  @param object  An object (of the same type as returned from the objectClassName selector).
  */
-- (NSUInteger)indexOfObject:(RLMObject *)object;
+- (NSUInteger)indexOfObject:(RLMObjectArgument)object;
 
 /**
  Gets the index of the first object matching the predicate.
@@ -217,7 +217,7 @@ RLM_ASSUME_NONNULL_BEGIN
  
  @return                An RLMResults of objects that match the given predicate
  */
-- (RLMResults *)objectsWhere:(NSString *)predicateFormat, ...;
+- (RLMResults RLM_GENERIC_COLLECTION*)objectsWhere:(NSString *)predicateFormat, ...;
 
 /**
  Get objects matching the given predicate in the RLMArray.
@@ -226,7 +226,7 @@ RLM_ASSUME_NONNULL_BEGIN
  
  @return            An RLMResults of objects that match the given predicate
  */
-- (RLMResults *)objectsWithPredicate:(NSPredicate *)predicate;
+- (RLMResults RLM_GENERIC_COLLECTION*)objectsWithPredicate:(NSPredicate *)predicate;
 
 /**
  Get a sorted RLMResults from an RLMArray
@@ -236,7 +236,7 @@ RLM_ASSUME_NONNULL_BEGIN
  
  @return    An RLMResults sorted by the specified property.
  */
-- (RLMResults *)sortedResultsUsingProperty:(NSString *)property ascending:(BOOL)ascending;
+- (RLMResults RLM_GENERIC_COLLECTION*)sortedResultsUsingProperty:(NSString *)property ascending:(BOOL)ascending;
 
 /**
  Get a sorted RLMResults from an RLMArray
@@ -245,12 +245,12 @@ RLM_ASSUME_NONNULL_BEGIN
 
  @return    An RLMResults sorted by the specified properties.
  */
-- (RLMResults *)sortedResultsUsingDescriptors:(NSArray *)properties;
+- (RLMResults RLM_GENERIC_COLLECTION*)sortedResultsUsingDescriptors:(NSArray *)properties;
 
 #pragma mark -
 
-- (id)objectAtIndexedSubscript:(NSUInteger)index;
-- (void)setObject:(id)newValue atIndexedSubscript:(NSUInteger)index;
+- (RLMObjectType)objectAtIndexedSubscript:(NSUInteger)index;
+- (void)setObject:(RLMObjectType)newValue atIndexedSubscript:(NSUInteger)index;
 
 #pragma mark -
 

--- a/Realm/RLMArray.h
+++ b/Realm/RLMArray.h
@@ -217,7 +217,7 @@ RLM_ASSUME_NONNULL_BEGIN
  
  @return                An RLMResults of objects that match the given predicate
  */
-- (RLMResults RLM_GENERIC_COLLECTION*)objectsWhere:(NSString *)predicateFormat, ...;
+- (RLMResults RLM_GENERIC_RETURN*)objectsWhere:(NSString *)predicateFormat, ...;
 
 /**
  Get objects matching the given predicate in the RLMArray.
@@ -226,7 +226,7 @@ RLM_ASSUME_NONNULL_BEGIN
  
  @return            An RLMResults of objects that match the given predicate
  */
-- (RLMResults RLM_GENERIC_COLLECTION*)objectsWithPredicate:(NSPredicate *)predicate;
+- (RLMResults RLM_GENERIC_RETURN*)objectsWithPredicate:(NSPredicate *)predicate;
 
 /**
  Get a sorted RLMResults from an RLMArray
@@ -236,7 +236,7 @@ RLM_ASSUME_NONNULL_BEGIN
  
  @return    An RLMResults sorted by the specified property.
  */
-- (RLMResults RLM_GENERIC_COLLECTION*)sortedResultsUsingProperty:(NSString *)property ascending:(BOOL)ascending;
+- (RLMResults RLM_GENERIC_RETURN*)sortedResultsUsingProperty:(NSString *)property ascending:(BOOL)ascending;
 
 /**
  Get a sorted RLMResults from an RLMArray
@@ -245,7 +245,7 @@ RLM_ASSUME_NONNULL_BEGIN
 
  @return    An RLMResults sorted by the specified properties.
  */
-- (RLMResults RLM_GENERIC_COLLECTION*)sortedResultsUsingDescriptors:(NSArray *)properties;
+- (RLMResults RLM_GENERIC_RETURN*)sortedResultsUsingDescriptors:(NSArray *)properties;
 
 #pragma mark -
 

--- a/Realm/RLMCollection.h
+++ b/Realm/RLMCollection.h
@@ -22,6 +22,15 @@ RLM_ASSUME_NONNULL_BEGIN
 
 @class RLMRealm, RLMResults, RLMObject;
 
+#if __has_extension(objc_generics)
+#define RLM_GENERIC_COLLECTION <RLMObjectType>
+#define RLMObjectArgument RLMObjectType
+#else
+#define RLM_GENERIC_COLLECTION
+typedef id RLMObjectType;
+typedef RLMObject * RLMObjectArgument;
+#endif
+
 @protocol RLMCollection <NSFastEnumeration>
 
 @required

--- a/Realm/RLMCollection.h
+++ b/Realm/RLMCollection.h
@@ -25,10 +25,12 @@ RLM_ASSUME_NONNULL_BEGIN
 #if __has_extension(objc_generics)
 #define RLM_GENERIC_COLLECTION <RLMObjectType>
 #define RLMObjectArgument RLMObjectType
+#define RLM_GENERIC_ARRAY(CLASS) RLMArray<CLASS *><CLASS>
 #else
 #define RLM_GENERIC_COLLECTION
 typedef id RLMObjectType;
 typedef RLMObject * RLMObjectArgument;
+#define RLM_GENERIC_ARRAY(CLASS) RLMArray<CLASS>
 #endif
 
 @protocol RLMCollection <NSFastEnumeration>

--- a/Realm/RLMCollection.h
+++ b/Realm/RLMCollection.h
@@ -22,17 +22,6 @@ RLM_ASSUME_NONNULL_BEGIN
 
 @class RLMRealm, RLMResults, RLMObject;
 
-#if __has_extension(objc_generics)
-#define RLM_GENERIC_COLLECTION <RLMObjectType>
-#define RLMObjectArgument RLMObjectType
-#define RLM_GENERIC_ARRAY(CLASS) RLMArray<CLASS *><CLASS>
-#else
-#define RLM_GENERIC_COLLECTION
-typedef id RLMObjectType;
-typedef RLMObject * RLMObjectArgument;
-#define RLM_GENERIC_ARRAY(CLASS) RLMArray<CLASS>
-#endif
-
 @protocol RLMCollection <NSFastEnumeration>
 
 @required

--- a/Realm/RLMDefines.h
+++ b/Realm/RLMDefines.h
@@ -27,11 +27,13 @@
 #pragma mark - Generics
 
 #if __has_extension(objc_generics)
-#define RLM_GENERIC_COLLECTION <RLMObjectType>
+#define RLM_GENERIC_COLLECTION <RLMObjectType: RLMObject *>
+#define RLM_GENERIC_RETURN <RLMObjectType>
 #define RLMObjectArgument RLMObjectType
 #define RLM_GENERIC_ARRAY(CLASS) RLMArray<CLASS *><CLASS>
 #else
 #define RLM_GENERIC_COLLECTION
+#define RLM_GENERIC_RETURN
 typedef id RLMObjectType;
 typedef RLMObject * RLMObjectArgument;
 #define RLM_GENERIC_ARRAY(CLASS) RLMArray<CLASS>

--- a/Realm/RLMDefines.h
+++ b/Realm/RLMDefines.h
@@ -18,6 +18,8 @@
 
 #import <Foundation/Foundation.h>
 
+@class RLMObject;
+
 #ifndef __has_feature
 #define __has_feature(x) 0
 #endif

--- a/Realm/RLMDefines.h
+++ b/Realm/RLMDefines.h
@@ -22,6 +22,21 @@
 #define __has_feature(x) 0
 #endif
 
+#pragma mark - Generics
+
+#if __has_extension(objc_generics)
+#define RLM_GENERIC_COLLECTION <RLMObjectType>
+#define RLMObjectArgument RLMObjectType
+#define RLM_GENERIC_ARRAY(CLASS) RLMArray<CLASS *><CLASS>
+#else
+#define RLM_GENERIC_COLLECTION
+typedef id RLMObjectType;
+typedef RLMObject * RLMObjectArgument;
+#define RLM_GENERIC_ARRAY(CLASS) RLMArray<CLASS>
+#endif
+
+#pragma mark - Nullability
+
 #if !__has_feature(nullability)
 #ifndef __nullable
 #define __nullable

--- a/Realm/RLMObject.h
+++ b/Realm/RLMObject.h
@@ -411,7 +411,7 @@ RLM_ASSUME_NONNULL_BEGIN
  
      RLM_ARRAY_TYPE(ObjectType)
      ...
-     @property RLMArray<ObjectType> *arrayOfObjectTypes;
+     @property RLM_GENERIC_ARRAY(ObjectType) *arrayOfObjectTypes;
   */
 #define RLM_ARRAY_TYPE(RLM_OBJECT_SUBCLASS)\
 @protocol RLM_OBJECT_SUBCLASS <NSObject>   \

--- a/Realm/RLMResults.h
+++ b/Realm/RLMResults.h
@@ -34,7 +34,7 @@ RLM_ASSUME_NONNULL_BEGIN
  RLMResults cannot be created directly.
  */
 
-@interface RLMResults : NSObject<RLMCollection, NSFastEnumeration>
+@interface RLMResults RLM_GENERIC_COLLECTION : NSObject<RLMCollection, NSFastEnumeration>
 
 /**---------------------------------------------------------------------------------------
  *  @name RLMResults Properties
@@ -70,7 +70,7 @@ RLM_ASSUME_NONNULL_BEGIN
 
  @return An RLMObject of the class contained by this RLMResults.
  */
-- (id)objectAtIndex:(NSUInteger)index;
+- (RLMObjectType)objectAtIndex:(NSUInteger)index;
 
 /**
  Returns the first object in the results.
@@ -79,7 +79,7 @@ RLM_ASSUME_NONNULL_BEGIN
 
  @return An RLMObject of the class contained by this RLMResults.
  */
-- (nullable id)firstObject;
+- (nullable RLMObjectType)firstObject;
 
 /**
  Returns the last object in the results.
@@ -88,7 +88,7 @@ RLM_ASSUME_NONNULL_BEGIN
 
  @return An RLMObject of the class contained by this RLMResults.
  */
-- (nullable id)lastObject;
+- (nullable RLMObjectType)lastObject;
 
 
 
@@ -106,7 +106,7 @@ RLM_ASSUME_NONNULL_BEGIN
 
  @param object  An object (of the same type as returned from the objectClassName selector).
  */
-- (NSUInteger)indexOfObject:(RLMObject *)object;
+- (NSUInteger)indexOfObject:(RLMObjectArgument)object;
 
 /**
  Gets the index of the first object matching the predicate.
@@ -133,7 +133,7 @@ RLM_ASSUME_NONNULL_BEGIN
 
  @return                An RLMResults of objects that match the given predicate
  */
-- (RLMResults *)objectsWhere:(NSString *)predicateFormat, ...;
+- (RLMResults RLM_GENERIC_COLLECTION*)objectsWhere:(NSString *)predicateFormat, ...;
 
 /**
  Get objects matching the given predicate in the RLMResults.
@@ -142,7 +142,7 @@ RLM_ASSUME_NONNULL_BEGIN
 
  @return            An RLMResults of objects that match the given predicate
  */
-- (RLMResults *)objectsWithPredicate:(NSPredicate *)predicate;
+- (RLMResults RLM_GENERIC_COLLECTION*)objectsWithPredicate:(NSPredicate *)predicate;
 
 /**
  Get a sorted `RLMResults` from an existing `RLMResults` sorted by a property.
@@ -152,7 +152,7 @@ RLM_ASSUME_NONNULL_BEGIN
 
  @return    An RLMResults sorted by the specified property.
  */
-- (RLMResults *)sortedResultsUsingProperty:(NSString *)property ascending:(BOOL)ascending;
+- (RLMResults RLM_GENERIC_COLLECTION*)sortedResultsUsingProperty:(NSString *)property ascending:(BOOL)ascending;
 
 /**
  Get a sorted `RLMResults` from an existing `RLMResults` sorted by an `NSArray`` of `RLMSortDescriptor`s.
@@ -161,7 +161,7 @@ RLM_ASSUME_NONNULL_BEGIN
 
  @return    An RLMResults sorted by the specified properties.
  */
-- (RLMResults *)sortedResultsUsingDescriptors:(NSArray *)properties;
+- (RLMResults RLM_GENERIC_COLLECTION*)sortedResultsUsingDescriptors:(NSArray *)properties;
 
 #pragma mark -
 

--- a/Realm/RLMResults.h
+++ b/Realm/RLMResults.h
@@ -133,7 +133,7 @@ RLM_ASSUME_NONNULL_BEGIN
 
  @return                An RLMResults of objects that match the given predicate
  */
-- (RLMResults RLM_GENERIC_COLLECTION*)objectsWhere:(NSString *)predicateFormat, ...;
+- (RLMResults RLM_GENERIC_RETURN*)objectsWhere:(NSString *)predicateFormat, ...;
 
 /**
  Get objects matching the given predicate in the RLMResults.
@@ -142,7 +142,7 @@ RLM_ASSUME_NONNULL_BEGIN
 
  @return            An RLMResults of objects that match the given predicate
  */
-- (RLMResults RLM_GENERIC_COLLECTION*)objectsWithPredicate:(NSPredicate *)predicate;
+- (RLMResults RLM_GENERIC_RETURN*)objectsWithPredicate:(NSPredicate *)predicate;
 
 /**
  Get a sorted `RLMResults` from an existing `RLMResults` sorted by a property.
@@ -152,7 +152,7 @@ RLM_ASSUME_NONNULL_BEGIN
 
  @return    An RLMResults sorted by the specified property.
  */
-- (RLMResults RLM_GENERIC_COLLECTION*)sortedResultsUsingProperty:(NSString *)property ascending:(BOOL)ascending;
+- (RLMResults RLM_GENERIC_RETURN*)sortedResultsUsingProperty:(NSString *)property ascending:(BOOL)ascending;
 
 /**
  Get a sorted `RLMResults` from an existing `RLMResults` sorted by an `NSArray`` of `RLMSortDescriptor`s.
@@ -161,7 +161,7 @@ RLM_ASSUME_NONNULL_BEGIN
 
  @return    An RLMResults sorted by the specified properties.
  */
-- (RLMResults RLM_GENERIC_COLLECTION*)sortedResultsUsingDescriptors:(NSArray *)properties;
+- (RLMResults RLM_GENERIC_RETURN*)sortedResultsUsingDescriptors:(NSArray *)properties;
 
 #pragma mark -
 

--- a/Realm/Tests/ArrayPropertyTests.m
+++ b/Realm/Tests/ArrayPropertyTests.m
@@ -206,7 +206,7 @@
     ArrayPropertyObject *intArray = [[ArrayPropertyObject alloc] init];
     IntObject *intObj = [[IntObject alloc] init];
     intObj.intCol = 1;
-    XCTAssertThrows([intArray.array addObject:intObj], @"Addint to string array should throw");
+    XCTAssertThrows([intArray.array addObject:(StringObject *)intObj], @"Addint to string array should throw");
     [intArray.intArray addObject:intObj];
 
     XCTAssertThrows([intArray.intArray objectsWhere:@"intCol == 1"], @"Should throw on standalone RLMArray");
@@ -271,8 +271,8 @@
     XCTAssertTrue([[array.intArray objectAtIndex:1] isEqualToObject:intObj4], @"Objects should be replaced");
     XCTAssertEqual(array.intArray.count, 3U, @"Should have 3 elements in int array");
 
-    XCTAssertThrows([array.array replaceObjectAtIndex:0 withObject:intObj4], @"Throws exception throws when type mismatched");
-    XCTAssertThrows([array.intArray replaceObjectAtIndex:1 withObject:stringObj4], @"Throws exception when type mismatched");
+    XCTAssertThrows([array.array replaceObjectAtIndex:0 withObject:(StringObject *)intObj4], @"Throws exception throws when type mismatched");
+    XCTAssertThrows([array.intArray replaceObjectAtIndex:1 withObject:(IntObject *)stringObj4], @"Throws exception when type mismatched");
 }
 
 - (void)testDeleteObjectInStandaloneArray {
@@ -362,7 +362,7 @@
     XCTAssertEqual((NSUInteger)NSNotFound, [company.employees indexOfObject:notInRealm]);
 
     // invalid object
-    XCTAssertThrows([company.employees indexOfObject:company]);
+    XCTAssertThrows([company.employees indexOfObject:(EmployeeObject *)company]);
 }
 
 - (void)testIndexOfObjectWhere

--- a/Realm/Tests/ObjectTests.m
+++ b/Realm/Tests/ObjectTests.m
@@ -80,7 +80,7 @@
 @class CycleObject;
 RLM_ARRAY_TYPE(CycleObject)
 @interface CycleObject :RLMObject
-@property RLMArray<CycleObject> *objects;
+@property RLM_GENERIC_ARRAY(CycleObject) *objects;
 @end
 
 @implementation CycleObject
@@ -128,7 +128,7 @@ RLM_ARRAY_TYPE(PrimaryIntObject);
 @property PrimaryStringObject *primaryStringObject;
 @property PrimaryStringObjectWrapper *primaryStringObjectWrapper;
 @property StringObject *stringObject;
-@property RLMArray<PrimaryIntObject> *primaryIntArray;
+@property RLM_GENERIC_ARRAY(PrimaryIntObject) *primaryIntArray;
 @property NSString *stringCol;
 @end
 
@@ -169,7 +169,7 @@ RLM_ARRAY_TYPE(PrimaryIntObject);
 
 @interface StringLinkObject : RLMObject
 @property StringObject *stringObjectCol;
-@property RLMArray<StringObject> *stringObjectArrayCol;
+@property RLM_GENERIC_ARRAY(StringObject) *stringObjectArrayCol;
 @end
 
 @implementation StringLinkObject
@@ -207,7 +207,7 @@ RLM_ARRAY_TYPE(PrimaryEmployeeObject);
 
 @interface PrimaryCompanyObject : RLMObject
 @property NSString *name;
-@property RLMArray<PrimaryEmployeeObject> *employees;
+@property RLM_GENERIC_ARRAY(PrimaryEmployeeObject) *employees;
 @property PrimaryEmployeeObject *intern;
 @property LinkToPrimaryEmployeeObject *wrappedIntern;
 @end

--- a/Realm/Tests/RLMTestObjects.h
+++ b/Realm/Tests/RLMTestObjects.h
@@ -123,7 +123,7 @@ RLM_ARRAY_TYPE(AllTypesObject)
 @end
 
 @interface ArrayOfAllTypesObject : RLMObject
-@property RLMArray<AllTypesObject> *array;
+@property RLM_GENERIC_ARRAY(AllTypesObject) *array;
 @end
 
 #pragma mark - Real Life Objects
@@ -146,7 +146,7 @@ RLM_ARRAY_TYPE(EmployeeObject)
 @interface CompanyObject : RLMObject
 
 @property NSString *name;
-@property RLMArray<EmployeeObject> *employees;
+@property RLM_GENERIC_ARRAY(EmployeeObject) *employees;
 
 @end
 
@@ -160,7 +160,7 @@ RLM_ARRAY_TYPE(EmployeeObject)
 RLM_ARRAY_TYPE(DogObject)
 
 @interface DogArrayObject : RLMObject
-@property RLMArray<DogObject> *dogs;
+@property RLM_GENERIC_ARRAY(DogObject) *dogs;
 @end
 
 
@@ -223,7 +223,7 @@ RLM_ARRAY_TYPE(CircleObject);
 #pragma mark CircleArrayObject
 
 @interface CircleArrayObject : RLMObject
-@property RLMArray<CircleObject> *circles;
+@property RLM_GENERIC_ARRAY(CircleObject) *circles;
 @end
 
 #pragma mark ArrayPropertyObject
@@ -231,8 +231,8 @@ RLM_ARRAY_TYPE(CircleObject);
 @interface ArrayPropertyObject : RLMObject
 
 @property NSString *name;
-@property RLMArray<StringObject> *array;
-@property RLMArray<IntObject> *intArray;
+@property RLM_GENERIC_ARRAY(StringObject) *array;
+@property RLM_GENERIC_ARRAY(IntObject) *intArray;
 
 @end
 

--- a/Realm/Tests/SchemaTests.mm
+++ b/Realm/Tests/SchemaTests.mm
@@ -57,9 +57,9 @@ RLM_ARRAY_TYPE(SchemaTestClassSecondChild)
 @property SchemaTestClassFirstChild *child;
 @property SchemaTestClassSecondChild *secondChild;
 
-@property RLMArray<SchemaTestClassBase> *baseArray;
-@property RLMArray<SchemaTestClassFirstChild> *childArray;
-@property RLMArray<SchemaTestClassSecondChild> *secondChildArray;
+@property RLM_GENERIC_ARRAY(SchemaTestClassBase) *baseArray;
+@property RLM_GENERIC_ARRAY(SchemaTestClassFirstChild) *childArray;
+@property RLM_GENERIC_ARRAY(SchemaTestClassSecondChild) *secondChildArray;
 @end
 @implementation SchemaTestClassLink
 @end


### PR DESCRIPTION
Not really very useful at the moment since you have to declare properties as `@property RLMArray<DogObject *><DogObject> *dogs` to get the typed version, and doing things like `RLMResults<DogObject *> dogs = [EmployeeObject allObjects]` doesn't give a warning.