### PR TITLE
Added RLM_GENERIC_ARRAY() macro

### DIFF
--- a/Realm/RLMArray.h
+++ b/Realm/RLMArray.h
@@ -19,7 +19,7 @@
 #import <Foundation/Foundation.h>
 #import <Realm/RLMCollection.h>
 
-@class RLMObject, RLMRealm, RLMResults;
+@class RLMObject, RLMRealm, RLMResults RLM_GENERIC_COLLECTION;
 
 /**
  
@@ -34,7 +34,7 @@
  lazily created when accessed, or can be obtained by querying a Realm.
  */
 
-@interface RLMArray : NSObject<RLMCollection, NSFastEnumeration>
+@interface RLMArray RLM_GENERIC_COLLECTION : NSObject<RLMCollection, NSFastEnumeration>
 
 /**---------------------------------------------------------------------------------------
  *  @name RLMArray Properties
@@ -75,7 +75,7 @@
  
  @return An RLMObject of the class contained by this RLMArray.
  */
-- (id)objectAtIndex:(NSUInteger)index;
+- (RLMObjectType)objectAtIndex:(NSUInteger)index;
 
 /**
  Returns the first object in the array.
@@ -84,7 +84,7 @@
  
  @return An RLMObject of the class contained by this RLMArray.
  */
-- (id)firstObject;
+- (RLMObjectType)firstObject;
 
 /**
  Returns the last object in the array.
@@ -93,7 +93,7 @@
 
  @return An RLMObject of the class contained by this RLMArray.
  */
-- (id)lastObject;
+- (RLMObjectType)lastObject;
 
 
 #pragma mark -
@@ -111,7 +111,7 @@
  
  @param object  An RLMObject of the class contained by this RLMArray.
  */
-- (void)addObject:(RLMObject *)object;
+- (void)addObject:(RLMObjectArgument)object;
 
 /**
  Adds an array of objects at the end of the array.
@@ -133,7 +133,7 @@
  @param anObject  An object (of the same type as returned from the objectClassName selector).
  @param index   The array index at which the object is inserted.
  */
-- (void)insertObject:(RLMObject *)anObject atIndex:(NSUInteger)index;
+- (void)insertObject:(RLMObjectArgument)anObject atIndex:(NSUInteger)index;
 
 /**
  Removes an object at a given index.
@@ -170,7 +170,7 @@
  @param index       The array index of the object to be replaced.
  @param anObject    An object (of the same type as returned from the objectClassName selector).
  */
-- (void)replaceObjectAtIndex:(NSUInteger)index withObject:(RLMObject *)anObject;
+- (void)replaceObjectAtIndex:(NSUInteger)index withObject:(RLMObjectArgument)anObject;
 
 
 #pragma mark -
@@ -187,7 +187,7 @@
  
  @param object  An object (of the same type as returned from the objectClassName selector).
  */
-- (NSUInteger)indexOfObject:(RLMObject *)object;
+- (NSUInteger)indexOfObject:(RLMObjectArgument)object;
 
 /**
  Gets the index of the first object matching the predicate.
@@ -214,7 +214,7 @@
  
  @return                An RLMResults of objects that match the given predicate
  */
-- (RLMResults *)objectsWhere:(NSString *)predicateFormat, ...;
+- (RLMResults RLM_GENERIC_COLLECTION*)objectsWhere:(NSString *)predicateFormat, ...;
 
 /**
  Get objects matching the given predicate in the RLMArray.
@@ -223,7 +223,7 @@
  
  @return            An RLMResults of objects that match the given predicate
  */
-- (RLMResults *)objectsWithPredicate:(NSPredicate *)predicate;
+- (RLMResults RLM_GENERIC_COLLECTION*)objectsWithPredicate:(NSPredicate *)predicate;
 
 /**
  Get a sorted RLMResults from an RLMArray
@@ -233,7 +233,7 @@
  
  @return    An RLMResults sorted by the specified property.
  */
-- (RLMResults *)sortedResultsUsingProperty:(NSString *)property ascending:(BOOL)ascending;
+- (RLMResults RLM_GENERIC_COLLECTION*)sortedResultsUsingProperty:(NSString *)property ascending:(BOOL)ascending;
 
 /**
  Get a sorted RLMResults from an RLMArray
@@ -242,12 +242,12 @@
 
  @return    An RLMResults sorted by the specified properties.
  */
-- (RLMResults *)sortedResultsUsingDescriptors:(NSArray *)properties;
+- (RLMResults RLM_GENERIC_COLLECTION*)sortedResultsUsingDescriptors:(NSArray *)properties;
 
 #pragma mark -
 
-- (id)objectAtIndexedSubscript:(NSUInteger)index;
-- (void)setObject:(id)newValue atIndexedSubscript:(NSUInteger)index;
+- (RLMObjectType)objectAtIndexedSubscript:(NSUInteger)index;
+- (void)setObject:(RLMObjectType)newValue atIndexedSubscript:(NSUInteger)index;
 
 #pragma mark -
 

