### PR TITLE
delete all realm files between Swift unit tests

### DIFF
--- a/RealmSwift-swift1.2/Tests/RealmTests.swift
+++ b/RealmSwift-swift1.2/Tests/RealmTests.swift
@@ -121,6 +121,7 @@ class RealmTests: TestCase {
 
     func testInitCustomClassList() {
         let configuration = Realm.Configuration(objectTypes: [SwiftStringObject.self])
+        NSFileManager.defaultManager().removeItemAtPath(configuration.path, error: nil)
         let realm = Realm(configuration: configuration)!
         XCTAssertEqual(["SwiftStringObject"], realm.schema.objectSchema.map { $0.className })
     }

--- a/RealmSwift-swift1.2/Tests/TestCase.swift
+++ b/RealmSwift-swift1.2/Tests/TestCase.swift
@@ -89,7 +89,7 @@ class TestCase: XCTestCase {
     }
 
     private func deleteRealmFiles() {
-        let succeeded = NSFileManager.defaultManager().removeItemAtPath(realmPathForFile(""), error: nil)
+        let succeeded = NSFileManager.defaultManager().removeItemAtPath(Realm.defaultPath.stringByDeletingLastPathComponent, error: nil)
         assert(succeeded, "Unable to delete realm files")
     }
 

--- a/RealmSwift-swift2.0/Tests/TestCase.swift
+++ b/RealmSwift-swift2.0/Tests/TestCase.swift
@@ -90,7 +90,7 @@ class TestCase: XCTestCase {
 
     private func deleteRealmFiles() {
         do {
-            try NSFileManager.defaultManager().removeItemAtPath(realmPathForFile(""))
+            try NSFileManager.defaultManager().removeItemAtPath((Realm.defaultPath as NSString).stringByDeletingLastPathComponent)
         } catch {
             XCTFail("Unable to delete realm files")
         }


### PR DESCRIPTION
Should fix the `RealmTests.testInitCustomClassList()` test case that's been failing lately /cc @segiddins 