### PR TITLE
Update core version to 0.92.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,11 @@ x.x.x Release notes (yyyy-MM-dd)
 * Throw an exception when a class subset has objects with array or object
   properties of a type that are not part of the class subset.
 
+0.95.3 Release notes (2015-10-02)
+=============================================================
+
+* Compile iOS Simulator framework architectures with `-fembed-bitcode-marker`.
+
 0.95.2 Release notes (2015-09-24)
 =============================================================
 

--- a/Realm.podspec
+++ b/Realm.podspec
@@ -44,8 +44,8 @@ Pod::Spec.new do |s|
                                 'OTHER_CPLUSPLUSFLAGS' => '-std=c++1y $(inherited)' }
   s.preserve_paths          = %w(build.sh)
 
-  s.ios.deployment_target   = '7.0'
-  s.ios.vendored_library    = 'core/librealm-ios.a'
+  s.ios.deployment_target   = '8.0'
+  s.ios.vendored_library    = 'core/librealm-ios-bitcode.a'
 
   s.osx.deployment_target   = '10.9'
   s.osx.vendored_library    = 'core/librealm-osx.a'

--- a/Realm.xcodeproj/project.pbxproj
+++ b/Realm.xcodeproj/project.pbxproj
@@ -1247,7 +1247,7 @@
 			buildConfigurationList = E856D1E8195614A400FB2FCF /* Build configuration list for PBXNativeTarget "iOS" */;
 			buildPhases = (
 				3F69DF9E19CA0DF900607109 /* Get Version Number */,
-				E856D1EE1956151D00FB2FCF /* Download Core */,
+				E856D1EE1956151D00FB2FCF /* Download Core & Set Bitcode Symlink */,
 				E856D1D0195614A300FB2FCF /* Sources */,
 				E856D1D2195614A300FB2FCF /* Headers */,
 			);
@@ -1486,19 +1486,19 @@
 			shellPath = /bin/sh;
 			shellScript = "sh build.sh download-core";
 		};
-		E856D1EE1956151D00FB2FCF /* Download Core */ = {
+		E856D1EE1956151D00FB2FCF /* Download Core & Set Bitcode Symlink */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Download Core";
+			name = "Download Core & Set Bitcode Symlink";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "sh build.sh download-core";
+			shellScript = "sh build.sh download-core\nsh build.sh set-core-bitcode-symlink";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/Realm.xcodeproj/project.pbxproj
+++ b/Realm.xcodeproj/project.pbxproj
@@ -6,31 +6,6 @@
 	objectVersion = 46;
 	objects = {
 
-/* Begin PBXAggregateTarget section */
-		C04B4BD71B55C47600FAE58E /* Set Swift Version iOS */ = {
-			isa = PBXAggregateTarget;
-			buildConfigurationList = C04B4BDA1B55C47600FAE58E /* Build configuration list for PBXAggregateTarget "Set Swift Version iOS" */;
-			buildPhases = (
-				C04B4BDB1B55C47A00FAE58E /* Set Swift Version */,
-			);
-			dependencies = (
-			);
-			name = "Set Swift Version iOS";
-			productName = "Swift Version";
-		};
-		E8DFDD8F1B5EAA3100282424 /* Set Swift Version OSX */ = {
-			isa = PBXAggregateTarget;
-			buildConfigurationList = E8DFDD911B5EAA3100282424 /* Build configuration list for PBXAggregateTarget "Set Swift Version OSX" */;
-			buildPhases = (
-				E8DFDD901B5EAA3100282424 /* Set Swift Version */,
-			);
-			dependencies = (
-			);
-			name = "Set Swift Version OSX";
-			productName = "Swift Version";
-		};
-/* End PBXAggregateTarget section */
-
 /* Begin PBXBuildFile section */
 		0207AB7F195DF9FB007EFB12 /* RLMMigration_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 0207AB7C195DF9FB007EFB12 /* RLMMigration_Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		0207AB80195DF9FB007EFB12 /* RLMMigration_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 0207AB7C195DF9FB007EFB12 /* RLMMigration_Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -480,27 +455,6 @@
 			remoteGlobalIDString = E856D1D4195614A300FB2FCF;
 			remoteInfo = iOS;
 		};
-		C04B4BDC1B55C51500FAE58E /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = E8D89B8F1955FC6D00CF2B9A /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = C04B4BD71B55C47600FAE58E;
-			remoteInfo = "Swift Version";
-		};
-		C04B4BDE1B55C51C00FAE58E /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = E8D89B8F1955FC6D00CF2B9A /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = C04B4BD71B55C47600FAE58E;
-			remoteInfo = "Swift Version";
-		};
-		C04B4BE01B55C52100FAE58E /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = E8D89B8F1955FC6D00CF2B9A /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = C04B4BD71B55C47600FAE58E;
-			remoteInfo = "Swift Version";
-		};
 		E81A20081955FE3B00FDED82 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = E8D89B8F1955FC6D00CF2B9A /* Project object */;
@@ -528,13 +482,6 @@
 			proxyType = 1;
 			remoteGlobalIDString = E8D89B971955FC6D00CF2B9A;
 			remoteInfo = Realm;
-		};
-		E8DFDD941B5EAA5600282424 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = E8D89B8F1955FC6D00CF2B9A /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = E8DFDD8F1B5EAA3100282424;
-			remoteInfo = "Set Swift Version OSX";
 		};
 /* End PBXContainerItemProxy section */
 
