### PR TITLE
Fix bug casting T.Type in Realm.swift

### DIFF
--- a/RealmSwift-swift2.0/Realm.swift
+++ b/RealmSwift-swift2.0/Realm.swift
@@ -279,8 +279,7 @@ public final class Realm {
     - returns: The created object.
     */
     public func create<T: Object>(type: T.Type, value: AnyObject = [:], update: Bool = false) -> T {
-        // FIXME: use T.className()
-        let className = (T.self as Object.Type).className()
+        let className = type.className()
         if update && schema[className]?.primaryKeyProperty == nil {
           throwRealmException("'\(className)' does not have a primary key and can not be updated")
         }
@@ -351,8 +350,7 @@ public final class Realm {
     - returns: All objects of the given type in Realm.
     */
     public func objects<T: Object>(type: T.Type) -> Results<T> {
-        // FIXME: use T.className()
-        return Results<T>(RLMGetObjects(rlmRealm, (T.self as Object.Type).className(), nil))
+        return Results<T>(RLMGetObjects(rlmRealm, type.className(), nil))
     }
 
     /**
@@ -370,8 +368,7 @@ public final class Realm {
     - returns: An object of type `type` or `nil` if an object with the given primary key does not exist.
     */
     public func objectForPrimaryKey<T: Object>(type: T.Type, key: AnyObject) -> T? {
-        // FIXME: use T.className()
-        return unsafeBitCast(RLMGetObject(rlmRealm, (T.self as Object.Type).className(), key), Optional<T>.self)
+        return unsafeBitCast(RLMGetObject(rlmRealm, type.className(), key), Optional<T>.self)
     }
 
 


### PR DESCRIPTION
Hello, i've been experiencing some issues using `objectForPrimaryKey` in swift.

It usually works, but under some circumstances it won't work saying that `"Object type 'Object' not persisted in Realm"`
This was caused by this casting `(T.self as Object.Type).className()`, although i was passing a valid T.Type to the func, it was taking `T.self` as `Object`.

I changed the casting by calling directly `type.className()`.
You had a FIXME comment saying to change it to `T.className()`, but that was failing for me also.

Let me know if this is a good solution for you! it definitely fix my issues :)