### PR TITLE
Fix tests with the current master version of core.

### DIFF
--- a/Realm/RLMQueryUtil.mm
+++ b/Realm/RLMQueryUtil.mm
@@ -410,7 +410,7 @@ struct ColumnOfTypeHelper {
 // FIXME: This specialization can be removed when core v0.92.x is no longer used.
 template <typename TableGetter>
 struct ColumnOfTypeHelper<realm::DateTime, TableGetter> {
-    template <typename ColumnType=std::conditional_t<std::is_convertible<DateTime, int64_t>::value, DateTime, Int>>
+    using ColumnType = std::conditional_t<std::is_convertible<DateTime, int64_t>::value, DateTime, Int>;
     static Columns<ColumnType> convert(TableGetter&& table, NSUInteger idx)
     {
         return table()->template column<ColumnType>(idx);
@@ -423,7 +423,7 @@ struct ValueOfTypeHelper;
 template <typename TableGetter>
 struct ValueOfTypeHelper<realm::DateTime, TableGetter> {
     // FIXME: The return type can simply be DateTime when core v0.92.x is no longer used.
-    template <typename ResultType=std::conditional_t<std::is_convertible<DateTime, int64_t>::value, DateTime, Int>>
+    using ResultType = std::conditional_t<std::is_convertible<DateTime, int64_t>::value, DateTime, Int>;
     static ResultType convert(TableGetter&&, id value)
     {
         return [value timeIntervalSince1970];

--- a/Realm/RLMQueryUtil.mm
+++ b/Realm/RLMQueryUtil.mm
@@ -407,11 +407,13 @@ struct ColumnOfTypeHelper {
     }
 };
 
+// FIXME: This specialization can be removed when core v0.92.x is no longer used.
 template <typename TableGetter>
 struct ColumnOfTypeHelper<realm::DateTime, TableGetter> {
-    static realm::Columns<Int> convert(TableGetter&& table, NSUInteger idx)
+    template <typename ColumnType=std::conditional_t<std::is_convertible<DateTime, int64_t>::value, DateTime, Int>>
+    static Columns<ColumnType> convert(TableGetter&& table, NSUInteger idx)
     {
-        return table()->template column<Int>(idx);
+        return table()->template column<ColumnType>(idx);
     }
 };
 
@@ -420,7 +422,9 @@ struct ValueOfTypeHelper;
 
 template <typename TableGetter>
 struct ValueOfTypeHelper<realm::DateTime, TableGetter> {
-    static Int convert(TableGetter&&, id value)
+    // FIXME: The return type can simply be DateTime when core v0.92.x is no longer used.
+    template <typename ResultType=std::conditional_t<std::is_convertible<DateTime, int64_t>::value, DateTime, Int>>
+    static ResultType convert(TableGetter&&, id value)
     {
         return [value timeIntervalSince1970];
     }


### PR DESCRIPTION
`Table::column<T>` now checks that `T` matches the stored type of the column. This breaks with the existing implementation of `ColumnOfTypeHelper` that uses `Table::column<Int>` for `DateTime` columns. This was done to avoid compilation errors from query_expression.hpp that occurred due to `DateTime`'s `operator int64_t` being private. In core master, it's no longer private so our hack is no longer necessary. As a temporary measure we conditionally select between `DateTime` and `Int` for the column types to allow building with both the latest core release and the current core master.

/cc @tgoyne 