### PR TITLE
Add `-[RLMResults limit:]` to return an `RLMResults` that contains at most the given number of objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ x.xx.x Release notes (yyyy-MM-dd)
 * Avoid evaluating results eagerly when filtering and sorting.
 * Add nullability annotations to the Objective-C API to provide enhanced compiler
   warnings and bridging to Swift.
+* Add `-[RLMResults limit:]` to return an `RLMResults` that contains at most the
+  given number of objects.
 
 ### Bugfixes
 

--- a/Realm/RLMArray_Private.hpp
+++ b/Realm/RLMArray_Private.hpp
@@ -71,11 +71,6 @@ namespace realm {
 
 + (instancetype)resultsWithObjectClassName:(NSString *)objectClassName
                                      query:(std::unique_ptr<realm::Query>)query
-                                      view:(realm::TableView &&)view
-                                     realm:(RLMRealm *)realm;
-
-+ (instancetype)resultsWithObjectClassName:(NSString *)objectClassName
-                                     query:(std::unique_ptr<realm::Query>)query
                                       sort:(RowIndexes::Sorter const&)sorter
                                      realm:(RLMRealm *)realm;
 

--- a/Realm/RLMResults.h
+++ b/Realm/RLMResults.h
@@ -163,6 +163,15 @@ RLM_ASSUME_NONNULL_BEGIN
  */
 - (RLMResults *)sortedResultsUsingDescriptors:(NSArray *)properties;
 
+/**
+ Get a `RLMResults` from an existing `RLMResults` limited to at most `limit` items.
+
+ @param limit  The maximum number of items to include.
+
+ @return   An RLMResults limited to at most `limit` items.
+ */
+- (RLMResults *)limit:(NSUInteger)limit;
+
 #pragma mark -
 
 


### PR DESCRIPTION
Depends on https://github.com/realm/realm-core/pull/933.

/cc @tgoyne @jpsim 