### PR TITLE
Validate that the value for an array property is enumerable even if validateNested is false

### DIFF
--- a/Realm/RLMArray.mm
+++ b/Realm/RLMArray.mm
@@ -107,7 +107,17 @@ static void RLMValidateMatchingObjectType(RLMArray *array, RLMObject *object) {
     }
 }
 
+static void RLMValidateArrayBounds(__unsafe_unretained RLMArray *const ar,
+                                   NSUInteger index, bool allowOnePastEnd=false) {
+    NSUInteger max = ar->_backingArray.count + allowOnePastEnd;
+    if (index >= max) {
+        @throw RLMException([NSString stringWithFormat:@"Index %llu is out of bounds (must be less than %llu).",
+                             (unsigned long long)index, (unsigned long long)max]);
+    }
+}
+
 - (id)objectAtIndex:(NSUInteger)index {
+    RLMValidateArrayBounds(self, index);
     return [_backingArray objectAtIndex:index];
 }
 
@@ -125,15 +135,18 @@ static void RLMValidateMatchingObjectType(RLMArray *array, RLMObject *object) {
 
 - (void)insertObject:(RLMObject *)anObject atIndex:(NSUInteger)index {
     RLMValidateMatchingObjectType(self, anObject);
+    RLMValidateArrayBounds(self, index, true);
     [_backingArray insertObject:anObject atIndex:index];
 }
 
 - (void)removeObjectAtIndex:(NSUInteger)index {
+    RLMValidateArrayBounds(self, index);
     [_backingArray removeObjectAtIndex:index];
 }
 
 - (void)replaceObjectAtIndex:(NSUInteger)index withObject:(id)anObject {
     RLMValidateMatchingObjectType(self, anObject);
+    RLMValidateArrayBounds(self, index);
     [_backingArray replaceObjectAtIndex:index withObject:anObject];
 }
 

--- a/Realm/RLMObjectBase.mm
+++ b/Realm/RLMObjectBase.mm
@@ -95,17 +95,7 @@ static id RLMValidatedObjectForProperty(id obj, RLMProperty *prop, RLMSchema *sc
         // assume our object is an NSDictionary or an object with kvc properties
         NSDictionary *defaultValues = nil;
         for (RLMProperty *prop in properties) {
-            id obj;
-            @try {
-                obj = [value valueForKey:prop.name];
-            }
-            @catch (NSException *e) {
-                if ([e.name isEqualToString:NSUndefinedKeyException]) {
-                    @throw RLMException([NSString stringWithFormat:@"Invalid value '%@' to initialize object of type '%@': missing key '%@'",
-                                         value, _objectSchema.className, prop.name]);
-                }
-                @throw;
-            }
+            id obj = RLMValidatedValueForProperty(value, prop.name, _objectSchema.className);
 
             // get default for nil object
             if (!obj) {
@@ -339,6 +329,18 @@ BOOL RLMObjectBaseAreEqual(RLMObjectBase *o1, RLMObjectBase *o2) {
     o1->_row.get_index() == o2->_row.get_index();
 }
 
+id RLMValidatedValueForProperty(id object, NSString *key, NSString *className) {
+    @try {
+        return [object valueForKey:key];
+    }
+    @catch (NSException *e) {
+        if ([e.name isEqualToString:NSUndefinedKeyException]) {
+            @throw RLMException([NSString stringWithFormat:@"Invalid value '%@' to initialize object of type '%@': missing key '%@'",
+                                 object, className, key]);
+        }
+        @throw;
+    }
+}
 
 Class RLMObjectUtilClass(BOOL isSwift) {
     static Class objectUtilObjc = [RLMObjectUtil class];

--- a/Realm/RLMObjectBase.mm
+++ b/Realm/RLMObjectBase.mm
@@ -95,7 +95,17 @@ static id RLMValidatedObjectForProperty(id obj, RLMProperty *prop, RLMSchema *sc
         // assume our object is an NSDictionary or an object with kvc properties
         NSDictionary *defaultValues = nil;
         for (RLMProperty *prop in properties) {
-            id obj = [value valueForKey:prop.name];
+            id obj;
+            @try {
+                obj = [value valueForKey:prop.name];
+            }
+            @catch (NSException *e) {
+                if ([e.name isEqualToString:NSUndefinedKeyException]) {
+                    @throw RLMException([NSString stringWithFormat:@"Invalid value '%@' to initialize object of type '%@': missing key '%@'",
+                                         value, _objectSchema.className, prop.name]);
+                }
+                @throw;
+            }
 
             // get default for nil object
             if (!obj) {

--- a/Realm/RLMObjectStore.mm
+++ b/Realm/RLMObjectStore.mm
@@ -370,11 +370,11 @@ static void RLMValidateValueForProperty(__unsafe_unretained id const obj,
             }
             break;
         case RLMPropertyTypeArray: {
-            if (validateNested) {
-                if (obj != nil && obj != NSNull.null) {
-                    if (![obj conformsToProtocol:@protocol(NSFastEnumeration)]) {
-                        @throw  RLMException([NSString stringWithFormat:@"Array property value (%@) is not enumerable.", obj]);
-                    }
+            if (obj != nil && obj != NSNull.null) {
+                if (![obj conformsToProtocol:@protocol(NSFastEnumeration)]) {
+                    @throw  RLMException([NSString stringWithFormat:@"Array property value (%@) is not enumerable.", obj]);
+                }
+                if (validateNested) {
                     id<NSFastEnumeration> array = obj;
                     for (id el in array) {
                         RLMValidateNestedObject(el, prop.objectClassName, schema, validateNested, allowMissing);

--- a/Realm/RLMObjectStore.mm
+++ b/Realm/RLMObjectStore.mm
@@ -467,7 +467,18 @@ RLMObjectBase *RLMCreateObjectInRealmWithValue(RLMRealm *realm, NSString *classN
         // populate
         NSDictionary *defaultValues = nil;
         for (RLMProperty *prop in objectSchema.properties) {
-            id propValue = [value valueForKey:prop.name];
+            id propValue;
+            @try {
+                propValue = [value valueForKey:prop.name];
+            }
+            @catch (NSException *e) {
+                if ([e.name isEqualToString:NSUndefinedKeyException]) {
+                    @throw RLMException([NSString stringWithFormat:@"Invalid value '%@' to initialize object of type '%@': missing key '%@'",
+                                         value, objectSchema.className, prop.name]);
+                }
+                @throw;
+            }
+
             if (!propValue && created) {
                 if (!defaultValues) {
                     defaultValues = RLMDefaultValuesForObjectSchema(objectSchema);

--- a/Realm/RLMObjectStore.mm
+++ b/Realm/RLMObjectStore.mm
@@ -467,17 +467,7 @@ RLMObjectBase *RLMCreateObjectInRealmWithValue(RLMRealm *realm, NSString *classN
         // populate
         NSDictionary *defaultValues = nil;
         for (RLMProperty *prop in objectSchema.properties) {
-            id propValue;
-            @try {
-                propValue = [value valueForKey:prop.name];
-            }
-            @catch (NSException *e) {
-                if ([e.name isEqualToString:NSUndefinedKeyException]) {
-                    @throw RLMException([NSString stringWithFormat:@"Invalid value '%@' to initialize object of type '%@': missing key '%@'",
-                                         value, objectSchema.className, prop.name]);
-                }
-                @throw;
-            }
+            id propValue = RLMValidatedValueForProperty(value, prop.name, objectSchema.className);
 
             if (!propValue && created) {
                 if (!defaultValues) {

--- a/Realm/RLMObject_Private.h
+++ b/Realm/RLMObject_Private.h
@@ -59,6 +59,9 @@ FOUNDATION_EXTERN NSArray *RLMObjectBaseLinkingObjectsOfClass(RLMObjectBase *obj
 FOUNDATION_EXTERN id RLMObjectBaseObjectForKeyedSubscript(RLMObjectBase *object, NSString *key);
 FOUNDATION_EXTERN void RLMObjectBaseSetObjectForKeyedSubscript(RLMObjectBase *object, NSString *key, id obj);
 
+// Calls valueForKey: and re-raises NSUndefinedKeyExceptions
+FOUNDATION_EXTERN id RLMValidatedValueForProperty(id object, NSString *key, NSString *className);
+
 // Compare two RLObjectBases
 FOUNDATION_EXTERN BOOL RLMObjectBaseAreEqual(RLMObjectBase *o1, RLMObjectBase *o2);
 

--- a/RealmSwift/Tests/ListTests.swift
+++ b/RealmSwift/Tests/ListTests.swift
@@ -148,7 +148,7 @@ class ListTests: TestCase {
         XCTAssertEqual(str2, array[0])
         XCTAssertEqual(str1, array[1])
 
-        assertThrows(self.array[200])
+        assertThrows(self.array[200], named: nil)
         assertThrows(self.array[-200])
     }
 
@@ -255,7 +255,7 @@ class ListTests: TestCase {
         XCTAssertEqual("2", sorted[0].stringCol)
         XCTAssertEqual("1", sorted[1].stringCol)
 
-        assertThrows(self.array.sorted("noSuchCol"))
+        assertThrows(self.array.sorted("noSuchCol"), named: "Invalid sort property")
     }
 
     func testSortWithDescriptors() {
@@ -297,7 +297,8 @@ class ListTests: TestCase {
         XCTAssertEqual(2, sorted[1].intCol)
         XCTAssertEqual(1.11, sorted[2].doubleCol)
 
-        assertThrows(array.sorted([SortDescriptor(property: "noSuchCol", ascending: true)]))
+        assertThrows(array.sorted([SortDescriptor(property: "noSuchCol", ascending: true)]),
+            named: "Invalid sort property")
     }
 
     func testFastEnumeration() {
@@ -347,7 +348,7 @@ class ListTests: TestCase {
         XCTAssertEqual(str2, array[0])
         XCTAssertEqual(str1, array[1])
 
-        assertThrows(self.array.insert(self.str2, atIndex: 200))
+        assertThrows(self.array.insert(self.str2, atIndex: 200), named: nil)
         assertThrows(self.array.insert(self.str2, atIndex: -200))
     }
 
@@ -358,7 +359,7 @@ class ListTests: TestCase {
         XCTAssertEqual(str1, array[0])
         XCTAssertEqual(str1, array[1])
 
-        assertThrows(self.array.removeAtIndex(200))
+        assertThrows(self.array.removeAtIndex(200), named: nil)
         assertThrows(self.array.removeAtIndex(-200))
     }
 
@@ -399,7 +400,7 @@ class ListTests: TestCase {
         XCTAssertEqual(str2, array[0])
         XCTAssertEqual(str2, array[1])
 
-        assertThrows(self.array.replace(200, object: self.str2))
+        assertThrows(self.array.replace(200, object: self.str2), named: nil)
         assertThrows(self.array.replace(-200, object: self.str2))
     }
 

--- a/RealmSwift/Tests/ListTests.swift
+++ b/RealmSwift/Tests/ListTests.swift
@@ -148,7 +148,7 @@ class ListTests: TestCase {
         XCTAssertEqual(str2, array[0])
         XCTAssertEqual(str1, array[1])
 
-        assertThrows(self.array[200], named: nil)
+        assertThrows(self.array[200])
         assertThrows(self.array[-200])
     }
 
@@ -348,7 +348,7 @@ class ListTests: TestCase {
         XCTAssertEqual(str2, array[0])
         XCTAssertEqual(str1, array[1])
 
-        assertThrows(self.array.insert(self.str2, atIndex: 200), named: nil)
+        assertThrows(self.array.insert(self.str2, atIndex: 200))
         assertThrows(self.array.insert(self.str2, atIndex: -200))
     }
 
@@ -359,7 +359,7 @@ class ListTests: TestCase {
         XCTAssertEqual(str1, array[0])
         XCTAssertEqual(str1, array[1])
 
-        assertThrows(self.array.removeAtIndex(200), named: nil)
+        assertThrows(self.array.removeAtIndex(200))
         assertThrows(self.array.removeAtIndex(-200))
     }
 
@@ -400,7 +400,7 @@ class ListTests: TestCase {
         XCTAssertEqual(str2, array[0])
         XCTAssertEqual(str2, array[1])
 
-        assertThrows(self.array.replace(200, object: self.str2), named: nil)
+        assertThrows(self.array.replace(200, object: self.str2))
         assertThrows(self.array.replace(-200, object: self.str2))
     }
 

--- a/RealmSwift/Tests/ObjectCreationTests.swift
+++ b/RealmSwift/Tests/ObjectCreationTests.swift
@@ -227,7 +227,8 @@ class ObjectCreationTests: TestCase {
                 values[propNum] = invalidValue
 
                 Realm().beginWrite()
-                assertThrows(Realm().create(SwiftObject.self, value: values), "Invalid property value '\(invalidValue)' for property number \(propNum)")
+                assertThrows(Realm().create(SwiftObject.self, value: values),
+                    "Invalid property value '\(invalidValue)' for property number \(propNum)")
                 Realm().cancelWrite()
             }
         }

--- a/RealmSwift/Tests/ResultsTests.swift
+++ b/RealmSwift/Tests/ResultsTests.swift
@@ -217,7 +217,7 @@ class ResultsTests: TestCase {
         XCTAssertEqual("2", sorted[0].stringCol)
         XCTAssertEqual("1", sorted[1].stringCol)
 
-        assertThrows(self.results.sorted("noSuchCol"))
+        assertThrows(self.results.sorted("noSuchCol"), named: "Invalid sort property")
     }
 
     func testSortWithDescriptor() {
@@ -234,7 +234,7 @@ class ResultsTests: TestCase {
         XCTAssertEqual(2, sorted[1].intCol)
         XCTAssertEqual(1.11, sorted[2].doubleCol)
 
-        assertThrows(results.sorted([SortDescriptor(property: "noSuchCol")]))
+        assertThrows(results.sorted([SortDescriptor(property: "noSuchCol")]), named: "Invalid sort property")
     }
 
     func testMin() {
@@ -244,7 +244,7 @@ class ResultsTests: TestCase {
         XCTAssertEqual(Double(1.11), results.min("doubleCol") as Double!)
         XCTAssertEqual(NSDate(timeIntervalSince1970: 1), results.min("dateCol") as NSDate!)
 
-        assertThrows(results.min("noSuchCol") as Float!)
+        assertThrows(results.min("noSuchCol") as Float!, named: "Invalid property name")
     }
 
     func testMax() {
@@ -254,7 +254,7 @@ class ResultsTests: TestCase {
         XCTAssertEqual(Double(2.22), results.max("doubleCol") as Double!)
         XCTAssertEqual(NSDate(timeIntervalSince1970: 2), results.max("dateCol") as NSDate!)
 
-        assertThrows(results.max("noSuchCol") as Float!)
+        assertThrows(results.max("noSuchCol") as Float!, named: "Invalid property name")
     }
 
     func testSum() {
@@ -263,7 +263,7 @@ class ResultsTests: TestCase {
         XCTAssertEqualWithAccuracy(Float(5.5), results.sum("floatCol") as Float, 0.001)
         XCTAssertEqualWithAccuracy(Double(5.55), results.sum("doubleCol") as Double, 0.001)
 
-        assertThrows(results.sum("noSuchCol") as Float)
+        assertThrows(results.sum("noSuchCol") as Float, named: "Invalid property name")
     }
 
     func testAverage() {
@@ -272,7 +272,7 @@ class ResultsTests: TestCase {
         XCTAssertEqualWithAccuracy(Float(1.8333), results.average("floatCol") as Float!, 0.001)
         XCTAssertEqualWithAccuracy(Double(1.85), results.average("doubleCol") as Double!, 0.001)
 
-        assertThrows(results.average("noSuchCol")! as Float)
+        assertThrows(results.average("noSuchCol")! as Float, named: "Invalid property name")
     }
 
     func testFastEnumeration() {

--- a/RealmSwift/Tests/TestCase.swift
+++ b/RealmSwift/Tests/TestCase.swift
@@ -56,7 +56,12 @@ class TestCase: XCTestCase {
 
     func assertThrows<T>(@autoclosure(escaping) block: () -> T, _ message: String? = nil, fileName: String = __FILE__, lineNumber: UInt = __LINE__) {
         exceptionThrown = true
-        RLMAssertThrows(self, { _ = block() } as dispatch_block_t, message, fileName, lineNumber)
+        RLMAssertThrows(self, { _ = block() } as dispatch_block_t, "RLMException", message, fileName, lineNumber)
+    }
+
+    func assertThrows<T>(@autoclosure(escaping) block: () -> T, named: String?, _ message: String? = nil, fileName: String = __FILE__, lineNumber: UInt = __LINE__) {
+        exceptionThrown = true
+        RLMAssertThrows(self, { _ = block() } as dispatch_block_t, named, message, fileName, lineNumber)
     }
 
     func assertNil<T>(@autoclosure block: () -> T?, _ message: String? = nil, fileName: String = __FILE__, lineNumber: UInt = __LINE__) {

--- a/RealmSwift/Tests/TestCase.swift
+++ b/RealmSwift/Tests/TestCase.swift
@@ -54,12 +54,7 @@ class TestCase: XCTestCase {
         dispatch_sync(queue) {}
     }
 
-    func assertThrows<T>(@autoclosure(escaping) block: () -> T, _ message: String? = nil, fileName: String = __FILE__, lineNumber: UInt = __LINE__) {
-        exceptionThrown = true
-        RLMAssertThrows(self, { _ = block() } as dispatch_block_t, "RLMException", message, fileName, lineNumber)
-    }
-
-    func assertThrows<T>(@autoclosure(escaping) block: () -> T, named: String?, _ message: String? = nil, fileName: String = __FILE__, lineNumber: UInt = __LINE__) {
+    func assertThrows<T>(@autoclosure(escaping) block: () -> T, _ message: String? = nil, named: String? = RLMExceptionName, fileName: String = __FILE__, lineNumber: UInt = __LINE__) {
         exceptionThrown = true
         RLMAssertThrows(self, { _ = block() } as dispatch_block_t, named, message, fileName, lineNumber)
     }

--- a/RealmSwift/Tests/TestUtils.h
+++ b/RealmSwift/Tests/TestUtils.h
@@ -19,7 +19,10 @@
 #import <Foundation/Foundation.h>
 #import <XCTest/XCTestCase.h>
 
-FOUNDATION_EXTERN void RLMAssertThrows(XCTestCase *self, __attribute__((noescape)) dispatch_block_t block, NSString *message, NSString *fileName, NSUInteger lineNumber);
+FOUNDATION_EXTERN void RLMAssertThrows(XCTestCase *self,
+                                       __attribute__((noescape)) dispatch_block_t block,
+                                       NSString *name, NSString *message,
+                                       NSString *fileName, NSUInteger lineNumber);
 
 // Forcibly deallocate the RLMRealm for the given path on the main thread
 // Will cause crashes if it's alive for a reason other than being leaked by RLMAssertThrows

--- a/RealmSwift/Tests/TestUtils.mm
+++ b/RealmSwift/Tests/TestUtils.mm
@@ -29,13 +29,18 @@ static void initializeSharedSchema() {
     [RLMSchema class];
 }
 
-void RLMAssertThrows(XCTestCase *self, dispatch_block_t block, NSString *message, NSString *fileName, NSUInteger lineNumber) {
+void RLMAssertThrows(XCTestCase *self, dispatch_block_t block, NSString *name, NSString *message, NSString *fileName, NSUInteger lineNumber) {
     BOOL didThrow = NO;
     @try {
         block();
     }
-    @catch (...) {
+    @catch (NSException *e) {
         didThrow = YES;
+        if (name && ![name isEqualToString:e.name]) {
+            NSString *msg = [NSString stringWithFormat:@"The given expression threw an exception named '%@', but expected '%@'",
+                             e.name, name];
+            [self recordFailureWithDescription:msg inFile:fileName atLine:lineNumber expected:NO];
+        }
     }
     if (!didThrow) {
         NSString *prefix = @"The given expression failed to throw an exception";

--- a/RealmSwift/Tests/TestUtils.mm
+++ b/RealmSwift/Tests/TestUtils.mm
@@ -36,7 +36,7 @@ void RLMAssertThrows(XCTestCase *self, dispatch_block_t block, NSString *name, N
     }
     @catch (NSException *e) {
         didThrow = YES;
-        if (name && ![name isEqualToString:e.name]) {
+        if (![name isEqualToString:e.name]) {
             NSString *msg = [NSString stringWithFormat:@"The given expression threw an exception named '%@', but expected '%@'",
                              e.name, name];
             [self recordFailureWithDescription:msg inFile:fileName atLine:lineNumber expected:NO];


### PR DESCRIPTION
Not doing this resulted in an unrecognized selector exception being thrown (and NSLogged) rather than our invalid property value exception being thrown.