### PR TITLE
Update for changes in core's API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,10 @@ x.x.x Release notes (yyyy-MM-dd)
 
 ### Bugfixes
 
-* None.
+* Fix assertion failure when inserting NSData between 8MB and 16MB in size.
+* Fix assertion failure when rolling back a migration which removed an object
+  link or `RLMArray`/`List` property.
+* Add the path of the file being opened to file open errors.
 
 0.95.1 Release notes (2015-09-23)
 =============================================================

--- a/Realm/RLMQueryUtil.mm
+++ b/Realm/RLMQueryUtil.mm
@@ -81,13 +81,13 @@ struct TrueExpression : realm::Expression {
         return realm::not_found;
     }
     void set_table() override {}
-    const Table* get_table() override { return nullptr; }
+    const Table* get_table() const override { return nullptr; }
 };
 
 struct FalseExpression : realm::Expression {
     size_t find_first(size_t, size_t) const override { return realm::not_found; }
     void set_table() override {}
-    const Table* get_table() override { return nullptr; }
+    const Table* get_table() const override { return nullptr; }
 };
 
 NSString *operatorName(NSPredicateOperatorType operatorType)

--- a/Realm/RLMRealm.mm
+++ b/Realm/RLMRealm.mm
@@ -240,8 +240,7 @@ void RLMRealmAddPathSettingsToConfiguration(RLMRealmConfiguration *configuration
             NSString *mode = readonly ? @"read" : @"read-write";
             NSString *additionalMessage = [NSString stringWithFormat:@"Unable to open a realm at path '%@'. Please use a path where your app has %@ permissions.", path, mode];
             NSString *newMessage = [NSString stringWithFormat:@"%s\n%@", ex.what(), additionalMessage];
-            error = RLMMakeError(RLMErrorFilePermissionDenied,
-                                     File::PermissionDenied(newMessage.UTF8String));
+            error = RLMMakeError(RLMErrorFilePermissionDenied, File::PermissionDenied(newMessage.UTF8String, ex.get_path()));
         }
         catch (File::Exists const& ex) {
             error = RLMMakeError(RLMErrorFileExists, ex);

--- a/Realm/RLMUtil.hpp
+++ b/Realm/RLMUtil.hpp
@@ -22,6 +22,7 @@
 #import <realm/array.hpp>
 #import <realm/binary_data.hpp>
 #import <realm/string_data.hpp>
+#import <realm/util/file.hpp>
 
 @class RLMObjectSchema;
 @class RLMProperty;
@@ -33,6 +34,7 @@ NSException *RLMException(NSString *message, NSDictionary *userInfo = nil);
 NSException *RLMException(std::exception const& exception);
 
 NSError *RLMMakeError(RLMError code, std::exception const& exception);
+NSError *RLMMakeError(RLMError code, const realm::util::File::AccessError&);
 NSError *RLMMakeError(NSException *exception);
 
 void RLMSetErrorOrThrow(NSError *error, NSError **outError);

--- a/Realm/RLMUtil.mm
+++ b/Realm/RLMUtil.mm
@@ -262,6 +262,14 @@ NSError *RLMMakeError(RLMError code, std::exception const& exception) {
                                       @"Error Code": @(code)}];
 }
 
+NSError *RLMMakeError(RLMError code, const realm::util::File::AccessError& exception) {
+    return [NSError errorWithDomain:RLMErrorDomain
+                               code:code
+                           userInfo:@{NSLocalizedDescriptionKey: @(exception.what()),
+                                      NSFilePathErrorKey: @(exception.get_path().c_str()),
+                                      @"Error Code": @(code)}];
+}
+
 NSError *RLMMakeError(NSException *exception) {
     return [NSError errorWithDomain:RLMErrorDomain
                                code:0

--- a/build.sh
+++ b/build.sh
@@ -14,7 +14,7 @@ set -o pipefail
 set -e
 
 # You can override the version of the core library
-: ${REALM_CORE_VERSION:=0.92.2} # set to "current" to always use the current build
+: ${REALM_CORE_VERSION:=0.93.0} # set to "current" to always use the current build
 
 # You can override the xcmode used
 : ${XCMODE:=xcodebuild} # must be one of: xcodebuild (default), xcpretty, xctool


### PR DESCRIPTION
1. `Expression::get_table` is now `const`.
2. `File::AccessError` now carries the path with it. Update how we call
   its constructor, and provide an overload of `RLMMakeError` that
   exposes the path as `NSFilePathErrorKey`.

Marking as a work in progress until we're ready to update to a new core release.