### PR TITLE
Add support for queries that perform comparisons on aggregates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ x.x.x Release notes (yyyy-MM-dd)
 
 * Fix crashes when the first Realm opened uses a class subset and later Realms
   opened do not.
+* Fix assertion failure when inserting NSData between 8MB and 16MB in size.
+* Fix assertion failure when rolling back a migration which removed an object
+  link or `RLMArray`/`List` property.
+* Add the path of the file being opened to file open errors.
 
 0.95.2 Release notes (2015-09-24)
 =============================================================

--- a/Realm/RLMProperty.mm
+++ b/Realm/RLMProperty.mm
@@ -38,6 +38,17 @@ BOOL RLMPropertyTypeIsNullable(RLMPropertyType propertyType) {
     }
 }
 
+BOOL RLMPropertyTypeIsNumeric(RLMPropertyType propertyType) {
+    switch (propertyType) {
+        case RLMPropertyTypeInt:
+        case RLMPropertyTypeFloat:
+        case RLMPropertyTypeDouble:
+            return YES;
+        default:
+            return NO;
+    }
+}
+
 @implementation RLMProperty {
     NSString *_objcRawType;
 }

--- a/Realm/RLMProperty_Private.h
+++ b/Realm/RLMProperty_Private.h
@@ -23,6 +23,7 @@
 @class RLMObjectBase;
 
 FOUNDATION_EXTERN BOOL RLMPropertyTypeIsNullable(RLMPropertyType propertyType);
+FOUNDATION_EXTERN BOOL RLMPropertyTypeIsNumeric(RLMPropertyType propertyType);
 
 // private property interface
 @interface RLMProperty ()

--- a/Realm/RLMQueryUtil.mm
+++ b/Realm/RLMQueryUtil.mm
@@ -126,13 +126,62 @@ NSString *operatorName(NSPredicateOperatorType operatorType)
     return [NSString stringWithFormat:@"unknown operator %lu", (unsigned long)operatorType];
 }
 
+class CollectionOperation {
+public:
+    enum Type {
+        Count,
+    };
+
+    CollectionOperation(Type type, RLMProperty *linkProperty, RLMProperty *property)
+        : m_type(type)
+        , m_link_property(linkProperty)
+        , m_property(property)
+    {
+        RLMPrecondition(m_link_property.type == RLMPropertyTypeArray, @"Invalid predicate", @"Collection operation can only be applied to a property of type RLMArray.");
+        switch (m_type) {
+            case Count:
+                RLMPrecondition(!m_property, @"Invalid predicate", @"Result of @count does not have any properties.");
+                break;
+        }
+    }
+
+    CollectionOperation(NSString *operationName, RLMProperty *linkProperty, RLMProperty *property = nil)
+        : CollectionOperation(type_for_name(operationName), linkProperty, property)
+    {
+    }
+
+    Type type() const { return m_type; }
+    NSUInteger linkColumnIndex() const { return m_link_property.column; }
+    NSUInteger columnIndex() const { return m_property.column; }
+
+    void validate_value(id value) const {
+        switch (m_type) {
+            case Count:
+                RLMPrecondition([value isKindOfClass:[NSNumber class]], @"Invalid operand", @"@count can only be compared with a numeric value.");
+                break;
+        }
+    }
+
+private:
+    static Type type_for_name(NSString *name) {
+        if ([name isEqualToString:@"@count"]) {
+            return Count;
+        }
+        @throw RLMPredicateException(@"Invalid predicate", @"Unsupported collection operation '%@'", name);
+    }
+
+    Type m_type;
+    RLMProperty *m_link_property;
+    RLMProperty *m_property;
+};
+
 // add a clause for numeric constraints based on operator type
 template <typename A, typename B>
 void add_numeric_constraint_to_query(realm::Query& query,
                                      RLMPropertyType datatype,
                                      NSPredicateOperatorType operatorType,
-                                     A lhs,
-                                     B rhs)
+                                     A&& lhs,
+                                     B&& rhs)
 {
     switch (operatorType) {
         case NSLessThanPredicateOperatorType:
@@ -539,7 +588,7 @@ void add_constraint_to_query(realm::Query &query, RLMPropertyType type,
 }
 
 RLMProperty *get_property_from_key_path(RLMSchema *schema, RLMObjectSchema *desc,
-                                        NSString *keyPath, std::vector<NSUInteger> &indexes, bool isAny)
+                                        NSString *keyPath, std::vector<NSUInteger> &indexes, bool isAggregate)
 {
     RLMProperty *prop = nil;
 
@@ -561,15 +610,15 @@ RLMProperty *get_property_from_key_path(RLMSchema *schema, RLMObjectSchema *desc
             RLMPrecondition(prop, @"Invalid property name",
                             @"Property '%@' not found in object of type '%@'", path, desc.className);
 
-            if (isAny) {
+            if (isAggregate) {
                 RLMPrecondition(prop.type == RLMPropertyTypeArray,
                                 @"Invalid predicate",
-                                @"ANY modifier can only be used for RLMArray properties");
+                                @"Aggregate operations can only be used on RLMArray properties");
             }
             else {
                 RLMPrecondition(prop.type != RLMPropertyTypeArray,
                                 @"Invalid predicate",
-                                @"RLMArray predicates must contain the ANY modifier");
+                                @"RLMArray predicates must use aggregate operations");
             }
         }
 
@@ -598,6 +647,113 @@ void validate_property_value(__unsafe_unretained RLMProperty *const prop,
     }
 }
 
