### PR TITLE
Added RLM_GENERIC_ARRAY() macro

### DIFF
--- a/Realm/RLMCollection.h
+++ b/Realm/RLMCollection.h
@@ -21,10 +21,12 @@
 #if __has_extension(objc_generics)
 #define RLM_GENERIC_COLLECTION <RLMObjectType>
 #define RLMObjectArgument RLMObjectType
+#define RLM_GENERIC_ARRAY(CLASS) RLMArray<CLASS *><CLASS>
 #else
 #define RLM_GENERIC_COLLECTION
 typedef id RLMObjectType;
 typedef RLMObject * RLMObjectArgument;
+#define RLM_GENERIC_ARRAY(CLASS) RLMArray<CLASS>
 #endif
 
 @protocol RLMCollection <NSFastEnumeration>

--- a/Realm/RLMObject.h
+++ b/Realm/RLMObject.h
@@ -396,7 +396,7 @@
  
      RLM_ARRAY_TYPE(ObjectType)
      ...
-     @property RLMArray<ObjectType> *arrayOfObjectTypes;
+     @property RLM_GENERIC_ARRAY(ObjectType) *arrayOfObjectTypes;
   */
 #define RLM_ARRAY_TYPE(RLM_OBJECT_SUBCLASS)\
 @protocol RLM_OBJECT_SUBCLASS <NSObject>   \

--- a/Realm/Tests/ArrayPropertyTests.m
+++ b/Realm/Tests/ArrayPropertyTests.m
@@ -191,7 +191,7 @@
     ArrayPropertyObject *intArray = [[ArrayPropertyObject alloc] init];
     IntObject *intObj = [[IntObject alloc] init];
     intObj.intCol = 1;
-    XCTAssertThrows([intArray.array addObject:intObj], @"Addint to string array should throw");
+    XCTAssertThrows([intArray.array addObject:(StringObject *)intObj], @"Addint to string array should throw");
     [intArray.intArray addObject:intObj];
 
     XCTAssertThrows([intArray.intArray objectsWhere:@"intCol == 1"], @"Should throw on standalone RLMArray");
@@ -256,8 +256,8 @@
     XCTAssertTrue([[array.intArray objectAtIndex:1] isEqualToObject:intObj4], @"Objects should be replaced");
     XCTAssertEqual(array.intArray.count, 3U, @"Should have 3 elements in int array");
 
-    XCTAssertThrows([array.array replaceObjectAtIndex:0 withObject:intObj4], @"Throws exception throws when type mismatched");
-    XCTAssertThrows([array.intArray replaceObjectAtIndex:1 withObject:stringObj4], @"Throws exception when type mismatched");
+    XCTAssertThrows([array.array replaceObjectAtIndex:0 withObject:(StringObject *)intObj4], @"Throws exception throws when type mismatched");
+    XCTAssertThrows([array.intArray replaceObjectAtIndex:1 withObject:(IntObject *)stringObj4], @"Throws exception when type mismatched");
 }
 
 - (void)testDeleteObjectInStandaloneArray {
@@ -347,7 +347,7 @@
     XCTAssertEqual((NSUInteger)NSNotFound, [company.employees indexOfObject:notInRealm]);
 
     // invalid object
-    XCTAssertThrows([company.employees indexOfObject:company]);
+    XCTAssertThrows([company.employees indexOfObject:(EmployeeObject *)company]);
 }
 
 - (void)testIndexOfObjectWhere

--- a/Realm/Tests/ObjectTests.m
+++ b/Realm/Tests/ObjectTests.m
@@ -80,7 +80,7 @@
 @class CycleObject;
 RLM_ARRAY_TYPE(CycleObject)
 @interface CycleObject :RLMObject
-@property RLMArray<CycleObject> *objects;
+@property RLM_GENERIC_ARRAY(CycleObject) *objects;
 @end
 
 @implementation CycleObject
@@ -128,7 +128,7 @@ RLM_ARRAY_TYPE(PrimaryIntObject);
 @property PrimaryStringObject *primaryStringObject;
 @property PrimaryStringObjectWrapper *primaryStringObjectWrapper;
 @property StringObject *stringObject;
