### PR TITLE
Improve performance of adding standalone Swift objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,8 @@ x.x.x Release notes (yyyy-MM-dd)
   `Results<>`) now enumerates over a copy of the collection, making it no
   longer an error to modify a collection during enumeration (either directly,
   or indirectly by modifying objects to make them no longer match a query).
+* Improve performance of object insertion in Swift to bring it roughly in line
+  with Objective-C.
 
 ### Bugfixes
 

--- a/Realm.podspec
+++ b/Realm.podspec
@@ -56,6 +56,6 @@ Pod::Spec.new do |s|
   s.subspec 'Headers' do |s|
     s.source_files          = 'include/**/*.{h,hpp}'
     s.public_header_files   = public_header_files
-    s.private_header_files  = 'include/Realm/*{RealmUtil,ListBase,ObjectStore,Private,Dynamic}.h', 'include/Realm/ObjectStore/*.hpp'
+    s.private_header_files  = 'include/Realm/*{Accessor,RealmUtil,ListBase,ObjectStore,Private,Dynamic}.h', 'include/Realm/ObjectStore/*.hpp'
   end
 end

--- a/Realm.xcodeproj/project.pbxproj
+++ b/Realm.xcodeproj/project.pbxproj
@@ -181,7 +181,7 @@
 		144C2F701B3D3529005C8F81 /* RLMRealmUtil.h in Headers */ = {isa = PBXBuildFile; fileRef = 027A4D211AB100E000AA46F9 /* RLMRealmUtil.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		144C2F711B3D3529005C8F81 /* RLMResults_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 29EDB8E51A7710B700458D80 /* RLMResults_Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		144C2F721B3D3529005C8F81 /* RLMSchema_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = E81A1F7D1955FC9300FDED82 /* RLMSchema_Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		144C2F731B3D3539005C8F81 /* RLMAccessor.h in Headers */ = {isa = PBXBuildFile; fileRef = E81A1F631955FC9300FDED82 /* RLMAccessor.h */; };
+		144C2F731B3D3539005C8F81 /* RLMAccessor.h in Headers */ = {isa = PBXBuildFile; fileRef = E81A1F631955FC9300FDED82 /* RLMAccessor.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		144C2F741B3D3539005C8F81 /* RLMObjectSchema_Private.hpp in Headers */ = {isa = PBXBuildFile; fileRef = E81A1F701955FC9300FDED82 /* RLMObjectSchema_Private.hpp */; };
 		144C2F751B3D3539005C8F81 /* RLMQueryUtil.hpp in Headers */ = {isa = PBXBuildFile; fileRef = E81A1F781955FC9300FDED82 /* RLMQueryUtil.hpp */; };
 		144C2F761B3D3539005C8F81 /* RLMSwiftSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 3FE79FF719BA6A5900780C9A /* RLMSwiftSupport.h */; };
@@ -214,7 +214,7 @@
 		29E3C7181A71C1C700B62C1D /* RLMUtil.mm in Sources */ = {isa = PBXBuildFile; fileRef = E81A1F821955FC9300FDED82 /* RLMUtil.mm */; };
 		29E3C7191A71C1C700B62C1D /* RLMObjectBase.mm in Sources */ = {isa = PBXBuildFile; fileRef = 023B19581A3BA90D0067FB81 /* RLMObjectBase.mm */; };
 		29E3C71B1A71C1C700B62C1D /* Realm.h in Headers */ = {isa = PBXBuildFile; fileRef = E8D89B9D1955FC6D00CF2B9A /* Realm.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		29E3C71C1A71C1C700B62C1D /* RLMAccessor.h in Headers */ = {isa = PBXBuildFile; fileRef = E81A1F631955FC9300FDED82 /* RLMAccessor.h */; };
+		29E3C71C1A71C1C700B62C1D /* RLMAccessor.h in Headers */ = {isa = PBXBuildFile; fileRef = E81A1F631955FC9300FDED82 /* RLMAccessor.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		29E3C71D1A71C1C700B62C1D /* RLMArray.h in Headers */ = {isa = PBXBuildFile; fileRef = E81A1F661955FC9300FDED82 /* RLMArray.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		29E3C71F1A71C1C700B62C1D /* RLMCollection.h in Headers */ = {isa = PBXBuildFile; fileRef = 02B8EF5B19E7048D0045A93D /* RLMCollection.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		29E3C7201A71C1C700B62C1D /* RLMConstants.h in Headers */ = {isa = PBXBuildFile; fileRef = E81A1F6B1955FC9300FDED82 /* RLMConstants.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -337,7 +337,7 @@
 		C0D2DD081B6BDEA1004E8919 /* RLMRealmConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = C0D2DD051B6BDEA1004E8919 /* RLMRealmConfiguration.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		C0D2DD091B6BDEA1004E8919 /* RLMRealmConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = C0D2DD051B6BDEA1004E8919 /* RLMRealmConfiguration.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		C0D2DD0A1B6BDEA1004E8919 /* RLMRealmConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = C0D2DD051B6BDEA1004E8919 /* RLMRealmConfiguration.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		E81A1F851955FC9300FDED82 /* RLMAccessor.h in Headers */ = {isa = PBXBuildFile; fileRef = E81A1F631955FC9300FDED82 /* RLMAccessor.h */; };
+		E81A1F851955FC9300FDED82 /* RLMAccessor.h in Headers */ = {isa = PBXBuildFile; fileRef = E81A1F631955FC9300FDED82 /* RLMAccessor.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E81A1F861955FC9300FDED82 /* RLMAccessor.mm in Sources */ = {isa = PBXBuildFile; fileRef = E81A1F641955FC9300FDED82 /* RLMAccessor.mm */; };
 		E81A1F891955FC9300FDED82 /* RLMArray.h in Headers */ = {isa = PBXBuildFile; fileRef = E81A1F661955FC9300FDED82 /* RLMArray.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		E81A1F8A1955FC9300FDED82 /* RLMArray.mm in Sources */ = {isa = PBXBuildFile; fileRef = E81A1F671955FC9300FDED82 /* RLMArray.mm */; };
@@ -384,7 +384,7 @@
 		E83591991B3DF05C0035F2F3 /* RLMAnalytics.hpp in Headers */ = {isa = PBXBuildFile; fileRef = E83591941B3DF05C0035F2F3 /* RLMAnalytics.hpp */; };
 		E835919A1B3DF05C0035F2F3 /* RLMAnalytics.hpp in Headers */ = {isa = PBXBuildFile; fileRef = E83591941B3DF05C0035F2F3 /* RLMAnalytics.hpp */; };
 		E856D1F11956154C00FB2FCF /* Realm.h in Headers */ = {isa = PBXBuildFile; fileRef = E8D89B9D1955FC6D00CF2B9A /* Realm.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		E856D1F21956154C00FB2FCF /* RLMAccessor.h in Headers */ = {isa = PBXBuildFile; fileRef = E81A1F631955FC9300FDED82 /* RLMAccessor.h */; };
+		E856D1F21956154C00FB2FCF /* RLMAccessor.h in Headers */ = {isa = PBXBuildFile; fileRef = E81A1F631955FC9300FDED82 /* RLMAccessor.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E856D1F31956154C00FB2FCF /* RLMAccessor.mm in Sources */ = {isa = PBXBuildFile; fileRef = E81A1F641955FC9300FDED82 /* RLMAccessor.mm */; };
 		E856D1F51956154C00FB2FCF /* RLMArray.h in Headers */ = {isa = PBXBuildFile; fileRef = E81A1F661955FC9300FDED82 /* RLMArray.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		E856D1F61956154C00FB2FCF /* RLMArray.mm in Sources */ = {isa = PBXBuildFile; fileRef = E81A1F671955FC9300FDED82 /* RLMArray.mm */; };

--- a/Realm/RLMAccessor.h
+++ b/Realm/RLMAccessor.h
@@ -18,9 +18,17 @@
 
 #import <Foundation/Foundation.h>
 
+#import <Realm/RLMDefines.h>
+
 @class RLMObjectSchema, RLMProperty, RLMObjectBase, RLMRealm, RLMProperty;
 
+#ifdef __cplusplus
 typedef NSUInteger RLMCreationOptions;
+#else
+typedef NS_OPTIONS(NSUInteger, RLMCreationOptions);
+#endif
+
+RLM_ASSUME_NONNULL_BEGIN
 
 //
 // Accessors Class Creation/Caching
@@ -33,9 +41,9 @@ Class RLMStandaloneAccessorClassForObjectClass(Class objectClass, RLMObjectSchem
 //
 // Dynamic getters/setters
 //
-void RLMDynamicValidatedSet(RLMObjectBase *obj, NSString *propName, id val);
-id RLMDynamicGet(RLMObjectBase *obj, NSString *propName);
-id RLMDynamicGet(RLMObjectBase *obj, RLMProperty *prop);
+FOUNDATION_EXTERN void RLMDynamicValidatedSet(RLMObjectBase *obj, NSString *propName, id __nullable val);
+FOUNDATION_EXTERN RLMProperty *RLMValidatedGetProperty(RLMObjectBase *obj, NSString *propName);
+FOUNDATION_EXTERN id __nullable RLMDynamicGet(RLMObjectBase *obj, RLMProperty *prop);
 
 // by property/column
 void RLMDynamicSet(RLMObjectBase *obj, RLMProperty *prop, id val, RLMCreationOptions options);
@@ -50,3 +58,4 @@ void RLMReplaceClassNameMethod(Class accessorClass, NSString *className);
 // Replace sharedSchema method for the given class
 void RLMReplaceSharedSchemaMethod(Class accessorClass, RLMObjectSchema *schema);
 
+RLM_ASSUME_NONNULL_END

--- a/Realm/RLMAccessor.mm
+++ b/Realm/RLMAccessor.mm
@@ -748,12 +748,12 @@ void RLMDynamicSet(__unsafe_unretained RLMObjectBase *const obj, __unsafe_unreta
     }
 }
 
-id RLMDynamicGet(__unsafe_unretained RLMObjectBase *obj, __unsafe_unretained NSString *propName) {
+RLMProperty *RLMValidatedGetProperty(__unsafe_unretained RLMObjectBase *const obj, __unsafe_unretained NSString *const propName) {
     RLMProperty *prop = obj->_objectSchema[propName];
     if (!prop) {
         @throw RLMException([NSString stringWithFormat:@"Invalid property name `%@` for class `%@`.", propName, obj->_objectSchema.className]);
     }
-    return RLMDynamicGet(obj, prop);
+    return prop;
 }
 
 id RLMDynamicGet(__unsafe_unretained RLMObjectBase *obj, __unsafe_unretained RLMProperty *prop) {

--- a/Realm/RLMObject.mm
+++ b/Realm/RLMObject.mm
@@ -186,7 +186,7 @@
 }
 
 - (id)valueForUndefinedKey:(NSString *)key {
-    return RLMDynamicGet(self, key);
+    return RLMDynamicGet(self, RLMValidatedGetProperty(self, key));
 }
 
 - (void)setValue:(id)value forUndefinedKey:(NSString *)key {

--- a/Realm/RLMObjectBase.mm
+++ b/Realm/RLMObjectBase.mm
@@ -20,9 +20,10 @@
 
 #import "RLMAccessor.h"
 #import "RLMArray_Private.hpp"
-#import "RLMObservation.hpp"
+#import "RLMListBase.h"
 #import "RLMObjectSchema_Private.hpp"
 #import "RLMObjectStore.h"
+#import "RLMObservation.hpp"
 #import "RLMProperty_Private.h"
 #import "RLMRealm_Private.hpp"
 #import "RLMSchema_Private.h"
@@ -137,6 +138,18 @@ static id RLMValidatedObjectForProperty(id obj, RLMProperty *prop, RLMSchema *sc
         return object_getIvar(self, ivar);
     }
     return [super valueForUndefinedKey:key];
+}
+
+- (void)setValue:(id)value forUndefinedKey:(NSString *)key {
+    if (Ivar ivar = _objectSchema[key].swiftListIvar) {
+        if ([value conformsToProtocol:@protocol(NSFastEnumeration)]) {
+            RLMArray *array = [object_getIvar(self, ivar) _rlmArray];
+            [array removeAllObjects];
+            [array addObjects:value];
+        }
+        return;
+    }
+    [super setValue:value forUndefinedKey:key];
 }
 
 // overridden at runtime per-class for performance

--- a/Realm/RLMObjectBase.mm
+++ b/Realm/RLMObjectBase.mm
@@ -342,7 +342,7 @@ id RLMObjectBaseObjectForKeyedSubscript(RLMObjectBase *object, NSString *key) {
     }
 
     if (object->_realm) {
-        return RLMDynamicGet(object, key);
+        return RLMDynamicGet(object, RLMValidatedGetProperty(object, key));
     }
     else {
         return [object valueForKey:key];

--- a/Realm/RLMUtil.mm
+++ b/Realm/RLMUtil.mm
@@ -19,9 +19,10 @@
 #import "RLMUtil.hpp"
 
 #import "RLMArray_Private.hpp"
+#import "RLMListBase.h"
 #import "RLMObjectSchema_Private.hpp"
-#import "RLMObject_Private.hpp"
 #import "RLMObjectStore.h"
+#import "RLMObject_Private.hpp"
 #import "RLMProperty_Private.h"
 #import "RLMSchema_Private.h"
 #import "RLMSwiftSupport.h"
@@ -147,6 +148,9 @@ BOOL RLMIsObjectValidForProperty(__unsafe_unretained id const obj,
         case RLMPropertyTypeArray: {
             if (RLMArray *array = RLMDynamicCast<RLMArray>(obj)) {
                 return [array.objectClassName isEqualToString:property.objectClassName];
+            }
+            if (RLMListBase *list = RLMDynamicCast<RLMListBase>(obj)) {
+                return [list._rlmArray.objectClassName isEqualToString:property.objectClassName];
             }
             if (NSArray *array = RLMDynamicCast<NSArray>(obj)) {
                 // check each element for compliance

--- a/Realm/module.modulemap
+++ b/Realm/module.modulemap
@@ -5,6 +5,7 @@ framework module Realm {
     module * { export * }
 
     explicit module Private {
+        header "RLMAccessor.h"
         header "RLMArray_Private.h"
         header "RLMRealmConfiguration_Private.h"
         header "RLMListBase.h"

--- a/RealmSwift-swift1.2/Object.swift
+++ b/RealmSwift-swift1.2/Object.swift
@@ -157,20 +157,22 @@ public class Object: RLMObjectBase, Equatable, Printable {
     /// Returns or sets the value of the property with the given name.
     public subscript(key: String) -> AnyObject? {
         get {
-            if let list = listProperty(key) {
-                return list
+            if realm == nil {
+                return self.valueForKey(key)
             }
-            return RLMObjectBaseObjectForKeyedSubscript(self, key)
+            let property = RLMValidatedGetProperty(self, key)
+            if property.type == .Array {
+                return self.listForProperty(property)
+            }
+            return RLMDynamicGet(self, property)
         }
         set(value) {
-            if let list = listProperty(key) {
-                if let value = value as? NSFastEnumeration {
-                    list._rlmArray.removeAllObjects()
-                    list._rlmArray.addObjects(value)
-                }
-                return
+            if realm == nil {
+                self.setValue(value, forKey: key)
             }
-            RLMObjectBaseSetObjectForKeyedSubscript(self, key, value)
+            else {
+                RLMDynamicValidatedSet(self, key, value)
+            }
         }
     }
 

--- a/RealmSwift-swift1.2/Object.swift
+++ b/RealmSwift-swift1.2/Object.swift
@@ -154,34 +154,6 @@ public class Object: RLMObjectBase, Equatable, Printable {
 
     // MARK: Key-Value Coding & Subscripting
 
-    /**
-    Returns the value for the property identified by the given key.
-    :param: key The name of one of the receiver's properties.
-    :returns: The value for the property identified by `key`.
-    */
-    public override func valueForKey(key: String) -> AnyObject? {
-        if let list = listProperty(key) {
-            return list
-        }
-        return super.valueForKey(key)
-    }
-
-    /**
-    Sets the property of the receiver specified by the given key to the given value.
-    :param: value The value for the property identified by `key`.
-    :param: key   The name of one of the receiver's properties.
-    */
-    public override func setValue(value: AnyObject?, forKey key: String) {
-        if let list = listProperty(key) {
-            if let value = value as? NSFastEnumeration {
-                list._rlmArray.removeAllObjects()
-                list._rlmArray.addObjects(value)
-            }
-            return
-        }
-        super.setValue(value, forKey: key)
-    }
-
     /// Returns or sets the value of the property with the given name.
     public subscript(key: String) -> AnyObject? {
         get {

--- a/RealmSwift-swift1.2/Tests/ObjectCreationTests.swift
+++ b/RealmSwift-swift1.2/Tests/ObjectCreationTests.swift
@@ -377,6 +377,21 @@ class ObjectCreationTests: TestCase {
         XCTAssertEqual(existingObject.intCol, 2)
     }
 
+    func testAddStandaloneObjectWithDynamicListProperty() {
+        let obj = SwiftObject()
+        obj.boolCol = true
+        let arrayObj = SwiftDynamicListOfSwiftObject()
+        arrayObj.array.append(obj)
+
+        let realm = Realm()
+        realm.write {
+            realm.add(arrayObj)
+        }
+
+        XCTAssertEqual(1, arrayObj.array.count)
+        XCTAssertEqual(true, arrayObj.array[0].boolCol)
+    }
+
     // MARK: Private utilities
     private func verifySwiftObjectWithArrayLiteral(object: SwiftObject, array: [AnyObject], boolObjectValue: Bool, boolObjectListValues: [Bool]) {
         XCTAssertEqual(object.boolCol, array[0] as! Bool)

--- a/RealmSwift-swift1.2/Tests/SwiftTestObjects.swift
+++ b/RealmSwift-swift1.2/Tests/SwiftTestObjects.swift
@@ -124,6 +124,10 @@ class SwiftListOfSwiftObject: Object {
     let array = List<SwiftObject>()
 }
 
+class SwiftDynamicListOfSwiftObject: Object {
+    dynamic let array = List<SwiftObject>()
+}
+
 class SwiftArrayPropertySubclassObject: SwiftArrayPropertyObject {
     let boolArray = List<SwiftBoolObject>()
 }

--- a/RealmSwift-swift2.0/Object.swift
+++ b/RealmSwift-swift2.0/Object.swift
@@ -158,37 +158,6 @@ public class Object: RLMObjectBase {
 
     // MARK: Key-Value Coding & Subscripting
 
-    /**
-    Returns the value for the property identified by the given key.
-
-    - parameter key: The name of one of the receiver's properties.
-
-    - returns: The value for the property identified by `key`.
-    */
-    public override func valueForKey(key: String) -> AnyObject? {
-        if let list = listProperty(key) {
-            return list
-        }
-        return super.valueForKey(key)
-    }
-
-    /**
-    Sets the property of the receiver specified by the given key to the given value.
-
-    - parameter value: The value for the property identified by `key`.
-    - parameter key:   The name of one of the receiver's properties.
-    */
-    public override func setValue(value: AnyObject?, forKey key: String) {
-        if let list = listProperty(key) {
-            if let value = value as? NSFastEnumeration {
-                list._rlmArray.removeAllObjects()
-                list._rlmArray.addObjects(value)
-            }
-            return
-        }
-        super.setValue(value, forKey: key)
-    }
-
     /// Returns or sets the value of the property with the given name.
     public subscript(key: String) -> AnyObject? {
         get {

--- a/RealmSwift-swift2.0/Object.swift
+++ b/RealmSwift-swift2.0/Object.swift
@@ -209,12 +209,14 @@ public class Object: RLMObjectBase {
 
     // Helper for getting a list property for the given key
     private func listProperty(key: String) -> RLMListBase? {
-        if let prop = RLMObjectBaseObjectSchema(self)?[key] {
-            if prop.type == .Array {
-                return object_getIvar(self, prop.swiftListIvar) as! RLMListBase?
-            }
+        if let prop = RLMObjectBaseObjectSchema(self)?[key] where prop.type == .Array {
+            return object_getIvar(self, prop.swiftListIvar) as! RLMListBase?
         }
         return nil
+    }
+
+    internal func listForProperty(prop: RLMProperty) -> RLMListBase {
+        return object_getIvar(self, prop.swiftListIvar) as! RLMListBase
     }
 }
 
@@ -225,18 +227,13 @@ public final class DynamicObject : Object {
     private var listProperties = [String: List<DynamicObject>]()
 
     // Override to create List<DynamicObject> on access
-    private override func listProperty(key: String) -> RLMListBase? {
-        if let prop = RLMObjectBaseObjectSchema(self)?[key] {
-            if prop.type == .Array {
-                if let list = listProperties[key] {
-                    return list
-                }
-                let list = List<DynamicObject>()
-                listProperties[key] = list
-                return list
-            }
+    internal override func listForProperty(prop: RLMProperty) -> RLMListBase {
+        if let list = listProperties[prop.name] {
+            return list
         }
-        return nil
+        let list = List<DynamicObject>()
+        listProperties[prop.name] = list
+        return list
     }
 
     /// :nodoc:
@@ -280,9 +277,8 @@ public class ObjectUtil: NSObject {
         }
     }
 
-    @objc private class func initializeListProperty(object: RLMObjectBase?, property: RLMProperty?, array: RLMArray?) {
-        let list = (object as! Object)[property!.name]! as! RLMListBase
-        list._rlmArray = array
+    @objc private class func initializeListProperty(object: RLMObjectBase, property: RLMProperty, array: RLMArray) {
+        (object as! Object).listForProperty(property)._rlmArray = array
     }
 
     @objc private class func getOptionalPropertyNames(object: AnyObject) -> NSArray {


### PR DESCRIPTION
Tweak how List properties are handled by KVC to avoid penalizing non-List properties, as they're the far more common case. Makes bulk-adding objects with a single int field nearly twice as fast overall.

The added test is just a sanity check to verify that we didn't actually need to be overriding the returned object for `dynamic` `List` properties, and is Swift 1.2-only because 2.0 switched back to forbidding them.

Fixes #2405.