### PR TITLE
Add SwiftLint target to RealmSwift.xcodeproj

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,8 +1,8 @@
 # Realm Swift's SwiftLint configuration file
 # Uncomment the commented lines to avoid any violations
 
-excluded:
-  - RealmSwift/Tests
+included:
+  - RealmSwift
 disabled_rules:
   - force_cast
   - todo

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,0 +1,8 @@
+excluded:
+  - RealmSwift/Tests
+disabled_rules:
+  - force_cast
+  - line_length
+  - file_length
+  - type_body_length
+  - todo

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,8 +1,14 @@
+# Realm Swift's SwiftLint configuration file
+# Uncomment the commented lines to avoid any violations
+
 excluded:
   - RealmSwift/Tests
 disabled_rules:
   - force_cast
-  - line_length
-  - file_length
-  - type_body_length
-  - todo
+  # - todo
+line_length:
+  - 120
+# file_length:
+#   - 670
+# type_body_length:
+#   - 581

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -2,7 +2,7 @@
 # Uncomment the commented lines to avoid any violations
 
 included:
-  - RealmSwift
+  - RealmSwift-swift2.0
 disabled_rules:
   - force_cast
   - todo

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -5,10 +5,10 @@ excluded:
   - RealmSwift/Tests
 disabled_rules:
   - force_cast
-  # - todo
+  - todo
 line_length:
   - 120
-# file_length:
-#   - 670
-# type_body_length:
-#   - 581
+file_length:
+  - 670
+type_body_length:
+  - 581

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -5,6 +5,7 @@ included:
   - RealmSwift-swift2.0
 disabled_rules:
   - force_cast
+  - force_try
   - todo
 line_length:
   - 120

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,15 +1,10 @@
-# Realm Swift's SwiftLint configuration file
-# Uncomment the commented lines to avoid any violations
-
 included:
   - RealmSwift-swift2.0
+line_length: 120
 disabled_rules:
   - force_cast
   - force_try
   - todo
-line_length:
-  - 120
-file_length:
-  - 670
-type_body_length:
-  - 581
+  - function_body_length
+  - file_length
+  - type_body_length

--- a/Realm.xcodeproj/project.pbxproj
+++ b/Realm.xcodeproj/project.pbxproj
@@ -18,6 +18,17 @@
 			name = "Set Swift Version";
 			productName = "Swift Version";
 		};
+		E83EAC791BED3D880085CCD2 /* SwiftLint */ = {
+			isa = PBXAggregateTarget;
+			buildConfigurationList = E83EAC7C1BED3D880085CCD2 /* Build configuration list for PBXAggregateTarget "SwiftLint" */;
+			buildPhases = (
+				E83EAC7D1BED3D8F0085CCD2 /* Run SwiftLint */,
+			);
+			dependencies = (
+			);
+			name = SwiftLint;
+			productName = SwiftLint;
+		};
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
@@ -1241,6 +1252,9 @@
 					C04B4BD71B55C47600FAE58E = {
 						CreatedOnToolsVersion = 6.4;
 					};
+					E83EAC791BED3D880085CCD2 = {
+						CreatedOnToolsVersion = 7.1;
+					};
 					E856D1DE195614A400FB2FCF = {
 						CreatedOnToolsVersion = 6.0;
 					};
@@ -1271,6 +1285,7 @@
 				C04B4BD71B55C47600FAE58E /* Set Swift Version */,
 				5D660FCB1BE98C560021E04F /* RealmSwift */,
 				5D660FD71BE98C7C0021E04F /* RealmSwift Tests */,
+				E83EAC791BED3D880085CCD2 /* SwiftLint */,
 			);
 		};
 /* End PBXProject section */
@@ -1282,7 +1297,6 @@
 			files = (
 				5D659ED21BE04556006515A0 /* CHANGELOG.md in Resources */,
 				5D659ED51BE04556006515A0 /* LICENSE in Resources */,
-				5D660FC31BE98BEF0021E04F /* RealmSwift.xcconfig in Resources */,
 				5D6157051BE13CBB00A4BD3F /* strip-frameworks.sh in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1458,6 +1472,20 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "sh build.sh set-swift-version";
+		};
+		E83EAC7D1BED3D8F0085CCD2 /* Run SwiftLint */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Run SwiftLint";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if which swiftlint >/dev/null; then\n  swiftlint\nelse\n  echo \"SwiftLint does not exist, download from https://github.com/realm/SwiftLint\"\nfi";
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -1817,6 +1845,20 @@
 			};
 			name = Release;
 		};
+		E83EAC7A1BED3D880085CCD2 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		E83EAC7B1BED3D880085CCD2 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
 		E856D1EC195614A400FB2FCF /* Debug */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 5DD755E31BE05EA1002800DA /* Tests iOS static.xcconfig */;
