### PR TITLE
Update release package to contain both Xcode 6 and 7 builds

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -735,7 +735,6 @@ case "$COMMAND" in
     "package-osx")
         cd tightdb_objc
         REALM_SWIFT_VERSION=2.0 sh build.sh test-osx
-        REALM_SWIFT_VERSION=2.0 sh build.sh osx
 
         cd build/DerivedData/Realm/Build/Products/Release
         zip --symlinks -r realm-framework-osx.zip Realm.framework

--- a/build.sh
+++ b/build.sh
@@ -582,7 +582,7 @@ case "$COMMAND" in
         ;;
 
     "examples-ios")
-        if [[ -f "examples/ios/objc" ]]; then
+        if [[ -d "examples/ios/objc" ]]; then
             project="examples/ios/objc/RealmExamples.xcodeproj"
         elif [[ "$REALM_SWIFT_VERSION" = 1.2 ]]; then
             project="examples/ios/xcode-6/objc/RealmExamples.xcodeproj"

--- a/build.sh
+++ b/build.sh
@@ -178,6 +178,12 @@ clean_retrieve() {
   cp -R "$1" "$2"
 }
 
+move_to_clean_dir() {
+    rm -rf "$2"
+    mkdir -p "$2"
+    mv "$1" "$2"
+}
+
 shutdown_simulators() {
     # Shut down simulators until there's no booted ones left
     # Only do one at a time because devices sometimes show up multiple times
@@ -701,24 +707,35 @@ case "$COMMAND" in
 
     "package-ios-static")
         cd tightdb_objc
-        sh build.sh test-ios-static
-        sh build.sh ios-static
 
-        cd build/ios
-        zip --symlinks -r realm-framework-ios.zip Realm.framework
+        REALM_SWIFT_VERSION=1.2 sh build.sh test-ios-static
+        REALM_SWIFT_VERSION=1.2 sh build.sh ios-static
+        move_to_clean_dir build/ios/Realm.framework xcode-6
+        rm -rf build
+
+        REALM_SWIFT_VERSION=2.0 sh build.sh test-ios-static
+        REALM_SWIFT_VERSION=2.0 sh build.sh ios-static
+        move_to_clean_dir build/ios/Realm.framework xcode-7
+
+        zip --symlinks -r build/ios/realm-framework-ios.zip xcode-6 xcode-7
         ;;
 
     "package-ios-dynamic")
         cd tightdb_objc
-        REALM_SWIFT_VERSION=2.0 sh build.sh ios-dynamic
+        REALM_SWIFT_VERSION=1.2 sh build.sh ios-dynamic
+        move_to_clean_dir build/ios-dynamic/Realm.framework xcode-6
+        rm -rf build
 
-        cd build/ios-dynamic
-        zip --symlinks -r realm-dynamic-framework-ios.zip Realm.framework
+        REALM_SWIFT_VERSION=2.0 sh build.sh ios-dynamic
+        move_to_clean_dir build/ios-dynamic/Realm.framework xcode-7
+
+        zip --symlinks -r build/ios-dynamic/realm-dynamic-framework-ios.zip xcode-6 xcode-7
         ;;
 
     "package-osx")
         cd tightdb_objc
         REALM_SWIFT_VERSION=2.0 sh build.sh test-osx
+        REALM_SWIFT_VERSION=2.0 sh build.sh osx
 
         cd build/DerivedData/Realm/Build/Products/Release
         zip --symlinks -r realm-framework-osx.zip Realm.framework

--- a/build.sh
+++ b/build.sh
@@ -582,12 +582,20 @@ case "$COMMAND" in
         ;;
 
     "examples-ios")
-        xc "-project examples/ios/objc/RealmExamples.xcodeproj -scheme Simple -configuration $CONFIGURATION build ${CODESIGN_PARAMS}"
-        xc "-project examples/ios/objc/RealmExamples.xcodeproj -scheme TableView -configuration $CONFIGURATION build ${CODESIGN_PARAMS}"
-        xc "-project examples/ios/objc/RealmExamples.xcodeproj -scheme Migration -configuration $CONFIGURATION build ${CODESIGN_PARAMS}"
-        xc "-project examples/ios/objc/RealmExamples.xcodeproj -scheme Backlink -configuration $CONFIGURATION build ${CODESIGN_PARAMS}"
-        xc "-project examples/ios/objc/RealmExamples.xcodeproj -scheme GroupedTableView -configuration $CONFIGURATION build ${CODESIGN_PARAMS}"
-        xc "-project examples/ios/objc/RealmExamples.xcodeproj -scheme Encryption -configuration $CONFIGURATION build ${CODESIGN_PARAMS}"
+        if [[ -f "examples/ios/objc" ]]; then
+            project="examples/ios/objc/RealmExamples.xcodeproj"
+        elif [[ "$REALM_SWIFT_VERSION" = 1.2 ]]; then
+            project="examples/ios/xcode-6/objc/RealmExamples.xcodeproj"
+        else
+            project="examples/ios/xcode-7/objc/RealmExamples.xcodeproj"
+        fi
+
+        xc "-project $project -scheme Simple -configuration $CONFIGURATION build ${CODESIGN_PARAMS}"
+        xc "-project $project -scheme TableView -configuration $CONFIGURATION build ${CODESIGN_PARAMS}"
+        xc "-project $project -scheme Migration -configuration $CONFIGURATION build ${CODESIGN_PARAMS}"
+        xc "-project $project -scheme Backlink -configuration $CONFIGURATION build ${CODESIGN_PARAMS}"
+        xc "-project $project -scheme GroupedTableView -configuration $CONFIGURATION build ${CODESIGN_PARAMS}"
+        xc "-project $project -scheme Encryption -configuration $CONFIGURATION build ${CODESIGN_PARAMS}"
 
         if [ ! -z "${JENKINS_HOME}" ]; then
             xc "-project examples/ios/objc/RealmExamples.xcodeproj -scheme Extension -configuration $CONFIGURATION build ${CODESIGN_PARAMS}"
