### PR TITLE
Fix running the Swift tests on iOS devices

### DIFF
--- a/Configuration/RealmSwift/TestHost.xcconfig
+++ b/Configuration/RealmSwift/TestHost.xcconfig
@@ -1,9 +1,14 @@
-SUPPORTED_PLATFORMS = iphonesimulator iphoneos;
+SUPPORTED_PLATFORMS = macosx iphonesimulator iphoneos;
 
-OTHER_LDFLAGS[sdk=iphone*] = -framework UIKit;
 COPY_PHASE_STRIP = NO;
 LD_RUNPATH_SEARCH_PATHS = $(inherited) @executable_path/Frameworks;
 INFOPLIST_FILE = Realm/Tests/TestHost/Info.plist;
 PRODUCT_NAME = $(TARGET_NAME);
 CLANG_MODULES_AUTOLINK = NO;
 ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+
+OTHER_LDFLAGS[sdk=iphone*] = -framework UIKit;
+OTHER_LDFLAGS[sdk=macosx*] = -framework Cocoa;
+
+PRINCIPAL_CLASS[sdk=iphone*] = UIApplication;
+PRINCIPAL_CLASS[sdk=macosx*] = NSApplication;

--- a/Configuration/RealmSwift/TestHost.xcconfig
+++ b/Configuration/RealmSwift/TestHost.xcconfig
@@ -6,6 +6,7 @@ INFOPLIST_FILE = Realm/Tests/TestHost/Info.plist;
 PRODUCT_NAME = $(TARGET_NAME);
 CLANG_MODULES_AUTOLINK = NO;
 ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+PRODUCT_BUNDLE_IDENTIFIER = io.realm.TestHost;
 
 OTHER_LDFLAGS[sdk=iphone*] = -framework UIKit;
 OTHER_LDFLAGS[sdk=macosx*] = -framework Cocoa;

