### PR TITLE
Fix crash when sorting RLMResults.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ x.x.x Release notes (yyyy-MM-dd)
 
 * Fix crash when adding a property to a model without updating the schema
   version.
+* Fix crash when sorting RLMResults.
 
 0.94.0 Release notes (2015-07-29)
 =============================================================

--- a/Realm/RLMResults.mm
+++ b/Realm/RLMResults.mm
@@ -102,7 +102,7 @@ static inline void RLMResultsValidateAttached(__unsafe_unretained RLMResults *co
         // create backing view if needed
         ar->_backingView = ar->_backingQuery->find_all();
         ar->_viewCreated = YES;
-        if (!ar->_sortOrder.m_column_indexes.empty()) {
+        if (!ar->_sortOrder.m_columns.empty()) {
             ar->_backingView.sort(ar->_sortOrder.m_column_indexes, ar->_sortOrder.m_ascending);
         }
     }


### PR DESCRIPTION
Fixes #2332. This was introduced in #2125, which is why we only started hearing about it after 0.94. /cc @tgoyne @segiddins 