@@ -1921,6 +1963,14 @@
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
+		};
+		E83EAC7C1BED3D880085CCD2 /* Build configuration list for PBXAggregateTarget "SwiftLint" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				E83EAC7A1BED3D880085CCD2 /* Debug */,
+				E83EAC7B1BED3D880085CCD2 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
 		};
 		E856D1EB195614A400FB2FCF /* Build configuration list for PBXNativeTarget "iOS static tests" */ = {
 			isa = XCConfigurationList;

--- a/RealmSwift-swift2.0/List.swift
+++ b/RealmSwift-swift2.0/List.swift
@@ -356,6 +356,7 @@ public final class List<T: Object>: ListBase {
         _rlmArray.replaceObjectAtIndex(UInt(index), withObject: unsafeBitCast(object, RLMObject.self))
     }
 
+    // swiftlint:disable variable_name
     /**
     Moves the object at the given source index to the given destination index.
 
@@ -367,6 +368,7 @@ public final class List<T: Object>: ListBase {
     - parameter to:    index to which the object at `from` should be moved.
     */
     public func move(from from: Int, to: Int) {
+        // swiftlint:enable variable_name
         throwForNegativeIndex(from)
         throwForNegativeIndex(to)
         _rlmArray.moveObjectAtIndex(UInt(from), toIndex: UInt(to))

--- a/RealmSwift-swift2.0/List.swift
+++ b/RealmSwift-swift2.0/List.swift
@@ -406,12 +406,12 @@ extension List: RealmCollectionType, RangeReplaceableCollectionType {
     */
     public func replaceRange<C: CollectionType where C.Generator.Element == T>(subRange: Range<Int>,
         with newElements: C) {
-        for _ in subRange {
-            removeAtIndex(subRange.startIndex)
-        }
-        for x in newElements.reverse() {
-            insert(x, atIndex: subRange.startIndex)
-        }
+            for _ in subRange {
+                removeAtIndex(subRange.startIndex)
+            }
+            for x in newElements.reverse() {
+                insert(x, atIndex: subRange.startIndex)
+            }
     }
 
     /// The position of the first element in a non-empty collection.

--- a/RealmSwift-swift2.0/List.swift
+++ b/RealmSwift-swift2.0/List.swift
@@ -405,13 +405,13 @@ extension List: RealmCollectionType, RangeReplaceableCollectionType {
     - parameter newElements: The new elements to be inserted into the List.
     */
     public func replaceRange<C: CollectionType where C.Generator.Element == T>(subRange: Range<Int>,
-        with newElements: C) {
-            for _ in subRange {
-                removeAtIndex(subRange.startIndex)
-            }
-            for x in newElements.reverse() {
-                insert(x, atIndex: subRange.startIndex)
-            }
+                                                                               with newElements: C) {
+        for _ in subRange {
+            removeAtIndex(subRange.startIndex)
+        }
+        for x in newElements.reverse() {
+            insert(x, atIndex: subRange.startIndex)
+        }
     }
 
     /// The position of the first element in a non-empty collection.

--- a/RealmSwift-swift2.0/List.swift
+++ b/RealmSwift-swift2.0/List.swift
@@ -356,7 +356,7 @@ public final class List<T: Object>: ListBase {
         _rlmArray.replaceObjectAtIndex(UInt(index), withObject: unsafeBitCast(object, RLMObject.self))
     }
 
-    // swiftlint:disable variable_name
+    // swiftlint:disable variable_name_min_length
     /**
     Moves the object at the given source index to the given destination index.
 
@@ -368,7 +368,7 @@ public final class List<T: Object>: ListBase {
     - parameter to:    index to which the object at `from` should be moved.
     */
     public func move(from from: Int, to: Int) {
-        // swiftlint:enable variable_name
+        // swiftlint:enable variable_name_min_length
         throwForNegativeIndex(from)
         throwForNegativeIndex(to)
         _rlmArray.moveObjectAtIndex(UInt(from), toIndex: UInt(to))

--- a/RealmSwift-swift2.0/List.swift
+++ b/RealmSwift-swift2.0/List.swift
@@ -69,7 +69,6 @@ public final class List<T: Object>: ListBase {
 
     /// Creates a `List` that holds objects of type `T`.
     public override init() {
-        // FIXME: use T.className()
         super.init(array: RLMArray(objectClassName: (T.self as Object.Type).className()))
     }
 
@@ -405,7 +404,8 @@ extension List: RealmCollectionType, RangeReplaceableCollectionType {
     - parameter subRange:    The range of elements to be replaced.
     - parameter newElements: The new elements to be inserted into the List.
     */
-    public func replaceRange<C: CollectionType where C.Generator.Element == T>(subRange: Range<Int>, with newElements: C) {
+    public func replaceRange<C: CollectionType where C.Generator.Element == T>(subRange: Range<Int>,
+        with newElements: C) {
         for _ in subRange {
             removeAtIndex(subRange.startIndex)
         }
@@ -419,6 +419,7 @@ extension List: RealmCollectionType, RangeReplaceableCollectionType {
     public var startIndex: Int { return 0 }
 
     /// The collection's "past the end" position.
-    /// endIndex is not a valid argument to subscript, and is always reachable from startIndex by zero or more applications of successor().
+    /// endIndex is not a valid argument to subscript, and is always reachable from startIndex by
+    /// zero or more applications of successor().
     public var endIndex: Int { return count }
 }

--- a/RealmSwift-swift2.0/Migration.swift
+++ b/RealmSwift-swift2.0/Migration.swift
@@ -111,7 +111,7 @@ public final class Migration {
     public func enumerate(objectClassName: String, _ block: MigrationObjectEnumerateBlock) {
         rlmMigration.enumerateObjects(objectClassName) {
             block(oldObject: unsafeBitCast($0, MigrationObject.self),
-                newObject: unsafeBitCast($1, MigrationObject.self))
+                  newObject: unsafeBitCast($1, MigrationObject.self))
         }
     }
 

--- a/RealmSwift-swift2.0/Migration.swift
+++ b/RealmSwift-swift2.0/Migration.swift
@@ -54,11 +54,11 @@ Get the schema version for a Realm at a given path.
 */
 public func schemaVersionAtPath(realmPath: String, encryptionKey: NSData? = nil,
     error: NSErrorPointer = nil) -> UInt64? {
-    let version = RLMRealm.schemaVersionAtPath(realmPath, encryptionKey: encryptionKey, error: error)
-    if version == RLMNotVersioned {
-        return nil
-    }
-    return version
+        let version = RLMRealm.schemaVersionAtPath(realmPath, encryptionKey: encryptionKey, error: error)
+        if version == RLMNotVersioned {
+            return nil
+        }
+        return version
 }
 
 /**

--- a/RealmSwift-swift2.0/Migration.swift
+++ b/RealmSwift-swift2.0/Migration.swift
@@ -52,8 +52,7 @@ Get the schema version for a Realm at a given path.
 
 - returns: The version of the Realm at `realmPath` or `nil` if the version cannot be read.
 */
-public func schemaVersionAtPath(realmPath: String,
-    encryptionKey: NSData? = nil,
+public func schemaVersionAtPath(realmPath: String, encryptionKey: NSData? = nil,
     error: NSErrorPointer = nil) -> UInt64? {
     let version = RLMRealm.schemaVersionAtPath(realmPath, encryptionKey: encryptionKey, error: error)
     if version == RLMNotVersioned {

--- a/RealmSwift-swift2.0/Migration.swift
+++ b/RealmSwift-swift2.0/Migration.swift
@@ -52,7 +52,9 @@ Get the schema version for a Realm at a given path.
 
 - returns: The version of the Realm at `realmPath` or `nil` if the version cannot be read.
 */
-public func schemaVersionAtPath(realmPath: String, encryptionKey: NSData? = nil, error: NSErrorPointer = nil) -> UInt64? {
+public func schemaVersionAtPath(realmPath: String,
+    encryptionKey: NSData? = nil,
+    error: NSErrorPointer = nil) -> UInt64? {
     let version = RLMRealm.schemaVersionAtPath(realmPath, encryptionKey: encryptionKey, error: error)
     if version == RLMNotVersioned {
         return nil
@@ -109,7 +111,8 @@ public final class Migration {
     */
     public func enumerate(objectClassName: String, _ block: MigrationObjectEnumerateBlock) {
         rlmMigration.enumerateObjects(objectClassName) {
-            block(oldObject: unsafeBitCast($0, MigrationObject.self), newObject: unsafeBitCast($1, MigrationObject.self))
+            block(oldObject: unsafeBitCast($0, MigrationObject.self),
+                newObject: unsafeBitCast($1, MigrationObject.self))
         }
     }
 

--- a/RealmSwift-swift2.0/Migration.swift
+++ b/RealmSwift-swift2.0/Migration.swift
@@ -53,12 +53,12 @@ Get the schema version for a Realm at a given path.
 - returns: The version of the Realm at `realmPath` or `nil` if the version cannot be read.
 */
 public func schemaVersionAtPath(realmPath: String, encryptionKey: NSData? = nil,
-    error: NSErrorPointer = nil) -> UInt64? {
-        let version = RLMRealm.schemaVersionAtPath(realmPath, encryptionKey: encryptionKey, error: error)
-        if version == RLMNotVersioned {
-            return nil
-        }
-        return version
+                                error: NSErrorPointer = nil) -> UInt64? {
+    let version = RLMRealm.schemaVersionAtPath(realmPath, encryptionKey: encryptionKey, error: error)
+    if version == RLMNotVersioned {
+        return nil
+    }
+    return version
 }
 
 /**

--- a/RealmSwift-swift2.0/Object.swift
+++ b/RealmSwift-swift2.0/Object.swift
@@ -80,7 +80,8 @@ public class Object: RLMObjectBase {
     }
 
     /**
-    Initialize a standalone (unpersisted) `Object` with values from an `Array<AnyObject>` or `Dictionary<String, AnyObject>`.
+    Initialize a standalone (unpersisted) `Object` with values from an `Array<AnyObject>` or
+    `Dictionary<String, AnyObject>`.
     Call `add(_:)` on a `Realm` to add standalone objects to a realm.
 
     - parameter value: The value used to populate the object. This can be any key/value coding compliant
@@ -168,7 +169,6 @@ public class Object: RLMObjectBase {
     - returns: An `Array` of objects of type `T` which have this object as their value for the `propertyName` property.
     */
     public func linkingObjects<T: Object>(type: T.Type, forProperty propertyName: String) -> [T] {
-        // FIXME: use T.className()
         return RLMObjectBaseLinkingObjectsOfClass(self, (T.self as Object.Type).className(), propertyName) as! [T]
     }
 

--- a/RealmSwift-swift2.0/Object.swift
+++ b/RealmSwift-swift2.0/Object.swift
@@ -47,9 +47,9 @@ class Dog: Object {
 - `List<T: Object>` for to-many relationships
 
 `String`, `NSString`, `NSDate`, `NSData` and `Object` subclass properties can be
-optional. `Int`, `Int8`, Int16`, Int32`, `Int64`, `Float`, `Double`, `Bool` 
-and `List` properties cannot. To store an optional number, instead use 
-`RealmOptional<Int>`, `RealmOptional<Float>`, `RealmOptional<Double>`, or 
+optional. `Int`, `Int8`, Int16`, Int32`, `Int64`, `Float`, `Double`, `Bool`
+and `List` properties cannot. To store an optional number, instead use
+`RealmOptional<Int>`, `RealmOptional<Float>`, `RealmOptional<Double>`, or
 `RealmOptional<Bool>` instead, which wraps an optional value of the generic type.
 
 All property types except for `List` and `RealmOptional` *must* be declared as
@@ -58,7 +58,7 @@ non-dynamic `let` properties.
 
 ### Querying
 
-You can gets `Results` of an Object subclass via the `objects(_:)` instance 
+You can gets `Results` of an Object subclass via the `objects(_:)` instance
 method on `Realm`.
 
 ### Relationships
@@ -224,7 +224,7 @@ public class Object: RLMObjectBase {
     /// Objects are considered equal when they are both from the same Realm
     /// and point to the same underlying object in the database.
     public override func isEqual(object: AnyObject?) -> Bool {
-        return RLMObjectBaseAreEqual(self as RLMObjectBase?, object as? RLMObjectBase);
+        return RLMObjectBaseAreEqual(self as RLMObjectBase?, object as? RLMObjectBase)
     }
 
     // MARK: Private functions
@@ -299,7 +299,7 @@ public final class DynamicObject: Object {
 
     /// :nodoc:
     public override class func shouldIncludeInDefaultSchema() -> Bool {
-        return false;
+        return false
     }
 }
 

--- a/RealmSwift-swift2.0/Object.swift
+++ b/RealmSwift-swift2.0/Object.swift
@@ -178,11 +178,11 @@ public class Object: RLMObjectBase {
     public subscript(key: String) -> AnyObject? {
         get {
             if realm == nil {
-                return self.valueForKey(key)
+                return valueForKey(key)
             }
             let property = RLMValidatedGetProperty(self, key)
             if property.type == .Array {
-                return self.listForProperty(property)
+                return listForProperty(property)
             }
             // No special logic is needed for optional numbers here because the NSNumber returned by RLMDynamicGet
             // is better for callers than the RealmOptional that optionalForProperty would give us.
@@ -190,9 +190,8 @@ public class Object: RLMObjectBase {
         }
         set(value) {
             if realm == nil {
-                self.setValue(value, forKey: key)
-            }
-            else {
+                setValue(value, forKey: key)
+            } else {
                 RLMDynamicValidatedSet(self, key, value)
             }
         }
@@ -341,7 +340,8 @@ public class ObjectUtil: NSObject {
     }
 
     @objc private class func getOptionalProperties(object: AnyObject) -> NSDictionary {
-        return Mirror(reflecting: object).children.reduce([String:AnyObject]()) { (var properties: [String:AnyObject], prop: Mirror.Child) in
+        let children = Mirror(reflecting: object).children
+        return children.reduce([String: AnyObject]()) { (var properties: [String:AnyObject], prop: Mirror.Child) in
             guard let name = prop.label else { return properties }
             let mirror = Mirror(reflecting: prop.value)
             let type = mirror.subjectType

--- a/RealmSwift-swift2.0/ObjectSchema.swift
+++ b/RealmSwift-swift2.0/ObjectSchema.swift
@@ -74,6 +74,6 @@ public final class ObjectSchema: CustomStringConvertible {
 extension ObjectSchema: Equatable {}
 
 /// Returns whether the two object schemas are equal.
-public func ==(lhs: ObjectSchema, rhs: ObjectSchema) -> Bool {
+public func == (lhs: ObjectSchema, rhs: ObjectSchema) -> Bool {
     return lhs.rlmObjectSchema.isEqualToObjectSchema(rhs.rlmObjectSchema)
 }

--- a/RealmSwift-swift2.0/Property.swift
+++ b/RealmSwift-swift2.0/Property.swift
@@ -63,6 +63,6 @@ public final class Property: CustomStringConvertible {
 extension Property: Equatable {}
 
 /// Returns whether the two properties are equal.
-public func ==(lhs: Property, rhs: Property) -> Bool {
+public func == (lhs: Property, rhs: Property) -> Bool {
     return lhs.rlmProperty.isEqualToProperty(rhs.rlmProperty)
 }

--- a/RealmSwift-swift2.0/Realm.swift
+++ b/RealmSwift-swift2.0/Realm.swift
@@ -248,7 +248,6 @@ public final class Realm {
     - returns: The created object.
     */
     public func create<T: Object>(type: T.Type, value: AnyObject = [:], update: Bool = false) -> T {
-        // FIXME: use T.className()
         let className = (type as Object.Type).className()
         if update && schema[className]?.primaryKeyProperty == nil {
           throwRealmException("'\(className)' does not have a primary key and can not be updated")
@@ -363,7 +362,6 @@ public final class Realm {
     - returns: All objects of the given type in Realm.
     */
     public func objects<T: Object>(type: T.Type) -> Results<T> {
-        // FIXME: use T.className()
         return Results<T>(RLMGetObjects(rlmRealm, (type as Object.Type).className(), nil))
     }
 
@@ -401,7 +399,6 @@ public final class Realm {
     - returns: An object of type `type` or `nil` if an object with the given primary key does not exist.
     */
     public func objectForPrimaryKey<T: Object>(type: T.Type, key: AnyObject) -> T? {
-        // FIXME: use T.className()
         return unsafeBitCast(RLMGetObject(rlmRealm, (type as Object.Type).className(), key), Optional<T>.self)
     }
 

--- a/RealmSwift-swift2.0/Realm.swift
+++ b/RealmSwift-swift2.0/Realm.swift
@@ -572,7 +572,7 @@ public final class Realm {
 extension Realm: Equatable { }
 
 /// Returns whether the two realms are equal.
-public func ==(lhs: Realm, rhs: Realm) -> Bool {
+public func == (lhs: Realm, rhs: Realm) -> Bool {
     return lhs.rlmRealm == rhs.rlmRealm
 }
 

--- a/RealmSwift-swift2.0/Realm.swift
+++ b/RealmSwift-swift2.0/Realm.swift
@@ -88,14 +88,14 @@ public final class Realm {
 
     /**
     Performs actions contained within the given block inside a write transation.
-	
-    Write transactions cannot be nested, and trying to execute a write transaction 
-	on a `Realm` which is already in a write transaction will throw an exception. 
+
+    Write transactions cannot be nested, and trying to execute a write transaction
+	on a `Realm` which is already in a write transaction will throw an exception.
 	Calls to `write` from `Realm` instances in other threads will block
     until the current write transaction completes.
 
-    Before executing the write transaction, `write` updates the `Realm` to the 
-	latest Realm version, as if `refresh()` was called, and generates notifications 
+    Before executing the write transaction, `write` updates the `Realm` to the
+	latest Realm version, as if `refresh()` was called, and generates notifications
 	if applicable. This has no effect if the `Realm` was already up to date.
 
     - parameter block: The block to be executed inside a write transaction.
@@ -467,8 +467,8 @@ public final class Realm {
     in this Realm on the next cycle of the run loop after the changes are
     committed.  If set to `false`, you must manually call `refresh()` on the Realm to
     update it to get the latest version.
-	
-	Note that on background threads, the run loop is not run by default and you will 
+
+	Note that on background threads, the run loop is not run by default and you will
 	will need to manually call `refresh()` in order to update to the latest version,
 	even if `autorefresh` is set to `true`.
 

--- a/RealmSwift-swift2.0/RealmCollectionType.swift
+++ b/RealmSwift-swift2.0/RealmCollectionType.swift
@@ -563,8 +563,8 @@ public final class AnyRealmCollection<T: Object>: RealmCollectionType {
 
     - returns: `Results` with elements sorted by the given sort descriptors.
     */
-    public func sorted<S: SequenceType where
-        S.Generator.Element == SortDescriptor>(sortDescriptors: S) -> Results<Element> {
+    public func sorted<S: SequenceType where S.Generator.Element == SortDescriptor>
+                      (sortDescriptors: S) -> Results<Element> {
         return base.sorted(sortDescriptors)
     }
 

--- a/RealmSwift-swift2.0/RealmCollectionType.swift
+++ b/RealmSwift-swift2.0/RealmCollectionType.swift
@@ -337,8 +337,8 @@ private final class _AnyRealmCollection<C: RealmCollectionType>: _AnyRealmCollec
 
     - returns: `Results` with elements sorted by the given sort descriptors.
     */
-    override func sorted<S: SequenceType where
-        S.Generator.Element == SortDescriptor>(sortDescriptors: S) -> Results<C.Element> {
+    override func sorted<S: SequenceType where S.Generator.Element == SortDescriptor>
+                        (sortDescriptors: S) -> Results<C.Element> {
         return base.sorted(sortDescriptors)
     }
 

--- a/RealmSwift-swift2.0/RealmCollectionType.swift
+++ b/RealmSwift-swift2.0/RealmCollectionType.swift
@@ -150,7 +150,8 @@ public protocol RealmCollectionType: CollectionType, CustomStringConvertible {
 
     - parameter property: The name of a property conforming to `MinMaxType` to look for a minimum on.
 
-    - returns: The minimum value for the property amongst objects in the collection, or `nil` if the collection is empty.
+    - returns: The minimum value for the property amongst objects in the collection, or `nil` if the
+               collection is empty.
     */
     func min<U: MinMaxType>(property: String) -> U?
 
@@ -161,7 +162,8 @@ public protocol RealmCollectionType: CollectionType, CustomStringConvertible {
 
     - parameter property: The name of a property conforming to `MinMaxType` to look for a maximum on.
 
-    - returns: The maximum value for the property amongst objects in the collection, or `nil` if the collection is empty.
+    - returns: The maximum value for the property amongst objects in the collection, or `nil` if the
+               collection is empty.
     */
     func max<U: MinMaxType>(property: String) -> U?
 
@@ -183,7 +185,8 @@ public protocol RealmCollectionType: CollectionType, CustomStringConvertible {
 
     - parameter property: The name of a property conforming to `AddableType` to calculate average on.
 
-    - returns: The average of the given property over all objects in the collection, or `nil` if the collection is empty.
+    - returns: The average of the given property over all objects in the collection, or `nil` if the
+               collection is empty.
     */
     func average<U: AddableType>(property: String) -> U?
 
@@ -221,7 +224,9 @@ private class _AnyRealmCollectionBase<T: Object>: RealmCollectionType {
     func filter(predicateFormat: String, _ args: AnyObject...) -> Results<Element> { fatalError() }
     func filter(predicate: NSPredicate) -> Results<Element> { fatalError() }
     func sorted(property: String, ascending: Bool) -> Results<Element> { fatalError() }
-    func sorted<S: SequenceType where S.Generator.Element == SortDescriptor>(sortDescriptors: S) -> Results<Element> { fatalError() }
+    func sorted<S: SequenceType where S.Generator.Element == SortDescriptor>(sortDescriptors: S) -> Results<Element> {
+        fatalError()
+    }
     func min<U: MinMaxType>(property: String) -> U? { fatalError() }
     func max<U: MinMaxType>(property: String) -> U? { fatalError() }
     func sum<U: AddableType>(property: String) -> U { fatalError() }
@@ -284,7 +289,9 @@ private final class _AnyRealmCollection<C: RealmCollectionType>: _AnyRealmCollec
 
     - returns: The index of the first matching object, or `nil` if no objects match.
     */
-    override func indexOf(predicateFormat: String, _ args: AnyObject...) -> Int? { return base.indexOf(NSPredicate(format: predicateFormat, argumentArray: args)) }
+    override func indexOf(predicateFormat: String, _ args: AnyObject...) -> Int? {
+        return base.indexOf(NSPredicate(format: predicateFormat, argumentArray: args))
+    }
 
     // MARK: Filtering
 
@@ -295,7 +302,9 @@ private final class _AnyRealmCollection<C: RealmCollectionType>: _AnyRealmCollec
 
     - returns: `Results` containing collection elements that match the given predicate.
     */
-    override func filter(predicateFormat: String, _ args: AnyObject...) -> Results<C.Element> { return base.filter(NSPredicate(format: predicateFormat, argumentArray: args)) }
+    override func filter(predicateFormat: String, _ args: AnyObject...) -> Results<C.Element> {
+        return base.filter(NSPredicate(format: predicateFormat, argumentArray: args))
+    }
 
     /**
     Returns `Results` containing collection elements that match the given predicate.
@@ -317,7 +326,9 @@ private final class _AnyRealmCollection<C: RealmCollectionType>: _AnyRealmCollec
 
     - returns: `Results` containing collection elements sorted by the given property.
     */
-    override func sorted(property: String, ascending: Bool) -> Results<C.Element> { return base.sorted(property, ascending: ascending) }
+    override func sorted(property: String, ascending: Bool) -> Results<C.Element> {
+        return base.sorted(property, ascending: ascending)
+    }
 
     /**
     Returns `Results` with elements sorted by the given sort descriptors.
@@ -326,7 +337,10 @@ private final class _AnyRealmCollection<C: RealmCollectionType>: _AnyRealmCollec
 
     - returns: `Results` with elements sorted by the given sort descriptors.
     */
-    override func sorted<S: SequenceType where S.Generator.Element == SortDescriptor>(sortDescriptors: S) -> Results<C.Element> { return base.sorted(sortDescriptors) }
+    override func sorted<S: SequenceType where
+        S.Generator.Element == SortDescriptor>(sortDescriptors: S) -> Results<C.Element> {
+        return base.sorted(sortDescriptors)
+    }
 
 
     // MARK: Aggregate Operations
@@ -338,7 +352,8 @@ private final class _AnyRealmCollection<C: RealmCollectionType>: _AnyRealmCollec
 
     - parameter property: The name of a property conforming to `MinMaxType` to look for a minimum on.
 
-    - returns: The minimum value for the property amongst objects in the collection, or `nil` if the collection is empty.
+    - returns: The minimum value for the property amongst objects in the collection, or `nil` if the
+               collection is empty.
     */
     override func min<U: MinMaxType>(property: String) -> U? { return base.min(property) }
 
@@ -349,7 +364,8 @@ private final class _AnyRealmCollection<C: RealmCollectionType>: _AnyRealmCollec
 
     - parameter property: The name of a property conforming to `MinMaxType` to look for a maximum on.
 
-    - returns: The maximum value for the property amongst objects in the collection, or `nil` if the collection is empty.
+    - returns: The maximum value for the property amongst objects in the collection, or `nil` if the
+               collection is empty.
     */
     override func max<U: MinMaxType>(property: String) -> U? { return base.max(property) }
 
@@ -371,7 +387,8 @@ private final class _AnyRealmCollection<C: RealmCollectionType>: _AnyRealmCollec
 
     - parameter property: The name of a property conforming to `AddableType` to calculate average on.
 
-    - returns: The average of the given property over all objects in the collection, or `nil` if the collection is empty.
+    - returns: The average of the given property over all objects in the collection, or `nil` if the
+               collection is empty.
     */
     override func average<U: AddableType>(property: String) -> U? { return base.average(property) }
 
@@ -385,21 +402,34 @@ private final class _AnyRealmCollection<C: RealmCollectionType>: _AnyRealmCollec
 
     - returns: The object at the given `index`.
     */
-    override subscript(index: Int) -> C.Element { return unsafeBitCast(base[index as! C.Index], C.Element.self) } // FIXME: it should be possible to avoid this force-casting
+    override subscript(index: Int) -> C.Element {
+        // FIXME: it should be possible to avoid this force-casting
+        return unsafeBitCast(base[index as! C.Index], C.Element.self)
+    }
 
     /// Returns a `GeneratorOf<Element>` that yields successive elements in the collection.
-    override func generate() -> RLMGenerator<Element> { return base.generate() as! RLMGenerator<Element> } // FIXME: it should be possible to avoid this force-casting
+    override func generate() -> RLMGenerator<Element> {
+        // FIXME: it should be possible to avoid this force-casting
+        return base.generate() as! RLMGenerator<Element>
+    }
 
 
     // MARK: Collection Support
 
     /// The position of the first element in a non-empty collection.
     /// Identical to endIndex in an empty collection.
-    override var startIndex: Int { return base.startIndex as! Int } // FIXME: it should be possible to avoid this force-casting
+    override var startIndex: Int {
+        // FIXME: it should be possible to avoid this force-casting
+        return base.startIndex as! Int
+    }
 
     /// The collection's "past the end" position.
-    /// endIndex is not a valid argument to subscript, and is always reachable from startIndex by zero or more applications of successor().
-    override var endIndex: Int { return base.endIndex as! Int } // FIXME: it should be possible to avoid this force-casting
+    /// endIndex is not a valid argument to subscript, and is always reachable from startIndex by
+    /// zero or more applications of successor().
+    override var endIndex: Int {
+        // FIXME: it should be possible to avoid this force-casting
+        return base.endIndex as! Int
+    }
 
 
     // MARK: Key-Value Coding
@@ -485,7 +515,9 @@ public final class AnyRealmCollection<T: Object>: RealmCollectionType {
 
     - returns: The index of the first matching object, or `nil` if no objects match.
     */
-    public func indexOf(predicateFormat: String, _ args: AnyObject...) -> Int? { return base.indexOf(NSPredicate(format: predicateFormat, argumentArray: args)) }
+    public func indexOf(predicateFormat: String, _ args: AnyObject...) -> Int? {
+        return base.indexOf(NSPredicate(format: predicateFormat, argumentArray: args))
+    }
 
     // MARK: Filtering
 
@@ -496,7 +528,9 @@ public final class AnyRealmCollection<T: Object>: RealmCollectionType {
 
     - returns: `Results` containing collection elements that match the given predicate.
     */
-    public func filter(predicateFormat: String, _ args: AnyObject...) -> Results<Element> { return base.filter(NSPredicate(format: predicateFormat, argumentArray: args)) }
+    public func filter(predicateFormat: String, _ args: AnyObject...) -> Results<Element> {
+        return base.filter(NSPredicate(format: predicateFormat, argumentArray: args))
+    }
 
     /**
     Returns `Results` containing collection elements that match the given predicate.
@@ -518,7 +552,9 @@ public final class AnyRealmCollection<T: Object>: RealmCollectionType {
 
     - returns: `Results` containing collection elements sorted by the given property.
     */
-    public func sorted(property: String, ascending: Bool) -> Results<Element> { return base.sorted(property, ascending: ascending) }
+    public func sorted(property: String, ascending: Bool) -> Results<Element> {
+        return base.sorted(property, ascending: ascending)
+    }
 
     /**
     Returns `Results` with elements sorted by the given sort descriptors.
@@ -527,7 +563,10 @@ public final class AnyRealmCollection<T: Object>: RealmCollectionType {
 
     - returns: `Results` with elements sorted by the given sort descriptors.
     */
-    public func sorted<S: SequenceType where S.Generator.Element == SortDescriptor>(sortDescriptors: S) -> Results<Element> { return base.sorted(sortDescriptors) }
+    public func sorted<S: SequenceType where
+        S.Generator.Element == SortDescriptor>(sortDescriptors: S) -> Results<Element> {
+        return base.sorted(sortDescriptors)
+    }
 
 
     // MARK: Aggregate Operations
@@ -539,7 +578,8 @@ public final class AnyRealmCollection<T: Object>: RealmCollectionType {
 
     - parameter property: The name of a property conforming to `MinMaxType` to look for a minimum on.
 
-    - returns: The minimum value for the property amongst objects in the collection, or `nil` if the collection is empty.
+    - returns: The minimum value for the property amongst objects in the collection, or `nil` if the
+               collection is empty.
     */
     public func min<U: MinMaxType>(property: String) -> U? { return base.min(property) }
 
@@ -550,7 +590,8 @@ public final class AnyRealmCollection<T: Object>: RealmCollectionType {
 
     - parameter property: The name of a property conforming to `MinMaxType` to look for a maximum on.
 
-    - returns: The maximum value for the property amongst objects in the collection, or `nil` if the collection is empty.
+    - returns: The maximum value for the property amongst objects in the collection, or `nil` if the
+               collection is empty.
     */
     public func max<U: MinMaxType>(property: String) -> U? { return base.max(property) }
 
@@ -572,7 +613,8 @@ public final class AnyRealmCollection<T: Object>: RealmCollectionType {
 
     - parameter property: The name of a property conforming to `AddableType` to calculate average on.
 
-    - returns: The average of the given property over all objects in the collection, or `nil` if the collection is empty.
+    - returns: The average of the given property over all objects in the collection, or `nil` if the
+               collection is empty.
     */
     public func average<U: AddableType>(property: String) -> U? { return base.average(property) }
 
@@ -599,7 +641,8 @@ public final class AnyRealmCollection<T: Object>: RealmCollectionType {
     public var startIndex: Int { return base.startIndex }
 
     /// The collection's "past the end" position.
-    /// endIndex is not a valid argument to subscript, and is always reachable from startIndex by zero or more applications of successor().
+    /// endIndex is not a valid argument to subscript, and is always reachable from startIndex by
+    /// zero or more applications of successor().
     public var endIndex: Int { return base.endIndex }
 
 

--- a/RealmSwift-swift2.0/RealmConfiguration.swift
+++ b/RealmSwift-swift2.0/RealmConfiguration.swift
@@ -168,6 +168,8 @@ extension Realm {
 extension Realm.Configuration: CustomStringConvertible {
     /// Returns a human-readable description of the configuration.
     public var description: String {
-        return gsub("\\ARLMRealmConfiguration", template: "Realm.Configuration", string: rlmConfiguration.description) ?? ""
+        return gsub("\\ARLMRealmConfiguration",
+            template: "Realm.Configuration",
+            string: rlmConfiguration.description) ?? ""
     }
 }

--- a/RealmSwift-swift2.0/RealmConfiguration.swift
+++ b/RealmSwift-swift2.0/RealmConfiguration.swift
@@ -169,7 +169,7 @@ extension Realm.Configuration: CustomStringConvertible {
     /// Returns a human-readable description of the configuration.
     public var description: String {
         return gsub("\\ARLMRealmConfiguration",
-            template: "Realm.Configuration",
-            string: rlmConfiguration.description) ?? ""
+                    template: "Realm.Configuration",
+                    string: rlmConfiguration.description) ?? ""
     }
 }

--- a/RealmSwift-swift2.0/RealmConfiguration.swift
+++ b/RealmSwift-swift2.0/RealmConfiguration.swift
@@ -77,7 +77,7 @@ extension Realm {
 
         /// The path to the realm file.
         /// Mutually exclusive with `inMemoryIdentifier`.
-        public var path: String?  {
+        public var path: String? {
             set {
                 _inMemoryIdentifier = nil
                 _path = newValue
@@ -91,7 +91,7 @@ extension Realm {
 
         /// A string used to identify a particular in-memory Realm.
         /// Mutually exclusive with `path`.
-        public var inMemoryIdentifier: String?  {
+        public var inMemoryIdentifier: String? {
             set {
                 _path = nil
                 _inMemoryIdentifier = newValue

--- a/RealmSwift-swift2.0/Results.swift
+++ b/RealmSwift-swift2.0/Results.swift
@@ -67,8 +67,8 @@ public class ResultsBase: NSObject, NSFastEnumeration {
                                             objects buffer: AutoreleasingUnsafeMutablePointer<AnyObject?>,
                                             count len: Int) -> Int {
         return Int(rlmResults.countByEnumeratingWithState(state,
-            objects: buffer,
-            count: UInt(len)))
+                   objects: buffer,
+                   count: UInt(len)))
     }
 }
 
@@ -138,7 +138,7 @@ public final class Results<T: Object>: ResultsBase {
     */
     public func indexOf(predicateFormat: String, _ args: AnyObject...) -> Int? {
         return notFoundToNil(rlmResults.indexOfObjectWithPredicate(NSPredicate(format: predicateFormat,
-            argumentArray: args)))
+                                                                               argumentArray: args)))
     }
 
     // MARK: Object Retrieval

--- a/RealmSwift-swift2.0/Results.swift
+++ b/RealmSwift-swift2.0/Results.swift
@@ -66,9 +66,9 @@ public class ResultsBase: NSObject, NSFastEnumeration {
     public func countByEnumeratingWithState(state: UnsafeMutablePointer<NSFastEnumerationState>,
         objects buffer: AutoreleasingUnsafeMutablePointer<AnyObject?>,
         count len: Int) -> Int {
-        return Int(rlmResults.countByEnumeratingWithState(state,
-            objects: buffer,
-            count: UInt(len)))
+            return Int(rlmResults.countByEnumeratingWithState(state,
+                objects: buffer,
+                count: UInt(len)))
     }
 }
 

--- a/RealmSwift-swift2.0/Results.swift
+++ b/RealmSwift-swift2.0/Results.swift
@@ -63,8 +63,12 @@ public class ResultsBase: NSObject, NSFastEnumeration {
 
     // MARK: Fast Enumeration
 
-    public func countByEnumeratingWithState(state: UnsafeMutablePointer<NSFastEnumerationState>, objects buffer: AutoreleasingUnsafeMutablePointer<AnyObject?>, count len: Int) -> Int {
-        return Int(rlmResults.countByEnumeratingWithState(state, objects: buffer, count: UInt(len)))
+    public func countByEnumeratingWithState(state: UnsafeMutablePointer<NSFastEnumerationState>,
+        objects buffer: AutoreleasingUnsafeMutablePointer<AnyObject?>,
+        count len: Int) -> Int {
+        return Int(rlmResults.countByEnumeratingWithState(state,
+            objects: buffer,
+            count: UInt(len)))
     }
 }
 
@@ -133,7 +137,11 @@ public final class Results<T: Object>: ResultsBase {
     - returns: The index of the first matching object, or `nil` if no objects match.
     */
     public func indexOf(predicateFormat: String, _ args: AnyObject...) -> Int? {
-        return notFoundToNil(rlmResults.indexOfObjectWithPredicate(NSPredicate(format: predicateFormat, argumentArray: args)))
+        return notFoundToNil(
+            rlmResults.indexOfObjectWithPredicate(
+                NSPredicate(format: predicateFormat, argumentArray: args)
+            )
+        )
     }
 
     // MARK: Object Retrieval
@@ -302,6 +310,7 @@ extension Results: RealmCollectionType {
     public var startIndex: Int { return 0 }
 
     /// The collection's "past the end" position.
-    /// endIndex is not a valid argument to subscript, and is always reachable from startIndex by zero or more applications of successor().
+    /// endIndex is not a valid argument to subscript, and is always reachable from startIndex by
+    /// zero or more applications of successor().
     public var endIndex: Int { return count }
 }

--- a/RealmSwift-swift2.0/Results.swift
+++ b/RealmSwift-swift2.0/Results.swift
@@ -137,11 +137,8 @@ public final class Results<T: Object>: ResultsBase {
     - returns: The index of the first matching object, or `nil` if no objects match.
     */
     public func indexOf(predicateFormat: String, _ args: AnyObject...) -> Int? {
-        return notFoundToNil(
-            rlmResults.indexOfObjectWithPredicate(
-                NSPredicate(format: predicateFormat, argumentArray: args)
-            )
-        )
+        return notFoundToNil(rlmResults.indexOfObjectWithPredicate(NSPredicate(format: predicateFormat,
+            argumentArray: args)))
     }
 
     // MARK: Object Retrieval

--- a/RealmSwift-swift2.0/Results.swift
+++ b/RealmSwift-swift2.0/Results.swift
@@ -64,11 +64,11 @@ public class ResultsBase: NSObject, NSFastEnumeration {
     // MARK: Fast Enumeration
 
     public func countByEnumeratingWithState(state: UnsafeMutablePointer<NSFastEnumerationState>,
-        objects buffer: AutoreleasingUnsafeMutablePointer<AnyObject?>,
-        count len: Int) -> Int {
-            return Int(rlmResults.countByEnumeratingWithState(state,
-                objects: buffer,
-                count: UInt(len)))
+                                            objects buffer: AutoreleasingUnsafeMutablePointer<AnyObject?>,
+                                            count len: Int) -> Int {
+        return Int(rlmResults.countByEnumeratingWithState(state,
+            objects: buffer,
+            count: UInt(len)))
     }
 }
 

--- a/RealmSwift-swift2.0/Schema.swift
+++ b/RealmSwift-swift2.0/Schema.swift
@@ -64,6 +64,6 @@ public final class Schema: CustomStringConvertible {
 extension Schema: Equatable {}
 
 /// Returns whether the two schemas are equal.
-public func ==(lhs: Schema, rhs: Schema) -> Bool {
+public func == (lhs: Schema, rhs: Schema) -> Bool {
     return lhs.rlmSchema.isEqualToSchema(rhs.rlmSchema)
 }

--- a/RealmSwift-swift2.0/SortDescriptor.swift
+++ b/RealmSwift-swift2.0/SortDescriptor.swift
@@ -76,7 +76,7 @@ extension SortDescriptor: CustomStringConvertible {
 extension SortDescriptor: Equatable {}
 
 /// Returns whether the two sort descriptors are equal.
-public func ==(lhs: SortDescriptor, rhs: SortDescriptor) -> Bool {
+public func == (lhs: SortDescriptor, rhs: SortDescriptor) -> Bool {
     return lhs.property == rhs.property &&
         lhs.ascending == lhs.ascending
 }

--- a/RealmSwift-swift2.0/Tests/KVOTests.swift
+++ b/RealmSwift-swift2.0/Tests/KVOTests.swift
@@ -25,7 +25,9 @@ func nextPrimaryKey() -> Int {
 }
 
 class KVOObject: Object {
+    // swiftlint:disable variable_name
     dynamic var pk = nextPrimaryKey() // primary key for equality
+    // swiftlint:enable variable_name
     dynamic var ignored: Int = 0
 
     dynamic var boolCol: Bool = false
@@ -70,11 +72,13 @@ class KVOTests: TestCase {
     }
 
     var changeDictionary: [NSObject: AnyObject]?
-    override func observeValueForKeyPath(keyPath: String?, ofObject object: AnyObject?, change: [String : AnyObject]?, context: UnsafeMutablePointer<Void>) {
+    override func observeValueForKeyPath(keyPath: String?, ofObject object: AnyObject?,
+                  change: [String : AnyObject]?, context: UnsafeMutablePointer<Void>) {
         changeDictionary = change
     }
 
-    func observeChange(obj: NSObject, _ key: String, _ old: AnyObject, _ new: AnyObject, fileName: String = __FILE__, lineNumber: UInt = __LINE__, _ block: () -> Void) {
+    func observeChange(obj: NSObject, _ key: String, _ old: AnyObject, _ new: AnyObject,
+                       fileName: String = __FILE__, lineNumber: UInt = __LINE__, _ block: () -> Void) {
         obj.addObserver(self, forKeyPath: key, options: [.Old, .New], context: nil)
         block()
         obj.removeObserver(self, forKeyPath: key)
@@ -86,13 +90,16 @@ class KVOTests: TestCase {
 
         let actualOld: AnyObject = changeDictionary![NSKeyValueChangeOldKey]!
         let actualNew: AnyObject = changeDictionary![NSKeyValueChangeNewKey]!
-        XCTAssert(actualOld.isEqual(old), "Old value: expected \(old), got \(actualOld)", file: fileName, line: lineNumber)
-        XCTAssert(actualNew.isEqual(new), "New value: expected \(new), got \(actualNew)", file: fileName, line: lineNumber)
+        XCTAssert(actualOld.isEqual(old), "Old value: expected \(old), got \(actualOld)", file: fileName,
+            line: lineNumber)
+        XCTAssert(actualNew.isEqual(new), "New value: expected \(new), got \(actualNew)", file: fileName,
+            line: lineNumber)
 
         changeDictionary = nil
     }
 
-    func observeListChange(obj: NSObject, _ key: String, _ kind: NSKeyValueChange, _ indexes: NSIndexSet, fileName: String = __FILE__, lineNumber: UInt = __LINE__, _ block: () -> Void) {
+    func observeListChange(obj: NSObject, _ key: String, _ kind: NSKeyValueChange, _ indexes: NSIndexSet,
+                           fileName: String = __FILE__, lineNumber: UInt = __LINE__, _ block: () -> Void) {
         obj.addObserver(self, forKeyPath: key, options: [.Old, .New], context: nil)
         block()
         obj.removeObserver(self, forKeyPath: key)
@@ -102,10 +109,13 @@ class KVOTests: TestCase {
             return
         }
 
-        let actualKind = NSKeyValueChange(rawValue: (changeDictionary![NSKeyValueChangeKindKey] as! NSNumber).unsignedLongValue)!
+        let actualKind = NSKeyValueChange(rawValue: (changeDictionary![NSKeyValueChangeKindKey] as! NSNumber)
+            .unsignedLongValue)!
         let actualIndexes = changeDictionary![NSKeyValueChangeIndexesKey]! as! NSIndexSet
-        XCTAssert(actualKind == kind, "Change kind: expected \(kind), got \(actualKind)", file: fileName, line: lineNumber)
-        XCTAssert(actualIndexes.isEqual(indexes), "Changed indexes: expected \(indexes), got \(actualIndexes)", file: fileName, line: lineNumber)
+        XCTAssert(actualKind == kind, "Change kind: expected \(kind), got \(actualKind)", file: fileName,
+            line: lineNumber)
+        XCTAssert(actualIndexes.isEqual(indexes), "Changed indexes: expected \(indexes), got \(actualIndexes)",
+            file: fileName, line: lineNumber)
 
         changeDictionary = nil
     }
@@ -154,6 +164,7 @@ class KVOTests: TestCase {
         observeChange(obj, "optDateCol", date, NSNull()) { obj.optDateCol = nil }
     }
 
+    // swiftlint:disable function_body_length
     func testAllPropertyTypesPersisted() {
         let obj = KVOObject()
         realm.add(obj)
@@ -263,4 +274,5 @@ class KVOTests: TestCase {
             self.realm.delete(obj2)
         }
     }
+    // swiftlint:enable function_body_length
 }

--- a/RealmSwift-swift2.0/Tests/KVOTests.swift
+++ b/RealmSwift-swift2.0/Tests/KVOTests.swift
@@ -164,7 +164,6 @@ class KVOTests: TestCase {
         observeChange(obj, "optDateCol", date, NSNull()) { obj.optDateCol = nil }
     }
 
-    // swiftlint:disable function_body_length
     func testAllPropertyTypesPersisted() {
         let obj = KVOObject()
         realm.add(obj)
@@ -274,5 +273,4 @@ class KVOTests: TestCase {
             self.realm.delete(obj2)
         }
     }
-    // swiftlint:enable function_body_length
 }

--- a/RealmSwift-swift2.0/Tests/KVOTests.swift
+++ b/RealmSwift-swift2.0/Tests/KVOTests.swift
@@ -25,9 +25,9 @@ func nextPrimaryKey() -> Int {
 }
 
 class KVOObject: Object {
-    // swiftlint:disable variable_name
+    // swiftlint:disable variable_name_min_length
     dynamic var pk = nextPrimaryKey() // primary key for equality
-    // swiftlint:enable variable_name
+    // swiftlint:enable variable_name_min_length
     dynamic var ignored: Int = 0
 
     dynamic var boolCol: Bool = false

--- a/RealmSwift-swift2.0/Tests/ListTests.swift
+++ b/RealmSwift-swift2.0/Tests/ListTests.swift
@@ -185,7 +185,7 @@ class ListTests: TestCase {
         assertThrows(self.array.replace(-200, object: self.str2))
     }
 
-    func testMove()  {
+    func testMove() {
         array.appendContentsOf([str1, str2])
 
         array.move(from: 1, to: 0)

--- a/RealmSwift-swift2.0/Tests/MigrationTests.swift
+++ b/RealmSwift-swift2.0/Tests/MigrationTests.swift
@@ -23,7 +23,7 @@ import Realm.Private
 import Realm.Dynamic
 import Foundation
 
-private func realmWithCustomSchema(path: String, schema :RLMSchema) -> RLMRealm {
+private func realmWithCustomSchema(path: String, schema: RLMSchema) -> RLMRealm {
     return try! RLMRealm(path: path, key: nil, readOnly: false, inMemory: false, dynamic: true, schema: schema)
 }
 
@@ -56,22 +56,23 @@ class MigrationTests: TestCase {
     }
 
     // migrate realm at path and ensure migration
-    private func migrateAndTestRealm(realmPath: String, shouldRun: Bool = true, schemaVersion: UInt64 = 1, autoMigration: Bool = false, block: MigrationBlock? = nil) {
+    private func migrateAndTestRealm(realmPath: String, shouldRun: Bool = true, schemaVersion: UInt64 = 1,
+                                     autoMigration: Bool = false, block: MigrationBlock? = nil) {
         var didRun = false
-        let config = Realm.Configuration(path: realmPath, schemaVersion: schemaVersion, migrationBlock: { migration, oldSchemaVersion in
-            if let block = block {
-                block(migration: migration, oldSchemaVersion: oldSchemaVersion)
-            }
-            didRun = true
-            return
+        let config = Realm.Configuration(path: realmPath, schemaVersion: schemaVersion,
+            migrationBlock: { migration, oldSchemaVersion in
+                if let block = block {
+                    block(migration: migration, oldSchemaVersion: oldSchemaVersion)
+                }
+                didRun = true
+                return
         })
 
         if autoMigration {
             autoreleasepool {
                 _ = try! Realm(configuration: config)
             }
-        }
-        else {
+        } else {
             migrateRealm(config)
         }
 
@@ -80,7 +81,8 @@ class MigrationTests: TestCase {
 
     private func migrateAndTestDefaultRealm(schemaVersion: UInt64 = 1, block: MigrationBlock) {
         migrateAndTestRealm(defaultRealmPath(), schemaVersion: schemaVersion, block: block)
-        Realm.Configuration.defaultConfiguration = Realm.Configuration(path: defaultRealmPath(), schemaVersion: schemaVersion)
+        Realm.Configuration.defaultConfiguration = Realm.Configuration(path: defaultRealmPath(),
+            schemaVersion: schemaVersion)
     }
 
     // MARK Test cases
@@ -89,7 +91,7 @@ class MigrationTests: TestCase {
         createAndTestRealmAtPath(defaultRealmPath())
 
         var didRun = false
-        let config = Realm.Configuration(path: defaultRealmPath(), schemaVersion: 1, migrationBlock: { migration, oldSchemaVersion in
+        let config = Realm.Configuration(path: defaultRealmPath(), schemaVersion: 1, migrationBlock: { _, _ in
             didRun = true
         })
         Realm.Configuration.defaultConfiguration = config
@@ -108,7 +110,7 @@ class MigrationTests: TestCase {
     }
 
     func testSchemaVersionAtPath() {
-        var error : NSError? = nil
+        var error: NSError? = nil
         assertNil(schemaVersionAtPath(defaultRealmPath(), error: &error), "Version should be nil before Realm creation")
         XCTAssertNotNil(error, "Error should be set")
 
@@ -131,7 +133,8 @@ class MigrationTests: TestCase {
     }
 
     func testMigrationProperties() {
-        let prop = RLMProperty(name: "stringCol", type: RLMPropertyType.Int, objectClassName: nil, indexed: false, optional: false)
+        let prop = RLMProperty(name: "stringCol", type: RLMPropertyType.Int, objectClassName: nil, indexed: false,
+            optional: false)
         autoreleasepool {
             realmWithSingleClassProperties(defaultRealmPath(), className: "SwiftStringObject", properties: [prop])
         }
@@ -146,6 +149,7 @@ class MigrationTests: TestCase {
         }
     }
 
+    // swiftlint:disable function_body_length
     func testEnumerate() {
         autoreleasepool {
             _ = try! Realm()
@@ -246,6 +250,7 @@ class MigrationTests: TestCase {
             }
         }
     }
+    // swiftlint:enable function_body_length
 
     func testCreate() {
         autoreleasepool {
@@ -312,6 +317,7 @@ class MigrationTests: TestCase {
         XCTAssertEqual(0, realm.allObjects("SwiftStringObject").count)
     }
 
+    // swiftlint:disable function_body_length
     // test getting/setting all property types
     func testMigrationObject() {
         autoreleasepool {
@@ -409,5 +415,5 @@ class MigrationTests: TestCase {
         // make sure we added new bool objects as object property and in the list
         XCTAssertEqual(try! Realm().objects(SwiftBoolObject).count, 4)
     }
+    // swiftlint:enable function_body_length
 }
-

--- a/RealmSwift-swift2.0/Tests/MigrationTests.swift
+++ b/RealmSwift-swift2.0/Tests/MigrationTests.swift
@@ -282,7 +282,7 @@ class MigrationTests: TestCase {
         }
 
         migrateAndTestDefaultRealm() { migration, oldSchemaVersion in
-            var deleted = false;
+            var deleted = false
             migration.enumerate("SwiftStringObject", { oldObj, newObj in
                 if deleted == false {
                     migration.delete(newObj!)
@@ -303,13 +303,13 @@ class MigrationTests: TestCase {
         }
 
         migrateAndTestDefaultRealm() { migration, oldSchemaVersion in
-            XCTAssertEqual(oldSchemaVersion, 0, "Initial schema version should be 0");
+            XCTAssertEqual(oldSchemaVersion, 0, "Initial schema version should be 0")
 
-            XCTAssertTrue(migration.deleteData("DeletedClass"));
-            XCTAssertFalse(migration.deleteData("NoSuchClass"));
+            XCTAssertTrue(migration.deleteData("DeletedClass"))
+            XCTAssertFalse(migration.deleteData("NoSuchClass"))
 
             migration.create(SwiftStringObject.className(), value: ["migration"])
-            XCTAssertTrue(migration.deleteData(SwiftStringObject.className()));
+            XCTAssertTrue(migration.deleteData(SwiftStringObject.className()))
         }
 
         let realm = dynamicRealm(defaultRealmPath())

--- a/RealmSwift-swift2.0/Tests/MigrationTests.swift
+++ b/RealmSwift-swift2.0/Tests/MigrationTests.swift
@@ -149,7 +149,6 @@ class MigrationTests: TestCase {
         }
     }
 
-    // swiftlint:disable function_body_length
     func testEnumerate() {
         autoreleasepool {
             _ = try! Realm()
@@ -250,7 +249,6 @@ class MigrationTests: TestCase {
             }
         }
     }
-    // swiftlint:enable function_body_length
 
     func testCreate() {
         autoreleasepool {
@@ -317,7 +315,6 @@ class MigrationTests: TestCase {
         XCTAssertEqual(0, realm.allObjects("SwiftStringObject").count)
     }
 
-    // swiftlint:disable function_body_length
     // test getting/setting all property types
     func testMigrationObject() {
         autoreleasepool {
@@ -415,5 +412,4 @@ class MigrationTests: TestCase {
         // make sure we added new bool objects as object property and in the list
         XCTAssertEqual(try! Realm().objects(SwiftBoolObject).count, 4)
     }
-    // swiftlint:enable function_body_length
 }

--- a/RealmSwift-swift2.0/Tests/ObjectAccessorTests.swift
+++ b/RealmSwift-swift2.0/Tests/ObjectAccessorTests.swift
@@ -21,7 +21,6 @@ import RealmSwift
 import Foundation
 
 class ObjectAccessorTests: TestCase {
-    // swiftlint:disable function_body_length
     func setAndTestAllProperties(object: SwiftObject) {
         object.boolCol = true
         XCTAssertEqual(object.boolCol, true)
@@ -66,7 +65,6 @@ class ObjectAccessorTests: TestCase {
         object.objectCol = SwiftBoolObject(value: [true])
         XCTAssertEqual(object.objectCol!.boolCol, true)
     }
-    // swiftlint:enable function_body_length
 
     func testStandaloneAccessors() {
         let object = SwiftObject()
@@ -86,7 +84,6 @@ class ObjectAccessorTests: TestCase {
         try! realm.commitWrite()
     }
 
-    // swiftlint:disable function_body_length
     func testIntSizes() {
         let realm = realmWithTestPath()
 
@@ -146,7 +143,6 @@ class ObjectAccessorTests: TestCase {
         XCTAssertEqual(obj.int32, v32)
         XCTAssertEqual(obj.int64, v64)
     }
-    // swiftlint:enable function_body_length
 
     func testLongType() {
         let longNumber: Int64 = 17179869184
@@ -230,7 +226,6 @@ class ObjectAccessorTests: TestCase {
         }
     }
 
-    // swiftlint:disable function_body_length
     func setAndTestAllOptionalProperties(object: SwiftOptionalObject) {
         object.optNSStringCol = ""
         XCTAssertEqual(object.optNSStringCol!, "")
@@ -334,5 +329,4 @@ class ObjectAccessorTests: TestCase {
         object.optObjectCol = nil
         XCTAssertNil(object.optObjectCol)
     }
-    // swiftlint:enable function_body_length
 }

--- a/RealmSwift-swift2.0/Tests/ObjectAccessorTests.swift
+++ b/RealmSwift-swift2.0/Tests/ObjectAccessorTests.swift
@@ -21,6 +21,7 @@ import RealmSwift
 import Foundation
 
 class ObjectAccessorTests: TestCase {
+    // swiftlint:disable function_body_length
     func setAndTestAllProperties(object: SwiftObject) {
         object.boolCol = true
         XCTAssertEqual(object.boolCol, true)
@@ -65,6 +66,7 @@ class ObjectAccessorTests: TestCase {
         object.objectCol = SwiftBoolObject(value: [true])
         XCTAssertEqual(object.objectCol!.boolCol, true)
     }
+    // swiftlint:enable function_body_length
 
     func testStandaloneAccessors() {
         let object = SwiftObject()
@@ -84,6 +86,7 @@ class ObjectAccessorTests: TestCase {
         try! realm.commitWrite()
     }
 
+    // swiftlint:disable function_body_length
     func testIntSizes() {
         let realm = realmWithTestPath()
 
@@ -143,6 +146,7 @@ class ObjectAccessorTests: TestCase {
         XCTAssertEqual(obj.int32, v32)
         XCTAssertEqual(obj.int64, v64)
     }
+    // swiftlint:enable function_body_length
 
     func testLongType() {
         let longNumber: Int64 = 17179869184
@@ -226,6 +230,7 @@ class ObjectAccessorTests: TestCase {
         }
     }
 
+    // swiftlint:disable function_body_length
     func setAndTestAllOptionalProperties(object: SwiftOptionalObject) {
         object.optNSStringCol = ""
         XCTAssertEqual(object.optNSStringCol!, "")
@@ -329,4 +334,5 @@ class ObjectAccessorTests: TestCase {
         object.optObjectCol = nil
         XCTAssertNil(object.optObjectCol)
     }
+    // swiftlint:enable function_body_length
 }

--- a/RealmSwift-swift2.0/Tests/ObjectCreationTests.swift
+++ b/RealmSwift-swift2.0/Tests/ObjectCreationTests.swift
@@ -202,7 +202,6 @@ class ObjectCreationTests: TestCase {
         }
     }
 
-    // swiftlint:disable function_body_length
     func testCreateWithDictionary() {
         // dictionary with all values specified
         let baselineValues: [String: AnyObject] = [
@@ -246,7 +245,6 @@ class ObjectCreationTests: TestCase {
             }
         }
     }
-    // swiftlint:enable function_body_length
 
     func testCreateWithDefaultsAndDictionary() {
         // test with dictionary with mix of default and one specified value

--- a/RealmSwift-swift2.0/Tests/ObjectCreationTests.swift
+++ b/RealmSwift-swift2.0/Tests/ObjectCreationTests.swift
@@ -30,7 +30,8 @@ class ObjectCreationTests: TestCase {
         XCTAssertNil(object.realm)
 
         // test defaults values
-        verifySwiftObjectWithDictionaryLiteral(object, dictionary: SwiftObject.defaultValues(), boolObjectValue: false, boolObjectListValues: [])
+        verifySwiftObjectWithDictionaryLiteral(object, dictionary: SwiftObject.defaultValues(), boolObjectValue: false,
+            boolObjectListValues: [])
 
         // test realm properties are nil for standalone
         XCTAssertNil(object.realm)
@@ -52,7 +53,8 @@ class ObjectCreationTests: TestCase {
 
     func testInitWithOptionalDefaults() {
         let object = SwiftOptionalDefaultValuesObject()
-        verifySwiftOptionalObjectWithDictionaryLiteral(object, dictionary: SwiftOptionalDefaultValuesObject.defaultValues(), boolObjectValue: true)
+        verifySwiftOptionalObjectWithDictionaryLiteral(object, dictionary:
+            SwiftOptionalDefaultValuesObject.defaultValues(), boolObjectValue: true)
     }
 
     func testInitWithDictionary() {
@@ -77,7 +79,8 @@ class ObjectCreationTests: TestCase {
                 var values = baselineValues
                 values[props[propNum].name] = validValue
                 let object = SwiftObject(value: values)
-                verifySwiftObjectWithDictionaryLiteral(object, dictionary: values, boolObjectValue: true, boolObjectListValues: [true, false])
+                verifySwiftObjectWithDictionaryLiteral(object, dictionary: values, boolObjectValue: true,
+                    boolObjectListValues: [true, false])
             }
         }
 
@@ -96,12 +99,14 @@ class ObjectCreationTests: TestCase {
         // test with dictionary with mix of default and one specified value
         let object = SwiftObject(value: ["intCol": 200])
         let valueDict = defaultSwiftObjectValuesWithReplacements(["intCol": 200])
-        verifySwiftObjectWithDictionaryLiteral(object, dictionary: valueDict, boolObjectValue: false, boolObjectListValues: [])
+        verifySwiftObjectWithDictionaryLiteral(object, dictionary: valueDict, boolObjectValue: false,
+            boolObjectListValues: [])
     }
 
     func testInitWithArray() {
         // array with all values specified
-        let baselineValues = [true, 1, 1.1, 11.1, "b", "b".dataUsingEncoding(NSUTF8StringEncoding)! as NSData, NSDate(timeIntervalSince1970: 2) as NSDate, ["boolCol": true], [[true], [false]]] as [AnyObject]
+        let baselineValues = [true, 1, 1.1, 11.1, "b", "b".dataUsingEncoding(NSUTF8StringEncoding)! as NSData,
+            NSDate(timeIntervalSince1970: 2) as NSDate, ["boolCol": true], [[true], [false]]] as [AnyObject]
 
         // test with valid dictionary literals
         let props = try! Realm().schema["SwiftObject"]!.properties
@@ -111,7 +116,8 @@ class ObjectCreationTests: TestCase {
                 var values = baselineValues
                 values[propNum] = validValue
                 let object = SwiftObject(value: values)
-                verifySwiftObjectWithArrayLiteral(object, array: values, boolObjectValue: true, boolObjectListValues: [true, false])
+                verifySwiftObjectWithArrayLiteral(object, array: values, boolObjectValue: true,
+                    boolObjectListValues: [true, false])
             }
         }
 
@@ -131,7 +137,8 @@ class ObjectCreationTests: TestCase {
         let objectWithInt = SwiftObject(value: ["intCol": 200])
         let objectWithKVCObject = SwiftObject(value: objectWithInt)
         let valueDict = defaultSwiftObjectValuesWithReplacements(["intCol": 200])
-        verifySwiftObjectWithDictionaryLiteral(objectWithKVCObject, dictionary: valueDict, boolObjectValue: false, boolObjectListValues: [])
+        verifySwiftObjectWithDictionaryLiteral(objectWithKVCObject, dictionary: valueDict, boolObjectValue: false,
+            boolObjectListValues: [])
     }
 
     func testGenericInit() {
@@ -140,7 +147,8 @@ class ObjectCreationTests: TestCase {
         }
         let obj1: SwiftBoolObject = createObject()
         let obj2 = SwiftBoolObject()
-        XCTAssertEqual(obj1.boolCol, obj2.boolCol, "object created via generic initializer should equal object created by calling initializer directly")
+        XCTAssertEqual(obj1.boolCol, obj2.boolCol,
+            "object created via generic initializer should equal object created by calling initializer directly")
     }
 
     // MARK: Creation tests
@@ -157,7 +165,8 @@ class ObjectCreationTests: TestCase {
             object = realm.create(SwiftObject)
             return
         }
-        verifySwiftObjectWithDictionaryLiteral(object, dictionary: SwiftObject.defaultValues(), boolObjectValue: false, boolObjectListValues: [])
+        verifySwiftObjectWithDictionaryLiteral(object, dictionary: SwiftObject.defaultValues(), boolObjectValue: false,
+            boolObjectListValues: [])
 
         // test realm properties are populated correctly
         XCTAssertEqual(object.realm!, realm)
@@ -179,7 +188,8 @@ class ObjectCreationTests: TestCase {
         let realm = try! Realm()
         try! realm.write {
             let object = realm.create(SwiftOptionalDefaultValuesObject)
-            self.verifySwiftOptionalObjectWithDictionaryLiteral(object, dictionary: SwiftOptionalDefaultValuesObject.defaultValues(), boolObjectValue: true)
+            self.verifySwiftOptionalObjectWithDictionaryLiteral(object,
+                dictionary: SwiftOptionalDefaultValuesObject.defaultValues(), boolObjectValue: true)
         }
     }
 
@@ -192,19 +202,20 @@ class ObjectCreationTests: TestCase {
         }
     }
 
+    // swiftlint:disable function_body_length
     func testCreateWithDictionary() {
         // dictionary with all values specified
-        let baselineValues =
-            ["boolCol": true as NSNumber,
-                "intCol": 1 as NSNumber,
-                "floatCol": 1.1 as NSNumber,
-                "doubleCol": 11.1 as NSNumber,
-                "stringCol": "b" as NSString,
-                "binaryCol": "b".dataUsingEncoding(NSUTF8StringEncoding)! as NSData,
-                "dateCol": NSDate(timeIntervalSince1970: 2) as NSDate,
-                "objectCol": SwiftBoolObject(value: [true]) as AnyObject,
-                "arrayCol": [SwiftBoolObject(value: [true]), SwiftBoolObject()]  as AnyObject
-            ]
+        let baselineValues: [String: AnyObject] = [
+            "boolCol": true,
+            "intCol": 1,
+            "floatCol": 1.1,
+            "doubleCol": 11.1,
+            "stringCol": "b",
+            "binaryCol": "b".dataUsingEncoding(NSUTF8StringEncoding)!,
+            "dateCol": NSDate(timeIntervalSince1970: 2),
+            "objectCol": SwiftBoolObject(value: [true]),
+            "arrayCol": [SwiftBoolObject(value: [true]), SwiftBoolObject()]
+        ]
 
         // test with valid dictionary literals
         let props = try! Realm().schema["SwiftObject"]!.properties
@@ -215,9 +226,11 @@ class ObjectCreationTests: TestCase {
                 values[props[propNum].name] = validValue
                 try! Realm().beginWrite()
                 let object = try! Realm().create(SwiftObject.self, value: values)
-                verifySwiftObjectWithDictionaryLiteral(object, dictionary: values, boolObjectValue: true, boolObjectListValues: [true, false])
+                verifySwiftObjectWithDictionaryLiteral(object, dictionary: values, boolObjectValue: true,
+                    boolObjectListValues: [true, false])
                 try! Realm().commitWrite()
-                verifySwiftObjectWithDictionaryLiteral(object, dictionary: values, boolObjectValue: true, boolObjectListValues: [true, false])
+                verifySwiftObjectWithDictionaryLiteral(object, dictionary: values, boolObjectValue: true,
+                    boolObjectListValues: [true, false])
             }
         }
 
@@ -233,6 +246,7 @@ class ObjectCreationTests: TestCase {
             }
         }
     }
+    // swiftlint:enable function_body_length
 
     func testCreateWithDefaultsAndDictionary() {
         // test with dictionary with mix of default and one specified value
@@ -242,12 +256,14 @@ class ObjectCreationTests: TestCase {
         try! realm.commitWrite()
 
         let valueDict = defaultSwiftObjectValuesWithReplacements(["intCol": 200])
-        verifySwiftObjectWithDictionaryLiteral(objectWithInt, dictionary: valueDict, boolObjectValue: false, boolObjectListValues: [])
+        verifySwiftObjectWithDictionaryLiteral(objectWithInt, dictionary: valueDict, boolObjectValue: false,
+            boolObjectListValues: [])
     }
 
     func testCreateWithArray() {
         // array with all values specified
-        let baselineValues = [true, 1, 1.1, 11.1, "b", "b".dataUsingEncoding(NSUTF8StringEncoding)! as NSData, NSDate(timeIntervalSince1970: 2) as NSDate, ["boolCol": true], [[true], [false]]] as [AnyObject]
+        let baselineValues = [true, 1, 1.1, 11.1, "b", "b".dataUsingEncoding(NSUTF8StringEncoding)! as NSData,
+            NSDate(timeIntervalSince1970: 2) as NSDate, ["boolCol": true], [[true], [false]]] as [AnyObject]
 
         // test with valid dictionary literals
         let props = try! Realm().schema["SwiftObject"]!.properties
@@ -258,9 +274,11 @@ class ObjectCreationTests: TestCase {
                 values[propNum] = validValue
                 try! Realm().beginWrite()
                 let object = try! Realm().create(SwiftObject.self, value: values)
-                verifySwiftObjectWithArrayLiteral(object, array: values, boolObjectValue: true, boolObjectListValues: [true, false])
+                verifySwiftObjectWithArrayLiteral(object, array: values, boolObjectValue: true,
+                    boolObjectListValues: [true, false])
                 try! Realm().commitWrite()
-                verifySwiftObjectWithArrayLiteral(object, array: values, boolObjectValue: true, boolObjectListValues: [true, false])
+                verifySwiftObjectWithArrayLiteral(object, array: values, boolObjectValue: true,
+                    boolObjectListValues: [true, false])
             }
         }
 
@@ -272,7 +290,8 @@ class ObjectCreationTests: TestCase {
                 values[propNum] = invalidValue
 
                 try! Realm().beginWrite()
-                assertThrows(try! Realm().create(SwiftObject.self, value: values), "Invalid property value '\(invalidValue)' for property number \(propNum)")
+                assertThrows(try! Realm().create(SwiftObject.self, value: values),
+                    "Invalid property value '\(invalidValue)' for property number \(propNum)")
                 try! Realm().cancelWrite()
             }
         }
@@ -286,7 +305,8 @@ class ObjectCreationTests: TestCase {
         let valueDict = defaultSwiftObjectValuesWithReplacements(["intCol": 200])
         try! Realm().commitWrite()
 
-        verifySwiftObjectWithDictionaryLiteral(objectWithKVCObject, dictionary: valueDict, boolObjectValue: false, boolObjectListValues: [])
+        verifySwiftObjectWithDictionaryLiteral(objectWithKVCObject, dictionary: valueDict, boolObjectValue: false,
+            boolObjectListValues: [])
         XCTAssertEqual(try! Realm().objects(SwiftObject).count, 2, "Object should have been copied")
     }
 
@@ -294,27 +314,31 @@ class ObjectCreationTests: TestCase {
         let standalone = SwiftPrimaryStringObject(value: ["p0", 11])
 
         try! Realm().beginWrite()
-        let objectWithNestedObjects = try! Realm().create(SwiftLinkToPrimaryStringObject.self, value: ["p1", ["p1", 11], [standalone]])
+        let objectWithNestedObjects = try! Realm().create(SwiftLinkToPrimaryStringObject.self, value: ["p1", ["p1", 11],
+            [standalone]])
         try! Realm().commitWrite()
 
         let stringObjects = try! Realm().objects(SwiftPrimaryStringObject)
         XCTAssertEqual(stringObjects.count, 2)
         let persistedObject = stringObjects.first!
 
-        XCTAssertNotEqual(standalone, persistedObject) // standalone object should be copied into the realm, not added directly
+        // standalone object should be copied into the realm, not added directly
+        XCTAssertNotEqual(standalone, persistedObject)
         XCTAssertEqual(objectWithNestedObjects.object!, persistedObject)
         XCTAssertEqual(objectWithNestedObjects.objects.first!, stringObjects.last!)
 
         let standalone1 = SwiftPrimaryStringObject(value: ["p3", 11])
         try! Realm().beginWrite()
-        assertThrows(try! Realm().create(SwiftLinkToPrimaryStringObject.self, value: ["p3", ["p3", 11], [standalone1]]), "Should throw with duplicate primary key")
+        assertThrows(try! Realm().create(SwiftLinkToPrimaryStringObject.self, value: ["p3", ["p3", 11], [standalone1]]),
+            "Should throw with duplicate primary key")
         try! Realm().commitWrite()
     }
 
     func testUpdateWithNestedObjects() {
         let standalone = SwiftPrimaryStringObject(value: ["primary", 11])
         try! Realm().beginWrite()
-        let object = try! Realm().create(SwiftLinkToPrimaryStringObject.self, value: ["otherPrimary", ["primary", 12], [["primary", 12]]], update: true)
+        let object = try! Realm().create(SwiftLinkToPrimaryStringObject.self, value: ["otherPrimary", ["primary", 12],
+            [["primary", 12]]], update: true)
         try! Realm().commitWrite()
 
         let stringObjects = try! Realm().objects(SwiftPrimaryStringObject)
@@ -349,12 +373,14 @@ class ObjectCreationTests: TestCase {
         try! Realm().commitWrite()
 
         XCTAssertNotEqual(otherRealmObject, object)
-        verifySwiftObjectWithDictionaryLiteral(object, dictionary: values, boolObjectValue: true, boolObjectListValues: [true, false])
+        verifySwiftObjectWithDictionaryLiteral(object, dictionary: values, boolObjectValue: true,
+            boolObjectListValues: [true, false])
     }
 
     func testUpdateWithObjectsFromAnotherRealm() {
         realmWithTestPath().beginWrite()
-        let otherRealmObject = realmWithTestPath().create(SwiftLinkToPrimaryStringObject.self, value: ["primary", NSNull(), [["2", 2], ["4", 4]]])
+        let otherRealmObject = realmWithTestPath().create(SwiftLinkToPrimaryStringObject.self,
+            value: ["primary", NSNull(), [["2", 2], ["4", 4]]])
         try! realmWithTestPath().commitWrite()
 
         try! Realm().beginWrite()
@@ -422,7 +448,8 @@ class ObjectCreationTests: TestCase {
     }
 
     // MARK: Private utilities
-    private func verifySwiftObjectWithArrayLiteral(object: SwiftObject, array: [AnyObject], boolObjectValue: Bool, boolObjectListValues: [Bool]) {
+    private func verifySwiftObjectWithArrayLiteral(object: SwiftObject, array: [AnyObject], boolObjectValue: Bool,
+                                                   boolObjectListValues: [Bool]) {
         XCTAssertEqual(object.boolCol, (array[0] as! Bool))
         XCTAssertEqual(object.intCol, (array[1] as! Int))
         XCTAssertEqual(object.floatCol, (array[2] as! Float))
@@ -437,7 +464,8 @@ class ObjectCreationTests: TestCase {
         }
     }
 
-    private func verifySwiftObjectWithDictionaryLiteral(object: SwiftObject, dictionary: [String:AnyObject], boolObjectValue: Bool, boolObjectListValues: [Bool]) {
+    private func verifySwiftObjectWithDictionaryLiteral(object: SwiftObject, dictionary: [String:AnyObject],
+                                                        boolObjectValue: Bool, boolObjectListValues: [Bool]) {
         XCTAssertEqual(object.boolCol, (dictionary["boolCol"] as! Bool))
         XCTAssertEqual(object.intCol, (dictionary["intCol"] as! Int))
         XCTAssertEqual(object.floatCol, (dictionary["floatCol"] as! Float))
@@ -452,12 +480,17 @@ class ObjectCreationTests: TestCase {
         }
     }
 
-    private func verifySwiftOptionalObjectWithDictionaryLiteral(object: SwiftOptionalDefaultValuesObject, dictionary: [String:AnyObject], boolObjectValue: Bool?) {
+    private func verifySwiftOptionalObjectWithDictionaryLiteral(object: SwiftOptionalDefaultValuesObject,
+                                                                dictionary: [String:AnyObject],
+                                                                boolObjectValue: Bool?) {
         XCTAssertEqual(object.optBoolCol.value, (dictionary["optBoolCol"] as! Bool?))
         XCTAssertEqual(object.optIntCol.value, (dictionary["optIntCol"] as! Int?))
-        XCTAssertEqual(object.optInt8Col.value, ((dictionary["optInt8Col"] as! NSNumber?)?.longValue).map({Int8($0)}))
-        XCTAssertEqual(object.optInt16Col.value, ((dictionary["optInt16Col"] as! NSNumber?)?.longValue).map({Int16($0)}))
-        XCTAssertEqual(object.optInt32Col.value, ((dictionary["optInt32Col"] as! NSNumber?)?.longValue).map({Int32($0)}))
+        XCTAssertEqual(object.optInt8Col.value,
+                       ((dictionary["optInt8Col"] as! NSNumber?)?.longValue).map({Int8($0)}))
+        XCTAssertEqual(object.optInt16Col.value,
+                       ((dictionary["optInt16Col"] as! NSNumber?)?.longValue).map({Int16($0)}))
+        XCTAssertEqual(object.optInt32Col.value,
+            ((dictionary["optInt32Col"] as! NSNumber?)?.longValue).map({Int32($0)}))
         XCTAssertEqual(object.optInt64Col.value, (dictionary["optInt64Col"] as! NSNumber?)?.longLongValue)
         XCTAssertEqual(object.optFloatCol.value, (dictionary["optFloatCol"] as! Float?))
         XCTAssertEqual(object.optDoubleCol.value, (dictionary["optDoubleCol"] as! Double?))
@@ -490,7 +523,12 @@ class ObjectCreationTests: TestCase {
             case .Data:     return ["b".dataUsingEncoding(NSUTF8StringEncoding, allowLossyConversion: false)! as NSData]
             case .Date:     return [NSDate(timeIntervalSince1970: 2) as AnyObject]
             case .Object:   return [[true], ["boolCol": true], SwiftBoolObject(value: [true]), persistedObject]
-            case .Array:    return [[[true], [false]], [["boolCol": true], ["boolCol": false]], [SwiftBoolObject(value: [true]), SwiftBoolObject(value: [false])], [persistedObject, [false]]]
+            case .Array:    return [
+                [[true], [false]],
+                [["boolCol": true], ["boolCol": false]],
+                [SwiftBoolObject(value: [true]), SwiftBoolObject(value: [false])],
+                [persistedObject, [false]]
+            ]
             case .Any:      XCTFail("not supported")
         }
         return []
@@ -515,4 +553,3 @@ class ObjectCreationTests: TestCase {
         return []
     }
 }
-

--- a/RealmSwift-swift2.0/Tests/ObjectSchemaInitializationTests.swift
+++ b/RealmSwift-swift2.0/Tests/ObjectSchemaInitializationTests.swift
@@ -23,6 +23,7 @@ import Realm.Dynamic
 import Foundation
 
 class ObjectSchemaInitializationTests: TestCase {
+    // swiftlint:disable function_body_length
     func testAllValidTypes() {
         let object = SwiftObject()
         let objectSchema = object.objectSchema
@@ -110,24 +111,33 @@ class ObjectSchemaInitializationTests: TestCase {
         XCTAssertFalse(arrayCol!.optional)
         XCTAssertEqual(dynamicArrayCol!.objectClassName!, "SwiftEmployeeObject")
     }
+    // swiftlint:enable function_body_length
 
     func testInvalidObjects() {
-        let schema = RLMObjectSchema(forObjectClass: SwiftFakeObjectSubclass.self) // Should be able to get a schema for a non-RLMObjectBase subclass
+        // Should be able to get a schema for a non-RLMObjectBase subclass
+        let schema = RLMObjectSchema(forObjectClass: SwiftFakeObjectSubclass.self)
         XCTAssertEqual(schema.properties.count, 1)
 
         // FIXME - disable any and make sure this fails
-        _ = RLMObjectSchema(forObjectClass: SwiftObjectWithAnyObject.self)  // Should throw when not ignoring a property of a type we can't persist
+        // Should throw when not ignoring a property of a type we can't persist
+        _ = RLMObjectSchema(forObjectClass: SwiftObjectWithAnyObject.self)
 
-        _ = RLMObjectSchema(forObjectClass: SwiftObjectWithEnum.self)       // Shouldn't throw when not ignoring a property of a type we can't persist if it's not dynamic
-        _ = RLMObjectSchema(forObjectClass: SwiftObjectWithStruct.self)     // Shouldn't throw when not ignoring a property of a type we can't persist if it's not dynamic
+        // Shouldn't throw when not ignoring a property of a type we can't persist if it's not dynamic
+        _ = RLMObjectSchema(forObjectClass: SwiftObjectWithEnum.self)
+        // Shouldn't throw when not ignoring a property of a type we can't persist if it's not dynamic
+        _ = RLMObjectSchema(forObjectClass: SwiftObjectWithStruct.self)
 
-        assertThrows(RLMObjectSchema(forObjectClass: SwiftObjectWithDatePrimaryKey.self), "Should throw when setting a non int/string primary key")
-        assertThrows(RLMObjectSchema(forObjectClass: SwiftObjectWithNSURL.self), "Should throw when not ignoring a property of a type we can't persist")
-        assertThrows(RLMObjectSchema(forObjectClass: SwiftObjectWithNonOptionalLinkProperty.self), "Should throw when not marking a link property as optional")
+        assertThrows(RLMObjectSchema(forObjectClass: SwiftObjectWithDatePrimaryKey.self),
+            "Should throw when setting a non int/string primary key")
+        assertThrows(RLMObjectSchema(forObjectClass: SwiftObjectWithNSURL.self),
+            "Should throw when not ignoring a property of a type we can't persist")
+        assertThrows(RLMObjectSchema(forObjectClass: SwiftObjectWithNonOptionalLinkProperty.self),
+            "Should throw when not marking a link property as optional")
     }
 
     func testPrimaryKey() {
-        XCTAssertNil(SwiftObject().objectSchema.primaryKeyProperty, "Object should default to having no primary key property")
+        XCTAssertNil(SwiftObject().objectSchema.primaryKeyProperty,
+            "Object should default to having no primary key property")
         XCTAssertEqual(SwiftPrimaryStringObject().objectSchema.primaryKeyProperty!.name, "stringCol")
     }
 
@@ -143,7 +153,8 @@ class ObjectSchemaInitializationTests: TestCase {
 
         let unindexibleSchema = RLMObjectSchema(forObjectClass: SwiftObjectWithUnindexibleProperties.self)
         for propName in SwiftObjectWithUnindexibleProperties.indexedProperties() {
-            XCTAssertFalse(unindexibleSchema[propName]!.indexed, "Shouldn't mark unindexible property '\(propName)' as indexed")
+            XCTAssertFalse(unindexibleSchema[propName]!.indexed,
+                "Shouldn't mark unindexible property '\(propName)' as indexed")
         }
     }
 
@@ -172,14 +183,14 @@ class ObjectSchemaInitializationTests: TestCase {
     }
 }
 
-class SwiftFakeObject : NSObject {
+class SwiftFakeObject: NSObject {
     dynamic class func primaryKey() -> String! { return nil }
     dynamic class func ignoredProperties() -> [String] { return [] }
     dynamic class func indexedProperties() -> [String] { return [] }
 }
 
 class SwiftObjectWithNSURL: SwiftFakeObject {
-    dynamic var URL = NSURL(string: "http://realm.io")!
+    dynamic var url = NSURL(string: "http://realm.io")!
 }
 
 class SwiftObjectWithAnyObject: SwiftFakeObject {
@@ -226,9 +237,11 @@ class SwiftObjectWithUnindexibleProperties: SwiftFakeObject {
     }
 }
 
+// swiftlint:disable type_name
 class SwiftObjectWithNonNullableOptionalProperties: SwiftFakeObject {
     dynamic var optDateCol: NSDate?
 }
+// swiftlint:enable type_name
 
 class SwiftObjectWithNonOptionalLinkProperty: SwiftFakeObject {
     dynamic var objectCol = SwiftBoolObject()

--- a/RealmSwift-swift2.0/Tests/ObjectSchemaInitializationTests.swift
+++ b/RealmSwift-swift2.0/Tests/ObjectSchemaInitializationTests.swift
@@ -23,7 +23,6 @@ import Realm.Dynamic
 import Foundation
 
 class ObjectSchemaInitializationTests: TestCase {
-    // swiftlint:disable function_body_length
     func testAllValidTypes() {
         let object = SwiftObject()
         let objectSchema = object.objectSchema
@@ -111,7 +110,6 @@ class ObjectSchemaInitializationTests: TestCase {
         XCTAssertFalse(arrayCol!.optional)
         XCTAssertEqual(dynamicArrayCol!.objectClassName!, "SwiftEmployeeObject")
     }
-    // swiftlint:enable function_body_length
 
     func testInvalidObjects() {
         // Should be able to get a schema for a non-RLMObjectBase subclass

--- a/RealmSwift-swift2.0/Tests/ObjectSchemaTests.swift
+++ b/RealmSwift-swift2.0/Tests/ObjectSchemaTests.swift
@@ -29,7 +29,9 @@ class ObjectSchemaTests: TestCase {
     func testProperties() {
         let objectSchema = swiftObjectSchema
         let propertyNames = objectSchema.properties.map { $0.name }
-        XCTAssertEqual(propertyNames, ["boolCol", "intCol", "floatCol", "doubleCol", "stringCol", "binaryCol", "dateCol", "objectCol", "arrayCol"])
+        XCTAssertEqual(propertyNames,
+            ["boolCol", "intCol", "floatCol", "doubleCol", "stringCol", "binaryCol", "dateCol", "objectCol", "arrayCol"]
+        )
     }
 
     // Cannot name testClassName() because it interferes with the method on XCTest
@@ -46,7 +48,9 @@ class ObjectSchemaTests: TestCase {
 
     func testDescription() {
         let objectSchema = swiftObjectSchema
+        // swiftlint:disable line_length
         XCTAssertEqual(objectSchema.description, "SwiftObject {\n\tboolCol {\n\t\ttype = bool;\n\t\tobjectClassName = (null);\n\t\tindexed = NO;\n\t\tisPrimary = NO;\n\t\toptional = NO;\n\t}\n\tintCol {\n\t\ttype = int;\n\t\tobjectClassName = (null);\n\t\tindexed = NO;\n\t\tisPrimary = NO;\n\t\toptional = NO;\n\t}\n\tfloatCol {\n\t\ttype = float;\n\t\tobjectClassName = (null);\n\t\tindexed = NO;\n\t\tisPrimary = NO;\n\t\toptional = NO;\n\t}\n\tdoubleCol {\n\t\ttype = double;\n\t\tobjectClassName = (null);\n\t\tindexed = NO;\n\t\tisPrimary = NO;\n\t\toptional = NO;\n\t}\n\tstringCol {\n\t\ttype = string;\n\t\tobjectClassName = (null);\n\t\tindexed = NO;\n\t\tisPrimary = NO;\n\t\toptional = NO;\n\t}\n\tbinaryCol {\n\t\ttype = data;\n\t\tobjectClassName = (null);\n\t\tindexed = NO;\n\t\tisPrimary = NO;\n\t\toptional = NO;\n\t}\n\tdateCol {\n\t\ttype = date;\n\t\tobjectClassName = (null);\n\t\tindexed = NO;\n\t\tisPrimary = NO;\n\t\toptional = NO;\n\t}\n\tobjectCol {\n\t\ttype = object;\n\t\tobjectClassName = SwiftBoolObject;\n\t\tindexed = NO;\n\t\tisPrimary = NO;\n\t\toptional = YES;\n\t}\n\tarrayCol {\n\t\ttype = array;\n\t\tobjectClassName = SwiftBoolObject;\n\t\tindexed = NO;\n\t\tisPrimary = NO;\n\t\toptional = NO;\n\t}\n}")
+        // swiftlint:enable line_length
     }
 
     func testSubscript() {

--- a/RealmSwift-swift2.0/Tests/ObjectTests.swift
+++ b/RealmSwift-swift2.0/Tests/ObjectTests.swift
@@ -53,7 +53,9 @@ class ObjectTests: TestCase {
         XCTAssert(schema as AnyObject is ObjectSchema)
         XCTAssert(schema.properties as AnyObject is [Property])
         XCTAssertEqual(schema.className, "SwiftObject")
-        XCTAssertEqual(schema.properties.map { $0.name }, ["boolCol", "intCol", "floatCol", "doubleCol", "stringCol", "binaryCol", "dateCol", "objectCol", "arrayCol"])
+        XCTAssertEqual(schema.properties.map { $0.name },
+            ["boolCol", "intCol", "floatCol", "doubleCol", "stringCol", "binaryCol", "dateCol", "objectCol", "arrayCol"]
+        )
     }
 
     func testInvalidated() {
@@ -75,11 +77,13 @@ class ObjectTests: TestCase {
 
     func testDescription() {
         let object = SwiftObject()
+        // swiftlint:disable line_length
         XCTAssertEqual(object.description, "SwiftObject {\n\tboolCol = 0;\n\tintCol = 123;\n\tfloatCol = 1.23;\n\tdoubleCol = 12.3;\n\tstringCol = a;\n\tbinaryCol = <61 — 1 total bytes>;\n\tdateCol = 1970-01-01 00:00:01 +0000;\n\tobjectCol = SwiftBoolObject {\n\t\tboolCol = 0;\n\t};\n\tarrayCol = List<SwiftBoolObject> (\n\t\n\t);\n}")
 
         let recursiveObject = SwiftRecursiveObject()
         recursiveObject.objects.append(recursiveObject)
         XCTAssertEqual(recursiveObject.description, "SwiftRecursiveObject {\n\tobjects = List<SwiftRecursiveObject> (\n\t\t[0] SwiftRecursiveObject {\n\t\t\tobjects = List<SwiftRecursiveObject> (\n\t\t\t\t[0] SwiftRecursiveObject {\n\t\t\t\t\tobjects = <Maximum depth exceeded>;\n\t\t\t\t}\n\t\t\t);\n\t\t}\n\t);\n}")
+        // swiftlint:enable line_length
     }
 
     func testPrimaryKey() {
@@ -125,7 +129,8 @@ class ObjectTests: TestCase {
             XCTAssertEqual(object.valueForKey("floatCol") as! Float!, 1.23 as Float)
             XCTAssertEqual(object.valueForKey("doubleCol") as! Double!, 12.3)
             XCTAssertEqual(object.valueForKey("stringCol") as! String!, "a")
-            XCTAssertEqual((object.valueForKey("binaryCol") as! NSData), "a".dataUsingEncoding(NSUTF8StringEncoding)! as NSData)
+            XCTAssertEqual((object.valueForKey("binaryCol") as! NSData),
+                "a".dataUsingEncoding(NSUTF8StringEncoding)! as NSData)
             XCTAssertEqual(object.valueForKey("dateCol") as! NSDate!, NSDate(timeIntervalSince1970: 1))
             XCTAssertEqual((object.valueForKey("objectCol")! as! SwiftBoolObject).boolCol, false)
             XCTAssert(object.valueForKey("arrayCol")! is List<SwiftBoolObject>)
@@ -138,7 +143,8 @@ class ObjectTests: TestCase {
         }
     }
 
-    func setAndTestAllTypes(setter: (SwiftObject, AnyObject?, String) -> (), getter: (SwiftObject, String) -> (AnyObject?), object: SwiftObject) {
+    func setAndTestAllTypes(setter: (SwiftObject, AnyObject?, String) -> (),
+                            getter: (SwiftObject, String) -> (AnyObject?), object: SwiftObject) {
         setter(object, true, "boolCol")
         XCTAssertEqual(getter(object, "boolCol") as! Bool!, true)
 
@@ -180,7 +186,9 @@ class ObjectTests: TestCase {
         XCTAssertEqual((getter(object, "arrayCol") as! List<SwiftBoolObject>).first!, boolObject)
     }
 
-    func dynamicSetAndTestAllTypes(setter: (DynamicObject, AnyObject?, String) -> (), getter: (DynamicObject, String) -> (AnyObject?), object: DynamicObject, boolObject: DynamicObject) {
+    func dynamicSetAndTestAllTypes(setter: (DynamicObject, AnyObject?, String) -> (),
+                                   getter: (DynamicObject, String) -> (AnyObject?), object: DynamicObject,
+                                   boolObject: DynamicObject) {
         setter(object, true, "boolCol")
         XCTAssertEqual((getter(object, "boolCol") as! Bool), true)
 

--- a/RealmSwift-swift2.0/Tests/ObjectTests.swift
+++ b/RealmSwift-swift2.0/Tests/ObjectTests.swift
@@ -177,7 +177,7 @@ class ObjectTests: TestCase {
         XCTAssertEqual((getter(object, "arrayCol") as! List<SwiftBoolObject>).count, 1)
         XCTAssertEqual((getter(object, "arrayCol") as! List<SwiftBoolObject>).first!, boolObject)
 
-        list.removeAll();
+        list.removeAll()
         setter(object, list, "arrayCol")
         XCTAssertEqual((getter(object, "arrayCol") as! List<SwiftBoolObject>).count, 0)
 
@@ -219,7 +219,7 @@ class ObjectTests: TestCase {
         XCTAssertEqual((getter(object, "arrayCol") as! List<DynamicObject>).first!, boolObject)
 
         let list = getter(object, "arrayCol") as! List<DynamicObject>
-        list.removeAll();
+        list.removeAll()
         setter(object, list, "arrayCol")
         XCTAssertEqual((getter(object, "arrayCol") as! List<DynamicObject>).count, 0)
 

--- a/RealmSwift-swift2.0/Tests/PerformanceTests.swift
+++ b/RealmSwift-swift2.0/Tests/PerformanceTests.swift
@@ -442,7 +442,6 @@ class SwiftPerformanceTests: TestCase {
         }
     }
 
-    // swiftlint:disable function_body_length
     func testCrossThreadSyncLatency() {
         let stopValue = 100
         inMeasureBlock {
@@ -487,5 +486,4 @@ class SwiftPerformanceTests: TestCase {
             realm.removeNotification(token)
         }
     }
-    // swiftlint:enable function_body_length
 }

--- a/RealmSwift-swift2.0/Tests/PerformanceTests.swift
+++ b/RealmSwift-swift2.0/Tests/PerformanceTests.swift
@@ -39,7 +39,7 @@ private let isRunningOnDevice = TARGET_IPHONE_SIMULATOR == 0
 class SwiftPerformanceTests: TestCase {
     override class func defaultTestSuite() -> XCTestSuite {
 #if !DEBUG && os(iOS)
-        if (isRunningOnDevice) {
+        if isRunningOnDevice {
             return super.defaultTestSuite()
         }
 #endif
@@ -91,11 +91,9 @@ class SwiftPerformanceTests: TestCase {
     private func copyRealmToTestPath(realm: Realm) -> Realm {
         do {
             try NSFileManager.defaultManager().removeItemAtPath(testRealmPath())
-        }
-        catch let error as NSError {
+        } catch let error as NSError {
             XCTAssertTrue(error.domain == NSCocoaErrorDomain && error.code == 4)
-        }
-        catch {
+        } catch {
             fatalError("Unexpected error: \(error)")
         }
 
@@ -199,7 +197,8 @@ class SwiftPerformanceTests: TestCase {
     func testEnumerateAndAccessArrayProperty() {
         let realm = copyRealmToTestPath(mediumRealm)
         realm.beginWrite()
-        let arrayPropertyObject = realm.create(SwiftArrayPropertyObject.self, value: ["name", realm.objects(SwiftStringObject).map { $0 }, []])
+        let arrayPropertyObject = realm.create(SwiftArrayPropertyObject.self,
+            value: ["name", realm.objects(SwiftStringObject).map { $0 }, []])
         try! realm.commitWrite()
 
         measureBlock {
@@ -212,7 +211,8 @@ class SwiftPerformanceTests: TestCase {
     func testEnumerateAndAccessArrayPropertySlow() {
         let realm = copyRealmToTestPath(mediumRealm)
         realm.beginWrite()
-        let arrayPropertyObject = realm.create(SwiftArrayPropertyObject.self, value: ["name", realm.objects(SwiftStringObject).map { $0 }, []])
+        let arrayPropertyObject = realm.create(SwiftArrayPropertyObject.self,
+            value: ["name", realm.objects(SwiftStringObject).map { $0 }, []])
         try! realm.commitWrite()
 
         measureBlock {
@@ -247,7 +247,8 @@ class SwiftPerformanceTests: TestCase {
 
     func testQueryConstruction() {
         let realm = realmWithTestPath()
-        let predicate = NSPredicate(format: "boolCol = false and (intCol = 5 or floatCol = 1.0) and objectCol = nil and doubleCol != 7.0 and stringCol IN {'a', 'b', 'c'}")
+        let predicate = "boolCol = false and (intCol = 5 or floatCol = 1.0) and objectCol = nil and doubleCol != 7.0 " +
+                        " and stringCol IN {'a', 'b', 'c'}"
 
         measureBlock {
             for _ in 0..<500 {
@@ -441,6 +442,7 @@ class SwiftPerformanceTests: TestCase {
         }
     }
 
+    // swiftlint:disable function_body_length
     func testCrossThreadSyncLatency() {
         let stopValue = 100
         inMeasureBlock {
@@ -485,4 +487,5 @@ class SwiftPerformanceTests: TestCase {
             realm.removeNotification(token)
         }
     }
+    // swiftlint:enable function_body_length
 }

--- a/RealmSwift-swift2.0/Tests/RealmCollectionTypeTests.swift
+++ b/RealmSwift-swift2.0/Tests/RealmCollectionTypeTests.swift
@@ -101,7 +101,9 @@ class RealmCollectionTypeTests: TestCase {
     }
 
     func testDescription() {
+        // swiftlint:disable line_length
         XCTAssertEqual(collection.description, "Results<SwiftStringObject> (\n\t[0] SwiftStringObject {\n\t\tstringCol = 1;\n\t},\n\t[1] SwiftStringObject {\n\t\tstringCol = 2;\n\t}\n)")
+        // swiftlint:enable line_length
     }
 
     func testCount() {
@@ -227,7 +229,8 @@ class RealmCollectionTypeTests: TestCase {
         XCTAssertEqual(1, sorted[0].intCol)
         XCTAssertEqual(2, sorted[1].intCol)
 
-        sorted = collection.sorted([SortDescriptor(property: "doubleCol", ascending: false), SortDescriptor(property: "intCol", ascending: false)])
+        sorted = collection.sorted([SortDescriptor(property: "doubleCol", ascending: false),
+            SortDescriptor(property: "intCol", ascending: false)])
         XCTAssertEqual(2.22, sorted[0].doubleCol)
         XCTAssertEqual(3, sorted[0].intCol)
         XCTAssertEqual(2.22, sorted[1].doubleCol)
@@ -359,7 +362,7 @@ class ResultsFromLinkViewTests: ResultsTests {
         let array = realmWithTestPath().create(SwiftArrayPropertyObject.self, value: ["", [str1, str2], []])
         return array.array.filter(NSPredicate(value: true))
     }
-    
+
     override func getAggregateableCollection() -> AnyRealmCollection<SwiftAggregateObject> {
         let list = SwiftAggregateObjectList()
         realmWithTestPath().add(list)
@@ -394,7 +397,9 @@ class ListRealmCollectionTypeTests: RealmCollectionTypeTests {
     }
 
     override func testDescription() {
+        // swiftlint:disable line_length
         XCTAssertEqual(collection.description, "List<SwiftStringObject> (\n\t[0] SwiftStringObject {\n\t\tstringCol = 1;\n\t},\n\t[1] SwiftStringObject {\n\t\tstringCol = 2;\n\t}\n)")
+        // swiftlint:enable line_length
     }
 }
 
@@ -423,7 +428,8 @@ class ListStandaloneRealmCollectionTypeTests: ListRealmCollectionTypeTests {
     override func testSortWithDescriptor() {
         let collection = getAggregateableCollection()
         assertThrows(collection.sorted([SortDescriptor(property: "intCol", ascending: true)]))
-        assertThrows(collection.sorted([SortDescriptor(property: "doubleCol", ascending: false), SortDescriptor(property: "intCol", ascending: false)]))
+        assertThrows(collection.sorted([SortDescriptor(property: "doubleCol", ascending: false),
+            SortDescriptor(property: "intCol", ascending: false)]))
     }
 
     override func testFastEnumerationWithMutation() {

--- a/RealmSwift-swift2.0/Tests/RealmConfigurationTests.swift
+++ b/RealmSwift-swift2.0/Tests/RealmConfigurationTests.swift
@@ -24,12 +24,12 @@ class RealmConfigurationTests: TestCase {
     func testDefaultConfiguration() {
         let defaultConfiguration = Realm.Configuration.defaultConfiguration
 
-        XCTAssertEqual(defaultConfiguration.path, try! Realm().path);
-        XCTAssertNil(defaultConfiguration.inMemoryIdentifier);
-        XCTAssertNil(defaultConfiguration.encryptionKey);
-        XCTAssertFalse(defaultConfiguration.readOnly);
-        XCTAssertEqual(defaultConfiguration.schemaVersion, 0);
-        XCTAssert(defaultConfiguration.migrationBlock == nil);
+        XCTAssertEqual(defaultConfiguration.path, try! Realm().path)
+        XCTAssertNil(defaultConfiguration.inMemoryIdentifier)
+        XCTAssertNil(defaultConfiguration.encryptionKey)
+        XCTAssertFalse(defaultConfiguration.readOnly)
+        XCTAssertEqual(defaultConfiguration.schemaVersion, 0)
+        XCTAssert(defaultConfiguration.migrationBlock == nil)
     }
 
     func testSetDefaultConfiguration() {

--- a/RealmSwift-swift2.0/Tests/RealmTests.swift
+++ b/RealmSwift-swift2.0/Tests/RealmTests.swift
@@ -60,7 +60,8 @@ class RealmTests: TestCase {
         realm.beginWrite()
         realm.create(SwiftStringObject.self, value: ["a"])
         try! realm.commitWrite()
-        XCTAssertFalse(realm.isEmpty, "Realm should not be empty after committing a write transaction that added an object.")
+        XCTAssertFalse(realm.isEmpty,
+            "Realm should not be empty after committing a write transaction that added an object.")
     }
 
     func testInit() {
@@ -107,7 +108,8 @@ class RealmTests: TestCase {
     }
 
     func testInitCustomClassList() {
-        let configuration = Realm.Configuration(path: Realm.Configuration.defaultConfiguration.path, objectTypes: [SwiftStringObject.self])
+        let configuration = Realm.Configuration(path: Realm.Configuration.defaultConfiguration.path,
+            objectTypes: [SwiftStringObject.self])
         XCTAssert(configuration.objectTypes! is [SwiftStringObject.Type])
         let realm = try! Realm(configuration: configuration)
         XCTAssertEqual(["SwiftStringObject"], realm.schema.objectSchema.map { $0.className })
@@ -122,7 +124,7 @@ class RealmTests: TestCase {
         }
         XCTAssertEqual(try! Realm().objects(SwiftStringObject).count, 1)
     }
-    
+
     func testDynamicWrite() {
         try! Realm().write {
             self.assertThrows(try! Realm().beginWrite())
@@ -132,14 +134,14 @@ class RealmTests: TestCase {
         }
         XCTAssertEqual(try! Realm().objects(SwiftStringObject).count, 1)
     }
-    
+
     func testDynamicWriteSubscripting() {
         try! Realm().beginWrite()
         let object = try! Realm().dynamicCreate("SwiftStringObject", value: ["1"])
         try! Realm().commitWrite()
-        
+
         XCTAssertNotNil(object,"Dynamic Object Creation Failed")
-        
+
         let stringVal = object["stringCol"] as! String
         XCTAssertEqual(stringVal, "1", "Object Subscripting Failed")
     }
@@ -364,7 +366,7 @@ class RealmTests: TestCase {
         XCTAssertEqual(3, try! Realm().objects(SwiftIntObject).count)
         assertThrows(try! Realm().objects(Object))
     }
-    
+
     func testDynamicObjects() {
         try! Realm().write {
             try! Realm().create(SwiftIntObject.self, value: [100])
@@ -390,28 +392,28 @@ class RealmTests: TestCase {
         let missingObject = realm.objectForPrimaryKey(SwiftPrimaryStringObject.self, key: "z")
         XCTAssertNil(missingObject)
     }
-    
+
     func testDynamicObjectForPrimaryKey() {
         let realm = try! Realm()
         try! realm.write {
             realm.create(SwiftPrimaryStringObject.self, value: ["a", 1])
             realm.create(SwiftPrimaryStringObject.self, value: ["b", 2])
         }
-        
+
         XCTAssertNotNil(realm.dynamicObjectForPrimaryKey("SwiftPrimaryStringObject", key: "a"))
         XCTAssertNil(realm.dynamicObjectForPrimaryKey("SwiftPrimaryStringObject", key: "z"))
     }
-    
+
     func testDynamicObjectForPrimaryKeySubscripting() {
         let realm = try! Realm()
         try! realm.write {
             realm.create(SwiftPrimaryStringObject.self, value: ["a", 1])
         }
-        
+
         let object = realm.dynamicObjectForPrimaryKey("SwiftPrimaryStringObject", key: "a")
-        
+
         let stringVal = object!["stringCol"] as! String
-        
+
         XCTAssertEqual(stringVal, "a", "Object Subscripting Failed!")
     }
 
@@ -527,7 +529,8 @@ class RealmTests: TestCase {
         try! realm.write {
             realm.add(SwiftObject())
         }
-        let path = ((defaultRealmPath() as NSString).stringByDeletingLastPathComponent as NSString ).stringByAppendingPathComponent("copy.realm")
+        let path = ((defaultRealmPath() as NSString).stringByDeletingLastPathComponent as NSString )
+            .stringByAppendingPathComponent("copy.realm")
         do {
             try realm.writeCopyToPath(path)
         } catch {

--- a/RealmSwift-swift2.0/Tests/SortDescriptorTests.swift
+++ b/RealmSwift-swift2.0/Tests/SortDescriptorTests.swift
@@ -40,6 +40,7 @@ class SortDescriptorTests: TestCase {
 
     func testStringLiteralConvertible() {
         let literalSortDescriptor: SortDescriptor = "property"
-        XCTAssertEqual(sortDescriptor, literalSortDescriptor, "SortDescriptor should conform to StringLiteralConvertible")
+        XCTAssertEqual(sortDescriptor, literalSortDescriptor,
+            "SortDescriptor should conform to StringLiteralConvertible")
     }
 }

--- a/RealmSwift-swift2.0/Tests/SwiftTestObjects.swift
+++ b/RealmSwift-swift2.0/Tests/SwiftTestObjects.swift
@@ -159,10 +159,10 @@ class SwiftAggregateObject: Object {
 }
 
 class SwiftAllIntSizesObject: Object {
-    dynamic var int8  : Int8  = 0
-    dynamic var int16 : Int16 = 0
-    dynamic var int32 : Int32 = 0
-    dynamic var int64 : Int64 = 0
+    dynamic var int8: Int8  = 0
+    dynamic var int16: Int16 = 0
+    dynamic var int32: Int32 = 0
+    dynamic var int64: Int64 = 0
 }
 
 class SwiftEmployeeObject: Object {
@@ -194,7 +194,9 @@ class SwiftArrayPropertySubclassObject: SwiftArrayPropertyObject {
 }
 
 class SwiftUTF8Object: Object {
+    // swiftlint:disable variable_name
     dynamic var 柱колоéнǢкƱаم👍 = "值значен™👍☞⎠‱௹♣︎☐▼❒∑⨌⧭иеمرحبا"
+    // swiftlint:enable variable_name
 }
 
 class SwiftIgnoredPropertiesObject: Object {

--- a/RealmSwift-swift2.0/Tests/SwiftTestObjects.swift
+++ b/RealmSwift-swift2.0/Tests/SwiftTestObjects.swift
@@ -193,6 +193,18 @@ class SwiftArrayPropertySubclassObject: SwiftArrayPropertyObject {
     let boolArray = List<SwiftBoolObject>()
 }
 
+class SwiftLinkToPrimaryStringObject: Object {
+    // swiftlint:disable variable_name_min_length
+    dynamic var pk = ""
+    // swiftlint:enable variable_name_min_length
+    dynamic var object: SwiftPrimaryStringObject?
+    let objects = List<SwiftPrimaryStringObject>()
+
+    override class func primaryKey() -> String? {
+        return "pk"
+    }
+}
+
 class SwiftUTF8Object: Object {
     // swiftlint:disable variable_name
     dynamic var 柱колоéнǢкƱаم👍 = "值значен™👍☞⎠‱௹♣︎☐▼❒∑⨌⧭иеمرحبا"
@@ -208,16 +220,6 @@ class SwiftIgnoredPropertiesObject: Object {
 
     override class func ignoredProperties() -> [String] {
         return ["runtimeProperty", "runtimeDefaultProperty"]
-    }
-}
-
-class SwiftLinkToPrimaryStringObject: Object {
-    dynamic var pk = ""
-    dynamic var object: SwiftPrimaryStringObject?
-    let objects = List<SwiftPrimaryStringObject>()
-
-    override class func primaryKey() -> String? {
-        return "pk"
     }
 }
 

--- a/RealmSwift-swift2.0/Tests/SwiftUnicodeTests.swift
+++ b/RealmSwift-swift2.0/Tests/SwiftUnicodeTests.swift
@@ -48,7 +48,8 @@ class SwiftUnicodeTests: TestCase {
         }
 
         let obj1 = realm.objects(SwiftUTF8Object).first!
-        XCTAssertEqual(obj1.柱колоéнǢкƱаم👍, utf8TestString, "Storing and retrieving a string with UTF8 content should work")
+        XCTAssertEqual(obj1.柱колоéнǢкƱаم👍, utf8TestString,
+            "Storing and retrieving a string with UTF8 content should work")
 
         // Test fails because of rdar://17735684
         let obj2 = realm.objects(SwiftUTF8Object).filter("%K == %@", "柱колоéнǢкƱаم👍", utf8TestString).first!

--- a/RealmSwift-swift2.0/Tests/TestCase.swift
+++ b/RealmSwift-swift2.0/Tests/TestCase.swift
@@ -65,7 +65,8 @@ class TestCase: XCTestCase {
         } catch {
             // The directory shouldn't actually already exist, so not an error
         }
-        try! NSFileManager.defaultManager().createDirectoryAtPath(testDir, withIntermediateDirectories: true, attributes: nil)
+        try! NSFileManager.defaultManager().createDirectoryAtPath(testDir, withIntermediateDirectories: true,
+            attributes: nil)
 
         Realm.Configuration.defaultConfiguration = Realm.Configuration(path: defaultRealmPath())
 
@@ -107,12 +108,14 @@ class TestCase: XCTestCase {
         dispatch_sync(queue) {}
     }
 
-    func assertThrows<T>(@autoclosure(escaping) block: () -> T, _ message: String? = nil, named: String? = RLMExceptionName, fileName: String = __FILE__, lineNumber: UInt = __LINE__) {
+    func assertThrows<T>(@autoclosure(escaping) block: () -> T, _ message: String? = nil,
+                         named: String? = RLMExceptionName, fileName: String = __FILE__, lineNumber: UInt = __LINE__) {
         exceptionThrown = true
         RLMAssertThrows(self, { _ = block() } as dispatch_block_t, named, message, fileName, lineNumber)
     }
 
-    func assertNil<T>(@autoclosure block: () -> T?, _ message: String? = nil, fileName: String = __FILE__, lineNumber: UInt = __LINE__) {
+    func assertNil<T>(@autoclosure block: () -> T?, _ message: String? = nil, fileName: String = __FILE__,
+                      lineNumber: UInt = __LINE__) {
         XCTAssert(block() == nil, message ?? "", file: fileName, line: lineNumber)
     }
 

--- a/RealmSwift-swift2.0/Util.swift
+++ b/RealmSwift-swift2.0/Util.swift
@@ -41,10 +41,8 @@ internal func throwForNegativeIndex(int: Int, parameterName: String = "index") {
 internal func gsub(pattern: String, template: String, string: String, error: NSErrorPointer = nil) -> String? {
     do {
         let regex = try NSRegularExpression(pattern: pattern, options: [])
-        return regex.stringByReplacingMatchesInString(string,
-            options: [],
-            range: NSRange(location: 0, length: string.utf16.count),
-            withTemplate: template)
+        return regex.stringByReplacingMatchesInString(string, options: [],
+            range: NSRange(location: 0, length: string.utf16.count), withTemplate: template)
     } catch {
         // no-op
     }

--- a/RealmSwift-swift2.0/Util.swift
+++ b/RealmSwift-swift2.0/Util.swift
@@ -41,7 +41,10 @@ internal func throwForNegativeIndex(int: Int, parameterName: String = "index") {
 internal func gsub(pattern: String, template: String, string: String, error: NSErrorPointer = nil) -> String? {
     do {
         let regex = try NSRegularExpression(pattern: pattern, options: [])
-        return regex.stringByReplacingMatchesInString(string, options: [], range: NSRange(location: 0, length: string.utf16.count), withTemplate: template)
+        return regex.stringByReplacingMatchesInString(string,
+            options: [],
+            range: NSRange(location: 0, length: string.utf16.count),
+            withTemplate: template)
     } catch {
         // no-op
     }

--- a/RealmSwift-swift2.0/Util.swift
+++ b/RealmSwift-swift2.0/Util.swift
@@ -42,7 +42,8 @@ internal func gsub(pattern: String, template: String, string: String, error: NSE
     do {
         let regex = try NSRegularExpression(pattern: pattern, options: [])
         return regex.stringByReplacingMatchesInString(string, options: [],
-            range: NSRange(location: 0, length: string.utf16.count), withTemplate: template)
+                                                      range: NSRange(location: 0, length: string.utf16.count),
+                                                      withTemplate: template)
     } catch {
         // no-op
     }

--- a/build.sh
+++ b/build.sh
@@ -54,7 +54,7 @@ command:
   test-ios-devices-swift: tests Swift iOS framework on all attached iOS devices
   test-osx:             tests OS X framework
   test-osx-swift:       tests RealmSwift OS X framework
-  verify:               verifies docs, osx, osx-swift, ios-static, ios-dynamic, ios-swift, ios-device in both Debug and Release configurations
+  verify:               verifies docs, osx, osx-swift, ios-static, ios-dynamic, ios-swift, ios-device in both Debug and Release configurations, swiftlint
   docs:                 builds docs in docs/output
   examples:             builds all examples
   examples-ios:         builds all static iOS examples
@@ -595,6 +595,7 @@ case "$COMMAND" in
         sh build.sh verify-ios-device-objc
         sh build.sh verify-ios-device-swift
         sh build.sh verify-watchos
+        sh build.sh verify-swiftlint
         ;;
 
     "verify-cocoapods")
@@ -665,6 +666,11 @@ case "$COMMAND" in
         if [ $REALM_SWIFT_VERSION != '1.2' ]; then
             sh build.sh watchos-swift
         fi
+        exit 0
+        ;;
+
+    "verify-swiftlint")
+        swiftlint lint --strict
         exit 0
         ;;
 


### PR DESCRIPTION
Also addresses some SwiftLint style violations. I didn't make changes to Swift 1.2 files because this PR relies on https://github.com/realm/SwiftLint/pull/106, which is Swift 2.0 only.

To really make this useful, we should enable this on CI and fail if there are any violations, but at the moment we have file length, type body length and todo/fixme violations. I could uncomment the relevant lines from `.swiftlint.yml` but it seems pointless to use SwiftLint if only to ignore its output.

/cc @segiddins @tgoyne @bdash 