### PR TITLE
make Object conform to Hashable in Swift 1.2

### DIFF
--- a/RealmSwift-swift1.2/Object.swift
+++ b/RealmSwift-swift1.2/Object.swift
@@ -53,7 +53,7 @@ the `objects(_:)` instance method on `Realm`.
 
 See our [Cocoa guide](http://realm.io/docs/cocoa) for more details.
 */
-public class Object: RLMObjectBase, Equatable, Printable {
+public class Object: RLMObjectBase, Hashable, Printable {
 
     // MARK: Initializers
 


### PR DESCRIPTION
Fixes #2519 for Swift 1.2. /cc @bdash 

Note: `Hashable` implies `Equatable` because it inherits from it.