### PR TITLE
Make backwards-compatible changes for Xcode 7

### DIFF
--- a/Realm.xcodeproj/project.pbxproj
+++ b/Realm.xcodeproj/project.pbxproj
@@ -1092,8 +1092,9 @@
 			isa = PBXProject;
 			attributes = {
 				CLASSPREFIX = RLM;
+				LastSwiftUpdateCheck = 0700;
 				LastTestingUpgradeCheck = 0510;
-				LastUpgradeCheck = 0610;
+				LastUpgradeCheck = 0700;
 				ORGANIZATIONNAME = Realm;
 				TargetAttributes = {
 					3F1A5E711992EB7400F45F4C = {
@@ -1573,6 +1574,7 @@
 					"-framework",
 					Realm,
 				);
+				PRODUCT_BUNDLE_IDENTIFIER = "io.Realm.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
 				SWIFT_OBJC_BRIDGING_HEADER = "Realm/Tests/Swift/Swift-Tests-Bridging-Header.h";
@@ -1607,6 +1609,7 @@
 					"-framework",
 					Realm,
 				);
+				PRODUCT_BUNDLE_IDENTIFIER = "io.Realm.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
 				SWIFT_OBJC_BRIDGING_HEADER = "Realm/Tests/Swift/Swift-Tests-Bridging-Header.h";
@@ -1646,6 +1649,7 @@
 				MODULEMAP_FILE = Realm/module.modulemap;
 				OTHER_LDFLAGS = "-lrealm-ios-dbg";
 				OTHER_LIBTOOLFLAGS = "-lrealm-ios-dbg";
+				PRODUCT_BUNDLE_IDENTIFIER = "io.Realm.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = Realm;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
@@ -1680,6 +1684,7 @@
 				MODULEMAP_FILE = Realm/module.modulemap;
 				OTHER_LDFLAGS = "-lrealm-ios";
 				OTHER_LIBTOOLFLAGS = "-lrealm-ios";
+				PRODUCT_BUNDLE_IDENTIFIER = "io.Realm.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = Realm;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
@@ -1702,6 +1707,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 8.1;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				MTL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "io.Realm.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
 			};
@@ -1717,6 +1723,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 8.1;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = "io.Realm.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
 				VALIDATE_PRODUCT = YES;
@@ -1738,6 +1745,7 @@
 				INFOPLIST_FILE = "Realm/Tests/RealmTests-Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MTL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "io.Realm.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/TestHost.app/TestHost";
@@ -1755,6 +1763,7 @@
 				INFOPLIST_FILE = "Realm/Tests/RealmTests-Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = "io.Realm.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/TestHost.app/TestHost";
@@ -1790,6 +1799,7 @@
 				MODULEMAP_FILE = "$(SRCROOT)/Realm/module.modulemap";
 				OTHER_LDFLAGS = "-lrealm-ios-dbg";
 				OTHER_LIBTOOLFLAGS = "-lrealm-ios-dbg";
+				PRODUCT_BUNDLE_IDENTIFIER = "io.Realm.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = Realm;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
@@ -1821,6 +1831,7 @@
 				MODULEMAP_FILE = "$(SRCROOT)/Realm/module.modulemap";
 				OTHER_LDFLAGS = "-lrealm-ios";
 				OTHER_LIBTOOLFLAGS = "-lrealm-ios";
+				PRODUCT_BUNDLE_IDENTIFIER = "io.Realm.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = Realm;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
@@ -1847,6 +1858,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				METAL_ENABLE_DEBUG_INFO = YES;
 				OTHER_CFLAGS = "-fobjc-arc-exceptions";
+				PRODUCT_BUNDLE_IDENTIFIER = "io.Realm.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
 				SWIFT_OBJC_BRIDGING_HEADER = "Realm/Tests/Swift/Swift-Tests-Bridging-Header.h";
@@ -1872,6 +1884,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				METAL_ENABLE_DEBUG_INFO = NO;
 				OTHER_CFLAGS = "-fobjc-arc-exceptions";
