### PR TITLE
Fix crash of GroupedTableView example in Swift 2.0

### DIFF
--- a/examples/ios/swift-2.0/GroupedTableView/TableViewController.swift
+++ b/examples/ios/swift-2.0/GroupedTableView/TableViewController.swift
@@ -139,5 +139,5 @@ func randomTitle() -> String {
 }
 
 func randomSectionTitle() -> String {
-    return sectionTitles[Int(arc4random()) % sectionTitles.count]
+    return sectionTitles[Int(rand()) % sectionTitles.count]
 }


### PR DESCRIPTION
Function arc4random returns an UInt32. If you get a value higher than Int.max, the Int(...) cast will crash.