### PR TITLE
[Swift-2.0][Examples] update Swift 2 examples to do/catch instead of try!

### DIFF
--- a/examples/ios/swift-2.0/Backlink/AppDelegate.swift
+++ b/examples/ios/swift-2.0/Backlink/AppDelegate.swift
@@ -45,7 +45,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         window?.rootViewController = UIViewController()
         window?.makeKeyAndVisible()
 
-        try! NSFileManager.defaultManager().removeItemAtPath(Realm.Configuration.defaultConfiguration.path!)
+        do {
+            try NSFileManager.defaultManager().removeItemAtPath(Realm.Configuration.defaultConfiguration.path!)
+        } catch {}
 
         let realm = try! Realm()
         realm.write {

--- a/examples/ios/swift-2.0/Migration/AppDelegate.swift
+++ b/examples/ios/swift-2.0/Migration/AppDelegate.swift
@@ -67,8 +67,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         let defaultParentPath = (defaultPath as NSString).stringByDeletingLastPathComponent
 
         if let v0Path = bundlePath("default-v0.realm") {
-            try! NSFileManager.defaultManager().removeItemAtPath(defaultPath)
-            try! NSFileManager.defaultManager().copyItemAtPath(v0Path, toPath: defaultPath)
+            do {
+                try NSFileManager.defaultManager().removeItemAtPath(defaultPath)
+                try NSFileManager.defaultManager().copyItemAtPath(v0Path, toPath: defaultPath)
+            } catch {}
         }
 
         // define a migration block
@@ -114,10 +116,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             let realmv1Configuration = Realm.Configuration(path: realmv1Path, schemaVersion: 3, migrationBlock: migrationBlock)
             let realmv2Configuration = Realm.Configuration(path: realmv2Path, schemaVersion: 3, migrationBlock: migrationBlock)
 
-            try! NSFileManager.defaultManager().removeItemAtPath(realmv1Path)
-            try! NSFileManager.defaultManager().copyItemAtPath(v1Path, toPath: realmv1Path)
-            try! NSFileManager.defaultManager().removeItemAtPath(realmv2Path)
-            try! NSFileManager.defaultManager().copyItemAtPath(v2Path, toPath: realmv2Path)
+            do {
+                try NSFileManager.defaultManager().removeItemAtPath(realmv1Path)
+                try NSFileManager.defaultManager().copyItemAtPath(v1Path, toPath: realmv1Path)
+                try NSFileManager.defaultManager().removeItemAtPath(realmv2Path)
+                try NSFileManager.defaultManager().copyItemAtPath(v2Path, toPath: realmv2Path)
+            } catch {}
 
             // migrate realms at realmv1Path manually, realmv2Path is migrated automatically on access
             migrateRealm(realmv1Configuration)

--- a/examples/ios/swift-2.0/Simple/AppDelegate.swift
+++ b/examples/ios/swift-2.0/Simple/AppDelegate.swift
@@ -39,7 +39,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         window?.rootViewController = UIViewController()
         window?.makeKeyAndVisible()
 
-        try! NSFileManager.defaultManager().removeItemAtPath(Realm.Configuration.defaultConfiguration.path!)
+        do {
+            try NSFileManager.defaultManager().removeItemAtPath(Realm.Configuration.defaultConfiguration.path!)
+        } catch {}
 
         // Create a standalone object
         let mydog = Dog()


### PR DESCRIPTION
In Swift 2, `try! ... removeItemAtPath` will assert if the file doesn't already exist and `try?` shows a warning in Xcode, so I'm using empty catch blocks instead. /cc @segiddins @tgoyne 