### PR TITLE
Fix an assertion failure when deleting objects while enumerating

### DIFF
--- a/Realm/RLMResults.mm
+++ b/Realm/RLMResults.mm
@@ -98,10 +98,13 @@ static const int RLMEnumerationBufferSize = 16;
 
     Class accessorClass = _objectSchema.accessorClass;
     for (NSUInteger index = state->state; index < count && batchCount < len; ++index) {
-        size_t row = _collection ? [_collection indexInSource:index] : _tableView.get_source_ndx(index);
-
         RLMObject *accessor = [[accessorClass alloc] initWithRealm:_realm schema:_objectSchema];
-        accessor->_row = (*_objectSchema.table)[row];
+        if (_collection) {
+            accessor->_row = (*_objectSchema.table)[[_collection indexInSource:index]];
+        }
+        else if (_tableView.is_row_attached(index)) {
+            accessor->_row = (*_objectSchema.table)[_tableView.get_source_ndx(index)];
+        }
         _strongBuffer[batchCount] = accessor;
         batchCount++;
     }

--- a/Realm/Tests/ArrayPropertyTests.m
+++ b/Realm/Tests/ArrayPropertyTests.m
@@ -565,7 +565,28 @@
     }
     XCTAssertEqual(totalCount, count);
     XCTAssertEqual(totalCount * 2, company.employees.count);
+}
 
+- (void)testDeleteDuringEnumeration {
+    RLMRealm *realm = self.realmWithTestPath;
+
+    [realm beginWriteTransaction];
+    CompanyObject *company = [[CompanyObject alloc] init];
+    company.name = @"name";
+    [realm addObject:company];
+
+    const size_t totalCount = 40;
+    for (size_t i = 0; i < totalCount; ++i) {
+        [company.employees addObject:[EmployeeObject createInRealm:realm withValue:@[@"name", @(i), @NO]]];
+    }
+
+    [realm commitWriteTransaction];
+
+    [realm beginWriteTransaction];
+    for (__unused EmployeeObject *eo in company.employees) {
+        [realm deleteObjects:company.employees];
+    }
+    [realm commitWriteTransaction];
 }
 
 - (void)testValueForKey {


### PR DESCRIPTION
Deleting objects after they're reached by the enumeration worked fine, but deleting them before they're reached wasn't handled correctly.

No changelog entry because 0.95.1 included a workaround (the proper fix required a core update).