@@ -1213,7 +1160,6 @@
 			buildRules = (
 			);
 			dependencies = (
-				C04B4BDF1B55C51C00FAE58E /* PBXTargetDependency */,
 				02DC515C1A82EA39002A6433 /* PBXTargetDependency */,
 			);
 			name = "iOS Dynamic Tests";
@@ -1226,7 +1172,7 @@
 			buildConfigurationList = 144C2F451B3D33D0005C8F81 /* Build configuration list for PBXNativeTarget "watchOS" */;
 			buildPhases = (
 				144C2F591B3D34B1005C8F81 /* Get Version Number */,
-				293F98F11A76E05A00C0199D /* Download Core */,
+				293F98F11A76E05A00C0199D /* Download Core & Set Bitcode Symlink */,
 				144C2F391B3D33D0005C8F81 /* Sources */,
 				144C2F3B1B3D33D0005C8F81 /* Headers */,
 				148FF9F51BB9A727000C7028 /* Copy Strip Frameworks Script */,
@@ -1245,7 +1191,7 @@
 			buildConfigurationList = 29E3C7371A71C1C700B62C1D /* Build configuration list for PBXNativeTarget "iOS Dynamic" */;
 			buildPhases = (
 				293F98F01A76E05700C0199D /* Get Version Number */,
-				293F98F11A76E05A00C0199D /* Download Core */,
+				293F98F11A76E05A00C0199D /* Download Core & Set Bitcode Symlink */,
 				29E3C7071A71C1C700B62C1D /* Sources */,
 				29E3C71A1A71C1C700B62C1D /* Headers */,
 				E81C393F1AE5CE7B00F03B56 /* Copy Strip Frameworks Script */,
@@ -1288,7 +1234,6 @@
 			buildRules = (
 			);
 			dependencies = (
-				C04B4BE11B55C52100FAE58E /* PBXTargetDependency */,
 				3F8DCA8019930FF70008BD7F /* PBXTargetDependency */,
 				3F8DCA6119930F580008BD7F /* PBXTargetDependency */,
 			);
@@ -1326,7 +1271,6 @@
 			buildRules = (
 			);
 			dependencies = (
-				C04B4BDD1B55C51500FAE58E /* PBXTargetDependency */,
 				02DC51521A82E52B002A6433 /* PBXTargetDependency */,
 			);
 			name = "iOS Tests";
@@ -1364,7 +1308,6 @@
 			buildRules = (
 			);
 			dependencies = (
-				E8DFDD951B5EAA5600282424 /* PBXTargetDependency */,
 				E8D89BA61955FC6D00CF2B9A /* PBXTargetDependency */,
 				E81A20091955FE3B00FDED82 /* PBXTargetDependency */,
 				E88AAAF1195603B700AA2020 /* PBXTargetDependency */,
@@ -1396,9 +1339,6 @@
 					3F8DCA5619930F550008BD7F = {
 						CreatedOnToolsVersion = 6.0;
 						TestTargetID = 3F1A5E711992EB7400F45F4C;
-					};
-					C04B4BD71B55C47600FAE58E = {
-						CreatedOnToolsVersion = 6.4;
 					};
 					E856D1D4195614A300FB2FCF = {
 						CreatedOnToolsVersion = 6.0;
@@ -1437,8 +1377,6 @@
 				3F8DCA5619930F550008BD7F /* iOS Device Tests */,
 				144C2F3D1B3D33D0005C8F81 /* watchOS */,
 				3F1A5E711992EB7400F45F4C /* TestHost */,
-				C04B4BD71B55C47600FAE58E /* Set Swift Version iOS */,
-				E8DFDD8F1B5EAA3100282424 /* Set Swift Version OSX */,
 			);
 		};
 /* End PBXProject section */
@@ -1504,19 +1442,19 @@
 			shellPath = /bin/sh;
 			shellScript = "echo \"#define REALM_COCOA_VERSION @\\\"$(sh build.sh get-version)\\\"\" > ${DERIVED_FILE_DIR}/RLMVersion.h";
 		};
-		293F98F11A76E05A00C0199D /* Download Core */ = {
+		293F98F11A76E05A00C0199D /* Download Core & Set Bitcode Symlink */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Download Core";
+			name = "Download Core & Set Bitcode Symlink";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "sh build.sh download-core";
+			shellScript = "sh build.sh download-core\nsh build.sh set-core-bitcode-symlink";
 		};
 		3F69DF9E19CA0DF900607109 /* Get Version Number */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -1533,20 +1471,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "echo \"#define REALM_COCOA_VERSION @\\\"$(sh build.sh get-version)\\\"\" > ${DERIVED_FILE_DIR}/RLMVersion.h";
-		};
-		C04B4BDB1B55C47A00FAE58E /* Set Swift Version */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Set Swift Version";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "sh build.sh set-swift-version";
 		};
 		E81A1FB71955FCE700FDED82 /* Download Core */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -1575,20 +1499,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "sh build.sh download-core";
