### PR TITLE
Remove CGFloat from "Supported property types" section of docs

### DIFF
--- a/Realm/RLMObject.h
+++ b/Realm/RLMObject.h
@@ -44,7 +44,7 @@ RLM_ASSUME_NONNULL_BEGIN
  ### Supported property types
  
  - `NSString`
- - `NSInteger`, `CGFloat`, `int`, `long`, `float`, and `double`
+ - `NSInteger`, `int`, `long`, `float`, and `double`
  - `BOOL` or `bool`
  - `NSDate`
  - `NSData`


### PR DESCRIPTION
While it technically works, it's a bad idea due to it differing in size between 32-bit and 64-bit. NSInteger is okay as our int columns aren't fixed-size.