### PR TITLE
Clean up lingering in-memory realms for perf tests

### DIFF
--- a/Realm/RLMRealm_Private.h
+++ b/Realm/RLMRealm_Private.h
@@ -86,4 +86,6 @@ FOUNDATION_EXTERN void RLMRealmAddPathSettingsToConfiguration(RLMRealmConfigurat
 - (void)registerEnumerator:(RLMFastEnumerator *)enumerator;
 - (void)unregisterEnumerator:(RLMFastEnumerator *)enumerator;
 
++ (NSString *)writeableTemporaryPathForFile:(NSString *)fileName;
+
 @end

--- a/Realm/Tests/PerformanceTests.m
+++ b/Realm/Tests/PerformanceTests.m
@@ -18,6 +18,8 @@
 
 #import "RLMTestCase.h"
 
+#import "RLMRealm_Private.h"
+
 #if !DEBUG
 
 @interface PerformanceTests : RLMTestCase
@@ -59,6 +61,12 @@ static RLMRealm *s_smallRealm, *s_mediumRealm, *s_largeRealm;
 + (RLMRealm *)createStringObjects:(int)factor {
     RLMRealmConfiguration *config = [RLMRealmConfiguration new];
     config.inMemoryIdentifier = @(factor).stringValue;
+
+    // If a previous run of the tests crashed there could be a lingering
+    // copy of the in-memory realm
+    // FIXME: remove this once core does it automatically
+    [NSFileManager.defaultManager removeItemAtPath:[RLMRealm writeableTemporaryPathForFile:config.inMemoryIdentifier] error:nil];
+
     RLMRealm *realm = [RLMRealm realmWithConfiguration:config error:nil];
     [realm beginWriteTransaction];
     for (int i = 0; i < 1000 * factor; ++i) {


### PR DESCRIPTION
If the test application crashes while running a performance test, the in-memory realm file isn't deleted, and then is opened the next time the tests are run. This works out fine when it's the same file format version, but upgrading in-memory realms doesn't work correctly (and of course downgrading isn't supported at all).

@jpsim 