### PR TITLE
Add support building on Swift version 2.1

### DIFF
--- a/RealmSwift-swift2.1
+++ b/RealmSwift-swift2.1
@@ -1,0 +1,1 @@
+RealmSwift-swift2.0


### PR DESCRIPTION
Xcode 7.1 beta 2 introduced Swift 2.1. Build fails due to returning Swift version `2.1` by beta2. This PR will just create a symbolic link to `RealmSwift-swift2.0` because Swift 2.1 does not break anything our code.

@jpsim @mrackwitz 