### PR TITLE
Lower the stack size for notification lister threads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+x.xx.x Release notes (yyyy-MM-dd)
+=============================================================
+
+### API breaking changes
+
+* None.
+
+### Enhancements
+
+* Reduce the amount of memory used by RLMRealm notification listener threads.
+
+### Bugfixes
+
+* None.
+
 0.93.2 Release notes (2015-06-12)
 =============================================================
 

--- a/Realm/RLMRealmUtil.mm
+++ b/Realm/RLMRealmUtil.mm
@@ -211,6 +211,7 @@ public:
 
         NSThread *thread = [[NSThread alloc] initWithTarget:self selector:@selector(listen) object:nil];
         // Use the minimum allowed stack size, as we need very little in our listener
+        // https://developer.apple.com/library/ios/documentation/Cocoa/Conceptual/Multithreading/CreatingThreads/CreatingThreads.html#//apple_ref/doc/uid/10000057i-CH15-SW7
         thread.stackSize = 16 * 1024;
         thread.name = @"RLMRealm notification listener";
         [thread start];

--- a/Realm/RLMRealmUtil.mm
+++ b/Realm/RLMRealmUtil.mm
@@ -209,13 +209,16 @@ public:
         _shutdownReadFd = pipeFd[0];
         _shutdownWriteFd = pipeFd[1];
 
-        [NSThread detachNewThreadSelector:@selector(listen) toTarget:self withObject:nil];
+        NSThread *thread = [[NSThread alloc] initWithTarget:self selector:@selector(listen) object:nil];
+        // Use the minimum allowed stack size, as we need very little in our listener
+        thread.stackSize = 16 * 1024;
+        thread.name = @"RLMRealm notification listener";
+        [thread start];
     }
     return self;
 }
 
 - (void)listen {
-    [NSThread currentThread].name = @"RLMRealm notification listener";
 
     // Create the runloop source
     CFRunLoopSourceContext ctx{};


### PR DESCRIPTION
The notifier listener threads need very little stack, so lower their stack size to the minimum allowed by the OS to cut down on the amount of address space used a bit.