### PR TITLE
[Realm Browser Plugin] Add Sanity check to alert user when more than file is being opened

### DIFF
--- a/plugin/RealmPlugin/RLMPRealmPlugin.m
+++ b/plugin/RealmPlugin/RLMPRealmPlugin.m
@@ -147,12 +147,31 @@ static NSArray * RLMPGlobFilesAtDirectoryURLWithPredicate(NSFileManager *fileMan
     
     NSDictionary *configuration = @{ NSWorkspaceLaunchConfigurationArguments : arguments };
     
+    // Show confirmation alert if 2 or more files are detected
+    if (arguments.count > 1) {
+        NSAlert *alert = [[NSAlert alloc] init];
+        [alert setMessageText:@"Realm Browser"];
+        [alert setInformativeText:[NSString stringWithFormat:@"%ld Realm files are detected. Are you sure to open them at once?", arguments.count]];
+        [alert setAlertStyle:NSInformationalAlertStyle];
+        [alert addButtonWithTitle:@"OK"];
+        [alert addButtonWithTitle:@"Cancel"];
+        [alert beginSheetModalForWindow:[NSApp mainWindow] completionHandler:^(NSModalResponse returnCode) {
+            if (returnCode == NSAlertFirstButtonReturn) {
+                [self openRealmBrowserWithConfiguration:configuration];
+            }
+        }];
+    } else {
+        [self openRealmBrowserWithConfiguration:configuration];
+    }
+}
+
+- (void)openRealmBrowserWithConfiguration:(NSDictionary *)configuration
+{
     NSError *error;
     if (![[NSWorkspace sharedWorkspace] launchApplicationAtURL:self.browserUrl options:NSWorkspaceLaunchNewInstance configuration:configuration error:&error]) {
         // This will happen if the Browser was present at Xcode launch and then was deleted
         [self showError:error];
     }
-    
 }
 
 - (NSArray *)realmFilesURLWithDeviceUUID:(NSString *)deviceUUID


### PR DESCRIPTION
This PR is a sequel from #2171. As suggested that, plugin should at least warn user in the case where 2 or more files are detected and about to open. This PR aims to fix this.

@TimOliver, I were trying several things, but I got no luck. :crying_cat_face: 

Using `[[NSWorkspace sharedWorkspace] launchApplicationAtURL:self.browserUrl options:0 configuration:configuration error:&error]`. or replacing with `options:NSWorkspaceLaunchDefault` seems to work, but it fails to open Realm File on the subsequent runs (meaning that closing the Realm file window without quitting the Realm Browser and go to File > Open Realm ... in order to open Browser with Realm file again)

I am not familiar enough with Apple Script so unfortunately I couldn't make the `[NSWorkspace openURLs:withAppBundleIdentifier:options:additionalEventParamDescriptor:launchIdentifiers:]` to work. 
:(

So, I decided that to the least having a check from plugin's standpoint is doable from my side. I went ahead and implemented those quickly in this PR. If you have a smarter way for this, I am all ears.