### PR TITLE
Split "Set Swift Version" into iOS and OS X versions

### DIFF
--- a/Realm.xcodeproj/project.pbxproj
+++ b/Realm.xcodeproj/project.pbxproj
@@ -7,15 +7,26 @@
 	objects = {
 
 /* Begin PBXAggregateTarget section */
-		C04B4BD71B55C47600FAE58E /* Set Swift Version */ = {
+		C04B4BD71B55C47600FAE58E /* Set Swift Version iOS */ = {
 			isa = PBXAggregateTarget;
-			buildConfigurationList = C04B4BDA1B55C47600FAE58E /* Build configuration list for PBXAggregateTarget "Set Swift Version" */;
+			buildConfigurationList = C04B4BDA1B55C47600FAE58E /* Build configuration list for PBXAggregateTarget "Set Swift Version iOS" */;
 			buildPhases = (
 				C04B4BDB1B55C47A00FAE58E /* Set Swift Version */,
 			);
 			dependencies = (
 			);
-			name = "Set Swift Version";
+			name = "Set Swift Version iOS";
+			productName = "Swift Version";
+		};
+		E8DFDD8F1B5EAA3100282424 /* Set Swift Version OSX */ = {
+			isa = PBXAggregateTarget;
+			buildConfigurationList = E8DFDD911B5EAA3100282424 /* Build configuration list for PBXAggregateTarget "Set Swift Version OSX" */;
+			buildPhases = (
+				E8DFDD901B5EAA3100282424 /* Set Swift Version */,
+			);
+			dependencies = (
+			);
+			name = "Set Swift Version OSX";
 			productName = "Swift Version";
 		};
 /* End PBXAggregateTarget section */
@@ -448,13 +459,6 @@
 			remoteGlobalIDString = C04B4BD71B55C47600FAE58E;
 			remoteInfo = "Swift Version";
 		};
-		C06EFEAB1B582746009A3D8B /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = E8D89B8F1955FC6D00CF2B9A /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = C04B4BD71B55C47600FAE58E;
-			remoteInfo = "Set Swift Version";
-		};
 		E81A20081955FE3B00FDED82 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = E8D89B8F1955FC6D00CF2B9A /* Project object */;
@@ -482,6 +486,13 @@
 			proxyType = 1;
 			remoteGlobalIDString = E8D89B971955FC6D00CF2B9A;
 			remoteInfo = Realm;
+		};
+		E8DFDD941B5EAA5600282424 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = E8D89B8F1955FC6D00CF2B9A /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = E8DFDD8F1B5EAA3100282424;
+			remoteInfo = "Set Swift Version OSX";
 		};
 /* End PBXContainerItemProxy section */
 
@@ -1266,7 +1277,7 @@
 			buildRules = (
 			);
 			dependencies = (
-				C06EFEAC1B582746009A3D8B /* PBXTargetDependency */,
+				E8DFDD951B5EAA5600282424 /* PBXTargetDependency */,
 				E8D89BA61955FC6D00CF2B9A /* PBXTargetDependency */,
 				E81A20091955FE3B00FDED82 /* PBXTargetDependency */,
 				E88AAAF1195603B700AA2020 /* PBXTargetDependency */,
@@ -1339,7 +1350,8 @@
 				3F8DCA5619930F550008BD7F /* iOS Device Tests */,
 				144C2F3D1B3D33D0005C8F81 /* watchOS */,
 				3F1A5E711992EB7400F45F4C /* TestHost */,
-				C04B4BD71B55C47600FAE58E /* Set Swift Version */,
+				C04B4BD71B55C47600FAE58E /* Set Swift Version iOS */,
+				E8DFDD8F1B5EAA3100282424 /* Set Swift Version OSX */,
 			);
 		};
 /* End PBXProject section */
@@ -1483,6 +1495,20 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "sh build.sh download-core";
+		};
+		E8DFDD901B5EAA3100282424 /* Set Swift Version */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Set Swift Version";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "sh build.sh set-swift-version";
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -1796,23 +1822,18 @@
 		};
 		C04B4BDD1B55C51500FAE58E /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = C04B4BD71B55C47600FAE58E /* Set Swift Version */;
+			target = C04B4BD71B55C47600FAE58E /* Set Swift Version iOS */;
 			targetProxy = C04B4BDC1B55C51500FAE58E /* PBXContainerItemProxy */;
 		};
 		C04B4BDF1B55C51C00FAE58E /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = C04B4BD71B55C47600FAE58E /* Set Swift Version */;
+			target = C04B4BD71B55C47600FAE58E /* Set Swift Version iOS */;
 			targetProxy = C04B4BDE1B55C51C00FAE58E /* PBXContainerItemProxy */;
 		};
 		C04B4BE11B55C52100FAE58E /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = C04B4BD71B55C47600FAE58E /* Set Swift Version */;
+			target = C04B4BD71B55C47600FAE58E /* Set Swift Version iOS */;
 			targetProxy = C04B4BE01B55C52100FAE58E /* PBXContainerItemProxy */;
-		};
-		C06EFEAC1B582746009A3D8B /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = C04B4BD71B55C47600FAE58E /* Set Swift Version */;
-			targetProxy = C06EFEAB1B582746009A3D8B /* PBXContainerItemProxy */;
 		};
 		E81A20091955FE3B00FDED82 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -1833,6 +1854,11 @@
 			isa = PBXTargetDependency;
 			target = E8D89B971955FC6D00CF2B9A /* OSX */;
 			targetProxy = E8D89BA51955FC6D00CF2B9A /* PBXContainerItemProxy */;
+		};
+		E8DFDD951B5EAA5600282424 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = E8DFDD8F1B5EAA3100282424 /* Set Swift Version OSX */;
+			targetProxy = E8DFDD941B5EAA5600282424 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -2136,7 +2162,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = "";
-				SUPPORTED_PLATFORMS = "macosx iphoneos iphonesimulator";
+				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
 			};
 			name = Debug;
 		};
@@ -2146,7 +2172,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = "";
-				SUPPORTED_PLATFORMS = "macosx iphoneos iphonesimulator";
+				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
 			};
 			name = Release;
 		};
@@ -2479,6 +2505,24 @@
 			};
 			name = Release;
 		};
+		E8DFDD921B5EAA3100282424 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				PRODUCT_NAME = "Set Swift Version OSX";
+				SDKROOT = "";
+				SUPPORTED_PLATFORMS = macosx;
+			};
+			name = Debug;
+		};
+		E8DFDD931B5EAA3100282424 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				PRODUCT_NAME = "Set Swift Version OSX";
+				SDKROOT = "";
+				SUPPORTED_PLATFORMS = macosx;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -2527,7 +2571,7 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		C04B4BDA1B55C47600FAE58E /* Build configuration list for PBXAggregateTarget "Set Swift Version" */ = {
+		C04B4BDA1B55C47600FAE58E /* Build configuration list for PBXAggregateTarget "Set Swift Version iOS" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				C04B4BD81B55C47600FAE58E /* Debug */,
@@ -2577,6 +2621,15 @@
 			buildConfigurations = (
 				E8D89BB21955FC6D00CF2B9A /* Debug */,
 				E8D89BB31955FC6D00CF2B9A /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		E8DFDD911B5EAA3100282424 /* Build configuration list for PBXAggregateTarget "Set Swift Version OSX" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				E8DFDD921B5EAA3100282424 /* Debug */,
+				E8DFDD931B5EAA3100282424 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;


### PR DESCRIPTION
This fixes an issue in `Realm.xcodeproj` where iOS destinations were available for OS X targets and vice-versa. /cc @segiddins @alazier 