@@ -689,7 +697,8 @@ case "$COMMAND" in
         cp $0 realm-objc-${VERSION}
         cp -r $(dirname $0)/scripts realm-objc-${VERSION}
         cd realm-objc-${VERSION}
-        sh build.sh examples-ios
+        REALM_SWIFT_VERSION=1.2 sh build.sh examples-ios
+        REALM_SWIFT_VERSION=2.0 sh build.sh examples-ios
         sh build.sh examples-osx
         cd ..
         rm -rf realm-objc-${VERSION}

--- a/examples/installation/ios/objc/DynamicExample/DynamicExample.xcodeproj/project.pbxproj
+++ b/examples/installation/ios/objc/DynamicExample/DynamicExample.xcodeproj/project.pbxproj
@@ -56,7 +56,7 @@
 		E8561AD61AFB1518006E087E /* DynamicExampleTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DynamicExampleTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		E8561ADB1AFB1518006E087E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		E8561ADC1AFB1518006E087E /* DynamicExampleTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = DynamicExampleTests.m; sourceTree = "<group>"; };
-		E8561AE61AFB1534006E087E /* Realm.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Realm.framework; path = "../../../realm-objc-latest/ios/dynamic/Realm.framework"; sourceTree = "<group>"; };
+		E8561AE61AFB1534006E087E /* Realm.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Realm.framework; path = "../../../realm-objc-latest/ios/dynamic/xcode-6/Realm.framework"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -323,7 +323,7 @@
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				FRAMEWORK_SEARCH_PATHS = "../../../realm-objc-latest/ios/dynamic";
+				FRAMEWORK_SEARCH_PATHS = "../../../realm-objc-latest/ios/dynamic/xcode-6";
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -368,7 +368,7 @@
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				FRAMEWORK_SEARCH_PATHS = "../../../realm-objc-latest/ios/dynamic";
+				FRAMEWORK_SEARCH_PATHS = "../../../realm-objc-latest/ios/dynamic/xcode-6";
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;

--- a/examples/installation/ios/objc/StaticExample/StaticExample.xcodeproj/project.pbxproj
+++ b/examples/installation/ios/objc/StaticExample/StaticExample.xcodeproj/project.pbxproj
@@ -44,7 +44,7 @@
 		E88ABBC81AFA9DE400FA1E1D /* StaticExampleTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = StaticExampleTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		E88ABBCD1AFA9DE400FA1E1D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		E88ABBCE1AFA9DE400FA1E1D /* StaticExampleTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = StaticExampleTests.m; sourceTree = "<group>"; };
-		E88ABBDA1AFAA5D600FA1E1D /* Realm.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Realm.framework; path = "../../../realm-objc-latest/ios/static/Realm.framework"; sourceTree = "<group>"; };
+		E88ABBDA1AFAA5D600FA1E1D /* Realm.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Realm.framework; path = "../../../realm-objc-latest/ios/static/xcode-6/Realm.framework"; sourceTree = "<group>"; };
 		E88ABBDC1AFAA5E000FA1E1D /* libc++.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = "libc++.dylib"; path = "usr/lib/libc++.dylib"; sourceTree = SDKROOT; };
 /* End PBXFileReference section */
 
@@ -361,7 +361,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
-					"../../../realm-objc-latest/ios/static",
+					"../../../realm-objc-latest/ios/static/xcode-6",
 				);
 				INFOPLIST_FILE = StaticExample/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -375,7 +375,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
-					"../../../realm-objc-latest/ios/static",
+					"../../../realm-objc-latest/ios/static/xcode-6",
 				);
 				INFOPLIST_FILE = StaticExample/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -391,7 +391,7 @@
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(SDKROOT)/Developer/Library/Frameworks",
 					"$(inherited)",
-					"../../../realm-objc-latest/ios/static/",
+					"../../../realm-objc-latest/ios/static/xcode-6/",
 				);
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
@@ -413,7 +413,7 @@
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(SDKROOT)/Developer/Library/Frameworks",
 					"$(inherited)",
-					"../../../realm-objc-latest/ios/static/",
+					"../../../realm-objc-latest/ios/static/xcode-6/",
 				);
 				INFOPLIST_FILE = StaticExampleTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";

