### PR TITLE
Temporarily disable bitcode in RealmSwift project

### DIFF
--- a/RealmSwift.xcodeproj/project.pbxproj
+++ b/RealmSwift.xcodeproj/project.pbxproj
@@ -516,6 +516,7 @@
 			baseConfigurationReference = 5DA0C4D11B16973B0077F097 /* RealmSwift.xcconfig */;
 			buildSettings = {
 				COMBINE_HIDPI_IMAGES = YES;
+				ENABLE_BITCODE = NO;
 			};
 			name = Debug;
 		};
@@ -524,6 +525,7 @@
 			baseConfigurationReference = 5DA0C4D11B16973B0077F097 /* RealmSwift.xcconfig */;
 			buildSettings = {
 				COMBINE_HIDPI_IMAGES = YES;
+				ENABLE_BITCODE = NO;
 			};
 			name = Release;
 		};


### PR DESCRIPTION
closes https://github.com/realm/realm-cocoa/issues/2184

- The RealmSwift build in branch `swift-2.0` is currently failing while running `sh build.sh build`.

```
The following build commands failed:
	Ld build/DerivedData/RealmSwift/Build/Intermediates/RealmSwift.build/Release-iphoneos/RealmSwift.build/Objects-normal/arm64/RealmSwift normal arm64
```

- The failure is being caused by the build for RealmSwift running with ENABLE_BITCODE set to YES implicitly (even though if you look through Xcode, it looks to be NO).
- This PR simply sets the flag to NO for the RealmSwift framework target in RealmSwift.xcodeproj.