-		};
-		E8DFDD901B5EAA3100282424 /* Set Swift Version */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Set Swift Version";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "sh build.sh set-swift-version";
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -1921,21 +1831,6 @@
 			target = E856D1D4195614A300FB2FCF /* iOS */;
 			targetProxy = 3F8DCA7F19930FF70008BD7F /* PBXContainerItemProxy */;
 		};
-		C04B4BDD1B55C51500FAE58E /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = C04B4BD71B55C47600FAE58E /* Set Swift Version iOS */;
-			targetProxy = C04B4BDC1B55C51500FAE58E /* PBXContainerItemProxy */;
-		};
-		C04B4BDF1B55C51C00FAE58E /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = C04B4BD71B55C47600FAE58E /* Set Swift Version iOS */;
-			targetProxy = C04B4BDE1B55C51C00FAE58E /* PBXContainerItemProxy */;
-		};
-		C04B4BE11B55C52100FAE58E /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = C04B4BD71B55C47600FAE58E /* Set Swift Version iOS */;
-			targetProxy = C04B4BE01B55C52100FAE58E /* PBXContainerItemProxy */;
-		};
 		E81A20091955FE3B00FDED82 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = E8D89B971955FC6D00CF2B9A /* OSX */;
@@ -1955,11 +1850,6 @@
 			isa = PBXTargetDependency;
 			target = E8D89B971955FC6D00CF2B9A /* OSX */;
 			targetProxy = E8D89BA51955FC6D00CF2B9A /* PBXContainerItemProxy */;