--- a/examples/installation/osx/swift-2.0/CarthageExample/CarthageExample.xcodeproj/project.pbxproj
+++ b/examples/installation/osx/swift-2.0/CarthageExample/CarthageExample.xcodeproj/project.pbxproj
@@ -44,8 +44,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		E802DBE01B3CD5410047225A /* Realm.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Realm.framework; path = Carthage/Build-Xcode-7.0/Mac/Realm.framework; sourceTree = "<group>"; };
-		E802DBE11B3CD5410047225A /* RealmSwift.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RealmSwift.framework; path = Carthage/Build-Xcode-7.0/Mac/RealmSwift.framework; sourceTree = "<group>"; };
+		E802DBE01B3CD5410047225A /* Realm.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Realm.framework; path = Carthage/Build/Mac/Realm.framework; sourceTree = "<group>"; };
+		E802DBE11B3CD5410047225A /* RealmSwift.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RealmSwift.framework; path = Carthage/Build/Mac/RealmSwift.framework; sourceTree = "<group>"; };
 		E8219DD01B3CD4A2006F2638 /* CarthageExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CarthageExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		E8219DD41B3CD4A2006F2638 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		E8219DD51B3CD4A2006F2638 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -290,7 +290,7 @@
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(PROJECT_DIR)/Carthage/Build-Xcode-7.0/Mac";
+				FRAMEWORK_SEARCH_PATHS = "$(PROJECT_DIR)/Carthage/Build/Mac";
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -336,7 +336,7 @@
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(PROJECT_DIR)/Carthage/Build-Xcode-7.0/Mac";
+				FRAMEWORK_SEARCH_PATHS = "$(PROJECT_DIR)/Carthage/Build/Mac";
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;

--- a/scripts/package_examples.rb
+++ b/scripts/package_examples.rb
@@ -32,27 +32,38 @@ def remove_all_dependencies(project_path)
   project.save
 end
 
+def replace_in_file(filepath, pattern, replacement)
+  contents = File.read(filepath)
+  File.open(filepath, "w") do |file|
+    file.puts contents.gsub(pattern, replacement)
+  end
+end
+
 ##########################
 # Script
 ##########################
 
-# Remove Realm target and dependencies from all example objc projects
+# Create Xcode 6 and Xcode 7 versions of the iOS examples
+FileUtils.mkdir 'examples/ios/xcode-6'
+FileUtils.move 'examples/ios/objc', 'examples/ios/xcode-6'
+FileUtils.move 'examples/ios/rubymotion', 'examples/ios/xcode-6'
+FileUtils.cp_r 'examples/ios/xcode-6', 'examples/ios/xcode-7'
 
+# Update the paths to the prebuilt frameworks
+replace_in_file('examples/ios/xcode-6/objc/RealmExamples.xcodeproj/project.pbxproj', '/build/ios', '/../ios/static/xcode-6')
+replace_in_file('examples/ios/xcode-7/objc/RealmExamples.xcodeproj/project.pbxproj', '/build/ios', '/../ios/static/xcode-7')
+replace_in_file('examples/osx/objc/RealmExamples.xcodeproj/project.pbxproj', '/build/osx', '/osx')
+
+# Remove Realm target and dependencies from all example objc projects
 objc_examples = [
-  "examples/ios/objc/RealmExamples.xcodeproj",
+  "examples/ios/xcode-6/objc/RealmExamples.xcodeproj",
+  "examples/ios/xcode-7/objc/RealmExamples.xcodeproj",
   "examples/osx/objc/RealmExamples.xcodeproj"
 ]
 
 objc_examples.each do |example|
   remove_all_dependencies(example)
   remove_target(example, "Realm")
-
-  filepath = File.join(example, "project.pbxproj")
-  contents = File.read(filepath)
-  File.open(filepath, "w") do |file|
-    file.puts contents.gsub("/build/ios", "/ios/static")
-                      .gsub("/build/osx", "/osx")
-  end
 end
 
 # Remove RealmSwift target and dependencies from all example swift projects
@@ -65,18 +76,11 @@ swift_examples = [
 swift_examples.each do |example|
   remove_all_dependencies(example)
   remove_target(example, "RealmSwift")
-
   filepath = File.join(example, "project.pbxproj")
-  contents = File.read(filepath)
-  File.open(filepath, "w") do |file|
-    file.puts contents.gsub("/build/ios", "/ios")
-  end
+  replace_in_file(filepath, "/build/ios", "/ios")
 end
 
 # Update RubyMotion sample
 
-rakefile_path = "examples/ios/rubymotion/Simple/Rakefile"
-contents = File.read(rakefile_path)
-File.open(rakefile_path, "w") do |file|
-  file.puts contents.gsub("/build/ios", "/ios/static")
-end
+replace_in_file('examples/ios/xcode-6/rubymotion/Simple/Rakefile', '/build/ios', '/ios/static/xcode-6')
+replace_in_file('examples/ios/xcode-7/rubymotion/Simple/Rakefile', '/build/ios', '/ios/static/xcode-7')


### PR DESCRIPTION
I suspect that the examples need updating as well, but everything else works. New package structure is `ios/xcode-6/Realm.framework` etc.