### PR TITLE
Help prevent className from being overridden

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+x.x.x Release notes (yyyy-MM-dd)
+=============================================================
+
+### API breaking changes
+
+* None.
+
+### Enhancements
+
+* `Object.className` is now marked as `final`.
+
+### Bugfixes
+
+* None.
+
 0.94.0 Release notes (2015-07-29)
 =============================================================
 

--- a/Realm/RLMObject.h
+++ b/Realm/RLMObject.h
@@ -96,8 +96,11 @@ RLM_ASSUME_NONNULL_BEGIN
 
 /**
  Helper to return the class name for an RLMObject subclass.
+
+ @warning Do not override. Realm relies on this method returning the exact class
+          name.
  
- @return    The class name for the model class.
+ @return  The class name for the model class.
  */
 + (NSString *)className;
 

--- a/RealmSwift-swift1.2/Object.swift
+++ b/RealmSwift-swift1.2/Object.swift
@@ -103,14 +103,18 @@ public class Object: RLMObjectBase, Equatable, Printable {
     /// Returns a human-readable description of this object.
     public override var description: String { return super.description }
 
+    /// Helper to return the class name for an Object subclass.
+    public final override var className: String { return super.className }
 
-    // MARK: Object customization
+
+    // MARK: Object Customization
 
     /**
     Override to designate a property as the primary key for an `Object` subclass. Only properties of
     type String and Int can be designated as the primary key. Primary key
     properties enforce uniqueness for each value whenever the property is set which incurs some overhead.
     Indexes are created automatically for primary key properties.
+
     :returns: Name of the property designated as the primary key, or `nil` if the model has no primary key.
     */
     public class func primaryKey() -> String? { return nil }
@@ -144,26 +148,7 @@ public class Object: RLMObjectBase, Equatable, Printable {
         return RLMObjectBaseLinkingObjectsOfClass(self, T.className(), propertyName) as! [T]
     }
 
-
-    // MARK: Private functions
-
-    // FIXME: None of these functions should be exposed in the public interface.
-
-    /**
-    WARNING: This is an internal initializer not intended for public use.
-    :nodoc:
-    */
-    public override init(realm: RLMRealm, schema: RLMObjectSchema) {
-        super.init(realm: realm, schema: schema)
-    }
-
-    /**
-    WARNING: This is an internal initializer not intended for public use.
-    :nodoc:
-    */
-    public override init(value: AnyObject, schema: RLMSchema) {
-        super.init(value: value, schema: schema)
-    }
+    // MARK: Key-Value Coding & Subscripting
 
     /**
     Returns the value for the property identified by the given key.
@@ -211,6 +196,26 @@ public class Object: RLMObjectBase, Equatable, Printable {
             }
             RLMObjectBaseSetObjectForKeyedSubscript(self, key, value)
         }
+    }
+
+    // MARK: Private functions
+
+    // FIXME: None of these functions should be exposed in the public interface.
+
+    /**
+    WARNING: This is an internal initializer not intended for public use.
+    :nodoc:
+    */
+    public override init(realm: RLMRealm, schema: RLMObjectSchema) {
+        super.init(realm: realm, schema: schema)
+    }
+
+    /**
+    WARNING: This is an internal initializer not intended for public use.
+    :nodoc:
+    */
+    public override init(value: AnyObject, schema: RLMSchema) {
+        super.init(value: value, schema: schema)
     }
 
     // Helper for getting a list property for the given key

--- a/RealmSwift-swift1.2/Object.swift
+++ b/RealmSwift-swift1.2/Object.swift
@@ -103,9 +103,13 @@ public class Object: RLMObjectBase, Equatable, Printable {
     /// Returns a human-readable description of this object.
     public override var description: String { return super.description }
 
+    #if os(OSX)
     /// Helper to return the class name for an Object subclass.
-    public final override var className: String { return super.className }
-
+    public final override var className: String { return "" }
+    #else
+    /// Helper to return the class name for an Object subclass.
+    public final var className: String { return "" }
+    #endif
 
     // MARK: Object Customization
 

--- a/RealmSwift-swift2.0/Object.swift
+++ b/RealmSwift-swift2.0/Object.swift
@@ -103,8 +103,10 @@ public class Object: RLMObjectBase {
     /// Returns a human-readable description of this object.
     public override var description: String { return super.description }
 
+    /// Helper to return the class name for an Object subclass.
+    public final override var className: String { return super.className }
 
-    // MARK: Object customization
+    // MARK: Object Customization
 
     /**
     Override to designate a property as the primary key for an `Object` subclass. Only properties of
@@ -149,26 +151,7 @@ public class Object: RLMObjectBase {
         return RLMObjectBaseLinkingObjectsOfClass(self, (T.self as Object.Type).className(), propertyName) as! [T]
     }
 
-
-    // MARK: Private functions
-
-    // FIXME: None of these functions should be exposed in the public interface.
-
-    /**
-    WARNING: This is an internal initializer not intended for public use.
-    :nodoc:
-    */
-    public override init(realm: RLMRealm, schema: RLMObjectSchema) {
-        super.init(realm: realm, schema: schema)
-    }
-
-    /**
-    WARNING: This is an internal initializer not intended for public use.
-    :nodoc:
-    */
-    public override init(value: AnyObject, schema: RLMSchema) {
-        super.init(value: value, schema: schema)
-    }
+    // MARK: Key-Value Coding & Subscripting
 
     /**
     Returns the value for the property identified by the given key.
@@ -221,6 +204,35 @@ public class Object: RLMObjectBase {
         }
     }
 
+    // MARK: Equatable
+
+    /// Returns whether both objects are equal.
+    /// Objects are considered equal when they are both from the same Realm
+    /// and point to the same underlying object in the database.
+    public override func isEqual(object: AnyObject?) -> Bool {
+        return RLMObjectBaseAreEqual(self as RLMObjectBase?, object as? RLMObjectBase);
+    }
+
+    // MARK: Private functions
+
+    // FIXME: None of these functions should be exposed in the public interface.
+
+    /**
+    WARNING: This is an internal initializer not intended for public use.
+    :nodoc:
+    */
+    public override init(realm: RLMRealm, schema: RLMObjectSchema) {
+        super.init(realm: realm, schema: schema)
+    }
+
+    /**
+    WARNING: This is an internal initializer not intended for public use.
+    :nodoc:
+    */
+    public override init(value: AnyObject, schema: RLMSchema) {
+        super.init(value: value, schema: schema)
+    }
+
     // Helper for getting a list property for the given key
     private func listProperty(key: String) -> RLMListBase? {
         if let prop = RLMObjectBaseObjectSchema(self)?[key] {
@@ -229,15 +241,6 @@ public class Object: RLMObjectBase {
             }
         }
         return nil
-    }
-
-    // MARK: Equatable
-
-    /// Returns whether both objects are equal.
-    /// Objects are considered equal when they are both from the same Realm
-    /// and point to the same underlying object in the database.
-    public override func isEqual(object: AnyObject?) -> Bool {
-        return RLMObjectBaseAreEqual(self as RLMObjectBase?, object as? RLMObjectBase);
     }
 }
 

--- a/RealmSwift-swift2.0/Object.swift
+++ b/RealmSwift-swift2.0/Object.swift
@@ -103,8 +103,13 @@ public class Object: RLMObjectBase {
     /// Returns a human-readable description of this object.
     public override var description: String { return super.description }
 
+    #if os(OSX)
     /// Helper to return the class name for an Object subclass.
-    public final override var className: String { return super.className }
+    public final override var className: String { return "" }
+    #else
+    /// Helper to return the class name for an Object subclass.
+    public final var className: String { return "" }
+    #endif
 
     // MARK: Object Customization
 


### PR DESCRIPTION
I've seen users assume that they could override `+[RLMObject className]`/`Object.className` to return something other than the actual exact class name (e.g. to removing a prefix).

As far as I know, we don't state anywhere that overriding this doesn't actually do anything, so might as well just discourage it in Objective-C and prevent it from happening in Swift. /cc @segiddins @bigfish24 