### PR TITLE
use temporary path for in-memory realms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ x.xx.x Release notes (yyyy-MM-dd)
 * Date properties on 32 bit devices will retain 64 bit second precision.
 * Wrap calls to the block passed to `enumerate` in an autoreleasepool to reduce
   memory growth when migrating a large amount of objects.
+* In-memory realms no longer write to the Documents directory on iOS or
+  Application Support on OS X.
 
 0.93.2 Release notes (2015-06-12)
 =============================================================

--- a/Realm/RLMRealm.mm
+++ b/Realm/RLMRealm.mm
@@ -276,7 +276,12 @@ static NSString * const c_defaultRealmFileName = @"default.realm";
     s_defaultRealmPath = defaultRealmPath;
 }
 
-+ (NSString *)writeablePathForFile:(NSString*)fileName
++ (NSString *)writeableTemporaryPathForFile:(NSString *)fileName
+{
+    return [NSTemporaryDirectory() stringByAppendingPathComponent:fileName];
+}
+
++ (NSString *)writeablePathForFile:(NSString *)fileName
 {
 #if TARGET_OS_IPHONE
     // On iOS the Documents directory isn't user-visible, so put files there
@@ -321,7 +326,7 @@ static NSString * const c_defaultRealmFileName = @"default.realm";
 }
 
 + (instancetype)inMemoryRealmWithIdentifier:(NSString *)identifier {
-    return [self realmWithPath:[RLMRealm writeablePathForFile:identifier] key:nil
+    return [self realmWithPath:[RLMRealm writeableTemporaryPathForFile:identifier] key:nil
                       readOnly:NO inMemory:YES dynamic:NO schema:nil error:nil];
 }
 

--- a/Realm/Tests/RealmTests.mm
+++ b/Realm/Tests/RealmTests.mm
@@ -527,6 +527,9 @@ extern "C" {
 {
     RLMRealm *inMemoryRealm = [RLMRealm inMemoryRealmWithIdentifier:@"identifier"];
 
+    // verify that the realm's path is in the temporary directory
+    XCTAssertEqualObjects(NSTemporaryDirectory(), [inMemoryRealm.path.stringByDeletingLastPathComponent stringByAppendingString:@"/"]);
+
     [self waitForNotification:RLMRealmDidChangeNotification realm:inMemoryRealm block:^{
         RLMRealm *inMemoryRealm = [RLMRealm inMemoryRealmWithIdentifier:@"identifier"];
         [inMemoryRealm beginWriteTransaction];


### PR DESCRIPTION
Closes #2032.

Otherwise, apps using in-memory realms risk violating Apple's data storage guidelines. /cc @segiddins 