### PR TITLE
Disable syncing to disk for debug builds of tests

### DIFF
--- a/Realm/RLMRealm.mm
+++ b/Realm/RLMRealm.mm
@@ -31,11 +31,16 @@
 
 #include "object_store.hpp"
 #include <realm/commit_log.hpp>
+#include <realm/disable_sync_to_disk.hpp>
 #include <realm/version.hpp>
 
 using namespace std;
 using namespace realm;
 using namespace realm::util;
+
+void RLMDisableSyncToDisk() {
+    realm::disable_sync_to_disk();
+}
 
 // Notification Token
 

--- a/Realm/RLMRealm_Private.h
+++ b/Realm/RLMRealm_Private.h
@@ -20,6 +20,9 @@
 
 @class RLMNotifier;
 
+// Disable syncing files to disk. Cannot be re-enabled. Use only for tests.
+FOUNDATION_EXTERN void RLMDisableSyncToDisk();
+
 // RLMRealm private members
 @interface RLMRealm () {
     @public

--- a/Realm/Tests/RLMTestCase.m
+++ b/Realm/Tests/RLMTestCase.m
@@ -18,6 +18,8 @@
 
 #import "RLMTestCase.h"
 
+#import <Realm/RLMRealm_Private.h>
+
 @interface RLMRealm ()
 + (instancetype)realmWithPath:(NSString *)path
                           key:(NSData *)key
@@ -84,6 +86,16 @@ static BOOL encryptTests() {
 }
 
 @implementation RLMTestCase
+
+#if DEBUG
++ (void)setUp {
+    [super setUp];
+    // Disable actually syncing anything to the disk to greatly speed up the
+    // tests, but only in debug mode because it can't be re-enabled and we need
+    // it enabled for performance tests
+    RLMDisableSyncToDisk();
+}
+#endif
 
 - (void)setUp {
     @autoreleasepool {

--- a/RealmSwift/Tests/TestCase.swift
+++ b/RealmSwift/Tests/TestCase.swift
@@ -29,6 +29,16 @@ class TestCase: XCTestCase {
         return Realm(path: testRealmPath())
     }
 
+    override class func setUp() {
+        super.setUp()
+#if DEBUG
+        // Disable actually syncing anything to the disk to greatly speed up the
+        // tests, but only in debug mode because it can't be re-enabled and we need
+        // it enabled for performance tests
+        RLMDisableSyncToDisk();
+#endif
+    }
+
     override func invokeTest() {
         Realm.defaultPath = realmPathForFile("\(realmFilePrefix()).default.realm")
         NSFileManager.defaultManager().createDirectoryAtPath(realmPathForFile(""), withIntermediateDirectories: true, attributes: nil, error: nil)


### PR DESCRIPTION
Speeds up tests on my machine from ~45 seconds to ~20 seconds.