### PR TITLE
Add verify-watchos CI target

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -306,11 +306,7 @@ case "$COMMAND" in
     "set-swift-version")
         version="$2"
         if [[ -z "$version" ]]; then
-            if [[ $REALM_SWIFT_VERSION ]]; then
-                version="$REALM_SWIFT_VERSION"
-            else
-                version="$(get_swift_version)"
-            fi
+            version="$REALM_SWIFT_VERSION"
         fi
 
         # Update the symlinks to point to the correct verion of the source, and
@@ -495,6 +491,7 @@ case "$COMMAND" in
         sh build.sh verify-ios-swift
         sh build.sh verify-ios-swift-debug
         sh build.sh verify-ios-device
+        sh build.sh verify-watchos
         ;;
 
     "verify-osx")
@@ -546,9 +543,10 @@ case "$COMMAND" in
         exit 0
         ;;
 
-
-    # FIXME: remove these targets from ci
-    "verify-ios")
+    "verify-watchos")
+        if [ $REALM_SWIFT_VERSION != '1.2' ]; then
+            sh build.sh watchos
+        fi
         exit 0
         ;;
 

--- a/build.sh
+++ b/build.sh
@@ -545,7 +545,7 @@ case "$COMMAND" in
 
     "verify-watchos")
         if [ $REALM_SWIFT_VERSION != '1.2' ]; then
-            sh build.sh watchos
+            sh build.sh watchos-swift
         fi
         exit 0
         ;;


### PR DESCRIPTION
Only tests that it builds, since you currently can't run tests for watchOS targets. Should currently fail to build due to #2376.