### PR TITLE
Handle leading blank lines in the core version check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ x.x.x Release notes (yyyy-MM-dd)
 
 * Fix crash when adding a property to a model without updating the schema
   version.
+* Fix unnecessary redownloading of the core library when building from source.
 
 0.94.0 Release notes (2015-07-29)
 =============================================================

--- a/build.sh
+++ b/build.sh
@@ -289,7 +289,10 @@ case "$COMMAND" in
             echo "core is not a symlink. Deleting..."
             rm -rf core
             download_core
-        elif ! $(head -n 1 core/release_notes.txt | grep -i ${REALM_CORE_VERSION} >/dev/null); then
+        # With a prebuilt version we only want to check the first non-empty
+        # line so that checking out an older commit will download the
+        # appropriate version of core if the already-present version is too new
+        elif ! $(grep -m 1 . core/release_notes.txt | grep -i "${REALM_CORE_VERSION} RELEASE NOTES" >/dev/null); then
             download_core
         else
             echo "The core library seems to be up to date."


### PR DESCRIPTION
Newer versions of pandoc insert blank lines before the header, so only checking the first line results in always redownloading the core.

@segiddins 