### PR TITLE
Remove RLM_GENERIC_ARRAY macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,7 @@ x.xx.x Release notes (yyyy-MM-dd)
 * Avoid evaluating results eagerly when filtering and sorting.
 * Add nullability annotations to the Objective-C API to provide enhanced compiler
   warnings and bridging to Swift.
-* Add `RLM_GENERIC_ARRAY(ObjectType)` macro to make `RLMArray`s use
-  Objective-C generics where available.
-* Make `RLMResult`s support being used as an Objective-C generic.
+* Make `RLMResult`s and `RLMArray`s support Objective-C generics.
 * Add support for building watchOS and bitcode-compatible apps with Realm and RealmSwift.
 * Make the exceptions thown in getters and setters more informative.
 * Add `-[RLMArray exchangeObjectAtIndex:withObjectAtIndex]` and `List.swap(_:_:)`

--- a/Realm/RLMArray.h
+++ b/Realm/RLMArray.h
@@ -25,11 +25,20 @@ RLM_ASSUME_NONNULL_BEGIN
 @class RLMObject, RLMRealm, RLMResults RLM_GENERIC_COLLECTION;
 
 /**
- 
+
  RLMArray is the container type in Realm used to define to-many relationships.
 
  Unlike an NSArray, RLMArrays hold a single type, specified by the `objectClassName` property.
  This is referred to in these docs as the “type” of the array.
+
+ When declaring an RLMArray property, the type must be marked as conforming to a
+ protocol by the same name as the objects it should contain (see the
+ `RLM_ARRAY_TYPE` macro). RLMArray properties can also use Objective-C generics
+ if available. For example:
+
+     RLM_ARRAY_TYPE(ObjectType)
+     ...
+     @property RLMArray<ObjectType *><ObjectType> *arrayOfObjectTypes;
  
  RLMArrays can be queried with the same predicates as RLMObject and RLMResults.
 

--- a/Realm/RLMDefines.h
+++ b/Realm/RLMDefines.h
@@ -30,13 +30,11 @@
 #define RLM_GENERIC_COLLECTION <RLMObjectType: RLMObject *>
 #define RLM_GENERIC_RETURN <RLMObjectType>
 #define RLMObjectArgument RLMObjectType
-#define RLM_GENERIC_ARRAY(CLASS) RLMArray<CLASS *><CLASS>
 #else
 #define RLM_GENERIC_COLLECTION
 #define RLM_GENERIC_RETURN
 typedef id RLMObjectType;
 typedef RLMObject * RLMObjectArgument;
-#define RLM_GENERIC_ARRAY(CLASS) RLMArray<CLASS>
 #endif
 
 #pragma mark - Nullability

--- a/Realm/RLMObject.h
+++ b/Realm/RLMObject.h
@@ -411,7 +411,7 @@ RLM_ASSUME_NONNULL_BEGIN
  
      RLM_ARRAY_TYPE(ObjectType)
      ...
-     @property RLM_GENERIC_ARRAY(ObjectType) *arrayOfObjectTypes;
+     @property RLMArray<ObjectType *><ObjectType> *arrayOfObjectTypes;
   */
 #define RLM_ARRAY_TYPE(RLM_OBJECT_SUBCLASS)\
 @protocol RLM_OBJECT_SUBCLASS <NSObject>   \

--- a/Realm/Tests/ObjectTests.m
+++ b/Realm/Tests/ObjectTests.m
@@ -79,8 +79,8 @@
 
 @class CycleObject;
 RLM_ARRAY_TYPE(CycleObject)
-@interface CycleObject :RLMObject
-@property RLM_GENERIC_ARRAY(CycleObject) *objects;
+@interface CycleObject : RLMObject
+@property RLMArray<CycleObject *><CycleObject> *objects;
 @end
 
 @implementation CycleObject
@@ -128,7 +128,7 @@ RLM_ARRAY_TYPE(PrimaryIntObject);
 @property PrimaryStringObject *primaryStringObject;
 @property PrimaryStringObjectWrapper *primaryStringObjectWrapper;
 @property StringObject *stringObject;
-@property RLM_GENERIC_ARRAY(PrimaryIntObject) *primaryIntArray;
+@property RLMArray<PrimaryIntObject *><PrimaryIntObject> *primaryIntArray;
 @property NSString *stringCol;
 @end
 
@@ -169,7 +169,7 @@ RLM_ARRAY_TYPE(PrimaryIntObject);
 
 @interface StringLinkObject : RLMObject
 @property StringObject *stringObjectCol;
-@property RLM_GENERIC_ARRAY(StringObject) *stringObjectArrayCol;
+@property RLMArray<StringObject *><StringObject> *stringObjectArrayCol;
 @end
 
 @implementation StringLinkObject