+template <typename RequestedType, CollectionOperation::Type OperationType, typename TableGetter>
+struct ValueOfTypeWithCollectionOperationHelper;
+
+template <typename RequestedType, typename TableGetter>
+struct ValueOfTypeWithCollectionOperationPassThrough {
+    template <typename T>
+    static auto convert(TableGetter&& table, T&& value)
+    {
+        return value_of_type_for_query<RequestedType>(std::forward<TableGetter>(table), std::forward<T>(value));
+    }
+};
+
+template <typename TableGetter>
+struct ValueOfTypeWithCollectionOperationHelper<Int, CollectionOperation::Count, TableGetter> : ValueOfTypeWithCollectionOperationPassThrough<Int, TableGetter> {
+    using ValueOfTypeWithCollectionOperationPassThrough<Int, TableGetter>::convert;
+
+    static auto convert(TableGetter&& table, CollectionOperation operation)
+    {
+        assert(operation.type() == CollectionOperation::Count);
+        return table()->template column<Link>(operation.linkColumnIndex()).count();
+    }
+};
+
+template <typename Requested, CollectionOperation::Type OperationType, typename TableGetter, typename T>
+auto value_of_type_for_query_with_collection_operation(TableGetter&& table, T&& value) {
+    using helper = ValueOfTypeWithCollectionOperationHelper<Requested, OperationType, TableGetter>;
+    return helper::convert(std::forward<TableGetter>(table), std::forward<T>(value));
+}
+
+template <typename... T>
+void add_collection_operation_constraint_to_query(realm::Query& query, NSPredicateOperatorType operatorType,
+                                                  CollectionOperation::Type collectionOperationType, const std::vector<NSUInteger> linkColumns, T... values)
+{
+    static_assert(sizeof...(T) == 2, "add_collection_operation_constraint_to_query accepts only two values as arguments");
+
+    auto table = [&] {
+        realm::TableRef& tbl = query.get_table();
+        for (NSUInteger col : linkColumns) {
+            tbl->link(col); // mutates m_link_chain on table
+        }
+        return tbl.get();
+    };
+
+    switch (collectionOperationType) {
+        case CollectionOperation::Count: {
+            add_numeric_constraint_to_query(query, RLMPropertyTypeInt, operatorType, value_of_type_for_query_with_collection_operation<Int, CollectionOperation::Count>(table, values)...);
+            break;
+        }
+    }
+}
+
+bool key_path_contains_collection_operator(NSString *keyPath) {
+    return [keyPath rangeOfString:@"@"].location != NSNotFound;
+}
+
+NSString *get_collection_operation_name_from_key_path(NSString *keyPath, NSString **leadingKeyPath, NSString **trailingKey) {
+    NSRange at  = [keyPath rangeOfString:@"@"];
+    if (at.location == NSNotFound || at.location >= keyPath.length - 1) {
+        @throw RLMPredicateException(@"Invalid key path", @"'%@' is not a valid key path'", keyPath);
+    }
+
+    if ([keyPath characterAtIndex:at.location - 1] != '.') {
+        @throw RLMPredicateException(@"Invalid key path", @"'%@' is not a valid key path'", keyPath);
+    }
+
+    NSRange trailingKeyRange = [keyPath rangeOfString:@"." options:0 range:{at.location, keyPath.length - at.location} locale:nil];
+
+    *leadingKeyPath = [keyPath substringToIndex:at.location - 1];
+    if (trailingKeyRange.location == NSNotFound) {
+        *trailingKey = nil;
+        return [keyPath substringFromIndex:at.location];
+    } else {
+        *trailingKey = [keyPath substringFromIndex:trailingKeyRange.location + 1];
+        return [keyPath substringWithRange:{at.location, trailingKeyRange.location - at.location}];
+    }
+}
+
+void update_query_with_collection_operator_expression(RLMSchema *schema,
+                                                      RLMObjectSchema *desc,
+                                                      realm::Query &query,
+                                                      NSString *keyPath,
+                                                      id value,
+                                                      NSComparisonPredicate *pred) {
+    NSString *leadingKeyPath;
+    NSString *trailingKey;
+    NSString *collectionOperationName = get_collection_operation_name_from_key_path(keyPath, &leadingKeyPath, &trailingKey);
+
+    std::vector<NSUInteger> indexes;
+    RLMProperty *linkProperty = get_property_from_key_path(schema, desc, leadingKeyPath, indexes, true);
+    RLMProperty *property;
+    if (trailingKey) {
+        RLMPrecondition([trailingKey rangeOfString:@"."].location == NSNotFound, @"Invalid key path", @"Right side of collection operator may only have a single level key");
+        NSString *fullKeyPath = [leadingKeyPath stringByAppendingFormat:@".%@", trailingKey];
+        std::vector<NSUInteger> ignoredIndexes;
+        property = get_property_from_key_path(schema, desc, fullKeyPath, ignoredIndexes, true);
+    }
+
+    CollectionOperation operation(collectionOperationName, linkProperty, property);
+    operation.validate_value(value);
+
+    if (pred.leftExpression.expressionType == NSKeyPathExpressionType) {
+        add_collection_operation_constraint_to_query(query, pred.predicateOperatorType, operation.type(), indexes, operation, value);
+    } else {
+        add_collection_operation_constraint_to_query(query, pred.predicateOperatorType, operation.type(), indexes, value, operation);
+    }
+}
+
 void update_query_with_value_expression(RLMSchema *schema,
                                         RLMObjectSchema *desc,
                                         realm::Query &query,
@@ -605,6 +761,11 @@ void update_query_with_value_expression(RLMSchema *schema,
                                         id value,
                                         NSComparisonPredicate *pred)
 {
+    if (key_path_contains_collection_operator(keyPath)) {
+        update_query_with_collection_operator_expression(schema, desc, query, keyPath, value, pred);
+        return;
+    }
+
     bool isAny = pred.comparisonPredicateModifier == NSAnyPredicateModifier;
     std::vector<NSUInteger> indexes;
     RLMProperty *prop = get_property_from_key_path(schema, desc, keyPath, indexes, isAny);

--- a/Realm/RLMQueryUtil.mm
+++ b/Realm/RLMQueryUtil.mm
@@ -81,13 +81,13 @@ struct TrueExpression : realm::Expression {
         return realm::not_found;
     }
     void set_table() override {}
-    const Table* get_table() override { return nullptr; }
+    const Table* get_table() const override { return nullptr; }
 };
 
 struct FalseExpression : realm::Expression {
     size_t find_first(size_t, size_t) const override { return realm::not_found; }
     void set_table() override {}
-    const Table* get_table() override { return nullptr; }
+    const Table* get_table() const override { return nullptr; }
 };
 
 NSString *operatorName(NSPredicateOperatorType operatorType)

--- a/Realm/RLMRealm.mm
+++ b/Realm/RLMRealm.mm
@@ -245,8 +245,7 @@ void RLMRealmAddPathSettingsToConfiguration(RLMRealmConfiguration *configuration
             NSString *mode = readonly ? @"read" : @"read-write";
             NSString *additionalMessage = [NSString stringWithFormat:@"Unable to open a realm at path '%@'. Please use a path where your app has %@ permissions.", path, mode];
             NSString *newMessage = [NSString stringWithFormat:@"%s\n%@", ex.what(), additionalMessage];
-            error = RLMMakeError(RLMErrorFilePermissionDenied,
-                                     File::PermissionDenied(newMessage.UTF8String));
+            error = RLMMakeError(RLMErrorFilePermissionDenied, File::PermissionDenied(newMessage.UTF8String, ex.get_path()));
         }
         catch (File::Exists const& ex) {
             error = RLMMakeError(RLMErrorFileExists, ex);

--- a/Realm/RLMUtil.hpp
+++ b/Realm/RLMUtil.hpp
@@ -22,6 +22,7 @@
 #import <realm/array.hpp>
 #import <realm/binary_data.hpp>
 #import <realm/string_data.hpp>
+#import <realm/util/file.hpp>
 
 @class RLMObjectSchema;
 @class RLMProperty;
@@ -33,6 +34,7 @@ NSException *RLMException(NSString *message, NSDictionary *userInfo = nil);
 NSException *RLMException(std::exception const& exception);
 
 NSError *RLMMakeError(RLMError code, std::exception const& exception);
+NSError *RLMMakeError(RLMError code, const realm::util::File::AccessError&);
 NSError *RLMMakeError(NSException *exception);
 
 void RLMSetErrorOrThrow(NSError *error, NSError **outError);

--- a/Realm/RLMUtil.mm
+++ b/Realm/RLMUtil.mm
@@ -262,6 +262,14 @@ NSError *RLMMakeError(RLMError code, std::exception const& exception) {
                                       @"Error Code": @(code)}];
 }
 
