### PR TITLE
Erase all available simulators when prelaunching

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -326,10 +326,23 @@ case "$COMMAND" in
     "prelaunch-simulator")
         killall "iOS Simulator" 2>/dev/null || true
         killall Simulator 2>/dev/null || true
+        # Erase all available simulators
+        (
+            IFS=$'\n' # make newlines the only separator
+            for LINE in $(xcrun simctl list); do
+                if [[ $LINE =~ unavailable ]]; then
+                    # skip unavailable simulators
+                    continue
+                fi
+                if [[ $LINE =~ ([0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}) ]]; then
+                    xcrun simctl erase "${BASH_REMATCH[1]}" 2>/dev/null || true
+                fi
+            done
+        )
         if [[ -a "${DEVELOPER_DIR}/Applications/iOS Simulator.app" ]]; then
-          open "${DEVELOPER_DIR}/Applications/iOS Simulator.app"
+            open "${DEVELOPER_DIR}/Applications/iOS Simulator.app"
         elif [[ -a "${DEVELOPER_DIR}/Applications/Simulator.app" ]]; then
-          open "${DEVELOPER_DIR}/Applications/Simulator.app"
+            open "${DEVELOPER_DIR}/Applications/Simulator.app"
         fi
         ;;
 

--- a/examples/installation/build.sh
+++ b/examples/installation/build.sh
@@ -31,6 +31,19 @@ COMMAND="$1"
 prelaunch_simulator() {
     killall "iOS Simulator" 2>/dev/null || true
     killall Simulator 2>/dev/null || true
+    # Erase all available simulators
+    (
+        IFS=$'\n' # make newlines the only separator
+        for LINE in $(xcrun simctl list); do
+            if [[ $LINE =~ unavailable ]]; then
+                # skip unavailable simulators
+                continue
+            fi
+            if [[ $LINE =~ ([0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}) ]]; then
+                xcrun simctl erase "${BASH_REMATCH[1]}" 2>/dev/null || true
+            fi
+        done
+    )
     if [[ -a "${DEVELOPER_DIR}/Applications/iOS Simulator.app" ]]; then
         open "${DEVELOPER_DIR}/Applications/iOS Simulator.app"
     elif [[ -a "${DEVELOPER_DIR}/Applications/Simulator.app" ]]; then


### PR DESCRIPTION
This should hopefully resolve issues on CI where the iOS Simulator doesn't boot when switching between Xcode 6 and Xcode 7. /cc @segiddins 