### PR TITLE
remove about office hour from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@ The API reference is located at [realm.io/docs/swift/latest/api](https://realm.i
 - **Need help with your code?**: Look for previous questions on the  [#realm tag](https://stackoverflow.com/questions/tagged/realm?sort=newest) — or [ask a new question](https://stackoverflow.com/questions/ask?tags=realm). We activtely monitor & answer questions on SO!
 - **Have a bug to report?** [Open an issue](https://github.com/realm/realm-cocoa/issues/new). If possible, include the version of Realm, a full log, the Realm file, and a project that shows the issue.
 - **Have a feature request?** [Open an issue](https://github.com/realm/realm-cocoa/issues/new). Tell us what the feature should do, and why you want the feature.
-- **Want to ask in-depth questions?** [Join our online office hours](https://attendee.gotowebinar.com/rt/1182038037080364033). We host these once a month, and you can join via chat, audio call, or video call.
 - Sign up for our [**Community Newsletter**](http://eepurl.com/VEKCn) to get regular tips, learn about other use-cases and get alerted of blogposts and tutorials about Realm.
 
 ## Building Realm


### PR DESCRIPTION
We will abolish current office hour system. So We are going to remove go-to-meeting's link from everywhere. I've deleted the sentence about office hour in `README.md`.
Could you please review this?

/cc @jpsim @timanglade
same as realm-java: https://github.com/realm/realm-java/pull/1459