### PR TITLE
Use a frozen copy of RLMResults/RLMArray for fast enumeration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,10 @@ x.x.x Release notes (yyyy-MM-dd)
   Observing compliant.
 * The different options used to create Realm instances have been consolidated
   into a single `RLMRealmConfiguration`/`Realm.Configuration` object.
+* Enumerating Realm collections (`RLMArray`, `RLMResults`, `List<>`,
+  `Results<>`) now enumerates over a copy of the collection, making it no
+  longer an error to modify a collection during enumeration (either directly,
+  or indirectly by modifying objects to make them no longer match a query).
 
 ### Bugfixes
 

--- a/Realm/RLMArray.mm
+++ b/Realm/RLMArray.mm
@@ -155,7 +155,8 @@ static void RLMValidateArrayBounds(__unsafe_unretained RLMArray *const ar,
 }
 
 - (NSUInteger)countByEnumeratingWithState:(NSFastEnumerationState *)state objects:(__unsafe_unretained id [])buffer count:(NSUInteger)len {
-    return [_backingArray countByEnumeratingWithState:state objects:buffer count:len];
+    __autoreleasing NSArray *copy = [[NSArray alloc] initWithArray:_backingArray];
+    return [copy countByEnumeratingWithState:state objects:buffer count:len];
 }
 
 - (void)addObjectsFromArray:(NSArray *)array {

--- a/Realm/RLMArray.mm
+++ b/Realm/RLMArray.mm
@@ -386,23 +386,3 @@ static void RLMValidateArrayBounds(__unsafe_unretained RLMArray *const ar,
 }
 
 @end
-
-//
-// RLMCArrayHolder implementation
-//
-@implementation RLMCArrayHolder
-- (instancetype)initWithSize:(NSUInteger)arraySize {
-    if ((self = [super init])) {
-        size = arraySize;
-        array = std::make_unique<id[]>(size);
-    }
-    return self;
-}
-
-- (void)resize:(NSUInteger)newSize {
-    if (newSize != size) {
-        size = newSize;
-        array = std::make_unique<id[]>(size);
-    }
-}
-@end

--- a/Realm/RLMArrayLinkView.mm
+++ b/Realm/RLMArrayLinkView.mm
@@ -38,7 +38,6 @@
 @public
     realm::LinkViewRef _backingLinkView;
     RLMRealm *_realm;
-    __unsafe_unretained RLMObjectSchema *_objectSchema;
     __unsafe_unretained RLMObjectSchema *_containingObjectSchema;
     std::unique_ptr<RLMObservationInfo> _observationInfo;
 }
@@ -360,18 +359,12 @@ static void RLMInsertObject(RLMArrayLinkView *ar, RLMObject *object, NSUInteger 
     }
 
     RLMLinkViewArrayValidateAttached(self);
