### PR TITLE
Add support for location-based bounding box queries

### DIFF
--- a/Realm.podspec
+++ b/Realm.podspec
@@ -21,6 +21,7 @@ Pod::Spec.new do |s|
                               'include/Realm/RLMConstants.h',
                               'include/Realm/RLMDefines.h',
                               'include/Realm/RLMListBase.h',
+                              'include/Realm/RLMLocationTypes.h',
                               'include/Realm/RLMMigration.h',
                               'include/Realm/RLMObject.h',
                               'include/Realm/RLMObjectBase.h',

--- a/Realm.xcodeproj/project.pbxproj
+++ b/Realm.xcodeproj/project.pbxproj
@@ -222,6 +222,9 @@
 		3FDE338D19C39A87003B7DBA /* RLMSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = E88C36FF19745E5500C9963D /* RLMSupport.swift */; };
 		3FE79FF819BA6A5900780C9A /* RLMSwiftSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 3FE79FF719BA6A5900780C9A /* RLMSwiftSupport.h */; };
 		3FE79FF919BA6A5900780C9A /* RLMSwiftSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 3FE79FF719BA6A5900780C9A /* RLMSwiftSupport.h */; };
+		5D0B26621B54585B00A0DD25 /* RLMLocationTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = 5D0B26611B54585B00A0DD25 /* RLMLocationTypes.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5D0B26631B54585B00A0DD25 /* RLMLocationTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = 5D0B26611B54585B00A0DD25 /* RLMLocationTypes.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5D0B26641B54585B00A0DD25 /* RLMLocationTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = 5D0B26611B54585B00A0DD25 /* RLMLocationTypes.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		5D30B74B1B42072600D90C5A /* RLMDefines.h in Headers */ = {isa = PBXBuildFile; fileRef = 5D30B74A1B42039F00D90C5A /* RLMDefines.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		5D30B74C1B42072700D90C5A /* RLMDefines.h in Headers */ = {isa = PBXBuildFile; fileRef = 5D30B74A1B42039F00D90C5A /* RLMDefines.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		5D30B74D1B42072800D90C5A /* RLMDefines.h in Headers */ = {isa = PBXBuildFile; fileRef = 5D30B74A1B42039F00D90C5A /* RLMDefines.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -471,6 +474,7 @@
 		3F6B89AE19EF40BA004E8EA8 /* librealm-ios.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = "librealm-ios.a"; path = "../core/librealm-ios.a"; sourceTree = "<group>"; };
 		3F8DCA5719930F550008BD7F /* iOS Device Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "iOS Device Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		3FE79FF719BA6A5900780C9A /* RLMSwiftSupport.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RLMSwiftSupport.h; sourceTree = "<group>"; };
+		5D0B26611B54585B00A0DD25 /* RLMLocationTypes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RLMLocationTypes.h; sourceTree = "<group>"; };
 		5D30B74A1B42039F00D90C5A /* RLMDefines.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RLMDefines.h; sourceTree = "<group>"; };
 		C073E1201AE9B705002C0A30 /* RLMObject_Private.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = RLMObject_Private.hpp; sourceTree = "<group>"; };
 		C0D6E4101AFBFAF7001F3027 /* RLMAssertions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RLMAssertions.h; sourceTree = "<group>"; };
@@ -740,6 +744,7 @@
 				5D30B74A1B42039F00D90C5A /* RLMDefines.h */,
 				023B19551A3BA90D0067FB81 /* RLMListBase.h */,
 				023B19561A3BA90D0067FB81 /* RLMListBase.m */,
+				5D0B26611B54585B00A0DD25 /* RLMLocationTypes.h */,
 				0207AB7D195DF9FB007EFB12 /* RLMMigration.h */,
 				0207AB7E195DF9FB007EFB12 /* RLMMigration.mm */,
 				0207AB7C195DF9FB007EFB12 /* RLMMigration_Private.h */,
@@ -829,6 +834,7 @@
 				29E3C7201A71C1C700B62C1D /* RLMConstants.h in Headers */,
 				023B2B321B28F0CF0021E54D /* object_store_exceptions.hpp in Headers */,
 				29E3C7211A71C1C700B62C1D /* RLMObjectBase.h in Headers */,
+				5D0B26641B54585B00A0DD25 /* RLMLocationTypes.h in Headers */,
 				29E3C7221A71C1C700B62C1D /* RLMMigration.h in Headers */,
 				29E3C7241A71C1C700B62C1D /* RLMObject.h in Headers */,
 				29E3C7251A71C1C700B62C1D /* RLMObjectSchema.h in Headers */,
@@ -872,6 +878,7 @@
 				E856D1FA1956154C00FB2FCF /* RLMConstants.h in Headers */,
 				023B2B311B28F0CF0021E54D /* object_store_exceptions.hpp in Headers */,
 				0207AB82195DF9FB007EFB12 /* RLMMigration.h in Headers */,
+				5D0B26631B54585B00A0DD25 /* RLMLocationTypes.h in Headers */,
 				E856D1FD1956154C00FB2FCF /* RLMObject.h in Headers */,
 				023B19601A3BA90E0067FB81 /* RLMObjectBase.h in Headers */,
 				E856D2001956154C00FB2FCF /* RLMObjectSchema.h in Headers */,
@@ -915,6 +922,7 @@
 				E81A1F921955FC9300FDED82 /* RLMConstants.h in Headers */,
 				023B2B301B28F0CF0021E54D /* object_store_exceptions.hpp in Headers */,
 				0207AB81195DF9FB007EFB12 /* RLMMigration.h in Headers */,
+				5D0B26621B54585B00A0DD25 /* RLMLocationTypes.h in Headers */,
 				E81A1F961955FC9300FDED82 /* RLMObject.h in Headers */,
 				023B195F1A3BA90E0067FB81 /* RLMObjectBase.h in Headers */,
 				E81A1F9A1955FC9300FDED82 /* RLMObjectSchema.h in Headers */,

--- a/Realm/RLMLocationTypes.h
+++ b/Realm/RLMLocationTypes.h
@@ -1,0 +1,27 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2015 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+#import <CoreLocation/CoreLocation.h>
+
+/**
+ A bounding box is rectangle that is represented by coordinates for opposing corners.
+ */
+typedef struct {
+    CLLocationCoordinate2D corner1;
+    CLLocationCoordinate2D corner2;
+} RLMBoundingBox;

--- a/Realm/RLMLocationTypes.h
+++ b/Realm/RLMLocationTypes.h
@@ -16,12 +16,24 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-#import <CoreLocation/CoreLocation.h>
+/**
+ RLMDegrees represents an angle in degrees. It is used to represent latitudes and longitudes,
+ with positive numbers representing North and East, and negative numbers representing South and West.
+ */
+typedef double RLMDegrees;
+
+/**
+ RLMCoordinate2D represents a geographical coordinate.
+ */
+typedef struct {
+    RLMDegrees latitude;
+    RLMDegrees longitude;
+} RLMCoordinate2D;
 
 /**
  A bounding box is rectangle that is represented by coordinates for opposing corners.
  */
 typedef struct {
-    CLLocationCoordinate2D corner1;
-    CLLocationCoordinate2D corner2;
+    RLMCoordinate2D corner1;
+    RLMCoordinate2D corner2;
 } RLMBoundingBox;

--- a/Realm/RLMObject.h
+++ b/Realm/RLMObject.h
@@ -19,6 +19,7 @@
 #import <Foundation/Foundation.h>
 
 #import <Realm/RLMObjectBase.h>
+#import <Realm/RLMLocationTypes.h>
 
 RLM_ASSUME_NONNULL_BEGIN
 
@@ -311,6 +312,17 @@ RLM_ASSUME_NONNULL_BEGIN
  */
 + (nullable instancetype)objectForPrimaryKey:(nullable id)primaryKey;
 
+/**
+ Get objects whose location is within the given bounding box.
+
+ @param box                The bounding box to find objects within.
+ @param latitudeProperty   The property of the object to interpret as the latitude.
+ @param longitudeProperty  The property of the object to interpret as the longitude.
+
+ @return                   An RLMResults of objects of the subclass type in the default Realm whose locations are within the bounding box.
+ */
++ (RLMResults *)objectsWithinBoundingBox:(RLMBoundingBox)box latitudeProperty:(NSString *)latitudeProperty longitudeProperty:(NSString *)longitudeProperty;
+
 
 /**---------------------------------------------------------------------------------------
  *  @name Querying Specific Realms
@@ -359,6 +371,18 @@ RLM_ASSUME_NONNULL_BEGIN
  @see       -primaryKey
  */
 + (nullable instancetype)objectInRealm:(RLMRealm *)realm forPrimaryKey:(nullable id)primaryKey;
+
+/**
+ Get objects whose location is within the given bounding box from the specified Realm.
+
+ @param realm              The Realm instance to query.
+ @param box                The bounding box to find objects within.
+ @param latitudeProperty   The property of the object to interpret as the latitude.
+ @param longitudeProperty  The property of the object to interpret as the longitude.
+
+ @return                   An RLMResults of objects of the subclass type in the specified Realm whose locations are within the bounding box.
+ */
++ (RLMResults *)objectsInRealm:(RLMRealm *)realm withinBoundingBox:(RLMBoundingBox)box latitudeProperty:(NSString *)latitudeProperty longitudeProperty:(NSString *)longitudeProperty;
 
 /**
  Get an `NSArray` of objects of type `className` which have this object as the given property value. This can

--- a/Realm/RLMObject.mm
+++ b/Realm/RLMObject.mm
@@ -145,6 +145,16 @@
     return RLMGetObject(realm, self.className, primaryKey);
 }
 
++ (RLMResults *)objectsWithinBoundingBox:(RLMBoundingBox)box latitudeProperty:(NSString *)latitudeProperty longitudeProperty:(NSString *)longitudeProperty
+{
+    return RLMGetObjectsWithinBoundingBox(RLMRealm.defaultRealm, self.className, box, latitudeProperty, longitudeProperty);
+}
+
++ (RLMResults *)objectsInRealm:(RLMRealm *)realm withinBoundingBox:(RLMBoundingBox)box latitudeProperty:(NSString *)latitudeProperty longitudeProperty:(NSString *)longitudeProperty
+{
+    return RLMGetObjectsWithinBoundingBox(realm, self.className, box, latitudeProperty, longitudeProperty);
+}
+
 - (NSArray *)linkingObjectsOfClass:(NSString *)className forProperty:(NSString *)property {
     return RLMObjectBaseLinkingObjectsOfClass(self, className, property);
 }

--- a/Realm/RLMObjectStore.h
+++ b/Realm/RLMObjectStore.h
@@ -17,6 +17,7 @@
 ////////////////////////////////////////////////////////////////////////////
 
 #import <Foundation/Foundation.h>
+#import <Realm/RLMLocationTypes.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -80,6 +81,9 @@ void RLMDeleteAllObjectsFromRealm(RLMRealm *realm);
 
 // get objects of a given class
 RLMResults *RLMGetObjects(RLMRealm *realm, NSString *objectClassName, NSPredicate *predicate) NS_RETURNS_RETAINED;
+
+RLMResults *RLMGetObjectsWithinBoundingBox(RLMRealm *realm, NSString *objectClassName, RLMBoundingBox box, NSString *latitudePropertyName, NSString *longitudePropertyName) NS_RETURNS_RETAINED;
+
 
 // get an object with the given primary key
 id RLMGetObject(RLMRealm *realm, NSString *objectClassName, id key) NS_RETURNS_RETAINED;

--- a/Realm/RLMObjectStore.mm
+++ b/Realm/RLMObjectStore.mm
@@ -559,6 +559,26 @@ RLMResults *RLMGetObjects(RLMRealm *realm, NSString *objectClassName, NSPredicat
     return [RLMTableResults tableResultsWithObjectSchema:objectSchema realm:realm];
 }
 
+RLMResults *RLMGetObjectsWithinBoundingBox(RLMRealm *realm, NSString *objectClassName, RLMBoundingBox box, NSString *latitudePropertyName, NSString *longitudePropertyName) {
+    RLMCheckThread(realm);
+
+    // create view from table and predicate
+    RLMObjectSchema *objectSchema = realm.schema[objectClassName];
+    if (!objectSchema.table) {
+        // read-only realms may be missing tables since we can't add any
+        // missing ones on init
+        return [RLMEmptyResults emptyResultsWithObjectClassName:objectClassName realm:realm];
+    }
+
+    realm::Query query = objectSchema.table->where();
+    RLMUpdateQueryWithBoundingBoxSearch(&query, box.corner1, box.corner2, latitudePropertyName, longitudePropertyName, realm.schema, objectSchema);
+
+    // create and populate array
+    return [RLMResults resultsWithObjectClassName:objectClassName
+                                            query:std::make_unique<Query>(query)
+                                            realm:realm];
+}
+
 id RLMGetObject(RLMRealm *realm, NSString *objectClassName, id key) {
     RLMCheckThread(realm);
 

--- a/Realm/RLMQueryUtil.hpp
+++ b/Realm/RLMQueryUtil.hpp
@@ -16,6 +16,7 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
+#import <CoreLocation/CoreLocation.h>
 #import <Foundation/Foundation.h>
 #import <vector>
 
@@ -34,6 +35,9 @@ extern NSString * const RLMUnsupportedTypesFoundInPropertyComparisonException;
 // apply the given predicate to the passed in query, returning the updated query
 void RLMUpdateQueryWithPredicate(realm::Query *query, NSPredicate *predicate, RLMSchema *schema,
                                  RLMObjectSchema *objectSchema);
+void RLMUpdateQueryWithBoundingBoxSearch(realm::Query *query, CLLocationCoordinate2D corner1, CLLocationCoordinate2D corner2,
+                                         NSString *latitudePropertyName, NSString *longitudePropertyName,
+                                         RLMSchema *schema, RLMObjectSchema *objectSchema);
 
 // return column index - throw for invalid column name
 NSUInteger RLMValidatedColumnIndex(RLMObjectSchema *schema, NSString *columnName);

--- a/Realm/RLMQueryUtil.hpp
+++ b/Realm/RLMQueryUtil.hpp
@@ -16,8 +16,8 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-#import <CoreLocation/CoreLocation.h>
 #import <Foundation/Foundation.h>
+#import <Realm/RLMLocationTypes.h>
 #import <vector>
 
 namespace realm {
@@ -35,7 +35,7 @@ extern NSString * const RLMUnsupportedTypesFoundInPropertyComparisonException;
 // apply the given predicate to the passed in query, returning the updated query
 void RLMUpdateQueryWithPredicate(realm::Query *query, NSPredicate *predicate, RLMSchema *schema,
                                  RLMObjectSchema *objectSchema);
-void RLMUpdateQueryWithBoundingBoxSearch(realm::Query *query, CLLocationCoordinate2D corner1, CLLocationCoordinate2D corner2,
+void RLMUpdateQueryWithBoundingBoxSearch(realm::Query *query, RLMCoordinate2D corner1, RLMCoordinate2D corner2,
                                          NSString *latitudePropertyName, NSString *longitudePropertyName,
                                          RLMSchema *schema, RLMObjectSchema *objectSchema);
 

--- a/Realm/RLMQueryUtil.mm
+++ b/Realm/RLMQueryUtil.mm
@@ -837,7 +837,7 @@ RLMProperty *RLMValidatedPropertyForSort(RLMObjectSchema *schema, NSString *prop
     return prop;
 }
 
-void validate_parameters_for_bounding_box_search(CLLocationCoordinate2D corner1, CLLocationCoordinate2D corner2,
+void validate_parameters_for_bounding_box_search(RLMCoordinate2D corner1, RLMCoordinate2D corner2,
                                                  NSString *latitudePropertyName, NSString *longitudePropertyName,
                                                  RLMObjectSchema *objectSchema)
 {
@@ -879,14 +879,14 @@ void RLMUpdateQueryWithPredicate(realm::Query *query, NSPredicate *predicate, RL
                     (int)validateMessage.size(), validateMessage.c_str());
 }
 
-void RLMUpdateQueryWithBoundingBoxSearch(realm::Query *query, CLLocationCoordinate2D corner1, CLLocationCoordinate2D corner2,
+void RLMUpdateQueryWithBoundingBoxSearch(realm::Query *query, RLMCoordinate2D corner1, RLMCoordinate2D corner2,
                                          NSString *latitudePropertyName, NSString *longitudePropertyName,
                                          RLMSchema *schema, RLMObjectSchema *objectSchema)
 {
     validate_parameters_for_bounding_box_search(corner1, corner2, latitudePropertyName, longitudePropertyName, objectSchema);
 
-    CLLocationCoordinate2D bottomLeft = { std::min(corner1.latitude, corner2.latitude), std::min(corner1.longitude, corner2.longitude) };
-    CLLocationCoordinate2D topRight = { std::max(corner1.latitude, corner2.latitude), std::max(corner1.longitude, corner2.longitude) };
+    RLMCoordinate2D bottomLeft = { std::min(corner1.latitude, corner2.latitude), std::min(corner1.longitude, corner2.longitude) };
+    RLMCoordinate2D topRight = { std::max(corner1.latitude, corner2.latitude), std::max(corner1.longitude, corner2.longitude) };
 
     NSPredicate *latitudePredicate = [NSPredicate predicateWithFormat:@"%K BETWEEN {%f, %f}", latitudePropertyName, bottomLeft.latitude, topRight.latitude];
     // The coordinate pair represents two possible boxes due to the discontinuity in longitudes at the 180th meridian.

--- a/Realm/RLMResults.h
+++ b/Realm/RLMResults.h
@@ -19,6 +19,7 @@
 #import <Foundation/Foundation.h>
 #import <Realm/RLMCollection.h>
 #import <Realm/RLMDefines.h>
+#import <Realm/RLMLocationTypes.h>
 
 RLM_ASSUME_NONNULL_BEGIN
 
@@ -143,6 +144,17 @@ RLM_ASSUME_NONNULL_BEGIN
  @return            An RLMResults of objects that match the given predicate
  */
 - (RLMResults *)objectsWithPredicate:(NSPredicate *)predicate;
+
+/**
+ Get objects whose location is within the given bounding box.
+
+ @param box                The bounding box to find objects within.
+ @param latitudeProperty   The property of the object to interpret as the latitude.
+ @param longitudeProperty  The property of the object to interpret as the longitude.
+
+ @return                   An RLMResults of objects whose locations are within the bounding box.
+ */
+- (RLMResults *)objectsWithinBoundingBox:(RLMBoundingBox)box latitudeProperty:(NSString *)latitudeProperty longitudeProperty:(NSString *)longitudeProperty;
 
 /**
  Get a sorted `RLMResults` from an existing `RLMResults` sorted by a property.

--- a/Realm/RLMResults.mm
+++ b/Realm/RLMResults.mm
@@ -300,6 +300,19 @@ static RowIndexes::Sorter RLMSorterFromDescriptors(RLMObjectSchema *schema, NSAr
                                             realm:_realm];
 }
 
+- (RLMResults *)objectsWithinBoundingBox:(RLMBoundingBox)box latitudeProperty:(NSString *)latitudeProperty longitudeProperty:(NSString *)longitudeProperty
+{
+    RLMCheckThread(_realm);
+
+    // copy array and apply new predicate creating a new query and view
+    auto query = [self cloneQuery];
+    RLMUpdateQueryWithBoundingBoxSearch(query.get(), box.corner1, box.corner2, latitudeProperty, longitudeProperty, _realm.schema, _realm.schema[self.objectClassName]);
+    return [RLMResults resultsWithObjectClassName:self.objectClassName
+                                            query:move(query)
+                                             sort:_sortOrder
+                                            realm:_realm];
+}
+
 - (RLMResults *)sortedResultsUsingProperty:(NSString *)property ascending:(BOOL)ascending {
     return [self sortedResultsUsingDescriptors:@[[RLMSortDescriptor sortDescriptorWithProperty:property ascending:ascending]]];
 }

--- a/Realm/Tests/RLMTestObjects.h
+++ b/Realm/Tests/RLMTestObjects.h
@@ -271,3 +271,11 @@ RLM_ARRAY_TYPE(CircleObject);
 
 @interface FakeObject : NSObject
 @end
+
+#pragma mark LocationObject
+
+@interface LocationObject : RLMObject
+@property NSString *name;
+@property double latitude;
+@property double longitude;
+@end

--- a/Realm/Tests/RLMTestObjects.m
+++ b/Realm/Tests/RLMTestObjects.m
@@ -171,3 +171,8 @@
 + (NSString *)primaryKey { return nil; }
 + (NSArray *)requiredProperties { return nil; }
 @end
+
+#pragma mark LocationObject
+
+@implementation LocationObject
+@end

--- a/RealmSwift/Results.swift
+++ b/RealmSwift/Results.swift
@@ -19,6 +19,8 @@
 import Foundation
 import Realm
 
+public typealias BoundingBox = RLMBoundingBox
+
 // MARK: MinMaxType
 
 /// Types which can be used for min()/max().
@@ -198,6 +200,19 @@ public final class Results<T: Object>: ResultsBase {
     */
     public func filter(predicate: NSPredicate) -> Results<T> {
         return Results<T>(rlmResults.objectsWithPredicate(predicate))
+    }
+
+    /**
+    Filters the results to the objects whose location is within the given bounding box.
+
+    :param: boundingBox        The bounding box to find objects within.
+    :param: latitudeProperty   The property of the object to interpret as the latitude.
+    :param: longitudeProperty  The property of the object to interpret as the longitude.
+
+    :returns: Results containing objects that are within the given bounding box.
+    */
+    public func filter(withinBoundingBox boundingBox: BoundingBox, latitudeProperty: String, longitudeProperty: String) -> Results<T> {
+        return Results<T>(rlmResults.objectsWithinBoundingBox(boundingBox, latitudeProperty: latitudeProperty, longitudeProperty: longitudeProperty))
     }
 
     // MARK: Sorting

--- a/RealmSwift/Results.swift
+++ b/RealmSwift/Results.swift
@@ -19,6 +19,7 @@
 import Foundation
 import Realm
 
+public typealias Coordinate2D = RLMCoordinate2D
 public typealias BoundingBox = RLMBoundingBox
 
 // MARK: MinMaxType

--- a/RealmSwift/Tests/ResultsTests.swift
+++ b/RealmSwift/Tests/ResultsTests.swift
@@ -18,6 +18,7 @@
 
 import XCTest
 import RealmSwift
+import CoreLocation
 
 class SwiftAggregateObjectList: Object {
     let list = List<SwiftAggregateObject>()
@@ -325,5 +326,31 @@ class ResultsFromLinkViewTests: ResultsTests {
         realmWithTestPath().add(list)
         list.list.extend(makeAggregateableObjects())
         return list.list.filter("intCol != 0") // i.e. all of them
+    }
+}
+
+class LocationResultsTests {
+    func testBoundingBoxQueries() {
+        Realm().write {
+            Realm().create(SwiftLocationObject.self, value: [ "Angel Stadium of Anaheim", 33.800278, -117.882778 ])
+            Realm().create(SwiftLocationObject.self, value: [ "AT&T Park", 37.778611, -122.389167 ]);
+            Realm().create(SwiftLocationObject.self, value: [ "Busch Stadium", 38.6225, -90.193056 ]);
+            Realm().create(SwiftLocationObject.self, value: [ "Chase Field", 33.445278, -112.066944 ]);
+            Realm().create(SwiftLocationObject.self, value: [ "Citi Field", 40.756944, -73.845833 ]);
+            Realm().create(SwiftLocationObject.self, value: [ "Citizens Bank Park", 39.905833, -75.166389 ]);
+        }
+
+        let anaheimToPhoenix = BoundingBox(corner1: CLLocationCoordinate2D(latitude: 33.3, longitude: -118), corner2: CLLocationCoordinate2D(latitude: 34, longitude: -112))
+        var results = Realm().objects(SwiftLocationObject).filter(withinBoundingBox: anaheimToPhoenix, latitudeProperty: "latitude", longitudeProperty: "longitude")
+        results = results.sorted("name", ascending: true)
+        XCTAssertEqual(results.count, 2);
+        XCTAssertEqual(results[0].name, "Angel Stadium of Anaheim");
+        XCTAssertEqual(results[1].name, "Chase Field");
+
+        // Chained queries.
+        results = Realm().objects(SwiftLocationObject).filter("name BEGINSWITH 'Chase'").filter(withinBoundingBox: anaheimToPhoenix, latitudeProperty: "latitude", longitudeProperty: "longitude")
+        XCTAssertEqual(results.count, 1);
+        XCTAssertEqual(results[0].name, "Chase Field");
+
     }
 }

--- a/RealmSwift/Tests/ResultsTests.swift
+++ b/RealmSwift/Tests/ResultsTests.swift
@@ -18,7 +18,6 @@
 
 import XCTest
 import RealmSwift
-import CoreLocation
 
 class SwiftAggregateObjectList: Object {
     let list = List<SwiftAggregateObject>()
@@ -340,7 +339,7 @@ class LocationResultsTests {
             Realm().create(SwiftLocationObject.self, value: [ "Citizens Bank Park", 39.905833, -75.166389 ]);
         }
 
-        let anaheimToPhoenix = BoundingBox(corner1: CLLocationCoordinate2D(latitude: 33.3, longitude: -118), corner2: CLLocationCoordinate2D(latitude: 34, longitude: -112))
+        let anaheimToPhoenix = BoundingBox(corner1: Coordinate2D(latitude: 33.3, longitude: -118), corner2: Coordinate2D(latitude: 34, longitude: -112))
         var results = Realm().objects(SwiftLocationObject).filter(withinBoundingBox: anaheimToPhoenix, latitudeProperty: "latitude", longitudeProperty: "longitude")
         results = results.sorted("name", ascending: true)
         XCTAssertEqual(results.count, 2);

--- a/RealmSwift/Tests/ResultsTests.swift
+++ b/RealmSwift/Tests/ResultsTests.swift
@@ -328,28 +328,28 @@ class ResultsFromLinkViewTests: ResultsTests {
     }
 }
 
-class LocationResultsTests {
+class LocationResultsTests : TestCase {
     func testBoundingBoxQueries() {
         Realm().write {
             Realm().create(SwiftLocationObject.self, value: [ "Angel Stadium of Anaheim", 33.800278, -117.882778 ])
-            Realm().create(SwiftLocationObject.self, value: [ "AT&T Park", 37.778611, -122.389167 ]);
-            Realm().create(SwiftLocationObject.self, value: [ "Busch Stadium", 38.6225, -90.193056 ]);
-            Realm().create(SwiftLocationObject.self, value: [ "Chase Field", 33.445278, -112.066944 ]);
-            Realm().create(SwiftLocationObject.self, value: [ "Citi Field", 40.756944, -73.845833 ]);
-            Realm().create(SwiftLocationObject.self, value: [ "Citizens Bank Park", 39.905833, -75.166389 ]);
+            Realm().create(SwiftLocationObject.self, value: [ "AT&T Park", 37.778611, -122.389167 ])
+            Realm().create(SwiftLocationObject.self, value: [ "Busch Stadium", 38.6225, -90.193056 ])
+            Realm().create(SwiftLocationObject.self, value: [ "Chase Field", 33.445278, -112.066944 ])
+            Realm().create(SwiftLocationObject.self, value: [ "Citi Field", 40.756944, -73.845833 ])
+            Realm().create(SwiftLocationObject.self, value: [ "Citizens Bank Park", 39.905833, -75.166389 ])
         }
 
         let anaheimToPhoenix = BoundingBox(corner1: Coordinate2D(latitude: 33.3, longitude: -118), corner2: Coordinate2D(latitude: 34, longitude: -112))
         var results = Realm().objects(SwiftLocationObject).filter(withinBoundingBox: anaheimToPhoenix, latitudeProperty: "latitude", longitudeProperty: "longitude")
         results = results.sorted("name", ascending: true)
-        XCTAssertEqual(results.count, 2);
-        XCTAssertEqual(results[0].name, "Angel Stadium of Anaheim");
-        XCTAssertEqual(results[1].name, "Chase Field");
+        XCTAssertEqual(results.count, 2)
+        XCTAssertEqual(results[0].name, "Angel Stadium of Anaheim")
+        XCTAssertEqual(results[1].name, "Chase Field")
 
         // Chained queries.
         results = Realm().objects(SwiftLocationObject).filter("name BEGINSWITH 'Chase'").filter(withinBoundingBox: anaheimToPhoenix, latitudeProperty: "latitude", longitudeProperty: "longitude")
-        XCTAssertEqual(results.count, 1);
-        XCTAssertEqual(results[0].name, "Chase Field");
+        XCTAssertEqual(results.count, 1)
+        XCTAssertEqual(results[0].name, "Chase Field")
 
     }
 }

--- a/RealmSwift/Tests/SwiftTestObjects.swift
+++ b/RealmSwift/Tests/SwiftTestObjects.swift
@@ -175,3 +175,9 @@ class SwiftIndexedPropertiesObject: Object {
         return ["stringCol"] // Add "intCol" when integer indexing is supported
     }
 }
+
+class SwiftLocationObject: Object {
+    dynamic var name = ""
+    dynamic var latitude = 0 as Double
+    dynamic var longitude = 0 as Double
+}


### PR DESCRIPTION
A few outstanding points:
* Does it make sense to add these methods directly on `RLMObject` / `RLMResults`? Since internally they just build `NSPredicate` they could be exposed as functions that produce `NSPredicate`. Alternatively, they could live in separate location-related categories on `RLMObject` / `RLMResults`?
* Is it reasonable to use CoreLocation's coordinate type in our API, or should we define our own?
* What should a Swift API look like? Querying in our Swift API is currently via a single `filter` method. There's no obvious extrapolation like there is with the Objective-C API.