### PR TITLE
[RLMTestCase] Ensure waitForNotification has an autoreleasepool

### DIFF
--- a/Realm/Tests/RLMTestCase.m
+++ b/Realm/Tests/RLMTestCase.m
@@ -149,15 +149,20 @@ static BOOL encryptTests() {
 
 - (void)waitForNotification:(NSString *)expectedNote realm:(RLMRealm *)realm block:(dispatch_block_t)block {
     XCTestExpectation *notificationFired = [self expectationWithDescription:@"notification fired"];
-    RLMNotificationToken *token = [realm addNotificationBlock:^(__unused NSString *note, RLMRealm *realm) {
+    RLMNotificationToken *token = [realm addNotificationBlock:^(NSString *note, RLMRealm *realm) {
+        XCTAssertNotNil(note, @"Note should not be nil");
         XCTAssertNotNil(realm, @"Realm should not be nil");
-        if (note == expectedNote) {
+        if ([note isEqualToString:expectedNote]) {
             [notificationFired fulfill];
         }
     }];
 
     dispatch_queue_t queue = dispatch_queue_create("background", 0);
-    dispatch_async(queue, block);
+    dispatch_async(queue, ^{
+        @autoreleasepool {
+            block();
+        }
+    });
 
     [self waitForExpectationsWithTimeout:2.0 handler:nil];
 


### PR DESCRIPTION
Might alleviate issues with testAutorefreshAfterBackgroundUpdate hanging

\c @jpsim 