@@ -207,7 +207,7 @@ RLM_ARRAY_TYPE(PrimaryEmployeeObject);
 
 @interface PrimaryCompanyObject : RLMObject
 @property NSString *name;
-@property RLM_GENERIC_ARRAY(PrimaryEmployeeObject) *employees;
+@property RLMArray<PrimaryEmployeeObject *><PrimaryEmployeeObject> *employees;
 @property PrimaryEmployeeObject *intern;
 @property LinkToPrimaryEmployeeObject *wrappedIntern;
 @end

--- a/Realm/Tests/ObjectTests.m
+++ b/Realm/Tests/ObjectTests.m
@@ -80,7 +80,7 @@
 @class CycleObject;
 RLM_ARRAY_TYPE(CycleObject)
 @interface CycleObject : RLMObject
-@property RLMArray<CycleObject *><CycleObject> *objects;
+@property RLM_GENERIC_ARRAY(CycleObject) *objects;
 @end
 
 @implementation CycleObject
@@ -128,7 +128,7 @@ RLM_ARRAY_TYPE(PrimaryIntObject);
 @property PrimaryStringObject *primaryStringObject;
 @property PrimaryStringObjectWrapper *primaryStringObjectWrapper;
 @property StringObject *stringObject;
-@property RLMArray<PrimaryIntObject *><PrimaryIntObject> *primaryIntArray;
+@property RLM_GENERIC_ARRAY(PrimaryIntObject) *primaryIntArray;
 @property NSString *stringCol;
 @end
 
@@ -169,7 +169,7 @@ RLM_ARRAY_TYPE(PrimaryIntObject);
 
 @interface StringLinkObject : RLMObject
 @property StringObject *stringObjectCol;
-@property RLMArray<StringObject *><StringObject> *stringObjectArrayCol;
+@property RLM_GENERIC_ARRAY(StringObject) *stringObjectArrayCol;
 @end
 
 @implementation StringLinkObject
@@ -207,7 +207,7 @@ RLM_ARRAY_TYPE(PrimaryEmployeeObject);
 
 @interface PrimaryCompanyObject : RLMObject
 @property NSString *name;
-@property RLMArray<PrimaryEmployeeObject *><PrimaryEmployeeObject> *employees;
+@property RLM_GENERIC_ARRAY(PrimaryEmployeeObject) *employees;
 @property PrimaryEmployeeObject *intern;
 @property LinkToPrimaryEmployeeObject *wrappedIntern;
 @end

--- a/Realm/Tests/RLMTestObjects.h
+++ b/Realm/Tests/RLMTestObjects.h
@@ -18,6 +18,12 @@
 
 #import <Realm/Realm.h>
 
+#if __has_extension(objc_generics)
+#define RLM_GENERIC_ARRAY(CLASS) RLMArray<CLASS *><CLASS>
+#else
+#define RLM_GENERIC_ARRAY(CLASS) RLMArray<CLASS>
+#endif
+
 #pragma mark - Abstract Objects
 #pragma mark -
 
@@ -123,7 +129,7 @@ RLM_ARRAY_TYPE(AllTypesObject)
 @end
 
 @interface ArrayOfAllTypesObject : RLMObject
-@property RLMArray<AllTypesObject *><AllTypesObject> *array;
+@property RLM_GENERIC_ARRAY(AllTypesObject) *array;
 @end
 
 #pragma mark - Real Life Objects
@@ -146,7 +152,7 @@ RLM_ARRAY_TYPE(EmployeeObject)
 @interface CompanyObject : RLMObject
 
 @property NSString *name;
-@property RLMArray<EmployeeObject *><EmployeeObject> *employees;
+@property RLM_GENERIC_ARRAY(EmployeeObject) *employees;
 
 @end
 
@@ -160,7 +166,7 @@ RLM_ARRAY_TYPE(EmployeeObject)
 RLM_ARRAY_TYPE(DogObject)
 
 @interface DogArrayObject : RLMObject
-@property RLMArray<DogObject *><DogObject> *dogs;
+@property RLM_GENERIC_ARRAY(DogObject) *dogs;
 @end
 
 
@@ -223,7 +229,7 @@ RLM_ARRAY_TYPE(CircleObject);
 #pragma mark CircleArrayObject
 
 @interface CircleArrayObject : RLMObject
-@property RLMArray<CircleObject *><CircleObject> *circles;
+@property RLM_GENERIC_ARRAY(CircleObject) *circles;
 @end
 
 #pragma mark ArrayPropertyObject
@@ -231,8 +237,8 @@ RLM_ARRAY_TYPE(CircleObject);
 @interface ArrayPropertyObject : RLMObject
 
 @property NSString *name;
