### PR TITLE
Remove RLMAutoreleasePoolTestCase

### DIFF
--- a/RealmSwift/Tests/TestCase.swift
+++ b/RealmSwift/Tests/TestCase.swift
@@ -22,7 +22,7 @@ import Realm.Private
 import RealmSwift
 import XCTest
 
-class TestCase: RLMAutoreleasePoolTestCase {
+class TestCase: XCTestCase {
     var exceptionThrown = false
 
     func realmWithTestPath() -> Realm {
@@ -34,7 +34,7 @@ class TestCase: RLMAutoreleasePoolTestCase {
         NSFileManager.defaultManager().createDirectoryAtPath(realmPathForFile(""), withIntermediateDirectories: true, attributes: nil, error: nil)
 
         exceptionThrown = false
-        super.invokeTest()
+        autoreleasepool { super.invokeTest() }
 
         if exceptionThrown {
             RLMDeallocateRealm(Realm.defaultPath)

--- a/RealmSwift/Tests/TestUtils.h
+++ b/RealmSwift/Tests/TestUtils.h
@@ -19,11 +19,6 @@
 #import <Foundation/Foundation.h>
 #import <XCTest/XCTestCase.h>
 
-// An XCTestCase that invokes each test in an autorelease pool
-// Works around a swift 1.1 limitation where `super` can't be used in a block
-@interface RLMAutoreleasePoolTestCase : XCTestCase
-@end
-
 FOUNDATION_EXTERN void RLMAssertThrows(XCTestCase *self, __attribute__((noescape)) dispatch_block_t block, NSString *message, NSString *fileName, NSUInteger lineNumber);
 
 // Forcibly deallocate the RLMRealm for the given path on the main thread

--- a/RealmSwift/Tests/TestUtils.mm
+++ b/RealmSwift/Tests/TestUtils.mm
@@ -21,14 +21,6 @@
 #import <Realm/Realm.h>
 #import <Realm/RLMRealmUtil.h>
 
-@implementation RLMAutoreleasePoolTestCase
-- (void)invokeTest {
-    @autoreleasepool {
-        [super invokeTest];
-    }
-}
-@end
-
 void RLMAssertThrows(XCTestCase *self, dispatch_block_t block, NSString *message, NSString *fileName, NSUInteger lineNumber) {
     BOOL didThrow = NO;
     @try {


### PR DESCRIPTION
This was just a workaround for a Swift shortcoming that was fixed in 1.2.