-    const size_t size = _backingLinkView->size();
-    return RLMCollectionValueForKey(key, _realm, _objectSchema, size, ^size_t(size_t index) {
-        return _backingLinkView->get(index).get_index();
-    });
+    return RLMCollectionValueForKey(self, key);
 }
 
 - (void)setValue:(id)value forKey:(NSString *)key {
     RLMLinkViewArrayValidateInWriteTransaction(self);
-    const size_t size = _backingLinkView->size();
-    RLMCollectionSetValueForKey(value, key, _realm, _objectSchema, size, ^size_t(size_t index) {
-        return _backingLinkView->get(index).get_index();
-    });
+    RLMCollectionSetValueForKey(self, key, value);
 }
 
 - (void)deleteObjectsFromRealm {
@@ -426,7 +419,7 @@ static void RLMInsertObject(RLMArrayLinkView *ar, RLMObject *object, NSUInteger 
     [super addObserver:observer forKeyPath:keyPath options:options context:context];
 }
 
-- (size_t)indexInSource:(NSUInteger)index {
+- (NSUInteger)indexInSource:(NSUInteger)index {
     return _backingLinkView->get(index).get_index();
 }
 

--- a/Realm/RLMArrayLinkView.mm
+++ b/Realm/RLMArrayLinkView.mm
@@ -171,9 +171,7 @@ static void changeArray(__unsafe_unretained RLMArrayLinkView *const ar, NSKeyVal
     if (state->state == 0) {
         RLMLinkViewArrayValidateAttached(self);
 
-        enumerator = [[RLMFastEnumerator alloc] initWithTableView:_backingLinkView->get_target_table().where(_backingLinkView).find_all()
-                                                            realm:_realm
-                                                     objectSchema:_objectSchema];
+        enumerator = [[RLMFastEnumerator alloc] initWithCollection:self objectSchema:_objectSchema];
         state->extra[0] = (long)enumerator;
         state->extra[1] = self.count;
     }
@@ -426,6 +424,14 @@ static void RLMInsertObject(RLMArrayLinkView *ar, RLMObject *object, NSUInteger 
             context:(void *)context {
     RLMEnsureArrayObservationInfo(_observationInfo, keyPath, self, self);
     [super addObserver:observer forKeyPath:keyPath options:options context:context];
+}
+
+- (size_t)indexInSource:(NSUInteger)index {
+    return _backingLinkView->get(index).get_index();
+}
+
+- (realm::TableView)tableView {
+    return _backingLinkView->get_target_table().where(_backingLinkView).find_all();
 }
 
 @end

--- a/Realm/RLMArray_Private.hpp
+++ b/Realm/RLMArray_Private.hpp
@@ -48,6 +48,8 @@ struct RLMSortOrder {
 
 @protocol RLMFastEnumerable
 @property (nonatomic, readonly) RLMRealm *realm;
+@property (nonatomic, readonly) RLMObjectSchema *objectSchema;
+@property (nonatomic, readonly) NSUInteger count;
 
 - (NSUInteger)indexInSource:(NSUInteger)index;
 - (realm::TableView)tableView;
@@ -68,6 +70,8 @@ struct RLMSortOrder {
 // LinkView backed RLMArray subclass
 //
 @interface RLMArrayLinkView : RLMArray <RLMFastEnumerable>
+@property (nonatomic, unsafe_unretained) RLMObjectSchema *objectSchema;
+
 + (RLMArrayLinkView *)arrayWithObjectClassName:(NSString *)objectClassName
                                           view:(realm::LinkViewRef)view
                                          realm:(RLMRealm *)realm

--- a/Realm/RLMArray_Private.hpp
+++ b/Realm/RLMArray_Private.hpp
@@ -113,18 +113,14 @@ void RLMEnsureArrayObservationInfo(std::unique_ptr<RLMObservationInfo>& info, NS
 + (RLMResults *)tableResultsWithObjectSchema:(RLMObjectSchema *)objectSchema realm:(RLMRealm *)realm;
 @end
 
-//
-// A simple holder for a C array of ids to enable autoreleasing the array without
-// the runtime overhead of a NSMutableArray
-//
-@interface RLMCArrayHolder : NSObject {
-@public
-    std::unique_ptr<id[]> array;
-    NSUInteger size;
-}
+// An object which encapulates the shared logic for fast-enumerating RLMArray
+// and RLMResults, and has a buffer to store strong references to the current
+// set of enumerated items
+@interface RLMFastEnumerator : NSObject
+- (instancetype)initWithTableView:(realm::TableView)tableView
+                            realm:(RLMRealm *)realm
+                     objectSchema:(RLMObjectSchema *)objectSchema;
 
-- (instancetype)initWithSize:(NSUInteger)size;
-
-// Reallocate the array if it is not already the given size
-- (void)resize:(NSUInteger)size;
+- (NSUInteger)countByEnumeratingWithState:(NSFastEnumerationState *)state
+                                    count:(NSUInteger)len;
 @end

--- a/Realm/RLMArray_Private.hpp
+++ b/Realm/RLMArray_Private.hpp
@@ -46,6 +46,13 @@ struct RLMSortOrder {
     }
 };
 
+@protocol RLMFastEnumerable
+@property (nonatomic, readonly) RLMRealm *realm;
+
+- (NSUInteger)indexInSource:(NSUInteger)index;
+- (realm::TableView)tableView;
+@end
+
 @interface RLMArray () {
   @protected
     NSString *_objectClassName;
@@ -60,7 +67,7 @@ struct RLMSortOrder {
 //
 // LinkView backed RLMArray subclass
 //
-@interface RLMArrayLinkView : RLMArray
+@interface RLMArrayLinkView : RLMArray <RLMFastEnumerable>
 + (RLMArrayLinkView *)arrayWithObjectClassName:(NSString *)objectClassName
                                           view:(realm::LinkViewRef)view
                                          realm:(RLMRealm *)realm
@@ -80,7 +87,7 @@ void RLMEnsureArrayObservationInfo(std::unique_ptr<RLMObservationInfo>& info, NS
 //
 // RLMResults private methods
 //
-@interface RLMResults ()
+@interface RLMResults () <RLMFastEnumerable>
 + (instancetype)resultsWithObjectClassName:(NSString *)objectClassName
                                      query:(std::unique_ptr<realm::Query>)query
                                      realm:(RLMRealm *)realm;
@@ -117,9 +124,11 @@ void RLMEnsureArrayObservationInfo(std::unique_ptr<RLMObservationInfo>& info, NS
 // and RLMResults, and has a buffer to store strong references to the current
 // set of enumerated items
 @interface RLMFastEnumerator : NSObject
-- (instancetype)initWithTableView:(realm::TableView)tableView
-                            realm:(RLMRealm *)realm
-                     objectSchema:(RLMObjectSchema *)objectSchema;
+- (instancetype)initWithCollection:(id<RLMFastEnumerable>)collection objectSchema:(RLMObjectSchema *)objectSchema;
+
+// Detach this enumerator from the source collection. Must be called before the
+// source collection is changed.
+- (void)detach;
 
 - (NSUInteger)countByEnumeratingWithState:(NSFastEnumerationState *)state
                                     count:(NSUInteger)len;

--- a/Realm/RLMRealm.mm
+++ b/Realm/RLMRealm.mm
@@ -174,6 +174,7 @@ void RLMRealmAddPathSettingsToConfiguration(RLMRealmConfiguration *configuration
 @implementation RLMRealm {
     // Used for read-write realms
     NSHashTable *_notificationHandlers;
+    NSHashTable *_collectionEnumerators;
 
     std::unique_ptr<ClientHistory> _history;
     std::unique_ptr<SharedGroup> _sharedGroup;
@@ -571,6 +572,12 @@ static void CheckReadWrite(RLMRealm *realm, NSString *msg=@"Cannot write to a re
 
             // begin the read transaction if needed
             [self getOrCreateGroup];
+
+            //
+            for (RLMFastEnumerator *enumerator in _collectionEnumerators) {
+                [enumerator detach];
+            }
+            _collectionEnumerators = nil;
 
             RLMPromoteToWrite(*_sharedGroup, *_history, _schema);
 
@@ -983,6 +990,18 @@ void RLMRealmSetSchemaVersionForPath(uint64_t version, NSString *path, RLMMigrat
     }
 
     return [self writeCopyToPath:path key:key error:error];
+}
+
+- (void)registerEnumerator:(RLMFastEnumerator *)enumerator {
+    if (!_collectionEnumerators) {
+        _collectionEnumerators = [NSHashTable hashTableWithOptions:NSPointerFunctionsWeakMemory];
+    }
+    [_collectionEnumerators addObject:enumerator];
+
+}
+
+- (void)unregisterEnumerator:(RLMFastEnumerator *)enumerator {
+    [_collectionEnumerators removeObject:enumerator];
 }
 
 @end

--- a/Realm/RLMRealm.mm
+++ b/Realm/RLMRealm.mm
@@ -573,7 +573,8 @@ static void CheckReadWrite(RLMRealm *realm, NSString *msg=@"Cannot write to a re
             // begin the read transaction if needed
             [self getOrCreateGroup];
 
-            //
+            // notify any collections currently being enumerated that they need
+            // to switch to enumerating a copy as the data may change on them
             for (RLMFastEnumerator *enumerator in _collectionEnumerators) {
                 [enumerator detach];
             }

--- a/Realm/RLMRealm_Private.h
+++ b/Realm/RLMRealm_Private.h
@@ -18,7 +18,7 @@
 
 #import <Realm/RLMRealm.h>
 
-@class RLMNotifier;
+@class RLMFastEnumerator, RLMNotifier;
 
 // Disable syncing files to disk. Cannot be re-enabled. Use only for tests.
 FOUNDATION_EXTERN void RLMDisableSyncToDisk();
@@ -54,5 +54,8 @@ FOUNDATION_EXTERN void RLMRealmAddPathSettingsToConfiguration(RLMRealmConfigurat
                       dynamic:(BOOL)dynamic
                        schema:(RLMSchema *)customSchema
                         error:(NSError **)outError;
+
+- (void)registerEnumerator:(RLMFastEnumerator *)enumerator;
+- (void)unregisterEnumerator:(RLMFastEnumerator *)enumerator;
 
 @end

--- a/Realm/RLMResults.mm
+++ b/Realm/RLMResults.mm
@@ -324,18 +324,12 @@ static inline void RLMResultsValidateInWriteTransaction(__unsafe_unretained RLMR
 
 - (id)valueForKey:(NSString *)key {
     RLMResultsValidate(self);
-    const size_t size = _backingView.size();
-    return RLMCollectionValueForKey(key, _realm, _objectSchema, size, ^size_t(size_t index) {
-        return _backingView.get_source_ndx(index);
-    });
+    return RLMCollectionValueForKey(self, key);
 }
 
 - (void)setValue:(id)value forKey:(NSString *)key {
     RLMResultsValidateInWriteTransaction(self);
-    const size_t size = _backingView.size();
-    RLMCollectionSetValueForKey(value, key, _realm, _objectSchema, size, ^size_t(size_t index) {
-        return _backingView.get_source_ndx(index);
-    });
+    RLMCollectionSetValueForKey(self, key, value);
 }
 
 - (RLMResults *)objectsWhere:(NSString *)predicateFormat, ... {
@@ -573,22 +567,6 @@ static NSNumber *averageOfProperty(TableType const& table, RLMRealm *realm, NSSt
     return _table->size();
 }
 
-- (id)valueForKey:(NSString *)key {
-    RLMResultsValidate(self);
-    const size_t size = _table->size();
-    return RLMCollectionValueForKey(key, _realm, _objectSchema, size, ^size_t(size_t index) {
-        return index;
-    });
-}
-
-- (void)setValue:(id)value forKey:(NSString *)key {
-    RLMResultsValidateInWriteTransaction(self);
-    const size_t size = _table->size();
-    RLMCollectionSetValueForKey(value, key, _realm, _objectSchema, size, ^size_t(size_t index) {
-        return index;
-    });
-}
-
 - (NSUInteger)indexOfObject:(RLMObject *)object {
     RLMCheckThread(_realm);
     if (object.invalidated) {
@@ -637,7 +615,7 @@ static NSNumber *averageOfProperty(TableType const& table, RLMRealm *realm, NSSt
 
 - (void)deleteObjectsFromRealm {
     RLMResultsValidateInWriteTransaction(self);
-    RLMClearTable(_objectSchema);
+    RLMClearTable(self.objectSchema);
 }
 
 - (std::unique_ptr<Query>)cloneQuery {

--- a/Realm/RLMResults.mm
+++ b/Realm/RLMResults.mm
@@ -85,7 +85,7 @@ static const int RLMEnumerationBufferSize = 16;
                                     count:(NSUInteger)len {
     RLMCheckThread(_realm);
     if (!_tableView.is_attached() && !_collection) {
-        @throw RLMException(@"RLMResults is no longer valid");
+        @throw RLMException(@"Collection is no longer valid");
     }
     // The fast enumeration buffer size is currently a hardcoded number in the
     // compiler so this can't actually happen, but just in case it changes in

--- a/Realm/RLMResults_Private.h
+++ b/Realm/RLMResults_Private.h
@@ -20,8 +20,6 @@
 
 @class RLMObjectSchema;
 
-@interface RLMResults () {
-  @public
-    RLMObjectSchema *_objectSchema;
-}
+@interface RLMResults ()
+@property (nonatomic, unsafe_unretained) RLMObjectSchema *objectSchema;
 @end

--- a/Realm/RLMUtil.hpp
+++ b/Realm/RLMUtil.hpp
@@ -27,6 +27,7 @@
 @class RLMProperty;
 @class RLMRealm;
 @class RLMSchema;
+@protocol RLMFastEnumerable;
 
 NSException *RLMException(NSString *message, NSDictionary *userInfo = nil);
 NSException *RLMException(std::exception const& exception);
@@ -43,9 +44,9 @@ BOOL RLMIsObjectValidForProperty(id obj, RLMProperty *prop);
 // merges with native property defaults if Swift class
 NSDictionary *RLMDefaultValuesForObjectSchema(RLMObjectSchema *objectSchema);
 
-NSArray *RLMCollectionValueForKey(NSString *key, RLMRealm *realm, RLMObjectSchema *objectSchema, size_t count, size_t (^indexGenerator)(size_t index));
+NSArray *RLMCollectionValueForKey(id<RLMFastEnumerable> collection, NSString *key);
 
-void RLMCollectionSetValueForKey(id value, NSString *key, RLMRealm *realm, RLMObjectSchema *objectSchema, size_t count, size_t (^indexGenerator)(size_t index));
+void RLMCollectionSetValueForKey(id<RLMFastEnumerable> collection, NSString *key, id value);
 
 BOOL RLMIsDebuggerAttached();
 

--- a/Realm/Tests/ArrayPropertyTests.m
+++ b/Realm/Tests/ArrayPropertyTests.m
@@ -527,24 +527,30 @@
         }
     }
     XCTAssertNil(objects[0], @"Object should have been released");
+}
 
-    void (^mutateDuringEnumeration)() = ^{
-        bool first = true;
-        for (__unused EmployeeObject *e in company.employees) {
-            // Only insert the first time so we don't infinite loop if the check
-            // doesn't work
-            if (first) {
-                [realm beginWriteTransaction];
-                EmployeeObject *eo = [EmployeeObject createInRealm:realm withValue:@{@"name": @"Joe",  @"age": @40, @"hired": @YES}];
-                [company.employees addObject:eo];
-                [realm commitWriteTransaction];
-                first = false;
-            }
-        }
-    };
+- (void)testModifyDuringEnumeration {
+    RLMRealm *realm = self.realmWithTestPath;
 
-    XCTAssertThrows(mutateDuringEnumeration(),
-                    @"Adding an object during fast enumeration did not throw");
+    [realm beginWriteTransaction];
+    CompanyObject *company = [[CompanyObject alloc] init];
+    company.name = @"name";
+    [realm addObject:company];
+
+    const size_t totalCount = 40;
+    for (size_t i = 0; i < totalCount; ++i) {
+        [company.employees addObject:[EmployeeObject createInRealm:realm withValue:@[@"name", @(i), @NO]]];
+    }
+
+    size_t count = 0;
+    for (EmployeeObject *eo in company.employees) {
+        ++count;
+        [company.employees addObject:eo];
+    }
+    XCTAssertEqual(totalCount, count);
+    XCTAssertEqual(totalCount * 2, company.employees.count);
+
+    [realm cancelWriteTransaction];
 }
 
 - (void)testValueForKey {

--- a/Realm/Tests/ArrayPropertyTests.m
+++ b/Realm/Tests/ArrayPropertyTests.m
@@ -551,6 +551,21 @@
     XCTAssertEqual(totalCount * 2, company.employees.count);
 
     [realm cancelWriteTransaction];
+
+    // Standalone array
+    company = [[CompanyObject alloc] init];
+    for (size_t i = 0; i < totalCount; ++i) {
+        [company.employees addObject:[[EmployeeObject alloc] initWithValue:@[@"name", @(i), @NO]]];
+    }
+
+    count = 0;
+    for (EmployeeObject *eo in company.employees) {
+        ++count;
+        [company.employees addObject:eo];
+    }
+    XCTAssertEqual(totalCount, count);
+    XCTAssertEqual(totalCount * 2, company.employees.count);
+
 }
 
 - (void)testValueForKey {

--- a/RealmSwift-swift1.2/Tests/ListTests.swift
+++ b/RealmSwift-swift1.2/Tests/ListTests.swift
@@ -311,6 +311,18 @@ class ListTests: TestCase {
         XCTAssertEqual(str, "121")
     }
 
+    func testFastEnumerationWithMutation() {
+        array.extend([str1, str2, str1, str2, str1, str2, str1, str2, str1,
+            str2, str1, str2, str1, str2, str1, str2, str1, str2, str1, str2])
+        var str = ""
+        for obj in array {
+            str += obj.stringCol
+            array.extend([str1])
+        }
+
+        XCTAssertEqual(str, "12121212121212121212")
+    }
+
     func testAppendObject() {
         for str in [str1, str2, str1] {
             array.append(str)

--- a/RealmSwift-swift1.2/Tests/ResultsTests.swift
+++ b/RealmSwift-swift1.2/Tests/ResultsTests.swift
@@ -284,6 +284,14 @@ class ResultsTests: TestCase {
         XCTAssertEqual(str, "12")
     }
 
+    func testFastEnumerationWithMutation() {
+        let realm = realmWithTestPath()
+        for obj in results {
+            realm.delete(obj)
+        }
+        XCTAssertEqual(0, results.count)
+    }
+
     func testArrayAggregateWithSwiftObjectDoesntThrow() {
         let results = getAggregateableResults()
 

--- a/RealmSwift-swift2.0/Tests/ListTests.swift
+++ b/RealmSwift-swift2.0/Tests/ListTests.swift
@@ -311,6 +311,18 @@ class ListTests: TestCase {
         XCTAssertEqual(str, "121")
     }
 
+    func testFastEnumerationWithMutation() {
+        array.extend([str1, str2, str1, str2, str1, str2, str1, str2, str1,
+            str2, str1, str2, str1, str2, str1, str2, str1, str2, str1, str2])
+        var str = ""
+        for obj in array {
+            str += obj.stringCol
+            array.extend([str1])
+        }
+
+        XCTAssertEqual(str, "12121212121212121212")
+    }
+
     func testAppendObject() {
         for str in [str1, str2, str1] {
             array.append(str)

--- a/RealmSwift-swift2.0/Tests/ResultsTests.swift
+++ b/RealmSwift-swift2.0/Tests/ResultsTests.swift
@@ -284,6 +284,14 @@ class ResultsTests: TestCase {
         XCTAssertEqual(str, "12")
     }
 
+    func testFastEnumerationWithMutation() {
+        let realm = realmWithTestPath()
+        for obj in results {
+            realm.delete(obj)
+        }
+        XCTAssertEqual(0, results.count)
+    }
+
     func testArrayAggregateWithSwiftObjectDoesntThrow() {
         let results = getAggregateableResults()
 


### PR DESCRIPTION
Makes enumerating and modifying actually work, at the cost of having to create a copy of the TableView, which can be somewhat expensive. In theory it should be possible to use the KVO machinery to lazily do the copy only when needed. Alternatively, we could require that users call `freeze` (or maybe some better name) on the results if they want to be able to enumerate-and-mutate.

Needs a new core release and similar changes for standalone RLMArray before it's mergeable.

Closes #1152.