### PR TITLE
Support using initWithValue: in Swift property defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ x.x.x Release notes (yyyy-MM-dd)
 
 * Fix crashes when the first Realm opened uses a class subset and later Realms
   opened do not.
+* Fix inconsistent errors when `Object(value: ...)` is used to initialize the
+  default value of a property of an `Object` subclass.
 
 0.95.2 Release notes (2015-09-24)
 =============================================================

--- a/Realm.xcodeproj/project.pbxproj
+++ b/Realm.xcodeproj/project.pbxproj
@@ -316,6 +316,7 @@
 		3FDE338D19C39A87003B7DBA /* RLMSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = E88C36FF19745E5500C9963D /* RLMSupport.swift */; };
 		3FE79FF819BA6A5900780C9A /* RLMSwiftSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 3FE79FF719BA6A5900780C9A /* RLMSwiftSupport.h */; };
 		3FE79FF919BA6A5900780C9A /* RLMSwiftSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 3FE79FF719BA6A5900780C9A /* RLMSwiftSupport.h */; };
+		3FEC4A3F1BBB18D400F009C3 /* SwiftSchemaTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FEC4A3D1BBB188B00F009C3 /* SwiftSchemaTests.swift */; settings = {ASSET_TAGS = (); }; };
 		5D30B74B1B42072600D90C5A /* RLMDefines.h in Headers */ = {isa = PBXBuildFile; fileRef = 5D30B74A1B42039F00D90C5A /* RLMDefines.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		5D30B74C1B42072700D90C5A /* RLMDefines.h in Headers */ = {isa = PBXBuildFile; fileRef = 5D30B74A1B42039F00D90C5A /* RLMDefines.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		5D30B74D1B42072800D90C5A /* RLMDefines.h in Headers */ = {isa = PBXBuildFile; fileRef = 5D30B74A1B42039F00D90C5A /* RLMDefines.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -639,6 +640,7 @@
 		3F6B89AE19EF40BA004E8EA8 /* librealm-ios.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = "librealm-ios.a"; path = "../core/librealm-ios.a"; sourceTree = "<group>"; };
 		3F8DCA5719930F550008BD7F /* iOS Device Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "iOS Device Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		3FE79FF719BA6A5900780C9A /* RLMSwiftSupport.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RLMSwiftSupport.h; sourceTree = "<group>"; };
+		3FEC4A3D1BBB188B00F009C3 /* SwiftSchemaTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SwiftSchemaTests.swift; path = SwiftSchemaTests.swift; sourceTree = "<group>"; };
 		5D30B74A1B42039F00D90C5A /* RLMDefines.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RLMDefines.h; sourceTree = "<group>"; };
 		A05FA61E1B62C3900000C9B2 /* RLMObjectBase_Dynamic.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RLMObjectBase_Dynamic.h; sourceTree = "<group>"; };
 		C042A48C1B7522A900771ED2 /* RealmConfigurationTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = RealmConfigurationTests.mm; sourceTree = "<group>"; };
@@ -814,6 +816,7 @@
 				E82FA60F195632F20043A3C3 /* SwiftObjectInterfaceTests.swift */,
 				26F3CA681986CC86004623E1 /* SwiftPropertyTypeTest.swift */,
 				E81A1FD01955FE0100FDED82 /* SwiftRealmTests.swift */,
+				3FEC4A3D1BBB188B00F009C3 /* SwiftSchemaTests.swift */,
 				E8F8D90B196CB8DD00475368 /* SwiftTestObjects.swift */,
 				E891759A197A1B600068ACC6 /* SwiftUnicodeTests.swift */,
 			);
@@ -1881,6 +1884,7 @@
 				3FB4FA1D19F5D2740020D53B /* SwiftObjectInterfaceTests.swift in Sources */,
 				3FB4FA1E19F5D2740020D53B /* SwiftPropertyTypeTest.swift in Sources */,
 				3FB4FA1F19F5D2740020D53B /* SwiftRealmTests.swift in Sources */,
+				3FEC4A3F1BBB18D400F009C3 /* SwiftSchemaTests.swift in Sources */,
 				3FB4FA1719F5D2740020D53B /* SwiftTestObjects.swift in Sources */,
 				3FB4FA2019F5D2740020D53B /* SwiftUnicodeTests.swift in Sources */,
 				E81A20021955FE0100FDED82 /* TransactionTests.m in Sources */,

--- a/Realm/RLMObjectBase.mm
+++ b/Realm/RLMObjectBase.mm
@@ -81,6 +81,11 @@ static id RLMValidatedObjectForProperty(id obj, RLMProperty *prop, RLMSchema *sc
 
 - (instancetype)initWithValue:(id)value schema:(RLMSchema *)schema {
     self = [self init];
+    if (!_objectSchema) {
+        // _objectSchema will not be set if we're called during schema init
+        return self;
+    }
+
     NSArray *properties = _objectSchema.properties;
     if (NSArray *array = RLMDynamicCast<NSArray>(value)) {
         if (array.count != properties.count) {

--- a/Realm/Tests/Swift1.2/Swift-Tests-Bridging-Header.h
+++ b/Realm/Tests/Swift1.2/Swift-Tests-Bridging-Header.h
@@ -17,5 +17,8 @@
 ////////////////////////////////////////////////////////////////////////////
 
 #import "RLMTestObjects.h"
-#import "RLMTestCase.h"
+#import "RLMMultiProcessTestCase.h"
 
+@interface RLMSchema (Private)
++ (void)registerClasses:(const Class[])classes count:(NSUInteger)count;
+@end

--- a/Realm/Tests/Swift1.2/SwiftSchemaTests.swift
+++ b/Realm/Tests/Swift1.2/SwiftSchemaTests.swift
@@ -1,0 +1,45 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2015 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+import XCTest
+import Realm
+
+class InitLinkedToClass: RLMObject {
+    dynamic var value = SwiftIntObject(value: [0])
+}
+
+class SwiftSchemaTests: RLMMultiProcessTestCase {
+    func testWorksAtAll() {
+        if isParent {
+            XCTAssertEqual(0, runChildAndWait(), "Tests in child process failed")
+        }
+    }
+
+    func testSchemaInitWithLinkedToObjectUsingInitWithValue() {
+        if isParent {
+            XCTAssertEqual(0, runChildAndWait(), "Tests in child process failed")
+            return
+        }
+
+        // registerClasses:count: happens to initialize the schemas in the same
+        // order as the classes appear in the array, so this initializes the
+        // schema for `InitLinkedToClass` before `IntObject` to verify that
+        // `initWithValue:` does not throw in that scenario
+        RLMSchema.registerClasses([InitLinkedToClass.self, SwiftIntObject.self], count: 2)
+    }
+}

--- a/Realm/Tests/Swift2.0/Swift-Tests-Bridging-Header.h
+++ b/Realm/Tests/Swift2.0/Swift-Tests-Bridging-Header.h
@@ -17,4 +17,8 @@
 ////////////////////////////////////////////////////////////////////////////
 
 #import "RLMTestObjects.h"
-#import "RLMTestCase.h"
+#import "RLMMultiProcessTestCase.h"
+
+@interface RLMSchema (Private)
++ (void)registerClasses:(const Class[])classes count:(NSUInteger)count;
+@end

--- a/Realm/Tests/Swift2.0/SwiftSchemaTests.swift
+++ b/Realm/Tests/Swift2.0/SwiftSchemaTests.swift
@@ -1,0 +1,45 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2015 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+import XCTest
+import Realm
+
+class InitLinkedToClass: RLMObject {
+    dynamic var value = SwiftIntObject(value: [0])
+}
+
+class SwiftSchemaTests: RLMMultiProcessTestCase {
+    func testWorksAtAll() {
+        if isParent {
+            XCTAssertEqual(0, runChildAndWait(), "Tests in child process failed")
+        }
+    }
+
+    func testSchemaInitWithLinkedToObjectUsingInitWithValue() {
+        if isParent {
+            XCTAssertEqual(0, runChildAndWait(), "Tests in child process failed")
+            return
+        }
+
+        // registerClasses:count: happens to initialize the schemas in the same
+        // order as the classes appear in the array, so this initializes the
+        // schema for `InitLinkedToClass` before `IntObject` to verify that
+        // `initWithValue:` does not throw in that scenario
+        RLMSchema.registerClasses([InitLinkedToClass.self, SwiftIntObject.self], count: 2)
+    }
+}


### PR DESCRIPTION
If an object has a property linking to another object and that property is initialized using `initWithValue:`, that initializer may get run during schema initialization before the linked class's schema is initialized and thus throw an exception. We don't actually use any of the property values of linked objects during schema init, so just do nothing in `initWithValue:` if the class's schema has not been initialized.

Fixes intermittent test failures hit by seg-nsnumber.