### PR TITLE
attempt to fix issues with launching simulators from different Xcodes

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -326,6 +326,7 @@ case "$COMMAND" in
     "prelaunch-simulator")
         killall "iOS Simulator" 2>/dev/null || true
         killall Simulator 2>/dev/null || true
+        pkill CoreSimulator 2>/dev/null || true
         # Erase all available simulators
         (
             IFS=$'\n' # make newlines the only separator
@@ -339,11 +340,13 @@ case "$COMMAND" in
                 fi
             done
         )
+        sleep 5
         if [[ -a "${DEVELOPER_DIR}/Applications/iOS Simulator.app" ]]; then
             open "${DEVELOPER_DIR}/Applications/iOS Simulator.app"
         elif [[ -a "${DEVELOPER_DIR}/Applications/Simulator.app" ]]; then
             open "${DEVELOPER_DIR}/Applications/Simulator.app"
         fi
+        sleep 5
         ;;
 
     ######################################

--- a/examples/installation/build.sh
+++ b/examples/installation/build.sh
@@ -33,6 +33,7 @@ COMMAND="$1"
 prelaunch_simulator() {
     killall "iOS Simulator" 2>/dev/null || true
     killall Simulator 2>/dev/null || true
+    pkill CoreSimulator 2>/dev/null || true
     # Erase all available simulators
     (
         IFS=$'\n' # make newlines the only separator
@@ -46,11 +47,13 @@ prelaunch_simulator() {
             fi
         done
     )
+    sleep 5
     if [[ -a "${DEVELOPER_DIR}/Applications/iOS Simulator.app" ]]; then
         open "${DEVELOPER_DIR}/Applications/iOS Simulator.app"
     elif [[ -a "${DEVELOPER_DIR}/Applications/Simulator.app" ]]; then
         open "${DEVELOPER_DIR}/Applications/Simulator.app"
     fi
+    sleep 5
 }
 
 xctest_ios() {


### PR DESCRIPTION
I ran this successfully a few times on `Test Xcode 6 Installation Examples` and `Test Xcode 7 Installation Examples`. /cc @segiddins 

Definitely hacky, but this is just as part of our tests so my standards are pretty low especially since things are so broken currently.