+				PRODUCT_BUNDLE_IDENTIFIER = "io.Realm.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
 				SWIFT_OBJC_BRIDGING_HEADER = "Realm/Tests/Swift/Swift-Tests-Bridging-Header.h";
@@ -1901,6 +1914,7 @@
 				COPY_PHASE_STRIP = NO;
 				CURRENT_PROJECT_VERSION = 1;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_OPTIMIZATION_LEVEL = 0;
@@ -2004,6 +2018,7 @@
 				MACH_O_TYPE = mh_dylib;
 				MODULEMAP_FILE = "$(SRCROOT)/Realm/module.modulemap";
 				OTHER_LDFLAGS = "-lrealm-dbg";
+				PRODUCT_BUNDLE_IDENTIFIER = "io.Realm.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = Realm;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
@@ -2032,6 +2047,7 @@
 				MACH_O_TYPE = mh_dylib;
 				MODULEMAP_FILE = "$(SRCROOT)/Realm/module.modulemap";
 				OTHER_LDFLAGS = "-lrealm";
+				PRODUCT_BUNDLE_IDENTIFIER = "io.Realm.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = Realm;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
@@ -2057,6 +2073,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				METAL_ENABLE_DEBUG_INFO = YES;
 				OTHER_CFLAGS = "-fobjc-arc-exceptions";
+				PRODUCT_BUNDLE_IDENTIFIER = "io.Realm.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
 				SWIFT_OBJC_BRIDGING_HEADER = "Realm/Tests/Swift/Swift-Tests-Bridging-Header.h";
@@ -2083,6 +2100,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				METAL_ENABLE_DEBUG_INFO = NO;
 				OTHER_CFLAGS = "-fobjc-arc-exceptions";
+				PRODUCT_BUNDLE_IDENTIFIER = "io.Realm.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
 				SWIFT_OBJC_BRIDGING_HEADER = "Realm/Tests/Swift/Swift-Tests-Bridging-Header.h";

--- a/Realm.xcodeproj/xcshareddata/xcschemes/OSX.xcscheme
+++ b/Realm.xcodeproj/xcshareddata/xcschemes/OSX.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0610"
+   LastUpgradeVersion = "0700"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -39,6 +39,8 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
@@ -48,6 +50,7 @@
       buildConfiguration = "Debug"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
       <MacroExpansion>
          <BuildableReference

--- a/Realm.xcodeproj/xcshareddata/xcschemes/iOS Device Tests.xcscheme
+++ b/Realm.xcodeproj/xcshareddata/xcschemes/iOS Device Tests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0610"
+   LastUpgradeVersion = "0700"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -48,6 +48,8 @@
             ReferencedContainer = "container:Realm.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
@@ -57,6 +59,7 @@
       buildConfiguration = "Debug"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
       <MacroExpansion>
          <BuildableReference
@@ -76,15 +79,6 @@
       useCustomWorkingDirectory = "NO"
       buildConfiguration = "Release"
       debugDocumentVersioning = "YES">
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "3F8DCA5619930F550008BD7F"
-            BuildableName = "iOS Device Tests.xctest"
-            BlueprintName = "iOS Device Tests"
-            ReferencedContainer = "container:Realm.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/Realm.xcodeproj/xcshareddata/xcschemes/iOS Dynamic.xcscheme
+++ b/Realm.xcodeproj/xcshareddata/xcschemes/iOS Dynamic.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0610"
+   LastUpgradeVersion = "0700"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -56,6 +56,8 @@
             ReferencedContainer = "container:Realm.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
@@ -65,6 +67,7 @@
       buildConfiguration = "Debug"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
       <MacroExpansion>
          <BuildableReference

--- a/Realm.xcodeproj/xcshareddata/xcschemes/iOS.xcscheme
+++ b/Realm.xcodeproj/xcshareddata/xcschemes/iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0610"
+   LastUpgradeVersion = "0700"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -39,6 +39,8 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
@@ -48,6 +50,7 @@
       buildConfiguration = "Debug"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
       <MacroExpansion>
          <BuildableReference