-		};
-		E8DFDD951B5EAA5600282424 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = E8DFDD8F1B5EAA3100282424 /* Set Swift Version OSX */;
-			targetProxy = E8DFDD941B5EAA5600282424 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -2258,26 +2148,6 @@
 				SDKROOT = iphoneos;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/TestHost.app/TestHost";
 				VALIDATE_PRODUCT = YES;
-			};
-			name = Release;
-		};
-		C04B4BD81B55C47600FAE58E /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = "";
-				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
-			};
-			name = Debug;
-		};
-		C04B4BD91B55C47600FAE58E /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = "";
-				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
 			};
 			name = Release;
 		};
@@ -2616,24 +2486,6 @@
 			};
 			name = Release;
 		};
-		E8DFDD921B5EAA3100282424 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				PRODUCT_NAME = "Set Swift Version OSX";
-				SDKROOT = "";
-				SUPPORTED_PLATFORMS = macosx;
-			};
-			name = Debug;
-		};
-		E8DFDD931B5EAA3100282424 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				PRODUCT_NAME = "Set Swift Version OSX";
-				SDKROOT = "";
-				SUPPORTED_PLATFORMS = macosx;
-			};
-			name = Release;
-		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -2682,15 +2534,6 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		C04B4BDA1B55C47600FAE58E /* Build configuration list for PBXAggregateTarget "Set Swift Version iOS" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				C04B4BD81B55C47600FAE58E /* Debug */,
-				C04B4BD91B55C47600FAE58E /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
 		E856D1E8195614A400FB2FCF /* Build configuration list for PBXNativeTarget "iOS" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -2732,15 +2575,6 @@
 			buildConfigurations = (
 				E8D89BB21955FC6D00CF2B9A /* Debug */,
 				E8D89BB31955FC6D00CF2B9A /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		E8DFDD911B5EAA3100282424 /* Build configuration list for PBXAggregateTarget "Set Swift Version OSX" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				E8DFDD921B5EAA3100282424 /* Debug */,
-				E8DFDD931B5EAA3100282424 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Realm.xcodeproj/project.pbxproj
+++ b/Realm.xcodeproj/project.pbxproj
@@ -6,6 +6,31 @@
 	objectVersion = 46;
 	objects = {
 
+/* Begin PBXAggregateTarget section */
+		C04B4BD71B55C47600FAE58E /* Set Swift Version iOS */ = {
+			isa = PBXAggregateTarget;
+			buildConfigurationList = C04B4BDA1B55C47600FAE58E /* Build configuration list for PBXAggregateTarget "Set Swift Version iOS" */;
+			buildPhases = (
+				C04B4BDB1B55C47A00FAE58E /* Set Swift Version */,
+			);
+			dependencies = (
+			);
+			name = "Set Swift Version iOS";
+			productName = "Swift Version";
+		};
+		E8DFDD8F1B5EAA3100282424 /* Set Swift Version OSX */ = {
+			isa = PBXAggregateTarget;
+			buildConfigurationList = E8DFDD911B5EAA3100282424 /* Build configuration list for PBXAggregateTarget "Set Swift Version OSX" */;
+			buildPhases = (
+				E8DFDD901B5EAA3100282424 /* Set Swift Version */,
+			);
+			dependencies = (
+			);
+			name = "Set Swift Version OSX";
+			productName = "Swift Version";
+		};
+/* End PBXAggregateTarget section */
+
 /* Begin PBXBuildFile section */
 		0207AB7F195DF9FB007EFB12 /* RLMMigration_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 0207AB7C195DF9FB007EFB12 /* RLMMigration_Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		0207AB80195DF9FB007EFB12 /* RLMMigration_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 0207AB7C195DF9FB007EFB12 /* RLMMigration_Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -455,6 +480,27 @@
 			remoteGlobalIDString = E856D1D4195614A300FB2FCF;
 			remoteInfo = iOS;
 		};
+		C04B4BDC1B55C51500FAE58E /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = E8D89B8F1955FC6D00CF2B9A /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = C04B4BD71B55C47600FAE58E;
+			remoteInfo = "Swift Version";
+		};
+		C04B4BDE1B55C51C00FAE58E /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = E8D89B8F1955FC6D00CF2B9A /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = C04B4BD71B55C47600FAE58E;
+			remoteInfo = "Swift Version";
+		};
+		C04B4BE01B55C52100FAE58E /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = E8D89B8F1955FC6D00CF2B9A /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = C04B4BD71B55C47600FAE58E;
+			remoteInfo = "Swift Version";
+		};
 		E81A20081955FE3B00FDED82 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = E8D89B8F1955FC6D00CF2B9A /* Project object */;
@@ -482,6 +528,13 @@
 			proxyType = 1;
 			remoteGlobalIDString = E8D89B971955FC6D00CF2B9A;
 			remoteInfo = Realm;
+		};
+		E8DFDD941B5EAA5600282424 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = E8D89B8F1955FC6D00CF2B9A /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = E8DFDD8F1B5EAA3100282424;
+			remoteInfo = "Set Swift Version OSX";
 		};
 /* End PBXContainerItemProxy section */
 
