### PR TITLE
[Podspec] Use pod_target_xcconfig to set C++ standard

### DIFF
--- a/Realm.podspec
+++ b/Realm.podspec
@@ -38,7 +38,7 @@ Pod::Spec.new do |s|
   s.prepare_command         = 'sh build.sh cocoapods-setup'
   s.source_files            = 'Realm/*.{m,mm}', 'Realm/ObjectStore/*.cpp'
   s.header_mappings_dir     = 'include'
-  s.xcconfig                = { 'CLANG_CXX_LANGUAGE_STANDARD' => 'compiler-default',
+  s.pod_target_xcconfig     = { 'CLANG_CXX_LANGUAGE_STANDARD' => 'compiler-default',
                                 'OTHER_CPLUSPLUSFLAGS' => '-std=c++1y $(inherited)' }
   s.preserve_paths          = %w(build.sh)
 


### PR DESCRIPTION
Fixes #2053. Fixes #2365.
Can be merged once we decide that the adoption of CocoaPods' version 0.38 has reached a point, that we can take it as required. As long this branch may be used via the Podfile in case of conflicts with the user targets C++ standard.