+NSError *RLMMakeError(RLMError code, const realm::util::File::AccessError& exception) {
+    return [NSError errorWithDomain:RLMErrorDomain
+                               code:code
+                           userInfo:@{NSLocalizedDescriptionKey: @(exception.what()),
+                                      NSFilePathErrorKey: @(exception.get_path().c_str()),
+                                      @"Error Code": @(code)}];
+}
+
 NSError *RLMMakeError(NSException *exception) {
     return [NSError errorWithDomain:RLMErrorDomain
                                code:0

--- a/Realm/Tests/QueryTests.m
+++ b/Realm/Tests/QueryTests.m
@@ -1827,4 +1827,24 @@
 }
 #endif
 
+- (void)testCountOnCollection {
+    RLMRealm *realm = [RLMRealm defaultRealm];
+    [realm beginWriteTransaction];
+
+    ArrayPropertyObject *arr = [ArrayPropertyObject createInRealm:realm withValue:@[@"name", @[], @[]]];
+    [arr.array addObject:[StringObject createInRealm:realm withValue:@[@"value"]]];
+    [realm commitWriteTransaction];
+
+
+    XCTAssertEqual(1U, ([ArrayPropertyObject objectsWhere:@"array.@count > 0"].count));
+    XCTAssertEqual(1U, ([ArrayPropertyObject objectsWhere:@"0 < array.@count"].count));
+
+    // We do not yet handle collection operations with a keypath on the other side of the comparison.
+    XCTAssertThrows(([ArrayPropertyObject objectsWhere:@"array.@count != name"]));
+
+    RLMAssertThrowsWithReasonMatching(([ArrayPropertyObject objectsWhere:@"array.@count.foo.bar != 0"]), @"single level key");
+    RLMAssertThrowsWithReasonMatching(([ArrayPropertyObject objectsWhere:@"array.@count.stringCol > 0"]), @"@count does not have any properties");
+    RLMAssertThrowsWithReasonMatching(([ArrayPropertyObject objectsWhere:@"array.@count != 'Hello'"]), @"@count can only be compared with a numeric value");
+}
+
 @end

--- a/Realm/Tests/QueryTests.m
+++ b/Realm/Tests/QueryTests.m
@@ -1831,20 +1831,20 @@
     RLMRealm *realm = [RLMRealm defaultRealm];
     [realm beginWriteTransaction];
 
-    ArrayPropertyObject *arr = [ArrayPropertyObject createInRealm:realm withValue:@[@"name", @[], @[]]];
-    [arr.array addObject:[StringObject createInRealm:realm withValue:@[@"value"]]];
+    IntegerArrayPropertyObject *arr = [IntegerArrayPropertyObject createInRealm:realm withValue:@[ @1234, @[]]];
+    [arr.array addObject:[IntObject createInRealm:realm withValue:@[ @456 ]]];
     [realm commitWriteTransaction];
 
 
-    XCTAssertEqual(1U, ([ArrayPropertyObject objectsWhere:@"array.@count > 0"].count));
-    XCTAssertEqual(1U, ([ArrayPropertyObject objectsWhere:@"0 < array.@count"].count));
+    XCTAssertEqual(1U, ([IntegerArrayPropertyObject objectsWhere:@"array.@count > 0"].count));
+    XCTAssertEqual(1U, ([IntegerArrayPropertyObject objectsWhere:@"0 < array.@count"].count));
 
     // We do not yet handle collection operations with a keypath on the other side of the comparison.
-    XCTAssertThrows(([ArrayPropertyObject objectsWhere:@"array.@count != name"]));
+    RLMAssertThrowsWithReasonMatching(([IntegerArrayPropertyObject objectsWhere:@"array.@count != number"]), @"'array.@count' not found in object");
 
-    RLMAssertThrowsWithReasonMatching(([ArrayPropertyObject objectsWhere:@"array.@count.foo.bar != 0"]), @"single level key");
-    RLMAssertThrowsWithReasonMatching(([ArrayPropertyObject objectsWhere:@"array.@count.stringCol > 0"]), @"@count does not have any properties");
-    RLMAssertThrowsWithReasonMatching(([ArrayPropertyObject objectsWhere:@"array.@count != 'Hello'"]), @"@count can only be compared with a numeric value");
+    RLMAssertThrowsWithReasonMatching(([IntegerArrayPropertyObject objectsWhere:@"array.@count.foo.bar != 0"]), @"single level key");
+    RLMAssertThrowsWithReasonMatching(([IntegerArrayPropertyObject objectsWhere:@"array.@count.intCol > 0"]), @"@count does not have any properties");
+    RLMAssertThrowsWithReasonMatching(([IntegerArrayPropertyObject objectsWhere:@"array.@count != 'Hello'"]), @"@count can only be compared with a numeric value");
 }
 
 @end