@@ -1160,6 +1213,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				C04B4BDF1B55C51C00FAE58E /* PBXTargetDependency */,
 				02DC515C1A82EA39002A6433 /* PBXTargetDependency */,
 			);
 			name = "iOS Dynamic Tests";
@@ -1234,6 +1288,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				C04B4BE11B55C52100FAE58E /* PBXTargetDependency */,
 				3F8DCA8019930FF70008BD7F /* PBXTargetDependency */,
 				3F8DCA6119930F580008BD7F /* PBXTargetDependency */,
 			);
@@ -1271,6 +1326,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				C04B4BDD1B55C51500FAE58E /* PBXTargetDependency */,
 				02DC51521A82E52B002A6433 /* PBXTargetDependency */,
 			);
 			name = "iOS Tests";
@@ -1308,6 +1364,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				E8DFDD951B5EAA5600282424 /* PBXTargetDependency */,
 				E8D89BA61955FC6D00CF2B9A /* PBXTargetDependency */,
 				E81A20091955FE3B00FDED82 /* PBXTargetDependency */,
 				E88AAAF1195603B700AA2020 /* PBXTargetDependency */,
@@ -1339,6 +1396,9 @@
 					3F8DCA5619930F550008BD7F = {
 						CreatedOnToolsVersion = 6.0;
 						TestTargetID = 3F1A5E711992EB7400F45F4C;
+					};
+					C04B4BD71B55C47600FAE58E = {
+						CreatedOnToolsVersion = 6.4;
 					};
 					E856D1D4195614A300FB2FCF = {
 						CreatedOnToolsVersion = 6.0;
@@ -1377,6 +1437,8 @@
 				3F8DCA5619930F550008BD7F /* iOS Device Tests */,
 				144C2F3D1B3D33D0005C8F81 /* watchOS */,
 				3F1A5E711992EB7400F45F4C /* TestHost */,
+				C04B4BD71B55C47600FAE58E /* Set Swift Version iOS */,
+				E8DFDD8F1B5EAA3100282424 /* Set Swift Version OSX */,
 			);
 		};
 /* End PBXProject section */
@@ -1472,6 +1534,20 @@
 			shellPath = /bin/sh;
 			shellScript = "echo \"#define REALM_COCOA_VERSION @\\\"$(sh build.sh get-version)\\\"\" > ${DERIVED_FILE_DIR}/RLMVersion.h";
 		};
+		C04B4BDB1B55C47A00FAE58E /* Set Swift Version */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Set Swift Version";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "sh build.sh set-swift-version";
+		};
 		E81A1FB71955FCE700FDED82 /* Download Core */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -1499,6 +1575,20 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "sh build.sh download-core\nsh build.sh set-core-bitcode-symlink";
