### PR TITLE
Remove uses of RowIndexes::Sorter

### DIFF
--- a/Realm/RLMArrayLinkView.mm
+++ b/Realm/RLMArrayLinkView.mm
@@ -271,14 +271,10 @@ static void RLMInsertObject(RLMArrayLinkView *ar, RLMObject *object, NSUInteger 
 {
     RLMLinkViewArrayValidateAttached(self);
 
-    std::vector<size_t> columns;
-    std::vector<bool> order;
-    RLMGetColumnIndices(_realm.schema[_objectClassName], properties, columns, order);
-
     auto query = std::make_unique<realm::Query>(_backingLinkView->get_target_table().where(_backingLinkView));
     return [RLMResults resultsWithObjectClassName:self.objectClassName
                                             query:move(query)
-                                             sort:realm::RowIndexes::Sorter(columns, order)
+                                             sort:RLMSortOrderFromDescriptors(_realm.schema[_objectClassName], properties)
                                             realm:_realm];
 
 }

--- a/Realm/RLMArray_Private.hpp
+++ b/Realm/RLMArray_Private.hpp
@@ -20,7 +20,7 @@
 #import <Realm/RLMResults.h>
 
 #import <memory>
-#import <realm/views.hpp>
+#import <vector>
 
 namespace realm {
     class LinkView;

--- a/Realm/RLMArray_Private.hpp
+++ b/Realm/RLMArray_Private.hpp
@@ -35,6 +35,15 @@ namespace realm {
 
 @class RLMObjectSchema;
 
+struct RLMSortOrder {
+    std::vector<size_t> columnIndices;
+    std::vector<bool> ascending;
+
+    explicit operator bool() const {
+        return !columnIndices.empty();
+    }
+};
+
 // RLMArray private properties/ivars for all subclasses
 @interface RLMArray () {
   @protected
@@ -76,7 +85,7 @@ namespace realm {
 
 + (instancetype)resultsWithObjectClassName:(NSString *)objectClassName
                                      query:(std::unique_ptr<realm::Query>)query
-                                      sort:(realm::RowIndexes::Sorter const&)sorter
+                                      sort:(RLMSortOrder)sorter
                                      realm:(RLMRealm *)realm;
 
 - (void)deleteObjectsFromRealm;

--- a/Realm/RLMQueryUtil.hpp
+++ b/Realm/RLMQueryUtil.hpp
@@ -38,10 +38,10 @@ void RLMUpdateQueryWithPredicate(realm::Query *query, NSPredicate *predicate, RL
                                  RLMObjectSchema *objectSchema);
 
 // return column index - throw for invalid column name
-NSUInteger RLMValidatedColumnIndex(RLMObjectSchema *schema, NSString *columnName);
+NSUInteger RLMValidatedColumnIndex(RLMObjectSchema *objectSchema, NSString *columnName);
 
 // validate the array of RLMSortDescriptors and convert it to an RLMSortOrder
-RLMSortOrder RLMSortOrderFromDescriptors(RLMObjectSchema *schema, NSArray *descriptors);
+RLMSortOrder RLMSortOrderFromDescriptors(RLMObjectSchema *objectSchema, NSArray *descriptors);
 
 // This macro validates predicate format with optional arguments
 #define RLM_VARARG(PREDICATE_FORMAT, ARGS) \

--- a/Realm/RLMQueryUtil.hpp
+++ b/Realm/RLMQueryUtil.hpp
@@ -28,6 +28,8 @@ namespace realm {
 @class RLMObjectSchema;
 @class RLMSchema;
 
+struct RLMSortOrder;
+
 extern NSString * const RLMPropertiesComparisonTypeMismatchException;
 extern NSString * const RLMUnsupportedTypesFoundInPropertyComparisonException;
 
@@ -38,10 +40,8 @@ void RLMUpdateQueryWithPredicate(realm::Query *query, NSPredicate *predicate, RL
 // return column index - throw for invalid column name
 NSUInteger RLMValidatedColumnIndex(RLMObjectSchema *schema, NSString *columnName);
 
-// populate columns and order with the values in properties and ascending, with validation
-void RLMGetColumnIndices(RLMObjectSchema *schema, NSArray *properties,
-                         std::vector<size_t> &columns, std::vector<bool> &order);
-
+// validate the array of RLMSortDescriptors and convert it to an RLMSortOrder
+RLMSortOrder RLMSortOrderFromDescriptors(RLMObjectSchema *schema, NSArray *descriptors);
 
 // This macro validates predicate format with optional arguments
 #define RLM_VARARG(PREDICATE_FORMAT, ARGS) \

--- a/Realm/RLMQueryUtil.mm
+++ b/Realm/RLMQueryUtil.mm
@@ -18,7 +18,7 @@
 
 #import "RLMQueryUtil.hpp"
 
-#import "RLMArray.h"
+#import "RLMArray_Private.hpp"
 #import "RLMObject_Private.hpp"
 #import "RLMObjectSchema_Private.hpp"
 #import "RLMProperty_Private.h"
@@ -856,13 +856,15 @@ void RLMUpdateQueryWithPredicate(realm::Query *query, NSPredicate *predicate, RL
                     (int)validateMessage.size(), validateMessage.c_str());
 }
 
-void RLMGetColumnIndices(RLMObjectSchema *schema, NSArray *properties,
-                         std::vector<size_t> &columns, std::vector<bool> &order) {
-    columns.reserve(properties.count);
-    order.reserve(properties.count);
+RLMSortOrder RLMSortOrderFromDescriptors(RLMObjectSchema *schema, NSArray *descriptors) {
+    RLMSortOrder sort;
+    sort.columnIndices.reserve(descriptors.count);
+    sort.ascending.reserve(descriptors.count);
 
-    for (RLMSortDescriptor *descriptor in properties) {
-        columns.push_back(RLMValidatedPropertyForSort(schema, descriptor.property).column);
-        order.push_back(descriptor.ascending);
+    for (RLMSortDescriptor *descriptor in descriptors) {
+        sort.columnIndices.push_back(RLMValidatedPropertyForSort(schema, descriptor.property).column);
+        sort.ascending.push_back(descriptor.ascending);
     }
+
+    return sort;
 }

--- a/Realm/RLMQueryUtil.mm
+++ b/Realm/RLMQueryUtil.mm
@@ -856,13 +856,13 @@ void RLMUpdateQueryWithPredicate(realm::Query *query, NSPredicate *predicate, RL
                     (int)validateMessage.size(), validateMessage.c_str());
 }
 
-RLMSortOrder RLMSortOrderFromDescriptors(RLMObjectSchema *schema, NSArray *descriptors) {
+RLMSortOrder RLMSortOrderFromDescriptors(RLMObjectSchema *objectSchema, NSArray *descriptors) {
     RLMSortOrder sort;
     sort.columnIndices.reserve(descriptors.count);
     sort.ascending.reserve(descriptors.count);
 
     for (RLMSortDescriptor *descriptor in descriptors) {
-        sort.columnIndices.push_back(RLMValidatedPropertyForSort(schema, descriptor.property).column);
+        sort.columnIndices.push_back(RLMValidatedPropertyForSort(objectSchema, descriptor.property).column);
         sort.ascending.push_back(descriptor.ascending);
     }
 

--- a/Realm/RLMResults.mm
+++ b/Realm/RLMResults.mm
@@ -30,7 +30,6 @@
 
 #import <objc/runtime.h>
 #import <realm/table_view.hpp>
-#import <realm/views.hpp>
 
 using namespace realm;
 

--- a/Realm/RLMResults.mm
+++ b/Realm/RLMResults.mm
@@ -41,7 +41,7 @@ using namespace realm;
     std::unique_ptr<realm::Query> _backingQuery;
     realm::TableView _backingView;
     BOOL _viewCreated;
-    RowIndexes::Sorter _sortOrder;
+    RLMSortOrder _sortOrder;
 
 @protected
     RLMRealm *_realm;
@@ -56,18 +56,18 @@ using namespace realm;
 + (instancetype)resultsWithObjectClassName:(NSString *)objectClassName
                                      query:(std::unique_ptr<realm::Query>)query
                                      realm:(RLMRealm *)realm {
-    return [self resultsWithObjectClassName:objectClassName query:move(query) sort:RowIndexes::Sorter{} realm:realm];
+    return [self resultsWithObjectClassName:objectClassName query:move(query) sort:{} realm:realm];
 }
 
 + (instancetype)resultsWithObjectClassName:(NSString *)objectClassName
                                      query:(std::unique_ptr<realm::Query>)query
-                                      sort:(RowIndexes::Sorter const&)sorter
+                                      sort:(RLMSortOrder)sorter
                                      realm:(RLMRealm *)realm {
     RLMResults *ar = [[self alloc] initPrivate];
     ar->_objectClassName = objectClassName;
     ar->_viewCreated = NO;
     ar->_backingQuery = move(query);
-    ar->_sortOrder = sorter;
+    ar->_sortOrder = std::move(sorter);
     ar->_realm = realm;
     ar->_objectSchema = realm.schema[objectClassName];
     return ar;
@@ -102,8 +102,8 @@ static inline void RLMResultsValidateAttached(__unsafe_unretained RLMResults *co
         // create backing view if needed
         ar->_backingView = ar->_backingQuery->find_all();
         ar->_viewCreated = YES;
-        if (!ar->_sortOrder.m_column_indexes.empty()) {
-            ar->_backingView.sort(ar->_sortOrder.m_column_indexes, ar->_sortOrder.m_ascending);
+        if (ar->_sortOrder) {
+            ar->_backingView.sort(ar->_sortOrder.columnIndices, ar->_sortOrder.ascending);
         }
     }
     // otherwise we're backed by a table and don't need to update anything
@@ -120,14 +120,6 @@ static inline void RLMResultsValidateInWriteTransaction(__unsafe_unretained RLMR
     if (!ar->_realm->_inWriteTransaction) {
         @throw RLMException(@"Can't mutate a persisted array outside of a write transaction.");
     }
-}
-
-static RowIndexes::Sorter RLMSorterFromDescriptors(RLMObjectSchema *schema, NSArray *descriptors)
-{
-    std::vector<size_t> columns;
-    std::vector<bool> order;
-    RLMGetColumnIndices(schema, descriptors, columns, order);
-    return RowIndexes::Sorter(columns, order);
 }
 
 //
@@ -308,8 +300,10 @@ static RowIndexes::Sorter RLMSorterFromDescriptors(RLMObjectSchema *schema, NSAr
     RLMCheckThread(_realm);
 
     auto query = [self cloneQuery];
-    auto sorter = RLMSorterFromDescriptors(_objectSchema, properties);
-    return [RLMResults resultsWithObjectClassName:self.objectClassName query:move(query) sort:sorter realm:_realm];
+    return [RLMResults resultsWithObjectClassName:self.objectClassName
+                                            query:move(query)
+                                             sort:RLMSortOrderFromDescriptors(_objectSchema, properties)
+                                            realm:_realm];
 }
 
 - (id)objectAtIndexedSubscript:(NSUInteger)index {


### PR DESCRIPTION
It's not actually part of the public API and using it directly is no longer useful anyway.

@segiddins 