--- a/Realm/Tests/QueryTests.m
+++ b/Realm/Tests/QueryTests.m
@@ -1858,4 +1858,24 @@
     RLMAssertThrowsWithReasonMatching(([IntegerArrayPropertyObject objectsWhere:@"array.@count != 'Hello'"]), @"@count can only be compared with a numeric value");
 }
 
+- (void)testMinOnCollection {
+    RLMRealm *realm = [RLMRealm defaultRealm];
+    [realm beginWriteTransaction];
+
+    ArrayPropertyObject *arr = [ArrayPropertyObject createInRealm:realm withValue:@[@"name", @[], @[]]];
+    [arr.intArray addObject:[IntObject createInRealm:realm withValue:@[ @1234 ]]];
+    [arr.intArray addObject:[IntObject createInRealm:realm withValue:@[ @0 ]]];
+    [arr.intArray addObject:[IntObject createInRealm:realm withValue:@[ @-12345 ]]];
+
+    arr = [ArrayPropertyObject createInRealm:realm withValue:@[@"name", @[], @[]]];
+    [arr.intArray addObject:[IntObject createInRealm:realm withValue:@[ @0 ]]];
+
+    [realm commitWriteTransaction];
+
+    XCTAssertEqual(1U, ([ArrayPropertyObject objectsWhere:@"intArray.@min.intCol == -12345"].count));
+    XCTAssertEqual(1U, ([ArrayPropertyObject objectsWhere:@"intArray.@min.intCol == 0"].count));
+    XCTAssertEqual(2U, ([ArrayPropertyObject objectsWhere:@"intArray.@min.intCol < 1000"].count));
+    XCTAssertEqual(1U, ([ArrayPropertyObject objectsWhere:@"intArray.@min.intCol > -1000"].count));
+}
+
 @end