+		};
+		E8DFDD901B5EAA3100282424 /* Set Swift Version */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Set Swift Version";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "sh build.sh set-swift-version";
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -1831,6 +1921,21 @@
 			target = E856D1D4195614A300FB2FCF /* iOS */;
 			targetProxy = 3F8DCA7F19930FF70008BD7F /* PBXContainerItemProxy */;
 		};
+		C04B4BDD1B55C51500FAE58E /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = C04B4BD71B55C47600FAE58E /* Set Swift Version iOS */;
+			targetProxy = C04B4BDC1B55C51500FAE58E /* PBXContainerItemProxy */;
+		};
+		C04B4BDF1B55C51C00FAE58E /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = C04B4BD71B55C47600FAE58E /* Set Swift Version iOS */;
+			targetProxy = C04B4BDE1B55C51C00FAE58E /* PBXContainerItemProxy */;
+		};
+		C04B4BE11B55C52100FAE58E /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = C04B4BD71B55C47600FAE58E /* Set Swift Version iOS */;
+			targetProxy = C04B4BE01B55C52100FAE58E /* PBXContainerItemProxy */;
+		};
 		E81A20091955FE3B00FDED82 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = E8D89B971955FC6D00CF2B9A /* OSX */;
@@ -1850,6 +1955,11 @@
 			isa = PBXTargetDependency;
 			target = E8D89B971955FC6D00CF2B9A /* OSX */;
 			targetProxy = E8D89BA51955FC6D00CF2B9A /* PBXContainerItemProxy */;
+		};
+		E8DFDD951B5EAA5600282424 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = E8DFDD8F1B5EAA3100282424 /* Set Swift Version OSX */;
+			targetProxy = E8DFDD941B5EAA5600282424 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -2148,6 +2258,26 @@
 				SDKROOT = iphoneos;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/TestHost.app/TestHost";
 				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		C04B4BD81B55C47600FAE58E /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = "";
+				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
+			};
+			name = Debug;
+		};
+		C04B4BD91B55C47600FAE58E /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = "";
+				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
 			};
 			name = Release;
 		};
@@ -2486,6 +2616,24 @@
 			};
 			name = Release;
 		};
+		E8DFDD921B5EAA3100282424 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				PRODUCT_NAME = "Set Swift Version OSX";
+				SDKROOT = "";
+				SUPPORTED_PLATFORMS = macosx;
+			};
+			name = Debug;
+		};
+		E8DFDD931B5EAA3100282424 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				PRODUCT_NAME = "Set Swift Version OSX";
+				SDKROOT = "";
+				SUPPORTED_PLATFORMS = macosx;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -2534,6 +2682,15 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
+		C04B4BDA1B55C47600FAE58E /* Build configuration list for PBXAggregateTarget "Set Swift Version iOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				C04B4BD81B55C47600FAE58E /* Debug */,
+				C04B4BD91B55C47600FAE58E /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		E856D1E8195614A400FB2FCF /* Build configuration list for PBXNativeTarget "iOS" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -2575,6 +2732,15 @@
 			buildConfigurations = (
 				E8D89BB21955FC6D00CF2B9A /* Debug */,
 				E8D89BB31955FC6D00CF2B9A /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		E8DFDD911B5EAA3100282424 /* Build configuration list for PBXAggregateTarget "Set Swift Version OSX" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				E8DFDD921B5EAA3100282424 /* Debug */,
+				E8DFDD931B5EAA3100282424 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 ##################################################################################
-# Custom build tool for Realm Objective C binding.
+# Custom build tool for Realm Objective-C binding.
 #
 # (C) Copyright 2011-2015 by realm.io.
 ##################################################################################
@@ -14,7 +14,7 @@ set -o pipefail
 set -e
 
 # You can override the version of the core library
