### PR TITLE
Automatically select the correct core library when installing via CocoaPods

### DIFF
--- a/Realm.podspec
+++ b/Realm.podspec
@@ -44,8 +44,8 @@ Pod::Spec.new do |s|
                                 'OTHER_CPLUSPLUSFLAGS' => '-std=c++1y $(inherited)' }
   s.preserve_paths          = %w(build.sh)
 
-  s.ios.deployment_target   = '8.0'
-  s.ios.vendored_library    = 'core/librealm-ios-bitcode.a'
+  s.ios.deployment_target   = '7.0'
+  s.ios.vendored_library    = 'core/librealm-ios.a'
 
   s.osx.deployment_target   = '10.9'
   s.osx.vendored_library    = 'core/librealm-osx.a'

--- a/build.sh
+++ b/build.sh
@@ -636,6 +636,13 @@ case "$COMMAND" in
         if [[ "$2" != "without-core" ]]; then
             sh build.sh download-core
             mv core/librealm.a core/librealm-osx.a
+            if [[ "$REALM_SWIFT_VERSION" = "1.2" ]]; then
+                echo 'Installing for Xcode 6.'
+                mv core/librealm-ios-no-bitcode.a core/librealm-ios.a
+              else
+                echo 'Installing for Xcode 7+.'
+                mv core/librealm-ios-bitcode.a core/librealm-ios.a
+            fi
         fi
 
         # CocoaPods won't automatically preserve files referenced via symlinks


### PR DESCRIPTION
Rather than requiring that people using Xcode 6 use the swift-1.2 branch.

@jpsim 