### PR TITLE
Remove ancient workaround in migration tests

### DIFF
--- a/Realm/Tests/MigrationTests.mm
+++ b/Realm/Tests/MigrationTests.mm
@@ -97,15 +97,9 @@ static void RLMAssertRealmSchemaMatchesTable(id self, RLMRealm *realm) {
 @implementation MigrationTests
 
 - (RLMRealm *)realmWithSingleObject:(RLMObjectSchema *)objectSchema {
-    // modify object schema to use RLMObject class (or else bad accessors will get created)
-    objectSchema.objectClass = RLMDynamicObject.class;
-    objectSchema.accessorClass = RLMDynamicObject.class;
-
     RLMSchema *schema = [[RLMSchema alloc] init];
     schema.objectSchema = @[objectSchema];
-    RLMRealm *realm = [self realmWithTestPathAndSchema:schema];
-    
-    return realm;
+    return [self realmWithTestPathAndSchema:schema];
 }
 
 - (void)testSchemaVersion {


### PR DESCRIPTION
Before we checked that the schema and accessors actually matched we had to ensure that accessor classes wouldn't get created for modified schemas in the migration tests (or other tests would end up using those classes), but that's long fixed.