### PR TITLE
Update to core 0.92.1.1

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -14,7 +14,7 @@ set -o pipefail
 set -e
 
 # You can override the version of the core library
-: ${REALM_CORE_VERSION:=0.92.1} # set to "current" to always use the current build
+: ${REALM_CORE_VERSION:=0.92.1.1} # set to "current" to always use the current build
 
 # You can override the xcmode used
 : ${XCMODE:=xcodebuild} # must be one of: xcodebuild (default), xcpretty, xctool


### PR DESCRIPTION
Same as 0.92.1, but without debugging symbols stripped from the watchOS library since that breaks things. Closes #2359.