### PR TITLE
Support assigning `Results` to `List` properties via KVC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ x.x.x Release notes (yyyy-MM-dd)
 
 ### Bugfixes
 
-* None.
+* Support assigning `Results` to `List` properties via KVC.
 
 0.96.0 Release notes (2015-10-14)
 =============================================================
@@ -48,7 +48,7 @@ x.x.x Release notes (yyyy-MM-dd)
 * Added `isEmpty` property on `RLMRealm`/`Realm` to indicate if it contains any
   objects.
 * The `@count`, `@min`, `@max`, `@sum` and `@avg` collection operators are now
-  supported in queries
+  supported in queries.
 
 ### Bugfixes
 

--- a/Realm/RLMUtil.mm
+++ b/Realm/RLMUtil.mm
@@ -152,9 +152,9 @@ BOOL RLMIsObjectValidForProperty(__unsafe_unretained id const obj,
             if (RLMListBase *list = RLMDynamicCast<RLMListBase>(obj)) {
                 return [list._rlmArray.objectClassName isEqualToString:property.objectClassName];
             }
-            if (NSArray *array = RLMDynamicCast<NSArray>(obj)) {
+            if ([obj conformsToProtocol:@protocol(NSFastEnumeration)]) {
                 // check each element for compliance
-                for (id el in array) {
+                for (id el in (id<NSFastEnumeration>)obj) {
                     RLMObjectBase *obj = RLMDynamicCast<RLMObjectBase>(el);
                     if (!obj || ![obj->_objectSchema.className isEqualToString:property.objectClassName]) {
                         return NO;

--- a/Realm/Tests/ArrayPropertyTests.m
+++ b/Realm/Tests/ArrayPropertyTests.m
@@ -822,4 +822,16 @@
     XCTAssertTrue([description rangeOfString:@"912 objects skipped"].location != NSNotFound);
 }
 
+- (void)testAssignArrayProperty {
+    RLMRealm *realm = self.realmWithTestPath;
+    [realm beginWriteTransaction];
+    ArrayPropertyObject *array = [ArrayPropertyObject createInRealm:realm withValue:@[@"arrayObject", @[], @[]]];
+    NSSet *stringSet = [NSSet setWithArray:@[[[StringObject alloc] initWithValue:@[@"a"]]]];
+    [array setValue:stringSet forKey:@"array"];
+    XCTAssertEqualObjects([[array valueForKey:@"array"] valueForKey:@"stringCol"], [[stringSet allObjects] valueForKey:@"stringCol"]);
+    [array setValue:[stringSet allObjects] forKey:@"array"];
+    XCTAssertEqualObjects([[array valueForKey:@"array"] valueForKey:@"stringCol"], [[stringSet allObjects] valueForKey:@"stringCol"]);
+    [realm commitWriteTransaction];
+}
+
 @end

--- a/RealmSwift-swift1.2/Tests/RealmCollectionTypeTests.swift
+++ b/RealmSwift-swift1.2/Tests/RealmCollectionTypeTests.swift
@@ -292,6 +292,10 @@ class RealmCollectionTypeTests: TestCase {
         XCTAssertEqual(0, collection.count)
     }
 
+    func testAssignListProperty() {
+        fatalError("abstract")
+    }
+
     func testArrayAggregateWithSwiftObjectDoesntThrow() {
         let collection = getAggregateableCollection()
 
@@ -302,9 +306,35 @@ class RealmCollectionTypeTests: TestCase {
 
 // MARK: Results
 
-class ResultsFromTableTests: RealmCollectionTypeTests {
+// MARK: Results
+
+class ResultsTests: RealmCollectionTypeTests {
+    override class func defaultTestSuite() -> XCTestSuite {
+        // Don't run tests for the base class
+        if isEqual(ResultsTests) {
+            return XCTestSuite(name: "empty")
+        }
+        return super.defaultTestSuite()
+    }
+
+    func base() -> Results<SwiftStringObject> {
+        fatalError("abstract")
+    }
+
     override func getCollection() -> AnyRealmCollection<SwiftStringObject> {
-        return AnyRealmCollection(realmWithTestPath().objects(SwiftStringObject))
+        return AnyRealmCollection(base())
+    }
+
+    override func testAssignListProperty() {
+        let array = SwiftArrayPropertyObject()
+        realmWithTestPath().add(array)
+        array["array"] = base()
+    }
+}
+
+class ResultsFromTableTests: ResultsTests {
+    override func base() -> Results<SwiftStringObject> {
+        return realmWithTestPath().objects(SwiftStringObject)
     }
 
     override func getAggregateableCollection() -> AnyRealmCollection<SwiftAggregateObject> {
@@ -313,9 +343,9 @@ class ResultsFromTableTests: RealmCollectionTypeTests {
     }
 }
 
-class ResultsFromTableViewTests: RealmCollectionTypeTests {
-    override func getCollection() -> AnyRealmCollection<SwiftStringObject> {
-        return AnyRealmCollection(realmWithTestPath().objects(SwiftStringObject).filter("stringCol != ''"))
+class ResultsFromTableViewTests: ResultsTests {
+    override func base() -> Results<SwiftStringObject> {
+        return realmWithTestPath().objects(SwiftStringObject).filter("stringCol != ''")
     }
 
     override func getAggregateableCollection() -> AnyRealmCollection<SwiftAggregateObject> {
@@ -324,10 +354,10 @@ class ResultsFromTableViewTests: RealmCollectionTypeTests {
     }
 }
 
-class ResultsFromLinkViewTests: RealmCollectionTypeTests {
-    override func getCollection() -> AnyRealmCollection<SwiftStringObject> {
+class ResultsFromLinkViewTests: ResultsTests {
+    override func base() -> Results<SwiftStringObject> {
         let array = realmWithTestPath().create(SwiftArrayPropertyObject.self, value: ["", [str1, str2], []])
-        return AnyRealmCollection(array.array.filter(NSPredicate(value: true)))
+        return array.array.filter(NSPredicate(value: true))
     }
     
     override func getAggregateableCollection() -> AnyRealmCollection<SwiftAggregateObject> {
@@ -349,14 +379,28 @@ class ListRealmCollectionTypeTests: RealmCollectionTypeTests {
         return super.defaultTestSuite()
     }
 
+    func base() -> List<SwiftStringObject> {
+        fatalError("abstract")
+    }
+
+    override func getCollection() -> AnyRealmCollection<SwiftStringObject> {
+        return AnyRealmCollection(base())
+    }
+
+    override func testAssignListProperty() {
+        let array = SwiftArrayPropertyObject()
+        realmWithTestPath().add(array)
+        array["array"] = base()
+    }
+
     override func testDescription() {
         XCTAssertEqual(collection.description, "List<SwiftStringObject> (\n\t[0] SwiftStringObject {\n\t\tstringCol = 1;\n\t},\n\t[1] SwiftStringObject {\n\t\tstringCol = 2;\n\t}\n)")
     }
 }
 
 class ListStandaloneRealmCollectionTypeTests: ListRealmCollectionTypeTests {
-    override func getCollection() -> AnyRealmCollection<SwiftStringObject> {
-        return AnyRealmCollection(SwiftArrayPropertyObject(value: ["", [str1, str2], []]).array)
+    override func base() -> List<SwiftStringObject> {
+        return SwiftArrayPropertyObject(value: ["", [str1, str2], []]).array
     }
 
     override func getAggregateableCollection() -> AnyRealmCollection<SwiftAggregateObject> {
@@ -446,10 +490,10 @@ class ListStandaloneRealmCollectionTypeTests: ListRealmCollectionTypeTests {
 }
 
 class ListNewlyAddedRealmCollectionTypeTests: ListRealmCollectionTypeTests {
-    override func getCollection() -> AnyRealmCollection<SwiftStringObject> {
+    override func base() -> List<SwiftStringObject> {
         let array = SwiftArrayPropertyObject(value: ["", [str1, str2], []])
         realmWithTestPath().add(array)
-        return AnyRealmCollection(array.array)
+        return array.array
     }
 
     override func getAggregateableCollection() -> AnyRealmCollection<SwiftAggregateObject> {
@@ -460,9 +504,9 @@ class ListNewlyAddedRealmCollectionTypeTests: ListRealmCollectionTypeTests {
 }
 
 class ListNewlyCreatedRealmCollectionTypeTests: ListRealmCollectionTypeTests {
-    override func getCollection() -> AnyRealmCollection<SwiftStringObject> {
+    override func base() -> List<SwiftStringObject> {
         let array = realmWithTestPath().create(SwiftArrayPropertyObject.self, value: ["", [str1, str2], []])
-        return AnyRealmCollection(array.array)
+        return array.array
     }
 
     override func getAggregateableCollection() -> AnyRealmCollection<SwiftAggregateObject> {
@@ -472,10 +516,10 @@ class ListNewlyCreatedRealmCollectionTypeTests: ListRealmCollectionTypeTests {
 }
 
 class ListRetrievedRealmCollectionTypeTests: ListRealmCollectionTypeTests {
-    override func getCollection() -> AnyRealmCollection<SwiftStringObject> {
+    override func base() -> List<SwiftStringObject> {
         realmWithTestPath().create(SwiftArrayPropertyObject.self, value: ["", [str1, str2], []])
         let array = realmWithTestPath().objects(SwiftArrayPropertyObject).first!
-        return AnyRealmCollection(array.array)
+        return array.array
     }
 
     override func getAggregateableCollection() -> AnyRealmCollection<SwiftAggregateObject> {

--- a/RealmSwift-swift1.2/Tests/RealmCollectionTypeTests.swift
+++ b/RealmSwift-swift1.2/Tests/RealmCollectionTypeTests.swift
@@ -293,6 +293,8 @@ class RealmCollectionTypeTests: TestCase {
     }
 
     func testAssignListProperty() {
+        // no way to make RealmCollectionType conform to NSFastEnumeration
+        // so test the concrete collections directly.
         fatalError("abstract")
     }
 
@@ -306,8 +308,6 @@ class RealmCollectionTypeTests: TestCase {
 
 // MARK: Results
 
-// MARK: Results
-
 class ResultsTests: RealmCollectionTypeTests {
     override class func defaultTestSuite() -> XCTestSuite {
         // Don't run tests for the base class
@@ -317,23 +317,23 @@ class ResultsTests: RealmCollectionTypeTests {
         return super.defaultTestSuite()
     }
 
-    func base() -> Results<SwiftStringObject> {
+    func collectionBase() -> Results<SwiftStringObject> {
         fatalError("abstract")
     }
 
     override func getCollection() -> AnyRealmCollection<SwiftStringObject> {
-        return AnyRealmCollection(base())
+        return AnyRealmCollection(collectionBase())
     }
 
     override func testAssignListProperty() {
         let array = SwiftArrayPropertyObject()
         realmWithTestPath().add(array)
-        array["array"] = base()
+        array["array"] = collectionBase()
     }
 }
 
 class ResultsFromTableTests: ResultsTests {
-    override func base() -> Results<SwiftStringObject> {
+    override func collectionBase() -> Results<SwiftStringObject> {
         return realmWithTestPath().objects(SwiftStringObject)
     }
 
@@ -344,7 +344,7 @@ class ResultsFromTableTests: ResultsTests {
 }
 
 class ResultsFromTableViewTests: ResultsTests {
-    override func base() -> Results<SwiftStringObject> {
+    override func collectionBase() -> Results<SwiftStringObject> {
         return realmWithTestPath().objects(SwiftStringObject).filter("stringCol != ''")
     }
 
@@ -355,7 +355,7 @@ class ResultsFromTableViewTests: ResultsTests {
 }
 
 class ResultsFromLinkViewTests: ResultsTests {
-    override func base() -> Results<SwiftStringObject> {
+    override func collectionBase() -> Results<SwiftStringObject> {
         let array = realmWithTestPath().create(SwiftArrayPropertyObject.self, value: ["", [str1, str2], []])
         return array.array.filter(NSPredicate(value: true))
     }
@@ -379,18 +379,18 @@ class ListRealmCollectionTypeTests: RealmCollectionTypeTests {
         return super.defaultTestSuite()
     }
 
-    func base() -> List<SwiftStringObject> {
+    func collectionBase() -> List<SwiftStringObject> {
         fatalError("abstract")
     }
 
     override func getCollection() -> AnyRealmCollection<SwiftStringObject> {
-        return AnyRealmCollection(base())
+        return AnyRealmCollection(collectionBase())
     }
 
     override func testAssignListProperty() {
         let array = SwiftArrayPropertyObject()
         realmWithTestPath().add(array)
-        array["array"] = base()
+        array["array"] = collectionBase()
     }
 
     override func testDescription() {
@@ -399,7 +399,7 @@ class ListRealmCollectionTypeTests: RealmCollectionTypeTests {
 }
 
 class ListStandaloneRealmCollectionTypeTests: ListRealmCollectionTypeTests {
-    override func base() -> List<SwiftStringObject> {
+    override func collectionBase() -> List<SwiftStringObject> {
         return SwiftArrayPropertyObject(value: ["", [str1, str2], []]).array
     }
 
@@ -490,7 +490,7 @@ class ListStandaloneRealmCollectionTypeTests: ListRealmCollectionTypeTests {
 }
 
 class ListNewlyAddedRealmCollectionTypeTests: ListRealmCollectionTypeTests {
-    override func base() -> List<SwiftStringObject> {
+    override func collectionBase() -> List<SwiftStringObject> {
         let array = SwiftArrayPropertyObject(value: ["", [str1, str2], []])
         realmWithTestPath().add(array)
         return array.array
@@ -504,7 +504,7 @@ class ListNewlyAddedRealmCollectionTypeTests: ListRealmCollectionTypeTests {
 }
 
 class ListNewlyCreatedRealmCollectionTypeTests: ListRealmCollectionTypeTests {
-    override func base() -> List<SwiftStringObject> {
+    override func collectionBase() -> List<SwiftStringObject> {
         let array = realmWithTestPath().create(SwiftArrayPropertyObject.self, value: ["", [str1, str2], []])
         return array.array
     }
@@ -516,7 +516,7 @@ class ListNewlyCreatedRealmCollectionTypeTests: ListRealmCollectionTypeTests {
 }
 
 class ListRetrievedRealmCollectionTypeTests: ListRealmCollectionTypeTests {
-    override func base() -> List<SwiftStringObject> {
+    override func collectionBase() -> List<SwiftStringObject> {
         realmWithTestPath().create(SwiftArrayPropertyObject.self, value: ["", [str1, str2], []])
         let array = realmWithTestPath().objects(SwiftArrayPropertyObject).first!
         return array.array

--- a/RealmSwift-swift2.0/Results.swift
+++ b/RealmSwift-swift2.0/Results.swift
@@ -62,8 +62,7 @@ public class ResultsBase: NSObject, NSFastEnumeration {
     // MARK: Fast Enumeration
 
     public func countByEnumeratingWithState(state: UnsafeMutablePointer<NSFastEnumerationState>, objects buffer: AutoreleasingUnsafeMutablePointer<AnyObject?>, count len: Int) -> Int {
-        let enumeration: NSFastEnumeration = rlmResults // FIXME: no idea why this is needed, but doesn't compile otherwise
-        return enumeration.countByEnumeratingWithState(state, objects: buffer, count: len)
+        return Int(rlmResults.countByEnumeratingWithState(state, objects: buffer, count: UInt(len)))
     }
 }
 

--- a/RealmSwift-swift2.0/Tests/RealmCollectionTypeTests.swift
+++ b/RealmSwift-swift2.0/Tests/RealmCollectionTypeTests.swift
@@ -292,6 +292,10 @@ class RealmCollectionTypeTests: TestCase {
         XCTAssertEqual(0, collection.count)
     }
 
+    func testAssignListProperty() {
+        fatalError("abstract")
+    }
+
     func testArrayAggregateWithSwiftObjectDoesntThrow() {
         let collection = getAggregateableCollection()
 
@@ -302,9 +306,33 @@ class RealmCollectionTypeTests: TestCase {
 
 // MARK: Results
 
-class ResultsFromTableTests: RealmCollectionTypeTests {
+class ResultsTests: RealmCollectionTypeTests {
+    override class func defaultTestSuite() -> XCTestSuite {
+        // Don't run tests for the base class
+        if isEqual(ResultsTests) {
+            return XCTestSuite(name: "empty")
+        }
+        return super.defaultTestSuite()
+    }
+
+    func base() -> Results<SwiftStringObject> {
+        fatalError("abstract")
+    }
+
     override func getCollection() -> AnyRealmCollection<SwiftStringObject> {
-        return AnyRealmCollection(realmWithTestPath().objects(SwiftStringObject))
+        return AnyRealmCollection(base())
+    }
+
+    override func testAssignListProperty() {
+        let array = SwiftArrayPropertyObject()
+        realmWithTestPath().add(array)
+        array["array"] = base()
+    }
+}
+
+class ResultsFromTableTests: ResultsTests {
+    override func base() -> Results<SwiftStringObject> {
+        return realmWithTestPath().objects(SwiftStringObject)
     }
 
     override func getAggregateableCollection() -> AnyRealmCollection<SwiftAggregateObject> {
@@ -313,9 +341,9 @@ class ResultsFromTableTests: RealmCollectionTypeTests {
     }
 }
 
-class ResultsFromTableViewTests: RealmCollectionTypeTests {
-    override func getCollection() -> AnyRealmCollection<SwiftStringObject> {
-        return AnyRealmCollection(realmWithTestPath().objects(SwiftStringObject).filter("stringCol != ''"))
+class ResultsFromTableViewTests: ResultsTests {
+    override func base() -> Results<SwiftStringObject> {
+        return realmWithTestPath().objects(SwiftStringObject).filter("stringCol != ''")
     }
 
     override func getAggregateableCollection() -> AnyRealmCollection<SwiftAggregateObject> {
@@ -324,10 +352,10 @@ class ResultsFromTableViewTests: RealmCollectionTypeTests {
     }
 }
 
-class ResultsFromLinkViewTests: RealmCollectionTypeTests {
-    override func getCollection() -> AnyRealmCollection<SwiftStringObject> {
+class ResultsFromLinkViewTests: ResultsTests {
+    override func base() -> Results<SwiftStringObject> {
         let array = realmWithTestPath().create(SwiftArrayPropertyObject.self, value: ["", [str1, str2], []])
-        return AnyRealmCollection(array.array.filter(NSPredicate(value: true)))
+        return array.array.filter(NSPredicate(value: true))
     }
     
     override func getAggregateableCollection() -> AnyRealmCollection<SwiftAggregateObject> {
@@ -349,14 +377,28 @@ class ListRealmCollectionTypeTests: RealmCollectionTypeTests {
         return super.defaultTestSuite()
     }
 
+    func base() -> List<SwiftStringObject> {
+        fatalError("abstract")
+    }
+
+    override func getCollection() -> AnyRealmCollection<SwiftStringObject> {
+        return AnyRealmCollection(base())
+    }
+
+    override func testAssignListProperty() {
+        let array = SwiftArrayPropertyObject()
+        realmWithTestPath().add(array)
+        array["array"] = base()
+    }
+
     override func testDescription() {
         XCTAssertEqual(collection.description, "List<SwiftStringObject> (\n\t[0] SwiftStringObject {\n\t\tstringCol = 1;\n\t},\n\t[1] SwiftStringObject {\n\t\tstringCol = 2;\n\t}\n)")
     }
 }
 
 class ListStandaloneRealmCollectionTypeTests: ListRealmCollectionTypeTests {
-    override func getCollection() -> AnyRealmCollection<SwiftStringObject> {
-        return AnyRealmCollection(SwiftArrayPropertyObject(value: ["", [str1, str2], []]).array)
+    override func base() -> List<SwiftStringObject> {
+        return SwiftArrayPropertyObject(value: ["", [str1, str2], []]).array
     }
 
     override func getAggregateableCollection() -> AnyRealmCollection<SwiftAggregateObject> {
@@ -446,10 +488,10 @@ class ListStandaloneRealmCollectionTypeTests: ListRealmCollectionTypeTests {
 }
 
 class ListNewlyAddedRealmCollectionTypeTests: ListRealmCollectionTypeTests {
-    override func getCollection() -> AnyRealmCollection<SwiftStringObject> {
+    override func base() -> List<SwiftStringObject> {
         let array = SwiftArrayPropertyObject(value: ["", [str1, str2], []])
         realmWithTestPath().add(array)
-        return AnyRealmCollection(array.array)
+        return array.array
     }
 
     override func getAggregateableCollection() -> AnyRealmCollection<SwiftAggregateObject> {
@@ -460,9 +502,9 @@ class ListNewlyAddedRealmCollectionTypeTests: ListRealmCollectionTypeTests {
 }
 
 class ListNewlyCreatedRealmCollectionTypeTests: ListRealmCollectionTypeTests {
-    override func getCollection() -> AnyRealmCollection<SwiftStringObject> {
+    override func base() -> List<SwiftStringObject> {
         let array = realmWithTestPath().create(SwiftArrayPropertyObject.self, value: ["", [str1, str2], []])
-        return AnyRealmCollection(array.array)
+        return array.array
     }
 
     override func getAggregateableCollection() -> AnyRealmCollection<SwiftAggregateObject> {
@@ -472,10 +514,10 @@ class ListNewlyCreatedRealmCollectionTypeTests: ListRealmCollectionTypeTests {
 }
 
 class ListRetrievedRealmCollectionTypeTests: ListRealmCollectionTypeTests {
-    override func getCollection() -> AnyRealmCollection<SwiftStringObject> {
+    override func base() -> List<SwiftStringObject> {
         realmWithTestPath().create(SwiftArrayPropertyObject.self, value: ["", [str1, str2], []])
         let array = realmWithTestPath().objects(SwiftArrayPropertyObject).first!
-        return AnyRealmCollection(array.array)
+        return array.array
     }
 
     override func getAggregateableCollection() -> AnyRealmCollection<SwiftAggregateObject> {

--- a/RealmSwift-swift2.0/Tests/RealmCollectionTypeTests.swift
+++ b/RealmSwift-swift2.0/Tests/RealmCollectionTypeTests.swift
@@ -293,6 +293,8 @@ class RealmCollectionTypeTests: TestCase {
     }
 
     func testAssignListProperty() {
+        // no way to make RealmCollectionType conform to NSFastEnumeration
+        // so test the concrete collections directly.
         fatalError("abstract")
     }
 
@@ -315,23 +317,23 @@ class ResultsTests: RealmCollectionTypeTests {
         return super.defaultTestSuite()
     }
 
-    func base() -> Results<SwiftStringObject> {
+    func collectionBase() -> Results<SwiftStringObject> {
         fatalError("abstract")
     }
 
     override func getCollection() -> AnyRealmCollection<SwiftStringObject> {
-        return AnyRealmCollection(base())
+        return AnyRealmCollection(collectionBase())
     }
 
     override func testAssignListProperty() {
         let array = SwiftArrayPropertyObject()
         realmWithTestPath().add(array)
-        array["array"] = base()
+        array["array"] = collectionBase()
     }
 }
 
 class ResultsFromTableTests: ResultsTests {
-    override func base() -> Results<SwiftStringObject> {
+    override func collectionBase() -> Results<SwiftStringObject> {
         return realmWithTestPath().objects(SwiftStringObject)
     }
 
@@ -342,7 +344,7 @@ class ResultsFromTableTests: ResultsTests {
 }
 
 class ResultsFromTableViewTests: ResultsTests {
-    override func base() -> Results<SwiftStringObject> {
+    override func collectionBase() -> Results<SwiftStringObject> {
         return realmWithTestPath().objects(SwiftStringObject).filter("stringCol != ''")
     }
 
@@ -353,7 +355,7 @@ class ResultsFromTableViewTests: ResultsTests {
 }
 
 class ResultsFromLinkViewTests: ResultsTests {
-    override func base() -> Results<SwiftStringObject> {
+    override func collectionBase() -> Results<SwiftStringObject> {
         let array = realmWithTestPath().create(SwiftArrayPropertyObject.self, value: ["", [str1, str2], []])
         return array.array.filter(NSPredicate(value: true))
     }
@@ -377,18 +379,18 @@ class ListRealmCollectionTypeTests: RealmCollectionTypeTests {
         return super.defaultTestSuite()
     }
 
-    func base() -> List<SwiftStringObject> {
+    func collectionBase() -> List<SwiftStringObject> {
         fatalError("abstract")
     }
 
     override func getCollection() -> AnyRealmCollection<SwiftStringObject> {
-        return AnyRealmCollection(base())
+        return AnyRealmCollection(collectionBase())
     }
 
     override func testAssignListProperty() {
         let array = SwiftArrayPropertyObject()
         realmWithTestPath().add(array)
-        array["array"] = base()
+        array["array"] = collectionBase()
     }
 
     override func testDescription() {
@@ -397,7 +399,7 @@ class ListRealmCollectionTypeTests: RealmCollectionTypeTests {
 }
 
 class ListStandaloneRealmCollectionTypeTests: ListRealmCollectionTypeTests {
-    override func base() -> List<SwiftStringObject> {
+    override func collectionBase() -> List<SwiftStringObject> {
         return SwiftArrayPropertyObject(value: ["", [str1, str2], []]).array
     }
 
@@ -488,7 +490,7 @@ class ListStandaloneRealmCollectionTypeTests: ListRealmCollectionTypeTests {
 }
 
 class ListNewlyAddedRealmCollectionTypeTests: ListRealmCollectionTypeTests {
-    override func base() -> List<SwiftStringObject> {
+    override func collectionBase() -> List<SwiftStringObject> {
         let array = SwiftArrayPropertyObject(value: ["", [str1, str2], []])
         realmWithTestPath().add(array)
         return array.array
@@ -502,7 +504,7 @@ class ListNewlyAddedRealmCollectionTypeTests: ListRealmCollectionTypeTests {
 }
 
 class ListNewlyCreatedRealmCollectionTypeTests: ListRealmCollectionTypeTests {
-    override func base() -> List<SwiftStringObject> {
+    override func collectionBase() -> List<SwiftStringObject> {
         let array = realmWithTestPath().create(SwiftArrayPropertyObject.self, value: ["", [str1, str2], []])
         return array.array
     }
@@ -514,7 +516,7 @@ class ListNewlyCreatedRealmCollectionTypeTests: ListRealmCollectionTypeTests {
 }
 
 class ListRetrievedRealmCollectionTypeTests: ListRealmCollectionTypeTests {
-    override func base() -> List<SwiftStringObject> {
+    override func collectionBase() -> List<SwiftStringObject> {
         realmWithTestPath().create(SwiftArrayPropertyObject.self, value: ["", [str1, str2], []])
         let array = realmWithTestPath().objects(SwiftArrayPropertyObject).first!
         return array.array


### PR DESCRIPTION
Fixes #2634.

Ideally we'd support this via RealmCollectionType as well, but I couldn't really get that to work. /cc @tgoyne @bdash 