--- a/Realm/RLMCollection.h
+++ b/Realm/RLMCollection.h
@@ -21,10 +21,12 @@
 #if __has_extension(objc_generics)
 #define RLM_GENERIC_COLLECTION <RLMObjectType>
 #define RLMObjectArgument RLMObjectType
+#define RLM_GENERIC_ARRAY(CLASS) RLMArray<CLASS *><CLASS>
 #else
 #define RLM_GENERIC_COLLECTION
 typedef id RLMObjectType;
 typedef RLMObject * RLMObjectArgument;
+#define RLM_GENERIC_ARRAY(CLASS) RLMArray<CLASS>
 #endif
 
 @protocol RLMCollection <NSFastEnumeration>

--- a/Realm/RLMCollection.h
+++ b/Realm/RLMCollection.h
@@ -18,6 +18,15 @@
 
 @class RLMRealm, RLMResults, RLMObject;
 
+#if __has_extension(objc_generics)
+#define RLM_GENERIC_COLLECTION <RLMObjectType>
+#define RLMObjectArgument RLMObjectType
+#else
+#define RLM_GENERIC_COLLECTION
+typedef id RLMObjectType;
+typedef RLMObject * RLMObjectArgument;
+#endif
+
 @protocol RLMCollection <NSFastEnumeration>
 
 @required

--- a/Realm/RLMObject.h
+++ b/Realm/RLMObject.h
@@ -396,7 +396,7 @@
  
      RLM_ARRAY_TYPE(ObjectType)
      ...
-     @property RLMArray<ObjectType> *arrayOfObjectTypes;
+     @property RLM_GENERIC_ARRAY(ObjectType) *arrayOfObjectTypes;
   */
 #define RLM_ARRAY_TYPE(RLM_OBJECT_SUBCLASS)\
 @protocol RLM_OBJECT_SUBCLASS <NSObject>   \

--- a/Realm/RLMResults.h
+++ b/Realm/RLMResults.h
@@ -31,7 +31,7 @@
  RLMResults cannot be created directly.
  */
 
-@interface RLMResults : NSObject<RLMCollection, NSFastEnumeration>
+@interface RLMResults RLM_GENERIC_COLLECTION : NSObject<RLMCollection, NSFastEnumeration>
 
 /**---------------------------------------------------------------------------------------
  *  @name RLMResults Properties
@@ -67,7 +67,7 @@
 
  @return An RLMObject of the class contained by this RLMResults.
  */
-- (id)objectAtIndex:(NSUInteger)index;
+- (RLMObjectType)objectAtIndex:(NSUInteger)index;
 
 /**
  Returns the first object in the results.
@@ -76,7 +76,7 @@
 
  @return An RLMObject of the class contained by this RLMResults.
  */
-- (id)firstObject;
+- (RLMObjectType)firstObject;
 
 /**
  Returns the last object in the results.
@@ -85,7 +85,7 @@
 
  @return An RLMObject of the class contained by this RLMResults.
  */
-- (id)lastObject;
+- (RLMObjectType)lastObject;
 
 
 
@@ -103,7 +103,7 @@
 
  @param object  An object (of the same type as returned from the objectClassName selector).
  */
-- (NSUInteger)indexOfObject:(RLMObject *)object;
+- (NSUInteger)indexOfObject:(RLMObjectArgument)object;
 
 /**
  Gets the index of the first object matching the predicate.
@@ -130,7 +130,7 @@
 
  @return                An RLMResults of objects that match the given predicate
  */
-- (RLMResults *)objectsWhere:(NSString *)predicateFormat, ...;
+- (RLMResults RLM_GENERIC_COLLECTION*)objectsWhere:(NSString *)predicateFormat, ...;
 
 /**
  Get objects matching the given predicate in the RLMResults.
@@ -139,7 +139,7 @@
 
  @return            An RLMResults of objects that match the given predicate
  */
-- (RLMResults *)objectsWithPredicate:(NSPredicate *)predicate;
+- (RLMResults RLM_GENERIC_COLLECTION*)objectsWithPredicate:(NSPredicate *)predicate;
 
 /**
  Get a sorted `RLMResults` from an existing `RLMResults` sorted by a property.
@@ -149,7 +149,7 @@
 
  @return    An RLMResults sorted by the specified property.
  */
-- (RLMResults *)sortedResultsUsingProperty:(NSString *)property ascending:(BOOL)ascending;
+- (RLMResults RLM_GENERIC_COLLECTION*)sortedResultsUsingProperty:(NSString *)property ascending:(BOOL)ascending;
 
 /**
  Get a sorted `RLMResults` from an existing `RLMResults` sorted by an `NSArray`` of `RLMSortDescriptor`s.
@@ -158,7 +158,7 @@
 
  @return    An RLMResults sorted by the specified properties.
  */
-- (RLMResults *)sortedResultsUsingDescriptors:(NSArray *)properties;
+- (RLMResults RLM_GENERIC_COLLECTION*)sortedResultsUsingDescriptors:(NSArray *)properties;
 
 #pragma mark -
 

