### PR TITLE
Add support for nullable primitives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,10 @@ x.x.x Release notes (yyyy-MM-dd)
 
 * Enable bitcode for iOS and watchOS frameworks.
 * Build libraries with Xcode 7 final rather than the GM.
+* Fix assertion failure when inserting NSData between 8MB and 16MB in size.
+* Fix assertion failure when rolling back a migration which removed an object
+  link or `RLMArray`/`List` property.
+* Add the path of the file being opened to file open errors.
 
 0.95.1 Release notes (2015-09-23)
 =============================================================

--- a/Configuration/RealmSwift/Base.xcconfig
+++ b/Configuration/RealmSwift/Base.xcconfig
@@ -38,3 +38,4 @@ REALM_FRAMEWORK_PATH[sdk=macosx*] = build/osx;
 REALM_OTHER_CFLAGS[sdk=iphone*] = -fembed-bitcode
 REALM_OTHER_CFLAGS[sdk=watch*] = -fembed-bitcode
 OTHER_CFLAGS = $(inherited) $(REALM_OTHER_FLAGS)
+OTHER_SWIFT_FLAGS = $(inherited) -DREALM_ENABLE_NULL

--- a/Configuration/RealmSwift/Base.xcconfig
+++ b/Configuration/RealmSwift/Base.xcconfig
@@ -38,4 +38,3 @@ REALM_FRAMEWORK_PATH[sdk=macosx*] = build/osx;
 REALM_OTHER_CFLAGS[sdk=iphone*] = -fembed-bitcode
 REALM_OTHER_CFLAGS[sdk=watch*] = -fembed-bitcode
 OTHER_CFLAGS = $(inherited) $(REALM_OTHER_FLAGS)
-OTHER_SWIFT_FLAGS = $(inherited) -DREALM_ENABLE_NULL

