### PR TITLE
Fix issues with partial shared schema init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,8 @@ x.x.x Release notes (yyyy-MM-dd)
 
 ### Bugfixes
 
-* None.
+* Fix crashes when the first Realm opened uses a class subset and later Realms
+  opened do not.
 
 0.95.2 Release notes (2015-09-24)
 =============================================================

--- a/Realm.xcodeproj/project.pbxproj
+++ b/Realm.xcodeproj/project.pbxproj
@@ -307,6 +307,9 @@
 		3FB4FA1E19F5D2740020D53B /* SwiftPropertyTypeTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26F3CA681986CC86004623E1 /* SwiftPropertyTypeTest.swift */; };
 		3FB4FA1F19F5D2740020D53B /* SwiftRealmTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E81A1FD01955FE0100FDED82 /* SwiftRealmTests.swift */; };
 		3FB4FA2019F5D2740020D53B /* SwiftUnicodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E891759A197A1B600068ACC6 /* SwiftUnicodeTests.swift */; };
+		3FC767071BB9FE7500FE0AFC /* RLMMultiProcessTestCase.m in Sources */ = {isa = PBXBuildFile; fileRef = 027A4D2B1AB1012500AA46F9 /* RLMMultiProcessTestCase.m */; settings = {ASSET_TAGS = (); }; };
+		3FC767081BB9FE7600FE0AFC /* RLMMultiProcessTestCase.m in Sources */ = {isa = PBXBuildFile; fileRef = 027A4D2B1AB1012500AA46F9 /* RLMMultiProcessTestCase.m */; settings = {ASSET_TAGS = (); }; };
+		3FC767091BB9FE7700FE0AFC /* RLMMultiProcessTestCase.m in Sources */ = {isa = PBXBuildFile; fileRef = 027A4D2B1AB1012500AA46F9 /* RLMMultiProcessTestCase.m */; settings = {ASSET_TAGS = (); }; };
 		3FDCFEB619F6A8D3005E414A /* RLMSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = E88C36FF19745E5500C9963D /* RLMSupport.swift */; };
 		3FDE338C19C37E4C003B7DBA /* RLMSwiftSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 3F452EC519C2279800AFC154 /* RLMSwiftSupport.m */; };
 		3FDE338D19C39A87003B7DBA /* RLMSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = E88C36FF19745E5500C9963D /* RLMSupport.swift */; };