-@property RLMArray<PrimaryIntObject> *primaryIntArray;
+@property RLM_GENERIC_ARRAY(PrimaryIntObject) *primaryIntArray;
 @property NSString *stringCol;
 @end
 
@@ -178,7 +178,7 @@ RLM_ARRAY_TYPE(PrimaryIntObject);
 
 @interface StringLinkObject : RLMObject
 @property StringObject *stringObjectCol;
-@property RLMArray<StringObject> *stringObjectArrayCol;
+@property RLM_GENERIC_ARRAY(StringObject) *stringObjectArrayCol;
 @end
 
 @implementation StringLinkObject
@@ -216,7 +216,7 @@ RLM_ARRAY_TYPE(PrimaryEmployeeObject);
 
 @interface PrimaryCompanyObject : RLMObject
 @property NSString *name;
-@property RLMArray<PrimaryEmployeeObject> *employees;
+@property RLM_GENERIC_ARRAY(PrimaryEmployeeObject) *employees;
 @property PrimaryEmployeeObject *intern;
 @property LinkToPrimaryEmployeeObject *wrappedIntern;
 @end

--- a/Realm/Tests/RLMTestObjects.h
+++ b/Realm/Tests/RLMTestObjects.h
@@ -110,7 +110,7 @@ RLM_ARRAY_TYPE(AllTypesObject)
 @end
 
 @interface ArrayOfAllTypesObject : RLMObject
-@property RLMArray<AllTypesObject> *array;
+@property RLM_GENERIC_ARRAY(AllTypesObject) *array;
 @end
 
 #pragma mark - Real Life Objects
@@ -133,7 +133,7 @@ RLM_ARRAY_TYPE(EmployeeObject)
 @interface CompanyObject : RLMObject
 
 @property NSString *name;
-@property RLMArray<EmployeeObject> *employees;
+@property RLM_GENERIC_ARRAY(EmployeeObject) *employees;
 
 @end
 
@@ -147,7 +147,7 @@ RLM_ARRAY_TYPE(EmployeeObject)
 RLM_ARRAY_TYPE(DogObject)
 
 @interface DogArrayObject : RLMObject
-@property RLMArray<DogObject> *dogs;
+@property RLM_GENERIC_ARRAY(DogObject) *dogs;
 @end
 
 
@@ -210,7 +210,7 @@ RLM_ARRAY_TYPE(CircleObject);
 #pragma mark CircleArrayObject
 
 @interface CircleArrayObject : RLMObject
-@property RLMArray<CircleObject> *circles;
+@property RLM_GENERIC_ARRAY(CircleObject) *circles;
 @end
 
 #pragma mark ArrayPropertyObject
@@ -218,8 +218,8 @@ RLM_ARRAY_TYPE(CircleObject);
 @interface ArrayPropertyObject : RLMObject
 
 @property NSString *name;
-@property RLMArray<StringObject> *array;
-@property RLMArray<IntObject> *intArray;
+@property RLM_GENERIC_ARRAY(StringObject) *array;
+@property RLM_GENERIC_ARRAY(IntObject) *intArray;
 
 @end
 

--- a/Realm/Tests/SchemaTests.mm
+++ b/Realm/Tests/SchemaTests.mm
@@ -57,9 +57,9 @@ RLM_ARRAY_TYPE(SchemaTestClassSecondChild)
 @property SchemaTestClassFirstChild *child;
 @property SchemaTestClassSecondChild *secondChild;
 
-@property RLMArray<SchemaTestClassBase> *baseArray;
-@property RLMArray<SchemaTestClassFirstChild> *childArray;
-@property RLMArray<SchemaTestClassSecondChild> *secondChildArray;
+@property RLM_GENERIC_ARRAY(SchemaTestClassBase) *baseArray;
+@property RLM_GENERIC_ARRAY(SchemaTestClassFirstChild) *childArray;
+@property RLM_GENERIC_ARRAY(SchemaTestClassSecondChild) *secondChildArray;
 @end
 @implementation SchemaTestClassLink
 @end


### PR DESCRIPTION
Unfortunately this generates warnings in our unit tests where we test incompatible models, but I've posted https://forums.developer.apple.com/message/16886 to see if there's a way to ignore that. /cc @tgoyne