### PR TITLE
Consolidate parameter validation in RLMRealmConfiguration

### DIFF
--- a/Realm/RLMRealm.mm
+++ b/Realm/RLMRealm.mm
@@ -346,8 +346,12 @@ void RLMRealmAddPathSettingsToConfiguration(RLMRealmConfiguration *configuration
                         error:(NSError **)outError
 {
     RLMRealmConfiguration *configuration = [[RLMRealmConfiguration alloc] init];
-    configuration.path = path;
-    configuration.inMemoryIdentifier = inMemory ? path.lastPathComponent : nil;
+    if (inMemory) {
+        configuration.inMemoryIdentifier = path.lastPathComponent;
+    }
+    else {
+        configuration.path = path;
+    }
     configuration.encryptionKey = key;
     configuration.readOnly = readonly;
     configuration.dynamic = dynamic;
@@ -375,16 +379,6 @@ static id RLMAutorelease(id value) {
     RLMSchema *customSchema = configuration.customSchema;
     bool dynamic = configuration.dynamic;
     bool readOnly = configuration.readOnly;
-
-    if (!path || path.length == 0) {
-        @throw RLMException([NSString stringWithFormat:@"Path '%@' is not valid", path]);
-    }
-
-    if (![NSRunLoop currentRunLoop]) {
-        @throw RLMException([NSString stringWithFormat:@"%@ \
-                             can only be called from a thread with a runloop.",
-                             NSStringFromSelector(_cmd)]);
-    }
 
     // try to reuse existing realm first
     RLMRealm *realm = RLMGetThreadLocalCachedRealmForPath(path);

--- a/Realm/RLMRealmConfiguration.mm
+++ b/Realm/RLMRealmConfiguration.mm
@@ -155,7 +155,7 @@ static NSString * const c_defaultRealmFileName = @"default.realm";
         @throw RLMException(@"In-memory identifier must not be empty");
     }
 
-    _inMemoryIdentifier = inMemoryIdentifier;
+    _inMemoryIdentifier = [inMemoryIdentifier copy];
     _path = nil;
 }
 
@@ -164,12 +164,12 @@ static NSString * const c_defaultRealmFileName = @"default.realm";
         @throw RLMException(@"Realm path must not be empty");
     }
 