--- a/Configuration/RealmSwift/Tests.xcconfig
+++ b/Configuration/RealmSwift/Tests.xcconfig
@@ -12,4 +12,4 @@ LD_RUNPATH_SEARCH_PATHS[sdk=macosx*] = $(inherited) @executable_path/../Framewor
 EXCLUDED_SOURCE_FILE_NAMES[sdk=iphone*] = build/osx/*;
 EXCLUDED_SOURCE_FILE_NAMES[sdk=macosx*] = build/ios-dynamic/*;
 
-TEST_HOST[sdk=iphoneos*] = $(BUILT_PRODUCTS_DIR)/TestHost.app/TestHost;
+TEST_HOST = $(BUILT_PRODUCTS_DIR)/TestHost.app/Contents/MacOS/TestHost;

--- a/Realm/Tests/TestHost/Info.plist
+++ b/Realm/Tests/TestHost/Info.plist
@@ -26,6 +26,8 @@
 	<array>
 		<string>armv7</string>
 	</array>
+	<key>NSPrincipalClass</key>
+	<string>$(PRINCIPAL_CLASS)</string>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>

--- a/Realm/Tests/TestHost/main.m
+++ b/Realm/Tests/TestHost/main.m
@@ -27,10 +27,12 @@ int main(int argc, char *argv[]) {
 
 #else
 
-#import <sys/cdefs.h>
+#import <Cocoa/Cocoa.h>
 
-int main(__unused int argc, __unused char *argv[]) {
-    return 1;
+int main(int argc, const char *argv[]) {
+    @autoreleasepool {
+        return NSApplicationMain(argc, argv);
+    }
 }
 
 #endif

--- a/RealmSwift-swift1.2/Tests/TestUtils.mm
+++ b/RealmSwift-swift1.2/Tests/TestUtils.mm
@@ -30,6 +30,15 @@ static void initializeSharedSchema() {
     [RLMSchema sharedSchema];
 }
 
+// Thread-local storage is used to store information about in-flight exceptions.
+// Something (no idea what) is using up all of the TLS slots, so creating the
+// TLS slot on-demand is failing. Work around this by throwing an exception very
+// early in startup to pre-allocate the main thread's exception TLS key.
+__attribute((constructor))
+static void allocateExceptionPthreadKey() {
+    try { throw 0; } catch (int) { }
+}
+
 void RLMAssertThrows(XCTestCase *self, dispatch_block_t block, NSString *name, NSString *message, NSString *fileName, NSUInteger lineNumber) {
     BOOL didThrow = NO;
     @try {

--- a/RealmSwift-swift2.0/Tests/PerformanceTests.swift
+++ b/RealmSwift-swift2.0/Tests/PerformanceTests.swift
@@ -85,7 +85,16 @@ class SwiftPerformanceTests: TestCase {
     }
 
     private func copyRealmToTestPath(realm: Realm) -> Realm {
-        try! NSFileManager.defaultManager().removeItemAtPath(testRealmPath())
+        do {
+            try NSFileManager.defaultManager().removeItemAtPath(testRealmPath())
+        }
+        catch let error as NSError {
+            XCTAssertTrue(error.domain == NSCocoaErrorDomain && error.code == 4)
+        }
+        catch {
+            fatalError("Unexpected error: \(error)")
+        }
+
         try! realm.writeCopyToPath(testRealmPath())
         return realmWithTestPath()
     }

--- a/RealmSwift-swift2.0/Tests/TestUtils.mm
+++ b/RealmSwift-swift2.0/Tests/TestUtils.mm
@@ -30,6 +30,15 @@ static void initializeSharedSchema() {
     [RLMSchema sharedSchema];
 }
 
+// Thread-local storage is used to store information about in-flight exceptions.
+// Something (no idea what) is using up all of the TLS slots, so creating the
+// TLS slot on-demand is failing. Work around this by throwing an exception very
+// early in startup to pre-allocate the main thread's exception TLS key.
+__attribute((constructor))
+static void allocateExceptionPthreadKey() {
+    try { throw 0; } catch (int) { }
+}
+
 void RLMAssertThrows(XCTestCase *self, dispatch_block_t block, NSString *name, NSString *message, NSString *fileName, NSUInteger lineNumber) {
     BOOL didThrow = NO;
     @try {

--- a/build.sh
+++ b/build.sh
@@ -467,7 +467,9 @@ case "$COMMAND" in
     "test-ios-devices")
         failed=0
         test_ios_devices xcrealm "iOS Device Tests" "$CONFIGURATION" || failed=1
-        # test_ios_devices xcrealmswift "RealmSwift" "$CONFIGURATION" || failed=1 # FIXME: Re-enable once fixed
+        if [ $REALM_SWIFT_VERSION != '1.2' ]; then
+            test_ios_devices xcrealmswift "RealmSwift" "$CONFIGURATION" || failed=1
+        fi
         exit $failed
         ;;
 

--- a/build.sh
+++ b/build.sh
@@ -437,30 +437,31 @@ case "$COMMAND" in
         ;;
 
     "test-ios-static")
-        xcrealm "-scheme iOS -configuration $CONFIGURATION -sdk iphonesimulator -destination 'name=iPhone 6' test"
+        xcrealm "-scheme iOS -configuration $CONFIGURATION -sdk iphonesimulator -destination 'name=iPhone 6' build test"
         shutdown_simulators
-        xcrealm "-scheme iOS -configuration $CONFIGURATION -sdk iphonesimulator -destination 'name=iPhone 4s' test"
+        xcrealm "-scheme iOS -configuration $CONFIGURATION -sdk iphonesimulator -destination 'name=iPhone 4s' build test"
         exit 0
         ;;
 
     "test-ios7-static")
-        xcrealm "-scheme iOS -configuration $CONFIGURATION -sdk iphonesimulator -destination 'name=iPhone 5S,OS=7.1' test"
+        xcrealm "-scheme iOS -configuration $CONFIGURATION -sdk iphonesimulator -destination 'name=iPhone 5S,OS=7.1' build test"
         shutdown_simulators
-        xcrealm "-scheme iOS -configuration $CONFIGURATION -sdk iphonesimulator -destination 'name=iPhone 4s,OS=7.1' test"
+        xcrealm "-scheme iOS -configuration $CONFIGURATION -sdk iphonesimulator -destination 'name=iPhone 4s,OS=7.1' build test"
         exit 0
         ;;
 
     "test-ios-dynamic")
-        xcrealm "-scheme 'iOS Dynamic' -configuration $CONFIGURATION -sdk iphonesimulator -destination 'name=iPhone 6' test"
+        xcrealm "-scheme 'iOS Dynamic' -configuration $CONFIGURATION -sdk iphonesimulator -destination 'name=iPhone 6' build test"
         shutdown_simulators
-        xcrealm "-scheme 'iOS Dynamic' -configuration $CONFIGURATION -sdk iphonesimulator -destination 'name=iPhone 4s' test"
+        xcrealm "-scheme 'iOS Dynamic' -configuration $CONFIGURATION -sdk iphonesimulator -destination 'name=iPhone 4s' build test"
         exit 0
         ;;
 
     "test-ios-swift")
-        xcrealmswift "-scheme RealmSwift -configuration $CONFIGURATION -sdk iphonesimulator -destination 'name=iPhone 6' test"
+        xcrealmswift "-scheme RealmSwift -configuration $CONFIGURATION -sdk iphonesimulator -destination 'name=iPhone 6' build test"
         shutdown_simulators
-        xcrealmswift "-scheme RealmSwift -configuration $CONFIGURATION -sdk iphonesimulator -destination 'name=iPhone 4s' test"
+        xcrealmswift "-scheme RealmSwift -configuration $CONFIGURATION -sdk iphonesimulator -destination 'name=iPhone 4s'"
+        xcrealmswift "-scheme RealmSwift -configuration $CONFIGURATION -sdk iphonesimulator -destination 'name=iPhone 4s' build test"
         exit 0
         ;;
 


### PR DESCRIPTION
My changes in #2008 broke them. Xcode requires that `TEST_HOST` be set for iOS device tests, but the conditional way in which it was being set in Tests.xcconfig was resulting in Xcode thinking it was unset.

To address this `TEST_HOST` is now set unconditionallly. This requires some minor changes to allow TestHost.app to build and run on OS X.