--- a/Realm.xcodeproj/project.pbxproj
+++ b/Realm.xcodeproj/project.pbxproj
@@ -324,6 +324,14 @@
 		A05AEB711B6A9B0E00072027 /* RLMObjectBase_Dynamic.h in Headers */ = {isa = PBXBuildFile; fileRef = A05FA61E1B62C3900000C9B2 /* RLMObjectBase_Dynamic.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A05AEB721B6A9B0F00072027 /* RLMObjectBase_Dynamic.h in Headers */ = {isa = PBXBuildFile; fileRef = A05FA61E1B62C3900000C9B2 /* RLMObjectBase_Dynamic.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A0CCA0BF1B7C0B4A000B6B0F /* RLMObjectBase_Dynamic.h in Headers */ = {isa = PBXBuildFile; fileRef = A05FA61E1B62C3900000C9B2 /* RLMObjectBase_Dynamic.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		C0004BED1B8E4FCF00304BF3 /* RLMOptionalBase.h in Headers */ = {isa = PBXBuildFile; fileRef = C0004BEB1B8E4FCF00304BF3 /* RLMOptionalBase.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		C0004BEE1B8E4FCF00304BF3 /* RLMOptionalBase.h in Headers */ = {isa = PBXBuildFile; fileRef = C0004BEB1B8E4FCF00304BF3 /* RLMOptionalBase.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		C0004BEF1B8E4FCF00304BF3 /* RLMOptionalBase.h in Headers */ = {isa = PBXBuildFile; fileRef = C0004BEB1B8E4FCF00304BF3 /* RLMOptionalBase.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		C0004BF01B8E4FCF00304BF3 /* RLMOptionalBase.h in Headers */ = {isa = PBXBuildFile; fileRef = C0004BEB1B8E4FCF00304BF3 /* RLMOptionalBase.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		C0004BF11B8E4FCF00304BF3 /* RLMOptionalBase.m in Sources */ = {isa = PBXBuildFile; fileRef = C0004BEC1B8E4FCF00304BF3 /* RLMOptionalBase.m */; };
+		C0004BF21B8E4FCF00304BF3 /* RLMOptionalBase.m in Sources */ = {isa = PBXBuildFile; fileRef = C0004BEC1B8E4FCF00304BF3 /* RLMOptionalBase.m */; };
+		C0004BF31B8E4FCF00304BF3 /* RLMOptionalBase.m in Sources */ = {isa = PBXBuildFile; fileRef = C0004BEC1B8E4FCF00304BF3 /* RLMOptionalBase.m */; };
+		C0004BF41B8E4FCF00304BF3 /* RLMOptionalBase.m in Sources */ = {isa = PBXBuildFile; fileRef = C0004BEC1B8E4FCF00304BF3 /* RLMOptionalBase.m */; };
 		C02E53E11B7A7E2B002586E8 /* RLMRealmConfiguration.mm in Sources */ = {isa = PBXBuildFile; fileRef = C0D2DD061B6BDEA1004E8919 /* RLMRealmConfiguration.mm */; };
 		C02E53E21B7A7E2B002586E8 /* RLMRealmConfiguration.mm in Sources */ = {isa = PBXBuildFile; fileRef = C0D2DD061B6BDEA1004E8919 /* RLMRealmConfiguration.mm */; };
 		C02E53E31B7A7E2C002586E8 /* RLMRealmConfiguration.mm in Sources */ = {isa = PBXBuildFile; fileRef = C0D2DD061B6BDEA1004E8919 /* RLMRealmConfiguration.mm */; };
@@ -643,6 +651,8 @@
 		3FEC4A3D1BBB188B00F009C3 /* SwiftSchemaTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SwiftSchemaTests.swift; path = SwiftSchemaTests.swift; sourceTree = "<group>"; };
 		5D30B74A1B42039F00D90C5A /* RLMDefines.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RLMDefines.h; sourceTree = "<group>"; };
 		A05FA61E1B62C3900000C9B2 /* RLMObjectBase_Dynamic.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RLMObjectBase_Dynamic.h; sourceTree = "<group>"; };
+		C0004BEB1B8E4FCF00304BF3 /* RLMOptionalBase.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RLMOptionalBase.h; sourceTree = "<group>"; };
+		C0004BEC1B8E4FCF00304BF3 /* RLMOptionalBase.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RLMOptionalBase.m; sourceTree = "<group>"; };
 		C042A48C1B7522A900771ED2 /* RealmConfigurationTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = RealmConfigurationTests.mm; sourceTree = "<group>"; };
 		C073E1201AE9B705002C0A30 /* RLMObject_Private.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = RLMObject_Private.hpp; sourceTree = "<group>"; };
 		C0D2DD051B6BDEA1004E8919 /* RLMRealmConfiguration.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RLMRealmConfiguration.h; sourceTree = "<group>"; };
@@ -939,6 +949,8 @@
 				E81A1F741955FC9300FDED82 /* RLMObjectStore.mm */,
 				3F0F02AC1B6FFF3D0046A4D5 /* RLMObservation.hpp */,
 				3F0F02AD1B6FFF3D0046A4D5 /* RLMObservation.mm */,
+				C0004BEB1B8E4FCF00304BF3 /* RLMOptionalBase.h */,
+				C0004BEC1B8E4FCF00304BF3 /* RLMOptionalBase.m */,
 				3F68BFCD1B558CA800D50FBD /* RLMPrefix.h */,
 				E81A1F761955FC9300FDED82 /* RLMProperty.h */,
 				E81A1F771955FC9300FDED82 /* RLMProperty.mm */,
@@ -1034,6 +1046,7 @@
 				144C2F741B3D3539005C8F81 /* RLMObjectSchema_Private.hpp in Headers */,
 				144C2F6C1B3D3529005C8F81 /* RLMObjectStore.h in Headers */,
 				C06C74031B797EF10027FF85 /* RLMObservation.hpp in Headers */,
+				C0004BF01B8E4FCF00304BF3 /* RLMOptionalBase.h in Headers */,
 				144C2F5A1B3D3516005C8F81 /* RLMPlatform.h in Headers */,
 				144C2F631B3D3517005C8F81 /* RLMProperty.h in Headers */,
 				144C2F6D1B3D3529005C8F81 /* RLMProperty_Private.h in Headers */,
@@ -1082,6 +1095,7 @@
 				29E3C7261A71C1C700B62C1D /* RLMObjectSchema_Private.hpp in Headers */,
 				29EDB8DA1A7703C500458D80 /* RLMObjectStore.h in Headers */,
 				3F0F02B01B6FFF3D0046A4D5 /* RLMObservation.hpp in Headers */,
+				C0004BEF1B8E4FCF00304BF3 /* RLMOptionalBase.h in Headers */,
 				29E3C7271A71C1C700B62C1D /* RLMPlatform.h in Headers */,
 				29E3C72E1A71C1C700B62C1D /* RLMProperty.h in Headers */,
 				29E3C72F1A71C1C700B62C1D /* RLMProperty_Private.h in Headers */,
@@ -1130,6 +1144,7 @@
 				E856D1FF1956154C00FB2FCF /* RLMObjectSchema_Private.hpp in Headers */,
 				29EDB8D91A7703C500458D80 /* RLMObjectStore.h in Headers */,
 				3F0F02AF1B6FFF3D0046A4D5 /* RLMObservation.hpp in Headers */,
+				C0004BEE1B8E4FCF00304BF3 /* RLMOptionalBase.h in Headers */,
 				024E6094198B2D51002FA042 /* RLMPlatform.h in Headers */,
 				E856D2051956154C00FB2FCF /* RLMProperty.h in Headers */,
 				E856D2041956154C00FB2FCF /* RLMProperty_Private.h in Headers */,
@@ -1178,6 +1193,7 @@
 				E81A1F991955FC9300FDED82 /* RLMObjectSchema_Private.hpp in Headers */,
 				29EDB8D81A7703C500458D80 /* RLMObjectStore.h in Headers */,
 				3F0F02AE1B6FFF3D0046A4D5 /* RLMObservation.hpp in Headers */,
+				C0004BED1B8E4FCF00304BF3 /* RLMOptionalBase.h in Headers */,
 				024E6097198B2D59002FA042 /* RLMPlatform.h in Headers */,
 				E81A1FA11955FC9300FDED82 /* RLMProperty.h in Headers */,
 				E81A1FA01955FC9300FDED82 /* RLMProperty_Private.h in Headers */,
@@ -1655,6 +1671,7 @@
 				144C2F4E1B3D34A2005C8F81 /* RLMObjectSchema.mm in Sources */,
 				144C2F4F1B3D34A2005C8F81 /* RLMObjectStore.mm in Sources */,
 				C06C74021B797EEF0027FF85 /* RLMObservation.mm in Sources */,
+				C0004BF41B8E4FCF00304BF3 /* RLMOptionalBase.m in Sources */,
 				144C2F501B3D34A2005C8F81 /* RLMProperty.mm in Sources */,
 				144C2F511B3D34A2005C8F81 /* RLMQueryUtil.mm in Sources */,
 				144C2F521B3D34A2005C8F81 /* RLMRealm.mm in Sources */,
@@ -1687,6 +1704,7 @@
 				29E3C70E1A71C1C700B62C1D /* RLMObjectSchema.mm in Sources */,
 				29E3C70F1A71C1C700B62C1D /* RLMObjectStore.mm in Sources */,
 				3F0F02B31B6FFF3D0046A4D5 /* RLMObservation.mm in Sources */,
+				C0004BF31B8E4FCF00304BF3 /* RLMOptionalBase.m in Sources */,
 				29E3C7101A71C1C700B62C1D /* RLMProperty.mm in Sources */,
 				29E3C7111A71C1C700B62C1D /* RLMQueryUtil.mm in Sources */,
 				29E3C7121A71C1C700B62C1D /* RLMRealm.mm in Sources */,
@@ -1760,6 +1778,7 @@
 				E856D2011956154C00FB2FCF /* RLMObjectSchema.mm in Sources */,
 				E856D2031956154C00FB2FCF /* RLMObjectStore.mm in Sources */,
 				3F0F02B21B6FFF3D0046A4D5 /* RLMObservation.mm in Sources */,
+				C0004BF21B8E4FCF00304BF3 /* RLMOptionalBase.m in Sources */,
 				E856D2061956154C00FB2FCF /* RLMProperty.mm in Sources */,
 				E856D2081956154C00FB2FCF /* RLMQueryUtil.mm in Sources */,
 				E856D20B1956154C00FB2FCF /* RLMRealm.mm in Sources */,
@@ -1835,6 +1854,7 @@
 				E81A1F9B1955FC9300FDED82 /* RLMObjectSchema.mm in Sources */,
 				E81A1F9E1955FC9300FDED82 /* RLMObjectStore.mm in Sources */,
 				3F0F02B11B6FFF3D0046A4D5 /* RLMObservation.mm in Sources */,
+				C0004BF11B8E4FCF00304BF3 /* RLMOptionalBase.m in Sources */,
 				E81A1FA21955FC9300FDED82 /* RLMProperty.mm in Sources */,
 				E81A1FA51955FC9300FDED82 /* RLMQueryUtil.mm in Sources */,
 				E81A1FA91955FC9300FDED82 /* RLMRealm.mm in Sources */,
@@ -2437,6 +2457,7 @@
 					REALM_DEBUG,
 					REALM_HAVE_CONFIG,
 					__ASSERTMACROS__,
+					"REALM_ENABLE_NULL=1",
 				);
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
@@ -2495,6 +2516,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					REALM_HAVE_CONFIG,
 					__ASSERTMACROS__,
+					"REALM_ENABLE_NULL=1",
 				);
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_MISSING_PROTOTYPES = YES;

--- a/Realm.xcodeproj/project.pbxproj
+++ b/Realm.xcodeproj/project.pbxproj
@@ -2478,6 +2478,7 @@
 					"-isystem",
 					core/include,
 				);
+				OTHER_SWIFT_FLAGS = "-DREALM_ENABLE_NULL";
 				SDKROOT = iphoneos;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_FILE = "$(PRODUCT_NAME)_vers.m";
@@ -2535,6 +2536,7 @@
 					"-isystem",
 					core/include,
 				);
+				OTHER_SWIFT_FLAGS = "-DREALM_ENABLE_NULL";
 				SDKROOT = iphoneos;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_FILE = "$(PRODUCT_NAME)_vers.m";

--- a/Realm.xcodeproj/project.pbxproj
+++ b/Realm.xcodeproj/project.pbxproj
@@ -328,10 +328,10 @@
 		C0004BEE1B8E4FCF00304BF3 /* RLMOptionalBase.h in Headers */ = {isa = PBXBuildFile; fileRef = C0004BEB1B8E4FCF00304BF3 /* RLMOptionalBase.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		C0004BEF1B8E4FCF00304BF3 /* RLMOptionalBase.h in Headers */ = {isa = PBXBuildFile; fileRef = C0004BEB1B8E4FCF00304BF3 /* RLMOptionalBase.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		C0004BF01B8E4FCF00304BF3 /* RLMOptionalBase.h in Headers */ = {isa = PBXBuildFile; fileRef = C0004BEB1B8E4FCF00304BF3 /* RLMOptionalBase.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		C0004BF11B8E4FCF00304BF3 /* RLMOptionalBase.m in Sources */ = {isa = PBXBuildFile; fileRef = C0004BEC1B8E4FCF00304BF3 /* RLMOptionalBase.m */; };
-		C0004BF21B8E4FCF00304BF3 /* RLMOptionalBase.m in Sources */ = {isa = PBXBuildFile; fileRef = C0004BEC1B8E4FCF00304BF3 /* RLMOptionalBase.m */; };
-		C0004BF31B8E4FCF00304BF3 /* RLMOptionalBase.m in Sources */ = {isa = PBXBuildFile; fileRef = C0004BEC1B8E4FCF00304BF3 /* RLMOptionalBase.m */; };
-		C0004BF41B8E4FCF00304BF3 /* RLMOptionalBase.m in Sources */ = {isa = PBXBuildFile; fileRef = C0004BEC1B8E4FCF00304BF3 /* RLMOptionalBase.m */; };
+		C0004BF11B8E4FCF00304BF3 /* RLMOptionalBase.mm in Sources */ = {isa = PBXBuildFile; fileRef = C0004BEC1B8E4FCF00304BF3 /* RLMOptionalBase.mm */; };
+		C0004BF21B8E4FCF00304BF3 /* RLMOptionalBase.mm in Sources */ = {isa = PBXBuildFile; fileRef = C0004BEC1B8E4FCF00304BF3 /* RLMOptionalBase.mm */; };
+		C0004BF31B8E4FCF00304BF3 /* RLMOptionalBase.mm in Sources */ = {isa = PBXBuildFile; fileRef = C0004BEC1B8E4FCF00304BF3 /* RLMOptionalBase.mm */; };
+		C0004BF41B8E4FCF00304BF3 /* RLMOptionalBase.mm in Sources */ = {isa = PBXBuildFile; fileRef = C0004BEC1B8E4FCF00304BF3 /* RLMOptionalBase.mm */; };
 		C02E53E11B7A7E2B002586E8 /* RLMRealmConfiguration.mm in Sources */ = {isa = PBXBuildFile; fileRef = C0D2DD061B6BDEA1004E8919 /* RLMRealmConfiguration.mm */; };
 		C02E53E21B7A7E2B002586E8 /* RLMRealmConfiguration.mm in Sources */ = {isa = PBXBuildFile; fileRef = C0D2DD061B6BDEA1004E8919 /* RLMRealmConfiguration.mm */; };
 		C02E53E31B7A7E2C002586E8 /* RLMRealmConfiguration.mm in Sources */ = {isa = PBXBuildFile; fileRef = C0D2DD061B6BDEA1004E8919 /* RLMRealmConfiguration.mm */; };
@@ -652,7 +652,7 @@
 		5D30B74A1B42039F00D90C5A /* RLMDefines.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RLMDefines.h; sourceTree = "<group>"; };
 		A05FA61E1B62C3900000C9B2 /* RLMObjectBase_Dynamic.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RLMObjectBase_Dynamic.h; sourceTree = "<group>"; };
 		C0004BEB1B8E4FCF00304BF3 /* RLMOptionalBase.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RLMOptionalBase.h; sourceTree = "<group>"; };
-		C0004BEC1B8E4FCF00304BF3 /* RLMOptionalBase.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RLMOptionalBase.m; sourceTree = "<group>"; };
+		C0004BEC1B8E4FCF00304BF3 /* RLMOptionalBase.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = RLMOptionalBase.mm; sourceTree = "<group>"; };
 		C042A48C1B7522A900771ED2 /* RealmConfigurationTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = RealmConfigurationTests.mm; sourceTree = "<group>"; };
 		C073E1201AE9B705002C0A30 /* RLMObject_Private.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = RLMObject_Private.hpp; sourceTree = "<group>"; };
 		C0D2DD051B6BDEA1004E8919 /* RLMRealmConfiguration.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RLMRealmConfiguration.h; sourceTree = "<group>"; };
@@ -950,7 +950,7 @@
 				3F0F02AC1B6FFF3D0046A4D5 /* RLMObservation.hpp */,
 				3F0F02AD1B6FFF3D0046A4D5 /* RLMObservation.mm */,
 				C0004BEB1B8E4FCF00304BF3 /* RLMOptionalBase.h */,
-				C0004BEC1B8E4FCF00304BF3 /* RLMOptionalBase.m */,
+				C0004BEC1B8E4FCF00304BF3 /* RLMOptionalBase.mm */,
 				3F68BFCD1B558CA800D50FBD /* RLMPrefix.h */,
 				E81A1F761955FC9300FDED82 /* RLMProperty.h */,
 				E81A1F771955FC9300FDED82 /* RLMProperty.mm */,
@@ -1671,7 +1671,7 @@
 				144C2F4E1B3D34A2005C8F81 /* RLMObjectSchema.mm in Sources */,
 				144C2F4F1B3D34A2005C8F81 /* RLMObjectStore.mm in Sources */,
 				C06C74021B797EEF0027FF85 /* RLMObservation.mm in Sources */,
-				C0004BF41B8E4FCF00304BF3 /* RLMOptionalBase.m in Sources */,
+				C0004BF41B8E4FCF00304BF3 /* RLMOptionalBase.mm in Sources */,
 				144C2F501B3D34A2005C8F81 /* RLMProperty.mm in Sources */,
 				144C2F511B3D34A2005C8F81 /* RLMQueryUtil.mm in Sources */,
 				144C2F521B3D34A2005C8F81 /* RLMRealm.mm in Sources */,
@@ -1704,7 +1704,7 @@
 				29E3C70E1A71C1C700B62C1D /* RLMObjectSchema.mm in Sources */,
 				29E3C70F1A71C1C700B62C1D /* RLMObjectStore.mm in Sources */,
 				3F0F02B31B6FFF3D0046A4D5 /* RLMObservation.mm in Sources */,
-				C0004BF31B8E4FCF00304BF3 /* RLMOptionalBase.m in Sources */,
+				C0004BF31B8E4FCF00304BF3 /* RLMOptionalBase.mm in Sources */,
 				29E3C7101A71C1C700B62C1D /* RLMProperty.mm in Sources */,
 				29E3C7111A71C1C700B62C1D /* RLMQueryUtil.mm in Sources */,
 				29E3C7121A71C1C700B62C1D /* RLMRealm.mm in Sources */,
@@ -1778,7 +1778,7 @@
 				E856D2011956154C00FB2FCF /* RLMObjectSchema.mm in Sources */,
 				E856D2031956154C00FB2FCF /* RLMObjectStore.mm in Sources */,
 				3F0F02B21B6FFF3D0046A4D5 /* RLMObservation.mm in Sources */,
-				C0004BF21B8E4FCF00304BF3 /* RLMOptionalBase.m in Sources */,
+				C0004BF21B8E4FCF00304BF3 /* RLMOptionalBase.mm in Sources */,
 				E856D2061956154C00FB2FCF /* RLMProperty.mm in Sources */,
 				E856D2081956154C00FB2FCF /* RLMQueryUtil.mm in Sources */,
 				E856D20B1956154C00FB2FCF /* RLMRealm.mm in Sources */,
@@ -1854,7 +1854,7 @@
 				E81A1F9B1955FC9300FDED82 /* RLMObjectSchema.mm in Sources */,
 				E81A1F9E1955FC9300FDED82 /* RLMObjectStore.mm in Sources */,
 				3F0F02B11B6FFF3D0046A4D5 /* RLMObservation.mm in Sources */,
-				C0004BF11B8E4FCF00304BF3 /* RLMOptionalBase.m in Sources */,
+				C0004BF11B8E4FCF00304BF3 /* RLMOptionalBase.mm in Sources */,
 				E81A1FA21955FC9300FDED82 /* RLMProperty.mm in Sources */,
 				E81A1FA51955FC9300FDED82 /* RLMQueryUtil.mm in Sources */,
 				E81A1FA91955FC9300FDED82 /* RLMRealm.mm in Sources */,

--- a/Realm.xcodeproj/project.pbxproj
+++ b/Realm.xcodeproj/project.pbxproj
@@ -2457,7 +2457,6 @@
 					REALM_DEBUG,
 					REALM_HAVE_CONFIG,
 					__ASSERTMACROS__,
-					"REALM_ENABLE_NULL=1",
 				);
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
@@ -2478,7 +2477,6 @@
 					"-isystem",
 					core/include,
 				);
-				OTHER_SWIFT_FLAGS = "-DREALM_ENABLE_NULL";
 				SDKROOT = iphoneos;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_FILE = "$(PRODUCT_NAME)_vers.m";
@@ -2517,7 +2515,6 @@
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					REALM_HAVE_CONFIG,
 					__ASSERTMACROS__,
-					"REALM_ENABLE_NULL=1",
 				);
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_MISSING_PROTOTYPES = YES;
@@ -2536,7 +2533,6 @@
 					"-isystem",
 					core/include,
 				);
-				OTHER_SWIFT_FLAGS = "-DREALM_ENABLE_NULL";
 				SDKROOT = iphoneos;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_FILE = "$(PRODUCT_NAME)_vers.m";

--- a/Realm/ObjectStore/object_schema.cpp
+++ b/Realm/ObjectStore/object_schema.cpp
@@ -37,11 +37,7 @@ ObjectSchema::ObjectSchema(Group *group, const std::string &name) : name(name) {
         property.type = (PropertyType)table->get_column_type(col);
         property.is_indexed = table->has_search_index(col);
         property.is_primary = false;
-#ifdef REALM_ENABLE_NULL
         property.is_nullable = table->is_nullable(col) || property.type == PropertyTypeObject;
-#else
-        property.is_nullable = property.type == PropertyTypeObject;
-#endif
         property.table_column = col;
         if (property.type == PropertyTypeObject || property.type == PropertyTypeArray) {
             // set link type for objects and arrays

--- a/Realm/ObjectStore/object_store.cpp
+++ b/Realm/ObjectStore/object_store.cpp
@@ -29,30 +29,6 @@
 using namespace realm;
 using namespace std;
 
-template <typename T>
-static inline
-T get_value(TableRef table, size_t row, size_t column);
-
-template <>
-StringData get_value(TableRef table, size_t row, size_t column) {
-    return table->get_string(column, row);
-}
-
-static inline
-void set_value(TableRef table, size_t row, size_t column, StringData value) {
-    table->set_string(column, row, value);
-}
-
-template <>
-BinaryData get_value(TableRef table, size_t row, size_t column) {
-    return table->get_binary(column, row);
-}
-
-static inline
-void set_value(TableRef table, size_t row, size_t column, BinaryData value) {
-    table->set_binary(column, row, value);
-}
-
 const char * const c_metadataTableName = "metadata";
 const char * const c_versionColumnName = "version";
 const size_t c_versionColumnIndex = 0;
@@ -240,12 +216,13 @@ static bool property_can_be_migrated_to_nullable(Property &old_property, Propert
 }
 
 template <typename T>
-static void copy_property_to_property(Property &old_property, Property &new_property, TableRef table) {
+static void copy_property_values(Property const& old_property, Property const& new_property, Table& table,
+                                 T (Table::*getter)(std::size_t, std::size_t) const noexcept,
+                                 void (Table::*setter)(std::size_t, std::size_t, T)) {
     size_t old_column = old_property.table_column, new_column = new_property.table_column;
-    size_t count = table->size();
+    size_t count = table.size();
     for (size_t i = 0; i < count; i++) {
-        T old_value = get_value<T>(table, i, old_column);
-        set_value(table, i, new_column, old_value);
+        (table.*setter)(new_column, i, (table.*getter)(old_column, i));
     }
 }
 
@@ -300,13 +277,28 @@ bool ObjectStore::create_tables(Group *group, ObjectStore::Schema &target_schema
                 if (current_prop && property_can_be_migrated_to_nullable(*current_prop, target_prop)) {
                     switch (target_prop.type) {
                         case PropertyTypeString:
-                            copy_property_to_property<StringData>(*current_prop, target_prop, table);
+                            copy_property_values(*current_prop, target_prop, *table, &Table::get_string, &Table::set_string);
                             break;
                         case PropertyTypeData:
-                            copy_property_to_property<BinaryData>(*current_prop, target_prop, table);
+                            copy_property_values(*current_prop, target_prop, *table, &Table::get_binary, &Table::set_binary);
+                            break;
+                        case PropertyTypeBool:
+                            copy_property_values(*current_prop, target_prop, *table, &Table::get_bool, &Table::set_bool);
+                            break;
+                        case PropertyTypeInt:
+                            copy_property_values(*current_prop, target_prop, *table, &Table::get_int, &Table::set_int);
+                            break;
+                        case PropertyTypeFloat:
+                            copy_property_values(*current_prop, target_prop, *table, &Table::get_float, &Table::set_float);
+                            break;
+                        case PropertyTypeDouble:
+                            copy_property_values(*current_prop, target_prop, *table, &Table::get_double, &Table::set_double);
+                            break;
+                        case PropertyTypeDate:
+                            copy_property_values(*current_prop, target_prop, *table, &Table::get_datetime, &Table::set_datetime);
                             break;
                         default:
-                            REALM_UNREACHABLE();
+                            break;
                     }
                 }
 

--- a/Realm/ObjectStore/object_store.cpp
+++ b/Realm/ObjectStore/object_store.cpp
@@ -266,11 +266,7 @@ bool ObjectStore::create_tables(Group *group, ObjectStore::Schema &target_schema
                         break;
                     }
                     default:
-#ifdef REALM_ENABLE_NULL
                         target_prop.table_column = table->add_column(DataType(target_prop.type), target_prop.name, target_prop.is_nullable);
-#else
-                        target_prop.table_column = table->add_column(DataType(target_prop.type), target_prop.name);
-#endif
                         break;
                 }
 

--- a/Realm/ObjectStore/object_store.cpp
+++ b/Realm/ObjectStore/object_store.cpp
@@ -46,10 +46,6 @@ const size_t c_object_table_prefix_length = c_object_table_prefix.length();
 
 const uint64_t ObjectStore::NotVersioned = numeric_limits<uint64_t>::max();
 
-bool ObjectStore::has_metadata_tables(Group *group) {
-    return group->get_table(c_primaryKeyTableName) && group->get_table(c_metadataTableName);
-}
-
 bool ObjectStore::create_metadata_tables(Group *group) {
     bool changed = false;
     TableRef table = group->get_or_add_table(c_primaryKeyTableName);

--- a/Realm/ObjectStore/object_store.hpp
+++ b/Realm/ObjectStore/object_store.hpp
@@ -81,9 +81,6 @@ namespace realm {
         // set a new schema version
         static void set_schema_version(Group *group, uint64_t version);
 
-        // check if the realm already has all metadata tables
-        static bool has_metadata_tables(Group *group);
-
         // create any metadata tables that don't already exist
         // must be in write transaction to set
         // returns true if it actually did anything

--- a/Realm/RLMAccessor.h
+++ b/Realm/RLMAccessor.h
@@ -49,7 +49,7 @@ FOUNDATION_EXTERN RLMProperty *RLMValidatedGetProperty(RLMObjectBase *obj, NSStr
 FOUNDATION_EXTERN id __nullable RLMDynamicGet(RLMObjectBase *obj, RLMProperty *prop);
 
 // by property/column
-void RLMDynamicSet(RLMObjectBase *obj, RLMProperty *prop, id val, RLMCreationOptions options);
+FOUNDATION_EXTERN void RLMDynamicSet(RLMObjectBase *obj, RLMProperty *prop, id val, RLMCreationOptions options);
 
 //
 // Class modification

--- a/Realm/RLMAccessor.mm
+++ b/Realm/RLMAccessor.mm
@@ -46,6 +46,11 @@ typedef NS_ENUM(char, RLMAccessorCode) {
     RLMAccessorCodeLink,
     RLMAccessorCodeArray,
     RLMAccessorCodeAny,
+
+    RLMAccessorCodeIntObject,
+    RLMAccessorCodeFloatObject,
+    RLMAccessorCodeDoubleObject,
+    RLMAccessorCodeBoolObject,
 };
 
 // long getter/setter
@@ -266,6 +271,116 @@ static inline void RLMSetValue(__unsafe_unretained RLMObjectBase *const obj, NSU
     }
 }
 
+static inline NSNumber<RLMInt> *RLMGetIntObject(__unsafe_unretained RLMObjectBase *const obj, NSUInteger colIndex) {
+    RLMVerifyAttached(obj);
+
+    if (obj->_row.is_null(colIndex)) {
+        return nil;
+    }
+    return @(obj->_row.get_int(colIndex));
+}
+static inline void RLMSetValue(__unsafe_unretained RLMObjectBase *const obj, NSUInteger colIndex,
+                               __unsafe_unretained NSNumber<RLMInt> *const intObject) {
+    RLMVerifyInWriteTransaction(obj);
+
+    if (intObject) {
+        obj->_row.set_int(colIndex, intObject.longLongValue);
+    }
+    else {
+        obj->_row.set_null(colIndex);
+    }
+}
+static inline void RLMSetValueUnique(__unsafe_unretained RLMObjectBase *const obj, NSUInteger colIndex, NSString *propName,
+                                     __unsafe_unretained NSNumber<RLMInt> *const intObject) {
+    RLMVerifyInWriteTransaction(obj);
+
+    long long longLongValue = 0;
+    size_t row;
+    if (intObject) {
+        longLongValue = intObject.longLongValue;
+        row = obj->_row.get_table()->find_first_int(colIndex, longLongValue);
+    }
+    else {
+        row = obj->_row.get_table()->find_first_null(colIndex);
+    }
+
+    if (row == obj->_row.get_index()) {
+        return;
+    }
+    if (row != realm::not_found) {
+        NSString *reason = [NSString stringWithFormat:@"Can't set primary key property '%@' to existing value '%@'.", propName, intObject];
+        @throw RLMException(reason);
+    }
+
+    if (intObject) {
+        obj->_row.set_int(colIndex, longLongValue);
+    }
+    else {
+        obj->_row.set_null(colIndex);
+    }
+}
+
+static inline NSNumber<RLMFloat> *RLMGetFloatObject(__unsafe_unretained RLMObjectBase *const obj, NSUInteger colIndex) {
+    RLMVerifyAttached(obj);
+
+    if (obj->_row.is_null(colIndex)) {
+        return nil;
+    }
+    return @(obj->_row.get_float(colIndex));
+}
+static inline void RLMSetValue(__unsafe_unretained RLMObjectBase *const obj, NSUInteger colIndex,
+                               __unsafe_unretained NSNumber<RLMFloat> *const floatObject) {
+    RLMVerifyInWriteTransaction(obj);
+
+    if (floatObject) {
+        obj->_row.set_float(colIndex, floatObject.floatValue);
+    }
+    else {
+        obj->_row.set_null(colIndex);
+    }
+}
+
+static inline NSNumber<RLMDouble> *RLMGetDoubleObject(__unsafe_unretained RLMObjectBase *const obj, NSUInteger colIndex) {
+    RLMVerifyAttached(obj);
+
+    if (obj->_row.is_null(colIndex)) {
+        return nil;
+    }
+    return @(obj->_row.get_double(colIndex));
+}
+static inline void RLMSetValue(__unsafe_unretained RLMObjectBase *const obj, NSUInteger colIndex,
+                               __unsafe_unretained NSNumber<RLMDouble> *const doubleObject) {
+    RLMVerifyInWriteTransaction(obj);
+
+    if (doubleObject) {
+        obj->_row.set_double(colIndex, doubleObject.doubleValue);
+    }
+    else {
+        obj->_row.set_null(colIndex);
+    }
+}
+
+static inline NSNumber<RLMBool> *RLMGetBoolObject(__unsafe_unretained RLMObjectBase *const obj, NSUInteger colIndex) {
+    RLMVerifyAttached(obj);
+
+    if (obj->_row.is_null(colIndex)) {
+        return nil;
+    }
+    return @(obj->_row.get_bool(colIndex));
+}
+static inline void RLMSetValue(__unsafe_unretained RLMObjectBase *const obj, NSUInteger colIndex,
+                               __unsafe_unretained NSNumber<RLMBool> *const boolObject) {
+    RLMVerifyInWriteTransaction(obj);
+
+    if (boolObject) {
+        obj->_row.set_bool(colIndex, boolObject.boolValue);
+    }
+    else {
+        obj->_row.set_null(colIndex);
+    }
+}
+
+
 // any getter/setter
 static inline id RLMGetAnyProperty(__unsafe_unretained RLMObjectBase *const obj, NSUInteger col_ndx) {
     RLMVerifyAttached(obj);
@@ -404,6 +519,22 @@ static IMP RLMAccessorGetter(RLMProperty *prop, RLMAccessorCode accessorCode) {
             return imp_implementationWithBlock(^(__unsafe_unretained RLMObjectBase *const obj) {
                 return RLMGetAnyProperty(obj, colIndex);
             });
+        case RLMAccessorCodeIntObject:
+            return imp_implementationWithBlock(^(__unsafe_unretained RLMObjectBase *const obj) {
+                return RLMGetIntObject(obj, colIndex);
+            });
+        case RLMAccessorCodeFloatObject:
+            return imp_implementationWithBlock(^(__unsafe_unretained RLMObjectBase *const obj) {
+                return RLMGetFloatObject(obj, colIndex);
+            });
+        case RLMAccessorCodeDoubleObject:
+            return imp_implementationWithBlock(^(__unsafe_unretained RLMObjectBase *const obj) {
+                return RLMGetDoubleObject(obj, colIndex);
+            });
+        case RLMAccessorCodeBoolObject:
+            return imp_implementationWithBlock(^(__unsafe_unretained RLMObjectBase *const obj) {
+                return RLMGetBoolObject(obj, colIndex);
+            });
     }
 }
 
@@ -438,20 +569,24 @@ static IMP RLMMakeSetter(RLMProperty *prop) {
 // dynamic setter with column closure
 static IMP RLMAccessorSetter(RLMProperty *prop, RLMAccessorCode accessorCode) {
     switch (accessorCode) {
-        case RLMAccessorCodeByte:     return RLMMakeSetter<char, long long>(prop);
-        case RLMAccessorCodeShort:    return RLMMakeSetter<short, long long>(prop);
-        case RLMAccessorCodeInt:      return RLMMakeSetter<int, long long>(prop);
-        case RLMAccessorCodeLong:     return RLMMakeSetter<long, long long>(prop);
-        case RLMAccessorCodeLongLong: return RLMMakeSetter<long long>(prop);
-        case RLMAccessorCodeFloat:    return RLMMakeSetter<float>(prop);
-        case RLMAccessorCodeDouble:   return RLMMakeSetter<double>(prop);
-        case RLMAccessorCodeBool:     return RLMMakeSetter<BOOL>(prop);
-        case RLMAccessorCodeString:   return RLMMakeSetter<NSString *>(prop);
-        case RLMAccessorCodeDate:     return RLMMakeSetter<NSDate *>(prop);
-        case RLMAccessorCodeData:     return RLMMakeSetter<NSData *>(prop);
-        case RLMAccessorCodeLink:     return RLMMakeSetter<RLMObjectBase *>(prop);
-        case RLMAccessorCodeArray:    return RLMMakeSetter<RLMArray *>(prop);
-        case RLMAccessorCodeAny:      return RLMMakeSetter<id>(prop);
+        case RLMAccessorCodeByte:         return RLMMakeSetter<char, long long>(prop);
+        case RLMAccessorCodeShort:        return RLMMakeSetter<short, long long>(prop);
+        case RLMAccessorCodeInt:          return RLMMakeSetter<int, long long>(prop);
+        case RLMAccessorCodeLong:         return RLMMakeSetter<long, long long>(prop);
+        case RLMAccessorCodeLongLong:     return RLMMakeSetter<long long>(prop);
+        case RLMAccessorCodeFloat:        return RLMMakeSetter<float>(prop);
+        case RLMAccessorCodeDouble:       return RLMMakeSetter<double>(prop);
+        case RLMAccessorCodeBool:         return RLMMakeSetter<BOOL>(prop);
+        case RLMAccessorCodeString:       return RLMMakeSetter<NSString *>(prop);
+        case RLMAccessorCodeDate:         return RLMMakeSetter<NSDate *>(prop);
+        case RLMAccessorCodeData:         return RLMMakeSetter<NSData *>(prop);
+        case RLMAccessorCodeLink:         return RLMMakeSetter<RLMObjectBase *>(prop);
+        case RLMAccessorCodeArray:        return RLMMakeSetter<RLMArray *>(prop);
+        case RLMAccessorCodeAny:          return RLMMakeSetter<id>(prop);
+        case RLMAccessorCodeIntObject:    return RLMMakeSetter<NSNumber<RLMInt> *>(prop);
+        case RLMAccessorCodeFloatObject:  return RLMMakeSetter<NSNumber<RLMFloat> *>(prop);
+        case RLMAccessorCodeDoubleObject: return RLMMakeSetter<NSNumber<RLMDouble> *>(prop);
+        case RLMAccessorCodeBoolObject:   return RLMMakeSetter<NSNumber<RLMBool> *>(prop);
     }
 }
 
@@ -558,13 +693,12 @@ static RLMAccessorCode accessorCodeForType(char objcTypeCode, RLMPropertyType rl
                 case RLMPropertyTypeDate: return RLMAccessorCodeDate;
                 case RLMPropertyTypeData: return RLMAccessorCodeData;
                 case RLMPropertyTypeAny: return RLMAccessorCodeAny;
-                    
-                // throw for all primitive types
-                case RLMPropertyTypeBool:
-                case RLMPropertyTypeDouble:
-                case RLMPropertyTypeFloat:
-                case RLMPropertyTypeInt:
-                    break;
+
+                case RLMPropertyTypeBool: return RLMAccessorCodeBoolObject;
+                case RLMPropertyTypeDouble: return RLMAccessorCodeDoubleObject;
+                case RLMPropertyTypeFloat: return RLMAccessorCodeFloatObject;
+                case RLMPropertyTypeInt: return RLMAccessorCodeIntObject;
+                default: break;
             }
         case 'c':
             switch (rlmType) {
@@ -636,7 +770,7 @@ static Class RLMCreateAccessorClass(Class objectClass,
     if (!RLMIsKindOfClass(objectClass, RLMObjectBase.class)) {
         @throw RLMException(@"objectClass must derive from RLMObject or Object");
     }
-    
+
     // create and register proxy class which derives from object class
     NSString *accessorClassName = [accessorClassPrefix stringByAppendingString:schema.className];
     Class accClass = objc_getClass(accessorClassName.UTF8String);
@@ -644,7 +778,7 @@ static Class RLMCreateAccessorClass(Class objectClass,
         accClass = objc_allocateClassPair(objectClass, accessorClassName.UTF8String, 0);
         objc_registerClassPair(accClass);
     }
-    
+
     // override getters/setters for each propery
     for (unsigned int propNum = 0; propNum < schema.properties.count; propNum++) {
         RLMProperty *prop = schema.properties[propNum];
@@ -662,7 +796,7 @@ static Class RLMCreateAccessorClass(Class objectClass,
             }
         }
     }
-    
+
     // implement className for accessor to return base className
     RLMReplaceClassNameMethod(accClass, schema.className);
     RLMReplaceShouldIncludeInDefaultSchemaMethod(accClass, false);
@@ -744,6 +878,23 @@ void RLMDynamicSet(__unsafe_unretained RLMObjectBase *const obj, __unsafe_unreta
         case RLMAccessorCodeBool:
             RLMSetValue(obj, col, [val boolValue]);
             break;
+        case RLMAccessorCodeIntObject:
+            if (prop.isPrimary) {
+                RLMSetValueUnique(obj, col, prop.name, (NSNumber<RLMInt> *)val);
+            }
+            else {
+                RLMSetValue(obj, col, (NSNumber<RLMInt> *)val);
+            }
+            break;
+        case RLMAccessorCodeFloatObject:
+            RLMSetValue(obj, col, (NSNumber<RLMFloat> *)val);
+            break;
+        case RLMAccessorCodeDoubleObject:
+            RLMSetValue(obj, col, (NSNumber<RLMDouble> *)val);
+            break;
+        case RLMAccessorCodeBoolObject:
+            RLMSetValue(obj, col, (NSNumber<RLMBool> *)val);
+            break;
         case RLMAccessorCodeString:
             if (prop.isPrimary) {
                 RLMSetValueUnique(obj, col, prop.name, (NSString *)val);
@@ -797,19 +948,23 @@ RLMProperty *RLMValidatedGetProperty(__unsafe_unretained RLMObjectBase *const ob
 id RLMDynamicGet(__unsafe_unretained RLMObjectBase *obj, __unsafe_unretained RLMProperty *prop) {
     NSUInteger col = prop.column;
     switch (accessorCodeForType(prop.objcType, prop.type)) {
-        case RLMAccessorCodeByte:     return @((char)RLMGetLong(obj, col));
-        case RLMAccessorCodeShort:    return @((short)RLMGetLong(obj, col));
-        case RLMAccessorCodeInt:      return @((int)RLMGetLong(obj, col));
-        case RLMAccessorCodeLong:     return @((long)RLMGetLong(obj, col));
-        case RLMAccessorCodeLongLong: return @(RLMGetLong(obj, col));
-        case RLMAccessorCodeFloat:    return @(RLMGetFloat(obj, col));
-        case RLMAccessorCodeDouble:   return @(RLMGetDouble(obj, col));
-        case RLMAccessorCodeBool:     return @(RLMGetBool(obj, col));
-        case RLMAccessorCodeString:   return RLMGetString(obj, col);
-        case RLMAccessorCodeDate:     return RLMGetDate(obj, col);
-        case RLMAccessorCodeData:     return RLMGetData(obj, col);
-        case RLMAccessorCodeLink:     return RLMGetLink(obj, col, prop.objectClassName);
-        case RLMAccessorCodeArray:    return RLMGetArray(obj, col, prop.objectClassName, prop.name);
-        case RLMAccessorCodeAny:      return RLMGetAnyProperty(obj, col);
+        case RLMAccessorCodeByte:         return @((char)RLMGetLong(obj, col));
+        case RLMAccessorCodeShort:        return @((short)RLMGetLong(obj, col));
+        case RLMAccessorCodeInt:          return @((int)RLMGetLong(obj, col));
+        case RLMAccessorCodeLong:         return @((long)RLMGetLong(obj, col));
+        case RLMAccessorCodeLongLong:     return @(RLMGetLong(obj, col));
+        case RLMAccessorCodeFloat:        return @(RLMGetFloat(obj, col));
+        case RLMAccessorCodeDouble:       return @(RLMGetDouble(obj, col));
+        case RLMAccessorCodeBool:         return @(RLMGetBool(obj, col));
+        case RLMAccessorCodeString:       return RLMGetString(obj, col);
+        case RLMAccessorCodeDate:         return RLMGetDate(obj, col);
+        case RLMAccessorCodeData:         return RLMGetData(obj, col);
+        case RLMAccessorCodeLink:         return RLMGetLink(obj, col, prop.objectClassName);
+        case RLMAccessorCodeArray:        return RLMGetArray(obj, col, prop.objectClassName, prop.name);
+        case RLMAccessorCodeAny:          return RLMGetAnyProperty(obj, col);
+        case RLMAccessorCodeIntObject:    return RLMGetIntObject(obj, col);
+        case RLMAccessorCodeFloatObject:  return RLMGetFloatObject(obj, col);
+        case RLMAccessorCodeDoubleObject: return RLMGetDoubleObject(obj, col);
+        case RLMAccessorCodeBoolObject:   return RLMGetBoolObject(obj, col);
     }
 }

--- a/Realm/RLMAccessor.mm
+++ b/Realm/RLMAccessor.mm
@@ -849,7 +849,7 @@ void RLMDynamicValidatedSet(RLMObjectBase *obj, NSString *propName, id val) {
     }
 
     RLMWrapSetter(obj, prop.name, [&] {
-        RLMDynamicSet(obj, prop, RLMNSNullToNil(val), RLMCreationOptionsPromoteStandalone);
+        RLMDynamicSet(obj, prop, RLMCoerceToNil(val), RLMCreationOptionsPromoteStandalone);
     });
 }
 

--- a/Realm/RLMObject.h
+++ b/Realm/RLMObject.h
@@ -282,11 +282,13 @@ RLM_ASSUME_NONNULL_BEGIN
  Implement to return an array of property names that should not allow storing nil.
 
  By default, all properties of a type that support storing nil are considered optional properties.
- To require that an object in a Realm always have a non-nil value for a property, add the name of the property to the array returned from this method.
-
- Currently only String, Data, and Object properties support storing nil, and all other properties are implicitly treated as if they were required properties.
- Support for additional types will come in the future.
+ To require that an object in a Realm always have a non-nil value for a property,
+ add the name of the property to the array returned from this method.
  
+ Currently Object properties cannot be required. Array and NSNumber properties
+ can, but it makes little sense to do so: arrays do not support storing nil, and
+ if you want a non-optional number you should instead use the primitive type.
+
  @return    NSArray of property names that are required.
  */
 + (NSArray *)requiredProperties;

--- a/Realm/RLMObjectBase.mm
+++ b/Realm/RLMObjectBase.mm
@@ -94,7 +94,7 @@ static id RLMValidatedObjectForProperty(id obj, RLMProperty *prop, RLMSchema *sc
         }
         for (NSUInteger i = 0; i < array.count; i++) {
             id propertyValue = RLMValidatedObjectForProperty(array[i], properties[i], schema);
-            [self setValue:RLMNSNullToNil(propertyValue) forKeyPath:[properties[i] name]];
+            [self setValue:RLMCoerceToNil(propertyValue) forKeyPath:[properties[i] name]];
         }
     }
     else {
@@ -112,7 +112,7 @@ static id RLMValidatedObjectForProperty(id obj, RLMProperty *prop, RLMSchema *sc
             }
 
             obj = RLMValidatedObjectForProperty(obj, prop, schema);
-            [self setValue:RLMNSNullToNil(obj) forKeyPath:prop.name];
+            [self setValue:RLMCoerceToNil(obj) forKeyPath:prop.name];
         }
     }
 

--- a/Realm/RLMObjectBase.mm
+++ b/Realm/RLMObjectBase.mm
@@ -436,7 +436,7 @@ Class RLMObjectUtilClass(BOOL isSwift) {
 + (void)initializeListProperty:(__unused RLMObjectBase *)object property:(__unused RLMProperty *)property array:(__unused RLMArray *)array {
 }
 
-+ (NSArray *)getOptionalPropertyNames:(__unused id)obj {
++ (NSDictionary *)getOptionalProperties:(__unused id)obj {
     return nil;
 }
 

--- a/Realm/RLMObjectBase.mm
+++ b/Realm/RLMObjectBase.mm
@@ -139,7 +139,7 @@ static id RLMValidatedObjectForProperty(id obj, RLMProperty *prop, RLMSchema *sc
 // Generic Swift properties can't be dynamic, so KVO doesn't work for them by default
 - (id)valueForUndefinedKey:(NSString *)key {
     if (Ivar ivar = _objectSchema[key].swiftIvar) {
-        return object_getIvar(self, ivar);
+        return RLMCoerceToNil(object_getIvar(self, ivar));
     }
     return [super valueForUndefinedKey:key];
 }

--- a/Realm/RLMObjectSchema.mm
+++ b/Realm/RLMObjectSchema.mm
@@ -206,9 +206,13 @@ using namespace realm;
         }
     }
 
-    if (NSArray *optionalProperties = [objectUtil getOptionalPropertyNames:swiftObjectInstance]) {
+    if (NSDictionary *optionalProperties = [objectUtil getOptionalProperties:swiftObjectInstance]) {
         for (RLMProperty *property in propArray) {
-            property.optional = [optionalProperties containsObject:property.name];
+            NSNumber *optionalType = optionalProperties[property.name];
+            property.optional = optionalType != nil;
+            if (auto type = RLMNSNullToNil(optionalType)) {
+                property.type = RLMPropertyType(type.intValue);
+            }
             if (!property.optional && property.type == RLMPropertyTypeObject) { // remove if/when core supports required link columns
                 NSString *message = [NSString stringWithFormat:@"The `%@.%@` property must be marked as being optional.", [objectClass className], property.name];
                 @throw RLMException(message);

--- a/Realm/RLMObjectSchema.mm
+++ b/Realm/RLMObjectSchema.mm
@@ -219,7 +219,7 @@ using namespace realm;
                 property = propArray[existing];
                 property.optional = true;
             }
-            if (auto type = RLMNSNullToNil(propertyType)) {
+            if (auto type = RLMCoerceToNil(propertyType)) {
                 if (existing == NSNotFound) {
                     property = [[RLMProperty alloc] initSwiftOptionalPropertyWithName:propertyName ivar:class_getInstanceVariable(objectClass, propertyName.UTF8String) propertyType:RLMPropertyType(type.intValue)];
                     [propArray addObject:property];

--- a/Realm/RLMObjectSchema.mm
+++ b/Realm/RLMObjectSchema.mm
@@ -137,14 +137,10 @@ using namespace realm;
     for (RLMProperty *prop in schema.properties) {
         RLMPropertyType type = prop.type;
         if (prop.optional && !RLMPropertyTypeIsNullable(type)) {
-#ifdef REALM_ENABLE_NULL
             NSString *error = [NSString stringWithFormat:@"Only 'string', 'binary', and 'object' properties can be made optional, and property '%@' is of type '%@'.", prop.name, RLMTypeToString(type)];
             if (prop.type == RLMPropertyTypeAny && isSwift) {
                 error = [error stringByAppendingString:@"\nIf this is a 'String?' property, it must be declared as 'NSString?' instead."];
             }
-#else
-            NSString *error = [NSString stringWithFormat:@"Only 'object' properties can be made optional, and property '%@' is of type '%@'.", prop.name, RLMTypeToString(type)];
-#endif
             @throw RLMException(error);
         }
     }

--- a/Realm/RLMObjectStore.h
+++ b/Realm/RLMObjectStore.h
@@ -98,7 +98,7 @@ RLMObjectBase *RLMCreateObjectAccessor(RLMRealm *realm,
                                        NSUInteger index) NS_RETURNS_RETAINED;
 
 // switch List<> properties from being backed by standalone RLMArrays to RLMArrayLinkView
-void RLMInitializeSwiftListAccessor(RLMObjectBase *object);
+void RLMInitializeSwiftAccessorGenerics(RLMObjectBase *object);
 
 #ifdef __cplusplus
 }

--- a/Realm/RLMObjectStore.mm
+++ b/Realm/RLMObjectStore.mm
@@ -325,7 +325,7 @@ void RLMAddObjectToRealm(__unsafe_unretained RLMObjectBase *const object,
         // set in table with out validation
         // skip primary key when updating since it doesn't change
         if (created || !prop.isPrimary) {
-            RLMDynamicSet(object, prop, RLMNSNullToNil(value), creationOptions);
+            RLMDynamicSet(object, prop, RLMCoerceToNil(value), creationOptions);
         }
 
         // set the ivars for object and array properties to nil as otherwise the
@@ -495,7 +495,7 @@ RLMObjectBase *RLMCreateObjectInRealmWithValue(RLMRealm *realm, NSString *classN
             if (created || !prop.isPrimary) {
                 id val = array[i];
                 RLMValidateValueForProperty(val, prop, schema, false, false);
-                RLMDynamicSet(object, prop, RLMNSNullToNil(val), creationOptions);
+                RLMDynamicSet(object, prop, RLMCoerceToNil(val), creationOptions);
             }
         }
     }
@@ -524,7 +524,7 @@ RLMObjectBase *RLMCreateObjectInRealmWithValue(RLMRealm *realm, NSString *classN
                 if (created || !prop.isPrimary) {
                     // skip missing properties and primary key when updating since it doesn't change
                     RLMValidateValueForProperty(propValue, prop, schema, false, false);
-                    RLMDynamicSet(object, prop, RLMNSNullToNil(propValue), creationOptions);
+                    RLMDynamicSet(object, prop, RLMCoerceToNil(propValue), creationOptions);
                 }
             }
             else if (created &&!prop.optional) {

--- a/Realm/RLMObjectStore.mm
+++ b/Realm/RLMObjectStore.mm
@@ -625,7 +625,7 @@ id RLMGetObject(RLMRealm *realm, NSString *objectClassName, id key) {
         if (number) {
             row = objectSchema.table->find_first_int(primaryProperty.column, number.longLongValue);
         }
-        else if (key) {
+        else if (!key) {
             row = objectSchema.table->find_first_null(primaryProperty.column);
         }
         else {

--- a/Realm/RLMObjectStore.mm
+++ b/Realm/RLMObjectStore.mm
@@ -613,7 +613,7 @@ id RLMGetObject(RLMRealm *realm, NSString *objectClassName, id key) {
     size_t row = realm::not_found;
     if (primaryProperty.type == RLMPropertyTypeString) {
         NSString *str = RLMDynamicCast<NSString>(key);
-        if (str || !key) {
+        if (str || (!key && primaryProperty.optional)) {
             row = objectSchema.table->find_first_string(primaryProperty.column, RLMStringDataWithNSString(str));
         }
         else {
@@ -625,7 +625,7 @@ id RLMGetObject(RLMRealm *realm, NSString *objectClassName, id key) {
         if (number) {
             row = objectSchema.table->find_first_int(primaryProperty.column, number.longLongValue);
         }
-        else if (!key) {
+        else if (!key && primaryProperty.optional) {
             row = objectSchema.table->find_first_null(primaryProperty.column);
         }
         else {

--- a/Realm/RLMObjectStore.mm
+++ b/Realm/RLMObjectStore.mm
@@ -608,9 +608,7 @@ id RLMGetObject(RLMRealm *realm, NSString *objectClassName, id key) {
         return nil;
     }
 
-    if (key == NSNull.null) {
-        key = nil;
-    }
+    key = RLMCoerceToNil(key);
 
     size_t row = realm::not_found;
     if (primaryProperty.type == RLMPropertyTypeString) {
@@ -623,8 +621,12 @@ id RLMGetObject(RLMRealm *realm, NSString *objectClassName, id key) {
         }
     }
     else {
-        if (NSNumber *number = RLMDynamicCast<NSNumber>(key)) {
+        NSNumber *number = RLMDynamicCast<NSNumber>(key);
+        if (number) {
             row = objectSchema.table->find_first_int(primaryProperty.column, number.longLongValue);
+        }
+        else if (key) {
+            row = objectSchema.table->find_first_null(primaryProperty.column);
         }
         else {
             @throw RLMException([NSString stringWithFormat:@"Invalid value '%@' for primary key", key]);

--- a/Realm/RLMObject_Private.h
+++ b/Realm/RLMObject_Private.h
@@ -79,7 +79,7 @@ FOUNDATION_EXTERN const NSUInteger RLMDescriptionMaxDepth;
 + (NSArray *)getGenericListPropertyNames:(id)obj;
 + (void)initializeListProperty:(RLMObjectBase *)object property:(RLMProperty *)property array:(RLMArray *)array;
 
-+ (NSArray *)getOptionalPropertyNames:(id)obj;
++ (NSDictionary *)getOptionalProperties:(id)obj;
 + (NSArray *)requiredPropertiesForClass:(Class)cls;
 
 @end

--- a/Realm/RLMObservation.mm
+++ b/Realm/RLMObservation.mm
@@ -181,6 +181,12 @@ void RLMObservationInfo::recordObserver(realm::Row& objectRow,
             array->_key = key;
             array->_parentObject = object;
         }
+        else if (auto swiftIvar = prop.swiftIvar) {
+            if (auto optional = RLMDynamicCast<RLMOptionalBase>(object_getIvar(object, swiftIvar))) {
+                optional.property = prop;
+                optional.object = object;
+            }
+        }
     }
 }
 

--- a/Realm/RLMObservation.mm
+++ b/Realm/RLMObservation.mm
@@ -209,11 +209,11 @@ id RLMObservationInfo::valueForKey(NSString *key) {
 
     static auto superValueForKey = reinterpret_cast<id(*)(id, SEL, NSString *)>([NSObject methodForSelector:@selector(valueForKey:)]);
     if (!lastProp) {
-        return superValueForKey(object, @selector(valueForKey:), key);
+        return RLMCoerceToNil(superValueForKey(object, @selector(valueForKey:), key));
     }
 
     auto getSuper = [&] {
-        return row ? RLMDynamicGet(object, lastProp) : superValueForKey(object, @selector(valueForKey:), key);
+        return row ? RLMDynamicGet(object, lastProp) : RLMCoerceToNil(superValueForKey(object, @selector(valueForKey:), key));
     };
 
     // We need to return the same object each time for observing over keypaths to work

--- a/Realm/RLMOptionalBase.h
+++ b/Realm/RLMOptionalBase.h
@@ -1,0 +1,34 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2015 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+#import <Foundation/Foundation.h>
+#import <Realm/RLMConstants.h>
+
+@class RLMObjectBase, RLMProperty;
+
+@interface RLMOptionalBase : NSProxy
+
+- (instancetype)init;
+
+@property (nonatomic, weak) RLMObjectBase *object;
+
+@property (nonatomic, unsafe_unretained) RLMProperty *property;
+
+@property (nonatomic) id underlyingValue;
+
+@end

--- a/Realm/RLMOptionalBase.m
+++ b/Realm/RLMOptionalBase.m
@@ -1,0 +1,67 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2015 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+#import "RLMAccessor.h"
+#import "RLMOptionalBase.h"
+#import "RLMObject_Private.h"
+#import "RLMObjectStore.h"
+
+@interface RLMOptionalBase ()
+@property (nonatomic) id standaloneValue;
+@end
+
+@implementation RLMOptionalBase
+
+- (instancetype)init {
+    return self;
+}
+
+- (id)underlyingValue {
+    if (_object && _object->_realm) {
+        return RLMDynamicGet(_object, _property);
+    }
+    else {
+        return _standaloneValue;
+    }
+}
+
+- (void)setUnderlyingValue:(id)underlyingValue {
+    if (_object && _object->_realm) {
+        RLMDynamicSet(_object, _property, underlyingValue, RLMCreationOptionsNone);
+    }
+    else {
+        _standaloneValue = underlyingValue;
+    }
+}
+
+- (NSMethodSignature *)methodSignatureForSelector:(SEL)sel {
+    return [self.underlyingValue methodSignatureForSelector:sel];
+}
+
+- (void)forwardInvocation:(NSInvocation *)invocation {
+    id val = self.underlyingValue;
+    if (val) {
+        [invocation invokeWithTarget:self.underlyingValue];
+    }
+}
+
+- (id)forwardingTargetForSelector:(__unused SEL)sel {
+    return self.underlyingValue;
+}
+
+@end

--- a/Realm/RLMOptionalBase.mm
+++ b/Realm/RLMOptionalBase.mm
@@ -20,6 +20,9 @@
 #import "RLMOptionalBase.h"
 #import "RLMObject_Private.h"
 #import "RLMObjectStore.h"
+#import "RLMUtil.hpp"
+
+#import <objc/runtime.h>
 
 @interface RLMOptionalBase ()
 @property (nonatomic) id standaloneValue;
@@ -47,6 +50,10 @@
     else {
         _standaloneValue = underlyingValue;
     }
+}
+
+- (BOOL)isKindOfClass:(Class)aClass {
+    return [self.underlyingValue isKindOfClass:aClass] || RLMIsKindOfClass(object_getClass(self), aClass);
 }
 
 - (NSMethodSignature *)methodSignatureForSelector:(SEL)sel {

--- a/Realm/RLMOptionalBase.mm
+++ b/Realm/RLMOptionalBase.mm
@@ -20,6 +20,7 @@
 #import "RLMOptionalBase.h"
 #import "RLMObject_Private.h"
 #import "RLMObjectStore.h"
+#import "RLMProperty.h"
 #import "RLMUtil.hpp"
 
 #import <objc/runtime.h>
@@ -44,12 +45,15 @@
 }
 
 - (void)setUnderlyingValue:(id)underlyingValue {
+    NSString *propertyName = _property.name;
+    [_object willChangeValueForKey:propertyName];
     if ((_object && _object->_realm) || _object.isInvalidated) {
         RLMDynamicSet(_object, _property, underlyingValue, RLMCreationOptionsNone);
     }
     else {
         _standaloneValue = underlyingValue;
     }
+    [_object didChangeValueForKey:propertyName];
 }
 
 - (BOOL)isKindOfClass:(Class)aClass {

--- a/Realm/RLMOptionalBase.mm
+++ b/Realm/RLMOptionalBase.mm
@@ -36,7 +36,7 @@
 }
 
 - (id)underlyingValue {
-    if (_object && _object->_realm) {
+    if ((_object && _object->_realm) || _object.isInvalidated) {
         return RLMDynamicGet(_object, _property);
     }
     else {
@@ -65,14 +65,22 @@
 }
 
 - (void)forwardInvocation:(NSInvocation *)invocation {
-    id val = self.underlyingValue;
-    if (val) {
-        [invocation invokeWithTarget:self.underlyingValue];
-    }
+    [invocation invokeWithTarget:self.underlyingValue];
 }
 
 - (id)forwardingTargetForSelector:(__unused SEL)sel {
     return self.underlyingValue;
+}
+
+- (BOOL)respondsToSelector:(SEL)aSelector {
+    if (id val = self.underlyingValue) {
+        return [val respondsToSelector:aSelector];
+    }
+    return NO;
+}
+
+- (void)doesNotRecognizeSelector:(SEL)aSelector {
+    [self.underlyingValue doesNotRecognizeSelector:aSelector];
 }
 
 @end

--- a/Realm/RLMOptionalBase.mm
+++ b/Realm/RLMOptionalBase.mm
@@ -44,7 +44,7 @@
 }
 
 - (void)setUnderlyingValue:(id)underlyingValue {
-    if (_object && _object->_realm) {
+    if ((_object && _object->_realm) || _object.isInvalidated) {
         RLMDynamicSet(_object, _property, underlyingValue, RLMCreationOptionsNone);
     }
     else {

--- a/Realm/RLMProperty.h
+++ b/Realm/RLMProperty.h
@@ -22,6 +22,18 @@
 
 RLM_ASSUME_NONNULL_BEGIN
 
+@protocol RLMInt
+@end
+@protocol RLMBool
+@end
+@protocol RLMDouble
+@end
+@protocol RLMFloat
+@end
+
+@interface NSNumber ()<RLMInt, RLMBool, RLMDouble, RLMFloat>
+@end
+
 /**
  This class models properties persisted to Realm in an RLMObjectSchema.
  

--- a/Realm/RLMProperty.mm
+++ b/Realm/RLMProperty.mm
@@ -31,6 +31,7 @@ BOOL RLMPropertyTypeIsNullable(RLMPropertyType propertyType) {
 #ifdef REALM_ENABLE_NULL
         case RLMPropertyTypeString:
         case RLMPropertyTypeData:
+        case RLMPropertyTypeDate:
 #endif
             return YES;
         default:
@@ -143,6 +144,9 @@ BOOL RLMPropertyTypeIsNullable(RLMPropertyType propertyType) {
             }
             else if (strcmp(code, "@\"NSDate\"") == 0) {
                 _type = RLMPropertyTypeDate;
+#if REALM_ENABLE_NULL
+                _optional = YES;
+#endif
             }
             else if (strcmp(code, "@\"NSData\"") == 0) {
                 _type = RLMPropertyTypeData;

--- a/Realm/RLMProperty.mm
+++ b/Realm/RLMProperty.mm
@@ -124,6 +124,9 @@ BOOL RLMPropertyTypeIsNullable(RLMPropertyType propertyType) {
             _type = RLMPropertyTypeBool;
             return YES;
         case '@': {
+#if REALM_ENABLE_NULL
+            _optional = true;
+#endif
             static const char arrayPrefix[] = "@\"RLMArray<";
             static const int arrayPrefixLen = sizeof(arrayPrefix) - 1;
 
@@ -133,26 +136,19 @@ BOOL RLMPropertyTypeIsNullable(RLMPropertyType propertyType) {
             if (code[1] == '\0') {
                 // string is "@"
                 _type = RLMPropertyTypeAny;
+                _optional = false;
             }
             else if (strcmp(code, "@\"NSString\"") == 0) {
                 _type = RLMPropertyTypeString;
-#if REALM_ENABLE_NULL
-                _optional = YES;
-#endif
             }
             else if (strcmp(code, "@\"NSDate\"") == 0) {
                 _type = RLMPropertyTypeDate;
-#if REALM_ENABLE_NULL
-                _optional = YES;
-#endif
             }
             else if (strcmp(code, "@\"NSData\"") == 0) {
                 _type = RLMPropertyTypeData;
-#if REALM_ENABLE_NULL
-                _optional = YES;
-#endif
             }
             else if (strncmp(code, arrayPrefix, arrayPrefixLen) == 0) {
+                _optional = false;
                 // get object class from type string - @"RLMArray<objectClassName>"
                 _type = RLMPropertyTypeArray;
                 _objectClassName = [[NSString alloc] initWithBytes:code + arrayPrefixLen
@@ -174,9 +170,6 @@ BOOL RLMPropertyTypeIsNullable(RLMPropertyType propertyType) {
 
                 if ([_objectClassName isEqualToString:@"RLMInt"]) {
                     _type = RLMPropertyTypeInt;
-#if REALM_ENABLE_NULL
-                    _optional = YES;
-#endif
                 }
                 else if ([_objectClassName isEqualToString:@"RLMFloat"]) {
                     _type = RLMPropertyTypeFloat;
@@ -186,9 +179,6 @@ BOOL RLMPropertyTypeIsNullable(RLMPropertyType propertyType) {
                 }
                 else if ([_objectClassName isEqualToString:@"RLMBool"]) {
                     _type = RLMPropertyTypeBool;
-#if REALM_ENABLE_NULL
-                    _optional = YES;
-#endif
                 }
                 else {
                     @throw RLMException([NSString stringWithFormat:@"'%@' is not supported as an NSNumber object type. NSNumbers can only be RLMInt at the moment. See http://realm.io/docs/cocoa/ for more information.", self.objectClassName]);

--- a/Realm/RLMProperty.mm
+++ b/Realm/RLMProperty.mm
@@ -29,7 +29,7 @@ BOOL RLMPropertyTypeIsNullable(RLMPropertyType propertyType) {
 #ifdef REALM_ENABLE_NULL
     return propertyType != RLMPropertyTypeAny && propertyType != RLMPropertyTypeArray;
 #else
-    return propertyType == RLMPropertyTypeObject
+    return propertyType == RLMPropertyTypeObject;
 #endif
 }
 

--- a/Realm/RLMProperty.mm
+++ b/Realm/RLMProperty.mm
@@ -162,30 +162,27 @@ BOOL RLMPropertyTypeIsNullable(RLMPropertyType propertyType) {
             }
             else if (strncmp(code, numberPrefix, numberPrefixLen) == 0) {
                 // get number type from type string - @"NSNumber<objectClassName>"
-                _type = RLMPropertyTypeArray;
-                _objectClassName = [[NSString alloc] initWithBytes:code + numberPrefixLen
-                                                            length:strlen(code + numberPrefixLen) - 2 // drop trailing >"
-                                                          encoding:NSUTF8StringEncoding];
+                NSString *numberType = [[NSString alloc] initWithBytes:code + numberPrefixLen
+                                                                length:strlen(code + numberPrefixLen) - 2 // drop trailing >"
+                                                              encoding:NSUTF8StringEncoding];
 
-
-                if ([_objectClassName isEqualToString:@"RLMInt"]) {
+                if ([numberType isEqualToString:@"RLMInt"]) {
                     _type = RLMPropertyTypeInt;
                 }
-                else if ([_objectClassName isEqualToString:@"RLMFloat"]) {
+                else if ([numberType isEqualToString:@"RLMFloat"]) {
                     _type = RLMPropertyTypeFloat;
                 }
-                else if ([_objectClassName isEqualToString:@"RLMDouble"]) {
+                else if ([numberType isEqualToString:@"RLMDouble"]) {
                     _type = RLMPropertyTypeDouble;
                 }
-                else if ([_objectClassName isEqualToString:@"RLMBool"]) {
+                else if ([numberType isEqualToString:@"RLMBool"]) {
                     _type = RLMPropertyTypeBool;
                 }
                 else {
                     NSString *message = [NSString stringWithFormat:@"'%@' is not supported as an NSNumber object type. NSNumbers can only be RLMInt, RLMFloat, RLMDouble, and RLMBool at the moment. "
-                                                                   @"See http://realm.io/docs/cocoa/ for more information.", self.objectClassName];
+                                                                   @"See http://realm.io/docs/cocoa/ for more information.", numberType];
                     @throw RLMException(message);
                 }
-                _objectClassName = nil;
             }
             else if (strcmp(code, "@\"NSNumber\"") == 0) {
                 @throw RLMException([NSString stringWithFormat:@"NSNumber properties require a protocol defining the contained type - example: NSNumber<RLMInt>."]);
@@ -287,7 +284,7 @@ BOOL RLMPropertyTypeIsNullable(RLMPropertyType propertyType) {
                 _objcRawType = @"@\"NSNumber<RLMBool>\"";
                 break;
             default:
-                @throw RLMException([NSString stringWithFormat:@"Can't persist NSNumber of type '%s', only integers, floats, doubles, and bools are currently supported.", numberType]);
+                @throw RLMException([NSString stringWithFormat:@"Can't persist NSNumber of type '%s': only integers, floats, doubles, and bools are currently supported.", numberType]);
         }
     }
 
@@ -378,7 +375,7 @@ BOOL RLMPropertyTypeIsNullable(RLMPropertyType propertyType) {
     _swiftIvar = ivar;
     _optional = true;
 
-    // no obj-c property for generic lists, and thus no getter/setter names
+    // no obj-c property for generic optionals, and thus no getter/setter names
 
     return self;
 }

--- a/Realm/RLMProperty.mm
+++ b/Realm/RLMProperty.mm
@@ -181,7 +181,9 @@ BOOL RLMPropertyTypeIsNullable(RLMPropertyType propertyType) {
                     _type = RLMPropertyTypeBool;
                 }
                 else {
-                    @throw RLMException([NSString stringWithFormat:@"'%@' is not supported as an NSNumber object type. NSNumbers can only be RLMInt at the moment. See http://realm.io/docs/cocoa/ for more information.", self.objectClassName]);
+                    NSString *message = [NSString stringWithFormat:@"'%@' is not supported as an NSNumber object type. NSNumbers can only be RLMInt, RLMFloat, RLMDouble, and RLMBool at the moment. "
+                                                                   @"See http://realm.io/docs/cocoa/ for more information.", self.objectClassName];
+                    @throw RLMException(message);
                 }
                 _objectClassName = nil;
             }

--- a/Realm/RLMProperty.mm
+++ b/Realm/RLMProperty.mm
@@ -268,6 +268,28 @@ BOOL RLMPropertyTypeIsNullable(RLMPropertyType propertyType) {
     if ([_objcRawType isEqualToString:@"@\"RLMArray\""]) {
         _objcRawType = [NSString stringWithFormat:@"@\"RLMArray<%@>\"", [[obj valueForKey:_name] objectClassName]];
     }
+    else if ([_objcRawType isEqualToString:@"@\"NSNumber\""]) {
+        const char *numberType = [[obj valueForKey:_name] objCType];
+        switch (*numberType) {
+            case 'i':
+            case 'l':
+            case 'q':
+                _objcRawType = @"@\"NSNumber<RLMInt>\"";
+                break;
+            case 'f':
+                _objcRawType = @"@\"NSNumber<RLMFloat>\"";
+                break;
+            case 'd':
+                _objcRawType = @"@\"NSNumber<RLMDouble>\"";
+                break;
+            case 'B':
+            case 'c':
+                _objcRawType = @"@\"NSNumber<RLMBool>\"";
+                break;
+            default:
+                @throw RLMException([NSString stringWithFormat:@"Can't persist NSNumber of type '%s', only integers, floats, doubles, and bools are currently supported.", numberType]);
+        }
+    }
 
     if (![self setTypeFromRawType]) {
         NSString *reason = [NSString stringWithFormat:@"Can't persist property '%@' with incompatible type. "

--- a/Realm/RLMProperty.mm
+++ b/Realm/RLMProperty.mm
@@ -157,7 +157,7 @@ BOOL RLMPropertyTypeIsNullable(RLMPropertyType propertyType) {
 
                 Class cls = [RLMSchema classForString:_objectClassName];
                 if (!RLMIsObjectSubclass(cls)) {
-                    @throw RLMException([NSString stringWithFormat:@"'%@' is not supported as an RLMArray object type. RLMArrays can only contain instances of RLMObject subclasses. See http://realm.io/docs/cocoa/#to-many for more information.", self.objectClassName]);
+                    @throw RLMException([NSString stringWithFormat:@"'%@' is not supported as an RLMArray object type. RLMArrays can only contain instances of RLMObject subclasses. See http://realm.io/docs/objc/#to-many for more information.", self.objectClassName]);
                 }
             }
             else if (strncmp(code, numberPrefix, numberPrefixLen) == 0) {
@@ -180,7 +180,7 @@ BOOL RLMPropertyTypeIsNullable(RLMPropertyType propertyType) {
                 }
                 else {
                     NSString *message = [NSString stringWithFormat:@"'%@' is not supported as an NSNumber object type. NSNumbers can only be RLMInt, RLMFloat, RLMDouble, and RLMBool at the moment. "
-                                                                   @"See http://realm.io/docs/cocoa/ for more information.", numberType];
+                                                                   @"See http://realm.io/docs/objc/ for more information.", numberType];
                     @throw RLMException(message);
                 }
             }
@@ -197,7 +197,7 @@ BOOL RLMPropertyTypeIsNullable(RLMPropertyType propertyType) {
                 // verify type
                 Class cls = [RLMSchema classForString:className];
                 if (!RLMIsObjectSubclass(cls)) {
-                    @throw RLMException([NSString stringWithFormat:@"'%@' is not supported as an RLMObject property. All properties must be primitives, NSString, NSDate, NSData, RLMArray, or subclasses of RLMObject. See http://realm.io/docs/cocoa/api/Classes/RLMObject.html for more information.", className]);
+                    @throw RLMException([NSString stringWithFormat:@"'%@' is not supported as an RLMObject property. All properties must be primitives, NSString, NSDate, NSData, RLMArray, or subclasses of RLMObject. See http://realm.io/docs/objc/api/Classes/RLMObject.html for more information.", className]);
                 }
 
                 _type = RLMPropertyTypeObject;
@@ -394,7 +394,7 @@ BOOL RLMPropertyTypeIsNullable(RLMPropertyType propertyType) {
     prop->_isPrimary = _isPrimary;
     prop->_swiftIvar = _swiftIvar;
     prop->_optional = _optional;
-    
+
     return prop;
 }
 

--- a/Realm/RLMProperty.mm
+++ b/Realm/RLMProperty.mm
@@ -26,11 +26,7 @@
 #import "RLMUtil.hpp"
 
 BOOL RLMPropertyTypeIsNullable(RLMPropertyType propertyType) {
-#ifdef REALM_ENABLE_NULL
     return propertyType != RLMPropertyTypeAny && propertyType != RLMPropertyTypeArray;
-#else
-    return propertyType == RLMPropertyTypeObject;
-#endif
 }
 
 
@@ -124,9 +120,7 @@ BOOL RLMPropertyTypeIsNullable(RLMPropertyType propertyType) {
             _type = RLMPropertyTypeBool;
             return YES;
         case '@': {
-#if REALM_ENABLE_NULL
             _optional = true;
-#endif
             static const char arrayPrefix[] = "@\"RLMArray<";
             static const int arrayPrefixLen = sizeof(arrayPrefix) - 1;
 

--- a/Realm/RLMProperty.mm
+++ b/Realm/RLMProperty.mm
@@ -26,25 +26,15 @@
 #import "RLMUtil.hpp"
 
 BOOL RLMPropertyTypeIsNullable(RLMPropertyType propertyType) {
-    switch (propertyType) {
-        case RLMPropertyTypeObject:
 #ifdef REALM_ENABLE_NULL
-        case RLMPropertyTypeString:
-        case RLMPropertyTypeData:
-        case RLMPropertyTypeDate:
-        case RLMPropertyTypeInt:
-        case RLMPropertyTypeBool:
+    return propertyType != RLMPropertyTypeAny && propertyType != RLMPropertyTypeArray;
+#else
+    return propertyType == RLMPropertyTypeObject
 #endif
-            return YES;
-        default:
-            return NO;
-    }
 }
 
-@implementation RLMProperty {
-    NSString *_objcRawType;
-}
 
+@implementation RLMProperty
 - (instancetype)initWithName:(NSString *)name
                         type:(RLMPropertyType)type
              objectClassName:(NSString *)objectClassName
@@ -353,7 +343,26 @@ BOOL RLMPropertyTypeIsNullable(RLMPropertyType propertyType) {
     _type = RLMPropertyTypeArray;
     _objectClassName = objectClassName;
     _objcType = 't';
-    _swiftListIvar = ivar;
+    _swiftIvar = ivar;
+
+    // no obj-c property for generic lists, and thus no getter/setter names
+
+    return self;
+}
+
+- (instancetype)initSwiftOptionalPropertyWithName:(NSString *)name
+                                             ivar:(Ivar)ivar
+                                     propertyType:(RLMPropertyType)propertyType {
+    self = [super init];
+    if (!self) {
+        return nil;
+    }
+
+    _name = name;
+    _type = propertyType;
+    _objcType = '@';
+    _swiftIvar = ivar;
+    _optional = true;
 
     // no obj-c property for generic lists, and thus no getter/setter names
 
@@ -372,7 +381,7 @@ BOOL RLMPropertyTypeIsNullable(RLMPropertyType propertyType) {
     prop->_getterSel = _getterSel;
     prop->_setterSel = _setterSel;
     prop->_isPrimary = _isPrimary;
-    prop->_swiftListIvar = _swiftListIvar;
+    prop->_swiftIvar = _swiftIvar;
     prop->_optional = _optional;
     
     return prop;

--- a/Realm/RLMProperty_Private.h
+++ b/Realm/RLMProperty_Private.h
@@ -40,6 +40,10 @@ FOUNDATION_EXTERN BOOL RLMPropertyTypeIsNullable(RLMPropertyType propertyType);
                                          ivar:(Ivar)ivar
                               objectClassName:(NSString *)objectClassName;
 
+- (instancetype)initSwiftOptionalPropertyWithName:(NSString *)name
+                                             ivar:(Ivar)ivar
+                                     propertyType:(RLMPropertyType)propertyType;
+
 // private setters
 @property (nonatomic, assign) NSUInteger column;
 @property (nonatomic, readwrite, assign) RLMPropertyType type;
@@ -49,8 +53,9 @@ FOUNDATION_EXTERN BOOL RLMPropertyTypeIsNullable(RLMPropertyType propertyType);
 
 // private properties
 @property (nonatomic, assign) char objcType;
+@property (nonatomic, copy) NSString *objcRawType;
 @property (nonatomic, assign) BOOL isPrimary;
-@property (nonatomic, assign) Ivar swiftListIvar;
+@property (nonatomic, assign) Ivar swiftIvar;
 
 // getter and setter names
 @property (nonatomic, copy) NSString *getterName;

--- a/Realm/RLMQueryUtil.mm
+++ b/Realm/RLMQueryUtil.mm
@@ -81,13 +81,13 @@ struct TrueExpression : realm::Expression {
         return realm::not_found;
     }
     void set_table() override {}
-    const Table* get_table() override { return nullptr; }
+    const Table* get_table() const override { return nullptr; }
 };
 
 struct FalseExpression : realm::Expression {
     size_t find_first(size_t, size_t) const override { return realm::not_found; }
     void set_table() override {}
-    const Table* get_table() override { return nullptr; }
+    const Table* get_table() const override { return nullptr; }
 };
 
 NSString *operatorName(NSPredicateOperatorType operatorType)

--- a/Realm/RLMRealm.mm
+++ b/Realm/RLMRealm.mm
@@ -245,8 +245,7 @@ void RLMRealmAddPathSettingsToConfiguration(RLMRealmConfiguration *configuration
             NSString *mode = readonly ? @"read" : @"read-write";
             NSString *additionalMessage = [NSString stringWithFormat:@"Unable to open a realm at path '%@'. Please use a path where your app has %@ permissions.", path, mode];
             NSString *newMessage = [NSString stringWithFormat:@"%s\n%@", ex.what(), additionalMessage];
-            error = RLMMakeError(RLMErrorFilePermissionDenied,
-                                     File::PermissionDenied(newMessage.UTF8String));
+            error = RLMMakeError(RLMErrorFilePermissionDenied, File::PermissionDenied(newMessage.UTF8String, ex.get_path()));
         }
         catch (File::Exists const& ex) {
             error = RLMMakeError(RLMErrorFileExists, ex);

--- a/Realm/RLMRealm.mm
+++ b/Realm/RLMRealm.mm
@@ -951,9 +951,11 @@ void RLMRealmSetSchemaVersionForPath(uint64_t version, NSString *path, RLMMigrat
     if (error)
         return error;
 
-    @try {
+    try {
         RLMUpdateRealmToSchemaVersion(realm, schemaVersionForPath(realmPath), configuration.customSchema ?: [RLMSchema.sharedSchema copy], [realm migrationBlock:configuration.migrationBlock key:key]);
-    } @catch (NSException *ex) {
+    } catch (std::exception const& ex) {
+        return RLMMakeError(RLMErrorFail, ex);
+    } catch (NSException *ex) {
         return RLMMakeError(ex);
     }
     return nil;

--- a/Realm/RLMUtil.hpp
+++ b/Realm/RLMUtil.hpp
@@ -148,11 +148,12 @@ static inline realm::BinaryData RLMBinaryDataForNSData(__unsafe_unretained NSDat
 
 // Date convertion utilities
 static inline NSDate *RLMDateTimeToNSDate(realm::DateTime dateTime) {
-    return [NSDate dateWithTimeIntervalSince1970:dateTime.get_datetime()];
+    auto timeInterval = static_cast<NSTimeInterval>(dateTime.get_datetime());
+    return [NSDate dateWithTimeIntervalSince1970:timeInterval];
 }
 
 static inline realm::DateTime RLMDateTimeForNSDate(__unsafe_unretained NSDate *const date) {
-    int64_t time = date.timeIntervalSince1970;
+    auto time = static_cast<int64_t>(date.timeIntervalSince1970);
     return realm::DateTime(time);
 }
 

--- a/Realm/RLMUtil.hpp
+++ b/Realm/RLMUtil.hpp
@@ -75,7 +75,7 @@ static inline T *RLMDynamicCast(__unsafe_unretained id obj) {
 
 template<typename T>
 static inline T *RLMNSNullToNil(T *obj) {
-    if (obj == NSNull.null) {
+    if (static_cast<id>(obj) == NSNull.null) {
         return nil;
     }
     return obj;

--- a/Realm/RLMUtil.hpp
+++ b/Realm/RLMUtil.hpp
@@ -22,6 +22,7 @@
 #import <realm/array.hpp>
 #import <realm/binary_data.hpp>
 #import <realm/string_data.hpp>
+#import <realm/util/file.hpp>
 
 @class RLMObjectSchema;
 @class RLMProperty;
@@ -33,6 +34,7 @@ NSException *RLMException(NSString *message, NSDictionary *userInfo = nil);
 NSException *RLMException(std::exception const& exception);
 
 NSError *RLMMakeError(RLMError code, std::exception const& exception);
+NSError *RLMMakeError(RLMError code, const realm::util::File::AccessError&);
 NSError *RLMMakeError(NSException *exception);
 
 void RLMSetErrorOrThrow(NSError *error, NSError **outError);

--- a/Realm/RLMUtil.hpp
+++ b/Realm/RLMUtil.hpp
@@ -75,7 +75,7 @@ static inline T *RLMDynamicCast(__unsafe_unretained id obj) {
 }
 
 template<typename T>
-static inline T *RLMNSNullToNil(T *obj) {
+static inline T *RLMCoerceToNil(T *obj) {
     if (static_cast<id>(obj) == NSNull.null) {
         return nil;
     }

--- a/Realm/RLMUtil.hpp
+++ b/Realm/RLMUtil.hpp
@@ -21,6 +21,7 @@
 
 #import <realm/array.hpp>
 #import <realm/binary_data.hpp>
+#import <realm/datetime.hpp>
 #import <realm/string_data.hpp>
 #import <realm/util/file.hpp>
 
@@ -139,6 +140,16 @@ static inline realm::BinaryData RLMBinaryDataForNSData(__unsafe_unretained NSDat
     // the casting bit ensures that we create a data with a non-null pointer
     auto bytes = static_cast<const char *>(data.bytes) ?: static_cast<char *>((__bridge void *)data);
     return realm::BinaryData(bytes, data.length);
+}
+
+// Date convertion utilities
+static inline NSDate *RLMDateTimeToNSDate(realm::DateTime dateTime) {
+    return [NSDate dateWithTimeIntervalSince1970:dateTime.get_datetime()];
+}
+
+static inline realm::DateTime RLMDateTimeForNSDate(__unsafe_unretained NSDate *const date) {
+    std::time_t time = date.timeIntervalSince1970;
+    return realm::DateTime(time);
 }
 
 static inline NSUInteger RLMConvertNotFound(size_t index) {

--- a/Realm/RLMUtil.hpp
+++ b/Realm/RLMUtil.hpp
@@ -75,7 +75,7 @@ static inline T *RLMDynamicCast(__unsafe_unretained id obj) {
 }
 
 template<typename T>
-static inline T *RLMCoerceToNil(T *obj) {
+static inline T RLMCoerceToNil(__unsafe_unretained T obj) {
     if (static_cast<id>(obj) == NSNull.null) {
         return nil;
     }

--- a/Realm/RLMUtil.hpp
+++ b/Realm/RLMUtil.hpp
@@ -79,8 +79,8 @@ static inline T RLMCoerceToNil(__unsafe_unretained T obj) {
     if (static_cast<id>(obj) == NSNull.null) {
         return nil;
     }
-    else if (RLMIsKindOfClass(object_getClass(obj), [RLMOptionalBase class])) {
-        return [static_cast<RLMOptionalBase *>(obj) underlyingValue];
+    else if (__unsafe_unretained auto optional = RLMDynamicCast<RLMOptionalBase>(obj)) {
+        return optional.underlyingValue;
     }
     return obj;
 }

--- a/Realm/RLMUtil.hpp
+++ b/Realm/RLMUtil.hpp
@@ -17,6 +17,7 @@
 ////////////////////////////////////////////////////////////////////////////
 
 #import <Realm/RLMConstants.h>
+#import <Realm/RLMOptionalBase.h>
 #import <objc/runtime.h>
 
 #import <realm/array.hpp>
@@ -77,6 +78,9 @@ template<typename T>
 static inline T *RLMNSNullToNil(T *obj) {
     if (static_cast<id>(obj) == NSNull.null) {
         return nil;
+    }
+    else if (RLMIsKindOfClass(object_getClass(obj), [RLMOptionalBase class])) {
+        return [static_cast<RLMOptionalBase *>(obj) underlyingValue];
     }
     return obj;
 }

--- a/Realm/RLMUtil.hpp
+++ b/Realm/RLMUtil.hpp
@@ -80,7 +80,7 @@ static inline T RLMCoerceToNil(__unsafe_unretained T obj) {
         return nil;
     }
     else if (__unsafe_unretained auto optional = RLMDynamicCast<RLMOptionalBase>(obj)) {
-        return optional.underlyingValue;
+        return RLMCoerceToNil(optional.underlyingValue);
     }
     return obj;
 }

--- a/Realm/RLMUtil.hpp
+++ b/Realm/RLMUtil.hpp
@@ -148,7 +148,7 @@ static inline NSDate *RLMDateTimeToNSDate(realm::DateTime dateTime) {
 }
 
 static inline realm::DateTime RLMDateTimeForNSDate(__unsafe_unretained NSDate *const date) {
-    std::time_t time = date.timeIntervalSince1970;
+    int64_t time = date.timeIntervalSince1970;
     return realm::DateTime(time);
 }
 

--- a/Realm/RLMUtil.mm
+++ b/Realm/RLMUtil.mm
@@ -107,7 +107,7 @@ static inline bool object_has_valid_type(__unsafe_unretained id const obj)
 
 BOOL RLMIsObjectValidForProperty(__unsafe_unretained id const obj,
                                  __unsafe_unretained RLMProperty *const property) {
-    if (property.optional && (!obj || obj == [NSNull null] || (RLMIsKindOfClass(object_getClass(obj), RLMOptionalBase.class) && ![obj underlyingValue]))) {
+    if (property.optional && !RLMCoerceToNil(obj)) {
         return YES;
     }
 

--- a/Realm/RLMUtil.mm
+++ b/Realm/RLMUtil.mm
@@ -23,6 +23,7 @@
 #import "RLMObjectSchema_Private.hpp"
 #import "RLMObjectStore.h"
 #import "RLMObject_Private.hpp"
+#import "RLMOptionalBase.h"
 #import "RLMProperty_Private.h"
 #import "RLMSchema_Private.h"
 #import "RLMSwiftSupport.h"
@@ -106,7 +107,7 @@ static inline bool object_has_valid_type(__unsafe_unretained id const obj)
 
 BOOL RLMIsObjectValidForProperty(__unsafe_unretained id const obj,
                                  __unsafe_unretained RLMProperty *const property) {
-    if (property.optional && (!obj || obj == [NSNull null])) {
+    if (property.optional && (!obj || obj == [NSNull null] || (RLMIsKindOfClass(object_getClass(obj), RLMOptionalBase.class) && ![obj underlyingValue]))) {
         return YES;
     }
 
@@ -215,7 +216,7 @@ NSArray *RLMCollectionValueForKey(id<RLMFastEnumerable> collection, NSString *ke
     for (size_t i = 0; i < count; i++) {
         size_t rowIndex = [collection indexInSource:i];
         accessor->_row = (*table)[rowIndex];
-        RLMInitializeSwiftListAccessor(accessor);
+        RLMInitializeSwiftAccessorGenerics(accessor);
         [results addObject:[accessor valueForKey:key] ?: NSNull.null];
     }
 
@@ -235,7 +236,7 @@ void RLMCollectionSetValueForKey(id<RLMFastEnumerable> collection, NSString *key
     for (size_t i = 0; i < count; i++) {
         size_t rowIndex = [collection indexInSource:i];
         accessor->_row = (*table)[rowIndex];
-        RLMInitializeSwiftListAccessor(accessor);
+        RLMInitializeSwiftAccessorGenerics(accessor);
         [accessor setValue:value forKey:key];
     }
 }

--- a/Realm/RLMUtil.mm
+++ b/Realm/RLMUtil.mm
@@ -262,6 +262,14 @@ NSError *RLMMakeError(RLMError code, std::exception const& exception) {
                                       @"Error Code": @(code)}];
 }
 
+NSError *RLMMakeError(RLMError code, const realm::util::File::AccessError& exception) {
+    return [NSError errorWithDomain:RLMErrorDomain
+                               code:code
+                           userInfo:@{NSLocalizedDescriptionKey: @(exception.what()),
+                                      NSFilePathErrorKey: @(exception.get_path().c_str()),
+                                      @"Error Code": @(code)}];
+}
+
 NSError *RLMMakeError(NSException *exception) {
     return [NSError errorWithDomain:RLMErrorDomain
                                code:0

--- a/Realm/RLMUtil.mm
+++ b/Realm/RLMUtil.mm
@@ -23,7 +23,6 @@
 #import "RLMObjectSchema_Private.hpp"
 #import "RLMObjectStore.h"
 #import "RLMObject_Private.hpp"
-#import "RLMOptionalBase.h"
 #import "RLMProperty_Private.h"
 #import "RLMSchema_Private.h"
 #import "RLMSwiftSupport.h"

--- a/Realm/Tests/KVOTests.mm
+++ b/Realm/Tests/KVOTests.mm
@@ -48,6 +48,11 @@ RLM_ARRAY_TYPE(KVOLinkObject1)
 @property NSDate              *dateCol;
 @property KVOObject           *objectCol;
 @property RLMArray<KVOObject> *arrayCol;
+
+@property NSNumber<RLMInt> *optIntCol;
+@property NSNumber<RLMFloat> *optFloatCol;
+@property NSNumber<RLMDouble> *optDoubleCol;
+@property NSNumber<RLMBool> *optBoolCol;
 @end
 @implementation KVOObject
 + (NSString *)primaryKey {
@@ -95,6 +100,11 @@ RLM_ARRAY_TYPE(KVOLinkObject1)
 @property NSDate         *dateCol;
 @property PlainKVOObject *objectCol;
 @property NSMutableArray *arrayCol;
+
+@property NSNumber<RLMInt> *optIntCol;
+@property NSNumber<RLMFloat> *optFloatCol;
+@property NSNumber<RLMDouble> *optDoubleCol;
+@property NSNumber<RLMBool> *optBoolCol;
 @end
 @implementation PlainKVOObject
 @end
@@ -162,7 +172,6 @@ public:
         @catch (NSException *e) {
             XCTFail(@"%@", e.description);
         }
-//        assert(_notifications.count == 0);
         XCTAssertEqual(0U, _notifications.count);
     }
 
@@ -560,6 +569,8 @@ public:
         KVORecorder r(self, obj, @"stringCol");
         obj.stringCol = @"abc";
         AssertChanged(r, @"", @"abc");
+        obj.stringCol = nil;
+        AssertChanged(r, @"abc", NSNull.null);
     }
 
     {
@@ -567,6 +578,8 @@ public:
         NSData *data = [@"abc" dataUsingEncoding:NSUTF8StringEncoding];
         obj.binaryCol = data;
         AssertChanged(r, NSData.data, data);
+        obj.binaryCol = nil;
+        AssertChanged(r, data, NSNull.null);
     }
 
     {
@@ -574,12 +587,16 @@ public:
         NSDate *date = [NSDate dateWithTimeIntervalSinceReferenceDate:1];
         obj.dateCol = date;
         AssertChanged(r, [NSDate dateWithTimeIntervalSinceReferenceDate:0], date);
+        obj.dateCol = nil;
+        AssertChanged(r, date, NSNull.null);
     }
 
     {
         KVORecorder r(self, obj, @"objectCol");
         obj.objectCol = obj;
         AssertChanged(r, NSNull.null, [self observableForObject:obj]);
+        obj.objectCol = nil;
+        AssertChanged(r, [self observableForObject:obj], NSNull.null);
     }
 
     {
@@ -587,6 +604,38 @@ public:
         obj.arrayCol = obj.arrayCol;
         r.refresh();
         r.pop_front(); // asserts that there's something to pop
+    }
+
+    {
+        KVORecorder r(self, obj, @"optIntCol");
+        obj.optIntCol = @1;
+        AssertChanged(r, NSNull.null, @1);
+        obj.optIntCol = nil;
+        AssertChanged(r, @1, NSNull.null);
+    }
+
+    {
+        KVORecorder r(self, obj, @"optFloatCol");
+        obj.optFloatCol = @1.1f;
+        AssertChanged(r, NSNull.null, @1.1f);
+        obj.optFloatCol = nil;
+        AssertChanged(r, @1.1f, NSNull.null);
+    }
+
+    {
+        KVORecorder r(self, obj, @"optDoubleCol");
+        obj.optDoubleCol = @1.1;
+        AssertChanged(r, NSNull.null, @1.1);
+        obj.optDoubleCol = nil;
+        AssertChanged(r, @1.1, NSNull.null);
+    }
+
+    {
+        KVORecorder r(self, obj, @"optBoolCol");
+        obj.optBoolCol = @YES;
+        AssertChanged(r, NSNull.null, @YES);
+        obj.optBoolCol = nil;
+        AssertChanged(r, @YES, NSNull.null);
     }
 }
 
@@ -639,6 +688,8 @@ public:
         KVORecorder r(self, obj, @"stringCol");
         [obj setValue:@"abc" forKey:@"stringCol"];
         AssertChanged(r, @"", @"abc");
+        [obj setValue:nil forKey:@"stringCol"];
+        AssertChanged(r, @"abc", NSNull.null);
     }
 
     {
@@ -646,6 +697,8 @@ public:
         NSData *data = [@"abc" dataUsingEncoding:NSUTF8StringEncoding];
         [obj setValue:data forKey:@"binaryCol"];
         AssertChanged(r, NSData.data, data);
+        [obj setValue:nil forKey:@"binaryCol"];
+        AssertChanged(r, data, NSNull.null);
     }
 
     {
@@ -653,12 +706,16 @@ public:
         NSDate *date = [NSDate dateWithTimeIntervalSinceReferenceDate:1];
         [obj setValue:date forKey:@"dateCol"];
         AssertChanged(r, [NSDate dateWithTimeIntervalSinceReferenceDate:0], date);
+        [obj setValue:nil forKey:@"dateCol"];
+        AssertChanged(r, date, NSNull.null);
     }
 
     {
         KVORecorder r(self, obj, @"objectCol");
         [obj setValue:obj forKey:@"objectCol"];
         AssertChanged(r, NSNull.null, [self observableForObject:obj]);
+        [obj setValue:nil forKey:@"objectCol"];
+        AssertChanged(r, [self observableForObject:obj], NSNull.null);
     }
 
     {
@@ -666,6 +723,38 @@ public:
         [obj setValue:obj.arrayCol forKey:@"arrayCol"];
         r.refresh();
         r.pop_front(); // asserts that there's something to pop
+    }
+
+    {
+        KVORecorder r(self, obj, @"optIntCol");
+        [obj setValue:@1 forKey:@"optIntCol"];
+        AssertChanged(r, NSNull.null, @1);
+        [obj setValue:nil forKey:@"optIntCol"];
+        AssertChanged(r, @1, NSNull.null);
+    }
+
+    {
+        KVORecorder r(self, obj, @"optFloatCol");
+        [obj setValue:@1.1f forKey:@"optFloatCol"];
+        AssertChanged(r, NSNull.null, @1.1f);
+        [obj setValue:nil forKey:@"optFloatCol"];
+        AssertChanged(r, @1.1f, NSNull.null);
+    }
+
+    {
+        KVORecorder r(self, obj, @"optDoubleCol");
+        [obj setValue:@1.1 forKey:@"optDoubleCol"];
+        AssertChanged(r, NSNull.null, @1.1);
+        [obj setValue:nil forKey:@"optDoubleCol"];
+        AssertChanged(r, @1.1, NSNull.null);
+    }
+
+    {
+        KVORecorder r(self, obj, @"optBoolCol");
+        [obj setValue:@YES forKey:@"optBoolCol"];
+        AssertChanged(r, NSNull.null, @YES);
+        [obj setValue:nil forKey:@"optBoolCol"];
+        AssertChanged(r, @YES, NSNull.null);
     }
 }
 
@@ -721,6 +810,8 @@ public:
         KVORecorder r(self, obj, @"stringCol");
         obj[@"stringCol"] = @"abc";
         AssertChanged(r, @"", @"abc");
+        obj[@"stringCol"] = nil;
+        AssertChanged(r, @"abc", NSNull.null);
     }
 
     {
@@ -728,6 +819,8 @@ public:
         NSData *data = [@"abc" dataUsingEncoding:NSUTF8StringEncoding];
         obj[@"binaryCol"] = data;
         AssertChanged(r, NSData.data, data);
+        obj[@"binaryCol"] = nil;
+        AssertChanged(r, data, NSNull.null);
     }
 
     {
@@ -735,12 +828,16 @@ public:
         NSDate *date = [NSDate dateWithTimeIntervalSinceReferenceDate:1];
         obj[@"dateCol"] = date;
         AssertChanged(r, [NSDate dateWithTimeIntervalSinceReferenceDate:0], date);
+        obj[@"dateCol"] = nil;
+        AssertChanged(r, date, NSNull.null);
     }
 
     {
         KVORecorder r(self, obj, @"objectCol");
         obj[@"objectCol"] = obj;
         AssertChanged(r, NSNull.null, [self observableForObject:obj]);
+        obj[@"objectCol"] = nil;
+        AssertChanged(r, [self observableForObject:obj], NSNull.null);
     }
 
     {
@@ -748,6 +845,38 @@ public:
         obj[@"arrayCol"] = obj.arrayCol;
         r.refresh();
         r.pop_front(); // asserts that there's something to pop
+    }
+
+    {
+        KVORecorder r(self, obj, @"optIntCol");
+        obj[@"optIntCol"] = @1;
+        AssertChanged(r, NSNull.null, @1);
+        obj[@"optIntCol"] = nil;
+        AssertChanged(r, @1, NSNull.null);
+    }
+
+    {
+        KVORecorder r(self, obj, @"optFloatCol");
+        obj[@"optFloatCol"] = @1.1f;
+        AssertChanged(r, NSNull.null, @1.1f);
+        obj[@"optFloatCol"] = nil;
+        AssertChanged(r, @1.1f, NSNull.null);
+    }
+
+    {
+        KVORecorder r(self, obj, @"optDoubleCol");
+        obj[@"optDoubleCol"] = @1.1;
+        AssertChanged(r, NSNull.null, @1.1);
+        obj[@"optDoubleCol"] = nil;
+        AssertChanged(r, @1.1, NSNull.null);
+    }
+
+    {
+        KVORecorder r(self, obj, @"optBoolCol");
+        obj[@"optBoolCol"] = @YES;
+        AssertChanged(r, NSNull.null, @YES);
+        obj[@"optBoolCol"] = nil;
+        AssertChanged(r, @YES, NSNull.null);
     }
 }
 
@@ -946,7 +1075,8 @@ public:
     return [KVOObject createInRealm:_realm withValue:@[@(++pk),
                                                        @NO, @1, @2, @3, @0, @0, @NO, @"",
                                                        NSData.data, [NSDate dateWithTimeIntervalSinceReferenceDate:0],
-                                                       NSNull.null, NSNull.null]];
+                                                       NSNull.null, NSNull.null,
+                                                       NSNull.null, NSNull.null, NSNull.null, NSNull.null]];
 }
 
 - (id)createLinkObject {

--- a/Realm/Tests/MigrationTests.mm
+++ b/Realm/Tests/MigrationTests.mm
@@ -908,7 +908,6 @@ static void RLMAssertRealmSchemaMatchesTable(id self, RLMRealm *realm) {
     [RLMRealm setSchemaVersion:RLMNotVersioned - 1 forRealmAtPath:RLMTestRealmPath() withMigrationBlock:nil];
 }
 
-#ifdef REALM_ENABLE_NULL
 - (void)testChangingColumnNullability {
     RLMSchema *nullable = [[RLMSchema alloc] init];
     nullable.objectSchema = @[[RLMObjectSchema schemaForObjectClass:StringObject.class]];
@@ -984,6 +983,5 @@ static void RLMAssertRealmSchemaMatchesTable(id self, RLMRealm *realm) {
         XCTAssertEqualObjects([NSDate dateWithTimeIntervalSince1970:2], obj.date);
     }
 }
-#endif
 
 @end

--- a/Realm/Tests/ObjectSchemaTests.m
+++ b/Realm/Tests/ObjectSchemaTests.m
@@ -33,11 +33,7 @@
                                                     @"\t\tobjectClassName = (null);\n"
                                                     @"\t\tindexed = YES;\n"
                                                     @"\t\tisPrimary = YES;\n"
-#ifdef REALM_ENABLE_NULL
                                                     @"\t\toptional = YES;\n"
-#else
-                                                    @"\t\toptional = NO;\n"
-#endif
                                                     @"\t}\n"
                                                     @"\tintCol {\n"
                                                     @"\t\ttype = int;\n"

--- a/Realm/Tests/ObjectTests.m
+++ b/Realm/Tests/ObjectTests.m
@@ -265,7 +265,27 @@ RLM_ARRAY_TYPE(PrimaryEmployeeObject);
 
 @implementation ObjectTests
 
--(void)testObjectInit
+- (void)testNSNumberProperties {
+    NSNumberObject *obj = [NSNumberObject new];
+    obj.intObj = @20;
+    obj.floatObj = @0.7f;
+    obj.doubleObj = @33.3;
+    obj.boolObj = @YES;
+    XCTAssertEqualObjects(@20, obj.intObj);
+    XCTAssertEqualObjects(@0.7f, obj.floatObj);
+    XCTAssertEqualObjects(@33.3, obj.doubleObj);
+    XCTAssertEqualObjects(@YES, obj.boolObj);
+    RLMRealm *realm = [RLMRealm defaultRealm];
+    [realm beginWriteTransaction];
+    [realm addObject:obj];
+    [realm commitWriteTransaction];
+    XCTAssertEqualObjects(@20, obj.intObj);
+    XCTAssertEqualObjects(@0.7f, obj.floatObj);
+    XCTAssertEqualObjects(@33.3, obj.doubleObj);
+    XCTAssertEqualObjects(@YES, obj.boolObj);
+}
+
+- (void)testObjectInit
 {
     RLMRealm *realm = [RLMRealm defaultRealm];
     

--- a/Realm/Tests/ObjectTests.m
+++ b/Realm/Tests/ObjectTests.m
@@ -265,26 +265,6 @@ RLM_ARRAY_TYPE(PrimaryEmployeeObject);
 
 @implementation ObjectTests
 
-- (void)testNSNumberProperties {
-    NumberObject *obj = [NumberObject new];
-    obj.intObj = @20;
-    obj.floatObj = @0.7f;
-    obj.doubleObj = @33.3;
-    obj.boolObj = @YES;
-    XCTAssertEqualObjects(@20, obj.intObj);
-    XCTAssertEqualObjects(@0.7f, obj.floatObj);
-    XCTAssertEqualObjects(@33.3, obj.doubleObj);
-    XCTAssertEqualObjects(@YES, obj.boolObj);
-    RLMRealm *realm = [RLMRealm defaultRealm];
-    [realm beginWriteTransaction];
-    [realm addObject:obj];
-    [realm commitWriteTransaction];
-    XCTAssertEqualObjects(@20, obj.intObj);
-    XCTAssertEqualObjects(@0.7f, obj.floatObj);
-    XCTAssertEqualObjects(@33.3, obj.doubleObj);
-    XCTAssertEqualObjects(@YES, obj.boolObj);
-}
-
 - (void)testObjectInit
 {
     RLMRealm *realm = [RLMRealm defaultRealm];
@@ -743,6 +723,26 @@ RLM_ARRAY_TYPE(PrimaryEmployeeObject);
     [realm cancelWriteTransaction];
 }
 
+- (void)testNSNumberProperties {
+    NumberObject *obj = [NumberObject new];
+    obj.intObj = @20;
+    obj.floatObj = @0.7f;
+    obj.doubleObj = @33.3;
+    obj.boolObj = @YES;
+    XCTAssertEqualObjects(@20, obj.intObj);
+    XCTAssertEqualObjects(@0.7f, obj.floatObj);
+    XCTAssertEqualObjects(@33.3, obj.doubleObj);
+    XCTAssertEqualObjects(@YES, obj.boolObj);
+    RLMRealm *realm = [RLMRealm defaultRealm];
+    [realm beginWriteTransaction];
+    [realm addObject:obj];
+    [realm commitWriteTransaction];
+    XCTAssertEqualObjects(@20, obj.intObj);
+    XCTAssertEqualObjects(@0.7f, obj.floatObj);
+    XCTAssertEqualObjects(@33.3, obj.doubleObj);
+    XCTAssertEqualObjects(@YES, obj.boolObj);
+}
+
 #ifdef REALM_ENABLE_NULL
 - (void)testOptionalStringProperties {
     RLMRealm *realm = [RLMRealm defaultRealm];
@@ -837,6 +837,89 @@ RLM_ARRAY_TYPE(PrimaryEmployeeObject);
     XCTAssertEqualObjects(bo.binaryCol, emptyData);
     XCTAssertEqualObjects([bo valueForKey:@"binaryCol"], emptyData);
     XCTAssertEqualObjects(bo[@"binaryCol"], emptyData);
+}
+
+- (void)testOptionalNumberProperties {
+    void (^assertNullProperties)(NumberObject *) = ^(NumberObject *no){
+        XCTAssertNil(no.intObj);
+        XCTAssertNil(no.doubleObj);
+        XCTAssertNil(no.floatObj);
+        XCTAssertNil(no.boolObj);
+
+        XCTAssertNil([no valueForKey:@"intObj"]);
+        XCTAssertNil([no valueForKey:@"doubleObj"]);
+        XCTAssertNil([no valueForKey:@"floatObj"]);
+        XCTAssertNil([no valueForKey:@"boolObj"]);
+
+        XCTAssertNil(no[@"intObj"]);
+        XCTAssertNil(no[@"doubleObj"]);
+        XCTAssertNil(no[@"floatObj"]);
+        XCTAssertNil(no[@"boolObj"]);
+    };
+
+    void (^assertNonNullProperties)(NumberObject *) = ^(NumberObject *no){
+        XCTAssertEqualObjects(no.intObj, @1);
+        XCTAssertEqualObjects(no.doubleObj, @1.1);
+        XCTAssertEqualObjects(no.floatObj, @2.2f);
+        XCTAssertEqualObjects(no.boolObj, @YES);
+
+        XCTAssertEqualObjects([no valueForKey:@"intObj"], @1);
+        XCTAssertEqualObjects([no valueForKey:@"doubleObj"], @1.1);
+        XCTAssertEqualObjects([no valueForKey:@"floatObj"], @2.2f);
+        XCTAssertEqualObjects([no valueForKey:@"boolObj"], @YES);
+
+        XCTAssertEqualObjects(no[@"intObj"], @1);
+        XCTAssertEqualObjects(no[@"doubleObj"], @1.1);
+        XCTAssertEqualObjects(no[@"floatObj"], @2.2f);
+        XCTAssertEqualObjects(no[@"boolObj"], @YES);
+    };
+
+    RLMRealm *realm = [RLMRealm defaultRealm];
+    NumberObject *no = [[NumberObject alloc] init];
+
+    assertNullProperties(no);
+
+    no.intObj = @1;
+    no.doubleObj = @1.1;
+    no.floatObj = @2.2f;
+    no.boolObj = @YES;
+
+    assertNonNullProperties(no);
+
+    no.intObj = nil;
+    no.doubleObj = nil;
+    no.floatObj = nil;
+    no.boolObj = nil;
+
+    assertNullProperties(no);
+
+    no[@"intObj"] = @1;
+    no[@"doubleObj"] = @1.1;
+    no[@"floatObj"] = @2.2f;
+    no[@"boolObj"] = @YES;
+
+    assertNonNullProperties(no);
+
+    no.intObj = nil;
+    no.doubleObj = nil;
+    no.floatObj = nil;
+    no.boolObj = nil;
+
+    [realm transactionWithBlock:^{
+        [realm addObject:no];
+        assertNullProperties(no);
+    }];
+
+    no = [NumberObject allObjectsInRealm:realm].firstObject;
+    assertNullProperties(no);
+
+    [realm transactionWithBlock:^{
+        no.intObj = @1;
+        no.doubleObj = @1.1;
+        no.floatObj = @2.2f;
+        no.boolObj = @YES;
+    }];
+    assertNonNullProperties(no);
 }
 
 - (void)testSettingNonOptionalPropertiesToNil {

--- a/Realm/Tests/ObjectTests.m
+++ b/Realm/Tests/ObjectTests.m
@@ -266,7 +266,7 @@ RLM_ARRAY_TYPE(PrimaryEmployeeObject);
 @implementation ObjectTests
 
 - (void)testNSNumberProperties {
-    NSNumberObject *obj = [NSNumberObject new];
+    NumberObject *obj = [NumberObject new];
     obj.intObj = @20;
     obj.floatObj = @0.7f;
     obj.doubleObj = @33.3;

--- a/Realm/Tests/ObjectTests.m
+++ b/Realm/Tests/ObjectTests.m
@@ -1644,6 +1644,7 @@ RLM_ARRAY_TYPE(PrimaryEmployeeObject);
     XCTAssertThrows([PrimaryInt64Object createInDefaultRealmWithValue:(@[@(1LL << 40)])], @"Duplicate primary key should throw");
     XCTAssertThrows(obj2.int64Col = 1LL << 41, @"Setting primary key should throw");
 
+#if REALM_ENABLE_NULL
     [PrimaryNullableIntObject createInDefaultRealmWithValue:@[@1]];
     PrimaryNullableIntObject *obj3 = [PrimaryNullableIntObject createInDefaultRealmWithValue:(@{@"optIntCol": @2})];
     XCTAssertThrows(obj3.optIntCol = @2, @"Setting primary key should throw");
@@ -1653,6 +1654,7 @@ RLM_ARRAY_TYPE(PrimaryEmployeeObject);
     XCTAssertThrows(obj4.optIntCol = nil, @"Setting primary key should throw");
     XCTAssertThrows([PrimaryNullableIntObject createInDefaultRealmWithValue:(@[@1])], @"Duplicate primary key should throw");
     XCTAssertThrows([PrimaryNullableIntObject createInDefaultRealmWithValue:(@[NSNull.null])], @"Duplicate primary key should throw");
+#endif
 
     [[RLMRealm defaultRealm] commitWriteTransaction];
 }

--- a/Realm/Tests/ObjectTests.m
+++ b/Realm/Tests/ObjectTests.m
@@ -1646,12 +1646,13 @@ RLM_ARRAY_TYPE(PrimaryEmployeeObject);
 
     [PrimaryNullableIntObject createInDefaultRealmWithValue:@[@1]];
     PrimaryNullableIntObject *obj3 = [PrimaryNullableIntObject createInDefaultRealmWithValue:(@{@"optIntCol": @2})];
-    XCTAssertThrows([PrimaryNullableIntObject createInDefaultRealmWithValue:(@[@1])], @"Duplicate primary key should throw");
     XCTAssertThrows(obj3.optIntCol = @2, @"Setting primary key should throw");
     XCTAssertThrows(obj3.optIntCol = nil, @"Setting primary key should throw");
     PrimaryNullableIntObject *obj4 = [PrimaryNullableIntObject createInDefaultRealmWithValue:@[NSNull.null]];
     XCTAssertThrows(obj4.optIntCol = @2, @"Setting primary key should throw");
     XCTAssertThrows(obj4.optIntCol = nil, @"Setting primary key should throw");
+    XCTAssertThrows([PrimaryNullableIntObject createInDefaultRealmWithValue:(@[@1])], @"Duplicate primary key should throw");
+    XCTAssertThrows([PrimaryNullableIntObject createInDefaultRealmWithValue:(@[NSNull.null])], @"Duplicate primary key should throw");
 
     [[RLMRealm defaultRealm] commitWriteTransaction];
 }
@@ -1773,7 +1774,8 @@ RLM_ARRAY_TYPE(PrimaryEmployeeObject);
 #ifdef REALM_ENABLE_NULL
     PrimaryStringObject *nullStrObj = [PrimaryStringObject createInDefaultRealmWithValue:@[NSNull.null, @0]];
     PrimaryIntObject *intObj = [PrimaryIntObject createInDefaultRealmWithValue:@[@0]];
-    PrimaryNullableIntObject *nullIntObj = [PrimaryNullableIntObject createInDefaultRealmWithValue:@[@0]];
+    PrimaryNullableIntObject *nonNullIntObj = [PrimaryNullableIntObject createInDefaultRealmWithValue:@[@0]];
+    PrimaryNullableIntObject *nullIntObj = [PrimaryNullableIntObject createInDefaultRealmWithValue:@[NSNull.null]];
 #endif
     [RLMRealm.defaultRealm commitWriteTransaction];
 
@@ -1798,6 +1800,7 @@ RLM_ARRAY_TYPE(PrimaryEmployeeObject);
 #ifdef REALM_ENABLE_NULL
     XCTAssertEqualObjects(nullStrObj, [PrimaryStringObject objectForPrimaryKey:NSNull.null]);
     XCTAssertEqualObjects(intObj, [PrimaryIntObject objectForPrimaryKey:@0]);
+    XCTAssertEqualObjects(nonNullIntObj, [PrimaryNullableIntObject objectForPrimaryKey:@0]);
     XCTAssertEqualObjects(nullIntObj, [PrimaryNullableIntObject objectForPrimaryKey:NSNull.null]);
 #endif
 }

--- a/Realm/Tests/ObjectTests.m
+++ b/Realm/Tests/ObjectTests.m
@@ -903,10 +903,16 @@ RLM_ARRAY_TYPE(PrimaryEmployeeObject);
     RLMRealm *realm = [RLMRealm defaultRealm];
     
     [realm beginWriteTransaction];
-    
+
+#ifdef REALM_ENABLE_NULL
+    // Test #1
+    DateObject *dateObject = [[DateObject alloc] init];
+    XCTAssertNoThrow(([realm addObject:dateObject]), @"Adding object with no values specified for NSObject properties shouldn't throw exception if NSObject property is nil");
+#else 
     // Test #1
     DateObject *dateObject = [[DateObject alloc] init];
     XCTAssertThrows(([realm addObject:dateObject]), @"Adding object with no values specified for NSObject properties should throw exception if NSObject property is nil");
+#endif
 
     // Test #2
     dateObject = [[DateObject alloc] init];
@@ -1279,7 +1285,11 @@ RLM_ARRAY_TYPE(PrimaryEmployeeObject);
     DateObjectNoThrow *object = [DateObjectNoThrow createInDefaultRealmWithValue:@[NSDate.date, NSDate.date]];
 
     // create subclass with instance of base class with/without default objects
+#ifdef REALM_ENABLE_NULL
+    XCTAssertNoThrow([DateSubclassObject createInDefaultRealmWithValue:object]);
+#else
     XCTAssertThrows([DateSubclassObject createInDefaultRealmWithValue:object]);
+#endif
     XCTAssertNoThrow([DateObjectNoThrow createInDefaultRealmWithValue:object]);
 
     // create using non-realm object with custom getter

--- a/Realm/Tests/ObjectTests.m
+++ b/Realm/Tests/ObjectTests.m
@@ -1094,6 +1094,22 @@ RLM_ARRAY_TYPE(PrimaryEmployeeObject);
     }
 }
 
+- (void)testDefaultNSNumberPropertyValues {
+    void (^assertDefaults)(NumberObject *) = ^(NumberObject *no) {
+        XCTAssertEqualObjects(no.intObj, @1);
+        XCTAssertEqualObjects(no.floatObj, @2.2f);
+        XCTAssertEqualObjects(no.doubleObj, @3.3);
+        XCTAssertEqualObjects(no.boolObj, @NO);
+    };
+
+    assertDefaults([[NumberDefaultsObject alloc] init]);
+
+    RLMRealm *realm = [RLMRealm defaultRealm];
+    [realm beginWriteTransaction];
+    assertDefaults([NumberDefaultsObject createInRealm:realm withValue:@{}]);
+    [realm cancelWriteTransaction];
+}
+
 #pragma mark - Ignored Properties
 
 - (void)testIgnoredUnsupportedProperty

--- a/Realm/Tests/ObjectTests.m
+++ b/Realm/Tests/ObjectTests.m
@@ -118,6 +118,16 @@ RLM_ARRAY_TYPE(PrimaryIntObject);
 }
 @end
 
+@interface PrimaryNullableIntObject : RLMObject
+@property NSNumber<RLMInt> *optIntCol;
+@end
+
+@implementation PrimaryNullableIntObject
++ (NSString *)primaryKey {
+    return @"optIntCol";
+}
+@end
+
 @interface PrimaryStringObjectWrapper : RLMObject
 @property PrimaryStringObject *primaryStringObject;
 @end
@@ -1634,6 +1644,15 @@ RLM_ARRAY_TYPE(PrimaryEmployeeObject);
     XCTAssertThrows([PrimaryInt64Object createInDefaultRealmWithValue:(@[@(1LL << 40)])], @"Duplicate primary key should throw");
     XCTAssertThrows(obj2.int64Col = 1LL << 41, @"Setting primary key should throw");
 
+    [PrimaryNullableIntObject createInDefaultRealmWithValue:@[@1]];
+    PrimaryNullableIntObject *obj3 = [PrimaryNullableIntObject createInDefaultRealmWithValue:(@{@"optIntCol": @2})];
+    XCTAssertThrows([PrimaryNullableIntObject createInDefaultRealmWithValue:(@[@1])], @"Duplicate primary key should throw");
+    XCTAssertThrows(obj3.optIntCol = @2, @"Setting primary key should throw");
+    XCTAssertThrows(obj3.optIntCol = nil, @"Setting primary key should throw");
+    PrimaryNullableIntObject *obj4 = [PrimaryNullableIntObject createInDefaultRealmWithValue:@[NSNull.null]];
+    XCTAssertThrows(obj4.optIntCol = @2, @"Setting primary key should throw");
+    XCTAssertThrows(obj4.optIntCol = nil, @"Setting primary key should throw");
+
     [[RLMRealm defaultRealm] commitWriteTransaction];
 }
 
@@ -1754,6 +1773,7 @@ RLM_ARRAY_TYPE(PrimaryEmployeeObject);
 #ifdef REALM_ENABLE_NULL
     PrimaryStringObject *nullStrObj = [PrimaryStringObject createInDefaultRealmWithValue:@[NSNull.null, @0]];
     PrimaryIntObject *intObj = [PrimaryIntObject createInDefaultRealmWithValue:@[@0]];
+    PrimaryNullableIntObject *nullIntObj = [PrimaryNullableIntObject createInDefaultRealmWithValue:@[@0]];
 #endif
     [RLMRealm.defaultRealm commitWriteTransaction];
 
@@ -1766,6 +1786,8 @@ RLM_ARRAY_TYPE(PrimaryEmployeeObject);
     // wrong PK type
     XCTAssertThrows([PrimaryStringObject objectForPrimaryKey:@0]);
     XCTAssertThrows([PrimaryIntObject objectForPrimaryKey:@""]);
+    XCTAssertThrows([PrimaryIntObject objectForPrimaryKey:@""]);
+    XCTAssertThrows([PrimaryIntObject objectForPrimaryKey:NSNull.null]);
 
     // no object with key
     XCTAssertNil([PrimaryStringObject objectForPrimaryKey:@"bad key"]);
@@ -1776,6 +1798,7 @@ RLM_ARRAY_TYPE(PrimaryEmployeeObject);
 #ifdef REALM_ENABLE_NULL
     XCTAssertEqualObjects(nullStrObj, [PrimaryStringObject objectForPrimaryKey:NSNull.null]);
     XCTAssertEqualObjects(intObj, [PrimaryIntObject objectForPrimaryKey:@0]);
+    XCTAssertEqualObjects(nullIntObj, [PrimaryNullableIntObject objectForPrimaryKey:NSNull.null]);
 #endif
 }
 

--- a/Realm/Tests/ObjectTests.m
+++ b/Realm/Tests/ObjectTests.m
@@ -308,7 +308,6 @@ RLM_ARRAY_TYPE(PrimaryEmployeeObject);
     XCTAssertEqual(soUsingDictionary.age, 25, @"Age should be 25");
     XCTAssertEqual(soUsingDictionary.hired, YES, @"Hired should YES");
 
-#ifdef REALM_ENABLE_NULL
     [realm beginWriteTransaction];
     soInit = [[EmployeeObject alloc] init];
     soInit.name = nil;
@@ -328,7 +327,6 @@ RLM_ARRAY_TYPE(PrimaryEmployeeObject);
     XCTAssertNil(soUsingDictionary.name, @"Name should be nil");
     XCTAssertEqual(soUsingDictionary.age, 25, @"Age should be 25");
     XCTAssertEqual(soUsingDictionary.hired, YES, @"Hired should YES");
-#endif
 }
 
 -(void)testObjectInitWithObjectTypeArray
@@ -382,11 +380,9 @@ RLM_ARRAY_TYPE(PrimaryEmployeeObject);
     XCTAssertNoThrow([[DefaultObject alloc] initWithValue:@{@"intCol": @1}],
                      "Overriding some default values at initialization should not throw");
 
-#ifdef REALM_ENABLE_NULL
     XCTAssertNil(([[EmployeeObject alloc] initWithValue:@[NSNull.null, @30, @YES]].name));
     XCTAssertNil(([[EmployeeObject alloc] initWithValue:@{@"name" : NSNull.null, @"age" : @30, @"hired" : @YES}].name));
     XCTAssertNil(([[EmployeeObject alloc] initWithValue:@{@"age" : @30, @"hired" : @YES}].name));
-#endif
 }
 
 -(void)testObjectInitWithObjectTypeObject
@@ -404,12 +400,10 @@ RLM_ARRAY_TYPE(PrimaryEmployeeObject);
     // nested objects should work
     XCTAssertNoThrow([[OwnerObject alloc] initWithValue:(@[@"Alex", dogExt])], @"Should not throw");
 
-#ifdef REALM_ENABLE_NULL
     dogExt.dogName = nil;
     dogExt.breed = nil;
     dog = [[DogObject alloc] initWithValue:dogExt];
     XCTAssertNil(dog.dogName);
-#endif
 }
 
 -(void)testObjectInitWithObjectLiterals {
@@ -511,13 +505,11 @@ RLM_ARRAY_TYPE(PrimaryEmployeeObject);
     
     XCTAssertEqualObjects(obj0[@"name"], @"newName",  @"Name should be newName");
 
-#ifdef REALM_ENABLE_NULL
     [realm beginWriteTransaction];
     obj0[@"name"] = nil;
     [realm commitWriteTransaction];
 
     XCTAssertNil(obj0[@"name"]);
-#endif
 }
 
 - (void)testCannotUpdatePrimaryKey {
@@ -753,7 +745,6 @@ RLM_ARRAY_TYPE(PrimaryEmployeeObject);
     XCTAssertEqualObjects(@YES, obj.boolObj);
 }
 
-#ifdef REALM_ENABLE_NULL
 - (void)testOptionalStringProperties {
     RLMRealm *realm = [RLMRealm defaultRealm];
     StringObject *so = [[StringObject alloc] init];
@@ -951,7 +942,6 @@ RLM_ARRAY_TYPE(PrimaryEmployeeObject);
     RLMAssertThrowsWithReasonMatching(ro.binaryCol = nil, @"null into non-nullable column");
     [realm cancelWriteTransaction];
 }
-#endif
 
 - (void)testObjectSubclassAddedAtRuntime {
     Class objectClass = objc_allocateClassPair(RLMObject.class, "RuntimeGeneratedObject", 0);
@@ -997,15 +987,9 @@ RLM_ARRAY_TYPE(PrimaryEmployeeObject);
     
     [realm beginWriteTransaction];
 
-#ifdef REALM_ENABLE_NULL
     // Test #1
     DateObject *dateObject = [[DateObject alloc] init];
     XCTAssertNoThrow(([realm addObject:dateObject]), @"Adding object with no values specified for NSObject properties shouldn't throw exception if NSObject property is nil");
-#else 
-    // Test #1
-    DateObject *dateObject = [[DateObject alloc] init];
-    XCTAssertThrows(([realm addObject:dateObject]), @"Adding object with no values specified for NSObject properties should throw exception if NSObject property is nil");
-#endif
 
     // Test #2
     dateObject = [[DateObject alloc] init];
@@ -1016,11 +1000,9 @@ RLM_ARRAY_TYPE(PrimaryEmployeeObject);
     IntObject *intObj = [[IntObject alloc] init];
     XCTAssertNoThrow(([realm addObject:intObj]), @"Having no NSObject properties should not throw exception when being added to realm");
 
-#ifdef REALM_ENABLE_NULL
     // Test #4
     StringObject *stringObject = [[StringObject alloc] init];
     XCTAssertNoThrow([realm addObject:stringObject], @"Having a nil value for a optional NSObject property should not throw");
-#endif
 
     [realm commitWriteTransaction];
 }
@@ -1394,11 +1376,7 @@ RLM_ARRAY_TYPE(PrimaryEmployeeObject);
     DateObjectNoThrow *object = [DateObjectNoThrow createInDefaultRealmWithValue:@[NSDate.date, NSDate.date]];
 
     // create subclass with instance of base class with/without default objects
-#ifdef REALM_ENABLE_NULL
     XCTAssertNoThrow([DateSubclassObject createInDefaultRealmWithValue:object]);
-#else
-    XCTAssertThrows([DateSubclassObject createInDefaultRealmWithValue:object]);
-#endif
     XCTAssertNoThrow([DateObjectNoThrow createInDefaultRealmWithValue:object]);
 
     // create using non-realm object with custom getter
@@ -1420,13 +1398,11 @@ RLM_ARRAY_TYPE(PrimaryEmployeeObject);
     
     // This exception only gets thrown when there is no default vaule and it is for an NSObject property
     XCTAssertThrows(([AggregateObject createInRealm:realm withValue:@{@"boolCol" : @YES}]), @"Missing values in NSDictionary should throw default value exception");
-#ifdef REALM_ENABLE_NULL
     EmployeeObject *eo = nil;
     eo = [EmployeeObject createInRealm:realm withValue:@{@"age":@20, @"hired": @YES}];
     XCTAssertNil(eo.name);
     eo = [EmployeeObject createInRealm:realm withValue:@{@"name":NSNull.null, @"age":@20, @"hired": @YES}];
     XCTAssertNil(eo.name);
-#endif
     
     // This exception gets thrown when count of array does not match with object schema
     XCTAssertThrows(([EmployeeObject createInRealm:realm withValue:@[@27, @YES]]), @"Missing values in NSDictionary should throw default value exception");
@@ -1644,7 +1620,6 @@ RLM_ARRAY_TYPE(PrimaryEmployeeObject);
     XCTAssertThrows([PrimaryInt64Object createInDefaultRealmWithValue:(@[@(1LL << 40)])], @"Duplicate primary key should throw");
     XCTAssertThrows(obj2.int64Col = 1LL << 41, @"Setting primary key should throw");
 
-#if REALM_ENABLE_NULL
     [PrimaryNullableIntObject createInDefaultRealmWithValue:@[@1]];
     PrimaryNullableIntObject *obj3 = [PrimaryNullableIntObject createInDefaultRealmWithValue:(@{@"optIntCol": @2})];
     XCTAssertThrows(obj3.optIntCol = @2, @"Setting primary key should throw");
@@ -1654,7 +1629,6 @@ RLM_ARRAY_TYPE(PrimaryEmployeeObject);
     XCTAssertThrows(obj4.optIntCol = nil, @"Setting primary key should throw");
     XCTAssertThrows([PrimaryNullableIntObject createInDefaultRealmWithValue:(@[@1])], @"Duplicate primary key should throw");
     XCTAssertThrows([PrimaryNullableIntObject createInDefaultRealmWithValue:(@[NSNull.null])], @"Duplicate primary key should throw");
-#endif
 
     [[RLMRealm defaultRealm] commitWriteTransaction];
 }
@@ -1671,21 +1645,15 @@ RLM_ARRAY_TYPE(PrimaryEmployeeObject);
     [PrimaryStringObject createOrUpdateInRealm:realm withValue:@{@"stringCol": @"string2", @"intCol": @2}];
     XCTAssertEqual([objects count], 2U, @"Should have 2 objects");
 
-#ifdef REALM_ENABLE_NULL
     [PrimaryStringObject createOrUpdateInRealm:realm withValue:@{@"intCol": @5}];
     [PrimaryStringObject createOrUpdateInRealm:realm withValue:@{@"intCol": @7}];
     XCTAssertEqual([PrimaryStringObject objectInRealm:realm forPrimaryKey:NSNull.null].intCol, 7);
     [PrimaryStringObject createOrUpdateInRealm:realm withValue:@{@"stringCol": NSNull.null, @"intCol": @11}];
     XCTAssertEqual([PrimaryStringObject objectInRealm:realm forPrimaryKey:nil].intCol, 11);
-#endif
 
     // upsert with new secondary property
     [PrimaryStringObject createOrUpdateInDefaultRealmWithValue:@[@"string", @3]];
-#ifdef REALM_ENABLE_NULL
     XCTAssertEqual([objects count], 3U, @"Should have 3 objects");
-#else
-    XCTAssertEqual([objects count], 2U, @"Should have 2 objects");
-#endif
     XCTAssertEqual([(PrimaryStringObject *)objects[0] intCol], 3, @"Value should be 3");
 
     // upsert on non-primary key object should throw
@@ -1773,12 +1741,10 @@ RLM_ARRAY_TYPE(PrimaryEmployeeObject);
 - (void)testObjectWithKey {
     [RLMRealm.defaultRealm beginWriteTransaction];
     PrimaryStringObject *strObj = [PrimaryStringObject createInDefaultRealmWithValue:@[@"key", @0]];
-#ifdef REALM_ENABLE_NULL
     PrimaryStringObject *nullStrObj = [PrimaryStringObject createInDefaultRealmWithValue:@[NSNull.null, @0]];
     PrimaryIntObject *intObj = [PrimaryIntObject createInDefaultRealmWithValue:@[@0]];
     PrimaryNullableIntObject *nonNullIntObj = [PrimaryNullableIntObject createInDefaultRealmWithValue:@[@0]];
     PrimaryNullableIntObject *nullIntObj = [PrimaryNullableIntObject createInDefaultRealmWithValue:@[NSNull.null]];
-#endif
     [RLMRealm.defaultRealm commitWriteTransaction];
 
     // no PK
@@ -1799,12 +1765,10 @@ RLM_ARRAY_TYPE(PrimaryEmployeeObject);
 
     // object with key exists
     XCTAssertEqualObjects(strObj, [PrimaryStringObject objectForPrimaryKey:@"key"]);
-#ifdef REALM_ENABLE_NULL
     XCTAssertEqualObjects(nullStrObj, [PrimaryStringObject objectForPrimaryKey:NSNull.null]);
     XCTAssertEqualObjects(intObj, [PrimaryIntObject objectForPrimaryKey:@0]);
     XCTAssertEqualObjects(nonNullIntObj, [PrimaryNullableIntObject objectForPrimaryKey:@0]);
     XCTAssertEqualObjects(nullIntObj, [PrimaryNullableIntObject objectForPrimaryKey:NSNull.null]);
-#endif
 }
 
 - (void)testBacklinks {

--- a/Realm/Tests/ObjectTests.m
+++ b/Realm/Tests/ObjectTests.m
@@ -1751,13 +1751,15 @@ RLM_ARRAY_TYPE(PrimaryEmployeeObject);
     XCTAssertThrows([StringObject objectForPrimaryKey:@""]);
     XCTAssertThrows([IntObject objectForPrimaryKey:@0]);
     XCTAssertThrows([StringObject objectForPrimaryKey:NSNull.null]);
-    XCTAssertThrows([IntObject objectForPrimaryKey:NSNull.null]);
+    XCTAssertThrows([StringObject objectForPrimaryKey:nil]);
+    XCTAssertThrows([IntObject objectForPrimaryKey:nil]);
 
     // wrong PK type
     XCTAssertThrows([PrimaryStringObject objectForPrimaryKey:@0]);
     XCTAssertThrows([PrimaryIntObject objectForPrimaryKey:@""]);
     XCTAssertThrows([PrimaryIntObject objectForPrimaryKey:@""]);
     XCTAssertThrows([PrimaryIntObject objectForPrimaryKey:NSNull.null]);
+    XCTAssertThrows([PrimaryIntObject objectForPrimaryKey:nil]);
 
     // no object with key
     XCTAssertNil([PrimaryStringObject objectForPrimaryKey:@"bad key"]);
@@ -1766,9 +1768,11 @@ RLM_ARRAY_TYPE(PrimaryEmployeeObject);
     // object with key exists
     XCTAssertEqualObjects(strObj, [PrimaryStringObject objectForPrimaryKey:@"key"]);
     XCTAssertEqualObjects(nullStrObj, [PrimaryStringObject objectForPrimaryKey:NSNull.null]);
+    XCTAssertEqualObjects(nullStrObj, [PrimaryStringObject objectForPrimaryKey:nil]);
     XCTAssertEqualObjects(intObj, [PrimaryIntObject objectForPrimaryKey:@0]);
     XCTAssertEqualObjects(nonNullIntObj, [PrimaryNullableIntObject objectForPrimaryKey:@0]);
     XCTAssertEqualObjects(nullIntObj, [PrimaryNullableIntObject objectForPrimaryKey:NSNull.null]);
+    XCTAssertEqualObjects(nullIntObj, [PrimaryNullableIntObject objectForPrimaryKey:nil]);
 }
 
 - (void)testBacklinks {

--- a/Realm/Tests/PropertyTests.m
+++ b/Realm/Tests/PropertyTests.m
@@ -19,6 +19,7 @@
 #import "RLMTestCase.h"
 
 #import <objc/runtime.h>
+#import "RLMObjectSchema_Private.h"
 #import "RLMProperty_Private.h"
 #import "RLMRealm_Dynamic.h"
 

--- a/Realm/Tests/PropertyTests.m
+++ b/Realm/Tests/PropertyTests.m
@@ -43,9 +43,9 @@
 
 - (void)testEqualityFromObjectSchema {
 #ifdef REALM_ENABLE_NULL
-    BOOL stringAndBinaryAreOptional = YES;
+    BOOL optionalsEnabled = YES;
 #else
-    BOOL stringAndBinaryAreOptional = NO;
+    BOOL optionalsEnabled = NO;
 #endif
 
     // Test all property types
@@ -56,9 +56,9 @@
                                              @"intCol":    [[RLMProperty alloc] initWithName:@"intCol"    type:RLMPropertyTypeInt    objectClassName:nil             indexed:NO optional:NO],
                                              @"floatCol":  [[RLMProperty alloc] initWithName:@"floatCol"  type:RLMPropertyTypeFloat  objectClassName:nil             indexed:NO optional:NO],
                                              @"doubleCol": [[RLMProperty alloc] initWithName:@"doubleCol" type:RLMPropertyTypeDouble objectClassName:nil             indexed:NO optional:NO],
-                                             @"stringCol": [[RLMProperty alloc] initWithName:@"stringCol" type:RLMPropertyTypeString objectClassName:nil             indexed:NO optional:stringAndBinaryAreOptional],
-                                             @"binaryCol": [[RLMProperty alloc] initWithName:@"binaryCol" type:RLMPropertyTypeData   objectClassName:nil             indexed:NO optional:stringAndBinaryAreOptional],
-                                             @"dateCol":   [[RLMProperty alloc] initWithName:@"dateCol"   type:RLMPropertyTypeDate   objectClassName:nil             indexed:NO optional:NO],
+                                             @"stringCol": [[RLMProperty alloc] initWithName:@"stringCol" type:RLMPropertyTypeString objectClassName:nil             indexed:NO optional:optionalsEnabled],
+                                             @"binaryCol": [[RLMProperty alloc] initWithName:@"binaryCol" type:RLMPropertyTypeData   objectClassName:nil             indexed:NO optional:optionalsEnabled],
+                                             @"dateCol":   [[RLMProperty alloc] initWithName:@"dateCol"   type:RLMPropertyTypeDate   objectClassName:nil             indexed:NO optional:optionalsEnabled],
                                              @"cBoolCol":  [[RLMProperty alloc] initWithName:@"cBoolCol"  type:RLMPropertyTypeBool   objectClassName:nil             indexed:NO optional:NO],
                                              @"longCol":   [[RLMProperty alloc] initWithName:@"longCol"   type:RLMPropertyTypeInt    objectClassName:nil             indexed:NO optional:NO],
                                              @"mixedCol":  [[RLMProperty alloc] initWithName:@"mixedCol"  type:RLMPropertyTypeAny    objectClassName:nil             indexed:NO optional:NO],
@@ -75,14 +75,14 @@
     {
         RLMObjectSchema *objectSchema = [RLMObjectSchema schemaForObjectClass:[IndexedStringObject class]];
         RLMProperty *stringProperty = objectSchema[@"stringCol"];
-        RLMProperty *expectedProperty = [[RLMProperty alloc] initWithName:@"stringCol" type:RLMPropertyTypeString objectClassName:nil indexed:YES optional:stringAndBinaryAreOptional];
+        RLMProperty *expectedProperty = [[RLMProperty alloc] initWithName:@"stringCol" type:RLMPropertyTypeString objectClassName:nil indexed:YES optional:optionalsEnabled];
         XCTAssertTrue([stringProperty isEqualToProperty:expectedProperty]);
     }
     // Test primary key property
     {
         RLMObjectSchema *objectSchema = [RLMObjectSchema schemaForObjectClass:[PrimaryStringObject class]];
         RLMProperty *stringProperty = objectSchema[@"stringCol"];
-        RLMProperty *expectedProperty = [[RLMProperty alloc] initWithName:@"stringCol" type:RLMPropertyTypeString objectClassName:nil indexed:YES optional:stringAndBinaryAreOptional];
+        RLMProperty *expectedProperty = [[RLMProperty alloc] initWithName:@"stringCol" type:RLMPropertyTypeString objectClassName:nil indexed:YES optional:optionalsEnabled];
         expectedProperty.isPrimary = YES;
         XCTAssertTrue([stringProperty isEqualToProperty:expectedProperty]);
     }

--- a/Realm/Tests/PropertyTests.m
+++ b/Realm/Tests/PropertyTests.m
@@ -43,11 +43,7 @@
 }
 
 - (void)testEqualityFromObjectSchema {
-#ifdef REALM_ENABLE_NULL
     BOOL optionalsEnabled = YES;
-#else
-    BOOL optionalsEnabled = NO;
-#endif
 
     // Test all property types
     {

--- a/Realm/Tests/QueryTests.m
+++ b/Realm/Tests/QueryTests.m
@@ -1883,7 +1883,51 @@
 }
 
 - (void)testSortingColumnsWithNull {
+    RLMRealm *realm = [RLMRealm defaultRealm];
+    [realm beginWriteTransaction];
 
+    {
+        NumberObject *no1 = [NumberObject createInRealm:realm withValue:@[@1, @1.1f, @1.1, @YES]];
+        NumberObject *noNull = [NumberObject createInRealm:realm withValue:@[NSNull.null, NSNull.null, NSNull.null, NSNull.null]];
+        NumberObject *no0 = [NumberObject createInRealm:realm withValue:@[@0, @0.0f, @0.0, @NO]];
+        for (RLMProperty *property in [[NumberObject alloc] init].objectSchema.properties) {
+            NSString *name = property.name;
+            RLMResults *ascending = [[NumberObject allObjectsInRealm:realm] sortedResultsUsingProperty:name ascending:YES];
+            XCTAssertEqualObjects([ascending valueForKey:name], ([@[noNull, no0, no1] valueForKey:name]));
+
+            RLMResults *descending = [[NumberObject allObjectsInRealm:realm] sortedResultsUsingProperty:name ascending:NO];
+            XCTAssertEqualObjects([descending valueForKey:name], ([@[no1, no0, noNull] valueForKey:name]));
+        }
+    }
+
+    {
+        DateObject *doPositive = [DateObject createInRealm:realm withValue:@[[NSDate dateWithTimeIntervalSince1970:100]]];
+        DateObject *doNegative = [DateObject createInRealm:realm withValue:@[[NSDate dateWithTimeIntervalSince1970:-100]]];
+        DateObject *doZero = [DateObject createInRealm:realm withValue:@[[NSDate dateWithTimeIntervalSince1970:0]]];
+        DateObject *doNull = [DateObject createInRealm:realm withValue:@[NSNull.null]];
+
+        RLMResults *ascending = [[DateObject allObjectsInRealm:realm] sortedResultsUsingProperty:@"dateCol" ascending:YES];
+        XCTAssertEqualObjects([ascending valueForKey:@"dateCol"], ([@[doNull, doNegative, doZero, doPositive] valueForKey:@"dateCol"]));
+
+        RLMResults *descending = [[DateObject allObjectsInRealm:realm] sortedResultsUsingProperty:@"dateCol" ascending:NO];
+        XCTAssertEqualObjects([descending valueForKey:@"dateCol"], ([@[doPositive, doZero, doNegative, doNull] valueForKey:@"dateCol"]));
+    }
+
+    {
+        StringObject *soA = [StringObject createInRealm:realm withValue:@[@"A"]];
+        StringObject *soEmpty = [StringObject createInRealm:realm withValue:@[@""]];
+        StringObject *soB = [StringObject createInRealm:realm withValue:@[@"B"]];
+        StringObject *soNull = [StringObject createInRealm:realm withValue:@[NSNull.null]];
+        StringObject *soAB = [StringObject createInRealm:realm withValue:@[@"AB"]];
+
+        RLMResults *ascending = [[StringObject allObjectsInRealm:realm] sortedResultsUsingProperty:@"stringCol" ascending:YES];
+        XCTAssertEqualObjects([ascending valueForKey:@"stringCol"], ([@[soNull, soEmpty, soA, soAB, soB] valueForKey:@"stringCol"]));
+
+        RLMResults *descending = [[StringObject allObjectsInRealm:realm] sortedResultsUsingProperty:@"stringCol" ascending:NO];
+        XCTAssertEqualObjects([descending valueForKey:@"stringCol"], ([@[soB, soAB, soA, soEmpty, soNull] valueForKey:@"stringCol"]));
+    }
+
+    [realm cancelWriteTransaction];
 }
 
 @end

--- a/Realm/Tests/QueryTests.m
+++ b/Realm/Tests/QueryTests.m
@@ -67,12 +67,38 @@
 @implementation QueryObject
 @end
 
+@interface NullQueryObject : RLMObject
+@property (nonatomic, copy) NSNumber<RLMBool>   *bool1;
+@property (nonatomic, copy) NSNumber<RLMBool>   *bool2;
+@property (nonatomic, copy) NSNumber<RLMInt>    *int1;
+@property (nonatomic, copy) NSNumber<RLMInt>    *int2;
+@property (nonatomic, copy) NSNumber<RLMFloat>  *float1;
+@property (nonatomic, copy) NSNumber<RLMFloat>  *float2;
+@property (nonatomic, copy) NSNumber<RLMDouble> *double1;
+@property (nonatomic, copy) NSNumber<RLMDouble> *double2;
+@property (nonatomic, copy) NSString            *string1;
+@property (nonatomic, copy) NSString            *string2;
+@end
+
+@implementation NullQueryObject
+@end
+
 #pragma mark - Tests
 
 @interface QueryTests : RLMTestCase
+- (Class)queryObjectClass;
+- (BOOL)isNull;
 @end
 
 @implementation QueryTests
+
+- (Class)queryObjectClass {
+    return [QueryObject class];
+}
+
+- (BOOL)isNull {
+    return NO;
+}
 
 - (void)testBasicQuery
 {
@@ -233,8 +259,6 @@
     results = [ar sortedResultsUsingProperty:column ascending:ascending];
     XCTAssertEqualWithAccuracy(getter(results[0][column]), val, accuracy, @"Array not sorted as expected");
 }
-
-
 
 - (void)testQuerySorting
 {
@@ -543,91 +567,91 @@
 
     [realm beginWriteTransaction];
 
-    [QueryObject createInRealm:realm withValue:@[@YES, @YES, @1, @2, @23.0f, @1.7f,  @0.0,  @5.55, @"a", @"a"]];
-    [QueryObject createInRealm:realm withValue:@[@YES, @NO,  @1, @3, @-5.3f, @4.21f, @1.0,  @4.44, @"a", @"A"]];
-    [QueryObject createInRealm:realm withValue:@[@NO,  @NO,  @2, @2, @1.0f,  @3.55f, @99.9, @6.66, @"a", @"ab"]];
-    [QueryObject createInRealm:realm withValue:@[@NO,  @YES, @3, @6, @4.21f, @1.0f,  @1.0,  @7.77, @"a", @"AB"]];
-    [QueryObject createInRealm:realm withValue:@[@YES, @YES, @4, @5, @23.0f, @23.0f, @7.4,  @8.88, @"a", @"b"]];
-    [QueryObject createInRealm:realm withValue:@[@YES, @NO,  @15, @8, @1.0f,  @66.0f, @1.01, @9.99, @"a", @"ba"]];
-    [QueryObject createInRealm:realm withValue:@[@NO,  @YES, @15, @15, @1.0f,  @66.0f, @1.01, @9.99, @"a", @"BA"]];
+    [self.queryObjectClass createInRealm:realm withValue:@[@YES, @YES, @1, @2, @23.0f, @1.7f,  @0.0,  @5.55, @"a", @"a"]];
+    [self.queryObjectClass createInRealm:realm withValue:@[@YES, @NO,  @1, @3, @-5.3f, @4.21f, @1.0,  @4.44, @"a", @"A"]];
+    [self.queryObjectClass createInRealm:realm withValue:@[@NO,  @NO,  @2, @2, @1.0f,  @3.55f, @99.9, @6.66, @"a", @"ab"]];
+    [self.queryObjectClass createInRealm:realm withValue:@[@NO,  @YES, @3, @6, @4.21f, @1.0f,  @1.0,  @7.77, @"a", @"AB"]];
+    [self.queryObjectClass createInRealm:realm withValue:@[@YES, @YES, @4, @5, @23.0f, @23.0f, @7.4,  @8.88, @"a", @"b"]];
+    [self.queryObjectClass createInRealm:realm withValue:@[@YES, @NO,  @15, @8, @1.0f,  @66.0f, @1.01, @9.99, @"a", @"ba"]];
+    [self.queryObjectClass createInRealm:realm withValue:@[@NO,  @YES, @15, @15, @1.0f,  @66.0f, @1.01, @9.99, @"a", @"BA"]];
 
     [realm commitWriteTransaction];
 
-    XCTAssertEqual(7U, [QueryObject objectsWhere:@"bool1 == bool1"].count);
-    XCTAssertEqual(3U, [QueryObject objectsWhere:@"bool1 == bool2"].count);
-    XCTAssertEqual(4U, [QueryObject objectsWhere:@"bool1 != bool2"].count);
+    XCTAssertEqual(7U, [self.queryObjectClass objectsWhere:@"bool1 == bool1"].count);
+    XCTAssertEqual(3U, [self.queryObjectClass objectsWhere:@"bool1 == bool2"].count);
+    XCTAssertEqual(4U, [self.queryObjectClass objectsWhere:@"bool1 != bool2"].count);
 
-    XCTAssertEqual(7U, [QueryObject objectsWhere:@"int1 == int1"].count);
-    XCTAssertEqual(2U, [QueryObject objectsWhere:@"int1 == int2"].count);
-    XCTAssertEqual(5U, [QueryObject objectsWhere:@"int1 != int2"].count);
-    XCTAssertEqual(1U, [QueryObject objectsWhere:@"int1 > int2"].count);
-    XCTAssertEqual(4U, [QueryObject objectsWhere:@"int1 < int2"].count);
-    XCTAssertEqual(3U, [QueryObject objectsWhere:@"int1 >= int2"].count);
-    XCTAssertEqual(6U, [QueryObject objectsWhere:@"int1 <= int2"].count);
+    XCTAssertEqual(7U, [self.queryObjectClass objectsWhere:@"int1 == int1"].count);
+    XCTAssertEqual(2U, [self.queryObjectClass objectsWhere:@"int1 == int2"].count);
+    XCTAssertEqual(5U, [self.queryObjectClass objectsWhere:@"int1 != int2"].count);
+    XCTAssertEqual(1U, [self.queryObjectClass objectsWhere:@"int1 > int2"].count);
+    XCTAssertEqual(4U, [self.queryObjectClass objectsWhere:@"int1 < int2"].count);
+    XCTAssertEqual(3U, [self.queryObjectClass objectsWhere:@"int1 >= int2"].count);
+    XCTAssertEqual(6U, [self.queryObjectClass objectsWhere:@"int1 <= int2"].count);
 
-    XCTAssertEqual(7U, [QueryObject objectsWhere:@"float1 == float1"].count);
-    XCTAssertEqual(1U, [QueryObject objectsWhere:@"float1 == float2"].count);
-    XCTAssertEqual(6U, [QueryObject objectsWhere:@"float1 != float2"].count);
-    XCTAssertEqual(2U, [QueryObject objectsWhere:@"float1 > float2"].count);
-    XCTAssertEqual(4U, [QueryObject objectsWhere:@"float1 < float2"].count);
-    XCTAssertEqual(3U, [QueryObject objectsWhere:@"float1 >= float2"].count);
-    XCTAssertEqual(5U, [QueryObject objectsWhere:@"float1 <= float2"].count);
+    XCTAssertEqual(7U, [self.queryObjectClass objectsWhere:@"float1 == float1"].count);
+    XCTAssertEqual(1U, [self.queryObjectClass objectsWhere:@"float1 == float2"].count);
+    XCTAssertEqual(6U, [self.queryObjectClass objectsWhere:@"float1 != float2"].count);
+    XCTAssertEqual(2U, [self.queryObjectClass objectsWhere:@"float1 > float2"].count);
+    XCTAssertEqual(4U, [self.queryObjectClass objectsWhere:@"float1 < float2"].count);
+    XCTAssertEqual(3U, [self.queryObjectClass objectsWhere:@"float1 >= float2"].count);
+    XCTAssertEqual(5U, [self.queryObjectClass objectsWhere:@"float1 <= float2"].count);
 
-    XCTAssertEqual(7U, [QueryObject objectsWhere:@"double1 == double1"].count);
-    XCTAssertEqual(0U, [QueryObject objectsWhere:@"double1 == double2"].count);
-    XCTAssertEqual(7U, [QueryObject objectsWhere:@"double1 != double2"].count);
-    XCTAssertEqual(1U, [QueryObject objectsWhere:@"double1 > double2"].count);
-    XCTAssertEqual(6U, [QueryObject objectsWhere:@"double1 < double2"].count);
-    XCTAssertEqual(1U, [QueryObject objectsWhere:@"double1 >= double2"].count);
-    XCTAssertEqual(6U, [QueryObject objectsWhere:@"double1 <= double2"].count);
+    XCTAssertEqual(7U, [self.queryObjectClass objectsWhere:@"double1 == double1"].count);
+    XCTAssertEqual(0U, [self.queryObjectClass objectsWhere:@"double1 == double2"].count);
+    XCTAssertEqual(7U, [self.queryObjectClass objectsWhere:@"double1 != double2"].count);
+    XCTAssertEqual(1U, [self.queryObjectClass objectsWhere:@"double1 > double2"].count);
+    XCTAssertEqual(6U, [self.queryObjectClass objectsWhere:@"double1 < double2"].count);
+    XCTAssertEqual(1U, [self.queryObjectClass objectsWhere:@"double1 >= double2"].count);
+    XCTAssertEqual(6U, [self.queryObjectClass objectsWhere:@"double1 <= double2"].count);
 
-    XCTAssertEqual(7U, [QueryObject objectsWhere:@"string1 == string1"].count);
-    XCTAssertEqual(1U, [QueryObject objectsWhere:@"string1 == string2"].count);
-    XCTAssertEqual(6U, [QueryObject objectsWhere:@"string1 != string2"].count);
-    XCTAssertEqual(7U, [QueryObject objectsWhere:@"string1 CONTAINS string1"].count);
-    XCTAssertEqual(1U, [QueryObject objectsWhere:@"string1 CONTAINS string2"].count);
-    XCTAssertEqual(3U, [QueryObject objectsWhere:@"string2 CONTAINS string1"].count);
-    XCTAssertEqual(7U, [QueryObject objectsWhere:@"string1 BEGINSWITH string1"].count);
-    XCTAssertEqual(1U, [QueryObject objectsWhere:@"string1 BEGINSWITH string2"].count);
-    XCTAssertEqual(2U, [QueryObject objectsWhere:@"string2 BEGINSWITH string1"].count);
-    XCTAssertEqual(7U, [QueryObject objectsWhere:@"string1 ENDSWITH string1"].count);
-    XCTAssertEqual(1U, [QueryObject objectsWhere:@"string1 ENDSWITH string2"].count);
-    XCTAssertEqual(2U, [QueryObject objectsWhere:@"string2 ENDSWITH string1"].count);
+    XCTAssertEqual(7U, [self.queryObjectClass objectsWhere:@"string1 == string1"].count);
+    XCTAssertEqual(1U, [self.queryObjectClass objectsWhere:@"string1 == string2"].count);
+    XCTAssertEqual(6U, [self.queryObjectClass objectsWhere:@"string1 != string2"].count);
+    XCTAssertEqual(7U, [self.queryObjectClass objectsWhere:@"string1 CONTAINS string1"].count);
+    XCTAssertEqual(1U, [self.queryObjectClass objectsWhere:@"string1 CONTAINS string2"].count);
+    XCTAssertEqual(3U, [self.queryObjectClass objectsWhere:@"string2 CONTAINS string1"].count);
+    XCTAssertEqual(7U, [self.queryObjectClass objectsWhere:@"string1 BEGINSWITH string1"].count);
+    XCTAssertEqual(1U, [self.queryObjectClass objectsWhere:@"string1 BEGINSWITH string2"].count);
+    XCTAssertEqual(2U, [self.queryObjectClass objectsWhere:@"string2 BEGINSWITH string1"].count);
+    XCTAssertEqual(7U, [self.queryObjectClass objectsWhere:@"string1 ENDSWITH string1"].count);
+    XCTAssertEqual(1U, [self.queryObjectClass objectsWhere:@"string1 ENDSWITH string2"].count);
+    XCTAssertEqual(2U, [self.queryObjectClass objectsWhere:@"string2 ENDSWITH string1"].count);
 
-    XCTAssertEqual(7U, [QueryObject objectsWhere:@"string1 ==[c] string1"].count);
-    XCTAssertEqual(2U, [QueryObject objectsWhere:@"string1 ==[c] string2"].count);
-    XCTAssertEqual(5U, [QueryObject objectsWhere:@"string1 !=[c] string2"].count);
-    XCTAssertEqual(7U, [QueryObject objectsWhere:@"string1 CONTAINS[c] string1"].count);
-    XCTAssertEqual(2U, [QueryObject objectsWhere:@"string1 CONTAINS[c] string2"].count);
-    XCTAssertEqual(6U, [QueryObject objectsWhere:@"string2 CONTAINS[c] string1"].count);
-    XCTAssertEqual(7U, [QueryObject objectsWhere:@"string1 BEGINSWITH[c] string1"].count);
-    XCTAssertEqual(2U, [QueryObject objectsWhere:@"string1 BEGINSWITH[c] string2"].count);
-    XCTAssertEqual(4U, [QueryObject objectsWhere:@"string2 BEGINSWITH[c] string1"].count);
-    XCTAssertEqual(7U, [QueryObject objectsWhere:@"string1 ENDSWITH[c] string1"].count);
-    XCTAssertEqual(2U, [QueryObject objectsWhere:@"string1 ENDSWITH[c] string2"].count);
-    XCTAssertEqual(4U, [QueryObject objectsWhere:@"string2 ENDSWITH[c] string1"].count);
+    XCTAssertEqual(7U, [self.queryObjectClass objectsWhere:@"string1 ==[c] string1"].count);
+    XCTAssertEqual(2U, [self.queryObjectClass objectsWhere:@"string1 ==[c] string2"].count);
+    XCTAssertEqual(5U, [self.queryObjectClass objectsWhere:@"string1 !=[c] string2"].count);
+    XCTAssertEqual(7U, [self.queryObjectClass objectsWhere:@"string1 CONTAINS[c] string1"].count);
+    XCTAssertEqual(2U, [self.queryObjectClass objectsWhere:@"string1 CONTAINS[c] string2"].count);
+    XCTAssertEqual(6U, [self.queryObjectClass objectsWhere:@"string2 CONTAINS[c] string1"].count);
+    XCTAssertEqual(7U, [self.queryObjectClass objectsWhere:@"string1 BEGINSWITH[c] string1"].count);
+    XCTAssertEqual(2U, [self.queryObjectClass objectsWhere:@"string1 BEGINSWITH[c] string2"].count);
+    XCTAssertEqual(4U, [self.queryObjectClass objectsWhere:@"string2 BEGINSWITH[c] string1"].count);
+    XCTAssertEqual(7U, [self.queryObjectClass objectsWhere:@"string1 ENDSWITH[c] string1"].count);
+    XCTAssertEqual(2U, [self.queryObjectClass objectsWhere:@"string1 ENDSWITH[c] string2"].count);
+    XCTAssertEqual(4U, [self.queryObjectClass objectsWhere:@"string2 ENDSWITH[c] string1"].count);
 
-    [self executeInvalidTwoColumnKeypathRealmComparisonQuery:[QueryObject className]
+    [self executeInvalidTwoColumnKeypathRealmComparisonQuery:[self.queryObjectClass className]
                                                    predicate:@"int1 == float1"
                                               expectedReason:@"Property type mismatch between int and float"];
 
-    [self executeInvalidTwoColumnKeypathRealmComparisonQuery:[QueryObject className]
+    [self executeInvalidTwoColumnKeypathRealmComparisonQuery:[self.queryObjectClass className]
                                                    predicate:@"float2 >= double1"
                                               expectedReason:@"Property type mismatch between float and double"];
 
-    [self executeInvalidTwoColumnKeypathRealmComparisonQuery:[QueryObject className]
+    [self executeInvalidTwoColumnKeypathRealmComparisonQuery:[self.queryObjectClass className]
                                                    predicate:@"double2 <= int2"
                                               expectedReason:@"Property type mismatch between double and int"];
 
-    [self executeInvalidTwoColumnKeypathRealmComparisonQuery:[QueryObject className]
+    [self executeInvalidTwoColumnKeypathRealmComparisonQuery:[self.queryObjectClass className]
                                                    predicate:@"int2 != string1"
                                               expectedReason:@"Property type mismatch between int and string"];
 
-    [self executeInvalidTwoColumnKeypathRealmComparisonQuery:[QueryObject className]
+    [self executeInvalidTwoColumnKeypathRealmComparisonQuery:[self.queryObjectClass className]
                                                    predicate:@"float1 > string1"
                                               expectedReason:@"Property type mismatch between float and string"];
 
-    [self executeInvalidTwoColumnKeypathRealmComparisonQuery:[QueryObject className]
+    [self executeInvalidTwoColumnKeypathRealmComparisonQuery:[self.queryObjectClass className]
                                                    predicate:@"double1 < string1"
                                               expectedReason:@"Property type mismatch between double and string"];
 }
@@ -729,6 +753,16 @@
                    0U, @"== operator in bool predicate.");
     XCTAssertEqual([BoolObject objectsWhere:@"boolCol != TRUE"].count,
                    0U, @"== operator in bool predicate.");
+    if (self.isNull) {
+        XCTAssertEqual([BoolObject objectsWhere:@"boolCol == NULL"].count,
+                       0U, @"== operator in bool predicate.");
+        XCTAssertEqual([BoolObject objectsWhere:@"boolCol != NULL"].count,
+                       0U, @"== operator in bool predicate.");
+    }
+    else {
+        XCTAssertThrows([BoolObject objectsWhere:@"boolCol == NULL"]);
+        XCTAssertThrows([BoolObject objectsWhere:@"boolCol != NULL"]);
+    }
 
     XCTAssertThrowsSpecificNamed([BoolObject objectsWhere:@"boolCol >= TRUE"],
                                  NSException,
@@ -743,6 +777,10 @@
     [realm beginWriteTransaction];
     StringObject *so = [StringObject createInRealm:realm withValue:(@[@"abc"])];
     [AllTypesObject createInRealm:realm withValue:@[@YES, @1, @1.0f, @1.0, @"a", [@"a" dataUsingEncoding:NSUTF8StringEncoding], NSDate.date, @YES, @1LL, @1, so]];
+    if (self.isNull) {
+        so = [StringObject createInRealm:realm withValue:@[NSNull.null]];
+        [AllTypesObject createInRealm:realm withValue:@[@YES, @1, @1.0f, @1.0, @"a", [@"a" dataUsingEncoding:NSUTF8StringEncoding], NSDate.date, @YES, @1LL, @1, so]];
+    }
     [realm commitWriteTransaction];
 
     XCTAssertEqual(1U, [StringObject objectsWhere:@"stringCol BEGINSWITH 'a'"].count);
@@ -769,6 +807,10 @@
     [realm beginWriteTransaction];
     StringObject *so = [StringObject createInRealm:realm withValue:(@[@"abc"])];
     [AllTypesObject createInRealm:realm withValue:@[@YES, @1, @1.0f, @1.0, @"a", [@"a" dataUsingEncoding:NSUTF8StringEncoding], NSDate.date, @YES, @1LL, @1, so]];
+    if (self.isNull) {
+        so = [StringObject createInRealm:realm withValue:@[NSNull.null]];
+        [AllTypesObject createInRealm:realm withValue:@[@YES, @1, @1.0f, @1.0, @"a", [@"a" dataUsingEncoding:NSUTF8StringEncoding], NSDate.date, @YES, @1LL, @1, so]];
+    }
     [realm commitWriteTransaction];
 
     XCTAssertEqual(1U, [StringObject objectsWhere:@"stringCol ENDSWITH 'c'"].count);
@@ -795,6 +837,10 @@
     [realm beginWriteTransaction];
     StringObject *so = [StringObject createInRealm:realm withValue:(@[@"abc"])];
     [AllTypesObject createInRealm:realm withValue:@[@YES, @1, @1.0f, @1.0, @"a", [@"a" dataUsingEncoding:NSUTF8StringEncoding], NSDate.date, @YES, @1LL, @1, so]];
+    if (self.isNull) {
+        so = [StringObject createInRealm:realm withValue:@[NSNull.null]];
+        [AllTypesObject createInRealm:realm withValue:@[@YES, @1, @1.0f, @1.0, @"a", [@"a" dataUsingEncoding:NSUTF8StringEncoding], NSDate.date, @YES, @1LL, @1, so]];
+    }
     [realm commitWriteTransaction];
 
     XCTAssertEqual(1U, [StringObject objectsWhere:@"stringCol CONTAINS 'a'"].count);
@@ -915,7 +961,7 @@
 - (void)executeTwoColumnKeypathComparisonQueryWithPredicate:(NSString *)predicate
                                               expectedCount:(NSUInteger)expectedCount
 {
-    RLMResults *queryResult = [QueryObject objectsWhere:predicate];
+    RLMResults *queryResult = [self.queryObjectClass objectsWhere:predicate];
     NSUInteger actualCount = queryResult.count;
     XCTAssertEqual(actualCount, expectedCount, @"Predicate: %@, Expecting %zd result(s), found %zd",
                    predicate, expectedCount, actualCount);
@@ -959,10 +1005,10 @@
 
     [realm beginWriteTransaction];
     {
-        [QueryObject createInRealm:realm withValue:@[@YES, @YES, @1, @2, @23.0f, @1.7f,  @0.0,  @5.55, @"", @""]];
+        [self.queryObjectClass createInRealm:realm withValue:@[@YES, @YES, @1, @2, @23.0f, @1.7f,  @0.0,  @5.55, @"", @""]];
 
-        RLMResults *resultsQuery = [QueryObject objectsWhere:@"bool1 = YES"];
-        RLMResults *resultsTableView = [QueryObject objectsWhere:@"bool1 = YES"];
+        RLMResults *resultsQuery = [self.queryObjectClass objectsWhere:@"bool1 = YES"];
+        RLMResults *resultsTableView = [self.queryObjectClass objectsWhere:@"bool1 = YES"];
 
         // Force resultsTableView to form the TableView to verify that it syncs
         // correctly, and don't call anything but count on resultsQuery so that
@@ -978,17 +1024,17 @@
         XCTAssertEqual(resultsTableView.count, 0U);
 
         // Add an object that does not match query
-        QueryObject *q1 = [QueryObject createInRealm:realm withValue:@[@NO, @YES, @1, @2, @23.0f, @1.7f,  @0.0,  @5.55, @"", @""]];
+        QueryObject *q1 = [self.queryObjectClass createInRealm:realm withValue:@[@NO, @YES, @1, @2, @23.0f, @1.7f,  @0.0,  @5.55, @"", @""]];
         XCTAssertEqual(resultsQuery.count, 0U);
         XCTAssertEqual(resultsTableView.count, 0U);
 
         // Change object to match query
-        q1.bool1 = YES;
+        q1[@"bool1"] = @YES;
         XCTAssertEqual(resultsQuery.count, 1U);
         XCTAssertEqual(resultsTableView.count, 1U);
 
         // Add another object that matches
-        [QueryObject createInRealm:realm withValue:@[@YES, @NO,  @1, @3, @-5.3f, @4.21f, @1.0,  @4.44, @"", @""]];
+        [self.queryObjectClass createInRealm:realm withValue:@[@YES, @NO,  @1, @3, @-5.3f, @4.21f, @1.0,  @4.44, @"", @""]];
         XCTAssertEqual(resultsQuery.count, 2U);
         XCTAssertEqual(resultsTableView.count, 2U);
     }
@@ -1000,11 +1046,11 @@
     RLMRealm *realm = [RLMRealm defaultRealm];
 
     [realm beginWriteTransaction];
-    [QueryObject createInRealm:realm withValue:@[@YES, @YES, @1, @2, @23.0f, @1.7f,  @0.0,  @5.55, @"", @""]];
+    [self.queryObjectClass createInRealm:realm withValue:@[@YES, @YES, @1, @2, @23.0f, @1.7f,  @0.0,  @5.55, @"", @""]];
     [realm commitWriteTransaction];
 
-    RLMResults *resultsQuery = [QueryObject objectsWhere:@"bool1 = YES"];
-    RLMResults *resultsTableView = [QueryObject objectsWhere:@"bool1 = YES"];
+    RLMResults *resultsQuery = [self.queryObjectClass objectsWhere:@"bool1 = YES"];
+    RLMResults *resultsTableView = [self.queryObjectClass objectsWhere:@"bool1 = YES"];
 
     // Force resultsTableView to form the TableView to verify that it syncs
     // correctly, and don't call anything but count on resultsQuery so that
@@ -1024,7 +1070,7 @@
 
     // Add an object that does not match query
     [realm beginWriteTransaction];
-    QueryObject *q1 = [QueryObject createInRealm:realm withValue:@[@NO, @YES, @1, @2, @23.0f, @1.7f,  @0.0,  @5.55, @"", @""]];
+    QueryObject *q1 = [self.queryObjectClass createInRealm:realm withValue:@[@NO, @YES, @1, @2, @23.0f, @1.7f,  @0.0,  @5.55, @"", @""]];
     [realm commitWriteTransaction];
 
     XCTAssertEqual(resultsQuery.count, 0U);
@@ -1032,7 +1078,7 @@
 
     // Change object to match query
     [realm beginWriteTransaction];
-    q1.bool1 = YES;
+    q1[@"bool1"] = @YES;
     [realm commitWriteTransaction];
 
     XCTAssertEqual(resultsQuery.count, 1U);
@@ -1040,7 +1086,7 @@
 
     // Add another object that matches
     [realm beginWriteTransaction];
-    [QueryObject createInRealm:realm withValue:@[@YES, @NO,  @1, @3, @-5.3f, @4.21f, @1.0,  @4.44, @"", @""]];
+    [self.queryObjectClass createInRealm:realm withValue:@[@YES, @NO,  @1, @3, @-5.3f, @4.21f, @1.0,  @4.44, @"", @""]];
     [realm commitWriteTransaction];
 
     XCTAssertEqual(resultsQuery.count, 2U);
@@ -1689,52 +1735,62 @@
 
     [realm beginWriteTransaction];
 
-    [QueryObject createInRealm:realm withValue:@[@YES, @YES, @1, @2, @23.0f, @1.7f,  @0.0,  @5.55, @"a", @"a"]];
-    [QueryObject createInRealm:realm withValue:@[@YES, @NO,  @1, @3, @-5.3f, @4.21f, @1.0,  @4.44, @"a", @"A"]];
-    [QueryObject createInRealm:realm withValue:@[@NO,  @NO,  @2, @2, @1.0f,  @3.55f, @99.9, @6.66, @"a", @"ab"]];
-    [QueryObject createInRealm:realm withValue:@[@NO,  @YES, @3, @6, @4.21f, @1.0f,  @1.0,  @7.77, @"a", @"AB"]];
-    [QueryObject createInRealm:realm withValue:@[@YES, @YES, @4, @5, @23.0f, @23.0f, @7.4,  @8.88, @"a", @"b"]];
-    [QueryObject createInRealm:realm withValue:@[@YES, @NO,  @15, @8, @1.0f,  @66.0f, @1.01, @9.99, @"a", @"ba"]];
-    [QueryObject createInRealm:realm withValue:@[@NO,  @YES, @15, @15, @1.0f,  @66.0f, @1.01, @9.99, @"a", @"BA"]];
+    [self.queryObjectClass createInRealm:realm withValue:@[@YES, @YES, @1, @2, @23.0f, @1.7f,  @0.0,  @5.55, @"a", @"a"]];
+    [self.queryObjectClass createInRealm:realm withValue:@[@YES, @NO,  @1, @3, @-5.3f, @4.21f, @1.0,  @4.44, @"a", @"A"]];
+    [self.queryObjectClass createInRealm:realm withValue:@[@NO,  @NO,  @2, @2, @1.0f,  @3.55f, @99.9, @6.66, @"a", @"ab"]];
+    [self.queryObjectClass createInRealm:realm withValue:@[@NO,  @YES, @3, @6, @4.21f, @1.0f,  @1.0,  @7.77, @"a", @"AB"]];
+    [self.queryObjectClass createInRealm:realm withValue:@[@YES, @YES, @4, @5, @23.0f, @23.0f, @7.4,  @8.88, @"a", @"b"]];
+    [self.queryObjectClass createInRealm:realm withValue:@[@YES, @NO,  @15, @8, @1.0f,  @66.0f, @1.01, @9.99, @"a", @"ba"]];
+    [self.queryObjectClass createInRealm:realm withValue:@[@NO,  @YES, @15, @15, @1.0f,  @66.0f, @1.01, @9.99, @"a", @"BA"]];
 
     [realm commitWriteTransaction];
 
-    XCTAssertEqual(4U, [QueryObject objectsWhere:@"TRUE == bool1"].count);
-    XCTAssertEqual(3U, [QueryObject objectsWhere:@"TRUE != bool2"].count);
+    XCTAssertEqual(4U, [self.queryObjectClass objectsWhere:@"TRUE == bool1"].count);
+    XCTAssertEqual(3U, [self.queryObjectClass objectsWhere:@"TRUE != bool2"].count);
 
-    XCTAssertEqual(2U, [QueryObject objectsWhere:@"1 == int1"].count);
-    XCTAssertEqual(5U, [QueryObject objectsWhere:@"2 != int2"].count);
-    XCTAssertEqual(2U, [QueryObject objectsWhere:@"2 > int1"].count);
-    XCTAssertEqual(4U, [QueryObject objectsWhere:@"2 < int1"].count);
-    XCTAssertEqual(3U, [QueryObject objectsWhere:@"2 >= int1"].count);
-    XCTAssertEqual(5U, [QueryObject objectsWhere:@"2 <= int1"].count);
+    XCTAssertEqual(2U, [self.queryObjectClass objectsWhere:@"1 == int1"].count);
+    XCTAssertEqual(5U, [self.queryObjectClass objectsWhere:@"2 != int2"].count);
+    XCTAssertEqual(2U, [self.queryObjectClass objectsWhere:@"2 > int1"].count);
+    XCTAssertEqual(4U, [self.queryObjectClass objectsWhere:@"2 < int1"].count);
+    XCTAssertEqual(3U, [self.queryObjectClass objectsWhere:@"2 >= int1"].count);
+    XCTAssertEqual(5U, [self.queryObjectClass objectsWhere:@"2 <= int1"].count);
 
-    XCTAssertEqual(3U, [QueryObject objectsWhere:@"1.0 == float1"].count);
-    XCTAssertEqual(6U, [QueryObject objectsWhere:@"1.0 != float2"].count);
-    XCTAssertEqual(1U, [QueryObject objectsWhere:@"1.0 > float1"].count);
-    XCTAssertEqual(6U, [QueryObject objectsWhere:@"1.0 < float2"].count);
-    XCTAssertEqual(4U, [QueryObject objectsWhere:@"1.0 >= float1"].count);
-    XCTAssertEqual(7U, [QueryObject objectsWhere:@"1.0 <= float2"].count);
+    XCTAssertEqual(3U, [self.queryObjectClass objectsWhere:@"1.0 == float1"].count);
+    XCTAssertEqual(6U, [self.queryObjectClass objectsWhere:@"1.0 != float2"].count);
+    XCTAssertEqual(1U, [self.queryObjectClass objectsWhere:@"1.0 > float1"].count);
+    XCTAssertEqual(6U, [self.queryObjectClass objectsWhere:@"1.0 < float2"].count);
+    XCTAssertEqual(4U, [self.queryObjectClass objectsWhere:@"1.0 >= float1"].count);
+    XCTAssertEqual(7U, [self.queryObjectClass objectsWhere:@"1.0 <= float2"].count);
 
-    XCTAssertEqual(2U, [QueryObject objectsWhere:@"1.0 == double1"].count);
-    XCTAssertEqual(5U, [QueryObject objectsWhere:@"1.0 != double1"].count);
-    XCTAssertEqual(1U, [QueryObject objectsWhere:@"5.0 > double2"].count);
-    XCTAssertEqual(6U, [QueryObject objectsWhere:@"5.0 < double2"].count);
-    XCTAssertEqual(2U, [QueryObject objectsWhere:@"5.55 >= double2"].count);
-    XCTAssertEqual(6U, [QueryObject objectsWhere:@"5.55 <= double2"].count);
+    XCTAssertEqual(2U, [self.queryObjectClass objectsWhere:@"1.0 == double1"].count);
+    XCTAssertEqual(5U, [self.queryObjectClass objectsWhere:@"1.0 != double1"].count);
+    XCTAssertEqual(1U, [self.queryObjectClass objectsWhere:@"5.0 > double2"].count);
+    XCTAssertEqual(6U, [self.queryObjectClass objectsWhere:@"5.0 < double2"].count);
+    XCTAssertEqual(2U, [self.queryObjectClass objectsWhere:@"5.55 >= double2"].count);
+    XCTAssertEqual(6U, [self.queryObjectClass objectsWhere:@"5.55 <= double2"].count);
 
-    XCTAssertEqual(1U, [QueryObject objectsWhere:@"'a' == string2"].count);
-    XCTAssertEqual(6U, [QueryObject objectsWhere:@"'a' != string2"].count);
+    XCTAssertEqual(1U, [self.queryObjectClass objectsWhere:@"'a' == string2"].count);
+    XCTAssertEqual(6U, [self.queryObjectClass objectsWhere:@"'a' != string2"].count);
 
-    RLMAssertThrowsWithReasonMatching([QueryObject objectsWhere:@"'Realm' CONTAINS string1"].count,
+    RLMAssertThrowsWithReasonMatching([self.queryObjectClass objectsWhere:@"'Realm' CONTAINS string1"].count,
                                       @"Operator 'CONTAINS' is not supported .* right side");
-    RLMAssertThrowsWithReasonMatching([QueryObject objectsWhere:@"'Amazon' BEGINSWITH string2"].count,
+    RLMAssertThrowsWithReasonMatching([self.queryObjectClass objectsWhere:@"'Amazon' BEGINSWITH string2"].count,
                                       @"Operator 'BEGINSWITH' is not supported .* right side");
-    RLMAssertThrowsWithReasonMatching([QueryObject objectsWhere:@"'Tuba' ENDSWITH string1"].count,
+    RLMAssertThrowsWithReasonMatching([self.queryObjectClass objectsWhere:@"'Tuba' ENDSWITH string1"].count,
                                       @"Operator 'ENDSWITH' is not supported .* right side");
 }
 
-#ifdef REALM_ENABLE_NULL
+@end
+
+#if REALM_ENABLE_NULL
+@interface NullQueryTests : QueryTests
+@end
+
+@implementation NullQueryTests
+- (Class)queryObjectClass {
+    return [NullQueryObject class];
+}
+
 - (void)testQueryOnNullableStringColumn {
     void (^testWithStringClass)(Class) = ^(Class stringObjectClass) {
         RLMRealm *realm = [RLMRealm defaultRealm];
@@ -1825,6 +1881,10 @@
     testWithStringClass([LinkStringObject class], [StringObject class]);
     testWithStringClass([LinkIndexedStringObject class], [IndexedStringObject class]);
 }
-#endif
+
+- (void)testSortingColumnsWithNull {
+
+}
 
 @end
+#endif

--- a/Realm/Tests/QueryTests.m
+++ b/Realm/Tests/QueryTests.m
@@ -1782,7 +1782,6 @@
 
 @end
 
-#if REALM_ENABLE_NULL
 @interface NullQueryTests : QueryTests
 @end
 
@@ -1931,4 +1930,3 @@
 }
 
 @end
-#endif

--- a/Realm/Tests/RLMTestObjects.h
+++ b/Realm/Tests/RLMTestObjects.h
@@ -24,7 +24,7 @@
 #define RLM_GENERIC_ARRAY(CLASS) RLMArray<CLASS>
 #endif
 
-@interface NSNumberObject : RLMObject
+@interface NumberObject : RLMObject
 @property NSNumber<RLMInt> *intObj;
 @property NSNumber<RLMFloat> *floatObj;
 @property NSNumber<RLMDouble> *doubleObj;

--- a/Realm/Tests/RLMTestObjects.h
+++ b/Realm/Tests/RLMTestObjects.h
@@ -102,6 +102,7 @@ RLM_ARRAY_TYPE(IntObject)
 @interface RequiredPropertiesObject : RLMObject
 @property NSString *stringCol;
 @property NSData *binaryCol;
+@property NSDate *dateCol;
 @end
 
 #pragma mark AllTypesObject

--- a/Realm/Tests/RLMTestObjects.h
+++ b/Realm/Tests/RLMTestObjects.h
@@ -24,13 +24,6 @@
 #define RLM_GENERIC_ARRAY(CLASS) RLMArray<CLASS>
 #endif
 
-@interface NumberObject : RLMObject
-@property NSNumber<RLMInt> *intObj;
-@property NSNumber<RLMFloat> *floatObj;
-@property NSNumber<RLMDouble> *doubleObj;
-@property NSNumber<RLMBool> *boolObj;
-@end
-
 #pragma mark - Abstract Objects
 #pragma mark -
 
@@ -279,6 +272,13 @@ RLM_ARRAY_TYPE(CircleObject);
 @interface ReadOnlyPropertyObject : RLMObject
 @property (readonly) NSNumber *readOnlyUnsupportedProperty;
 @property (readonly) int readOnlyPropertyMadeReadWriteInClassExtension;
+@end
+
+@interface NumberObject : RLMObject
+@property NSNumber<RLMInt> *intObj;
+@property NSNumber<RLMFloat> *floatObj;
+@property NSNumber<RLMDouble> *doubleObj;
+@property NSNumber<RLMBool> *boolObj;
 @end
 
 #pragma mark FakeObject

--- a/Realm/Tests/RLMTestObjects.h
+++ b/Realm/Tests/RLMTestObjects.h
@@ -24,6 +24,13 @@
 #define RLM_GENERIC_ARRAY(CLASS) RLMArray<CLASS>
 #endif
 
+@interface NSNumberObject : RLMObject
+@property NSNumber<RLMInt> *intObj;
+@property NSNumber<RLMFloat> *floatObj;
+@property NSNumber<RLMDouble> *doubleObj;
+@property NSNumber<RLMBool> *boolObj;
+@end
+
 #pragma mark - Abstract Objects
 #pragma mark -
 

--- a/Realm/Tests/RLMTestObjects.h
+++ b/Realm/Tests/RLMTestObjects.h
@@ -281,6 +281,9 @@ RLM_ARRAY_TYPE(CircleObject);
 @property NSNumber<RLMBool> *boolObj;
 @end
 
+@interface NumberDefaultsObject : NumberObject
+@end
+
 #pragma mark FakeObject
 
 @interface FakeObject : NSObject

--- a/Realm/Tests/RLMTestObjects.m
+++ b/Realm/Tests/RLMTestObjects.m
@@ -18,7 +18,7 @@
 
 #import "RLMTestObjects.h"
 
-@implementation NSNumberObject
+@implementation NumberObject
 @end
 
 #pragma mark - Abstract Objects

--- a/Realm/Tests/RLMTestObjects.m
+++ b/Realm/Tests/RLMTestObjects.m
@@ -18,6 +18,9 @@
 
 #import "RLMTestObjects.h"
 
+@implementation NSNumberObject
+@end
+
 #pragma mark - Abstract Objects
 #pragma mark -
 

--- a/Realm/Tests/RLMTestObjects.m
+++ b/Realm/Tests/RLMTestObjects.m
@@ -18,9 +18,6 @@
 
 #import "RLMTestObjects.h"
 
-@implementation NumberObject
-@end
-
 #pragma mark - Abstract Objects
 #pragma mark -
 
@@ -164,6 +161,9 @@
 - (NSNumber *)readOnlyUnsupportedProperty {
     return nil;
 }
+@end
+
+@implementation NumberObject
 @end
 
 #pragma mark FakeObject

--- a/Realm/Tests/RLMTestObjects.m
+++ b/Realm/Tests/RLMTestObjects.m
@@ -166,6 +166,17 @@
 @implementation NumberObject
 @end
 
+@implementation NumberDefaultsObject
++ (nullable NSDictionary *)defaultPropertyValues {
+    return @{
+             @"intObj" : @1,
+             @"floatObj" : @2.2f,
+             @"doubleObj" : @3.3,
+             @"boolObj" : @NO,
+             };
+}
+@end
+
 #pragma mark FakeObject
 
 @implementation FakeObject

--- a/Realm/Tests/SchemaTests.mm
+++ b/Realm/Tests/SchemaTests.mm
@@ -326,9 +326,9 @@ RLM_ARRAY_TYPE(SchemaTestClassSecondChild)
     schema.objectSchema = objectSchema;
 
 #ifdef REALM_ENABLE_NULL
-#   define StringOrBinaryOptionalString @"\t\t\toptional = YES;\n"
+#   define OptionalString @"\t\t\toptional = YES;\n"
 #else
-#   define StringOrBinaryOptionalString @"\t\t\toptional = NO;\n"
+#   define OptionalString @"\t\t\toptional = NO;\n"
 #endif
 
     XCTAssertEqualObjects(schema.description, @"Schema {\n"
@@ -366,21 +366,21 @@ RLM_ARRAY_TYPE(SchemaTestClassSecondChild)
                                               @"\t\t\tobjectClassName = (null);\n"
                                               @"\t\t\tindexed = NO;\n"
                                               @"\t\t\tisPrimary = NO;\n"
-                                              StringOrBinaryOptionalString
+                                              OptionalString
                                               @"\t\t}\n"
                                               @"\t\tbinaryCol {\n"
                                               @"\t\t\ttype = data;\n"
                                               @"\t\t\tobjectClassName = (null);\n"
                                               @"\t\t\tindexed = NO;\n"
                                               @"\t\t\tisPrimary = NO;\n"
-                                              StringOrBinaryOptionalString
+                                              OptionalString
                                               @"\t\t}\n"
                                               @"\t\tdateCol {\n"
                                               @"\t\t\ttype = date;\n"
                                               @"\t\t\tobjectClassName = (null);\n"
                                               @"\t\t\tindexed = NO;\n"
                                               @"\t\t\tisPrimary = NO;\n"
-                                              @"\t\t\toptional = NO;\n"
+                                              OptionalString
                                               @"\t\t}\n"
                                               @"\t\tcBoolCol {\n"
                                               @"\t\t\ttype = bool;\n"
@@ -417,7 +417,7 @@ RLM_ARRAY_TYPE(SchemaTestClassSecondChild)
                                               @"\t\t\tobjectClassName = (null);\n"
                                               @"\t\t\tindexed = NO;\n"
                                               @"\t\t\tisPrimary = NO;\n"
-                                              StringOrBinaryOptionalString
+                                              OptionalString
                                               @"\t\t}\n"
                                               @"\t}\n"
                                               @"\tIntObject {\n"
@@ -431,7 +431,7 @@ RLM_ARRAY_TYPE(SchemaTestClassSecondChild)
                                               @"\t}\n"
                                               @"}");
 
-#undef StringOrBinaryOptionalString
+#undef OptionalString
 }
 
 - (void)testClassWithDuplicateProperties

--- a/Realm/Tests/SchemaTests.mm
+++ b/Realm/Tests/SchemaTests.mm
@@ -125,6 +125,18 @@ RLM_ARRAY_TYPE(SchemaTestClassSecondChild)
 }
 @end
 
+@interface InvalidNSNumberProtocolObject : FakeObject
+@property NSNumber<RLMFastEnumerable> *number;
+@end
+@implementation InvalidNSNumberProtocolObject
+@end
+
+@interface InvalidNSNumberNoProtocolObject : FakeObject
+@property NSNumber *number;
+@end
+@implementation InvalidNSNumberNoProtocolObject
+@end
+
 @interface SchemaTests : RLMMultiProcessTestCase
 @end
 
@@ -460,6 +472,14 @@ RLM_ARRAY_TYPE(SchemaTestClassSecondChild)
 
 - (void)testClassWithRequiredLinkProperty {
     RLMAssertThrowsWithReasonMatching([RLMObjectSchema schemaForObjectClass:RequiredLinkProperty.class], @"cannot be made required.*'object'");
+}
+
+- (void)testClassWithInvalidNSNumberProtocolProperty {
+    RLMAssertThrowsWithReasonMatching([RLMObjectSchema schemaForObjectClass:InvalidNSNumberProtocolObject.class], @"RLMFastEnumerable' is not supported as an NSNumber object type.");
+}
+
+- (void)testClassWithInvalidNSNumberNoProtocolProperty {
+    RLMAssertThrowsWithReasonMatching([RLMObjectSchema schemaForObjectClass:InvalidNSNumberNoProtocolObject.class], @"NSNumber properties require a protocol defining the contained type");
 }
 
 // Can't spawn child processes on iOS

--- a/Realm/Tests/SchemaTests.mm
+++ b/Realm/Tests/SchemaTests.mm
@@ -288,7 +288,6 @@ RLM_ARRAY_TYPE(SchemaTestClassSecondChild)
         NSUInteger occurrenceCount = 0;
         
         for (RLMObjectSchema *objectSchema in objectSchemas) {
-            NSLog(@"Scheme %@", objectSchema.className);
             if ([objectSchema.className isEqualToString:expectedType]) {
                 occurrenceCount++;
             }

--- a/Realm/Tests/SchemaTests.mm
+++ b/Realm/Tests/SchemaTests.mm
@@ -336,11 +336,7 @@ RLM_ARRAY_TYPE(SchemaTestClassSecondChild)
     RLMSchema *schema = [[RLMSchema alloc] init];
     schema.objectSchema = objectSchema;
 
-#ifdef REALM_ENABLE_NULL
 #   define OptionalString @"\t\t\toptional = YES;\n"
-#else
-#   define OptionalString @"\t\t\toptional = NO;\n"
-#endif
 
     XCTAssertEqualObjects(schema.description, @"Schema {\n"
                                               @"\tAllTypesObject {\n"

--- a/Realm/Tests/Swift1.2/SwiftObjectInterfaceTests.swift
+++ b/Realm/Tests/Swift1.2/SwiftObjectInterfaceTests.swift
@@ -146,6 +146,7 @@ class SwiftObjectInterfaceTests: RLMTestCase {
         XCTAssertNil(firstObj.optObjectCol)
         XCTAssertNil(firstObj.optStringCol)
         XCTAssertNil(firstObj.optBinaryCol)
+        XCTAssertNil(firstObj.optDateCol)
 
         realm.transactionWithBlock {
             firstObj.optObjectCol = SwiftBoolObject()
@@ -153,19 +154,23 @@ class SwiftObjectInterfaceTests: RLMTestCase {
 
             firstObj.optStringCol = "Hi!"
             firstObj.optBinaryCol = NSData(bytes: "hi", length: 2)
+            firstObj.optDateCol = NSDate(timeIntervalSinceReferenceDate: 10)
         }
         XCTAssertTrue(firstObj.optObjectCol!.boolCol)
         XCTAssertEqual(firstObj.optStringCol!, "Hi!")
         XCTAssertEqual(firstObj.optBinaryCol!, NSData(bytes: "hi", length: 2))
+        XCTAssertEqual(firstObj.optDateCol!,  NSDate(timeIntervalSinceReferenceDate: 10))
 
         realm.transactionWithBlock {
             firstObj.optObjectCol = nil
             firstObj.optStringCol = nil
             firstObj.optBinaryCol = nil
+            firstObj.optDateCol = nil
         }
         XCTAssertNil(firstObj.optObjectCol)
         XCTAssertNil(firstObj.optStringCol)
         XCTAssertNil(firstObj.optBinaryCol)
+        XCTAssertNil(firstObj.optDateCol)
     }
 #endif
 

--- a/Realm/Tests/Swift1.2/SwiftObjectInterfaceTests.swift
+++ b/Realm/Tests/Swift1.2/SwiftObjectInterfaceTests.swift
@@ -44,6 +44,13 @@ class SwiftDefaultObject: RLMObject {
     }
 }
 
+class SwiftOptionalNumberObject: RLMObject {
+    dynamic var intCol: NSNumber? = 1
+    dynamic var floatCol: NSNumber? = 2.2 as Float
+    dynamic var doubleCol: NSNumber? = 3.3 as Double
+    dynamic var boolCol: NSNumber? = true
+}
+
 class SwiftObjectInterfaceTests: RLMTestCase {
 
     // Swift models
@@ -138,6 +145,42 @@ class SwiftObjectInterfaceTests: RLMTestCase {
     }
 
 #if REALM_ENABLE_NULL
+    func testOptionalNSNumberProperties() {
+        let realm = realmWithTestPath()
+        let no = SwiftOptionalNumberObject()
+        XCTAssertEqual([.Int, .Float, .Double, .Bool], map(no.objectSchema.properties) { $0.type })
+
+        XCTAssertEqual(1, no.intCol!)
+        XCTAssertEqual(2.2 as Float, no.floatCol!)
+        XCTAssertEqual(3.3, no.doubleCol!)
+        XCTAssertEqual(true, no.boolCol!)
+
+        realm.transactionWithBlock {
+            realm.addObject(no)
+            no.intCol = nil
+            no.floatCol = nil
+            no.doubleCol = nil
+            no.boolCol = nil
+        }
+
+        XCTAssertNil(no.intCol)
+        XCTAssertNil(no.floatCol)
+        XCTAssertNil(no.doubleCol)
+        XCTAssertNil(no.boolCol)
+
+        realm.transactionWithBlock {
+            no.intCol = 1.1
+            no.floatCol = 2.2 as Float
+            no.doubleCol = 3.3
+            no.boolCol = false
+        }
+
+        XCTAssertEqual(1, no.intCol!)
+        XCTAssertEqual(2.2 as Float, no.floatCol!)
+        XCTAssertEqual(3.3, no.doubleCol!)
+        XCTAssertEqual(false, no.boolCol!)
+    }
+
     func testOptionalSwiftProperties() {
         let realm = realmWithTestPath()
         realm.transactionWithBlock { realm.addObject(SwiftOptionalObject()) }

--- a/Realm/Tests/Swift1.2/SwiftObjectInterfaceTests.swift
+++ b/Realm/Tests/Swift1.2/SwiftObjectInterfaceTests.swift
@@ -144,7 +144,6 @@ class SwiftObjectInterfaceTests: RLMTestCase {
         }
     }
 
-#if REALM_ENABLE_NULL
     func testOptionalNSNumberProperties() {
         let realm = realmWithTestPath()
         let no = SwiftOptionalNumberObject()
@@ -215,7 +214,6 @@ class SwiftObjectInterfaceTests: RLMTestCase {
         XCTAssertNil(firstObj.optBinaryCol)
         XCTAssertNil(firstObj.optDateCol)
     }
-#endif
 
     func testSwiftClassNameIsDemangled() {
         XCTAssertEqual(SwiftObject.className(), "SwiftObject", "Calling className() on Swift class should return demangled name")

--- a/Realm/Tests/Swift1.2/SwiftTestObjects.swift
+++ b/Realm/Tests/Swift1.2/SwiftTestObjects.swift
@@ -54,7 +54,7 @@ class SwiftOptionalObject: RLMObject {
 //    dynamic var optDoubleCol: Double?
     dynamic var optStringCol: NSString?
     dynamic var optBinaryCol: NSData?
-//    dynamic var optDateCol: NSDate?
+    dynamic var optDateCol: NSDate?
     dynamic var optObjectCol: SwiftBoolObject?
 //    dynamic var arrayCol = RLMArray(objectClassName: SwiftBoolObject.className())
 }

--- a/Realm/Tests/Swift2.0/SwiftObjectInterfaceTests.swift
+++ b/Realm/Tests/Swift2.0/SwiftObjectInterfaceTests.swift
@@ -146,6 +146,7 @@ class SwiftObjectInterfaceTests: RLMTestCase {
         XCTAssertNil(firstObj.optObjectCol)
         XCTAssertNil(firstObj.optStringCol)
         XCTAssertNil(firstObj.optBinaryCol)
+        XCTAssertNil(firstObj.optDateCol)
 
         realm.transactionWithBlock {
             firstObj.optObjectCol = SwiftBoolObject()
@@ -153,19 +154,23 @@ class SwiftObjectInterfaceTests: RLMTestCase {
 
             firstObj.optStringCol = "Hi!"
             firstObj.optBinaryCol = NSData(bytes: "hi", length: 2)
+            firstObj.optDateCol = NSDate(timeIntervalSinceReferenceDate: 10)
         }
         XCTAssertTrue(firstObj.optObjectCol!.boolCol)
         XCTAssertEqual(firstObj.optStringCol!, "Hi!")
         XCTAssertEqual(firstObj.optBinaryCol!, NSData(bytes: "hi", length: 2))
+        XCTAssertEqual(firstObj.optDateCol!,  NSDate(timeIntervalSinceReferenceDate: 10))
 
         realm.transactionWithBlock {
             firstObj.optObjectCol = nil
             firstObj.optStringCol = nil
             firstObj.optBinaryCol = nil
+            firstObj.optDateCol = nil
         }
         XCTAssertNil(firstObj.optObjectCol)
         XCTAssertNil(firstObj.optStringCol)
         XCTAssertNil(firstObj.optBinaryCol)
+        XCTAssertNil(firstObj.optDateCol)
     }
 #endif
 

--- a/Realm/Tests/Swift2.0/SwiftObjectInterfaceTests.swift
+++ b/Realm/Tests/Swift2.0/SwiftObjectInterfaceTests.swift
@@ -44,6 +44,13 @@ class SwiftDefaultObject: RLMObject {
     }
 }
 
+class SwiftOptionalNumberObject: RLMObject {
+    dynamic var intCol: NSNumber? = 1
+    dynamic var floatCol: NSNumber? = 2.2 as Float
+    dynamic var doubleCol: NSNumber? = 3.3 as Double
+    dynamic var boolCol: NSNumber? = true
+}
+
 class SwiftObjectInterfaceTests: RLMTestCase {
 
     // Swift models
@@ -138,6 +145,42 @@ class SwiftObjectInterfaceTests: RLMTestCase {
     }
 
 #if REALM_ENABLE_NULL
+    func testOptionalNSNumberProperties() {
+        let realm = realmWithTestPath()
+        let no = SwiftOptionalNumberObject()
+        XCTAssertEqual([.Int, .Float, .Double, .Bool], map(no.objectSchema.properties) { $0.type })
+
+        XCTAssertEqual(1, no.intCol!)
+        XCTAssertEqual(2.2 as Float, no.floatCol!)
+        XCTAssertEqual(3.3, no.doubleCol!)
+        XCTAssertEqual(true, no.boolCol!)
+
+        realm.transactionWithBlock {
+            realm.addObject(no)
+            no.intCol = nil
+            no.floatCol = nil
+            no.doubleCol = nil
+            no.boolCol = nil
+        }
+
+        XCTAssertNil(no.intCol)
+        XCTAssertNil(no.floatCol)
+        XCTAssertNil(no.doubleCol)
+        XCTAssertNil(no.boolCol)
+
+        realm.transactionWithBlock {
+            no.intCol = 1.1
+            no.floatCol = 2.2 as Float
+            no.doubleCol = 3.3
+            no.boolCol = false
+        }
+
+        XCTAssertEqual(1, no.intCol!)
+        XCTAssertEqual(2.2 as Float, no.floatCol!)
+        XCTAssertEqual(3.3, no.doubleCol!)
+        XCTAssertEqual(false, no.boolCol!)
+    }
+
     func testOptionalSwiftProperties() {
         let realm = realmWithTestPath()
         realm.transactionWithBlock { realm.addObject(SwiftOptionalObject()) }

--- a/Realm/Tests/Swift2.0/SwiftObjectInterfaceTests.swift
+++ b/Realm/Tests/Swift2.0/SwiftObjectInterfaceTests.swift
@@ -148,14 +148,14 @@ class SwiftObjectInterfaceTests: RLMTestCase {
     func testOptionalNSNumberProperties() {
         let realm = realmWithTestPath()
         let no = SwiftOptionalNumberObject()
-        XCTAssertEqual([.Int, .Float, .Double, .Bool], map(no.objectSchema.properties) { $0.type })
+        XCTAssertEqual([.Int, .Float, .Double, .Bool], no.objectSchema.properties.map { $0.type })
 
         XCTAssertEqual(1, no.intCol!)
         XCTAssertEqual(2.2 as Float, no.floatCol!)
         XCTAssertEqual(3.3, no.doubleCol!)
         XCTAssertEqual(true, no.boolCol!)
 
-        realm.transactionWithBlock {
+        try! realm.transactionWithBlock {
             realm.addObject(no)
             no.intCol = nil
             no.floatCol = nil
@@ -168,7 +168,7 @@ class SwiftObjectInterfaceTests: RLMTestCase {
         XCTAssertNil(no.doubleCol)
         XCTAssertNil(no.boolCol)
 
-        realm.transactionWithBlock {
+        try! realm.transactionWithBlock {
             no.intCol = 1.1
             no.floatCol = 2.2 as Float
             no.doubleCol = 3.3
@@ -183,7 +183,7 @@ class SwiftObjectInterfaceTests: RLMTestCase {
 
     func testOptionalSwiftProperties() {
         let realm = realmWithTestPath()
-        realm.transactionWithBlock { realm.addObject(SwiftOptionalObject()) }
+        try! realm.transactionWithBlock { realm.addObject(SwiftOptionalObject()) }
 
         let firstObj = SwiftOptionalObject.allObjectsInRealm(realm).firstObject() as! SwiftOptionalObject
         XCTAssertNil(firstObj.optObjectCol)
@@ -191,7 +191,7 @@ class SwiftObjectInterfaceTests: RLMTestCase {
         XCTAssertNil(firstObj.optBinaryCol)
         XCTAssertNil(firstObj.optDateCol)
 
-        realm.transactionWithBlock {
+        try! realm.transactionWithBlock {
             firstObj.optObjectCol = SwiftBoolObject()
             firstObj.optObjectCol!.boolCol = true
 
@@ -204,7 +204,7 @@ class SwiftObjectInterfaceTests: RLMTestCase {
         XCTAssertEqual(firstObj.optBinaryCol!, NSData(bytes: "hi", length: 2))
         XCTAssertEqual(firstObj.optDateCol!,  NSDate(timeIntervalSinceReferenceDate: 10))
 
-        realm.transactionWithBlock {
+        try! realm.transactionWithBlock {
             firstObj.optObjectCol = nil
             firstObj.optStringCol = nil
             firstObj.optBinaryCol = nil

--- a/Realm/Tests/Swift2.0/SwiftObjectInterfaceTests.swift
+++ b/Realm/Tests/Swift2.0/SwiftObjectInterfaceTests.swift
@@ -144,7 +144,6 @@ class SwiftObjectInterfaceTests: RLMTestCase {
         }
     }
 
-#if REALM_ENABLE_NULL
     func testOptionalNSNumberProperties() {
         let realm = realmWithTestPath()
         let no = SwiftOptionalNumberObject()
@@ -215,7 +214,6 @@ class SwiftObjectInterfaceTests: RLMTestCase {
         XCTAssertNil(firstObj.optBinaryCol)
         XCTAssertNil(firstObj.optDateCol)
     }
-#endif
 
     func testSwiftClassNameIsDemangled() {
         XCTAssertEqual(SwiftObject.className(), "SwiftObject", "Calling className() on Swift class should return demangled name")

--- a/Realm/Tests/Swift2.0/SwiftTestObjects.swift
+++ b/Realm/Tests/Swift2.0/SwiftTestObjects.swift
@@ -54,7 +54,7 @@ class SwiftOptionalObject: RLMObject {
 //    dynamic var optDoubleCol: Double?
     dynamic var optStringCol: NSString?
     dynamic var optBinaryCol: NSData?
-//    dynamic var optDateCol: NSDate?
+    dynamic var optDateCol: NSDate?
     dynamic var optObjectCol: SwiftBoolObject?
 //    dynamic var arrayCol = RLMArray(objectClassName: SwiftBoolObject.className())
 }

--- a/Realm/module.modulemap
+++ b/Realm/module.modulemap
@@ -13,6 +13,7 @@ framework module Realm {
         header "RLMObjectSchema_Private.h"
         header "RLMObjectStore.h"
         header "RLMObject_Private.h"
+        header "RLMOptionalBase.h"
         header "RLMProperty_Private.h"
         header "RLMRealmUtil.h"
         header "RLMRealm_Private.h"

--- a/RealmSwift-swift1.2/Object.swift
+++ b/RealmSwift-swift1.2/Object.swift
@@ -202,7 +202,7 @@ public class Object: RLMObjectBase, Equatable, Printable {
 
     // Helper for getting the list object for a property
     internal func listForProperty(prop: RLMProperty) -> RLMListBase {
-        return object_getIvar(self, prop.swiftListIvar) as! RLMListBase
+        return object_getIvar(self, prop.swiftIvar) as! RLMListBase
     }
 }
 
@@ -294,19 +294,28 @@ public class ObjectUtil: NSObject {
         // super is an implicit property on Swift objects
         for i in 1..<reflection.count {
             let mirror = reflection[i].1
-            if mirror.disposition == .Optional {
-                let name = reflection[i].0
-                if mirror.valueType is Optional<String>.Type || mirror.valueType is Optional<NSString>.Type {
-                    properties[name] = Int(PropertyType.String.rawValue)
-                } else if mirror.valueType is Optional<NSDate>.Type {
-                    properties[name] = Int(PropertyType.Date.rawValue)
-                } else if mirror.valueType is Optional<NSData>.Type {
-                    properties[name] = Int(PropertyType.Data.rawValue)
-                } else if mirror.valueType is Optional<Object>.Type {
-                    properties[name] = Int(PropertyType.Object.rawValue)
-                } else {
-                    properties[name] = NSNull()
-                }
+            let name = reflection[i].0
+            if mirror.valueType is Optional<String>.Type || mirror.valueType is Optional<NSString>.Type {
+                properties[name] = Int(PropertyType.String.rawValue)
+            } else if mirror.valueType is Optional<NSDate>.Type {
+                properties[name] = Int(PropertyType.Date.rawValue)
+            } else if mirror.valueType is Optional<NSData>.Type {
+                properties[name] = Int(PropertyType.Data.rawValue)
+            } else if mirror.valueType is Optional<Object>.Type {
+                properties[name] = Int(PropertyType.Object.rawValue)
+            } else if mirror.valueType is RealmOptional<Int>.Type ||
+                mirror.valueType is RealmOptional<Int16>.Type ||
+                mirror.valueType is RealmOptional<Int32>.Type ||
+                mirror.valueType is RealmOptional<Int64>.Type {
+                properties[name] = Int(PropertyType.Int.rawValue)
+            } else if mirror.valueType is RealmOptional<Float>.Type {
+                properties[name] = Int(PropertyType.Float.rawValue)
+            } else if mirror.valueType is RealmOptional<Double>.Type {
+                properties[name] = Int(PropertyType.Double.rawValue)
+            } else if mirror.valueType is RealmOptional<Bool>.Type {
+                properties[name] = Int(PropertyType.Bool.rawValue)
+            } else if mirror.disposition == .Optional {
+                properties[name] = NSNull()
             }
         }
 

--- a/RealmSwift-swift1.2/Object.swift
+++ b/RealmSwift-swift1.2/Object.swift
@@ -285,17 +285,28 @@ public class ObjectUtil: NSObject {
         (object as! Object).listForProperty(property)._rlmArray = array
     }
 
-    @objc private class func getOptionalPropertyNames(object: AnyObject) -> NSArray {
+    @objc private class func getOptionalProperties(object: AnyObject) -> NSDictionary {
         let reflection = reflect(object)
 
-        var properties = [String]()
+        var properties = [String:AnyObject]()
 
         // Skip the first property (super):
         // super is an implicit property on Swift objects
         for i in 1..<reflection.count {
             let mirror = reflection[i].1
             if mirror.disposition == .Optional {
-                properties.append(reflection[i].0)
+                let name = reflection[i].0
+                if mirror.valueType is Optional<String>.Type || mirror.valueType is Optional<NSString>.Type {
+                    properties[name] = Int(PropertyType.String.rawValue)
+                } else if mirror.valueType is Optional<NSDate>.Type {
+                    properties[name] = Int(PropertyType.Date.rawValue)
+                } else if mirror.valueType is Optional<NSData>.Type {
+                    properties[name] = Int(PropertyType.Data.rawValue)
+                } else if mirror.valueType is Optional<Object>.Type {
+                    properties[name] = Int(PropertyType.Object.rawValue)
+                } else {
+                    properties[name] = NSNull()
+                }
             }
         }
 

--- a/RealmSwift-swift1.2/Object.swift
+++ b/RealmSwift-swift1.2/Object.swift
@@ -304,9 +304,9 @@ public class ObjectUtil: NSObject {
             } else if mirror.valueType is Optional<Object>.Type {
                 properties[name] = Int(PropertyType.Object.rawValue)
             } else if mirror.valueType is RealmOptional<Int>.Type ||
-                mirror.valueType is RealmOptional<Int16>.Type ||
-                mirror.valueType is RealmOptional<Int32>.Type ||
-                mirror.valueType is RealmOptional<Int64>.Type {
+                      mirror.valueType is RealmOptional<Int16>.Type ||
+                      mirror.valueType is RealmOptional<Int32>.Type ||
+                      mirror.valueType is RealmOptional<Int64>.Type {
                 properties[name] = Int(PropertyType.Int.rawValue)
             } else if mirror.valueType is RealmOptional<Float>.Type {
                 properties[name] = Int(PropertyType.Float.rawValue)
@@ -314,6 +314,8 @@ public class ObjectUtil: NSObject {
                 properties[name] = Int(PropertyType.Double.rawValue)
             } else if mirror.valueType is RealmOptional<Bool>.Type {
                 properties[name] = Int(PropertyType.Bool.rawValue)
+            } else if mirror.value as? RLMOptionalBase != nil {
+                throwRealmException("'\(mirror.valueType)' is not a a valid RealmOptional type.")
             } else if mirror.disposition == .Optional {
                 properties[name] = NSNull()
             }

--- a/RealmSwift-swift1.2/Optional.swift
+++ b/RealmSwift-swift1.2/Optional.swift
@@ -1,0 +1,48 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2015 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+public protocol RealmOptionalType {}
+extension Int: RealmOptionalType {}
+extension Int16: RealmOptionalType {}
+extension Int32: RealmOptionalType {}
+extension Int64: RealmOptionalType {}
+extension Float: RealmOptionalType {}
+extension Double: RealmOptionalType {}
+extension Bool: RealmOptionalType {}
+
+import Realm
+
+public final class RealmOptional<T: RealmOptionalType> : RLMOptionalBase {
+    public var value: T? {
+        get {
+            return underlyingValue as! T?
+        }
+        set {
+            if let value = newValue {
+                self.underlyingValue = value as! AnyObject
+            } else {
+                self.underlyingValue = nil
+            }
+        }
+    }
+
+    public init(_ v: T? = nil) {
+        super.init()
+        value = v
+    }
+}

--- a/RealmSwift-swift1.2/Optional.swift
+++ b/RealmSwift-swift1.2/Optional.swift
@@ -16,6 +16,9 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
+import Realm
+
+/// Types that can be represented in a `RealmOptional`.
 public protocol RealmOptionalType {}
 extension Int: RealmOptionalType {}
 extension Int16: RealmOptionalType {}
@@ -25,9 +28,15 @@ extension Float: RealmOptionalType {}
 extension Double: RealmOptionalType {}
 extension Bool: RealmOptionalType {}
 
-import Realm
+/**
+A `RealmOptional` represents a optional value for types that can't be directly
+declared as `dynamic` in Swift, such as `Int`s, `Float`, `Double`, and `Bool`.
 
+It encapsulates a value in its `value` property, which is the only way to mutate
+a `RealmOptional` property on an `Object`.
+*/
 public final class RealmOptional<T: RealmOptionalType> : RLMOptionalBase {
+    /// The value this optional represents.
     public var value: T? {
         get {
             return underlyingValue as! T?
@@ -37,6 +46,7 @@ public final class RealmOptional<T: RealmOptionalType> : RLMOptionalBase {
         }
     }
 
+    /// Creates a `RealmOptional` with a `nil` default value.
     public override init() {
         super.init()
     }

--- a/RealmSwift-swift1.2/Optional.swift
+++ b/RealmSwift-swift1.2/Optional.swift
@@ -33,16 +33,11 @@ public final class RealmOptional<T: RealmOptionalType> : RLMOptionalBase {
             return underlyingValue as! T?
         }
         set {
-            if let value = newValue {
-                self.underlyingValue = value as! AnyObject
-            } else {
-                self.underlyingValue = nil
-            }
+            self.underlyingValue = newValue as! AnyObject?
         }
     }
 
-    public init(_ v: T? = nil) {
+    public override init() {
         super.init()
-        value = v
     }
 }

--- a/RealmSwift-swift1.2/RealmCollectionType.swift
+++ b/RealmSwift-swift1.2/RealmCollectionType.swift
@@ -35,7 +35,7 @@ public final class RLMGenerator<T: Object>: GeneratorType {
     public func next() -> T? {
         let accessor = generatorBase.next() as! T?
         if let accessor = accessor {
-            RLMInitializeSwiftListAccessor(accessor)
+            RLMInitializeSwiftAccessorGenerics(accessor)
         }
         return accessor
     }

--- a/RealmSwift-swift1.2/Tests/KVOTests.swift
+++ b/RealmSwift-swift1.2/Tests/KVOTests.swift
@@ -40,6 +40,13 @@ class KVOObject: Object {
     dynamic var dateCol: NSDate = NSDate(timeIntervalSince1970: 0)
     dynamic var objectCol: KVOObject?
     dynamic var arrayCol = List<KVOObject>()
+    let optIntCol = RealmOptional<Int>()
+    let optFloatCol = RealmOptional<Float>()
+    let optDoubleCol = RealmOptional<Double>()
+    let optBoolCol = RealmOptional<Bool>()
+    dynamic var optStringCol: String?
+    dynamic var optBinaryCol: NSData?
+    dynamic var optDateCol: NSDate?
 
     override class func primaryKey() -> String { return "pk" }
     override class func ignoredProperties() -> [String] { return ["ignored"] }
@@ -129,6 +136,22 @@ class KVOTests: TestCase {
         observeListChange(obj, "arrayCol", .Removal, NSIndexSet(index: 0)) {
             obj.arrayCol.removeAll()
         }
+
+        observeChange(obj, "optIntCol", NSNull(), 10) { obj.optIntCol.value = 10 }
+        observeChange(obj, "optFloatCol", NSNull(), 10) { obj.optFloatCol.value = 10 }
+        observeChange(obj, "optDoubleCol", NSNull(), 10) { obj.optDoubleCol.value = 10 }
+        observeChange(obj, "optBoolCol", NSNull(), true) { obj.optBoolCol.value = true }
+        observeChange(obj, "optStringCol", NSNull(), "abc") { obj.optStringCol = "abc" }
+        observeChange(obj, "optBinaryCol", NSNull(), data) { obj.optBinaryCol = data }
+        observeChange(obj, "optDateCol", NSNull(), date) { obj.optDateCol = date }
+
+        observeChange(obj, "optIntCol", 10, NSNull()) { obj.optIntCol.value = nil }
+        observeChange(obj, "optFloatCol", 10, NSNull()) { obj.optFloatCol.value = nil }
+        observeChange(obj, "optDoubleCol", 10, NSNull()) { obj.optDoubleCol.value = nil }
+        observeChange(obj, "optBoolCol", true, NSNull()) { obj.optBoolCol.value = nil }
+        observeChange(obj, "optStringCol", "abc", NSNull()) { obj.optStringCol = nil }
+        observeChange(obj, "optBinaryCol", data, NSNull()) { obj.optBinaryCol = nil }
+        observeChange(obj, "optDateCol", date, NSNull()) { obj.optDateCol = nil }
     }
 
     func testAllPropertyTypesPersisted() {
@@ -157,6 +180,22 @@ class KVOTests: TestCase {
         observeListChange(obj, "arrayCol", .Removal, NSIndexSet(index: 0)) {
             obj.arrayCol.removeAll()
         }
+
+        observeChange(obj, "optIntCol", NSNull(), 10) { obj.optIntCol.value = 10 }
+        observeChange(obj, "optFloatCol", NSNull(), 10) { obj.optFloatCol.value = 10 }
+        observeChange(obj, "optDoubleCol", NSNull(), 10) { obj.optDoubleCol.value = 10 }
+        observeChange(obj, "optBoolCol", NSNull(), true) { obj.optBoolCol.value = true }
+        observeChange(obj, "optStringCol", NSNull(), "abc") { obj.optStringCol = "abc" }
+        observeChange(obj, "optBinaryCol", NSNull(), data) { obj.optBinaryCol = data }
+        observeChange(obj, "optDateCol", NSNull(), date) { obj.optDateCol = date }
+
+        observeChange(obj, "optIntCol", 10, NSNull()) { obj.optIntCol.value = nil }
+        observeChange(obj, "optFloatCol", 10, NSNull()) { obj.optFloatCol.value = nil }
+        observeChange(obj, "optDoubleCol", 10, NSNull()) { obj.optDoubleCol.value = nil }
+        observeChange(obj, "optBoolCol", true, NSNull()) { obj.optBoolCol.value = nil }
+        observeChange(obj, "optStringCol", "abc", NSNull()) { obj.optStringCol = nil }
+        observeChange(obj, "optBinaryCol", data, NSNull()) { obj.optBinaryCol = nil }
+        observeChange(obj, "optDateCol", date, NSNull()) { obj.optDateCol = nil }
 
         observeChange(obj, "invalidated", false, true) {
             self.realm.delete(obj)
@@ -196,6 +235,22 @@ class KVOTests: TestCase {
         observeListChange(obs, "arrayCol", .Removal, NSIndexSet(index: 0)) {
             obj.arrayCol.removeAll()
         }
+
+        observeChange(obj, "optIntCol", NSNull(), 10) { obj.optIntCol.value = 10 }
+        observeChange(obj, "optFloatCol", NSNull(), 10) { obj.optFloatCol.value = 10 }
+        observeChange(obj, "optDoubleCol", NSNull(), 10) { obj.optDoubleCol.value = 10 }
+        observeChange(obj, "optBoolCol", NSNull(), true) { obj.optBoolCol.value = true }
+        observeChange(obj, "optStringCol", NSNull(), "abc") { obj.optStringCol = "abc" }
+        observeChange(obj, "optBinaryCol", NSNull(), data) { obj.optBinaryCol = data }
+        observeChange(obj, "optDateCol", NSNull(), date) { obj.optDateCol = date }
+
+        observeChange(obj, "optIntCol", 10, NSNull()) { obj.optIntCol.value = nil }
+        observeChange(obj, "optFloatCol", 10, NSNull()) { obj.optFloatCol.value = nil }
+        observeChange(obj, "optDoubleCol", 10, NSNull()) { obj.optDoubleCol.value = nil }
+        observeChange(obj, "optBoolCol", true, NSNull()) { obj.optBoolCol.value = nil }
+        observeChange(obj, "optStringCol", "abc", NSNull()) { obj.optStringCol = nil }
+        observeChange(obj, "optBinaryCol", data, NSNull()) { obj.optBinaryCol = nil }
+        observeChange(obj, "optDateCol", date, NSNull()) { obj.optDateCol = nil }
 
         observeChange(obs, "invalidated", false, true) {
             self.realm.delete(obj)

--- a/RealmSwift-swift1.2/Tests/ObjectAccessorTests.swift
+++ b/RealmSwift-swift1.2/Tests/ObjectAccessorTests.swift
@@ -69,13 +69,17 @@ class ObjectAccessorTests: TestCase {
     func testStandaloneAccessors() {
         let object = SwiftObject()
         setAndTestAllProperties(object)
+
+        let optionalObject = SwiftOptionalObject()
+        setAndTestAllOptionalProperties(optionalObject)
     }
 
     func testPersistedAccessors() {
-        let object = SwiftObject()
         Realm().beginWrite()
-        Realm().create(SwiftObject)
+        let object = Realm().create(SwiftObject)
+        let optionalObject = Realm().create(SwiftOptionalObject)
         setAndTestAllProperties(object)
+        setAndTestAllOptionalProperties(optionalObject)
         Realm().commitWrite()
     }
 
@@ -204,5 +208,73 @@ class ObjectAccessorTests: TestCase {
         for obj in objects {
             XCTAssertEqual(2, obj.arrayCol.count)
         }
+    }
+
+    func setAndTestAllOptionalProperties(object: SwiftOptionalObject) {
+        object.optNSStringCol = ""
+        XCTAssertEqual(object.optNSStringCol!, "")
+        let utf8TestString = "值значен™👍☞⎠‱௹♣︎☐▼❒∑⨌⧭иеمرحبا"
+        object.optNSStringCol = utf8TestString
+        XCTAssertEqual(object.optNSStringCol!, utf8TestString)
+        object.optNSStringCol = nil
+        XCTAssertNil(object.optNSStringCol)
+
+        object.optStringCol = ""
+        XCTAssertEqual(object.optStringCol!, "")
+        object.optStringCol = utf8TestString
+        XCTAssertEqual(object.optStringCol!, utf8TestString)
+        object.optStringCol = nil
+        XCTAssertNil(object.optStringCol)
+
+        let data = "b".dataUsingEncoding(NSUTF8StringEncoding, allowLossyConversion: false)!
+        object.optBinaryCol = data
+        XCTAssertEqual(object.optBinaryCol!, data)
+        object.optBinaryCol = nil
+        XCTAssertNil(object.optBinaryCol)
+
+        let date = NSDate(timeIntervalSinceReferenceDate: 2) as NSDate
+        object.optDateCol = date
+        XCTAssertEqual(object.optDateCol!, date)
+        object.optDateCol = nil
+        XCTAssertNil(object.optDateCol)
+
+        object.optIntCol.value = -1
+        XCTAssertEqual(object.optIntCol.value!, -1)
+        object.optIntCol.value = 0
+        XCTAssertEqual(object.optIntCol.value!, 0)
+        object.optIntCol.value = 1
+        XCTAssertEqual(object.optIntCol.value!, 1)
+        object.optIntCol.value = nil
+        XCTAssertNil(object.optIntCol.value)
+
+        object.optFloatCol.value = 20
+        XCTAssertEqual(object.optFloatCol.value!, 20 as Float)
+        object.optFloatCol.value = 20.2
+        XCTAssertEqual(object.optFloatCol.value!, 20.2 as Float)
+        object.optFloatCol.value = 16777217
+        XCTAssertEqual(Double(object.optFloatCol.value!), 16777216.0 as Double)
+        object.optFloatCol.value = nil
+        XCTAssertNil(object.optFloatCol.value)
+
+        object.optDoubleCol.value = 20
+        XCTAssertEqual(object.optDoubleCol.value!, 20)
+        object.optDoubleCol.value = 20.2
+        XCTAssertEqual(object.optDoubleCol.value!, 20.2)
+        object.optDoubleCol.value = 16777217
+        XCTAssertEqual(object.optDoubleCol.value!, 16777217)
+        object.optDoubleCol.value = nil
+        XCTAssertNil(object.optDoubleCol.value)
+
+        object.optBoolCol.value = true
+        XCTAssertEqual(object.optBoolCol.value!, true)
+        object.optBoolCol.value = false
+        XCTAssertEqual(object.optBoolCol.value!, false)
+        object.optBoolCol.value = nil
+        XCTAssertNil(object.optBoolCol.value)
+
+        object.optObjectCol = SwiftBoolObject(value: [true])
+        XCTAssertEqual(object.optObjectCol!.boolCol, true)
+        object.optObjectCol = nil
+        XCTAssertNil(object.optObjectCol)
     }
 }

--- a/RealmSwift-swift1.2/Tests/ObjectAccessorTests.swift
+++ b/RealmSwift-swift1.2/Tests/ObjectAccessorTests.swift
@@ -211,6 +211,7 @@ class ObjectAccessorTests: TestCase {
     }
 
     func setAndTestAllOptionalProperties(object: SwiftOptionalObject) {
+#if REALM_ENABLE_NULL
         object.optNSStringCol = ""
         XCTAssertEqual(object.optNSStringCol!, "")
         let utf8TestString = "值значен™👍☞⎠‱௹♣︎☐▼❒∑⨌⧭иеمرحبا"
@@ -271,6 +272,7 @@ class ObjectAccessorTests: TestCase {
         XCTAssertEqual(object.optBoolCol.value!, false)
         object.optBoolCol.value = nil
         XCTAssertNil(object.optBoolCol.value)
+#endif
 
         object.optObjectCol = SwiftBoolObject(value: [true])
         XCTAssertEqual(object.optObjectCol!.boolCol, true)

--- a/RealmSwift-swift1.2/Tests/ObjectAccessorTests.swift
+++ b/RealmSwift-swift1.2/Tests/ObjectAccessorTests.swift
@@ -210,6 +210,21 @@ class ObjectAccessorTests: TestCase {
         }
     }
 
+    func testSettingOptionalPropertyOnDeletedObjectsThrows() {
+        let realm = Realm()
+        realm.write {
+            let obj = realm.create(SwiftOptionalObject)
+            let copy = realm.objects(SwiftOptionalObject).first!
+            realm.delete(obj)
+
+            self.assertThrows(copy.optIntCol.value = 1)
+            self.assertThrows(copy.optIntCol.value = nil)
+
+            self.assertThrows(obj.optIntCol.value = 1)
+            self.assertThrows(obj.optIntCol.value = nil)
+        }
+    }
+
     func setAndTestAllOptionalProperties(object: SwiftOptionalObject) {
 #if REALM_ENABLE_NULL
         object.optNSStringCol = ""

--- a/RealmSwift-swift1.2/Tests/ObjectAccessorTests.swift
+++ b/RealmSwift-swift1.2/Tests/ObjectAccessorTests.swift
@@ -226,7 +226,6 @@ class ObjectAccessorTests: TestCase {
     }
 
     func setAndTestAllOptionalProperties(object: SwiftOptionalObject) {
-#if REALM_ENABLE_NULL
         object.optNSStringCol = ""
         XCTAssertEqual(object.optNSStringCol!, "")
         let utf8TestString = "值значен™👍☞⎠‱௹♣︎☐▼❒∑⨌⧭иеمرحبا"
@@ -287,7 +286,6 @@ class ObjectAccessorTests: TestCase {
         XCTAssertEqual(object.optBoolCol.value!, false)
         object.optBoolCol.value = nil
         XCTAssertNil(object.optBoolCol.value)
-#endif
 
         object.optObjectCol = SwiftBoolObject(value: [true])
         XCTAssertEqual(object.optObjectCol!.boolCol, true)

--- a/RealmSwift-swift1.2/Tests/ObjectCreationTests.swift
+++ b/RealmSwift-swift1.2/Tests/ObjectCreationTests.swift
@@ -466,6 +466,7 @@ class ObjectCreationTests: TestCase {
             if let _ = val as? NSNull { return nil }
             return val
         }
+#if REALM_ENABLE_NULL
         XCTAssert(object.optBoolCol.value == (get("optBoolCol") as! Bool?))
         XCTAssert(object.optIntCol.value == (get("optIntCol") as! Int?))
         XCTAssert(object.optFloatCol.value == (get("optFloatCol") as! Float?))
@@ -474,6 +475,7 @@ class ObjectCreationTests: TestCase {
         XCTAssert(object.optNSStringCol == (get("optNSStringCol") as! String?))
         XCTAssert(object.optBinaryCol == (get("optBinaryCol") as! NSData?))
         XCTAssert(object.optDateCol == (get("optDateCol") as! NSDate?))
+#endif
         XCTAssert(object.optObjectCol?.boolCol == boolObjectValue)
     }
 

--- a/RealmSwift-swift1.2/Tests/ObjectCreationTests.swift
+++ b/RealmSwift-swift1.2/Tests/ObjectCreationTests.swift
@@ -466,7 +466,6 @@ class ObjectCreationTests: TestCase {
             if let _ = val as? NSNull { return nil }
             return val
         }
-#if REALM_ENABLE_NULL
         XCTAssert(object.optBoolCol.value == (get("optBoolCol") as! Bool?))
         XCTAssert(object.optIntCol.value == (get("optIntCol") as! Int?))
         XCTAssert(object.optFloatCol.value == (get("optFloatCol") as! Float?))
@@ -475,7 +474,6 @@ class ObjectCreationTests: TestCase {
         XCTAssert(object.optNSStringCol == (get("optNSStringCol") as! String?))
         XCTAssert(object.optBinaryCol == (get("optBinaryCol") as! NSData?))
         XCTAssert(object.optDateCol == (get("optDateCol") as! NSDate?))
-#endif
         XCTAssert(object.optObjectCol?.boolCol == boolObjectValue)
     }
 

--- a/RealmSwift-swift1.2/Tests/ObjectSchemaInitializationTests.swift
+++ b/RealmSwift-swift1.2/Tests/ObjectSchemaInitializationTests.swift
@@ -147,10 +147,6 @@ class ObjectSchemaInitializationTests: TestCase {
         }
     }
 
-    func testNonNullableOptionalPropertiesAreCoerced() {
-        assertThrows(RLMObjectSchema(forObjectClass: SwiftObjectWithNonNullableOptionalProperties.self), "Should throw when marking non-String and non-Data properties as optional")
-    }
-
     func testImplicitlyUnwrappedOptionalsAreParsedAsOptionals() {
         let schema = SwiftImplicitlyUnwrappedOptionalObject().objectSchema
         XCTAssertTrue(schema["optObjectCol"]!.optional)

--- a/RealmSwift-swift1.2/Tests/ObjectSchemaInitializationTests.swift
+++ b/RealmSwift-swift1.2/Tests/ObjectSchemaInitializationTests.swift
@@ -147,6 +147,24 @@ class ObjectSchemaInitializationTests: TestCase {
         }
     }
 
+    func testOptionalProperties() {
+        let schema = RLMObjectSchema(forObjectClass: SwiftOptionalObject.self)
+
+        for prop in schema.properties {
+            XCTAssertTrue((prop as! RLMProperty).optional)
+        }
+
+        let types = map(schema.properties) { prop in
+            (prop as! RLMProperty).type
+        }
+
+#if REALM_ENABLE_NULL
+        XCTAssertEqual(types, [.String, .String, .Data, .Date, .Object])
+#else
+        XCTAssertEqual(types, [.Object])
+#endif
+    }
+
     func testImplicitlyUnwrappedOptionalsAreParsedAsOptionals() {
         let schema = SwiftImplicitlyUnwrappedOptionalObject().objectSchema
         XCTAssertTrue(schema["optObjectCol"]!.optional)

--- a/RealmSwift-swift1.2/Tests/ObjectSchemaInitializationTests.swift
+++ b/RealmSwift-swift1.2/Tests/ObjectSchemaInitializationTests.swift
@@ -154,14 +154,14 @@ class ObjectSchemaInitializationTests: TestCase {
             XCTAssertTrue((prop as! RLMProperty).optional)
         }
 
-        let types = map(schema.properties) { prop in
+        let types = Set(map(schema.properties) { prop in
             (prop as! RLMProperty).type
-        }
+        })
 
 #if REALM_ENABLE_NULL
-        XCTAssertEqual(types, [.String, .String, .Data, .Date, .Object])
+        XCTAssertEqual(types, Set([.String, .String, .Data, .Date, .Object, .Int, .Float, .Double, .Bool]))
 #else
-        XCTAssertEqual(types, [.Object])
+        XCTAssertEqual(types, Set([.Object]))
 #endif
     }
 
@@ -169,8 +169,10 @@ class ObjectSchemaInitializationTests: TestCase {
         let schema = SwiftImplicitlyUnwrappedOptionalObject().objectSchema
         XCTAssertTrue(schema["optObjectCol"]!.optional)
 #if REALM_ENABLE_NULL
+        XCTAssertTrue(schema["optNSStringCol"]!.optional)
         XCTAssertTrue(schema["optStringCol"]!.optional)
         XCTAssertTrue(schema["optBinaryCol"]!.optional)
+        XCTAssertTrue(schema["optDateCol"]!.optional)
 #endif
     }
 }

--- a/RealmSwift-swift1.2/Tests/ObjectSchemaInitializationTests.swift
+++ b/RealmSwift-swift1.2/Tests/ObjectSchemaInitializationTests.swift
@@ -243,7 +243,7 @@ class SwiftObjectWithNonOptionalLinkProperty: SwiftFakeObject {
     dynamic var objectCol = SwiftBoolObject()
 }
 
-extension Set: Set { }
+extension Set: RealmOptionalType { }
 
 class SwiftObjectWithNonRealmOptionalType: SwiftFakeObject {
     let set = RealmOptional<Set<Int>>()

--- a/RealmSwift-swift1.2/Tests/ObjectSchemaInitializationTests.swift
+++ b/RealmSwift-swift1.2/Tests/ObjectSchemaInitializationTests.swift
@@ -175,6 +175,10 @@ class ObjectSchemaInitializationTests: TestCase {
         XCTAssertTrue(schema["optDateCol"]!.optional)
 #endif
     }
+
+    func testNonRealmOptionalTypesDeclaredAsRealmOptional() {
+        assertThrows(RLMObjectSchema(forObjectClass: SwiftObjectWithNonRealmOptionalType.self))
+    }
 }
 
 class SwiftFakeObject : NSObject {
@@ -237,4 +241,10 @@ class SwiftObjectWithNonNullableOptionalProperties: SwiftFakeObject {
 
 class SwiftObjectWithNonOptionalLinkProperty : SwiftFakeObject {
     dynamic var objectCol = SwiftBoolObject()
+}
+
+extension Set : RealmOptionalType { }
+
+class SwiftObjectWithNonRealmOptionalType : SwiftFakeObject {
+    let set = RealmOptional<Set<Int>>()
 }

--- a/RealmSwift-swift1.2/Tests/ObjectSchemaInitializationTests.swift
+++ b/RealmSwift-swift1.2/Tests/ObjectSchemaInitializationTests.swift
@@ -187,11 +187,11 @@ class SwiftFakeObject : NSObject {
     dynamic class func indexedProperties() -> [String] { return [] }
 }
 
-class SwiftObjectWithNSURL : SwiftFakeObject {
+class SwiftObjectWithNSURL: SwiftFakeObject {
     dynamic var URL = NSURL(string: "http://realm.io")!
 }
 
-class SwiftObjectWithAnyObject : SwiftFakeObject {
+class SwiftObjectWithAnyObject: SwiftFakeObject {
     dynamic var anyObject: AnyObject = NSString(string: "")
 }
 
@@ -200,15 +200,15 @@ enum SwiftEnum {
     case Case2
 }
 
-class SwiftObjectWithEnum : SwiftFakeObject {
+class SwiftObjectWithEnum: SwiftFakeObject {
     var swiftEnum = SwiftEnum.Case1
 }
 
-class SwiftObjectWithStruct : SwiftFakeObject {
+class SwiftObjectWithStruct: SwiftFakeObject {
     var swiftStruct = SortDescriptor(property: "prop")
 }
 
-class SwiftObjectWithDatePrimaryKey : SwiftFakeObject {
+class SwiftObjectWithDatePrimaryKey: SwiftFakeObject {
     dynamic var date = NSDate()
 
     dynamic override class func primaryKey() -> String! {
@@ -216,11 +216,11 @@ class SwiftObjectWithDatePrimaryKey : SwiftFakeObject {
     }
 }
 
-class SwiftFakeObjectSubclass : SwiftFakeObject {
+class SwiftFakeObjectSubclass: SwiftFakeObject {
     dynamic var dateCol = NSDate()
 }
 
-class SwiftObjectWithUnindexibleProperties : SwiftFakeObject {
+class SwiftObjectWithUnindexibleProperties: SwiftFakeObject {
     dynamic var boolCol = false
     dynamic var intCol = 123
     dynamic var floatCol = 1.23 as Float
@@ -239,12 +239,12 @@ class SwiftObjectWithNonNullableOptionalProperties: SwiftFakeObject {
     dynamic var optDateCol: NSDate?
 }
 
-class SwiftObjectWithNonOptionalLinkProperty : SwiftFakeObject {
+class SwiftObjectWithNonOptionalLinkProperty: SwiftFakeObject {
     dynamic var objectCol = SwiftBoolObject()
 }
 
-extension Set : RealmOptionalType { }
+extension Set: Set { }
 
-class SwiftObjectWithNonRealmOptionalType : SwiftFakeObject {
+class SwiftObjectWithNonRealmOptionalType: SwiftFakeObject {
     let set = RealmOptional<Set<Int>>()
 }

--- a/RealmSwift-swift1.2/Tests/ObjectSchemaInitializationTests.swift
+++ b/RealmSwift-swift1.2/Tests/ObjectSchemaInitializationTests.swift
@@ -158,22 +158,16 @@ class ObjectSchemaInitializationTests: TestCase {
             (prop as! RLMProperty).type
         })
 
-#if REALM_ENABLE_NULL
         XCTAssertEqual(types, Set([.String, .String, .Data, .Date, .Object, .Int, .Float, .Double, .Bool]))
-#else
-        XCTAssertEqual(types, Set([.Object]))
-#endif
     }
 
     func testImplicitlyUnwrappedOptionalsAreParsedAsOptionals() {
         let schema = SwiftImplicitlyUnwrappedOptionalObject().objectSchema
         XCTAssertTrue(schema["optObjectCol"]!.optional)
-#if REALM_ENABLE_NULL
         XCTAssertTrue(schema["optNSStringCol"]!.optional)
         XCTAssertTrue(schema["optStringCol"]!.optional)
         XCTAssertTrue(schema["optBinaryCol"]!.optional)
         XCTAssertTrue(schema["optDateCol"]!.optional)
-#endif
     }
 
     func testNonRealmOptionalTypesDeclaredAsRealmOptional() {

--- a/RealmSwift-swift1.2/Tests/SwiftTestObjects.swift
+++ b/RealmSwift-swift1.2/Tests/SwiftTestObjects.swift
@@ -60,32 +60,27 @@ class SwiftObject: Object {
 }
 
 class SwiftOptionalObject: Object {
-//    FIXME: Support all optional property types
-//    dynamic var optBoolCol: Bool?
-//    dynamic var optIntCol: Int?
-//    dynamic var optFloatCol: Float?
-//    dynamic var optDoubleCol: Double?
 #if REALM_ENABLE_NULL
     dynamic var optNSStringCol: NSString?
     dynamic var optStringCol: String?
     dynamic var optBinaryCol: NSData?
     dynamic var optDateCol: NSDate?
+    let optIntCol = RealmOptional<Int>()
+    let optFloatCol = RealmOptional<Float>()
+    let optDoubleCol = RealmOptional<Double>()
+    let optBoolCol = RealmOptional<Bool>()
 #endif
     dynamic var optObjectCol: SwiftBoolObject?
 //    let arrayCol = List<SwiftBoolObject?>()
 }
 
 class SwiftImplicitlyUnwrappedOptionalObject: Object {
-//    FIXME: Support all optional property types
-//    dynamic var optBoolCol: Bool!
-//    dynamic var optIntCol: Int!
-//    dynamic var optFloatCol: Float!
-//    dynamic var optDoubleCol: Double!
 #if REALM_ENABLE_NULL
-    dynamic var optStringCol: NSString!
+    dynamic var optNSStringCol: NSString!
+    dynamic var optStringCol: String!
     dynamic var optBinaryCol: NSData!
+    dynamic var optDateCol: NSDate!
 #endif
-//    dynamic var optDateCol: NSDate!
     dynamic var optObjectCol: SwiftBoolObject!
 //    let arrayCol = List<SwiftBoolObject!>()
 }

--- a/RealmSwift-swift1.2/Tests/SwiftTestObjects.swift
+++ b/RealmSwift-swift1.2/Tests/SwiftTestObjects.swift
@@ -68,8 +68,8 @@ class SwiftOptionalObject: Object {
 #if REALM_ENABLE_NULL
     dynamic var optStringCol: NSString?
     dynamic var optBinaryCol: NSData?
+    dynamic var optDateCol: NSDate?
 #endif
-//    dynamic var optDateCol: NSDate?
     dynamic var optObjectCol: SwiftBoolObject?
 //    let arrayCol = List<SwiftBoolObject?>()
 }

--- a/RealmSwift-swift1.2/Tests/SwiftTestObjects.swift
+++ b/RealmSwift-swift1.2/Tests/SwiftTestObjects.swift
@@ -66,7 +66,8 @@ class SwiftOptionalObject: Object {
 //    dynamic var optFloatCol: Float?
 //    dynamic var optDoubleCol: Double?
 #if REALM_ENABLE_NULL
-    dynamic var optStringCol: NSString?
+    dynamic var optNSStringCol: NSString?
+    dynamic var optStringCol: String?
     dynamic var optBinaryCol: NSData?
     dynamic var optDateCol: NSDate?
 #endif

--- a/RealmSwift-swift1.2/Tests/SwiftTestObjects.swift
+++ b/RealmSwift-swift1.2/Tests/SwiftTestObjects.swift
@@ -85,6 +85,35 @@ class SwiftImplicitlyUnwrappedOptionalObject: Object {
 //    let arrayCol = List<SwiftBoolObject!>()
 }
 
+class SwiftOptionalDefaultValuesObject: Object {
+#if REALM_ENABLE_NULL
+    dynamic var optNSStringCol: NSString? = "A"
+    dynamic var optStringCol: String? = "B"
+    dynamic var optBinaryCol: NSData? = "C".dataUsingEncoding(NSUTF8StringEncoding)
+    dynamic var optDateCol: NSDate? = NSDate(timeIntervalSince1970: 10)
+    let optIntCol = RealmOptional<Int>()
+    let optFloatCol = RealmOptional<Float>()
+    let optDoubleCol = RealmOptional<Double>()
+    let optBoolCol = RealmOptional<Bool>()
+#endif
+    dynamic var optObjectCol: SwiftBoolObject? = SwiftBoolObject(value: [true])
+    //    let arrayCol = List<SwiftBoolObject?>()
+
+    class func defaultValues() -> [String: AnyObject] {
+        return [
+            "optNSStringCol" : "A",
+            "optStringCol" : "B",
+            "optBinaryCol" : "C".dataUsingEncoding(NSUTF8StringEncoding)! as NSData,
+            "optDateCol" : NSDate(timeIntervalSince1970: 10),
+            "optIntCol" : NSNull(),
+            "optFloatCol" : NSNull(),
+            "optDoubleCol" : NSNull(),
+            "optBoolCol" : NSNull()
+        ]
+    }
+}
+
+
 class SwiftDogObject: Object {
     dynamic var dogName = ""
 }

--- a/RealmSwift-swift1.2/Tests/SwiftTestObjects.swift
+++ b/RealmSwift-swift1.2/Tests/SwiftTestObjects.swift
@@ -60,7 +60,6 @@ class SwiftObject: Object {
 }
 
 class SwiftOptionalObject: Object {
-#if REALM_ENABLE_NULL
     dynamic var optNSStringCol: NSString?
     dynamic var optStringCol: String?
     dynamic var optBinaryCol: NSData?
@@ -69,24 +68,20 @@ class SwiftOptionalObject: Object {
     let optFloatCol = RealmOptional<Float>()
     let optDoubleCol = RealmOptional<Double>()
     let optBoolCol = RealmOptional<Bool>()
-#endif
     dynamic var optObjectCol: SwiftBoolObject?
 //    let arrayCol = List<SwiftBoolObject?>()
 }
 
 class SwiftImplicitlyUnwrappedOptionalObject: Object {
-#if REALM_ENABLE_NULL
     dynamic var optNSStringCol: NSString!
     dynamic var optStringCol: String!
     dynamic var optBinaryCol: NSData!
     dynamic var optDateCol: NSDate!
-#endif
     dynamic var optObjectCol: SwiftBoolObject!
 //    let arrayCol = List<SwiftBoolObject!>()
 }
 
 class SwiftOptionalDefaultValuesObject: Object {
-#if REALM_ENABLE_NULL
     dynamic var optNSStringCol: NSString? = "A"
     dynamic var optStringCol: String? = "B"
     dynamic var optBinaryCol: NSData? = "C".dataUsingEncoding(NSUTF8StringEncoding)
@@ -95,7 +90,6 @@ class SwiftOptionalDefaultValuesObject: Object {
     let optFloatCol = RealmOptional<Float>()
     let optDoubleCol = RealmOptional<Double>()
     let optBoolCol = RealmOptional<Bool>()
-#endif
     dynamic var optObjectCol: SwiftBoolObject? = SwiftBoolObject(value: [true])
     //    let arrayCol = List<SwiftBoolObject?>()
 

--- a/RealmSwift-swift2.0/Object.swift
+++ b/RealmSwift-swift2.0/Object.swift
@@ -296,16 +296,18 @@ public class ObjectUtil: NSObject {
             } else if type is Optional<Object>.Type {
                 properties[name] = Int(PropertyType.Object.rawValue)
             } else if type is RealmOptional<Int>.Type ||
-                type is RealmOptional<Int16>.Type ||
-                type is RealmOptional<Int32>.Type ||
-                type is RealmOptional<Int64>.Type {
-                    properties[name] = Int(PropertyType.Int.rawValue)
+                      type is RealmOptional<Int16>.Type ||
+                      type is RealmOptional<Int32>.Type ||
+                      type is RealmOptional<Int64>.Type {
+                properties[name] = Int(PropertyType.Int.rawValue)
             } else if type is RealmOptional<Float>.Type {
                 properties[name] = Int(PropertyType.Float.rawValue)
             } else if type is RealmOptional<Double>.Type {
                 properties[name] = Int(PropertyType.Double.rawValue)
             } else if type is RealmOptional<Bool>.Type {
                 properties[name] = Int(PropertyType.Bool.rawValue)
+            } else if prop.value as? RLMOptionalBase != nil {
+                throwRealmException("'\(type)' is not a a valid RealmOptional type.")
             } else if mirror.displayStyle == .Optional {
                 properties[name] = NSNull()
             }

--- a/RealmSwift-swift2.0/Object.swift
+++ b/RealmSwift-swift2.0/Object.swift
@@ -223,7 +223,7 @@ public class Object: RLMObjectBase {
 
 /// Object interface which allows untyped getters and setters for Objects.
 /// :nodoc:
-public final class DynamicObject : Object {
+public final class DynamicObject: Object {
     private var listProperties = [String: List<DynamicObject>]()
 
     // Override to create List<DynamicObject> on access

--- a/RealmSwift-swift2.0/Optional.swift
+++ b/RealmSwift-swift2.0/Optional.swift
@@ -1,0 +1,48 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2015 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+public protocol RealmOptionalType {}
+extension Int: RealmOptionalType {}
+extension Int16: RealmOptionalType {}
+extension Int32: RealmOptionalType {}
+extension Int64: RealmOptionalType {}
+extension Float: RealmOptionalType {}
+extension Double: RealmOptionalType {}
+extension Bool: RealmOptionalType {}
+
+import Realm
+
+public final class RealmOptional<T: RealmOptionalType> : RLMOptionalBase {
+    public var value: T? {
+        get {
+            return underlyingValue as! T?
+        }
+        set {
+            if let value = newValue {
+                self.underlyingValue = value as! AnyObject
+            } else {
+                self.underlyingValue = nil
+            }
+        }
+    }
+
+    public init(_ v: T? = nil) {
+        super.init()
+        value = v
+    }
+}

--- a/RealmSwift-swift2.0/Optional.swift
+++ b/RealmSwift-swift2.0/Optional.swift
@@ -16,6 +16,9 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
+import Realm
+
+/// Types that can be represented in a `RealmOptional`.
 public protocol RealmOptionalType {}
 extension Int: RealmOptionalType {}
 extension Int16: RealmOptionalType {}
@@ -25,9 +28,15 @@ extension Float: RealmOptionalType {}
 extension Double: RealmOptionalType {}
 extension Bool: RealmOptionalType {}
 
-import Realm
+/**
+A `RealmOptional` represents a optional value for types that can't be directly
+declared as `dynamic` in Swift, such as `Int`s, `Float`, `Double`, and `Bool`.
 
+It encapsulates a value in its `value` property, which is the only way to mutate
+a `RealmOptional` property on an `Object`.
+*/
 public final class RealmOptional<T: RealmOptionalType> : RLMOptionalBase {
+    /// The value this optional represents.
     public var value: T? {
         get {
             return underlyingValue as! T?
@@ -37,6 +46,11 @@ public final class RealmOptional<T: RealmOptionalType> : RLMOptionalBase {
         }
     }
 
+    /**
+    Creates a `RealmOptional` with the given default value (defaults to `nil`).
+
+    - parameter value: The default value for this optional.
+    */
     public init(_ value: T? = nil) {
         super.init()
         self.value = value

--- a/RealmSwift-swift2.0/Optional.swift
+++ b/RealmSwift-swift2.0/Optional.swift
@@ -33,16 +33,12 @@ public final class RealmOptional<T: RealmOptionalType> : RLMOptionalBase {
             return underlyingValue as! T?
         }
         set {
-            if let value = newValue {
-                self.underlyingValue = value as! AnyObject
-            } else {
-                self.underlyingValue = nil
-            }
+            self.underlyingValue = newValue as! AnyObject?
         }
     }
 
-    public init(_ v: T? = nil) {
+    public init(_ value: T? = nil) {
         super.init()
-        value = v
+        self.value = value
     }
 }

--- a/RealmSwift-swift2.0/RealmCollectionType.swift
+++ b/RealmSwift-swift2.0/RealmCollectionType.swift
@@ -35,7 +35,7 @@ public final class RLMGenerator<T: Object>: GeneratorType {
     public func next() -> T? {
         let accessor = generatorBase.next() as! T?
         if let accessor = accessor {
-            RLMInitializeSwiftListAccessor(accessor)
+            RLMInitializeSwiftAccessorGenerics(accessor)
         }
         return accessor
     }

--- a/RealmSwift-swift2.0/Tests/KVOTests.swift
+++ b/RealmSwift-swift2.0/Tests/KVOTests.swift
@@ -40,6 +40,13 @@ class KVOObject: Object {
     dynamic var dateCol: NSDate = NSDate(timeIntervalSince1970: 0)
     dynamic var objectCol: KVOObject?
     let arrayCol = List<KVOObject>()
+    let optIntCol = RealmOptional<Int>()
+    let optFloatCol = RealmOptional<Float>()
+    let optDoubleCol = RealmOptional<Double>()
+    let optBoolCol = RealmOptional<Bool>()
+    dynamic var optStringCol: String?
+    dynamic var optBinaryCol: NSData?
+    dynamic var optDateCol: NSDate?
 
     override class func primaryKey() -> String { return "pk" }
     override class func ignoredProperties() -> [String] { return ["ignored"] }
@@ -129,6 +136,22 @@ class KVOTests: TestCase {
         observeListChange(obj, "arrayCol", .Removal, NSIndexSet(index: 0)) {
             obj.arrayCol.removeAll()
         }
+
+        observeChange(obj, "optIntCol", NSNull(), 10) { obj.optIntCol.value = 10 }
+        observeChange(obj, "optFloatCol", NSNull(), 10) { obj.optFloatCol.value = 10 }
+        observeChange(obj, "optDoubleCol", NSNull(), 10) { obj.optDoubleCol.value = 10 }
+        observeChange(obj, "optBoolCol", NSNull(), true) { obj.optBoolCol.value = true }
+        observeChange(obj, "optStringCol", NSNull(), "abc") { obj.optStringCol = "abc" }
+        observeChange(obj, "optBinaryCol", NSNull(), data) { obj.optBinaryCol = data }
+        observeChange(obj, "optDateCol", NSNull(), date) { obj.optDateCol = date }
+
+        observeChange(obj, "optIntCol", 10, NSNull()) { obj.optIntCol.value = nil }
+        observeChange(obj, "optFloatCol", 10, NSNull()) { obj.optFloatCol.value = nil }
+        observeChange(obj, "optDoubleCol", 10, NSNull()) { obj.optDoubleCol.value = nil }
+        observeChange(obj, "optBoolCol", true, NSNull()) { obj.optBoolCol.value = nil }
+        observeChange(obj, "optStringCol", "abc", NSNull()) { obj.optStringCol = nil }
+        observeChange(obj, "optBinaryCol", data, NSNull()) { obj.optBinaryCol = nil }
+        observeChange(obj, "optDateCol", date, NSNull()) { obj.optDateCol = nil }
     }
 
     func testAllPropertyTypesPersisted() {
@@ -157,6 +180,22 @@ class KVOTests: TestCase {
         observeListChange(obj, "arrayCol", .Removal, NSIndexSet(index: 0)) {
             obj.arrayCol.removeAll()
         }
+
+        observeChange(obj, "optIntCol", NSNull(), 10) { obj.optIntCol.value = 10 }
+        observeChange(obj, "optFloatCol", NSNull(), 10) { obj.optFloatCol.value = 10 }
+        observeChange(obj, "optDoubleCol", NSNull(), 10) { obj.optDoubleCol.value = 10 }
+        observeChange(obj, "optBoolCol", NSNull(), true) { obj.optBoolCol.value = true }
+        observeChange(obj, "optStringCol", NSNull(), "abc") { obj.optStringCol = "abc" }
+        observeChange(obj, "optBinaryCol", NSNull(), data) { obj.optBinaryCol = data }
+        observeChange(obj, "optDateCol", NSNull(), date) { obj.optDateCol = date }
+
+        observeChange(obj, "optIntCol", 10, NSNull()) { obj.optIntCol.value = nil }
+        observeChange(obj, "optFloatCol", 10, NSNull()) { obj.optFloatCol.value = nil }
+        observeChange(obj, "optDoubleCol", 10, NSNull()) { obj.optDoubleCol.value = nil }
+        observeChange(obj, "optBoolCol", true, NSNull()) { obj.optBoolCol.value = nil }
+        observeChange(obj, "optStringCol", "abc", NSNull()) { obj.optStringCol = nil }
+        observeChange(obj, "optBinaryCol", data, NSNull()) { obj.optBinaryCol = nil }
+        observeChange(obj, "optDateCol", date, NSNull()) { obj.optDateCol = nil }
 
         observeChange(obj, "invalidated", false, true) {
             self.realm.delete(obj)
@@ -196,6 +235,22 @@ class KVOTests: TestCase {
         observeListChange(obs, "arrayCol", .Removal, NSIndexSet(index: 0)) {
             obj.arrayCol.removeAll()
         }
+
+        observeChange(obj, "optIntCol", NSNull(), 10) { obj.optIntCol.value = 10 }
+        observeChange(obj, "optFloatCol", NSNull(), 10) { obj.optFloatCol.value = 10 }
+        observeChange(obj, "optDoubleCol", NSNull(), 10) { obj.optDoubleCol.value = 10 }
+        observeChange(obj, "optBoolCol", NSNull(), true) { obj.optBoolCol.value = true }
+        observeChange(obj, "optStringCol", NSNull(), "abc") { obj.optStringCol = "abc" }
+        observeChange(obj, "optBinaryCol", NSNull(), data) { obj.optBinaryCol = data }
+        observeChange(obj, "optDateCol", NSNull(), date) { obj.optDateCol = date }
+
+        observeChange(obj, "optIntCol", 10, NSNull()) { obj.optIntCol.value = nil }
+        observeChange(obj, "optFloatCol", 10, NSNull()) { obj.optFloatCol.value = nil }
+        observeChange(obj, "optDoubleCol", 10, NSNull()) { obj.optDoubleCol.value = nil }
+        observeChange(obj, "optBoolCol", true, NSNull()) { obj.optBoolCol.value = nil }
+        observeChange(obj, "optStringCol", "abc", NSNull()) { obj.optStringCol = nil }
+        observeChange(obj, "optBinaryCol", data, NSNull()) { obj.optBinaryCol = nil }
+        observeChange(obj, "optDateCol", date, NSNull()) { obj.optDateCol = nil }
 
         observeChange(obs, "invalidated", false, true) {
             self.realm.delete(obj)

--- a/RealmSwift-swift2.0/Tests/ObjectAccessorTests.swift
+++ b/RealmSwift-swift2.0/Tests/ObjectAccessorTests.swift
@@ -69,14 +69,19 @@ class ObjectAccessorTests: TestCase {
     func testStandaloneAccessors() {
         let object = SwiftObject()
         setAndTestAllProperties(object)
+
+        let optionalObject = SwiftOptionalObject()
+        setAndTestAllOptionalProperties(optionalObject)
     }
 
     func testPersistedAccessors() {
-        let object = SwiftObject()
-        try! Realm().beginWrite()
-        try! Realm().create(SwiftObject)
+        let realm = try! Realm()
+        realm.beginWrite()
+        let object = realm.create(SwiftObject)
+        let optionalObject = realm.create(SwiftOptionalObject)
         setAndTestAllProperties(object)
-        try! Realm().commitWrite()
+        setAndTestAllOptionalProperties(optionalObject)
+        realm.commitWrite()
     }
 
     func testIntSizes() {
@@ -204,5 +209,73 @@ class ObjectAccessorTests: TestCase {
         for obj in objects {
             XCTAssertEqual(2, obj.arrayCol.count)
         }
+    }
+
+    func setAndTestAllOptionalProperties(object: SwiftOptionalObject) {
+        object.optNSStringCol = ""
+        XCTAssertEqual(object.optNSStringCol!, "")
+        let utf8TestString = "值значен™👍☞⎠‱௹♣︎☐▼❒∑⨌⧭иеمرحبا"
+        object.optNSStringCol = utf8TestString
+        XCTAssertEqual(object.optNSStringCol!, utf8TestString)
+        object.optNSStringCol = nil
+        XCTAssertNil(object.optNSStringCol)
+
+        object.optStringCol = ""
+        XCTAssertEqual(object.optStringCol!, "")
+        object.optStringCol = utf8TestString
+        XCTAssertEqual(object.optStringCol!, utf8TestString)
+        object.optStringCol = nil
+        XCTAssertNil(object.optStringCol)
+
+        let data = "b".dataUsingEncoding(NSUTF8StringEncoding, allowLossyConversion: false)!
+        object.optBinaryCol = data
+        XCTAssertEqual(object.optBinaryCol!, data)
+        object.optBinaryCol = nil
+        XCTAssertNil(object.optBinaryCol)
+
+        let date = NSDate(timeIntervalSinceReferenceDate: 2) as NSDate
+        object.optDateCol = date
+        XCTAssertEqual(object.optDateCol!, date)
+        object.optDateCol = nil
+        XCTAssertNil(object.optDateCol)
+
+        object.optIntCol.value = -1
+        XCTAssertEqual(object.optIntCol.value!, -1)
+        object.optIntCol.value = 0
+        XCTAssertEqual(object.optIntCol.value!, 0)
+        object.optIntCol.value = 1
+        XCTAssertEqual(object.optIntCol.value!, 1)
+        object.optIntCol.value = nil
+        XCTAssertNil(object.optIntCol.value)
+
+        object.optFloatCol.value = 20
+        XCTAssertEqual(object.optFloatCol.value!, 20 as Float)
+        object.optFloatCol.value = 20.2
+        XCTAssertEqual(object.optFloatCol.value!, 20.2 as Float)
+        object.optFloatCol.value = 16777217
+        XCTAssertEqual(Double(object.optFloatCol.value!), 16777216.0 as Double)
+        object.optFloatCol.value = nil
+        XCTAssertNil(object.optFloatCol.value)
+
+        object.optDoubleCol.value = 20
+        XCTAssertEqual(object.optDoubleCol.value!, 20)
+        object.optDoubleCol.value = 20.2
+        XCTAssertEqual(object.optDoubleCol.value!, 20.2)
+        object.optDoubleCol.value = 16777217
+        XCTAssertEqual(object.optDoubleCol.value!, 16777217)
+        object.optDoubleCol.value = nil
+        XCTAssertNil(object.optDoubleCol.value)
+
+        object.optBoolCol.value = true
+        XCTAssertEqual(object.optBoolCol.value!, true)
+        object.optBoolCol.value = false
+        XCTAssertEqual(object.optBoolCol.value!, false)
+        object.optBoolCol.value = nil
+        XCTAssertNil(object.optBoolCol.value)
+
+        object.optObjectCol = SwiftBoolObject(value: [true])
+        XCTAssertEqual(object.optObjectCol!.boolCol, true)
+        object.optObjectCol = nil
+        XCTAssertNil(object.optObjectCol)
     }
 }

--- a/RealmSwift-swift2.0/Tests/ObjectAccessorTests.swift
+++ b/RealmSwift-swift2.0/Tests/ObjectAccessorTests.swift
@@ -81,7 +81,7 @@ class ObjectAccessorTests: TestCase {
         let optionalObject = realm.create(SwiftOptionalObject)
         setAndTestAllProperties(object)
         setAndTestAllOptionalProperties(optionalObject)
-        realm.commitWrite()
+        try! realm.commitWrite()
     }
 
     func testIntSizes() {
@@ -212,6 +212,7 @@ class ObjectAccessorTests: TestCase {
     }
 
     func setAndTestAllOptionalProperties(object: SwiftOptionalObject) {
+#if REALM_ENABLE_NULL
         object.optNSStringCol = ""
         XCTAssertEqual(object.optNSStringCol!, "")
         let utf8TestString = "值значен™👍☞⎠‱௹♣︎☐▼❒∑⨌⧭иеمرحبا"
@@ -272,6 +273,7 @@ class ObjectAccessorTests: TestCase {
         XCTAssertEqual(object.optBoolCol.value!, false)
         object.optBoolCol.value = nil
         XCTAssertNil(object.optBoolCol.value)
+#endif
 
         object.optObjectCol = SwiftBoolObject(value: [true])
         XCTAssertEqual(object.optObjectCol!.boolCol, true)

--- a/RealmSwift-swift2.0/Tests/ObjectAccessorTests.swift
+++ b/RealmSwift-swift2.0/Tests/ObjectAccessorTests.swift
@@ -211,6 +211,21 @@ class ObjectAccessorTests: TestCase {
         }
     }
 
+    func testSettingOptionalPropertyOnDeletedObjectsThrows() {
+        let realm = try! Realm()
+        try! realm.write {
+            let obj = realm.create(SwiftOptionalObject)
+            let copy = realm.objects(SwiftOptionalObject).first!
+            realm.delete(obj)
+
+            self.assertThrows(copy.optIntCol.value = 1)
+            self.assertThrows(copy.optIntCol.value = nil)
+
+            self.assertThrows(obj.optIntCol.value = 1)
+            self.assertThrows(obj.optIntCol.value = nil)
+        }
+    }
+
     func setAndTestAllOptionalProperties(object: SwiftOptionalObject) {
 #if REALM_ENABLE_NULL
         object.optNSStringCol = ""

--- a/RealmSwift-swift2.0/Tests/ObjectAccessorTests.swift
+++ b/RealmSwift-swift2.0/Tests/ObjectAccessorTests.swift
@@ -227,7 +227,6 @@ class ObjectAccessorTests: TestCase {
     }
 
     func setAndTestAllOptionalProperties(object: SwiftOptionalObject) {
-#if REALM_ENABLE_NULL
         object.optNSStringCol = ""
         XCTAssertEqual(object.optNSStringCol!, "")
         let utf8TestString = "值значен™👍☞⎠‱௹♣︎☐▼❒∑⨌⧭иеمرحبا"
@@ -288,7 +287,6 @@ class ObjectAccessorTests: TestCase {
         XCTAssertEqual(object.optBoolCol.value!, false)
         object.optBoolCol.value = nil
         XCTAssertNil(object.optBoolCol.value)
-#endif
 
         object.optObjectCol = SwiftBoolObject(value: [true])
         XCTAssertEqual(object.optObjectCol!.boolCol, true)

--- a/RealmSwift-swift2.0/Tests/ObjectCreationTests.swift
+++ b/RealmSwift-swift2.0/Tests/ObjectCreationTests.swift
@@ -17,6 +17,7 @@
 ////////////////////////////////////////////////////////////////////////////
 
 import XCTest
+import Realm.Private
 import RealmSwift
 import Foundation
 
@@ -35,6 +36,23 @@ class ObjectCreationTests: TestCase {
         XCTAssertNil(object.realm)
         XCTAssertNil(object.objectCol!.realm)
         XCTAssertNil(object.arrayCol.realm)
+    }
+
+    func testInitWithOptionalWithoutDefaults() {
+        let object = SwiftOptionalObject()
+        for prop in object.objectSchema.properties {
+            let value = object[prop.name]
+            if let value = value as? RLMOptionalBase {
+                XCTAssertNil(value.underlyingValue)
+            } else {
+                XCTAssertNil(value)
+            }
+        }
+    }
+
+    func testInitWithOptionalDefaults() {
+        let object = SwiftOptionalDefaultValuesObject()
+        verifySwiftOptionalObjectWithDictionaryLiteral(object, dictionary: SwiftOptionalDefaultValuesObject.defaultValues(), boolObjectValue: true)
     }
 
     func testInitWithDictionary() {
@@ -145,6 +163,24 @@ class ObjectCreationTests: TestCase {
         XCTAssertEqual(object.realm!, realm)
         XCTAssertEqual(object.objectCol!.realm!, realm)
         XCTAssertEqual(object.arrayCol.realm!, realm)
+    }
+
+    func testCreateWithOptionalWithoutDefaults() {
+        let realm = try! Realm()
+        realm.write {
+            let object = realm.create(SwiftOptionalObject)
+            for prop in object.objectSchema.properties {
+                XCTAssertNil(object[prop.name])
+            }
+        }
+    }
+
+    func testCreateWithOptionalDefaults() {
+        let realm = try! Realm()
+        realm.write {
+            let object = realm.create(SwiftOptionalDefaultValuesObject)
+            self.verifySwiftOptionalObjectWithDictionaryLiteral(object, dictionary: SwiftOptionalDefaultValuesObject.defaultValues(), boolObjectValue: true)
+        }
     }
 
     func testCreateWithDictionary() {
@@ -405,6 +441,18 @@ class ObjectCreationTests: TestCase {
         for i in 0..<boolObjectListValues.count {
             XCTAssertEqual(object.arrayCol[i].boolCol, boolObjectListValues[i])
         }
+    }
+
+    private func verifySwiftOptionalObjectWithDictionaryLiteral(object: SwiftOptionalDefaultValuesObject, dictionary: [String:AnyObject], boolObjectValue: Bool?) {
+        XCTAssertEqual(object.optBoolCol.value, (dictionary["optBoolCol"] as! Bool?))
+        XCTAssertEqual(object.optIntCol.value, (dictionary["optIntCol"] as! Int?))
+        XCTAssertEqual(object.optFloatCol.value, (dictionary["optFloatCol"] as! Float?))
+        XCTAssertEqual(object.optDoubleCol.value, (dictionary["optDoubleCol"] as! Double?))
+        XCTAssertEqual(object.optStringCol, (dictionary["optStringCol"] as! String?))
+        XCTAssertEqual(object.optNSStringCol, (dictionary["optNSStringCol"] as! String?))
+        XCTAssertEqual(object.optBinaryCol, (dictionary["optBinaryCol"] as! NSData?))
+        XCTAssertEqual(object.optDateCol, (dictionary["optDateCol"] as! NSDate?))
+        XCTAssertEqual(object.optObjectCol?.boolCol, boolObjectValue)
     }
 
     private func defaultSwiftObjectValuesWithReplacements(replace: [String: AnyObject]) -> [String: AnyObject] {

--- a/RealmSwift-swift2.0/Tests/ObjectCreationTests.swift
+++ b/RealmSwift-swift2.0/Tests/ObjectCreationTests.swift
@@ -167,7 +167,7 @@ class ObjectCreationTests: TestCase {
 
     func testCreateWithOptionalWithoutDefaults() {
         let realm = try! Realm()
-        realm.write {
+        try! realm.write {
             let object = realm.create(SwiftOptionalObject)
             for prop in object.objectSchema.properties {
                 XCTAssertNil(object[prop.name])
@@ -177,7 +177,7 @@ class ObjectCreationTests: TestCase {
 
     func testCreateWithOptionalDefaults() {
         let realm = try! Realm()
-        realm.write {
+        try! realm.write {
             let object = realm.create(SwiftOptionalDefaultValuesObject)
             self.verifySwiftOptionalObjectWithDictionaryLiteral(object, dictionary: SwiftOptionalDefaultValuesObject.defaultValues(), boolObjectValue: true)
         }
@@ -444,6 +444,7 @@ class ObjectCreationTests: TestCase {
     }
 
     private func verifySwiftOptionalObjectWithDictionaryLiteral(object: SwiftOptionalDefaultValuesObject, dictionary: [String:AnyObject], boolObjectValue: Bool?) {
+#if REALM_ENABLE_NULL
         XCTAssertEqual(object.optBoolCol.value, (dictionary["optBoolCol"] as! Bool?))
         XCTAssertEqual(object.optIntCol.value, (dictionary["optIntCol"] as! Int?))
         XCTAssertEqual(object.optFloatCol.value, (dictionary["optFloatCol"] as! Float?))
@@ -452,6 +453,7 @@ class ObjectCreationTests: TestCase {
         XCTAssertEqual(object.optNSStringCol, (dictionary["optNSStringCol"] as! String?))
         XCTAssertEqual(object.optBinaryCol, (dictionary["optBinaryCol"] as! NSData?))
         XCTAssertEqual(object.optDateCol, (dictionary["optDateCol"] as! NSDate?))
+#endif
         XCTAssertEqual(object.optObjectCol?.boolCol, boolObjectValue)
     }
 

--- a/RealmSwift-swift2.0/Tests/ObjectCreationTests.swift
+++ b/RealmSwift-swift2.0/Tests/ObjectCreationTests.swift
@@ -444,7 +444,6 @@ class ObjectCreationTests: TestCase {
     }
 
     private func verifySwiftOptionalObjectWithDictionaryLiteral(object: SwiftOptionalDefaultValuesObject, dictionary: [String:AnyObject], boolObjectValue: Bool?) {
-#if REALM_ENABLE_NULL
         XCTAssertEqual(object.optBoolCol.value, (dictionary["optBoolCol"] as! Bool?))
         XCTAssertEqual(object.optIntCol.value, (dictionary["optIntCol"] as! Int?))
         XCTAssertEqual(object.optFloatCol.value, (dictionary["optFloatCol"] as! Float?))
@@ -453,7 +452,6 @@ class ObjectCreationTests: TestCase {
         XCTAssertEqual(object.optNSStringCol, (dictionary["optNSStringCol"] as! String?))
         XCTAssertEqual(object.optBinaryCol, (dictionary["optBinaryCol"] as! NSData?))
         XCTAssertEqual(object.optDateCol, (dictionary["optDateCol"] as! NSDate?))
-#endif
         XCTAssertEqual(object.optObjectCol?.boolCol, boolObjectValue)
     }
 

--- a/RealmSwift-swift2.0/Tests/ObjectSchemaInitializationTests.swift
+++ b/RealmSwift-swift2.0/Tests/ObjectSchemaInitializationTests.swift
@@ -147,16 +147,32 @@ class ObjectSchemaInitializationTests: TestCase {
         }
     }
 
-    func testNonNullableOptionalPropertiesAreCoerced() {
-        assertThrows(RLMObjectSchema(forObjectClass: SwiftObjectWithNonNullableOptionalProperties.self), "Should throw when marking non-String and non-Data properties as optional")
+    func testOptionalProperties() {
+        let schema = RLMObjectSchema(forObjectClass: SwiftOptionalObject.self)
+
+        for prop in schema.properties {
+            XCTAssertTrue((prop as! RLMProperty).optional)
+        }
+
+        let types = Set(schema.properties.map { prop in
+            (prop as! RLMProperty).type
+        })
+
+#if REALM_ENABLE_NULL
+        XCTAssertEqual(types, Set([.String, .String, .Data, .Date, .Object, .Int, .Float, .Double, .Bool]))
+#else
+        XCTAssertEqual(types, Set([.Object]))
+#endif
     }
 
     func testImplicitlyUnwrappedOptionalsAreParsedAsOptionals() {
         let schema = SwiftImplicitlyUnwrappedOptionalObject().objectSchema
         XCTAssertTrue(schema["optObjectCol"]!.optional)
 #if REALM_ENABLE_NULL
+        XCTAssertTrue(schema["optNSStringCol"]!.optional)
         XCTAssertTrue(schema["optStringCol"]!.optional)
         XCTAssertTrue(schema["optBinaryCol"]!.optional)
+        XCTAssertTrue(schema["optDateCol"]!.optional)
 #endif
     }
 }

--- a/RealmSwift-swift2.0/Tests/ObjectSchemaInitializationTests.swift
+++ b/RealmSwift-swift2.0/Tests/ObjectSchemaInitializationTests.swift
@@ -243,7 +243,7 @@ class SwiftObjectWithNonOptionalLinkProperty: SwiftFakeObject {
     dynamic var objectCol = SwiftBoolObject()
 }
 
-extension Set: Set { }
+extension Set: RealmOptionalType { }
 
 class SwiftObjectWithNonRealmOptionalType: SwiftFakeObject {
     let set = RealmOptional<Set<Int>>()

--- a/RealmSwift-swift2.0/Tests/ObjectSchemaInitializationTests.swift
+++ b/RealmSwift-swift2.0/Tests/ObjectSchemaInitializationTests.swift
@@ -175,6 +175,10 @@ class ObjectSchemaInitializationTests: TestCase {
         XCTAssertTrue(schema["optDateCol"]!.optional)
 #endif
     }
+
+    func testNonRealmOptionalTypesDeclaredAsRealmOptional() {
+        assertThrows(RLMObjectSchema(forObjectClass: SwiftObjectWithNonRealmOptionalType.self))
+    }
 }
 
 class SwiftFakeObject : NSObject {
@@ -237,4 +241,10 @@ class SwiftObjectWithNonNullableOptionalProperties: SwiftFakeObject {
 
 class SwiftObjectWithNonOptionalLinkProperty : SwiftFakeObject {
     dynamic var objectCol = SwiftBoolObject()
+}
+
+extension Set : RealmOptionalType { }
+
+class SwiftObjectWithNonRealmOptionalType : SwiftFakeObject {
+    let set = RealmOptional<Set<Int>>()
 }

--- a/RealmSwift-swift2.0/Tests/ObjectSchemaInitializationTests.swift
+++ b/RealmSwift-swift2.0/Tests/ObjectSchemaInitializationTests.swift
@@ -187,11 +187,11 @@ class SwiftFakeObject : NSObject {
     dynamic class func indexedProperties() -> [String] { return [] }
 }
 
-class SwiftObjectWithNSURL : SwiftFakeObject {
+class SwiftObjectWithNSURL: SwiftFakeObject {
     dynamic var URL = NSURL(string: "http://realm.io")!
 }
 
-class SwiftObjectWithAnyObject : SwiftFakeObject {
+class SwiftObjectWithAnyObject: SwiftFakeObject {
     dynamic var anyObject: AnyObject = NSString(string: "")
 }
 
@@ -200,15 +200,15 @@ enum SwiftEnum {
     case Case2
 }
 
-class SwiftObjectWithEnum : SwiftFakeObject {
+class SwiftObjectWithEnum: SwiftFakeObject {
     var swiftEnum = SwiftEnum.Case1
 }
 
-class SwiftObjectWithStruct : SwiftFakeObject {
+class SwiftObjectWithStruct: SwiftFakeObject {
     var swiftStruct = SortDescriptor(property: "prop")
 }
 
-class SwiftObjectWithDatePrimaryKey : SwiftFakeObject {
+class SwiftObjectWithDatePrimaryKey: SwiftFakeObject {
     dynamic var date = NSDate()
 
     dynamic override class func primaryKey() -> String! {
@@ -216,11 +216,11 @@ class SwiftObjectWithDatePrimaryKey : SwiftFakeObject {
     }
 }
 
-class SwiftFakeObjectSubclass : SwiftFakeObject {
+class SwiftFakeObjectSubclass: SwiftFakeObject {
     dynamic var dateCol = NSDate()
 }
 
-class SwiftObjectWithUnindexibleProperties : SwiftFakeObject {
+class SwiftObjectWithUnindexibleProperties: SwiftFakeObject {
     dynamic var boolCol = false
     dynamic var intCol = 123
     dynamic var floatCol = 1.23 as Float
@@ -239,12 +239,12 @@ class SwiftObjectWithNonNullableOptionalProperties: SwiftFakeObject {
     dynamic var optDateCol: NSDate?
 }
 
-class SwiftObjectWithNonOptionalLinkProperty : SwiftFakeObject {
+class SwiftObjectWithNonOptionalLinkProperty: SwiftFakeObject {
     dynamic var objectCol = SwiftBoolObject()
 }
 
-extension Set : RealmOptionalType { }
+extension Set: Set { }
 
-class SwiftObjectWithNonRealmOptionalType : SwiftFakeObject {
+class SwiftObjectWithNonRealmOptionalType: SwiftFakeObject {
     let set = RealmOptional<Set<Int>>()
 }

--- a/RealmSwift-swift2.0/Tests/ObjectSchemaInitializationTests.swift
+++ b/RealmSwift-swift2.0/Tests/ObjectSchemaInitializationTests.swift
@@ -158,22 +158,16 @@ class ObjectSchemaInitializationTests: TestCase {
             (prop as! RLMProperty).type
         })
 
-#if REALM_ENABLE_NULL
         XCTAssertEqual(types, Set([.String, .String, .Data, .Date, .Object, .Int, .Float, .Double, .Bool]))
-#else
-        XCTAssertEqual(types, Set([.Object]))
-#endif
     }
 
     func testImplicitlyUnwrappedOptionalsAreParsedAsOptionals() {
         let schema = SwiftImplicitlyUnwrappedOptionalObject().objectSchema
         XCTAssertTrue(schema["optObjectCol"]!.optional)
-#if REALM_ENABLE_NULL
         XCTAssertTrue(schema["optNSStringCol"]!.optional)
         XCTAssertTrue(schema["optStringCol"]!.optional)
         XCTAssertTrue(schema["optBinaryCol"]!.optional)
         XCTAssertTrue(schema["optDateCol"]!.optional)
-#endif
     }
 
     func testNonRealmOptionalTypesDeclaredAsRealmOptional() {

--- a/RealmSwift-swift2.0/Tests/SwiftTestObjects.swift
+++ b/RealmSwift-swift2.0/Tests/SwiftTestObjects.swift
@@ -60,34 +60,31 @@ class SwiftObject: Object {
 }
 
 class SwiftOptionalObject: Object {
-//    FIXME: Support all optional property types
-//    dynamic var optBoolCol: Bool?
-//    dynamic var optIntCol: Int?
-//    dynamic var optFloatCol: Float?
-//    dynamic var optDoubleCol: Double?
 #if REALM_ENABLE_NULL
-    dynamic var optStringCol: NSString?
+    dynamic var optNSStringCol: NSString?
+    dynamic var optStringCol: String?
     dynamic var optBinaryCol: NSData?
+    dynamic var optDateCol: NSDate?
+    let optIntCol = RealmOptional<Int>()
+    let optFloatCol = RealmOptional<Float>()
+    let optDoubleCol = RealmOptional<Double>()
+    let optBoolCol = RealmOptional<Bool>()
 #endif
-//    dynamic var optDateCol: NSDate?
     dynamic var optObjectCol: SwiftBoolObject?
-//    let arrayCol = List<SwiftBoolObject?>()
+    //    let arrayCol = List<SwiftBoolObject?>()
 }
 
 class SwiftImplicitlyUnwrappedOptionalObject: Object {
-//    FIXME: Support all optional property types
-//    dynamic var optBoolCol: Bool!
-//    dynamic var optIntCol: Int!
-//    dynamic var optFloatCol: Float!
-//    dynamic var optDoubleCol: Double!
 #if REALM_ENABLE_NULL
-    dynamic var optStringCol: NSString!
+    dynamic var optNSStringCol: NSString!
+    dynamic var optStringCol: String!
     dynamic var optBinaryCol: NSData!
+    dynamic var optDateCol: NSDate!
 #endif
-//    dynamic var optDateCol: NSDate!
     dynamic var optObjectCol: SwiftBoolObject!
-//    let arrayCol = List<SwiftBoolObject!>()
+    //    let arrayCol = List<SwiftBoolObject!>()
 }
+
 
 class SwiftDogObject: Object {
     dynamic var dogName = ""

--- a/RealmSwift-swift2.0/Tests/SwiftTestObjects.swift
+++ b/RealmSwift-swift2.0/Tests/SwiftTestObjects.swift
@@ -85,6 +85,35 @@ class SwiftImplicitlyUnwrappedOptionalObject: Object {
     //    let arrayCol = List<SwiftBoolObject!>()
 }
 
+class SwiftOptionalDefaultValuesObject: Object {
+#if REALM_ENABLE_NULL
+    dynamic var optNSStringCol: NSString? = "A"
+    dynamic var optStringCol: String? = "B"
+    dynamic var optBinaryCol: NSData? = "C".dataUsingEncoding(NSUTF8StringEncoding)
+    dynamic var optDateCol: NSDate? = NSDate(timeIntervalSince1970: 10)
+    let optIntCol = RealmOptional<Int>(1)
+    let optFloatCol = RealmOptional<Float>(2.2)
+    let optDoubleCol = RealmOptional<Double>(3.3)
+    let optBoolCol = RealmOptional<Bool>(true)
+#endif
+    dynamic var optObjectCol: SwiftBoolObject? = SwiftBoolObject(value: [true])
+    //    let arrayCol = List<SwiftBoolObject?>()
+
+    class func defaultValues() -> [String: AnyObject] {
+        return [
+            "optNSStringCol" : "A",
+            "optStringCol" : "B",
+            "optBinaryCol" : "C".dataUsingEncoding(NSUTF8StringEncoding)! as NSData,
+            "optDateCol" : NSDate(timeIntervalSince1970: 10),
+            "optIntCol" : 1,
+            "optFloatCol" : 2.2 as Float,
+            "optDoubleCol" : 3.3,
+            "optBoolCol" : true,
+        ]
+    }
+}
+
+
 
 class SwiftDogObject: Object {
     dynamic var dogName = ""

--- a/RealmSwift-swift2.0/Tests/SwiftTestObjects.swift
+++ b/RealmSwift-swift2.0/Tests/SwiftTestObjects.swift
@@ -60,7 +60,6 @@ class SwiftObject: Object {
 }
 
 class SwiftOptionalObject: Object {
-#if REALM_ENABLE_NULL
     dynamic var optNSStringCol: NSString?
     dynamic var optStringCol: String?
     dynamic var optBinaryCol: NSData?
@@ -69,24 +68,20 @@ class SwiftOptionalObject: Object {
     let optFloatCol = RealmOptional<Float>()
     let optDoubleCol = RealmOptional<Double>()
     let optBoolCol = RealmOptional<Bool>()
-#endif
     dynamic var optObjectCol: SwiftBoolObject?
     //    let arrayCol = List<SwiftBoolObject?>()
 }
 
 class SwiftImplicitlyUnwrappedOptionalObject: Object {
-#if REALM_ENABLE_NULL
     dynamic var optNSStringCol: NSString!
     dynamic var optStringCol: String!
     dynamic var optBinaryCol: NSData!
     dynamic var optDateCol: NSDate!
-#endif
     dynamic var optObjectCol: SwiftBoolObject!
     //    let arrayCol = List<SwiftBoolObject!>()
 }
 
 class SwiftOptionalDefaultValuesObject: Object {
-#if REALM_ENABLE_NULL
     dynamic var optNSStringCol: NSString? = "A"
     dynamic var optStringCol: String? = "B"
     dynamic var optBinaryCol: NSData? = "C".dataUsingEncoding(NSUTF8StringEncoding)
@@ -95,7 +90,6 @@ class SwiftOptionalDefaultValuesObject: Object {
     let optFloatCol = RealmOptional<Float>(2.2)
     let optDoubleCol = RealmOptional<Double>(3.3)
     let optBoolCol = RealmOptional<Bool>(true)
-#endif
     dynamic var optObjectCol: SwiftBoolObject? = SwiftBoolObject(value: [true])
     //    let arrayCol = List<SwiftBoolObject?>()
 

--- a/RealmSwift.xcodeproj/project.pbxproj
+++ b/RealmSwift.xcodeproj/project.pbxproj
@@ -50,6 +50,7 @@
 		C02E53E01B7A7E00002586E8 /* RealmConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D2DD101B6BF849004E8919 /* RealmConfiguration.swift */; };
 		C042A4921B753A1C00771ED2 /* RealmConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C042A4911B753A1C00771ED2 /* RealmConfigurationTests.swift */; };
 		C04DAEBE1A8E7FBD008A9623 /* Util.swift in Sources */ = {isa = PBXBuildFile; fileRef = C04DAEBD1A8E7FBD008A9623 /* Util.swift */; };
+		C0716FC11B8E456A00B37CD6 /* Optional.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0716FC01B8E456A00B37CD6 /* Optional.swift */; };
 		C081AEB21AAF865C00BA3E31 /* PropertyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C081AEB11AAF865C00BA3E31 /* PropertyTests.swift */; };
 		C0D8E12C1A8174090077C784 /* SortDescriptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D8E12B1A8174090077C784 /* SortDescriptor.swift */; };
 		C0D8E12F1A81749D0077C784 /* SortDescriptorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D8E12E1A81749D0077C784 /* SortDescriptorTests.swift */; };
@@ -142,6 +143,7 @@
 		C0240C2A1A84090000858BFA /* RealmTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RealmTests.swift; sourceTree = "<group>"; };
 		C042A4911B753A1C00771ED2 /* RealmConfigurationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RealmConfigurationTests.swift; sourceTree = "<group>"; };
 		C04DAEBD1A8E7FBD008A9623 /* Util.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Util.swift; path = RealmSwift/Util.swift; sourceTree = SOURCE_ROOT; };
+		C0716FC01B8E456A00B37CD6 /* Optional.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Optional.swift; path = "RealmSwift-swift1.2/Optional.swift"; sourceTree = SOURCE_ROOT; };
 		C081AEB11AAF865C00BA3E31 /* PropertyTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PropertyTests.swift; sourceTree = "<group>"; };
 		C0CA5BCC1AC0951C007338C5 /* PerformanceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PerformanceTests.swift; sourceTree = "<group>"; };
 		C0D2DD101B6BF849004E8919 /* RealmConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = RealmConfiguration.swift; path = RealmSwift/RealmConfiguration.swift; sourceTree = SOURCE_ROOT; };
@@ -226,6 +228,7 @@
 				020F63BB1A8037AE007CB52E /* Migration.swift */,
 				020F63BC1A8037AE007CB52E /* Object.swift */,
 				020F63BD1A8037AE007CB52E /* ObjectSchema.swift */,
+				C0716FC01B8E456A00B37CD6 /* Optional.swift */,
 				020F63BE1A8037AE007CB52E /* Property.swift */,
 				020F63BF1A8037AE007CB52E /* Realm.swift */,
 				E8ED19B21B6AB94600DD2D15 /* RealmCollectionType.swift */,
@@ -473,11 +476,12 @@
 				020F63C21A8037AE007CB52E /* Aliases.swift in Sources */,
 				020F63C41A8037AE007CB52E /* List.swift in Sources */,
 				020F63C61A8037AE007CB52E /* Migration.swift in Sources */,
-				E8ED19B31B6AB94600DD2D15 /* RealmCollectionType.swift in Sources */,
 				020F63C81A8037AE007CB52E /* Object.swift in Sources */,
 				020F63CA1A8037AE007CB52E /* ObjectSchema.swift in Sources */,
+				C0716FC11B8E456A00B37CD6 /* Optional.swift in Sources */,
 				020F63CC1A8037AE007CB52E /* Property.swift in Sources */,
 				020F63CE1A8037AE007CB52E /* Realm.swift in Sources */,
+				E8ED19B31B6AB94600DD2D15 /* RealmCollectionType.swift in Sources */,
 				C02E53E01B7A7E00002586E8 /* RealmConfiguration.swift in Sources */,
 				020F63D01A8037AE007CB52E /* Results.swift in Sources */,
 				020F63D21A8037AE007CB52E /* Schema.swift in Sources */,
@@ -500,9 +504,9 @@
 				C0FE465C1A9BE7A6006E0539 /* ObjectTests.swift in Sources */,
 				5DE0B6D21B1001AE007831D9 /* PerformanceTests.swift in Sources */,
 				C081AEB21AAF865C00BA3E31 /* PropertyTests.swift in Sources */,
+				020F63E11A8037DC007CB52E /* RealmCollectionTypeTests.swift in Sources */,
 				C042A4921B753A1C00771ED2 /* RealmConfigurationTests.swift in Sources */,
 				C0240C2B1A84090000858BFA /* RealmTests.swift in Sources */,
-				020F63E11A8037DC007CB52E /* RealmCollectionTypeTests.swift in Sources */,
 				C0027B071AAF6FBC00F013A2 /* SchemaTests.swift in Sources */,
 				C0D8E12F1A81749D0077C784 /* SortDescriptorTests.swift in Sources */,
 				020F63E71A8037DC007CB52E /* SwiftLinkTests.swift in Sources */,
@@ -596,6 +600,7 @@
 			buildSettings = {
 				ENABLE_TESTABILITY = YES;
 				ONLY_ACTIVE_ARCH = YES;
+				OTHER_SWIFT_FLAGS = "-D\"REALM_ENABLE_NULL\"";
 			};
 			name = Debug;
 		};
@@ -603,6 +608,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 5DE0B6CB1B0FECF4007831D9 /* Release.xcconfig */;
 			buildSettings = {
+				OTHER_SWIFT_FLAGS = "-D\"REALM_ENABLE_NULL\"";
 			};
 			name = Release;
 		};

--- a/RealmSwift.xcodeproj/project.pbxproj
+++ b/RealmSwift.xcodeproj/project.pbxproj
@@ -143,7 +143,7 @@
 		C0240C2A1A84090000858BFA /* RealmTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RealmTests.swift; sourceTree = "<group>"; };
 		C042A4911B753A1C00771ED2 /* RealmConfigurationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RealmConfigurationTests.swift; sourceTree = "<group>"; };
 		C04DAEBD1A8E7FBD008A9623 /* Util.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Util.swift; path = RealmSwift/Util.swift; sourceTree = SOURCE_ROOT; };
-		C0716FC01B8E456A00B37CD6 /* Optional.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Optional.swift; path = "RealmSwift-swift1.2/Optional.swift"; sourceTree = SOURCE_ROOT; };
+		C0716FC01B8E456A00B37CD6 /* Optional.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Optional.swift; path = "RealmSwift/Optional.swift"; sourceTree = SOURCE_ROOT; };
 		C081AEB11AAF865C00BA3E31 /* PropertyTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PropertyTests.swift; sourceTree = "<group>"; };
 		C0CA5BCC1AC0951C007338C5 /* PerformanceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PerformanceTests.swift; sourceTree = "<group>"; };
 		C0D2DD101B6BF849004E8919 /* RealmConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = RealmConfiguration.swift; path = RealmSwift/RealmConfiguration.swift; sourceTree = SOURCE_ROOT; };

--- a/RealmSwift.xcodeproj/project.pbxproj
+++ b/RealmSwift.xcodeproj/project.pbxproj
@@ -143,7 +143,7 @@
 		C0240C2A1A84090000858BFA /* RealmTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RealmTests.swift; sourceTree = "<group>"; };
 		C042A4911B753A1C00771ED2 /* RealmConfigurationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RealmConfigurationTests.swift; sourceTree = "<group>"; };
 		C04DAEBD1A8E7FBD008A9623 /* Util.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Util.swift; path = RealmSwift/Util.swift; sourceTree = SOURCE_ROOT; };
-		C0716FC01B8E456A00B37CD6 /* Optional.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Optional.swift; path = "RealmSwift/Optional.swift"; sourceTree = SOURCE_ROOT; };
+		C0716FC01B8E456A00B37CD6 /* Optional.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Optional.swift; path = RealmSwift/Optional.swift; sourceTree = SOURCE_ROOT; };
 		C081AEB11AAF865C00BA3E31 /* PropertyTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PropertyTests.swift; sourceTree = "<group>"; };
 		C0CA5BCC1AC0951C007338C5 /* PerformanceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PerformanceTests.swift; sourceTree = "<group>"; };
 		C0D2DD101B6BF849004E8919 /* RealmConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = RealmConfiguration.swift; path = RealmSwift/RealmConfiguration.swift; sourceTree = SOURCE_ROOT; };
@@ -600,7 +600,6 @@
 			buildSettings = {
 				ENABLE_TESTABILITY = YES;
 				ONLY_ACTIVE_ARCH = YES;
-				OTHER_SWIFT_FLAGS = "-D\"REALM_ENABLE_NULL\"";
 			};
 			name = Debug;
 		};
@@ -608,7 +607,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 5DE0B6CB1B0FECF4007831D9 /* Release.xcconfig */;
 			buildSettings = {
-				OTHER_SWIFT_FLAGS = "-D\"REALM_ENABLE_NULL\"";
 			};
 			name = Release;
 		};

--- a/build.sh
+++ b/build.sh
@@ -14,7 +14,7 @@ set -o pipefail
 set -e
 
 # You can override the version of the core library
-: ${REALM_CORE_VERSION:=0.92.2} # set to "current" to always use the current build
+: ${REALM_CORE_VERSION:=0.93.0} # set to "current" to always use the current build
 
 # You can override the xcmode used
 : ${XCMODE:=xcodebuild} # must be one of: xcodebuild (default), xcpretty, xctool


### PR DESCRIPTION
Closes https://github.com/realm/realm-cocoa/issues/2147.
Closes https://github.com/realm/realm-cocoa/issues/2308.

Requires a new core release because of https://github.com/realm/realm-core/pull/1063 and lots more test coverage, but the things I'm doing (particularly the reflection bits and the proxy optional object) are ugly enough to warrant suggestions even now.

- [x] ~~Return `RealmOptional` from `DynamicObject`~~
- [x] Test default values from `RealmOptional`
- [x] Test `NSNumber` default values
- [x] Test schema initialization with non-`RealmOptionalType` `RealmOptional`s
- [x] Test `NSNumber` schema initialization with incorrect protocols
- [x] Decide how to handle optional primitives using Realm Objective-C from Swift, if at all
- [x] Add query tests