### PR TITLE
Add validation for class subsets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ x.x.x Release notes (yyyy-MM-dd)
   opened do not.
 * Fix inconsistent errors when `Object(value: ...)` is used to initialize the
   default value of a property of an `Object` subclass.
+* Throw an exception when a class subset has objects with array or object
+  properties of a type that are not part of the class subset.
 
 0.95.2 Release notes (2015-09-24)
 =============================================================

--- a/Realm/Tests/RealmConfigurationTests.mm
+++ b/Realm/Tests/RealmConfigurationTests.mm
@@ -19,6 +19,7 @@
 #import "RLMTestCase.h"
 
 #import "RLMRealmConfiguration_Private.h"
+#import "RLMTestObjects.h"
 #import "RLMUtil.hpp"
 
 @interface RealmConfigurationTests : RLMTestCase
@@ -98,6 +99,16 @@
 
     configuration.schemaVersion = 1;
     XCTAssertEqual(configuration.schemaVersion, 1U);
+}
+
+- (void)testClassSubsetsValidateLinks {
+    RLMRealmConfiguration *configuration = [[RLMRealmConfiguration alloc] init];
+
+    XCTAssertThrows(configuration.objectClasses = @[LinkStringObject.class]);
+    XCTAssertNoThrow(configuration.objectClasses = (@[LinkStringObject.class, StringObject.class]));
+
+    XCTAssertThrows(configuration.objectClasses = @[CompanyObject.class]);
+    XCTAssertNoThrow(configuration.objectClasses = (@[CompanyObject.class, EmployeeObject.class]));
 }
 
 @end


### PR DESCRIPTION
If the configurations objectTypes/objectClasses array contained objects which linked to objects not in the array, trying to open a Realm with the configuration would result in a crash. Fix this by validating that all links are valid when the class subset is set.