-@property RLMArray<StringObject *><StringObject> *array;
-@property RLMArray<IntObject *><IntObject> *intArray;
+@property RLM_GENERIC_ARRAY(StringObject) *array;
+@property RLM_GENERIC_ARRAY(IntObject) *intArray;
 
 @end
 

--- a/Realm/Tests/RLMTestObjects.h
+++ b/Realm/Tests/RLMTestObjects.h
@@ -123,7 +123,7 @@ RLM_ARRAY_TYPE(AllTypesObject)
 @end
 
 @interface ArrayOfAllTypesObject : RLMObject
-@property RLM_GENERIC_ARRAY(AllTypesObject) *array;
+@property RLMArray<AllTypesObject *><AllTypesObject> *array;
 @end
 
 #pragma mark - Real Life Objects
@@ -146,7 +146,7 @@ RLM_ARRAY_TYPE(EmployeeObject)
 @interface CompanyObject : RLMObject
 
 @property NSString *name;
-@property RLM_GENERIC_ARRAY(EmployeeObject) *employees;
+@property RLMArray<EmployeeObject *><EmployeeObject> *employees;
 
 @end
 
@@ -160,7 +160,7 @@ RLM_ARRAY_TYPE(EmployeeObject)
 RLM_ARRAY_TYPE(DogObject)
 
 @interface DogArrayObject : RLMObject
-@property RLM_GENERIC_ARRAY(DogObject) *dogs;
+@property RLMArray<DogObject *><DogObject> *dogs;
 @end
 
 
@@ -223,7 +223,7 @@ RLM_ARRAY_TYPE(CircleObject);
 #pragma mark CircleArrayObject
 
 @interface CircleArrayObject : RLMObject
-@property RLM_GENERIC_ARRAY(CircleObject) *circles;
+@property RLMArray<CircleObject *><CircleObject> *circles;
 @end
 
 #pragma mark ArrayPropertyObject
@@ -231,8 +231,8 @@ RLM_ARRAY_TYPE(CircleObject);
 @interface ArrayPropertyObject : RLMObject
 
 @property NSString *name;
-@property RLM_GENERIC_ARRAY(StringObject) *array;
-@property RLM_GENERIC_ARRAY(IntObject) *intArray;
+@property RLMArray<StringObject *><StringObject> *array;
+@property RLMArray<IntObject *><IntObject> *intArray;
 
 @end
 

--- a/Realm/Tests/SchemaTests.mm
+++ b/Realm/Tests/SchemaTests.mm
@@ -57,9 +57,9 @@ RLM_ARRAY_TYPE(SchemaTestClassSecondChild)
 @property SchemaTestClassFirstChild *child;
 @property SchemaTestClassSecondChild *secondChild;
 
-@property RLM_GENERIC_ARRAY(SchemaTestClassBase) *baseArray;
-@property RLM_GENERIC_ARRAY(SchemaTestClassFirstChild) *childArray;
-@property RLM_GENERIC_ARRAY(SchemaTestClassSecondChild) *secondChildArray;
+@property RLMArray<SchemaTestClassBase *><SchemaTestClassBase> *baseArray;
+@property RLMArray<SchemaTestClassFirstChild *><SchemaTestClassFirstChild> *childArray;
+@property RLMArray<SchemaTestClassSecondChild *><SchemaTestClassSecondChild> *secondChildArray;
 @end
 @implementation SchemaTestClassLink
 @end

--- a/Realm/Tests/SchemaTests.mm
+++ b/Realm/Tests/SchemaTests.mm
@@ -57,9 +57,9 @@ RLM_ARRAY_TYPE(SchemaTestClassSecondChild)
 @property SchemaTestClassFirstChild *child;
 @property SchemaTestClassSecondChild *secondChild;
 
-@property RLMArray<SchemaTestClassBase *><SchemaTestClassBase> *baseArray;
-@property RLMArray<SchemaTestClassFirstChild *><SchemaTestClassFirstChild> *childArray;
-@property RLMArray<SchemaTestClassSecondChild *><SchemaTestClassSecondChild> *secondChildArray;
+@property RLM_GENERIC_ARRAY(SchemaTestClassBase) *baseArray;
+@property RLM_GENERIC_ARRAY(SchemaTestClassFirstChild) *childArray;
+@property RLM_GENERIC_ARRAY(SchemaTestClassSecondChild) *secondChildArray;
 @end
 @implementation SchemaTestClassLink
 @end


### PR DESCRIPTION
We determined that it was better to encourage users to use the full (albeit unsightly) representation rather than hiding it behind a macro. /cc @segiddins 