### PR TITLE
Ignore if update checker encountered server errors

### DIFF
--- a/Realm/RLMUpdateChecker.mm
+++ b/Realm/RLMUpdateChecker.mm
@@ -30,8 +30,8 @@ void RLMCheckForUpdates() {
         return;
     }
 
-    auto handler = ^(NSData *data, __unused NSURLResponse *response, NSError *error) {
-        if (error) {
+    auto handler = ^(NSData *data, NSURLResponse *response, NSError *error) {
+        if (error || ((NSHTTPURLResponse *)response).statusCode != 200) {
             return;
         }
 


### PR DESCRIPTION
I saw raw HTML text in the Xcode console when launched the app that uses realm because update checker encountered S3 trouble, like below:

```
2015-08-10 18:09:02.069 SampleApp[89745:5544644] Version <!DOCTYPE html>
<!--[if lt IE 7]> <html class="no-js ie6 oldie" lang="en-US"> <![endif]-->
<!--[if IE 7]>    <html class="no-js ie7 oldie" lang="en-US"> <![endif]-->
<!--[if IE 8]>    <html class="no-js ie8 oldie" lang="en-US"> <![endif]-->
<!--[if gt IE 8]><!--> <html class="no-js" lang="en-US"> <!--<![endif]-->
<head>
<meta http-equiv="refresh" content="0">
<meta http-equiv="set-cookie" content="cf_use_ob=443; expires=Mon, 10-Aug-15 09:09:32 GMT; path=/">
<meta http-equiv="set-cookie" content="cf_ob_info=520:213a8f3c896e018e:NRT; expires=Mon, 10-Aug-15 09:09:32 GMT; path=/">
<title>static.realm.io | 520: Web server is returning an unknown error</title>
<meta charset="UTF-8"/>
...
```

The error object is `nil` regardless of the status code. It is better to check status code in addition to the error object.