### PR TITLE
Fix a memory leak when constructing standalone Swift objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ x.x.x Release notes (yyyy-MM-dd)
 * Fixed an issue where the packaged OS X Realm.framework was built with
   `GCC_GENERATE_TEST_COVERAGE_FILES` and `GCC_INSTRUMENT_PROGRAM_FLOW_ARCS`
   enabled.
+* Fix a memory leak when constructing standalone Swift objects with NSDate
+  properties.
 
 0.93.1 Release notes (2015-05-29)
 =============================================================

--- a/Realm/RLMObjectBase.mm
+++ b/Realm/RLMObjectBase.mm
@@ -35,25 +35,20 @@ const NSUInteger RLMDescriptionMaxDepth = 5;
 
 // standalone init
 - (instancetype)init {
-    if (RLMSchema.sharedSchema) {
-        __unsafe_unretained RLMObjectSchema *const objectSchema = [self.class sharedSchema];
-        self = [self initWithRealm:nil schema:objectSchema];
+    self = [super init];
+    if (self && RLMSchema.sharedSchema) {
+        _objectSchema = [self.class sharedSchema];
 
         // set default values
-        if (!objectSchema.isSwiftClass) {
-            NSDictionary *dict = RLMDefaultValuesForObjectSchema(objectSchema);
+        if (!_objectSchema.isSwiftClass) {
+            NSDictionary *dict = RLMDefaultValuesForObjectSchema(_objectSchema);
             for (NSString *key in dict) {
                 [self setValue:dict[key] forKey:key];
             }
         }
 
         // set standalone accessor class
-        object_setClass(self, objectSchema.standaloneClass);
-    }
-    else {
-        // if schema not initialized
-        // this is only used for introspection
-        self = [super init];
+        object_setClass(self, _objectSchema.standaloneClass);
     }
 
     return self;


### PR DESCRIPTION
Calling `initWithRealm:schema:` from `init` results in the Swift property initialization code running twice and not properly deallocating the values created during the first run, so don't do that (it didn't save any code anyway).

Closes #2064.