### PR TITLE
[Query] Make sure that linked objects are attached

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ x.x.x Release notes (yyyy-MM-dd)
 ### Bugfixes
 
 * Fix crash when trying to retrieve object instances via `dynamicObjects`.
+* Throw an exception when querying on a link providing objects, which are from a different Realm.
+* Return empty results when querying on a link providing an unattached object.
 * Fix crashes or incorrect results when calling `-[RLMRealm refresh]` during
   fast enumeration.
 * Add `Int8` support for `RealmOptional`, `MinMaxType` and `AddableType`.

--- a/Realm/RLMQueryUtil.mm
+++ b/Realm/RLMQueryUtil.mm
@@ -444,6 +444,11 @@ void add_link_constraint_to_query(realm::Query & query,
         return;
     }
 
+    // NOTE: This precondition assumes that the argument `obj` will be always originating from the
+    // queried table as verified before by `validate_property_value`
+    RLMPrecondition(query.get_table()->get_link_target(column).get() == obj->_row.get_table(),
+                    @"Invalid value origin", @"Object must be from the Realm being queried");
+
     query.links_to(column, obj->_row.get_index());
 }
 

--- a/Realm/RLMQueryUtil.mm
+++ b/Realm/RLMQueryUtil.mm
@@ -439,6 +439,11 @@ void add_link_constraint_to_query(realm::Query & query,
         query.Not();
     }
 
+    if (!obj->_row.is_attached()) {
+        query.and_query(new FalseExpression);
+        return;
+    }
+
     query.links_to(column, obj->_row.get_index());
 }
 

--- a/Realm/Tests/QueryTests.m
+++ b/Realm/Tests/QueryTests.m
@@ -1122,6 +1122,21 @@
     XCTAssertEqual(([OwnerObject objectsInRealm:realm where:@"dog = %@", newDogObject].count), 0U);
 }
 
+- (void)testLinkQueryDifferentRealmsThrows
+{
+    RLMRealm *testRealm = [self realmWithTestPath];
+    [self makeDogWithName:@"Harvie" owner:@"Tim"];
+
+    RLMRealm *defaultRealm = [RLMRealm defaultRealm];
+    DogObject *dog = [[DogObject alloc] init];
+    dog.dogName = @"Fido";
+    [defaultRealm beginWriteTransaction];
+    [defaultRealm addObject:dog];
+    [defaultRealm commitWriteTransaction];
+
+    XCTAssertThrows(([OwnerObject objectsInRealm:testRealm where:@"dog = %@", dog]));
+}
+
 - (void)testLinkQueryString
 {
     RLMRealm *realm = [self realmWithTestPath];

--- a/Realm/Tests/QueryTests.m
+++ b/Realm/Tests/QueryTests.m
@@ -1113,6 +1113,15 @@
     [realm commitWriteTransaction];
 }
 
+- (void)testLinkQueryNewObjectCausesEmptyResults
+{
+    RLMRealm *realm = [self realmWithTestPath];
+
+    [self makeDogWithName:@"Harvie" owner:@"Tim"];
+    DogObject *newDogObject = [[DogObject alloc] init];
+    XCTAssertEqual(([OwnerObject objectsInRealm:realm where:@"dog = %@", newDogObject].count), 0U);
+}
+
 - (void)testLinkQueryString
 {
     RLMRealm *realm = [self realmWithTestPath];


### PR DESCRIPTION
Without that change, if you query for an object, which is linked to a just newly created object, which was never attached to the Realm, you get something arbitrary returned.

* [x] Changelog
* [x] Check whether object is in the *same* realm as the one being queried
* [x] ~~Check whether object is from the *same* class as the one being queried~~ (done already by `validate_property_value`)
* [x] Fix `RealmCollectionTypeTests.testArrayAggregateWithSwiftObjectDoesntThrow` Swift tests
