### PR TITLE
Set default Swift version to 2.0

### DIFF
--- a/Realm/Tests/Swift
+++ b/Realm/Tests/Swift
@@ -1,1 +1,1 @@
-Swift1.2
+Swift2.0

--- a/RealmSwift
+++ b/RealmSwift
@@ -1,1 +1,1 @@
-RealmSwift-swift1.2
+RealmSwift-swift2.0

--- a/scripts/github_release.rb
+++ b/scripts/github_release.rb
@@ -22,8 +22,8 @@ Dir.mktmpdir do |tmp|
     system('unzip', SWIFT_ZIP.to_path, :out=>"/dev/null")
     FileUtils.rm_f CARTHAGE_ZIP
 
-    FileUtils.mv(%W(realm-swift-#{VERSION}/ios/swift-1.2/Realm.framework realm-swift-#{VERSION}/ios/swift-1.2/RealmSwift.framework), 'Carthage/Build/iOS')
-    FileUtils.mv(%W(realm-swift-#{VERSION}/osx/swift-1.2/Realm.framework realm-swift-#{VERSION}/osx/swift-1.2/RealmSwift.framework), 'Carthage/Build/Mac')
+    FileUtils.mv(%W(realm-swift-#{VERSION}/ios/swift-2.0/Realm.framework realm-swift-#{VERSION}/ios/swift-2.0/RealmSwift.framework), 'Carthage/Build/iOS')
+    FileUtils.mv(%W(realm-swift-#{VERSION}/osx/swift-2.0/Realm.framework realm-swift-#{VERSION}/osx/swift-2.0/RealmSwift.framework), 'Carthage/Build/Mac')
 
     system('zip', '--symlinks', '-r', CARTHAGE_ZIP.to_path, 'Carthage', :out=>"/dev/null")
   end


### PR DESCRIPTION
Now's the time to do this with Xcode 7 being officially out. I also updated the our web app to mirror changes in `master` in both `swift-1.2` and `swift-2.0` branches.

- [x] Update packaging format