--- a/Realm/Tests/QueryTests.m
+++ b/Realm/Tests/QueryTests.m
@@ -1833,11 +1833,22 @@
 
     IntegerArrayPropertyObject *arr = [IntegerArrayPropertyObject createInRealm:realm withValue:@[ @1234, @[]]];
     [arr.array addObject:[IntObject createInRealm:realm withValue:@[ @456 ]]];
+
+    arr = [IntegerArrayPropertyObject createInRealm:realm withValue:@[ @4567, @[]]];
+    [arr.array addObject:[IntObject createInRealm:realm withValue:@[ @1 ]]];
+    [arr.array addObject:[IntObject createInRealm:realm withValue:@[ @2 ]]];
+    [arr.array addObject:[IntObject createInRealm:realm withValue:@[ @3 ]]];
+
+    arr = [IntegerArrayPropertyObject createInRealm:realm withValue:@[ @4567, @[]]];
+
     [realm commitWriteTransaction];
 
-
-    XCTAssertEqual(1U, ([IntegerArrayPropertyObject objectsWhere:@"array.@count > 0"].count));
-    XCTAssertEqual(1U, ([IntegerArrayPropertyObject objectsWhere:@"0 < array.@count"].count));
+    XCTAssertEqual(2U, ([IntegerArrayPropertyObject objectsWhere:@"array.@count > 0"].count));
+    XCTAssertEqual(1U, ([IntegerArrayPropertyObject objectsWhere:@"array.@count == 3"].count));
+    XCTAssertEqual(1U, ([IntegerArrayPropertyObject objectsWhere:@"array.@count < 1"].count));
+    XCTAssertEqual(2U, ([IntegerArrayPropertyObject objectsWhere:@"0 < array.@count"].count));
+    XCTAssertEqual(1U, ([IntegerArrayPropertyObject objectsWhere:@"3 == array.@count"].count));
+    XCTAssertEqual(1U, ([IntegerArrayPropertyObject objectsWhere:@"1 >  array.@count"].count));
 
     // We do not yet handle collection operations with a keypath on the other side of the comparison.
     RLMAssertThrowsWithReasonMatching(([IntegerArrayPropertyObject objectsWhere:@"array.@count != number"]), @"'array.@count' not found in object");

