### PR TITLE
Have CocoaPods set APPLICATION_EXTENSION_API_ONLY=YES when building our frameworks

### DIFF
--- a/Realm.podspec
+++ b/Realm.podspec
@@ -41,7 +41,8 @@ Pod::Spec.new do |s|
   s.source_files            = 'Realm/*.{m,mm}', 'Realm/ObjectStore/*.cpp'
   s.header_mappings_dir     = 'include'
   s.pod_target_xcconfig     = { 'CLANG_CXX_LANGUAGE_STANDARD' => 'compiler-default',
-                                'OTHER_CPLUSPLUSFLAGS' => '-std=c++1y $(inherited)' }
+                                'OTHER_CPLUSPLUSFLAGS' => '-std=c++1y $(inherited)',
+                                'APPLICATION_EXTENSION_API_ONLY' => 'YES' }
   s.preserve_paths          = %w(build.sh)
 
   s.ios.deployment_target   = '7.0'

--- a/RealmSwift.podspec
+++ b/RealmSwift.podspec
@@ -21,7 +21,8 @@ Pod::Spec.new do |s|
   s.prepare_command           = 'sh build.sh cocoapods-setup without-core'
   s.preserve_paths            = %w(build.sh)
   
-  s.pod_target_xcconfig = { 'SWIFT_WHOLE_MODULE_OPTIMIZATION' => 'YES' }
+  s.pod_target_xcconfig = { 'SWIFT_WHOLE_MODULE_OPTIMIZATION' => 'YES',
+                            'APPLICATION_EXTENSION_API_ONLY' => 'YES' }
 
   s.ios.deployment_target     = '8.0'
   s.osx.deployment_target     = '10.9'


### PR DESCRIPTION
This avoids linker warnings for application extensions that link against either framework.