### PR TITLE
Add Realm.isEmpty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ x.x.x Release notes (yyyy-MM-dd)
 * Committing write transactions (via `commitWrite` / `commitWriteTransaction` and
   `write` / `transactionWithBlock`) now optionally allow for handling errors when
   the disk is out of space.
+* Added `isEmpty` property on `RLMRealm`/`Realm` to indicate if it contains any
+  objects.
 
 ### Bugfixes
 

--- a/Realm/ObjectStore/object_store.cpp
+++ b/Realm/ObjectStore/object_store.cpp
@@ -479,3 +479,16 @@ void ObjectStore::delete_data_for_object(Group *group, const StringData &object_
     }
 }
 
+bool ObjectStore::is_empty(const Group *group) {
+    for (size_t i = 0; i < group->size(); i++) {
+        ConstTableRef table = group->get_table(i);
+        string object_type = object_type_for_table_name(table->get_name());
+        if (!object_type.length()) {
+            continue;
+        }
+        if (!table->is_empty()) {
+            return false;
+        }
+    }
+    return true;
+}

--- a/Realm/ObjectStore/object_store.hpp
+++ b/Realm/ObjectStore/object_store.hpp
@@ -74,6 +74,9 @@ namespace realm {
         // deletes the table for the given type
         static void delete_data_for_object(Group *group, const StringData &object_type);
 
+        // indicates if this group contains any objects
+        static bool is_empty(const Group *group);
+
     private:
         // set a new schema version
         static void set_schema_version(Group *group, uint64_t version);

--- a/Realm/RLMRealm.h
+++ b/Realm/RLMRealm.h
@@ -204,6 +204,11 @@ RLM_ASSUME_NONNULL_BEGIN
  */
 @property (nonatomic, readonly) RLMRealmConfiguration *configuration;
 
+/**
+ Indicates if this Realm contains any objects.
+ */
+@property (nonatomic, readonly) BOOL isEmpty;
+
 /**---------------------------------------------------------------------------------------
  *  @name Default Realm Path
  * ---------------------------------------------------------------------------------------

--- a/Realm/RLMRealm.mm
+++ b/Realm/RLMRealm.mm
@@ -190,6 +190,11 @@ void RLMRealmAddPathSettingsToConfiguration(RLMRealmConfiguration *configuration
     NSData *_encryptionKey;
 }
 
+- (BOOL)isEmpty
+{
+    return realm::ObjectStore::is_empty(self.group);
+}
+
 + (BOOL)isCoreDebug {
     return realm::Version::has_feature(realm::feature_Debug);
 }

--- a/Realm/Tests/RealmTests.mm
+++ b/Realm/Tests/RealmTests.mm
@@ -95,6 +95,24 @@ extern "C" {
     XCTAssertEqualObjects(testRealm.path, RLMTestRealmPath(), @"Test path");
 }
 
+- (void)testIsEmpty
+{
+    RLMRealm *realm = [RLMRealm defaultRealm];
+    XCTAssertTrue(realm.isEmpty, @"Realm should be empty on creation.");
+
+    [realm beginWriteTransaction];
+    [StringObject createInRealm:realm withValue:@[@"a"]];
+    XCTAssertFalse(realm.isEmpty, @"Realm should not be empty within a write transaction after adding an object.");
+    [realm cancelWriteTransaction];
+
+    XCTAssertTrue(realm.isEmpty, @"Realm should be empty after canceling a write transaction that added an object.");
+
+    [realm beginWriteTransaction];
+    [StringObject createInRealm:realm withValue:@[@"a"]];
+    [realm commitWriteTransaction];
+    XCTAssertFalse(realm.isEmpty, @"Realm should not be empty after committing a write transaction that added an object.");
+}
+
 - (void)testRealmConfiguration {
     RLMRealm *realm = [RLMRealm defaultRealm];
     RLMRealmConfiguration *configuration = realm.configuration;

--- a/RealmSwift-swift1.2/Realm.swift
+++ b/RealmSwift-swift1.2/Realm.swift
@@ -58,6 +58,9 @@ public final class Realm {
     /// Returns a `Configuration` that can be used to create this `Realm` instance.
     public var configuration: Configuration { return Configuration.fromRLMRealmConfiguration(rlmRealm.configuration) }
 
+    /// Indicates if this Realm contains any objects.
+    public var isEmpty: Bool { return rlmRealm.isEmpty }
+
     /**
     The location of the default Realm as a string. Can be overridden.
 

--- a/RealmSwift-swift1.2/Tests/RealmTests.swift
+++ b/RealmSwift-swift1.2/Tests/RealmTests.swift
@@ -61,6 +61,24 @@ class RealmTests: TestCase {
         XCTAssertEqual(1, schema.objectSchema.filter({ $0.className == "SwiftStringObject" }).count)
     }
 
+    func testIsEmpty() {
+        NSFileManager.defaultManager().removeItemAtPath(Realm.defaultPath, error: nil)
+        let realm = Realm()
+        XCTAssert(realm.isEmpty, "Realm should be empty on creation.")
+
+        realm.beginWrite()
+        realm.create(SwiftStringObject.self, value: ["a"])
+        XCTAssertFalse(realm.isEmpty, "Realm should not be empty within a write transaction after adding an object.")
+        realm.cancelWrite()
+
+        XCTAssertTrue(realm.isEmpty, "Realm should be empty after canceling a write transaction that added an object.")
+
+        realm.beginWrite()
+        realm.create(SwiftStringObject.self, value: ["a"])
+        realm.commitWrite()
+        XCTAssertFalse(realm.isEmpty, "Realm should not be empty after committing a write transaction that added an object.")
+    }
+
     func testDefaultPath() {
         let defaultPath =  Realm().path
         XCTAssertEqual(Realm.defaultPath, defaultPath)

--- a/RealmSwift-swift2.0/Realm.swift
+++ b/RealmSwift-swift2.0/Realm.swift
@@ -58,6 +58,9 @@ public final class Realm {
     /// Returns a `Configuration` that can be used to create this `Realm` instance.
     public var configuration: Configuration { return Configuration.fromRLMRealmConfiguration(rlmRealm.configuration) }
 
+    /// Indicates if this Realm contains any objects.
+    public var isEmpty: Bool { return rlmRealm.isEmpty }
+
     /**
     The location of the default Realm as a string. Can be overridden.
 

--- a/RealmSwift-swift2.0/Tests/RealmTests.swift
+++ b/RealmSwift-swift2.0/Tests/RealmTests.swift
@@ -61,6 +61,24 @@ class RealmTests: TestCase {
         XCTAssertEqual(1, schema.objectSchema.filter({ $0.className == "SwiftStringObject" }).count)
     }
 
+    func testIsEmpty() {
+        try! NSFileManager.defaultManager().removeItemAtPath(Realm.defaultPath)
+        let realm = try! Realm()
+        XCTAssert(realm.isEmpty, "Realm should be empty on creation.")
+
+        realm.beginWrite()
+        realm.create(SwiftStringObject.self, value: ["a"])
+        XCTAssertFalse(realm.isEmpty, "Realm should not be empty within a write transaction after adding an object.")
+        realm.cancelWrite()
+
+        XCTAssertTrue(realm.isEmpty, "Realm should be empty after canceling a write transaction that added an object.")
+
+        realm.beginWrite()
+        realm.create(SwiftStringObject.self, value: ["a"])
+        try! realm.commitWrite()
+        XCTAssertFalse(realm.isEmpty, "Realm should not be empty after committing a write transaction that added an object.")
+    }
+
     func testDefaultPath() {
         let defaultPath =  try! Realm().path
         XCTAssertEqual(Realm.defaultPath, defaultPath)


### PR DESCRIPTION
Fixes #2501.

We've avoided doing this for a long time because it's fairly easy to do via existing means, but this is much more semantic and clear, so probably a good thing to do. /cc @tgoyne @bdash 

I didn't do this for `RLMCollection` despite it being available on `RealmCollectionType` (in Swift 2, by "inheritance"), because it's only there implicitly, and I think `isEmpty` provides the same level of clarity and semantic meaning as `.count == 0`.