### PR TITLE
Guarantee 64 bit integer precision for dates even on 32-bit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ x.xx.x Release notes (yyyy-MM-dd)
   requires 64 bits to represent with a CPU that supports SSE 4.2.
 * An exception will no longer be thrown when attempt to reset the schema version or
   encryption key on an open Realm to the current value.
+* Date properties on 32 bit devices will retain 64 bit second precision.
 
 0.93.2 Release notes (2015-06-12)
 =============================================================

--- a/Realm/RLMAccessor.mm
+++ b/Realm/RLMAccessor.mm
@@ -140,7 +140,7 @@ static inline NSDate *RLMGetDate(__unsafe_unretained RLMObjectBase *const obj, N
 }
 static inline void RLMSetValue(__unsafe_unretained RLMObjectBase *const obj, NSUInteger colIndex, __unsafe_unretained NSDate *const date) {
     RLMVerifyInWriteTransaction(obj);
-    std::time_t time = date.timeIntervalSince1970;
+    int64_t time = date.timeIntervalSince1970;
     obj->_row.set_datetime(colIndex, realm::DateTime(time));
 }
 
@@ -298,7 +298,7 @@ static inline void RLMSetValue(__unsafe_unretained RLMObjectBase *const obj, NSU
         return;
     }
     if (NSDate *date = RLMDynamicCast<NSDate>(val)) {
-        obj->_row.set_mixed(col_ndx, realm::DateTime(time_t([date timeIntervalSince1970])));
+        obj->_row.set_mixed(col_ndx, realm::DateTime(int64_t([date timeIntervalSince1970])));
         return;
     }
     if (NSData *data = RLMDynamicCast<NSData>(val)) {

--- a/Realm/RLMQueryUtil.mm
+++ b/Realm/RLMQueryUtil.mm
@@ -678,8 +678,6 @@ void update_query_with_column_expression(RLMObjectSchema *scheme, Query &query,
             query.and_query(column_expression<Double>(type, leftIndex, rightIndex, table));
             break;
         case type_DateTime:
-            // FIXME: int64_t should be DateTime but that doesn't work on 32 bit
-            // FIXME: as time_t(32bit) != time_t(64bit)
             query.and_query(column_expression<int64_t>(type, leftIndex, rightIndex, table));
             break;
         case type_String: {

--- a/Realm/Tests/ObjectTests.m
+++ b/Realm/Tests/ObjectTests.m
@@ -606,6 +606,27 @@ RLM_ARRAY_TYPE(PrimaryEmployeeObject);
     [realm commitWriteTransaction];
 }
 
+- (void)testDatePrecisionPreservation
+{
+    DateObject *dateObject = [[DateObject alloc] initWithValue:@[NSDate.distantFuture]];
+    RLMRealm *realm = [RLMRealm defaultRealm];
+    [realm beginWriteTransaction];
+    [realm addObject:dateObject];
+    [realm commitWriteTransaction];
+    XCTAssertEqualObjects(NSDate.distantFuture, dateObject.dateCol);
+
+    [realm beginWriteTransaction];
+    NSDate *date = ({
+        NSDateComponents *components = [[NSCalendar currentCalendar] components:NSCalendarUnitMonth|NSCalendarUnitYear|NSCalendarUnitDay fromDate:NSDate.date];
+        components.calendar = [NSCalendar currentCalendar];
+        components.year += 50000;
+        components.date;
+    });
+    dateObject.dateCol = date;
+    [realm commitWriteTransaction];
+    XCTAssertEqualObjects(date, dateObject.dateCol);
+}
+
 - (void)testDataSizeLimits {
     RLMRealm *realm = [RLMRealm defaultRealm];
 


### PR DESCRIPTION
See https://github.com/realm/realm-cocoa/pull/2154.
Closes https://github.com/realm/realm-cocoa/issues/2152.

\c @tgoyne @bdash 