### PR TITLE
Include a watchOS framework to GitHub release zip

### DIFF
--- a/scripts/github_release.rb
+++ b/scripts/github_release.rb
@@ -18,12 +18,13 @@ CARTHAGE_ZIP = BUILD + 'Carthage.framework.zip'
 puts 'Creating Carthage release zip'
 Dir.mktmpdir do |tmp|
   Dir.chdir(tmp) do
-    FileUtils.mkdir_p %w(Carthage/Build/Mac Carthage/Build/iOS)
+    FileUtils.mkdir_p %w(Carthage/Build/Mac Carthage/Build/iOS Carthage/Build/watchOS)
     system('unzip', SWIFT_ZIP.to_path, :out=>"/dev/null")
     FileUtils.rm_f CARTHAGE_ZIP
 
     FileUtils.mv(%W(realm-swift-#{VERSION}/ios/swift-2.0/Realm.framework realm-swift-#{VERSION}/ios/swift-2.0/RealmSwift.framework), 'Carthage/Build/iOS')
     FileUtils.mv(%W(realm-swift-#{VERSION}/osx/swift-2.0/Realm.framework realm-swift-#{VERSION}/osx/swift-2.0/RealmSwift.framework), 'Carthage/Build/Mac')
+    FileUtils.mv(%W(realm-swift-#{VERSION}/watchos/Realm.framework realm-swift-#{VERSION}/watchos/RealmSwift.framework), 'Carthage/Build/watchOS')
 
     system('zip', '--symlinks', '-r', CARTHAGE_ZIP.to_path, 'Carthage', :out=>"/dev/null")
   end


### PR DESCRIPTION
Fix not to contain a watchOS framework to GitHub release zip for Carthage installation.