### PR TITLE
Fix failing install with CocoaPods 0.39 to case-sensitive file system.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -674,6 +674,7 @@ case "$COMMAND" in
           # CocoaPods doesn't support multiple header_mappings_dir, so combine
           # both sets of headers into a single directory
           rm -rf include
+          cp -R core/include/realm core/include/Realm
           cp -R core/include include
           mkdir -p include/Realm
           cp Realm/*.{h,hpp} include/Realm

--- a/build.sh
+++ b/build.sh
@@ -674,7 +674,9 @@ case "$COMMAND" in
           # CocoaPods doesn't support multiple header_mappings_dir, so combine
           # both sets of headers into a single directory
           rm -rf include
-          cp -R core/include/realm core/include/Realm
+          if [ ! -e core/include/Realm ]; then
+            cp -R core/include/realm core/include/Realm
+          fi
           cp -R core/include include
           mkdir -p include/Realm
           cp Realm/*.{h,hpp} include/Realm

--- a/build.sh
+++ b/build.sh
@@ -674,6 +674,8 @@ case "$COMMAND" in
           # CocoaPods doesn't support multiple header_mappings_dir, so combine
           # both sets of headers into a single directory
           rm -rf include
+          # Create uppercase `Realm` header directory for a case-sensitive filesystem.
+          # Both `Realm` and `realm` directories are required.
           if [ ! -e core/include/Realm ]; then
             cp -R core/include/realm core/include/Realm
           fi


### PR DESCRIPTION
This PR fixes the issue that fails to build when Realm is installed to case-sensitive file system using CocoaPods 0.39 due to following error:

```
...Pods/Realm/Realm/ObjectStore/object_store_exceptions.cpp:19:10: 'object_store_exceptions.hpp' file not found
```

<img width="619" alt="screen shot 2015-10-14 at 19 13 51" src="https://cloud.githubusercontent.com/assets/40610/10480989/b73075e6-72a8-11e5-8f73-684712b0d092.png">

Because two different directories (`Ream` and `realm`) are copied to `include` directory. Each directory has different headers.

```
include
├── Realm
│   ├── RLMAccessor.h
│   ├── RLMAnalytics.hpp
│   ├── ...
│   ├── object_store_exceptions.hpp
│   └── property.hpp
├── realm
│   ├── alloc.hpp
│   ├── alloc_slab.hpp
│   ├── ...
│   ├── version.hpp
│   └── views.hpp
└── realm.hpp
```