@@ -315,6 +318,10 @@
 		5D30B74B1B42072600D90C5A /* RLMDefines.h in Headers */ = {isa = PBXBuildFile; fileRef = 5D30B74A1B42039F00D90C5A /* RLMDefines.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		5D30B74C1B42072700D90C5A /* RLMDefines.h in Headers */ = {isa = PBXBuildFile; fileRef = 5D30B74A1B42039F00D90C5A /* RLMDefines.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		5D30B74D1B42072800D90C5A /* RLMDefines.h in Headers */ = {isa = PBXBuildFile; fileRef = 5D30B74A1B42039F00D90C5A /* RLMDefines.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A05AEB701B6A9B0D00072027 /* RLMObjectBase_Dynamic.h in Headers */ = {isa = PBXBuildFile; fileRef = A05FA61E1B62C3900000C9B2 /* RLMObjectBase_Dynamic.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A05AEB711B6A9B0E00072027 /* RLMObjectBase_Dynamic.h in Headers */ = {isa = PBXBuildFile; fileRef = A05FA61E1B62C3900000C9B2 /* RLMObjectBase_Dynamic.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A05AEB721B6A9B0F00072027 /* RLMObjectBase_Dynamic.h in Headers */ = {isa = PBXBuildFile; fileRef = A05FA61E1B62C3900000C9B2 /* RLMObjectBase_Dynamic.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A0CCA0BF1B7C0B4A000B6B0F /* RLMObjectBase_Dynamic.h in Headers */ = {isa = PBXBuildFile; fileRef = A05FA61E1B62C3900000C9B2 /* RLMObjectBase_Dynamic.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		C02E53E11B7A7E2B002586E8 /* RLMRealmConfiguration.mm in Sources */ = {isa = PBXBuildFile; fileRef = C0D2DD061B6BDEA1004E8919 /* RLMRealmConfiguration.mm */; };
 		C02E53E21B7A7E2B002586E8 /* RLMRealmConfiguration.mm in Sources */ = {isa = PBXBuildFile; fileRef = C0D2DD061B6BDEA1004E8919 /* RLMRealmConfiguration.mm */; };
 		C02E53E31B7A7E2C002586E8 /* RLMRealmConfiguration.mm in Sources */ = {isa = PBXBuildFile; fileRef = C0D2DD061B6BDEA1004E8919 /* RLMRealmConfiguration.mm */; };
@@ -329,14 +336,6 @@
 		C07BC7D31B702BD500A08906 /* RLMRealmConfiguration_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = C0D2DD0F1B6BE0DD004E8919 /* RLMRealmConfiguration_Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		C07BC7D41B702BD700A08906 /* RLMRealmConfiguration_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = C0D2DD0F1B6BE0DD004E8919 /* RLMRealmConfiguration_Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		C07BC7D51B702BD800A08906 /* RLMRealmConfiguration_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = C0D2DD0F1B6BE0DD004E8919 /* RLMRealmConfiguration_Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		A05FA61F1B62CDD20000C9B2 /* RLMObjectBase_Dynamic.h in Headers */ = {isa = PBXBuildFile; fileRef = A05FA61E1B62C3900000C9B2 /* RLMObjectBase_Dynamic.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		A05FA6201B62CDD30000C9B2 /* RLMObjectBase_Dynamic.h in Headers */ = {isa = PBXBuildFile; fileRef = A05FA61E1B62C3900000C9B2 /* RLMObjectBase_Dynamic.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		A05FA6211B62CDD40000C9B2 /* RLMObjectBase_Dynamic.h in Headers */ = {isa = PBXBuildFile; fileRef = A05FA61E1B62C3900000C9B2 /* RLMObjectBase_Dynamic.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		A05FA6221B62CDD40000C9B2 /* RLMObjectBase_Dynamic.h in Headers */ = {isa = PBXBuildFile; fileRef = A05FA61E1B62C3900000C9B2 /* RLMObjectBase_Dynamic.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		A05AEB701B6A9B0D00072027 /* RLMObjectBase_Dynamic.h in Headers */ = {isa = PBXBuildFile; fileRef = A05FA61E1B62C3900000C9B2 /* RLMObjectBase_Dynamic.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		A05AEB711B6A9B0E00072027 /* RLMObjectBase_Dynamic.h in Headers */ = {isa = PBXBuildFile; fileRef = A05FA61E1B62C3900000C9B2 /* RLMObjectBase_Dynamic.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		A05AEB721B6A9B0F00072027 /* RLMObjectBase_Dynamic.h in Headers */ = {isa = PBXBuildFile; fileRef = A05FA61E1B62C3900000C9B2 /* RLMObjectBase_Dynamic.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		A0CCA0BF1B7C0B4A000B6B0F /* RLMObjectBase_Dynamic.h in Headers */ = {isa = PBXBuildFile; fileRef = A05FA61E1B62C3900000C9B2 /* RLMObjectBase_Dynamic.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		C0CDC0821B38DABA00C5716D /* UtilTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 021A88311AAFB5BE00EEAC84 /* UtilTests.mm */; };
 		C0CDC0831B38DABB00C5716D /* UtilTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 021A88311AAFB5BE00EEAC84 /* UtilTests.mm */; };
 		C0CDC0841B38DABB00C5716D /* UtilTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 021A88311AAFB5BE00EEAC84 /* UtilTests.mm */; };
@@ -629,8 +628,8 @@
 		3F8DCA5719930F550008BD7F /* iOS Device Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "iOS Device Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		3FE79FF719BA6A5900780C9A /* RLMSwiftSupport.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RLMSwiftSupport.h; sourceTree = "<group>"; };
 		5D30B74A1B42039F00D90C5A /* RLMDefines.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RLMDefines.h; sourceTree = "<group>"; };
-		C042A48C1B7522A900771ED2 /* RealmConfigurationTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = RealmConfigurationTests.mm; sourceTree = "<group>"; };
 		A05FA61E1B62C3900000C9B2 /* RLMObjectBase_Dynamic.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RLMObjectBase_Dynamic.h; sourceTree = "<group>"; };
+		C042A48C1B7522A900771ED2 /* RealmConfigurationTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = RealmConfigurationTests.mm; sourceTree = "<group>"; };
 		C073E1201AE9B705002C0A30 /* RLMObject_Private.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = RLMObject_Private.hpp; sourceTree = "<group>"; };
 		C0D2DD051B6BDEA1004E8919 /* RLMRealmConfiguration.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RLMRealmConfiguration.h; sourceTree = "<group>"; };
 		C0D2DD061B6BDEA1004E8919 /* RLMRealmConfiguration.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = RLMRealmConfiguration.mm; sourceTree = "<group>"; };
@@ -923,6 +922,7 @@
 				C073E1201AE9B705002C0A30 /* RLMObject_Private.hpp */,
 				023B19571A3BA90D0067FB81 /* RLMObjectBase.h */,
 				023B19581A3BA90D0067FB81 /* RLMObjectBase.mm */,
+				A05FA61E1B62C3900000C9B2 /* RLMObjectBase_Dynamic.h */,
 				E81A1F711955FC9300FDED82 /* RLMObjectSchema.h */,
 				E81A1F721955FC9300FDED82 /* RLMObjectSchema.mm */,
 				29EDB8E91A7712E500458D80 /* RLMObjectSchema_Private.h */,
@@ -940,7 +940,6 @@
 				E81A1F7B1955FC9300FDED82 /* RLMRealm.h */,
 				E81A1F7C1955FC9300FDED82 /* RLMRealm.mm */,
 				E8951F01196C96DE00D6461C /* RLMRealm_Dynamic.h */,
-				A05FA61E1B62C3900000C9B2 /* RLMObjectBase_Dynamic.h */,
 				29EDB8E01A77070200458D80 /* RLMRealm_Private.h */,
 				02E334C41A5F4923009F8810 /* RLMRealm_Private.hpp */,
 				C0D2DD051B6BDEA1004E8919 /* RLMRealmConfiguration.h */,
@@ -1021,9 +1020,9 @@
 				144C2F601B3D3517005C8F81 /* RLMObject.h in Headers */,
 				144C2F6A1B3D3529005C8F81 /* RLMObject_Private.h in Headers */,
 				144C2F611B3D3517005C8F81 /* RLMObjectBase.h in Headers */,
+				A0CCA0BF1B7C0B4A000B6B0F /* RLMObjectBase_Dynamic.h in Headers */,
 				144C2F621B3D3517005C8F81 /* RLMObjectSchema.h in Headers */,
 				144C2F6B1B3D3529005C8F81 /* RLMObjectSchema_Private.h in Headers */,
-				A0CCA0BF1B7C0B4A000B6B0F /* RLMObjectBase_Dynamic.h in Headers */,
 				144C2F741B3D3539005C8F81 /* RLMObjectSchema_Private.hpp in Headers */,
 				144C2F6C1B3D3529005C8F81 /* RLMObjectStore.h in Headers */,
 				C06C74031B797EF10027FF85 /* RLMObservation.hpp in Headers */,
@@ -1069,9 +1068,9 @@
 				29E3C7241A71C1C700B62C1D /* RLMObject.h in Headers */,
 				29E3C72B1A71C1C700B62C1D /* RLMObject_Private.h in Headers */,
 				29E3C7211A71C1C700B62C1D /* RLMObjectBase.h in Headers */,
+				A05AEB721B6A9B0F00072027 /* RLMObjectBase_Dynamic.h in Headers */,
 				29E3C7251A71C1C700B62C1D /* RLMObjectSchema.h in Headers */,
 				29EDB8EC1A7712E500458D80 /* RLMObjectSchema_Private.h in Headers */,
-				A05AEB721B6A9B0F00072027 /* RLMObjectBase_Dynamic.h in Headers */,
 				29E3C7261A71C1C700B62C1D /* RLMObjectSchema_Private.hpp in Headers */,
 				29EDB8DA1A7703C500458D80 /* RLMObjectStore.h in Headers */,
 				3F0F02B01B6FFF3D0046A4D5 /* RLMObservation.hpp in Headers */,
@@ -1117,9 +1116,9 @@
 				E856D1FD1956154C00FB2FCF /* RLMObject.h in Headers */,
 				29EDB8DD1A7705EA00458D80 /* RLMObject_Private.h in Headers */,
 				023B19601A3BA90E0067FB81 /* RLMObjectBase.h in Headers */,
+				A05AEB711B6A9B0E00072027 /* RLMObjectBase_Dynamic.h in Headers */,
 				E856D2001956154C00FB2FCF /* RLMObjectSchema.h in Headers */,
 				29EDB8EB1A7712E500458D80 /* RLMObjectSchema_Private.h in Headers */,
-				A05AEB711B6A9B0E00072027 /* RLMObjectBase_Dynamic.h in Headers */,
 				E856D1FF1956154C00FB2FCF /* RLMObjectSchema_Private.hpp in Headers */,
 				29EDB8D91A7703C500458D80 /* RLMObjectStore.h in Headers */,
 				3F0F02AF1B6FFF3D0046A4D5 /* RLMObservation.hpp in Headers */,
@@ -1165,9 +1164,9 @@
 				E81A1F961955FC9300FDED82 /* RLMObject.h in Headers */,
 				29EDB8DE1A7705EB00458D80 /* RLMObject_Private.h in Headers */,
 				023B195F1A3BA90E0067FB81 /* RLMObjectBase.h in Headers */,
+				A05AEB701B6A9B0D00072027 /* RLMObjectBase_Dynamic.h in Headers */,
 				E81A1F9A1955FC9300FDED82 /* RLMObjectSchema.h in Headers */,
 				29EDB8EA1A7712E500458D80 /* RLMObjectSchema_Private.h in Headers */,
-				A05AEB701B6A9B0D00072027 /* RLMObjectBase_Dynamic.h in Headers */,
 				E81A1F991955FC9300FDED82 /* RLMObjectSchema_Private.hpp in Headers */,
 				29EDB8D81A7703C500458D80 /* RLMObjectStore.h in Headers */,
 				3F0F02AE1B6FFF3D0046A4D5 /* RLMObservation.hpp in Headers */,
@@ -1615,6 +1614,7 @@
 				C042A48F1B7522A900771ED2 /* RealmConfigurationTests.mm in Sources */,
 				026B0F141A780680005E26C8 /* RealmTests.mm in Sources */,
 				02AFB4691A80343600E11938 /* ResultsTests.m in Sources */,
+				3FC767081BB9FE7600FE0AFC /* RLMMultiProcessTestCase.m in Sources */,
 				026B0F151A780680005E26C8 /* RLMPredicateUtil.m in Sources */,
 				026B0F161A780680005E26C8 /* RLMSupport.swift in Sources */,
 				026B0F171A780680005E26C8 /* RLMTestCase.m in Sources */,
@@ -1730,6 +1730,7 @@
 				C042A4901B7522A900771ED2 /* RealmConfigurationTests.mm in Sources */,
 				3F8DCA7319930F960008BD7F /* RealmTests.mm in Sources */,
 				02AFB46A1A80343600E11938 /* ResultsTests.m in Sources */,
+				3FC767091BB9FE7700FE0AFC /* RLMMultiProcessTestCase.m in Sources */,
 				3F8DCA6219930F8E0008BD7F /* RLMPredicateUtil.m in Sources */,
 				3F8DCA6319930F8E0008BD7F /* RLMTestCase.m in Sources */,
 				3F8DCA81199310D40008BD7F /* RLMTestObjects.m in Sources */,
@@ -1793,6 +1794,7 @@
 				C042A48E1B7522A900771ED2 /* RealmConfigurationTests.mm in Sources */,
 				E856D21E195615A900FB2FCF /* RealmTests.mm in Sources */,
 				02AFB4681A80343600E11938 /* ResultsTests.m in Sources */,
+				3FC767071BB9FE7500FE0AFC /* RLMMultiProcessTestCase.m in Sources */,
 				E8A5DEEE1968E521006A50F6 /* RLMPredicateUtil.m in Sources */,
 				3FDE338D19C39A87003B7DBA /* RLMSupport.swift in Sources */,
 				E856D21F195615B100FB2FCF /* RLMTestCase.m in Sources */,

--- a/Realm/RLMAccessor.h
+++ b/Realm/RLMAccessor.h
@@ -38,6 +38,9 @@ RLM_ASSUME_NONNULL_BEGIN
 Class RLMAccessorClassForObjectClass(Class objectClass, RLMObjectSchema *schema, NSString *prefix);
 Class RLMStandaloneAccessorClassForObjectClass(Class objectClass, RLMObjectSchema *schema);
 
+// Check if a given class is a generated accessor class
+bool RLMIsGeneratedClass(Class cls);
+
 //
 // Dynamic getters/setters
 //

--- a/Realm/RLMSchema.mm
+++ b/Realm/RLMSchema.mm
@@ -97,7 +97,7 @@ static NSMutableDictionary *s_localNameToClass = [[NSMutableDictionary alloc] in
         for (NSUInteger i = 0; i < count; i++) {
             Class cls = classes[i];
 
-            if (!RLMIsObjectSubclass(cls)) {
+            if (!RLMIsObjectSubclass(cls) || RLMIsGeneratedClass(cls)) {
                 continue;
             }
 

--- a/Realm/Tests/RLMMultiProcessTestCase.h
+++ b/Realm/Tests/RLMMultiProcessTestCase.h
@@ -18,6 +18,8 @@
 
 #import "RLMTestCase.h"
 
+@class NSTask;
+
 @interface RLMMultiProcessTestCase : RLMTestCase
 // if true, this is running the main test process
 @property (nonatomic, readonly) bool isParent;

--- a/Realm/Tests/RLMMultiProcessTestCase.m
+++ b/Realm/Tests/RLMMultiProcessTestCase.m
@@ -75,6 +75,7 @@
     // Do nothing so that we can test global schema init in child processes
 }
 
+#if !TARGET_OS_IPHONE && !TARGET_IPHONE_SIMULATOR
 - (NSTask *)childTask {
     NSString *testName = [NSString stringWithFormat:@"%@/%@", self.className, self.testName];
     NSMutableDictionary *env = [NSProcessInfo.processInfo.environment mutableCopy];
@@ -128,4 +129,13 @@
 
     return task.terminationStatus;
 }
+#else
+- (NSTask *)childTask {
+    return nil;
+}
+
+- (int)runChildAndWait {
+    return 1;
+}
+#endif
 @end

--- a/Realm/Tests/RLMMultiProcessTestCase.m
+++ b/Realm/Tests/RLMMultiProcessTestCase.m
@@ -71,6 +71,10 @@
     }
 }
 
++ (void)preintializeSchema {
+    // Do nothing so that we can test global schema init in child processes
+}
+
 - (NSTask *)childTask {
     NSString *testName = [NSString stringWithFormat:@"%@/%@", self.className, self.testName];
     NSMutableDictionary *env = [NSProcessInfo.processInfo.environment mutableCopy];

--- a/Realm/Tests/RLMTestCase.m
+++ b/Realm/Tests/RLMTestCase.m
@@ -83,10 +83,7 @@ static BOOL encryptTests() {
     // re-enabled and we need it enabled for performance tests
     RLMDisableSyncToDisk();
 #endif
-    // This ensures the shared schema is initialized outside of of a test case,
-    // so if an exception is thrown, it will kill the test process rather than
-    // allowing hundreds of test cases to fail in strange ways
-    [RLMSchema sharedSchema];
+    [self preintializeSchema];
 
     // Ensure the documents directory exists as it sometimes doesn't after
     // resetting the simulator
@@ -114,6 +111,14 @@ static BOOL encryptTests() {
         }
         [self deleteFiles];
     }
+}
+
+// This ensures the shared schema is initialized outside of of a test case,
+// so if an exception is thrown, it will kill the test process rather than
+// allowing hundreds of test cases to fail in strange ways
+// This is overridden by RLMMultiProcessTestCase to support testing the schema init
++ (void)preintializeSchema {
+    [RLMSchema sharedSchema];
 }
 
 - (void)deleteFiles {

--- a/Realm/Tests/SchemaTests.mm
+++ b/Realm/Tests/SchemaTests.mm
@@ -463,7 +463,7 @@ RLM_ARRAY_TYPE(SchemaTestClassSecondChild)
 }
 
 // Can't spawn child processes on iOS
-#if !TARGET_OS_IOS
+#if !TARGET_OS_IPHONE && !TARGET_IPHONE_SIMULATOR
 - (void)testPartialSharedSchemaInit {
     if (self.isParent) {
         RLMRunChildAndWait();

--- a/Realm/Tests/SchemaTests.mm
+++ b/Realm/Tests/SchemaTests.mm
@@ -18,7 +18,7 @@
 
 #import <XCTest/XCTest.h>
 
-#import "RLMTestCase.h"
+#import "RLMMultiProcessTestCase.h"
 
 #import "RLMAccessor.h"
 #import "RLMObjectSchema_Private.hpp"
@@ -125,7 +125,7 @@ RLM_ARRAY_TYPE(SchemaTestClassSecondChild)
 }
 @end
 
-@interface SchemaTests : RLMTestCase
+@interface SchemaTests : RLMMultiProcessTestCase
 @end
 
 @implementation SchemaTests
@@ -461,5 +461,48 @@ RLM_ARRAY_TYPE(SchemaTestClassSecondChild)
 - (void)testClassWithRequiredLinkProperty {
     RLMAssertThrowsWithReasonMatching([RLMObjectSchema schemaForObjectClass:RequiredLinkProperty.class], @"cannot be made required.*'object'");
 }
+
+// Can't spawn child processes on iOS
+#if !TARGET_OS_IOS
+- (void)testPartialSharedSchemaInit {
+    if (self.isParent) {
+        RLMRunChildAndWait();
+        return;
+    }
+
+    RLMRealmConfiguration *config = [RLMRealmConfiguration new];
+
+    // Verify that opening with class subsets without the shared schema being
+    // initialized works
+    config.objectClasses = @[IntObject.class];
+    @autoreleasepool {
+        RLMRealm *realm = [RLMRealm realmWithConfiguration:config error:nil];
+        XCTAssertEqual(1U, realm.schema.objectSchema.count);
+    }
+
+    config.objectClasses = @[IntObject.class, StringObject.class];
+    @autoreleasepool {
+        RLMRealm *realm = [RLMRealm realmWithConfiguration:config error:nil];
+        XCTAssertEqual(2U, realm.schema.objectSchema.count);
+    }
+
+    // Verify that the shared schema generated afterwards is valid
+    config.objectClasses = nil;
+    @autoreleasepool {
+        RLMRealm *realm = [RLMRealm defaultRealm];
+
+        // Shared schema shouldn't have accessor classes
+        for (RLMObjectSchema *objectSchema in realm.schema.objectSchema) {
+            const char *actualClassName = class_getName(objectSchema.objectClass);
+            XCTAssertEqual(nullptr, strstr(actualClassName, "RLMAccessor"));
+            XCTAssertEqual(nullptr, strstr(actualClassName, "RLMStandalone"));
+        }
+
+        // Shared schema shouldn't have duplicate entries
+        XCTAssertEqual(realm.schema.objectSchema.count,
+                       [NSSet setWithArray:[realm.schema.objectSchema valueForKey:@"className"]].count);
+    }
+}
+#endif
 
 @end


### PR DESCRIPTION
When the initial partial schema init is done with an explicit class list, duplicate object schemas for those classes would end up in the final shared schema, along with object schemas for the accessor classes. No new tests for any of this because we can't test it via our testing framework....

Closes #2534.

@jpsim @bdash 