### PR TITLE
Update RLMProperty.mm

### DIFF
--- a/Realm/RLMProperty.mm
+++ b/Realm/RLMProperty.mm
@@ -19,7 +19,6 @@
 #import "RLMProperty_Private.h"
 
 #import "RLMArray.h"
-#import "RLMObject.h"
 #import "RLMSchema_Private.h"
 #import "RLMObject_Private.h"
 #import "RLMSwiftSupport.h"


### PR DESCRIPTION
Drop `#import "RLMObject.h"`. `RLMObject_Private.h` imports `<Realm/RLMObject.h>`. Hence `RLMObject.h` is transitively imported.
Import of `RLMObject.h` and `<Realm/RLMObject.h>` confuses `clang` and results in duplicate interface.

```
In file included from Realm/RLMProperty.mm:24:
In file included from Realm/RLMObject_Private.h:19:
Realm/Realm/RLMObject.h:66:1: error: duplicate interface definition for class 'RLMObject'
@interface RLMObject : RLMObjectBase
^
In file included from realm-cocoa/Realm/RLMProperty.mm:22:
realm-cocoa/Realm/RLMObject.h:66:12: note: previous definition is here
@interface RLMObject : RLMObjectBase
           ^
```

*Note:* This happens when using `realm-cocoa` with `cococapods` with the `:path` argument in the `Podfile`.