-: ${REALM_CORE_VERSION:=0.92.2} # set to "current" to always use the current build
+: ${REALM_CORE_VERSION:=0.92.4} # set to "current" to always use the current build
 
 # You can override the xcmode used
 : ${XCMODE:=xcodebuild} # must be one of: xcodebuild (default), xcpretty, xctool
@@ -35,6 +35,7 @@ Usage: sh $0 command [argument]
 command:
   clean:                clean up/remove all generated files
   download-core:        downloads core library (binary version)
+  set-core-bitcode-symlink: set core symlink to bitcode version for Xcode 7+ or non-bitcode version otherwise
   build:                builds all iOS  and OS X frameworks
   ios-static:           builds fat iOS static framework
   ios-dynamic:          builds iOS dynamic frameworks
@@ -278,7 +279,7 @@ case "$COMMAND" in
         ;;
 
     ######################################
-    # Download Core Library
+    # Core
     ######################################
     "download-core")
         if [ "$REALM_CORE_VERSION" = "current" ]; then
@@ -307,6 +308,20 @@ case "$COMMAND" in
             echo "The core library seems to be up to date."
         fi
         exit 0
+        ;;
+
+    "set-core-bitcode-symlink")
+        cd core
+        rm librealm-ios.a librealm-ios-dbg.a
+        if [ $REALM_SWIFT_VERSION = '1.2' ]; then
+            echo "Using core without bitcode"
+            ln -s librealm-ios-no-bitcode.a librealm-ios.a
+            ln -s librealm-ios-no-bitcode-dbg.a librealm-ios-dbg.a
+        else
+            echo "Using core with bitcode"
+            ln -s librealm-ios-bitcode.a librealm-ios.a
+            ln -s librealm-ios-bitcode-dbg.a librealm-ios-dbg.a
+        fi
         ;;
 
     ######################################

--- a/build.sh
+++ b/build.sh
@@ -312,7 +312,7 @@ case "$COMMAND" in
 
     "set-core-bitcode-symlink")
         cd core
-        rm librealm-ios.a librealm-ios-dbg.a || true
+        rm -f librealm-ios.a librealm-ios-dbg.a
         if [ $REALM_SWIFT_VERSION = '1.2' ]; then
             echo "Using core without bitcode"
             ln -s librealm-ios-no-bitcode.a librealm-ios.a

--- a/build.sh
+++ b/build.sh
@@ -312,7 +312,7 @@ case "$COMMAND" in
 
     "set-core-bitcode-symlink")
         cd core
-        rm librealm-ios.a librealm-ios-dbg.a
+        rm librealm-ios.a librealm-ios-dbg.a || true
         if [ $REALM_SWIFT_VERSION = '1.2' ]; then
             echo "Using core without bitcode"
             ln -s librealm-ios-no-bitcode.a librealm-ios.a


### PR DESCRIPTION
This expects core's tarball to have the following structure:

```
LICENSE
include/
librealm-dbg.a
librealm-ios-bitcode-dbg.a
librealm-ios-bitcode.a
librealm-ios-dbg.a -> librealm-ios-bitcode-dbg.a
librealm-ios-no-bitcode-dbg.a
librealm-ios-no-bitcode.a
librealm-ios.a -> librealm-ios-bitcode.a
librealm-watchos-dbg.a
librealm-watchos.a
librealm.a
release_notes.txt
```

This automatically switches core bitcode symlink when building the "iOS Dynamic" target of Realm.xcodeproj.

Once this is merged, we'll need to update the `swift-1.2` branch's `Realm.podspec` to use `s.ios.vendored_library = librealm-ios-no-bitcode.a`. This way, we can point CocoaPods users of Realm Objective-C who can't update to Xcode 7 to point to the `swift-1.2` branch. This will also support CP users of Realm Swift.

To be extra safe, we should probably also be running `set-core-bitcode-symlink` when building the static iOS framework target (EDIT: Done).

/cc @tgoyne @bdash 