### PR TITLE
Remove generic specialization.

### DIFF
--- a/Realm/RLMArray.h
+++ b/Realm/RLMArray.h
@@ -38,7 +38,7 @@ RLM_ASSUME_NONNULL_BEGIN
 
      RLM_ARRAY_TYPE(ObjectType)
      ...
-     @property RLMArray<ObjectType *><ObjectType> *arrayOfObjectTypes;
+     @property RLMArray<ObjectType> *arrayOfObjectTypes;
 
  RLMArrays can be queried with the same predicates as RLMObject and RLMResults.
 


### PR DESCRIPTION
Testing on v0.94.0, defining an entity relationship does not require generic specialization <ObjectType*>.

Defining a property with generic specialization would cause a compiler error.

Tested on:
Xcode 6.4
iOS Deployment target 7.0
iOS Base SDK 8.4
Mac OS X Yosemite 10.10.4

Online [Objective-C documentation](https://realm.io/docs/objc/latest/#models) may need to be updated as well.