### PR TITLE
Make `Object.init(value:)` a required initializer

### DIFF
--- a/RealmSwift-swift1.2/Object.swift
+++ b/RealmSwift-swift1.2/Object.swift
@@ -76,7 +76,7 @@ public class Object: RLMObjectBase, Equatable, Printable {
                     or an `Array` with one object for each persisted property. An exception will be
                     thrown if any required properties are not present and no default is set.
     */
-    public init(value: AnyObject) {
+    public required init(value: AnyObject) {
         self.dynamicType.sharedSchema() // ensure this class' objectSchema is loaded in the partialSharedSchema
         super.init(value: value, schema: RLMSchema.partialSharedSchema())
     }

--- a/RealmSwift-swift1.2/Tests/ObjectCreationTests.swift
+++ b/RealmSwift-swift1.2/Tests/ObjectCreationTests.swift
@@ -125,6 +125,15 @@ class ObjectCreationTests: TestCase {
         XCTAssertEqual(obj1.boolCol, obj2.boolCol, "object created via generic initializer should equal object created by calling initializer directly")
     }
 
+    func testGenericInitWithValue() {
+        func createObject<T: Object>(#value: AnyObject) -> T {
+            return T(value: value)
+        }
+        let obj1: SwiftBoolObject = createObject(value: ["boolCol": true])
+        let obj2 = SwiftBoolObject(value: ["boolCol": true])
+        XCTAssertEqual(obj1.boolCol, obj2.boolCol, "object created via generic initializer should equal object created by calling initializer directly")
+    }
+
     // MARK: Creation tests
 
     func testCreateWithDefaults() {

--- a/RealmSwift-swift2.0/Object.swift
+++ b/RealmSwift-swift2.0/Object.swift
@@ -76,7 +76,7 @@ public class Object: RLMObjectBase {
                        or an `Array` with one object for each persisted property. An exception will be
                        thrown if any required properties are not present and no default is set.
     */
-    public init(value: AnyObject) {
+    public required init(value: AnyObject) {
         self.dynamicType.sharedSchema() // ensure this class' objectSchema is loaded in the partialSharedSchema
         super.init(value: value, schema: RLMSchema.partialSharedSchema())
     }

--- a/RealmSwift-swift2.0/Tests/ObjectCreationTests.swift
+++ b/RealmSwift-swift2.0/Tests/ObjectCreationTests.swift
@@ -125,6 +125,15 @@ class ObjectCreationTests: TestCase {
         XCTAssertEqual(obj1.boolCol, obj2.boolCol, "object created via generic initializer should equal object created by calling initializer directly")
     }
 
+    func testGenericInitWithValue() {
+        func createObject<T: Object>(value value: AnyObject) -> T {
+            return T(value: value)
+        }
+        let obj1: SwiftBoolObject = createObject(value: ["boolCol": true])
+        let obj2 = SwiftBoolObject(value: ["boolCol": true])
+        XCTAssertEqual(obj1.boolCol, obj2.boolCol, "object created via generic initializer should equal object created by calling initializer directly")
+    }
+
     // MARK: Creation tests
 
     func testCreateWithDefaults() {


### PR DESCRIPTION
Related: https://github.com/realm/realm-cocoa/issues/1916

Invoking `init(value:)` with generics type will cause a crash due to Swift compiler cannot find appropriate initializer. (In Swift 2, the compiler treats it as compile error: `Constructing an object of class type 'T' with a metatype value must use a 'required' initializer`)

In Objective-C, both `- init` and `- initWithValue:` are specified `NS_DESIGNATED_INITIALIZER`. Assuming the same meaning it is a 'required' in Swift, `init(value:)` also should be specified `required`, I think. 

@tgoyne @segiddins @jpsim 