### PR TITLE
Validate that the encryption key matches for cached realms

### DIFF
--- a/Realm/RLMRealm.mm
+++ b/Realm/RLMRealm.mm
@@ -379,6 +379,7 @@ static id RLMAutorelease(id value) {
     RLMSchema *customSchema = configuration.customSchema;
     bool dynamic = configuration.dynamic;
     bool readOnly = configuration.readOnly;
+    NSData *key = configuration.encryptionKey ?: keyForPath(path);
 
     // try to reuse existing realm first
     RLMRealm *realm = RLMGetThreadLocalCachedRealmForPath(path);
@@ -392,10 +393,12 @@ static id RLMAutorelease(id value) {
         if (realm->_dynamic != dynamic) {
             @throw RLMException(@"Realm at path already opened with different dynamic settings", @{@"path":realm.path});
         }
+        if (realm->_encryptionKey != key && (!key || ![realm->_encryptionKey isEqualToData:key])) {
+            @throw RLMException(@"Realm at path already opened with different encryption key", @{@"path":realm.path});
+        }
         return RLMAutorelease(realm);
     }
 
-    NSData *key = configuration.encryptionKey ?: keyForPath(path);
     realm = [[RLMRealm alloc] initWithPath:path key:key readOnly:readOnly inMemory:inMemory dynamic:dynamic error:error];
     if (error && *error) {
         return nil;

--- a/Realm/Tests/EncryptionTests.mm
+++ b/Realm/Tests/EncryptionTests.mm
@@ -127,6 +127,11 @@
     }
 }
 
+- (void)testOpenWithNewKeyWhileAlreadyOpenThrows {
+    [self realmWithKey:RLMGenerateKey()];
+    XCTAssertThrows([self realmWithKey:RLMGenerateKey()]);
+}
+
 #pragma mark - Registered encryption key
 
 - (void)testRegisteredKeyIsUsed {


### PR DESCRIPTION
This was previously handled by not allowing registering an encryption key for already-open paths, but that doesn't do anything about supplying a different encryption key in the RLMRealmConfiguration directly.