### PR TITLE
Fix crash when adding a property to a model without updating the schema version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ x.x.x Release notes (yyyy-MM-dd)
 
 ### Bugfixes
 
-* None.
+* Fix crash when adding a property to a model without updating the schema
+  version.
 
 0.94.0 Release notes (2015-07-29)
 =============================================================

--- a/Realm/ObjectStore/object_store.cpp
+++ b/Realm/ObjectStore/object_store.cpp
@@ -222,9 +222,10 @@ void ObjectStore::update_column_mapping(Group *group, ObjectSchema &target_schem
     ObjectSchema table_schema(group, target_schema.name);
     for (auto& target_prop : target_schema.properties) {
         auto table_prop = table_schema.property_for_name(target_prop.name);
-        REALM_ASSERT_DEBUG(table_prop);
-
-        target_prop.table_column = table_prop->table_column;
+        if (table_prop) {
+            // Update target property column to match what's in the realm if it exists
+            target_prop.table_column = table_prop->table_column;
+        }
     }
 }
 

--- a/Realm/Tests/MigrationTests.mm
+++ b/Realm/Tests/MigrationTests.mm
@@ -196,6 +196,17 @@ static void RLMAssertRealmSchemaMatchesTable(id self, RLMRealm *realm) {
     }
 }
 
+- (void)testAddingPropertyRequiresMigration {
+    RLMObjectSchema *objectSchema = [RLMObjectSchema schemaForObjectClass:MigrationObject.class];
+    objectSchema.properties = @[objectSchema.properties[0]];
+    @autoreleasepool {
+        XCTAssertNoThrow([self realmWithSingleObject:objectSchema], @"Migration shouldn't be required on first access.");
+    }
+    @autoreleasepool {
+        XCTAssertThrows([self realmWithSingleObject:[RLMObjectSchema schemaForObjectClass:MigrationObject.class]], @"Migration should be required");
+    }
+}
+
 - (void)testAddingPropertyAtEnd {
     // create schema to migrate from with single string column
     RLMObjectSchema *objectSchema = [RLMObjectSchema schemaForObjectClass:MigrationObject.class];


### PR DESCRIPTION
Fixes #2320. /cc @segiddins @tgoyne 