--- a/Realm/RLMUtil.mm
+++ b/Realm/RLMUtil.mm
@@ -36,7 +36,9 @@
 static inline bool nsnumber_is_like_integer(__unsafe_unretained NSNumber *const obj)
 {
     char data_type = [obj objCType][0];
-    return data_type == *@encode(short) ||
+    return data_type == *@encode(bool) ||
+           data_type == *@encode(char) ||
+           data_type == *@encode(short) ||
            data_type == *@encode(int) ||
            data_type == *@encode(long) ||
            data_type == *@encode(long long) ||

--- a/Realm/Realm-Info.plist
+++ b/Realm/Realm-Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleIconFile</key>
 	<string></string>
 	<key>CFBundleIdentifier</key>
-	<string>io.Realm.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Realm/Swift/RLMSupport.swift
+++ b/Realm/Swift/RLMSupport.swift
@@ -29,18 +29,27 @@ extension RLMObject {
     }
 }
 
+public class RLMGenerator: GeneratorType {
+    private var i: UInt = 0
+    private let collection: RLMCollection
+
+    init(collection: RLMCollection) {
+        self.collection = collection
+    }
+
+    public func next() -> RLMObject? {
+        if i >= collection.count {
+            return .None
+        } else {
+            return collection[i++] as? RLMObject
+        }
+    }
+}
+
 extension RLMArray: SequenceType {
     // Support Sequence-style enumeration
-    public func generate() -> GeneratorOf<RLMObject> {
-        var i: UInt  = 0
-
-        return GeneratorOf<RLMObject> {
-            if (i >= self.count) {
-                return .None
-            } else {
-                return self[i++] as? RLMObject
-            }
-        }
+    public func generate() -> RLMGenerator {
+        return RLMGenerator(collection: self)
     }
 
     // Swift query convenience functions
@@ -55,16 +64,8 @@ extension RLMArray: SequenceType {
 
 extension RLMResults: SequenceType {
     // Support Sequence-style enumeration
-    public func generate() -> GeneratorOf<RLMObject> {
-        var i: UInt  = 0
-
-        return GeneratorOf<RLMObject> {
-            if (i >= self.count) {
-                return .None
-            } else {
-                return self[i++] as? RLMObject
-            }
-        }
+    public func generate() -> RLMGenerator {
+        return RLMGenerator(collection: self)
     }
 
     // Swift query convenience functions

--- a/Realm/Tests/RLMMultiProcessTestCase.m
+++ b/Realm/Tests/RLMMultiProcessTestCase.m
@@ -58,10 +58,8 @@
 
 - (void)setUp {
     self.isParent = !getenv("RLMProcessIsChild");
-
-    NSProcessInfo *info = NSProcessInfo.processInfo;
-    self.xctestPath = info.arguments[0];
-    self.testsPath = [info.arguments lastObject];
+    self.xctestPath = NSProcessInfo.processInfo.arguments[0];
+    self.testsPath = [NSBundle bundleForClass:[self class]].bundlePath;
 
     [super setUp];
 }
@@ -77,6 +75,10 @@
     NSString *testName = [NSString stringWithFormat:@"%@/%@", self.className, self.testName];
     NSMutableDictionary *env = [NSProcessInfo.processInfo.environment mutableCopy];
     env[@"RLMProcessIsChild"] = @"true";
+
+    // Don't inherit the config file in the subprocess, as multiple XCTest
+    // processes talking to a single Xcode instance doesn't work at all
+    [env removeObjectForKey:@"XCTestConfigurationFilePath"];
 
     NSTask *task = [[NSTask alloc] init];
     task.launchPath = self.xctestPath;

--- a/Realm/Tests/RealmTests-Info.plist
+++ b/Realm/Tests/RealmTests-Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>${EXECUTABLE_NAME}</string>
 	<key>CFBundleIdentifier</key>
-	<string>io.Realm.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundlePackageType</key>

--- a/Realm/Tests/Swift/SwiftArrayPropertyTests.swift
+++ b/Realm/Tests/Swift/SwiftArrayPropertyTests.swift
@@ -48,7 +48,7 @@ class SwiftArrayPropertyTests: SwiftTestCase {
         let arrayObjects = SwiftArrayPropertyObject.allObjectsInRealm(realm)
 
         XCTAssertEqual(arrayObjects.count, UInt(1), "There should be a single SwiftStringObject in the realm")
-        var cmp = (arrayObjects.firstObject() as! SwiftArrayPropertyObject).array.firstObject() as! SwiftStringObject
+        let cmp = (arrayObjects.firstObject() as! SwiftArrayPropertyObject).array.firstObject() as! SwiftStringObject
         XCTAssertTrue(string.isEqualToObject(cmp), "First array object should be the string object we added")
     }
 
@@ -159,7 +159,7 @@ class SwiftArrayPropertyTests: SwiftTestCase {
         let arrayObjects = ArrayPropertyObject.allObjectsInRealm(realm)
 
         XCTAssertEqual(arrayObjects.count, UInt(1), "There should be a single StringObject in the realm")
-        var cmp = (arrayObjects.firstObject() as! ArrayPropertyObject).array.firstObject() as! StringObject
+        let cmp = (arrayObjects.firstObject() as! ArrayPropertyObject).array.firstObject() as! StringObject
         XCTAssertTrue(string.isEqualToObject(cmp), "First array object should be the string object we added")
     }
 

--- a/Realm/Tests/Swift/SwiftArrayTests.swift
+++ b/Realm/Tests/Swift/SwiftArrayTests.swift
@@ -165,7 +165,7 @@ class SwiftArrayTests: SwiftTestCase {
 
         realm.beginWriteTransaction()
 
-        for i in 0..<1012 {
+        for _ in 0..<1012 {
             let person = SwiftEmployeeObject()
             person.name = "Mary"
             person.age = 24
@@ -392,7 +392,7 @@ class SwiftArrayTests: SwiftTestCase {
 
         realm.beginWriteTransaction()
 
-        for i in 0..<1012 {
+        for _ in 0..<1012 {
             let person = EmployeeObject()
             person.name = "Mary"
             person.age = 24
@@ -427,7 +427,7 @@ class SwiftArrayTests: SwiftTestCase {
         realm.beginWriteTransaction()
 
         let po1 = makeEmployee(realm, 40, "Joe", true)
-        let po2 = makeEmployee(realm, 30, "John", false)
+        _ = makeEmployee(realm, 30, "John", false)
         let po3 = makeEmployee(realm, 25, "Jill", true)
 
         let company = CompanyObject()

--- a/Realm/Tests/Swift/SwiftLinkTests.swift
+++ b/Realm/Tests/Swift/SwiftLinkTests.swift
@@ -92,9 +92,9 @@ class SwiftLinkTests: SwiftTestCase {
         XCTAssertNil(owner.dog, "Dog should be nullified when deleted")
 
         // refresh owner and check
-        let owner2 = SwiftOwnerObject.allObjectsInRealm(realm).firstObject
-        XCTAssertNotNil(owner, "Should have 1 owner")
-        XCTAssertNil(owner.dog, "Dog should be nullified when deleted")
+        let owner2 = SwiftOwnerObject.allObjectsInRealm(realm).firstObject() as! SwiftOwnerObject
+        XCTAssertNotNil(owner2, "Should have 1 owner")
+        XCTAssertNil(owner2.dog, "Dog should be nullified when deleted")
         XCTAssertEqual(SwiftDogObject.allObjectsInRealm(realm).count, UInt(0), "Expecting 0 dogs")
     }
 
@@ -187,9 +187,9 @@ class SwiftLinkTests: SwiftTestCase {
         XCTAssertNil(owner.dog, "Dog should be nullified when deleted")
 
         // refresh owner and check
-        let owner2 = OwnerObject.allObjectsInRealm(realm).firstObject
-        XCTAssertNotNil(owner, "Should have 1 owner")
-        XCTAssertNil(owner.dog, "Dog should be nullified when deleted")
+        let owner2 = OwnerObject.allObjectsInRealm(realm).firstObject() as! OwnerObject
+        XCTAssertNotNil(owner2, "Should have 1 owner")
+        XCTAssertNil(owner2.dog, "Dog should be nullified when deleted")
         XCTAssertEqual(DogObject.allObjectsInRealm(realm).count, UInt(0), "Expecting 0 dogs")
     }
 

--- a/Realm/Tests/Swift/SwiftObjectInterfaceTests.swift
+++ b/Realm/Tests/Swift/SwiftObjectInterfaceTests.swift
@@ -122,7 +122,7 @@ class SwiftObjectInterfaceTests: SwiftTestCase {
         realm.beginWriteTransaction()
         SwiftStringObject.createInDefaultRealmWithValue(["string"])
 
-        let obj = SwiftStringObjectSubclass.createInDefaultRealmWithValue(["string", "string2"])
+        SwiftStringObjectSubclass.createInDefaultRealmWithValue(["string", "string2"])
         realm.commitWriteTransaction()
 
         // ensure creation in proper table
@@ -131,8 +131,8 @@ class SwiftObjectInterfaceTests: SwiftTestCase {
 
         realm.transactionWithBlock { () -> Void in
             // create self referencing subclass
-            var sub = SwiftSelfRefrencingSubclass.createInDefaultRealmWithValue(["string", []])
-            var sub2 = SwiftSelfRefrencingSubclass()
+            let sub = SwiftSelfRefrencingSubclass.createInDefaultRealmWithValue(["string", []])
+            let sub2 = SwiftSelfRefrencingSubclass()
             sub.objects.addObject(sub2)
         }
     }

--- a/Realm/Tests/Swift/SwiftRealmTests.swift
+++ b/Realm/Tests/Swift/SwiftRealmTests.swift
@@ -24,7 +24,7 @@ class SwiftRealmTests: SwiftTestCase {
     // No models
 
     func testRealmExists() {
-        var realm = realmWithTestPath()
+        let realm = realmWithTestPath()
         XCTAssertNotNil(realm, "realm should not be nil");
         XCTAssertTrue((realm as AnyObject) is RLMRealm, "realm should be of class RLMRealm")
     }
@@ -34,7 +34,7 @@ class SwiftRealmTests: SwiftTestCase {
     }
 
     func testEmptyWriteTransaction() {
-        var realm = realmWithTestPath()
+        let realm = realmWithTestPath()
         realm.beginWriteTransaction()
         realm.commitWriteTransaction()
     }
@@ -42,7 +42,7 @@ class SwiftRealmTests: SwiftTestCase {
     // Swift models
 
     func testRealmAddAndRemoveObjects() {
-        var realm = realmWithTestPath()
+        let realm = realmWithTestPath()
         realm.beginWriteTransaction()
         SwiftStringObject.createInRealm(realm, withValue: ["a"])
         SwiftStringObject.createInRealm(realm, withValue: ["b"])
@@ -177,7 +177,7 @@ class SwiftRealmTests: SwiftTestCase {
     // Objective-C models
 
     func testRealmAddAndRemoveObjects_objc() {
-        var realm = realmWithTestPath()
+        let realm = realmWithTestPath()
         realm.beginWriteTransaction()
         StringObject.createInRealm(realm, withValue: ["a"])
         StringObject.createInRealm(realm, withValue: ["b"])

--- a/Realm/Tests/TestHost/Info.plist
+++ b/Realm/Tests/TestHost/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>io.Realm.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/RealmSwift/Configuration/RealmSwift.xcconfig
+++ b/RealmSwift/Configuration/RealmSwift.xcconfig
@@ -9,5 +9,6 @@ LD_RUNPATH_SEARCH_PATHS = $(inherited) @executable_path/Frameworks @loader_path/
 DEFINES_MODULE = YES;
 INFOPLIST_FILE = RealmSwift/RealmSwift-Info.plist;
 PRODUCT_NAME = RealmSwift;
+PRODUCT_BUNDLE_IDENTIFIER = io.realm.RealmSwit;
 
 FRAMEWORK_SEARCH_PATHS = $(REALM_FRAMEWORK_PATH);

--- a/RealmSwift/Tests/ObjectCreationTests.swift
+++ b/RealmSwift/Tests/ObjectCreationTests.swift
@@ -441,7 +441,7 @@ class ObjectCreationTests: TestCase {
         Realm().commitWrite()
         switch type {
             case .Bool:     return ["invalid", 2 as Int, 1.1 as Float, 11.1 as Double]
-            case .Int:      return ["invalid", true, false, 1.1 as Float, 11.1 as Double]
+            case .Int:      return ["invalid", 1.1 as Float, 11.1 as Double]
             case .Float:    return ["invalid", true, false]
             case .Double:   return ["invalid", true, false]
             case .String:   return [0x197A71D, true, false]

--- a/RealmSwift/Tests/PerformanceTests.swift
+++ b/RealmSwift/Tests/PerformanceTests.swift
@@ -19,8 +19,6 @@
 import XCTest
 import RealmSwift
 
-#if !DEBUG && os(iOS)
-
 private func createStringObjects(factor: Int) -> Realm {
     let realm = Realm(inMemoryIdentifier: factor.description)
     realm.write {
@@ -39,11 +37,13 @@ private var largeRealm: Realm!
 private let isRunningOnDevice = TARGET_IPHONE_SIMULATOR == 0
 
 class SwiftPerformanceTests: TestCase {
-    override class func defaultTestSuite() -> XCTestSuite? {
+    override class func defaultTestSuite() -> XCTestSuite {
+#if !DEBUG && os(iOS)
         if (isRunningOnDevice) {
             return super.defaultTestSuite()
         }
-        return nil
+#endif
+        return XCTestSuite(name: "SwiftPerformanceTests")
     }
 
     override class func setUp() {
@@ -137,7 +137,7 @@ class SwiftPerformanceTests: TestCase {
     func testCountWhereQuery() {
         let realm = copyRealmToTestPath(largeRealm)
         measureBlock {
-            for i in 0..<50 {
+            for _ in 0..<50 {
                 let results = realm.objects(SwiftStringObject).filter("stringCol = 'a'")
                 _ = results.count
             }
@@ -147,7 +147,7 @@ class SwiftPerformanceTests: TestCase {
     func testCountWhereTableView() {
         let realm = copyRealmToTestPath(mediumRealm)
         measureBlock {
-            for i in 0..<50 {
+            for _ in 0..<50 {
                 let results = realm.objects(SwiftStringObject).filter("stringCol = 'a'")
                 _ = results.first
                 _ = results.count
@@ -159,7 +159,7 @@ class SwiftPerformanceTests: TestCase {
         let realm = copyRealmToTestPath(mediumRealm)
         measureBlock {
             for stringObject in realm.objects(SwiftStringObject).filter("stringCol = 'a'") {
-                let string = stringObject.stringCol
+                _ = stringObject.stringCol
             }
         }
     }
@@ -168,7 +168,7 @@ class SwiftPerformanceTests: TestCase {
         let realm = copyRealmToTestPath(mediumRealm)
         measureBlock {
             for stringObject in realm.objects(SwiftStringObject) {
-                let string = stringObject.stringCol
+                _ = stringObject.stringCol
             }
         }
     }
@@ -178,7 +178,7 @@ class SwiftPerformanceTests: TestCase {
         measureBlock {
             let results = realm.objects(SwiftStringObject)
             for i in 0..<results.count {
-                let string = results[i].stringCol
+                _ = results[i].stringCol
             }
         }
     }
@@ -191,7 +191,7 @@ class SwiftPerformanceTests: TestCase {
 
         measureBlock {
             for stringObject in arrayPropertyObject.array {
-                let string = stringObject.stringCol
+                _ = stringObject.stringCol
             }
         }
     }
@@ -205,7 +205,7 @@ class SwiftPerformanceTests: TestCase {
         measureBlock {
             let list = arrayPropertyObject.array
             for i in 0..<list.count {
-                let string = list[i].stringCol
+                _ = list[i].stringCol
             }
         }
     }
@@ -471,5 +471,3 @@ class SwiftPerformanceTests: TestCase {
         }
     }
 }
-
-#endif


### PR DESCRIPTION
This makes all of the obj-c stuff build and pass tests in both Xcode 6 and 7. Swift stuff obviously doesn't build in Xcode 7, but this includes all of the changes needed for it that don't break 6 to cut down on the diff a bit.