### PR TITLE
Add `NS_DESIGNATED_INITIALIZER` macro to `RLMObject`s init

### DIFF
--- a/Realm/RLMObject.h
+++ b/Realm/RLMObject.h
@@ -98,7 +98,7 @@ RLM_ASSUME_NONNULL_BEGIN
  
  @see [RLMRealm addObject:]:
  */
-- (instancetype)init;
+- (instancetype)init NS_DESIGNATED_INITIALIZER;
 
 
 /**

--- a/Realm/RLMObject.h
+++ b/Realm/RLMObject.h
@@ -109,7 +109,7 @@ RLM_ASSUME_NONNULL_BEGIN
  
  @see [RLMRealm addObject:]:
  */
-- (instancetype)initWithValue:(id)value;
+- (instancetype)initWithValue:(id)value NS_DESIGNATED_INITIALIZER;
 
 - (instancetype)initWithObject:(id)object DEPRECATED_MSG_ATTRIBUTE("use initWithValue:");
 


### PR DESCRIPTION
This fixes https://github.com/realm/realm-cocoa/issues/2416 . It makes to be able to find the custom init method that has been added in the category from Swift. I'm not sure that this change reasonable or not. I'd like to hear thoughts of others. @bdash @tgoyne @segiddins 