### PR TITLE
remove mention of CGFloat from docs

### DIFF
--- a/Realm/ObjectStore/property.hpp
+++ b/Realm/ObjectStore/property.hpp
@@ -27,9 +27,9 @@ namespace realm {
         PropertyTypeInt    = 0,
         /** Boolean type: BOOL, bool, Bool (Swift) */
         PropertyTypeBool   = 1,
-        /** Float type: CGFloat (32bit), float, Float (Swift) */
+        /** Float type: float, Float (Swift) */
         PropertyTypeFloat  = 9,
-        /** Double type: CGFloat (64bit), double, Double (Swift) */
+        /** Double type: double, Double (Swift) */
         PropertyTypeDouble = 10,
         /** String type: NSString, String (Swift) */
         PropertyTypeString = 2,

--- a/Realm/RLMConstants.h
+++ b/Realm/RLMConstants.h
@@ -33,9 +33,9 @@ typedef NS_ENUM(int32_t, RLMPropertyType) {
     RLMPropertyTypeInt    = 0,
     /** Boolean type: BOOL, bool, Bool (Swift) */
     RLMPropertyTypeBool   = 1,
-    /** Float type: CGFloat (32bit), float, Float (Swift) */
+    /** Float type: float, Float (Swift) */
     RLMPropertyTypeFloat  = 9,
-    /** Double type: CGFloat (64bit), double, Double (Swift) */
+    /** Double type: double, Double (Swift) */
     RLMPropertyTypeDouble = 10,
 
     ////////////////////////////////


### PR DESCRIPTION
`CGFloat` properties are discouraged, as the type is not platform independent. /cc @tgoyne 