### PR TITLE
Add KVO support for array move and exchange

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ x.x.x Release notes (yyyy-MM-dd)
   cannot exist independently from a `Realm`.
 * Aggregate operations are now available on `List`: `min`, `max`, `sum`,
   `average`.
+* Add missing KVO handling for moving and exchanging objects in `RLMArray` and
+  `List`.
 
 ### Bugfixes
 

--- a/Realm/RLMArray.mm
+++ b/Realm/RLMArray.mm
@@ -248,14 +248,26 @@ static void RLMValidateArrayBounds(__unsafe_unretained RLMArray *const ar,
     RLMValidateArrayBounds(self, sourceIndex);
     RLMValidateArrayBounds(self, destinationIndex);
     RLMObjectBase *original = _backingArray[sourceIndex];
-    [_backingArray removeObjectAtIndex:sourceIndex];
-    [_backingArray insertObject:original atIndex:destinationIndex];
+
+    auto start = std::min(sourceIndex, destinationIndex);
+    auto len = std::max(sourceIndex, destinationIndex) - start + 1;
+    changeArray(self, NSKeyValueChangeReplacement, {start, len}, ^{
+        [_backingArray removeObjectAtIndex:sourceIndex];
+        [_backingArray insertObject:original atIndex:destinationIndex];
+    });
 }
 
 - (void)exchangeObjectAtIndex:(NSUInteger)index1 withObjectAtIndex:(NSUInteger)index2 {
     RLMValidateArrayBounds(self, index1);
     RLMValidateArrayBounds(self, index2);
-    [_backingArray exchangeObjectAtIndex:index1 withObjectAtIndex:index2];
+
+    changeArray(self, NSKeyValueChangeReplacement, ^{
+        [_backingArray exchangeObjectAtIndex:index1 withObjectAtIndex:index2];
+    }, [=] {
+        NSMutableIndexSet *set = [[NSMutableIndexSet alloc] initWithIndex:index1];
+        [set addIndex:index2];
+        return set;
+    });
 }
 
 - (NSUInteger)indexOfObject:(RLMObject *)object {

--- a/Realm/RLMObservation.mm
+++ b/Realm/RLMObservation.mm
@@ -675,8 +675,30 @@ public:
         return true;
     }
 
-    // Will need to handle this once it's exposed in RLMArray
-    bool link_list_move(size_t, size_t) { return true; }
+    bool link_list_move(size_t from, size_t to) {
+        ObserverState::change *o = activeLinkList;
+        if (!o || o->multipleLinkviewChanges) {
+            return true;
+        }
+        if (from > to) {
+            std::swap(from, to);
+        }
+
+        NSRange range{from, to - from + 1};
+        if (!o->linkviewChangeIndexes) {
+            o->linkviewChangeIndexes = [NSMutableIndexSet indexSetWithIndexesInRange:range];
+            o->linkviewChangeKind = NSKeyValueChangeReplacement;
+            o->changed = true;
+        }
+        else if (o->linkviewChangeKind == NSKeyValueChangeReplacement) {
+            [o->linkviewChangeIndexes addIndexesInRange:range];
+        }
+        else {
+            o->linkviewChangeIndexes = nil;
+            o->multipleLinkviewChanges = true;
+        }
+        return true;
+    }
 
     // Things that just mark the field as modified
     bool set_int(size_t col, size_t row, int_fast64_t) { return markDirty(row, col); }


### PR DESCRIPTION
This were added to RLMArray after KVO was finished but before it was merged, and naturally didn't produce any merge conflicts, so they were missed.