-    _path = path;
+    _path = [path copy];
     _inMemoryIdentifier = nil;
 }
 
 - (void)setEncryptionKey:(NSData * __nullable)encryptionKey {
-    _encryptionKey = RLMRealmValidatedEncryptionKey(encryptionKey);
+    _encryptionKey = [RLMRealmValidatedEncryptionKey(encryptionKey) copy];
 }
 
 - (void)setSchemaVersion:(uint64_t)schemaVersion {

--- a/Realm/RLMRealmConfiguration.mm
+++ b/Realm/RLMRealmConfiguration.mm
@@ -33,7 +33,6 @@ static NSString * const c_RLMRealmConfigurationProperties[] = {
     @"dynamic",
     @"customSchema",
 };
-static const NSUInteger c_RLMRealmConfigurationPropertiesCount = sizeof(c_RLMRealmConfigurationProperties) / sizeof(NSString *);
 
 typedef NS_ENUM(NSUInteger, RLMRealmConfigurationUsage) {
     RLMRealmConfigurationUsageNone,
@@ -132,17 +131,17 @@ static NSString * const c_defaultRealmFileName = @"default.realm";
 
 - (instancetype)copyWithZone:(NSZone *)zone {
     RLMRealmConfiguration *configuration = [[[self class] allocWithZone:zone] init];
-    for (NSUInteger i = 0; i < c_RLMRealmConfigurationPropertiesCount; i++) {
-        NSString *key = c_RLMRealmConfigurationProperties[i];
-        [configuration setValue:[self valueForKey:key] forKey:key];
+    for (NSString *key : c_RLMRealmConfigurationProperties) {
+        if (id value = [self valueForKey:key]) {
+            [configuration setValue:value forKey:key];
+        }
     }
     return configuration;
 }
 
 - (NSString *)description {
     NSMutableString *string = [NSMutableString stringWithFormat:@"%@ {\n", self.class];
-    for (NSUInteger i = 0; i < c_RLMRealmConfigurationPropertiesCount; i++) {
-        NSString *key = c_RLMRealmConfigurationProperties[i];
+    for (NSString *key : c_RLMRealmConfigurationProperties) {
         NSString *description = [[self valueForKey:key] description];
         description = [description stringByReplacingOccurrencesOfString:@"\n" withString:@"\n\t"];
 
@@ -152,15 +151,21 @@ static NSString * const c_defaultRealmFileName = @"default.realm";
 }
 
 - (void)setInMemoryIdentifier:(NSString *)inMemoryIdentifier {
-    if ((_inMemoryIdentifier = inMemoryIdentifier)) {
-        _path = nil;
+    if (inMemoryIdentifier.length == 0) {
+        @throw RLMException(@"In-memory identifier must not be empty");
     }
+
+    _inMemoryIdentifier = inMemoryIdentifier;
+    _path = nil;
 }
 
 - (void)setPath:(NSString *)path {
-    if ((_path = path)) {
-        _inMemoryIdentifier = nil;
+    if (path.length == 0) {
+        @throw RLMException(@"Realm path must not be empty");
     }
+
+    _path = path;
+    _inMemoryIdentifier = nil;
 }
 
 - (void)setEncryptionKey:(NSData * __nullable)encryptionKey {

--- a/RealmSwift-swift1.2/RealmConfiguration.swift
+++ b/RealmSwift-swift1.2/RealmConfiguration.swift
@@ -106,16 +106,7 @@ extension Realm {
         private var _inMemoryIdentifier: String? = nil
 
         /// 64-byte key to use to encrypt the data.
-        public var encryptionKey: NSData? {
-            set {
-                _encryptionKey = RLMRealmValidatedEncryptionKey(newValue)
-            }
-            get {
-                return _encryptionKey
-            }
-        }
-
-        private var _encryptionKey: NSData? = nil
+        public var encryptionKey: NSData? = nil
 
         /// Whether the Realm is read-only (must be true for read-only files).
         public var readOnly: Bool = false
@@ -152,8 +143,11 @@ extension Realm {
 
         internal var rlmConfiguration: RLMRealmConfiguration {
             let configuration = RLMRealmConfiguration()
-            configuration.path = self.path
-            configuration.inMemoryIdentifier = self.inMemoryIdentifier
+            if self.path != nil {
+                configuration.path = self.path
+            } else {
+                configuration.inMemoryIdentifier = self.inMemoryIdentifier
+            }
             configuration.encryptionKey = self.encryptionKey
             configuration.readOnly = self.readOnly
             configuration.schemaVersion = self.schemaVersion

--- a/RealmSwift-swift2.0/RealmConfiguration.swift
+++ b/RealmSwift-swift2.0/RealmConfiguration.swift
@@ -106,17 +106,7 @@ extension Realm {
         private var _inMemoryIdentifier: String? = nil
 
         /// 64-byte key to use to encrypt the data.
-        public var encryptionKey: NSData? {
-            set {
-                _encryptionKey = RLMRealmValidatedEncryptionKey(newValue)
-            }
-            get {
-                return _encryptionKey
-            }
-        }
-
-        private var _encryptionKey: NSData? = nil
-
+        public var encryptionKey: NSData? = nil
 
         /// Whether the Realm is read-only (must be true for read-only files).
         public var readOnly: Bool = false
@@ -144,8 +134,11 @@ extension Realm {
 
         internal var rlmConfiguration: RLMRealmConfiguration {
             let configuration = RLMRealmConfiguration()
-            configuration.path = self.path
-            configuration.inMemoryIdentifier = self.inMemoryIdentifier
+            if path != nil {
+                configuration.path = self.path
+            } else {
+                configuration.inMemoryIdentifier = self.inMemoryIdentifier
+            }
             configuration.encryptionKey = self.encryptionKey
             configuration.readOnly = self.readOnly
             configuration.schemaVersion = self.schemaVersion


### PR DESCRIPTION
Previously some things were validated on property set, some were validated in RLMRealm, and in RealmSwift some were validated on both. This makes RLMRealmConfiguration's setters validate everything that it can, Realm.Configuration validate nothing until it's converted to an RLMRealmConfiguration, and RLMRealm trusts that the passed-in config is valid.

This makes supporting the objectstore config object a bit easier and makes the tests more coherent.