### PR TITLE
Fix for a race condition with RLMRealmConfiguration.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ x.x.x Release notes (yyyy-MM-dd)
 
 * Setting the primary key property on persisted `RLMObject`s / `Object`s
   via subscripting or key-value coding will cause an exception to be thrown.
+* Fix crash due to race condition in `RLMRealmConfiguration` where the default
+  configuration was in the process of being copied in one thread, while
+  released in another.
 
 0.95.0 Release notes (2015-08-25)
 =============================================================

--- a/Realm/RLMRealmConfiguration.mm
+++ b/Realm/RLMRealmConfiguration.mm
@@ -86,8 +86,10 @@ static NSString * const c_defaultRealmFileName = @"default.realm";
 }
 
 + (instancetype)defaultConfiguration {
-    if (!s_defaultConfiguration) {
-        s_defaultConfiguration = [[RLMRealmConfiguration alloc] init];
+    @synchronized(c_defaultRealmFileName) {
+        if (!s_defaultConfiguration) {
+            s_defaultConfiguration = [[RLMRealmConfiguration alloc] init];
+        }
     }
     return [s_defaultConfiguration copy];
 }
@@ -99,17 +101,23 @@ static NSString * const c_defaultRealmFileName = @"default.realm";
     if (!configuration) {
         @throw RLMException(@"Cannot set the default configuration to nil.");
     }
-    s_defaultConfiguration = [configuration copy];
+    @synchronized(c_defaultRealmFileName) {
+        s_defaultConfiguration = [configuration copy];
+    }
 }
 
 + (void)setDefaultPath:(NSString *)path {
     RLMRealmConfiguration *configuration = [[RLMRealmConfiguration alloc] init];
     configuration.path = path;
-    s_defaultConfiguration = configuration;
+    @synchronized(c_defaultRealmFileName) {
+        s_defaultConfiguration = configuration;
+    }
 }
 
 + (void)resetRealmConfigurationState {
-    s_defaultConfiguration = nil;
+    @synchronized(c_defaultRealmFileName) {
+        s_defaultConfiguration = nil;
+    }
     s_configurationUsage = RLMRealmConfigurationUsageNone;
 }
 


### PR DESCRIPTION
Appeared in `ABFRealmGridController` where the `defaultConfiguration` was requested from 3 threads at the same time. The result was that one thread was attempting to copy `s_defaultConfiguration` while another was mutating the value.

`@synchronized` directive is used with` c_defaultRealmFileName` object as the token to lock from.