--- a/Realm/Tests/ObjectTests.m
+++ b/Realm/Tests/ObjectTests.m
@@ -80,7 +80,7 @@
 @class CycleObject;
 RLM_ARRAY_TYPE(CycleObject)
 @interface CycleObject :RLMObject
-@property RLMArray<CycleObject> *objects;
+@property RLM_GENERIC_ARRAY(CycleObject) *objects;
 @end
 
 @implementation CycleObject
@@ -128,7 +128,7 @@ RLM_ARRAY_TYPE(PrimaryIntObject);
 @property PrimaryStringObject *primaryStringObject;
 @property PrimaryStringObjectWrapper *primaryStringObjectWrapper;
 @property StringObject *stringObject;
-@property RLMArray<PrimaryIntObject> *primaryIntArray;
+@property RLM_GENERIC_ARRAY(PrimaryIntObject) *primaryIntArray;
 @property NSString *stringCol;
 @end
 
@@ -178,7 +178,7 @@ RLM_ARRAY_TYPE(PrimaryIntObject);
 
 @interface StringLinkObject : RLMObject
 @property StringObject *stringObjectCol;
-@property RLMArray<StringObject> *stringObjectArrayCol;
+@property RLM_GENERIC_ARRAY(StringObject) *stringObjectArrayCol;
 @end
 
 @implementation StringLinkObject
@@ -216,7 +216,7 @@ RLM_ARRAY_TYPE(PrimaryEmployeeObject);
 
 @interface PrimaryCompanyObject : RLMObject
 @property NSString *name;
-@property RLMArray<PrimaryEmployeeObject> *employees;
+@property RLM_GENERIC_ARRAY(PrimaryEmployeeObject) *employees;
 @property PrimaryEmployeeObject *intern;
 @property LinkToPrimaryEmployeeObject *wrappedIntern;
 @end

--- a/Realm/Tests/RLMTestObjects.h
+++ b/Realm/Tests/RLMTestObjects.h
@@ -110,7 +110,7 @@ RLM_ARRAY_TYPE(AllTypesObject)
 @end
 
 @interface ArrayOfAllTypesObject : RLMObject
-@property RLMArray<AllTypesObject> *array;
+@property RLM_GENERIC_ARRAY(AllTypesObject) *array;
 @end
 
 #pragma mark - Real Life Objects
@@ -133,7 +133,7 @@ RLM_ARRAY_TYPE(EmployeeObject)
 @interface CompanyObject : RLMObject
 
 @property NSString *name;
-@property RLMArray<EmployeeObject> *employees;
+@property RLM_GENERIC_ARRAY(EmployeeObject) *employees;
 
 @end
 
@@ -147,7 +147,7 @@ RLM_ARRAY_TYPE(EmployeeObject)
 RLM_ARRAY_TYPE(DogObject)
 
 @interface DogArrayObject : RLMObject
-@property RLMArray<DogObject> *dogs;
+@property RLM_GENERIC_ARRAY(DogObject) *dogs;
 @end
 
 
@@ -210,7 +210,7 @@ RLM_ARRAY_TYPE(CircleObject);
 #pragma mark CircleArrayObject
 
 @interface CircleArrayObject : RLMObject
-@property RLMArray<CircleObject> *circles;
+@property RLM_GENERIC_ARRAY(CircleObject) *circles;
 @end
 
 #pragma mark ArrayPropertyObject
@@ -218,8 +218,8 @@ RLM_ARRAY_TYPE(CircleObject);
 @interface ArrayPropertyObject : RLMObject
 
 @property NSString *name;
-@property RLMArray<StringObject> *array;
-@property RLMArray<IntObject> *intArray;
+@property RLM_GENERIC_ARRAY(StringObject) *array;
+@property RLM_GENERIC_ARRAY(IntObject) *intArray;
 
 @end
 

--- a/Realm/Tests/SchemaTests.mm
+++ b/Realm/Tests/SchemaTests.mm
@@ -57,9 +57,9 @@ RLM_ARRAY_TYPE(SchemaTestClassSecondChild)
 @property SchemaTestClassFirstChild *child;
 @property SchemaTestClassSecondChild *secondChild;
 
-@property RLMArray<SchemaTestClassBase> *baseArray;
-@property RLMArray<SchemaTestClassFirstChild> *childArray;
-@property RLMArray<SchemaTestClassSecondChild> *secondChildArray;
+@property RLM_GENERIC_ARRAY(SchemaTestClassBase) *baseArray;
+@property RLM_GENERIC_ARRAY(SchemaTestClassFirstChild) *childArray;
+@property RLM_GENERIC_ARRAY(SchemaTestClassSecondChild) *secondChildArray;
 @end
 @implementation SchemaTestClassLink
 @end


### PR DESCRIPTION
Unfortunately this generates warnings in our unit tests where we test incompatible models, but I've posted https://forums.developer.apple.com/message/16886 to see if there's a way to ignore that. /cc @tgoyne 