### PR TITLE
Disable syncing to disk for everything but running on device

### DIFF
--- a/Realm/Tests/RLMTestCase.m
+++ b/Realm/Tests/RLMTestCase.m
@@ -87,12 +87,12 @@ static BOOL encryptTests() {
 
 @implementation RLMTestCase
 
-#if DEBUG
+#if DEBUG || !TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR
 + (void)setUp {
     [super setUp];
     // Disable actually syncing anything to the disk to greatly speed up the
-    // tests, but only in debug mode because it can't be re-enabled and we need
-    // it enabled for performance tests
+    // tests, but only when not running on device because it can't be
+    // re-enabled and we need it enabled for performance tests
     RLMDisableSyncToDisk();
 }
 #endif

--- a/RealmSwift-swift1.2/Tests/TestCase.swift
+++ b/RealmSwift-swift1.2/Tests/TestCase.swift
@@ -31,11 +31,11 @@ class TestCase: XCTestCase {
 
     override class func setUp() {
         super.setUp()
-#if DEBUG
+#if DEBUG || arch(i386) || arch(x86_64)
         // Disable actually syncing anything to the disk to greatly speed up the
-        // tests, but only in debug mode because it can't be re-enabled and we need
-        // it enabled for performance tests
-        RLMDisableSyncToDisk();
+        // tests, but only when not running on device because it can't be
+        // re-enabled and we need it enabled for performance tests
+        RLMDisableSyncToDisk()
 #endif
     }
 

--- a/RealmSwift-swift2.0/Tests/TestCase.swift
+++ b/RealmSwift-swift2.0/Tests/TestCase.swift
@@ -31,11 +31,11 @@ class TestCase: XCTestCase {
 
     override class func setUp() {
         super.setUp()
-#if DEBUG
+#if DEBUG || arch(i386) || arch(x86_64)
         // Disable actually syncing anything to the disk to greatly speed up the
-        // tests, but only in debug mode because it can't be re-enabled and we need
-        // it enabled for performance tests
-        RLMDisableSyncToDisk();
+        // tests, but only when not running on device because it can't be
+        // re-enabled and we need it enabled for performance tests
+        RLMDisableSyncToDisk()
 #endif
     }
 


### PR DESCRIPTION
Should save about three minutes of worker time on the CI PR runs.