--- a/Realm/Tests/RLMTestObjects.h
+++ b/Realm/Tests/RLMTestObjects.h
@@ -263,6 +263,8 @@ RLM_ARRAY_TYPE(CircleObject);
 
 @end
 
+#pragma mark PrimaryStringObject
+
 @interface PrimaryStringObject : RLMObject
 @property NSString *stringCol;
 @property int intCol;
@@ -271,6 +273,15 @@ RLM_ARRAY_TYPE(CircleObject);
 @interface ReadOnlyPropertyObject : RLMObject
 @property (readonly) NSNumber *readOnlyUnsupportedProperty;
 @property (readonly) int readOnlyPropertyMadeReadWriteInClassExtension;
+@end
+
+#pragma mark IntegerArrayPropertyObject
+
+@interface IntegerArrayPropertyObject : RLMObject
+
+@property NSInteger number;
+@property RLM_GENERIC_ARRAY(IntObject) *array;
+
 @end
 
 #pragma mark FakeObject

--- a/Realm/Tests/RLMTestObjects.m
+++ b/Realm/Tests/RLMTestObjects.m
@@ -146,12 +146,15 @@
 @implementation AggregateObject
 @end
 
+#pragma mark PrimaryStringObject
 
 @implementation PrimaryStringObject
 + (NSString *)primaryKey {
     return @"stringCol";
 }
 @end
+
+#pragma mark ReadOnlyPropertyObject
 
 @interface ReadOnlyPropertyObject ()
 @property (readwrite) int readOnlyPropertyMadeReadWriteInClassExtension;
@@ -161,6 +164,11 @@
 - (NSNumber *)readOnlyUnsupportedProperty {
     return nil;
 }
+@end
+
+#pragma mark IntegerArrayPropertyObject
+
+@implementation IntegerArrayPropertyObject
 @end
 
 #pragma mark FakeObject

--- a/build.sh
+++ b/build.sh
@@ -14,7 +14,7 @@ set -o pipefail
 set -e
 
 # You can override the version of the core library
-: ${REALM_CORE_VERSION:=0.92.2} # set to "current" to always use the current build
+: ${REALM_CORE_VERSION:=0.93.0} # set to "current" to always use the current build
 
 # You can override the xcmode used
 : ${XCMODE:=xcodebuild} # must be one of: xcodebuild (default), xcpretty, xctool


### PR DESCRIPTION
This adds support for comparisons of the form `collection.@min.intCol > 10`, with support for `@min`, `@max`, `@sum` and `@avg`.

Fixes #1166.

Note that this requires a new release of core, and so will fail to build for now. The branch currently includes changes from #2449, and will until that is merged.