### PR TITLE
Remove all deprecated things

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@ x.x.x Release notes (yyyy-MM-dd)
 
 ### API breaking changes
 
-* None.
+* All functionality deprecated in previously releases has been removed
+  entirely.
 
 ### Enhancements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,7 @@ x.x.x Release notes (yyyy-MM-dd)
 
 ### API breaking changes
 
-* All functionality deprecated in previously releases has been removed
-  entirely.
+* All functionality deprecated in previous releases has been removed entirely.
 
 ### Enhancements
 

--- a/Realm/RLMMigration.h
+++ b/Realm/RLMMigration.h
@@ -81,8 +81,6 @@ typedef void (^RLMObjectMigrationBlock)(RLMObject * __nullable oldObject, RLMObj
  */
 -(RLMObject *)createObject:(NSString *)className withValue:(id)value;
 
--(RLMObject *)createObject:(NSString *)className withObject:(id)object DEPRECATED_MSG_ATTRIBUTE("use createObject:withValue:");
-
 /**
  Delete an object from a Realm during a migration. This can be called within `enumerateObjects:block:`.
 

--- a/Realm/RLMObject.h
+++ b/Realm/RLMObject.h
@@ -112,8 +112,6 @@ RLM_ASSUME_NONNULL_BEGIN
  */
 - (instancetype)initWithValue:(id)value NS_DESIGNATED_INITIALIZER;
 
-- (instancetype)initWithObject:(id)object DEPRECATED_MSG_ATTRIBUTE("use initWithValue:");
-
 
 /**
  Helper to return the class name for an RLMObject subclass.
@@ -145,8 +143,6 @@ RLM_ASSUME_NONNULL_BEGIN
  */
 + (instancetype)createInDefaultRealmWithValue:(id)value;
 
-+ (instancetype)createInDefaultRealmWithObject:(id)object DEPRECATED_MSG_ATTRIBUTE("use createInDefaultRealmWithValue:");
-
 /**
  Create an RLMObject in a Realm with a given object.
  
@@ -167,8 +163,6 @@ RLM_ASSUME_NONNULL_BEGIN
  @see   defaultPropertyValues
  */
 + (instancetype)createInRealm:(RLMRealm *)realm withValue:(id)value;
-
-+ (instancetype)createInRealm:(RLMRealm *)realm withObject:(id)object DEPRECATED_MSG_ATTRIBUTE("use createInRealm:withValue:");
 
 /**
  Create or update an RLMObject in the default Realm with a given object.
@@ -193,8 +187,6 @@ RLM_ASSUME_NONNULL_BEGIN
  */
 + (instancetype)createOrUpdateInDefaultRealmWithValue:(id)value;
 
-+ (instancetype)createOrUpdateInDefaultRealmWithObject:(id)object DEPRECATED_MSG_ATTRIBUTE("use createOrUpdateInDefaultRealmWithValue:");
-
 /**
  Create or update an RLMObject with a given object.
 
@@ -218,8 +210,6 @@ RLM_ASSUME_NONNULL_BEGIN
  @see   defaultPropertyValues, primaryKey
  */
 + (instancetype)createOrUpdateInRealm:(RLMRealm *)realm withValue:(id)value;
-
-+ (instancetype)createOrUpdateInRealm:(RLMRealm *)realm withObject:(id)object DEPRECATED_MSG_ATTRIBUTE("use createOrUpdateInRealm:withValue:");
 
 /**
  The Realm in which this object is persisted. Returns nil for standalone objects.

--- a/Realm/RLMObject.h
+++ b/Realm/RLMObject.h
@@ -239,8 +239,6 @@ RLM_ASSUME_NONNULL_BEGIN
  */
 @property (nonatomic, readonly, getter = isInvalidated) BOOL invalidated;
 
-@property (nonatomic, readonly, getter = isDeletedFromRealm) BOOL deletedFromRealm __attribute__((deprecated("Use `invalidated` instead.")));
-
 
 /**---------------------------------------------------------------------------------------
  *  @name Customizing your Objects

--- a/Realm/RLMObjectBase.mm
+++ b/Realm/RLMObjectBase.mm
@@ -231,10 +231,6 @@ static id RLMValidatedObjectForProperty(id obj, RLMProperty *prop, RLMSchema *sc
     return self.class == _objectSchema.accessorClass && !_row.is_attached();
 }
 
-- (BOOL)isDeletedFromRealm {
-    return self.isInvalidated;
-}
-
 - (BOOL)isEqual:(id)object {
     if (RLMObjectBase *other = RLMDynamicCast<RLMObjectBase>(object)) {
         if (_objectSchema.primaryKeyProperty) {

--- a/Realm/RLMRealm.h
+++ b/Realm/RLMRealm.h
@@ -89,92 +89,6 @@ RLM_ASSUME_NONNULL_BEGIN
 + (instancetype)realmWithPath:(NSString *)path;
 
 /**
- Obtains an `RLMRealm` instance with persistence to a specific file path with
- options.
-
- Like `realmWithPath:`, but with the ability to open read-only realms and get
- errors as an `NSError` inout parameter rather than exceptions.
-
- @warning Read-only Realms do not support changes made to the file while the
- `RLMRealm` exists. This means that you cannot open a Realm as both read-only
- and read-write at the same time. Read-only Realms should normally only be used
- on files which cannot be opened in read-write mode, and not just for enforcing
- correctness in code that should not need to write to the Realm.
-
- @param path        Path to the file you want the data saved in.
- @param readonly    BOOL indicating if this Realm is read-only (must use for read-only files)
- @param error       If an error occurs, upon return contains an `NSError` object
-                    that describes the problem. If you are not interested in
-                    possible errors, pass in `NULL`.
-
- @return An `RLMRealm` instance.
- */
-+ (nullable instancetype)realmWithPath:(NSString *)path readOnly:(BOOL)readonly error:(NSError **)error DEPRECATED_MSG_ATTRIBUTE("Use +[RLMRealm realmWithConfiguration:error:]");
-
-/**
- Obtains an `RLMRealm` instance persisted to an encrypted file.
-
- The on-disk storage for encrypted Realms are encrypted using AES256+HMAC-SHA2,
- but otherwise they behave like normal persisted Realms.
-
- Encrypted Realms currently cannot be opened while lldb is attached to the
- process since lldb often hangs in this situation. See issue #1625 for
- further discussion. Attempting to open an encrypted Realm with lldb attached
- will result in an EXC_BAD_ACCESS. Running your application with
- REALM_DISABLE_ENCRYPTION=YES set in your environment will result in Realm
- treating requests to open an encrypted Realm as requesting an unencrypted Realm.
-
- @param path        Path to the file you want the data saved in.
- @param key         64-byte key to use to encrypt the data.
- @param readonly    BOOL indicating if this Realm is read-only (must use for read-only files)
- @param error       If an error occurs, upon return contains an `NSError` object
-                    that describes the problem. If you are not interested in
-                    possible errors, pass in `NULL`.
-
- @return An encrypted `RLMRealm` instance.
- */
-+ (nullable instancetype)realmWithPath:(NSString *)path
-                         encryptionKey:(NSData *)key
-                              readOnly:(BOOL)readonly
-                                 error:(NSError **)error DEPRECATED_MSG_ATTRIBUTE("Use +[RLMRealm realmWithConfiguration:error:]");
-
-/**
- Set the encryption key to use when opening Realms at a certain path.
-
- This can be used as an alternative to explicitly passing the key to
- `realmWithPath:key:readOnly:error:` each time a Realm instance is
- needed. The encryption key will be used any time a Realm is opened with
- `realmWithPath:` or `defaultRealm`.
-
- If you do not want Realm to hold on to your encryption keys any longer than
- needed, then use `realmWithPath:encryptionKey:readOnly:error:` rather than this
- method.
-
- @param key     64-byte encryption key to use, or `nil` to unset.
- @param path    Realm path to set the encryption key for.
- */
-+ (void)setEncryptionKey:(nullable NSData *)key forRealmsAtPath:(NSString *)path DEPRECATED_MSG_ATTRIBUTE("Use RLMRealmConfiguration to set an encryption key");
-
-/**
- Obtains an `RLMRealm` instance for an un-persisted in-memory Realm. The identifier
- used to create this instance can be used to access the same in-memory Realm from
- multiple threads.
-
- Because in-memory Realms are not persisted, you must be sure to hold on to a
- reference to the `RLMRealm` object returned from this for as long as you want
- the data to last. Realm's internal cache of `RLMRealm`s will not keep the
- in-memory Realm alive across cycles of the run loop, so without a strong
- reference to the `RLMRealm` a new Realm will be created each time. Note that
- `RLMObject`s, `RLMArray`s, and `RLMResults` that refer to objects persisted in a Realm have a
- strong reference to the relevant `RLMRealm`, as do `RLMNotifcationToken`s.
-
- @param identifier  A string used to identify a particular in-memory Realm.
-
- @return An `RLMRealm` instance.
- */
-+ (instancetype)inMemoryRealmWithIdentifier:(NSString *)identifier DEPRECATED_MSG_ATTRIBUTE("Use +[RLMRealm realmWithConfiguration:error:]");
-
-/**
  Path to the file where this Realm is persisted.
  */
 @property (nonatomic, readonly) NSString *path;
@@ -208,33 +122,6 @@ RLM_ASSUME_NONNULL_BEGIN
  Indicates if this Realm contains any objects.
  */
 @property (nonatomic, readonly) BOOL isEmpty;
-
-/**---------------------------------------------------------------------------------------
- *  @name Default Realm Path
- * ---------------------------------------------------------------------------------------
- */
-/**
- Returns the location of the default Realm as a string.
-
- `~/Library/Application Support/{bundle ID}/default.realm` on OS X.
-
- `default.realm` in your application's documents directory on iOS.
-
- @return Location of the default Realm.
-
- @see defaultRealm
- */
-+ (NSString *)defaultRealmPath DEPRECATED_MSG_ATTRIBUTE("Use [RLMRealmConfiguration defaultConfiguration].path");
-
-/**
- Set the default Realm path to a given path.
-
- @param defaultRealmPath    The path to use for the default Realm.
-
- @see defaultRealm
- */
-+ (void)setDefaultRealmPath:(NSString *)defaultRealmPath DEPRECATED_MSG_ATTRIBUTE("Use +[RLMRealmConfiguration setDefaultConfiguration:]");
-
 
 #pragma mark - Notifications
 
@@ -550,49 +437,6 @@ typedef void(^RLMNotificationBlock)(NSString *notification, RLMRealm *realm);
 typedef void (^RLMMigrationBlock)(RLMMigration *migration, uint64_t oldSchemaVersion);
 
 /**
- Specify a schema version and an associated migration block which is applied when
- opening the default Realm with an old schema version.
-
- Before you can open an existing `RLMRealm` which has a different on-disk schema
- from the schema defined in your object interfaces you must provide a migration 
- block which converts from the disk schema to your current object schema. At the
- minimum your migration block must initialize any properties which were added to
- existing objects without defaults and ensure uniqueness if a primary key
- property is added to an existing object.
-
- You should call this method before accessing any `RLMRealm` instances which
- require migration. After registering your migration block Realm will call your 
- block automatically as needed.
-
- @warning Unsuccessful migrations will throw exceptions when the migration block
- is applied. This will happen in the following cases:
-
- - The migration block was run and returns a schema version which is not higher
-   than the previous schema version.
- - A new property without a default was added to an object and not initialized
-   during the migration. You are required to either supply a default value or to
-   manually populate added properties during a migration.
-
- @param version     The current schema version.
- @param block       The block which migrates the Realm to the current version.
-
- @see               RLMMigration
- */
-+ (void)setDefaultRealmSchemaVersion:(uint64_t)version withMigrationBlock:(nullable RLMMigrationBlock)block DEPRECATED_MSG_ATTRIBUTE("Use RLMRealmConfiguration.schemaVersion and RLMRealmConfiguration.migrationBlock");
-
-/**
- Specify a schema version and an associated migration block which is applied when
- opening the Realm at realmPath with an old schema version.
-
- @param version     The current schema version.
- @param realmPath   The path at which this schema version and migration block is applied.
- @param block       The block which migrates the Realm to the current version.
-
- @see               RLMMigration
- */
-+ (void)setSchemaVersion:(uint64_t)version forRealmAtPath:(NSString *)realmPath withMigrationBlock:(nullable RLMMigrationBlock)block DEPRECATED_MSG_ATTRIBUTE("Use RLMRealmConfiguration.schemaVersion and RLMRealmConfiguration.migrationBlock");
-
-/**
  Get the schema version for a Realm at a given path.
 
  @param realmPath   Path to a Realm file
@@ -630,32 +474,6 @@ typedef void (^RLMMigrationBlock)(RLMMigration *migration, uint64_t oldSchemaVer
  @see                 RLMMigration
  */
 + (NSError *)migrateRealm:(RLMRealmConfiguration *)configuration;
-
-/**
- Performs the registered migration block on a Realm at the given path.
-
- This method is called automatically when opening a Realm for the first time and does
- not need to be called explicitly. You can choose to call this method to control 
- exactly when and how migrations are performed.
-
- @param realmPath   The path of the Realm to migrate.
- @return            The error that occurred while applying the migration if any.
-
- @see               RLMMigration
- @see               setSchemaVersion:forRealmAtPath:withMigrationBlock:
- */
-+ (NSError *)migrateRealmAtPath:(NSString *)realmPath DEPRECATED_MSG_ATTRIBUTE("Use +[RLMRealm migrateRealm:]");
-
-/**
- Performs the registered migration block on an encrypted Realm at the given path.
-
- As `migrateRealmAtPath:`, but for encrypted realms.
-
- @param realmPath   The path of the Realm to migrate.
- @param key         64-byte encryption key.
- @return            The error that occurred while applying the migration, if any.
- */
-+ (NSError *)migrateRealmAtPath:(NSString *)realmPath encryptionKey:(NSData *)key DEPRECATED_MSG_ATTRIBUTE("Use +[RLMRealm migrateRealm:]");
 
 #pragma mark -
 

--- a/Realm/RLMRealm.mm
+++ b/Realm/RLMRealm.mm
@@ -41,9 +41,8 @@
 #include <realm/lang_bind_helper.hpp>
 #include <realm/version.hpp>
 
-using namespace std;
 using namespace realm;
-using namespace realm::util;
+using util::File;
 
 void RLMDisableSyncToDisk() {
     realm::disable_sync_to_disk();
@@ -67,35 +66,10 @@ void RLMDisableSyncToDisk() {
 }
 @end
 
-using namespace std;
-using namespace realm;
-using namespace realm::util;
-
-//
-// Global encryption key cache and validation
-//
-
 static bool shouldForciblyDisableEncryption()
 {
     static bool disableEncryption = getenv("REALM_DISABLE_ENCRYPTION");
     return disableEncryption;
-}
-
-static NSMutableDictionary *s_keysPerPath = [NSMutableDictionary new];
-static NSData *keyForPath(NSString *path) {
-    if (shouldForciblyDisableEncryption()) {
-        return nil;
-    }
-
-    @synchronized (s_keysPerPath) {
-        return s_keysPerPath[path];
-    }
-}
-
-static void clearKeyCache() {
-    @synchronized(s_keysPerPath) {
-        [s_keysPerPath removeAllObjects];
-    }
 }
 
 NSData *RLMRealmValidatedEncryptionKey(NSData *key) {
@@ -116,59 +90,6 @@ NSData *RLMRealmValidatedEncryptionKey(NSData *key) {
     }
 
     return key;
-}
-
-static void setKeyForPath(NSData *key, NSString *path) {
-    key = RLMRealmValidatedEncryptionKey(key);
-    @synchronized (s_keysPerPath) {
-        if (key) {
-            s_keysPerPath[path] = key;
-        }
-        else {
-            [s_keysPerPath removeObjectForKey:path];
-        }
-    }
-}
-
-//
-// Schema version and migration blocks
-//
-static NSMutableDictionary *s_migrationBlocks = [NSMutableDictionary new];
-static NSMutableDictionary *s_schemaVersions = [NSMutableDictionary new];
-
-NSUInteger RLMRealmSchemaVersionForPath(NSString *path) {
-    @synchronized(s_migrationBlocks) {
-        NSNumber *version = s_schemaVersions[path];
-        if (version) {
-            return [version unsignedIntegerValue];
-        }
-        return 0;
-    }
-}
-
-RLMMigrationBlock RLMRealmMigrationBlockForPath(NSString *path) {
-    @synchronized(s_migrationBlocks) {
-        return s_migrationBlocks[path];
-    }
-}
-
-static void clearMigrationCache() {
-    @synchronized(s_migrationBlocks) {
-        [s_migrationBlocks removeAllObjects];
-        [s_schemaVersions removeAllObjects];
-    }
-}
-
-void RLMRealmAddPathSettingsToConfiguration(RLMRealmConfiguration *configuration) {
-    if (!configuration.encryptionKey) {
-        configuration.encryptionKey = keyForPath(configuration.path);
-    }
-    if (!configuration.migrationBlock) {
-        configuration.migrationBlock = RLMRealmMigrationBlockForPath(configuration.path);
-    }
-    if (configuration.schemaVersion == 0) {
-        configuration.schemaVersion = RLMRealmSchemaVersionForPath(configuration.path);
-    }
 }
 
 @implementation RLMRealm {
@@ -225,11 +146,8 @@ void RLMRealmAddPathSettingsToConfiguration(RLMRealmConfiguration *configuration
 
         NSError *error = nil;
         try {
-            // NOTE: we do these checks here as is this is the first time encryption keys are used
-            key = RLMRealmValidatedEncryptionKey(key);
-
             if (readonly) {
-                _readGroup = make_unique<Group>(path.UTF8String, static_cast<const char *>(key.bytes));
+                _readGroup = std::make_unique<Group>(path.UTF8String, static_cast<const char *>(key.bytes));
                 _group = _readGroup.get();
             }
             else {
@@ -237,8 +155,8 @@ void RLMRealmAddPathSettingsToConfiguration(RLMRealmConfiguration *configuration
                                                       static_cast<const char *>(key.bytes));
                 SharedGroup::DurabilityLevel durability = inMemory ? SharedGroup::durability_MemOnly :
                                                                      SharedGroup::durability_Full;
-                _sharedGroup = make_unique<SharedGroup>(*_history, durability,
-                                                        static_cast<const char *>(key.bytes));
+                _sharedGroup = std::make_unique<SharedGroup>(*_history, durability,
+                                                             static_cast<const char *>(key.bytes));
             }
         }
         catch (File::PermissionDenied const& ex) {
@@ -265,7 +183,7 @@ void RLMRealmAddPathSettingsToConfiguration(RLMRealmConfiguration *configuration
                                     userInfo:@{NSLocalizedDescriptionKey: err,
                                                @"Error Code": @(RLMErrorIncompatibleLockFile)}];
         }
-        catch (exception const& ex) {
+        catch (std::exception const& ex) {
             error = RLMMakeError(RLMErrorFail, ex);
         }
 
@@ -285,55 +203,20 @@ void RLMRealmAddPathSettingsToConfiguration(RLMRealmConfiguration *configuration
     return _group;
 }
 
-+ (NSString *)defaultRealmPath
-{
-    return [RLMRealmConfiguration defaultConfiguration].path;
-}
-
-+ (void)setDefaultRealmPath:(NSString *)defaultRealmPath {
-    [RLMRealmConfiguration setDefaultPath:defaultRealmPath];
-}
-
-+ (NSString *)writeableTemporaryPathForFile:(NSString *)fileName
-{
++ (NSString *)writeableTemporaryPathForFile:(NSString *)fileName {
     return [NSTemporaryDirectory() stringByAppendingPathComponent:fileName];
 }
 
 + (instancetype)defaultRealm
 {
-    RLMRealmConfiguration *configuration = [RLMRealmConfiguration defaultConfiguration];
-    RLMRealmAddPathSettingsToConfiguration(configuration);
-    return [RLMRealm realmWithConfiguration:configuration error:nil];
+    return [RLMRealm realmWithConfiguration:[RLMRealmConfiguration rawDefaultConfiguration] error:nil];
 }
 
 + (instancetype)realmWithPath:(NSString *)path
 {
-    return [self realmWithPath:path key:nil readOnly:false inMemory:false dynamic:false schema:nil error:nil];
-}
-
-+ (instancetype)realmWithPath:(NSString *)path
-                     readOnly:(BOOL)readonly
-                        error:(NSError **)outError
-{
-    return [self realmWithPath:path key:nil readOnly:readonly inMemory:NO dynamic:NO schema:nil error:outError];
-}
-
-+ (instancetype)inMemoryRealmWithIdentifier:(NSString *)identifier {
     RLMRealmConfiguration *configuration = [[RLMRealmConfiguration alloc] init];
-    configuration.inMemoryIdentifier = identifier;
+    configuration.path = path;
     return [RLMRealm realmWithConfiguration:configuration error:nil];
-}
-
-+ (instancetype)realmWithPath:(NSString *)path
-                encryptionKey:(NSData *)key
-                     readOnly:(BOOL)readonly
-                        error:(NSError **)error
-{
-    if (!key) {
-        @throw RLMException(@"Encryption key must not be nil");
-    }
-
-    return [self realmWithPath:path key:key readOnly:readonly inMemory:NO dynamic:NO schema:nil error:error];
 }
 
 + (instancetype)realmWithPath:(NSString *)path
@@ -355,8 +238,6 @@ void RLMRealmAddPathSettingsToConfiguration(RLMRealmConfiguration *configuration
     configuration.readOnly = readonly;
     configuration.dynamic = dynamic;
     configuration.customSchema = customSchema;
-    configuration.migrationBlock = RLMRealmMigrationBlockForPath(path);
-    configuration.schemaVersion = RLMRealmSchemaVersionForPath(path);
     return [RLMRealm realmWithConfiguration:configuration error:outError];
 }
 
@@ -378,7 +259,7 @@ static id RLMAutorelease(id value) {
     RLMSchema *customSchema = configuration.customSchema;
     bool dynamic = configuration.dynamic;
     bool readOnly = configuration.readOnly;
-    NSData *key = configuration.encryptionKey ?: keyForPath(path);
+    NSData *key = configuration.encryptionKey;
 
     // try to reuse existing realm first
     RLMRealm *realm = RLMGetThreadLocalCachedRealmForPath(path);
@@ -458,7 +339,6 @@ static id RLMAutorelease(id value) {
 }
 
 - (NSError *(^)())migrationBlock:(RLMMigrationBlock)userBlock key:(NSData *)encryptionKey {
-    userBlock = userBlock ?: RLMRealmMigrationBlockForPath(_path);
     if (userBlock) {
         return ^{
             NSError *error;
@@ -474,30 +354,7 @@ static id RLMAutorelease(id value) {
     return nil;
 }
 
-+ (void)setEncryptionKey:(NSData *)key forRealmsAtPath:(NSString *)path {
-    RLMRealmConfigurationUsePerPath(_cmd);
-    @synchronized (s_keysPerPath) {
-        if (RLMGetAnyCachedRealmForPath(path)) {
-            NSData *existingKey = keyForPath(path);
-            if (!(existingKey == key || [existingKey isEqual:key])) {
-                @throw RLMException(@"Cannot set encryption key for Realms that are already open.");
-            }
-        }
-
-        setKeyForPath(key, path);
-    }
-}
-
-void RLMRealmSetEncryptionKeyForPath(NSData *encryptionKey, NSString *path) {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-    [RLMRealm setEncryptionKey:encryptionKey forRealmsAtPath:path];
-#pragma clang diagnostic pop
-}
-
 + (void)resetRealmState {
-    clearMigrationCache();
-    clearKeyCache();
     RLMClearRealmCache();
     [RLMRealmConfiguration resetRealmConfigurationState];
 }
@@ -545,7 +402,7 @@ static void CheckReadWrite(RLMRealm *realm, NSString *msg=@"Cannot write to a re
 - (RLMRealmConfiguration *)configuration {
     RLMRealmConfiguration *configuration = [[RLMRealmConfiguration alloc] init];
     configuration.path = self.path;
-    configuration.schemaVersion = [RLMRealm schemaVersionAtPath:_path encryptionKey:_encryptionKey error:nil];
+    configuration.schemaVersion = realm::ObjectStore::get_schema_version(self.group);
     if (_inMemory) {
         configuration.inMemoryIdentifier = [_path lastPathComponent];
     }
@@ -755,7 +612,7 @@ static void CheckReadWrite(RLMRealm *realm, NSString *msg=@"Cannot write to a re
             }
         }
     }
-    catch (exception &ex) {
+    catch (std::exception &ex) {
         @throw RLMException(ex);
     }
 }
@@ -784,7 +641,7 @@ static void CheckReadWrite(RLMRealm *realm, NSString *msg=@"Cannot write to a re
         }
         return NO;
     }
-    catch (exception &ex) {
+    catch (std::exception &ex) {
         @throw RLMException(ex);
     }
 }
@@ -867,44 +724,12 @@ static void CheckReadWrite(RLMRealm *realm, NSString *msg=@"Cannot write to a re
     return RLMGetObject(self, className, primaryKey);
 }
 
-+ (void)setDefaultRealmSchemaVersion:(uint64_t)version withMigrationBlock:(RLMMigrationBlock)block {
-    [RLMRealm setSchemaVersion:version forRealmAtPath:[RLMRealm defaultRealmPath] withMigrationBlock:block];
-}
-
-+ (void)setSchemaVersion:(uint64_t)version forRealmAtPath:(NSString *)realmPath withMigrationBlock:(RLMMigrationBlock)block {
-    RLMRealmConfigurationUsePerPath(_cmd);
-    @synchronized(s_migrationBlocks) {
-        if (RLMGetAnyCachedRealmForPath(realmPath) && RLMRealmSchemaVersionForPath(realmPath) != version) {
-            @throw RLMException(@"Cannot set schema version for Realms that are already open.");
-        }
-
-        if (version == realm::ObjectStore::NotVersioned) {
-            @throw RLMException(@"Cannot set schema version to RLMNotVersioned.");
-        }
-
-        if (block) {
-            s_migrationBlocks[realmPath] = block;
-        }
-        else {
-            [s_migrationBlocks removeObjectForKey:realmPath];
-        }
-        s_schemaVersions[realmPath] = @(version);
-    }
-}
-
-void RLMRealmSetSchemaVersionForPath(uint64_t version, NSString *path, RLMMigrationBlock migrationBlock) {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-    [RLMRealm setSchemaVersion:version forRealmAtPath:path withMigrationBlock:migrationBlock];
-#pragma clang diagnostic pop
-}
-
 + (uint64_t)schemaVersionAtPath:(NSString *)realmPath error:(NSError **)error {
     return [RLMRealm schemaVersionAtPath:realmPath encryptionKey:nil error:error];
 }
 
 + (uint64_t)schemaVersionAtPath:(NSString *)realmPath encryptionKey:(NSData *)key error:(NSError **)outError {
-    key = RLMRealmValidatedEncryptionKey(key) ?: keyForPath(realmPath);
+    key = RLMRealmValidatedEncryptionKey(key);
     RLMRealm *realm = RLMGetThreadLocalCachedRealmForPath(realmPath);
     if (!realm) {
         NSError *error;
@@ -918,33 +743,13 @@ void RLMRealmSetSchemaVersionForPath(uint64_t version, NSString *path, RLMMigrat
     return realm::ObjectStore::get_schema_version(realm.group);
 }
 
-+ (NSError *)migrateRealmAtPath:(NSString *)realmPath {
-    RLMRealmConfiguration *configuration = [RLMRealmConfiguration defaultConfiguration];
-    configuration.path = realmPath;
-    configuration.schemaVersion = RLMRealmSchemaVersionForPath(realmPath);
-    configuration.migrationBlock = RLMRealmMigrationBlockForPath(realmPath);
-    return [self migrateRealm:configuration];
-}
-
-+ (NSError *)migrateRealmAtPath:(NSString *)realmPath encryptionKey:(NSData *)key {
-    if (!key) {
-        @throw RLMException(@"Encryption key must not be nil");
-    }
-    RLMRealmConfiguration *configuration = [RLMRealmConfiguration defaultConfiguration];
-    configuration.path = realmPath;
-    configuration.schemaVersion = RLMRealmSchemaVersionForPath(realmPath);
-    configuration.migrationBlock = RLMRealmMigrationBlockForPath(realmPath);
-    configuration.encryptionKey = key;
-    return [self migrateRealm:configuration];
-}
-
 + (NSError *)migrateRealm:(RLMRealmConfiguration *)configuration {
     NSString *realmPath = configuration.path;
     if (RLMGetAnyCachedRealmForPath(realmPath)) {
         @throw RLMException(@"Cannot migrate Realms that are already open.");
     }
 
-    NSData *key = configuration.encryptionKey ?: keyForPath(realmPath);
+    NSData *key = configuration.encryptionKey;
 
     NSError *error;
     RLMRealm *realm = [[RLMRealm alloc] initWithPath:realmPath key:key readOnly:NO inMemory:NO dynamic:YES error:&error];
@@ -968,7 +773,7 @@ void RLMRealmSetSchemaVersionForPath(uint64_t version, NSString *path, RLMMigrat
 }
 
 - (BOOL)writeCopyToPath:(NSString *)path key:(NSData *)key error:(NSError **)error {
-    key = RLMRealmValidatedEncryptionKey(key) ?: keyForPath(path);
+    key = RLMRealmValidatedEncryptionKey(key);
 
     try {
         self.group->write(path.UTF8String, static_cast<const char *>(key.bytes));
@@ -989,7 +794,7 @@ void RLMRealmSetSchemaVersionForPath(uint64_t version, NSString *path, RLMMigrat
             *error = RLMMakeError(RLMErrorFileAccessError, ex);
         }
     }
-    catch (exception &ex) {
+    catch (std::exception &ex) {
         if (error) {
             *error = RLMMakeError(RLMErrorFail, ex);
         }

--- a/Realm/RLMRealmConfiguration.mm
+++ b/Realm/RLMRealmConfiguration.mm
@@ -42,23 +42,10 @@ typedef NS_ENUM(NSUInteger, RLMRealmConfigurationUsage) {
 
 static std::atomic<RLMRealmConfigurationUsage> s_configurationUsage;
 
-@implementation RLMRealmConfiguration
-
+static NSString *const c_defaultRealmFileName = @"default.realm";
 RLMRealmConfiguration *s_defaultConfiguration;
-static NSString * const c_defaultRealmFileName = @"default.realm";
 
-+ (NSString *)defaultRealmPath
-{
-    static NSString *defaultRealmPath;
-    static dispatch_once_t onceToken;
-    dispatch_once(&onceToken, ^{
-        defaultRealmPath = [[self class] writeablePathForFile:c_defaultRealmFileName];
-    });
-    return defaultRealmPath;
-}
-
-+ (NSString *)writeablePathForFile:(NSString*)fileName
-{
+NSString *RLMRealmPathForFile(NSString *fileName) {
 #if TARGET_OS_IPHONE
     // On iOS the Documents directory isn't user-visible, so put files there
     NSString *path = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES)[0];
@@ -82,6 +69,13 @@ static NSString * const c_defaultRealmFileName = @"default.realm";
     }
 #endif
     return [path stringByAppendingPathComponent:fileName];
+}
+
+@implementation RLMRealmConfiguration
+
++ (NSString *)defaultRealmPath {
+    static NSString *defaultRealmPath = RLMRealmPathForFile(c_defaultRealmFileName);
+    return defaultRealmPath;
 }
 
 + (instancetype)defaultConfiguration {

--- a/Realm/RLMRealmConfiguration.mm
+++ b/Realm/RLMRealmConfiguration.mm
@@ -131,11 +131,14 @@ static NSString * const c_defaultRealmFileName = @"default.realm";
 
 - (instancetype)copyWithZone:(NSZone *)zone {
     RLMRealmConfiguration *configuration = [[[self class] allocWithZone:zone] init];
-    for (NSString *key : c_RLMRealmConfigurationProperties) {
-        if (id value = [self valueForKey:key]) {
-            [configuration setValue:value forKey:key];
-        }
-    }
+    configuration->_path = _path;
+    configuration->_inMemoryIdentifier = _inMemoryIdentifier;
+    configuration->_encryptionKey = _encryptionKey;
+    configuration->_readOnly = _readOnly;
+    configuration->_schemaVersion = _schemaVersion;
+    configuration->_migrationBlock = _migrationBlock;
+    configuration->_dynamic = _dynamic;
+    configuration->_customSchema = _customSchema;
     return configuration;
 }
 

--- a/Realm/RLMRealmConfiguration_Private.h
+++ b/Realm/RLMRealmConfiguration_Private.h
@@ -35,3 +35,6 @@
 @end
 
 FOUNDATION_EXTERN void RLMRealmConfigurationUsePerPath(SEL methodName);
+
+// Get a path in the platform-appropriate documents directory with the given filename
+FOUNDATION_EXTERN NSString *RLMRealmPathForFile(NSString *fileName);

--- a/Realm/RLMRealmConfiguration_Private.h
+++ b/Realm/RLMRealmConfiguration_Private.h
@@ -21,20 +21,14 @@
 @class RLMSchema;
 
 @interface RLMRealmConfiguration ()
-
 @property (nonatomic, readwrite) bool dynamic;
-
 @property (nonatomic, copy) RLMSchema *customSchema;
 
-+ (NSString *)defaultRealmPath;
-
-+ (void)setDefaultPath:(NSString *)path;
+// Get the default confiugration without copying it
++ (RLMRealmConfiguration *)rawDefaultConfiguration;
 
 + (void)resetRealmConfigurationState;
-
 @end
-
-FOUNDATION_EXTERN void RLMRealmConfigurationUsePerPath(SEL methodName);
 
 // Get a path in the platform-appropriate documents directory with the given filename
 FOUNDATION_EXTERN NSString *RLMRealmPathForFile(NSString *fileName);

--- a/Realm/RLMRealm_Private.h
+++ b/Realm/RLMRealm_Private.h
@@ -25,14 +25,6 @@ FOUNDATION_EXTERN void RLMDisableSyncToDisk();
 
 FOUNDATION_EXTERN NSData *RLMRealmValidatedEncryptionKey(NSData *key);
 
-FOUNDATION_EXTERN void RLMRealmSetEncryptionKeyForPath(NSData *encryptionKey, NSString *path);
-
-FOUNDATION_EXTERN NSUInteger RLMRealmSchemaVersionForPath(NSString *path);
-FOUNDATION_EXTERN RLMMigrationBlock RLMRealmMigrationBlockForPath(NSString *path);
-FOUNDATION_EXTERN void RLMRealmSetSchemaVersionForPath(uint64_t version, NSString *path, RLMMigrationBlock migrationBlock);
-
-FOUNDATION_EXTERN void RLMRealmAddPathSettingsToConfiguration(RLMRealmConfiguration *configuration);
-
 // RLMRealm private members
 @interface RLMRealm () {
     @public

--- a/Realm/Tests/EncryptionTests.mm
+++ b/Realm/Tests/EncryptionTests.mm
@@ -28,11 +28,15 @@
 
 @implementation EncryptionTests
 
-- (RLMRealm *)realmWithKey:(NSData *)key {
+- (RLMRealmConfiguration *)configurationWithKey:(NSData *)key {
     RLMRealmConfiguration *configuration = [[RLMRealmConfiguration alloc] init];
     configuration.path = RLMDefaultRealmPath();
     configuration.encryptionKey = key;
-    return [RLMRealm realmWithConfiguration:configuration error:nil];
+    return configuration;
+}
+
+- (RLMRealm *)realmWithKey:(NSData *)key {
+    return [RLMRealm realmWithConfiguration:[self configurationWithKey:key] error:nil];
 }
 
 + (XCTestSuite *)defaultTestSuite
@@ -53,27 +57,13 @@
 #pragma mark - Key validation
 
 - (void)testBadEncryptionKeys {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-    XCTAssertThrows([RLMRealm realmWithPath:RLMRealm.defaultRealmPath encryptionKey:self.nonLiteralNil readOnly:NO error:nil]);
-    XCTAssertThrows([RLMRealm realmWithPath:RLMRealm.defaultRealmPath encryptionKey:NSData.data readOnly:NO error:nil]);
-    XCTAssertThrows([RLMRealm migrateRealmAtPath:RLMRealm.defaultRealmPath encryptionKey:self.nonLiteralNil]);
-    XCTAssertThrows([RLMRealm migrateRealmAtPath:RLMRealm.defaultRealmPath encryptionKey:NSData.data]);
-    XCTAssertThrows([RLMRealm setEncryptionKey:NSData.data forRealmsAtPath:RLMRealm.defaultRealmPath]);
     XCTAssertThrows([RLMRealm.defaultRealm writeCopyToPath:RLMTestRealmPath() encryptionKey:self.nonLiteralNil error:nil]);
     XCTAssertThrows([RLMRealm.defaultRealm writeCopyToPath:RLMTestRealmPath() encryptionKey:NSData.data error:nil]);
-#pragma clang diagnostic pop
 }
 
 - (void)testValidEncryptionKeys {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     NSData *key = [[NSMutableData alloc] initWithLength:64];
-    XCTAssertNoThrow([RLMRealm setEncryptionKey:key
-                                forRealmsAtPath:RLMRealm.defaultRealmPath]);
-    XCTAssertNoThrow([RLMRealm setEncryptionKey:nil forRealmsAtPath:RLMRealm.defaultRealmPath]);
     XCTAssertNoThrow([RLMRealm.defaultRealm writeCopyToPath:RLMTestRealmPath() encryptionKey:key error:nil]);
-#pragma clang diagnostic pop
 }
 
 #pragma mark - realmWithPath:
@@ -132,78 +122,9 @@
     XCTAssertThrows([self realmWithKey:RLMGenerateKey()]);
 }
 
-#pragma mark - Registered encryption key
-
-- (void)testRegisteredKeyIsUsed {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-    NSData *key = RLMGenerateKey();
-    @autoreleasepool {
-        RLMRealm *realm = [self realmWithKey:key];
-        [realm transactionWithBlock:^{
-            [IntObject createInRealm:realm withValue:@[@1]];
-        }];
-    }
-
-    [RLMRealm setEncryptionKey:RLMGenerateKey() forRealmsAtPath:RLMDefaultRealmPath()];
-    @autoreleasepool {
-        XCTAssertThrows([IntObject allObjects]);
-    }
-
-    [RLMRealm setEncryptionKey:key forRealmsAtPath:RLMDefaultRealmPath()];
-    @autoreleasepool {
-        XCTAssertEqual(1U, [IntObject allObjects].count);
-    }
-#pragma clang diagnostic pop
-}
-
-- (void)testExplicitlyPassedKeyOverridesRegisteredKey {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-    NSData *key = RLMGenerateKey();
-    @autoreleasepool {
-        RLMRealm *realm = [self realmWithKey:key];
-        [realm transactionWithBlock:^{
-            [IntObject createInRealm:realm withValue:@[@1]];
-        }];
-    }
-
-    [RLMRealm setEncryptionKey:RLMGenerateKey() forRealmsAtPath:RLMDefaultRealmPath()];
-    @autoreleasepool {
-        RLMRealm *realm = [self realmWithKey:key];
-        XCTAssertEqual(1U, [IntObject allObjectsInRealm:realm].count);
-    }
-#pragma clang diagnostic pop
-}
-
-- (void)testCannotSetEncryptionKeyToNilWhenRealmIsOpen {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-    NSData *key = RLMGenerateKey();
-    RLMRealm *realm = [self realmWithTestPath];
-    NSString *path = realm.path;
-
-    XCTAssertNoThrow([RLMRealm setEncryptionKey:nil forRealmsAtPath:path]);
-    XCTAssertThrows([RLMRealm setEncryptionKey:key forRealmsAtPath:path]);
-#pragma clang diagnostic pop
-}
-
-- (void)testCannotSetEncryptionKeyFromNilWhenRealmIsOpen {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-    NSData *key = RLMGenerateKey();
-    NSString *path = RLMTestRealmPath();
-    [RLMRealm setEncryptionKey:key forRealmsAtPath:path];
-    [self realmWithTestPath];
-
-    XCTAssertThrows([RLMRealm setEncryptionKey:nil forRealmsAtPath:path]);
-    XCTAssertNoThrow([RLMRealm setEncryptionKey:key forRealmsAtPath:path]);
-#pragma clang diagnostic pop
-}
-
 #pragma mark - writeCopyToPath:
 
-- (void)testWriteCopyToPathWithNoRegisteredKeyWritesDecrypted {
+- (void)testWriteCopyToPathWithNoKeyWritesDecrypted {
     NSData *key = RLMGenerateKey();
     @autoreleasepool {
         RLMRealm *realm = [self realmWithKey:key];
@@ -219,34 +140,9 @@
     }
 }
 
-- (void)testWriteCopyToPathUsesRegisteredKey {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-    NSData *key = RLMGenerateKey();
-    [RLMRealm setEncryptionKey:key forRealmsAtPath:RLMTestRealmPath()];
-
-    @autoreleasepool {
-        RLMRealm *realm = [self realmWithKey:key];
-        [realm transactionWithBlock:^{
-            [IntObject createInRealm:realm withValue:@[@1]];
-        }];
-        [realm writeCopyToPath:RLMTestRealmPath() error:nil];
-    }
-
-    @autoreleasepool {
-        RLMRealm *realm = [self realmWithKey:key];
-        XCTAssertEqual(1U, [IntObject allObjectsInRealm:realm].count);
-    }
-#pragma clang diagnostic pop
-}
-
 - (void)testWriteCopyToPathWithNewKey {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     NSData *key1 = RLMGenerateKey();
     NSData *key2 = RLMGenerateKey();
-    NSData *key3 = RLMGenerateKey();
-    [RLMRealm setEncryptionKey:key3 forRealmsAtPath:RLMTestRealmPath()];
 
     @autoreleasepool {
         RLMRealm *realm = [self realmWithKey:key1];
@@ -257,13 +153,11 @@
     }
 
     @autoreleasepool {
-        RLMRealm *realm = [RLMRealm realmWithPath:RLMTestRealmPath()
-                                    encryptionKey:key2
-                                         readOnly:NO
-                                            error:nil];
+        RLMRealmConfiguration *config = [self configurationWithKey:key2];
+        config.path = RLMTestRealmPath();
+        RLMRealm *realm = [RLMRealm realmWithConfiguration:config error:nil];
         XCTAssertEqual(1U, [IntObject allObjectsInRealm:realm].count);
     }
-#pragma clang diagnostic pop
 }
 
 #pragma mark - Migrations
@@ -282,17 +176,15 @@
                        inMemory:NO dynamic:YES schema: schema error:nil];
     }
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-    [RLMRealm setDefaultRealmSchemaVersion:1 withMigrationBlock:^(__unused RLMMigration *migration, __unused uint64_t oldSchemaVersion) {
+    RLMRealmConfiguration *config = [RLMRealmConfiguration defaultConfiguration];
+    config.schemaVersion = 1;
+    config.migrationBlock = ^(__unused RLMMigration *migration, __unused uint64_t oldSchemaVersion) {
         *migrationRun = YES;
-    }];
-#pragma clang diagnostic pop
+    };
+    [RLMRealmConfiguration setDefaultConfiguration:config];
 }
 
-- (void)testImplicitMigrationWithRegisteredKey {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+- (void)testImplicitMigration {
     NSData *key = RLMGenerateKey();
     BOOL migrationRan = NO;
     [self createRealmRequiringMigrationWithKey:key migrationRun:&migrationRan];
@@ -300,44 +192,13 @@
     XCTAssertThrows([RLMRealm defaultRealm]);
     XCTAssertFalse(migrationRan);
 
-    [RLMRealm setEncryptionKey:key forRealmsAtPath:RLMDefaultRealmPath()];
-    XCTAssertNoThrow([RLMRealm defaultRealm]);
+    RLMRealmConfiguration *config = [RLMRealmConfiguration defaultConfiguration];
+    config.encryptionKey = key;
+    XCTAssertNoThrow([RLMRealm realmWithConfiguration:config error:nil]);
     XCTAssertTrue(migrationRan);
-#pragma clang diagnostic pop
 }
 
-- (void)testImplicitMigrationWithExplicitKey {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-    NSData *key = RLMGenerateKey();
-    BOOL migrationRan = NO;
-    [self createRealmRequiringMigrationWithKey:key migrationRun:&migrationRan];
-
-    XCTAssertThrows([RLMRealm defaultRealm]);
-    XCTAssertFalse(migrationRan);
-
-    XCTAssertNoThrow([RLMRealm realmWithPath:[RLMRealm defaultRealmPath] encryptionKey:key readOnly:NO error:nil]);
-    XCTAssertTrue(migrationRan);
-#pragma clang diagnostic pop
-}
-
-- (void)testExplicitMigrationWithRegisteredKey {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-    NSData *key = RLMGenerateKey();
-    BOOL migrationRan = NO;
-    [self createRealmRequiringMigrationWithKey:key migrationRun:&migrationRan];
-
-    XCTAssertNotNil([RLMRealm migrateRealmAtPath:RLMRealm.defaultRealmPath]);
-    XCTAssertFalse(migrationRan);
-
-    [RLMRealm setEncryptionKey:key forRealmsAtPath:RLMRealm.defaultRealmPath];
-    XCTAssertNil([RLMRealm migrateRealmAtPath:RLMRealm.defaultRealmPath]);
-    XCTAssertTrue(migrationRan);
-#pragma clang diagnostic pop
-}
-
-- (void)testExplicitMigrationWithExplicitKey {
+- (void)testExplicitMigration {
     NSData *key = RLMGenerateKey();
     __block BOOL migrationRan = NO;
     [self createRealmRequiringMigrationWithKey:key migrationRun:&migrationRan];

--- a/Realm/Tests/MigrationTests.mm
+++ b/Realm/Tests/MigrationTests.mm
@@ -39,7 +39,7 @@ static void RLMAssertRealmSchemaMatchesTable(id self, RLMRealm *realm) {
         Table *table = objectSchema.table;
         for (RLMProperty *property in objectSchema.properties) {
             XCTAssertEqual(property.column, table->get_column_index(RLMStringDataWithNSString(property.name)));
-            XCTAssertEqual(property.indexed, table->has_search_index(property.column));
+            XCTAssertEqual(property.indexed || property.isPrimary, table->has_search_index(property.column));
         }
     }
 }
@@ -101,9 +101,6 @@ RLM_ARRAY_TYPE(MigrationObject);
 @interface MigrationTests : RLMTestCase
 @end
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-
 @implementation MigrationTests
 #pragma mark - Helper methods
 - (RLMSchema *)schemaWithObjects:(NSArray *)objects {
@@ -112,12 +109,8 @@ RLM_ARRAY_TYPE(MigrationObject);
     return schema;
 }
 
-- (RLMSchema *)schemaWithSingleObject:(RLMObjectSchema *)objectSchema {
-    return [self schemaWithObjects:@[objectSchema]];
-}
-
 - (RLMRealm *)realmWithSingleObject:(RLMObjectSchema *)objectSchema {
-    return [self realmWithTestPathAndSchema:[self schemaWithSingleObject:objectSchema]];
+    return [self realmWithTestPathAndSchema:[self schemaWithObjects:@[objectSchema]]];
 }
 
 - (RLMRealmConfiguration *)config {
@@ -126,8 +119,20 @@ RLM_ARRAY_TYPE(MigrationObject);
     return config;
 }
 
-- (void)initializeRealmWithConfig:(RLMRealmConfiguration *)config block:(void (^)(RLMRealm *))block {
+- (void)createTestRealmWithClasses:(NSArray *)classes block:(void (^)(RLMRealm *realm))block {
+    NSMutableArray *objectSchema = [NSMutableArray arrayWithCapacity:classes.count];
+    for (Class cls in classes) {
+        [objectSchema addObject:[RLMObjectSchema schemaForObjectClass:cls]];
+    }
+    [self createTestRealmWithSchema:objectSchema block:block];
+}
+
+- (void)createTestRealmWithSchema:(NSArray *)objectSchema block:(void (^)(RLMRealm *realm))block {
     @autoreleasepool {
+        RLMRealmConfiguration *config = [RLMRealmConfiguration new];
+        config.path = RLMTestRealmPath();
+        config.customSchema = [self schemaWithObjects:objectSchema];
+
         RLMRealm *realm = [RLMRealm realmWithConfiguration:config error:nil];
         [realm beginWriteTransaction];
         block(realm);
@@ -135,737 +140,303 @@ RLM_ARRAY_TYPE(MigrationObject);
     }
 }
 
-- (void)assertConfigRequiresMigration:(RLMRealmConfiguration *)config {
-    config = [config copy];
+- (RLMRealm *)migrateTestRealmWithBlock:(RLMMigrationBlock)block NS_RETURNS_RETAINED {
+    @autoreleasepool {
+        RLMRealmConfiguration *config = [RLMRealmConfiguration new];
+        config.path = RLMTestRealmPath();
+        config.schemaVersion = 1;
+        config.migrationBlock = block;
+        XCTAssertNil([RLMRealm migrateRealm:config]);
+
+        RLMRealm *realm = [RLMRealm realmWithConfiguration:config error:nil];
+        RLMAssertRealmSchemaMatchesTable(self, realm);
+        return realm;
+    }
+}
+
+- (void)failToMigrateTestRealmWithBlock:(RLMMigrationBlock)block {
+    @autoreleasepool {
+        RLMRealmConfiguration *config = [RLMRealmConfiguration new];
+        config.path = RLMTestRealmPath();
+        config.schemaVersion = 1;
+        config.migrationBlock = block;
+        XCTAssertNotNil([RLMRealm migrateRealm:config]);
+    }
+}
+
+- (void)assertMigrationRequiredForChangeFrom:(NSArray *)from to:(NSArray *)to {
+    RLMRealmConfiguration *config = [RLMRealmConfiguration new];
+    config.customSchema = [self schemaWithObjects:from];
+    @autoreleasepool { [RLMRealm realmWithConfiguration:config error:nil]; }
+
+    config.customSchema = [self schemaWithObjects:to];
     config.migrationBlock = ^(__unused RLMMigration *migration, __unused uint64_t oldSchemaVersion) {
         XCTFail(@"Migration block should not have been called");
     };
 
     XCTAssertThrows([RLMRealm realmWithConfiguration:config error:nil]);
+
+    __block bool migrationCalled = false;
+    config.schemaVersion = 1;
+    config.migrationBlock = ^(__unused RLMMigration *migration, __unused uint64_t oldSchemaVersion) {
+        migrationCalled = true;
+    };
+
+    XCTAssertNoThrow([RLMRealm realmWithConfiguration:config error:nil]);
+    XCTAssertTrue(migrationCalled);
+    RLMAssertRealmSchemaMatchesTable(self, [RLMRealm realmWithConfiguration:config error:nil]);
+}
+- (void)assertNoMigrationRequiredForChangeFrom:(NSArray *)from to:(NSArray *)to {
+    RLMRealmConfiguration *config = [RLMRealmConfiguration new];
+    config.customSchema = [self schemaWithObjects:from];
+    @autoreleasepool { [RLMRealm realmWithConfiguration:config error:nil]; }
+
+    config.customSchema = [self schemaWithObjects:to];
+    config.migrationBlock = ^(__unused RLMMigration *migration, __unused uint64_t oldSchemaVersion) {
+        XCTFail(@"Migration block should not have been called");
+    };
+
+    XCTAssertNoThrow([RLMRealm realmWithConfiguration:config error:nil]);
+    RLMAssertRealmSchemaMatchesTable(self, [RLMRealm realmWithConfiguration:config error:nil]);
 }
 
-#pragma mark - Tests
-
-- (void)testSchemaVersion {
-    [RLMRealm setDefaultRealmSchemaVersion:1 withMigrationBlock:^(__unused RLMMigration *migration,
-                                                                  __unused uint64_t oldSchemaVersion) {
-    }];
-
-    RLMRealm *defaultRealm = [RLMRealm defaultRealm];
-    XCTAssertEqual(1U, realm::ObjectStore::get_schema_version(defaultRealm.group));
-}
+#pragma mark - Schema versions
 
 - (void)testGetSchemaVersion {
-    XCTAssertThrows([RLMRealm schemaVersionAtPath:RLMRealm.defaultRealmPath encryptionKey:nil error:nil]);
-    @autoreleasepool {
-        [RLMRealm defaultRealm];
-    }
+    XCTAssertThrows([RLMRealm schemaVersionAtPath:RLMDefaultRealmPath() encryptionKey:nil error:nil]);
+    NSError *error;
+    XCTAssertEqual(RLMNotVersioned, [RLMRealm schemaVersionAtPath:RLMDefaultRealmPath() encryptionKey:nil error:&error]);
+    XCTAssertNotNil(error);
 
-    XCTAssertEqual(0U, [RLMRealm schemaVersionAtPath:RLMRealm.defaultRealmPath encryptionKey:nil error:nil]);
-    [RLMRealm setDefaultRealmSchemaVersion:1 withMigrationBlock:^(__unused RLMMigration *migration,
-                                                                  uint64_t oldSchemaVersion) {
+    RLMRealmConfiguration *config = [RLMRealmConfiguration defaultConfiguration];
+    @autoreleasepool { [RLMRealm realmWithConfiguration:config error:nil]; }
+    XCTAssertEqual(0U, [RLMRealm schemaVersionAtPath:config.path encryptionKey:nil error:nil]);
+
+    config.schemaVersion = 1;
+    config.migrationBlock = ^(__unused RLMMigration *migration, uint64_t oldSchemaVersion) {
         XCTAssertEqual(0U, oldSchemaVersion);
-    }];
-
-    RLMRealm *realm = [RLMRealm defaultRealm];
-    XCTAssertEqual(1U, [RLMRealm schemaVersionAtPath:RLMRealm.defaultRealmPath encryptionKey:nil error:nil]);
-    realm = nil;
-}
-
-- (void)testPerRealmMigration {
-    @autoreleasepool {
-        [RLMRealm defaultRealm];
-    }
-
-    XCTAssertEqual(0U, [RLMRealm schemaVersionAtPath:RLMRealm.defaultRealmPath encryptionKey:nil error:nil]);
-    [RLMRealm setDefaultRealmSchemaVersion:1 withMigrationBlock:nil];
-
-    @autoreleasepool {
-        RLMRealm *defaultRealm = [RLMRealm defaultRealm];
-        RLMRealm *anotherRealm = [RLMRealm realmWithPath:RLMTestRealmPath()];
-
-        XCTAssertEqual(1U, [RLMRealm schemaVersionAtPath:defaultRealm.path encryptionKey:nil error:nil]);
-        XCTAssertEqual(0U, [RLMRealm schemaVersionAtPath:anotherRealm.path encryptionKey:nil error:nil]);
-    }
-
-    __block bool migrationComplete = false;
-    [RLMRealm setSchemaVersion:2 forRealmAtPath:RLMTestRealmPath() withMigrationBlock:^(__unused RLMMigration *migration,
-                                                                                        uint64_t oldSchemaVersion) {
-        XCTAssertEqual(0U, oldSchemaVersion);
-        migrationComplete = true;
-    }];
-    RLMRealm *anotherRealm = [RLMRealm realmWithPath:RLMTestRealmPath()];
-
-    RLMAssertRealmSchemaMatchesTable(self, [RLMRealm defaultRealm]);
-    RLMAssertRealmSchemaMatchesTable(self, anotherRealm);
-
-    XCTAssertEqual(2U, [RLMRealm schemaVersionAtPath:anotherRealm.path encryptionKey:nil error:nil]);
-    XCTAssertTrue(migrationComplete);
-}
-
-- (void)testRemovingSubclass {
-    @autoreleasepool {
-        RLMObjectSchema *objectSchema = [[RLMObjectSchema alloc] initWithClassName:@"DeletedClass" objectClass:RLMObject.class properties:@[]];
-        RLMRealm *realm = [self realmWithSingleObject:objectSchema];
-
-        [realm transactionWithBlock:^{
-            [realm createObject:@"DeletedClass" withValue:@[]];
-        }];
-    }
-
-    @autoreleasepool {
-        // apply migration
-        [RLMRealm setSchemaVersion:1 forRealmAtPath:RLMTestRealmPath() withMigrationBlock:^(RLMMigration *migration, uint64_t oldSchemaVersion) {
-            XCTAssertEqual(oldSchemaVersion, 0U, @"Initial schema version should be 0");
-
-            XCTAssertTrue([migration deleteDataForClassName:@"DeletedClass"]);
-            XCTAssertFalse([migration deleteDataForClassName:@"NoSuchClass"]);
-            XCTAssertFalse([migration deleteDataForClassName:self.nonLiteralNil]);
-
-            [migration createObject:StringObject.className withValue:@[@"migration"]];
-            XCTAssertTrue([migration deleteDataForClassName:StringObject.className]);
-        }];
-        [RLMRealm migrateRealmAtPath:RLMTestRealmPath()];
-    }
-
-    @autoreleasepool {
-        // verify migration
-        RLMRealm *realm = [self realmWithTestPath];
-        RLMAssertRealmSchemaMatchesTable(self, realm);
-        XCTAssertFalse(ObjectStore::table_for_object_type(realm.group, "DeletedClass"), @"The deleted class should not have a table.");
-        XCTAssertEqual(0U, [StringObject allObjectsInRealm:realm].count);
-    }
-}
-
-- (void)testAddingPropertyRequiresMigration {
-    RLMObjectSchema *objectSchema = [RLMObjectSchema schemaForObjectClass:MigrationObject.class];
-    objectSchema.properties = @[objectSchema.properties[0]];
-    @autoreleasepool {
-        XCTAssertNoThrow([self realmWithSingleObject:objectSchema], @"Migration shouldn't be required on first access.");
-    }
-    @autoreleasepool {
-        XCTAssertThrows([self realmWithSingleObject:[RLMObjectSchema schemaForObjectClass:MigrationObject.class]], @"Migration should be required");
-    }
-}
-
-- (void)testAddingPropertyAtEnd {
-    // create schema to migrate from with single string column
-    RLMObjectSchema *objectSchema = [RLMObjectSchema schemaForObjectClass:MigrationObject.class];
-    objectSchema.properties = @[objectSchema.properties[0]];
-
-    @autoreleasepool {
-        // create realm with old schema and populate
-        RLMRealm *realm = [self realmWithSingleObject:objectSchema];
-        [realm beginWriteTransaction];
-        [realm createObject:MigrationObject.className withValue:@[@1]];
-        [realm createObject:MigrationObject.className withValue:@[@2]];
-        [realm commitWriteTransaction];
-    }
-
-    @autoreleasepool {
-        // open realm with new schema before migration to test migration is necessary
-        objectSchema = [RLMObjectSchema schemaForObjectClass:MigrationObject.class];
-        XCTAssertThrows([self realmWithTestPath], @"Migration should be required");
-    }
-
-    // apply migration
-    [RLMRealm setSchemaVersion:1 forRealmAtPath:RLMTestRealmPath() withMigrationBlock:^(RLMMigration *migration, uint64_t oldSchemaVersion) {
-        XCTAssertEqual(oldSchemaVersion, 0U, @"Initial schema version should be 0");
-        [migration enumerateObjects:MigrationObject.className
-                              block:^(RLMObject *oldObject, RLMObject *newObject) {
-            XCTAssertThrows(oldObject[@"stringCol"], @"stringCol should not exist on old object");
-            NSNumber *intObj;
-            XCTAssertNoThrow(intObj = oldObject[@"intCol"], @"Should be able to access intCol on oldObject");
-            XCTAssertEqualObjects(newObject[@"intCol"], oldObject[@"intCol"]);
-            NSString *stringObj = [NSString stringWithFormat:@"%@", intObj];
-            XCTAssertNoThrow(newObject[@"stringCol"] = stringObj, @"Should be able to set stringCol");
-        }];
-    }];
-    [RLMRealm migrateRealmAtPath:RLMTestRealmPath()];
-
-    // verify migration
-    @autoreleasepool {
-        RLMRealm *realm = [self realmWithTestPath];
-        RLMAssertRealmSchemaMatchesTable(self, realm);
-        MigrationObject *mig1 = [MigrationObject allObjectsInRealm:realm][1];
-        XCTAssertEqual(mig1.intCol, 2, @"Int column should have value 2");
-        XCTAssertEqualObjects(mig1.stringCol, @"2", @"String column should be populated");
-    }
-
-    [RLMRealm setSchemaVersion:0 forRealmAtPath:RLMTestRealmPath() withMigrationBlock:nil];
-    XCTAssertNotNil([RLMRealm migrateRealmAtPath:RLMTestRealmPath()]);
-}
-
-- (void)testAddingPropertyAtBeginningPreservesData {
-    // create schema to migrate from with the second and third columns from the final data
-    RLMObjectSchema *objectSchema = [RLMObjectSchema schemaForObjectClass:ThreeFieldMigrationObject.class];
-    objectSchema.properties = @[objectSchema.properties[1], objectSchema.properties[2]];
-
-    // create realm with old schema and populate
-    RLMRealm *realm = [self realmWithSingleObject:objectSchema];
-    [realm beginWriteTransaction];
-    [realm createObject:ThreeFieldMigrationObject.className withValue:@[@1, @2]];
-    [realm commitWriteTransaction];
-
-    [RLMRealm setSchemaVersion:1 forRealmAtPath:RLMTestRealmPath() withMigrationBlock:^(RLMMigration *migration, uint64_t) {
-        [migration enumerateObjects:ThreeFieldMigrationObject.className
-                              block:^(RLMObject *oldObject, RLMObject *newObject) {
-            XCTAssertThrows(oldObject[@"col1"]);
-            XCTAssertEqualObjects(oldObject[@"col2"], newObject[@"col2"]);
-            XCTAssertEqualObjects(oldObject[@"col3"], newObject[@"col3"]);
-        }];
-    }];
-    [RLMRealm migrateRealmAtPath:RLMTestRealmPath()];
-
-    // verify migration
-    realm = [self realmWithTestPath];
-    RLMAssertRealmSchemaMatchesTable(self, realm);
-    ThreeFieldMigrationObject *mig = [ThreeFieldMigrationObject allObjectsInRealm:realm][0];
-    XCTAssertEqual(0, mig.col1);
-    XCTAssertEqual(1, mig.col2);
-    XCTAssertEqual(2, mig.col3);
-}
-
-- (void)testRemoveProperty {
-    // create schema with an extra column
-    RLMObjectSchema *objectSchema = [RLMObjectSchema schemaForObjectClass:MigrationObject.class];
-    RLMProperty *thirdProperty = [[RLMProperty alloc] initWithName:@"deletedCol" type:RLMPropertyTypeBool objectClassName:nil indexed:NO optional:NO];
-    thirdProperty.column = 2;
-    objectSchema.properties = [objectSchema.properties arrayByAddingObject:thirdProperty];
-
-    // create realm with old schema and populate
-    RLMRealmConfiguration *config = [self config];
-    config.customSchema = [self schemaWithSingleObject:objectSchema];
-    [self initializeRealmWithConfig:config block:^(RLMRealm *realm) {
-        [realm createObject:MigrationObject.className withValue:@[@1, @"1", @YES]];
-        [realm createObject:MigrationObject.className withValue:@[@2, @"2", @NO]];
-    }];
-
-    config.customSchema = nil;
-    [self assertConfigRequiresMigration:config];
-
-    // apply migration
-    config.schemaVersion = 1;
-    config.migrationBlock = ^(RLMMigration *migration, uint64_t oldSchemaVersion) {
-        XCTAssertEqual(oldSchemaVersion, 0U, @"Initial schema version should be 0");
-        [migration enumerateObjects:MigrationObject.className
-                                       block:^(RLMObject *oldObject, RLMObject *newObject) {
-            XCTAssertNoThrow(oldObject[@"deletedCol"], @"Deleted column should be accessible on old object.");
-            XCTAssertThrows(newObject[@"deletedCol"], @"Deleted column should not be accessible on new object.");
-
-            XCTAssertEqualObjects(newObject[@"intCol"], oldObject[@"intCol"]);
-            XCTAssertEqualObjects(newObject[@"stringCol"], oldObject[@"stringCol"]);
-        }];
-    };
-    RLMRealm *realm = [RLMRealm realmWithConfiguration:config error:nil];
-
-    // verify migration
-    RLMAssertRealmSchemaMatchesTable(self, realm);
-    MigrationObject *mig1 = [MigrationObject allObjectsInRealm:realm][1];
-    XCTAssertThrows(mig1[@"deletedCol"], @"Deleted column should no longer be accessible.");
-}
-
-- (void)testRemoveAndAddProperty {
-    // create schema to migrate from with single string column
-    RLMObjectSchema *objectSchema = [RLMObjectSchema schemaForObjectClass:MigrationObject.class];
-    RLMProperty *oldInt = [[RLMProperty alloc] initWithName:@"oldIntCol" type:RLMPropertyTypeInt objectClassName:nil indexed:NO optional:NO];
-    objectSchema.properties = @[oldInt, objectSchema.properties[1]];
-
-    // create realm with old schema and populate
-    RLMRealm *realm = [self realmWithSingleObject:objectSchema];
-    [realm beginWriteTransaction];
-    [realm createObject:MigrationObject.className withValue:@[@1, @"1"]];
-    [realm createObject:MigrationObject.className withValue:@[@1, @"2"]];
-    [realm commitWriteTransaction];
-
-    // object migration object
-    void (^migrateObjectBlock)(RLMObject *, RLMObject *) = ^(RLMObject *oldObject, RLMObject *newObject) {
-        XCTAssertNoThrow(oldObject[@"oldIntCol"], @"Deleted column should be accessible on old object.");
-        XCTAssertThrows(oldObject[@"intCol"], @"New column should not be accessible on old object.");
-        XCTAssertEqual([oldObject[@"oldIntCol"] intValue], 1, @"Deleted column value is correct.");
-        XCTAssertNoThrow(newObject[@"intCol"], @"New column is accessible on new object.");
-        XCTAssertThrows(newObject[@"oldIntCol"], @"Old column should not be accessible on old object.");
-        XCTAssertEqual([newObject[@"intCol"] intValue], 0, @"New column value is uninitialized.");
     };
 
-    // apply migration
-    [RLMRealm setSchemaVersion:1 forRealmAtPath:RLMTestRealmPath() withMigrationBlock:^(RLMMigration *migration, uint64_t oldSchemaVersion) {
-        XCTAssertEqual(oldSchemaVersion, 0U, @"Initial schema version should be 0");
-        [migration enumerateObjects:MigrationObject.className block:migrateObjectBlock];
-    }];
-    [RLMRealm migrateRealmAtPath:RLMTestRealmPath()];
-
-    // verify migration
-    realm = [self realmWithTestPath];
-    RLMAssertRealmSchemaMatchesTable(self, realm);
-    MigrationObject *mig1 = [MigrationObject allObjectsInRealm:realm][1];
-    XCTAssertThrows(mig1[@"oldIntCol"], @"Deleted column should no longer be accessible.");
+    @autoreleasepool { [RLMRealm realmWithConfiguration:config error:nil]; }
+    XCTAssertEqual(1U, [RLMRealm schemaVersionAtPath:config.path encryptionKey:nil error:nil]);
 }
 
-- (void)testMigrationProperlySetsPropertyColumns {
-    RLMObjectSchema *objectSchema = [RLMObjectSchema schemaForObjectClass:MigrationObject.class];
-    objectSchema.properties = @[
-                                [[RLMProperty alloc] initWithName:@"firstName" type:RLMPropertyTypeString objectClassName:nil indexed:false optional:NO],
-                                [[RLMProperty alloc] initWithName:@"lastName" type:RLMPropertyTypeString objectClassName:nil indexed:false optional:NO],
-                                [[RLMProperty alloc] initWithName:@"age" type:RLMPropertyTypeInt objectClassName:nil indexed:false optional:NO],
-                                ];
+- (void)testSchemaVersionCannotGoDown {
+    RLMRealmConfiguration *config = [RLMRealmConfiguration defaultConfiguration];
+    config.schemaVersion = 10;
+    @autoreleasepool { [RLMRealm realmWithConfiguration:config error:nil]; }
+    XCTAssertEqual(10U, [RLMRealm schemaVersionAtPath:config.path encryptionKey:nil error:nil]);
 
-    RLMRealm *realm = [self realmWithSingleObject:objectSchema];
-    [realm beginWriteTransaction];
-    [realm createObject:MigrationObject.className withValue:@[@"a", @"b", @1]];
-    [realm createObject:MigrationObject.className withValue:@[@"c", @"d", @2]];
-    [realm commitWriteTransaction];
-
-    [RLMRealm setSchemaVersion:1 forRealmAtPath:RLMTestRealmPath() withMigrationBlock:^(__unused RLMMigration *migration, uint64_t oldSchemaVersion) {
-        XCTAssertEqual(oldSchemaVersion, 0U, @"Initial schema version should be 0");
-    }];
-
-    // verify migration
-    objectSchema.properties = @[
-                                [[RLMProperty alloc] initWithName:@"fullName" type:RLMPropertyTypeString objectClassName:nil indexed:false optional:NO],
-                                [[RLMProperty alloc] initWithName:@"age" type:RLMPropertyTypeInt objectClassName:nil indexed:false optional:NO],
-                                [[RLMProperty alloc] initWithName:@"pets" type:RLMPropertyTypeArray objectClassName:MigrationObject.className indexed:false optional:NO],
-                                ];
-    realm = [self realmWithSingleObject:objectSchema];
-    RLMAssertRealmSchemaMatchesTable(self, realm);
+    config.schemaVersion = 5;
+    XCTAssertThrows([RLMRealm realmWithConfiguration:config error:nil]);
 }
 
-- (void)testChangePropertyType {
-    // make string an int
-    RLMObjectSchema *objectSchema = [RLMObjectSchema schemaForObjectClass:MigrationObject.class];
-    RLMProperty *stringCol = objectSchema.properties[1];
-    stringCol.type = RLMPropertyTypeInt;
-    stringCol.objcType = 'i';
-    stringCol.optional = NO;
+- (void)testDifferentSchemaVersionsAtDifferentPaths {
+    RLMRealmConfiguration *config = [RLMRealmConfiguration defaultConfiguration];
+    config.schemaVersion = 10;
+    @autoreleasepool { [RLMRealm realmWithConfiguration:config error:nil]; }
+    XCTAssertEqual(10U, [RLMRealm schemaVersionAtPath:config.path encryptionKey:nil error:nil]);
 
-    // create realm with old schema and populate
-    RLMRealmConfiguration *config = [self config];
-    config.customSchema = [self schemaWithSingleObject:objectSchema];
-    [self initializeRealmWithConfig:config block:^(RLMRealm *realm) {
-        [realm createObject:MigrationObject.className withValue:@[@1, @1]];
-        [realm createObject:MigrationObject.className withValue:@[@2, @2]];
-    }];
+    RLMRealmConfiguration *config2 = [RLMRealmConfiguration defaultConfiguration];
+    config2.schemaVersion = 5;
+    config2.path = RLMTestRealmPath();
+    @autoreleasepool { [RLMRealm realmWithConfiguration:config2 error:nil]; }
+    XCTAssertEqual(5U, [RLMRealm schemaVersionAtPath:config2.path encryptionKey:nil error:nil]);
 
-    config.customSchema = nil;
-    [self assertConfigRequiresMigration:config];
-
-    // apply migration
-    config.schemaVersion = 1;
-    config.migrationBlock = ^(RLMMigration *migration, uint64_t oldSchemaVersion) {
-        XCTAssertEqual(oldSchemaVersion, 0U, @"Initial schema version should be 0");
-        [migration enumerateObjects:MigrationObject.className
-                                       block:^(RLMObject *oldObject, RLMObject *newObject) {
-            XCTAssertEqualObjects(newObject[@"intCol"], oldObject[@"intCol"]);
-            NSNumber *intObj = oldObject[@"stringCol"];
-            XCTAssert([intObj isKindOfClass:NSNumber.class], @"Old stringCol should be int");
-            newObject[@"stringCol"] = intObj.stringValue;
-        }];
-    };
-    RLMRealm *realm = [RLMRealm realmWithConfiguration:config error:nil];
-
-    // verify migration
-    RLMAssertRealmSchemaMatchesTable(self, realm);
-    MigrationObject *mig1 = [MigrationObject allObjectsInRealm:realm][1];
-    XCTAssertEqualObjects(mig1[@"stringCol"], @"2", @"stringCol should be string after migration.");
+    // Should not have been changed
+    XCTAssertEqual(10U, [RLMRealm schemaVersionAtPath:config.path encryptionKey:nil error:nil]);
 }
 
-- (void)testChangeObjectLinkType {
-    // create realm with old schema and populate
-    RLMRealmConfiguration *config = [self config];
-    [self initializeRealmWithConfig:config block:^(RLMRealm *realm) {
-        id obj = [realm createObject:MigrationObject.className withValue:@[@1, @"1"]];
-        [realm createObject:MigrationLinkObject.className withValue:@[obj, @[obj]]];
-    }];
+#pragma mark - Migration Requirements
 
-    // Make the object link property link to a different class
-    RLMObjectSchema *objectSchema = [RLMObjectSchema schemaForObjectClass:MigrationLinkObject.class];
-    [objectSchema.properties[0] setObjectClassName:MigrationLinkObject.className];
-    config.customSchema = [self schemaWithObjects:@[objectSchema, [RLMObjectSchema schemaForObjectClass:MigrationObject.class]]];
+- (void)testAddingClassDoesNotRequireMigration {
+    RLMRealmConfiguration *config = [RLMRealmConfiguration new];
+    config.objectClasses = @[MigrationObject.class];
+    @autoreleasepool { [RLMRealm realmWithConfiguration:config error:nil]; }
 
-    // Should now need a migration
-    [self assertConfigRequiresMigration:config];
-
-    // Apply migration
-    config.schemaVersion = 1;
-    config.migrationBlock = ^(RLMMigration *migration, uint64_t oldSchemaVersion) {
-        XCTAssertEqual(oldSchemaVersion, 0U, @"Initial schema version should be 0");
-        [migration enumerateObjects:MigrationLinkObject.className
-                                       block:^(RLMObject *oldObject, RLMObject *newObject) {
-                                           XCTAssertNotNil(oldObject[@"object"]);
-                                           XCTAssertNil(newObject[@"object"]);
-
-                                           XCTAssertEqual(1U, [oldObject[@"array"] count]);
-                                           XCTAssertEqual(1U, [newObject[@"array"] count]);
-                                       }];
-    };
-    RLMRealm *realm = [RLMRealm realmWithConfiguration:config error:nil];
-    RLMAssertRealmSchemaMatchesTable(self, realm);
+    config.objectClasses = @[MigrationObject.class, ThreeFieldMigrationObject.class];
+    XCTAssertNoThrow([RLMRealm realmWithConfiguration:config error:nil]);
 }
 
-- (void)testChangeArrayLinkType {
-    // create realm with old schema and populate
-    RLMRealmConfiguration *config = [self config];
-    [self initializeRealmWithConfig:config block:^(RLMRealm *realm) {
-        id obj = [realm createObject:MigrationObject.className withValue:@[@1, @"1"]];
-        [realm createObject:MigrationLinkObject.className withValue:@[obj, @[obj]]];
-    }];
+- (void)testRemovingClassDoesNotRequireMigration {
+    RLMRealmConfiguration *config = [RLMRealmConfiguration new];
+    config.objectClasses = @[MigrationObject.class, ThreeFieldMigrationObject.class];
+    @autoreleasepool { [RLMRealm realmWithConfiguration:config error:nil]; }
 
-    // Make the array linklist property link to a different class
-    RLMObjectSchema *objectSchema = [RLMObjectSchema schemaForObjectClass:MigrationLinkObject.class];
-    [objectSchema.properties[1] setObjectClassName:MigrationLinkObject.className];
-    config.customSchema = [self schemaWithObjects:@[objectSchema, [RLMObjectSchema schemaForObjectClass:MigrationObject.class]]];
+    config.objectClasses = @[MigrationObject.class];
+    XCTAssertNoThrow([RLMRealm realmWithConfiguration:config error:nil]);
+}
 
-    // Should now need a migration
-    [self assertConfigRequiresMigration:config];
+- (void)testAddingColumnRequiresMigration {
+    RLMObjectSchema *from = [RLMObjectSchema schemaForObjectClass:MigrationTwoStringObject.class];
+    from.properties = [from.properties subarrayWithRange:{0, 1}];
 
-    // Apply migration
-    config.schemaVersion = 1;
-    config.migrationBlock = ^(RLMMigration *migration, uint64_t oldSchemaVersion) {
-        XCTAssertEqual(oldSchemaVersion, 0U, @"Initial schema version should be 0");
-        [migration enumerateObjects:MigrationLinkObject.className
-                                       block:^(RLMObject *oldObject, RLMObject *newObject) {
-                                           XCTAssertNotNil(oldObject[@"object"]);
-                                           XCTAssertNotNil(newObject[@"object"]);
+    RLMObjectSchema *to = [RLMObjectSchema schemaForObjectClass:MigrationTwoStringObject.class];
 
-                                           XCTAssertEqual(1U, [oldObject[@"array"] count]);
-                                           XCTAssertEqual(0U, [newObject[@"array"] count]);
-                                       }];
-    };
-    RLMRealm *realm = [RLMRealm realmWithConfiguration:config error:nil];
-    RLMAssertRealmSchemaMatchesTable(self, realm);
+    [self assertMigrationRequiredForChangeFrom:@[from] to:@[to]];
+}
+
+- (void)testRemovingColumnRequiresMigration {
+    RLMObjectSchema *from = [RLMObjectSchema schemaForObjectClass:MigrationTwoStringObject.class];
+
+    RLMObjectSchema *to = [RLMObjectSchema schemaForObjectClass:MigrationTwoStringObject.class];
+    to.properties = [to.properties subarrayWithRange:{0, 1}];
+
+    [self assertMigrationRequiredForChangeFrom:@[from] to:@[to]];
+}
+
+- (void)testChangingColumnOrderDoesNotRequireMigration {
+    RLMObjectSchema *from = [RLMObjectSchema schemaForObjectClass:MigrationTwoStringObject.class];
+
+    RLMObjectSchema *to = [RLMObjectSchema schemaForObjectClass:MigrationTwoStringObject.class];
+    to.properties = @[to.properties[1], to.properties[0]];
+
+    [self assertNoMigrationRequiredForChangeFrom:@[from] to:@[to]];
+}
+
+- (void)testAddingIndexDoesNotRequireMigration {
+    RLMObjectSchema *from = [RLMObjectSchema schemaForObjectClass:MigrationTwoStringObject.class];
+
+    RLMObjectSchema *to = [RLMObjectSchema schemaForObjectClass:MigrationTwoStringObject.class];
+    [to.properties[0] setIndexed:YES];
+
+    [self assertNoMigrationRequiredForChangeFrom:@[from] to:@[to]];
+}
+
+- (void)testRemovingIndexDoesNotRequireMigration {
+    RLMObjectSchema *from = [RLMObjectSchema schemaForObjectClass:MigrationTwoStringObject.class];
+    [from.properties[0] setIndexed:YES];
+
+    RLMObjectSchema *to = [RLMObjectSchema schemaForObjectClass:MigrationTwoStringObject.class];
+
+    [self assertNoMigrationRequiredForChangeFrom:@[from] to:@[to]];
 }
 
 - (void)testAddingPrimaryKeyRequiresMigration {
-    RLMRealmConfiguration *config = [self config];
+    RLMObjectSchema *from = [RLMObjectSchema schemaForObjectClass:MigrationTwoStringObject.class];
 
-    RLMObjectSchema *objectSchema = [RLMObjectSchema schemaForObjectClass:MigrationPrimaryKeyObject.class];
-    objectSchema.primaryKeyProperty.isPrimary = NO;
-    objectSchema.primaryKeyProperty = nil;
-    config.customSchema = [self schemaWithSingleObject:objectSchema];
+    RLMObjectSchema *to = [RLMObjectSchema schemaForObjectClass:MigrationTwoStringObject.class];
+    to.primaryKeyProperty = to.properties[0];
 
-    // Create Realm file without the primary key set
-    [self initializeRealmWithConfig:config block:^(RLMRealm *realm) {
-        [realm createObject:MigrationPrimaryKeyObject.className withValue:@[@1]];
-    }];
-
-    // Should not be able to open as the schema version needs to be increased
-    config.customSchema = nil;
-    [self assertConfigRequiresMigration:config];
-
-    config.schemaVersion = 1;
-    config.migrationBlock = ^(__unused RLMMigration *migration, __unused uint64_t oldSchemaVersion) { };
-    XCTAssertNoThrow([RLMRealm realmWithConfiguration:config error:nil]);
-
-    // Verify that indexes were updated correctly
-    RLMAssertRealmSchemaMatchesTable(self, [self realmWithTestPath]);
+    [self assertMigrationRequiredForChangeFrom:@[from] to:@[to]];
 }
 
 - (void)testRemovingPrimaryKeyRequiresMigration {
+    RLMObjectSchema *from = [RLMObjectSchema schemaForObjectClass:MigrationTwoStringObject.class];
+    from.primaryKeyProperty = from.properties[0];
+
+    RLMObjectSchema *to = [RLMObjectSchema schemaForObjectClass:MigrationTwoStringObject.class];
+
+    [self assertMigrationRequiredForChangeFrom:@[from] to:@[to]];
+}
+
+- (void)testChangingPrimaryKeyRequiresMigration {
+    RLMObjectSchema *from = [RLMObjectSchema schemaForObjectClass:MigrationTwoStringObject.class];
+    from.primaryKeyProperty = from.properties[0];
+
+    RLMObjectSchema *to = [RLMObjectSchema schemaForObjectClass:MigrationTwoStringObject.class];
+    to.primaryKeyProperty = to.properties[1];
+
+    [self assertMigrationRequiredForChangeFrom:@[from] to:@[to]];
+}
+
+- (void)testMakingPropertyOptionalRequiresMigration {
+    RLMObjectSchema *from = [RLMObjectSchema schemaForObjectClass:MigrationTwoStringObject.class];
+    [from.properties[0] setOptional:NO];
+
+    RLMObjectSchema *to = [RLMObjectSchema schemaForObjectClass:MigrationTwoStringObject.class];
+
+    [self assertMigrationRequiredForChangeFrom:@[from] to:@[to]];
+}
+
+- (void)testMakingPropertyNonOptionalRequiresMigration {
+    RLMObjectSchema *from = [RLMObjectSchema schemaForObjectClass:MigrationTwoStringObject.class];
+
+    RLMObjectSchema *to = [RLMObjectSchema schemaForObjectClass:MigrationTwoStringObject.class];
+    [to.properties[0] setOptional:NO];
+
+    [self assertMigrationRequiredForChangeFrom:@[from] to:@[to]];
+}
+
+- (void)testChangingLinkTargetRequiresMigration {
+    NSArray *linkTargets = @[[RLMObjectSchema schemaForObjectClass:MigrationObject.class],
+                             [RLMObjectSchema schemaForObjectClass:MigrationTwoStringObject.class]];
+    RLMObjectSchema *from = [RLMObjectSchema schemaForObjectClass:MigrationLinkObject.class];
+
+    RLMObjectSchema *to = [RLMObjectSchema schemaForObjectClass:MigrationLinkObject.class];
+    [to.properties[0] setObjectClassName:@"MigrationTwoStringObject"];
+
+    [self assertMigrationRequiredForChangeFrom:[linkTargets arrayByAddingObject:from]
+                                            to:[linkTargets arrayByAddingObject:to]];
+}
+
+- (void)testChangingLinkListTargetRequiresMigration {
+    NSArray *linkTargets = @[[RLMObjectSchema schemaForObjectClass:MigrationObject.class],
+                             [RLMObjectSchema schemaForObjectClass:MigrationTwoStringObject.class]];
+    RLMObjectSchema *from = [RLMObjectSchema schemaForObjectClass:MigrationLinkObject.class];
+
+    RLMObjectSchema *to = [RLMObjectSchema schemaForObjectClass:MigrationLinkObject.class];
+    [to.properties[1] setObjectClassName:@"MigrationTwoStringObject"];
+
+    [self assertMigrationRequiredForChangeFrom:[linkTargets arrayByAddingObject:from]
+                                            to:[linkTargets arrayByAddingObject:to]];
+}
+
+- (void)testChangingPropertyTypesRequiresMigration {
+    RLMObjectSchema *from = [RLMObjectSchema schemaForObjectClass:MigrationObject.class];
+
+    RLMObjectSchema *to = [RLMObjectSchema schemaForObjectClass:MigrationObject.class];
+    RLMProperty *prop = to.properties[0];
+    RLMProperty *strProp = to.properties[1];
+    prop.type = strProp.type;
+    prop.objcRawType = strProp.objcRawType;
+    prop.objcType = strProp.objcType;
+
+    [self assertMigrationRequiredForChangeFrom:@[from] to:@[to]];
+}
+
+- (void)testChangingIntSizeDoesNotRequireMigration {
+    RLMObjectSchema *from = [RLMObjectSchema schemaForObjectClass:MigrationObject.class];
+
+    RLMObjectSchema *to = [RLMObjectSchema schemaForObjectClass:MigrationObject.class];
+    RLMProperty *prop = to.properties[0];
+    prop.objcRawType = @"q"; // 'long long' rather than 'int'
+    prop.objcType = 'q';
+
+    [self assertNoMigrationRequiredForChangeFrom:@[from] to:@[to]];
+}
+
+#pragma mark - Allowed schema mismatches
+
+- (void)testMismatchedIndexAllowedForReadOnly {
+    RLMObjectSchema *objectSchema = [RLMObjectSchema schemaForObjectClass:StringObject.class];
+    [objectSchema.properties[0] setIndexed:YES];
+
+    [self createTestRealmWithSchema:@[objectSchema] block:^(RLMRealm *) { }];
+
+    // should be able to open readonly with mismatched index schema
     RLMRealmConfiguration *config = [self config];
-    // Create Realm file with the primary key set
-    [self initializeRealmWithConfig:config block:^(RLMRealm *realm) {
-        [realm createObject:MigrationPrimaryKeyObject.className withValue:@[@1]];
-    }];
-
-    // Should not be able to open as the schema version needs to be increased
-    RLMObjectSchema *objectSchema = [RLMObjectSchema schemaForObjectClass:MigrationPrimaryKeyObject.class];
-    objectSchema.primaryKeyProperty.isPrimary = NO;
-    objectSchema.primaryKeyProperty = nil;
-    config.customSchema = [self schemaWithSingleObject:objectSchema];
-    [self assertConfigRequiresMigration:config];
-
-    config.schemaVersion = 1;
-    config.migrationBlock = ^(__unused RLMMigration *migration, __unused uint64_t oldSchemaVersion) { };
-    XCTAssertNoThrow([RLMRealm realmWithConfiguration:config error:nil]);
-
-    // Verify that indexes were updated correctly
-    RLMAssertRealmSchemaMatchesTable(self, [self realmWithTestPath]);
-}
-
-- (void)testAddingPrimaryKeyShouldRejectDuplicateValues {
-    RLMRealmConfiguration *config = [self config];
-
-    RLMObjectSchema *objectSchema = [RLMObjectSchema schemaForObjectClass:MigrationPrimaryKeyObject.class];
-    objectSchema.primaryKeyProperty.isPrimary = NO;
-    objectSchema.primaryKeyProperty = nil;
-    config.customSchema = [self schemaWithSingleObject:objectSchema];
-
-    // Create Realm file without the primary key set and duplicate values for
-    // the property which will become the primary key
-    [self initializeRealmWithConfig:config block:^(RLMRealm *realm) {
-        [realm createObject:MigrationPrimaryKeyObject.className withValue:@[@1]];
-        [realm createObject:MigrationPrimaryKeyObject.className withValue:@[@1]];
-    }];
-
-    // Should fail due to the duplicate primary keys
-    config.customSchema = nil;
-    config.schemaVersion = 1;
-    config.migrationBlock = ^(__unused RLMMigration *migration, __unused uint64_t oldSchemaVersion) { };
-    XCTAssertThrows([RLMRealm realmWithConfiguration:config error:nil]);
-
-    // Should work after giving them all unique values
-    config.migrationBlock = ^(__unused RLMMigration *migration, __unused uint64_t oldSchemaVersion) {
-        __block int objectID = 0;
-        [migration enumerateObjects:@"MigrationPrimaryKeyObject" block:^(__unused RLMObject *oldObject, RLMObject *newObject) {
-            newObject[@"intCol"] = @(objectID++);
-        }];
-    };
-    XCTAssertNoThrow([RLMRealm realmWithConfiguration:config error:nil]);
-
-    // Verify that indexes were updated correctly
-    RLMAssertRealmSchemaMatchesTable(self, [self realmWithTestPath]);
-}
-
-- (void)testStringPrimaryKeyMigration {
-    // make string an int
-    RLMObjectSchema *objectSchema = [RLMObjectSchema schemaForObjectClass:MigrationStringPrimaryKeyObject.class];
-    objectSchema.primaryKeyProperty.isPrimary = NO;
-    objectSchema.primaryKeyProperty = nil;
-
-    // create realm with old schema and populate
-    RLMRealm *realm = [self realmWithSingleObject:objectSchema];
-    [realm beginWriteTransaction];
-    [realm createObject:MigrationStringPrimaryKeyObject.className withValue:@[@"1"]];
-    [realm createObject:MigrationStringPrimaryKeyObject.className withValue:@[@"2"]];
-    [realm commitWriteTransaction];
-
-    // apply migration
-    [RLMRealm setSchemaVersion:1
-                forRealmAtPath:RLMTestRealmPath()
-            withMigrationBlock:^(__unused RLMMigration *migration, __unused uint64_t oldSchemaVersion) {
-        [migration enumerateObjects:@"MigrationStringPrimaryKeyObject" block:^(__unused RLMObject *oldObject, RLMObject *newObject) {
-            newObject[@"stringCol"] = [[NSUUID UUID] UUIDString];
-        }];
-    }];
-    [RLMRealm migrateRealmAtPath:RLMTestRealmPath()];
-    RLMAssertRealmSchemaMatchesTable(self, [self realmWithTestPath]);
-}
-
-- (void)testStringPrimaryKeyNoIndexMigration {
-    // make string an int
-    RLMObjectSchema *objectSchema = [RLMObjectSchema schemaForObjectClass:MigrationStringPrimaryKeyObject.class];
-
-    // create without search index
-    objectSchema.primaryKeyProperty.indexed = NO;
-
-    // create realm with old schema and populate
-    RLMRealm *realm = [self realmWithSingleObject:objectSchema];
-    [realm beginWriteTransaction];
-    [realm createObject:MigrationStringPrimaryKeyObject.className withValue:@[@"1"]];
-    [realm createObject:MigrationStringPrimaryKeyObject.className withValue:@[@"2"]];
-    [realm commitWriteTransaction];
-
-    // apply migration
-    [RLMRealm setSchemaVersion:1
-                forRealmAtPath:RLMTestRealmPath()
-            withMigrationBlock:^(__unused RLMMigration *migration, __unused uint64_t oldSchemaVersion) {
-        [migration enumerateObjects:@"MigrationStringPrimaryKeyObject" block:^(__unused RLMObject *oldObject, RLMObject *newObject) {
-            newObject[@"stringCol"] = [[NSUUID UUID] UUIDString];
-        }];
-    }];
-    [RLMRealm migrateRealmAtPath:RLMTestRealmPath()];
-    RLMAssertRealmSchemaMatchesTable(self, [self realmWithTestPath]);
-}
-
-- (void)testIntPrimaryKeyNoIndexMigration {
-    // make string an int
-    RLMObjectSchema *objectSchema = [RLMObjectSchema schemaForObjectClass:MigrationPrimaryKeyObject.class];
-
-    // create without search index
-    objectSchema.primaryKeyProperty.indexed = NO;
-
-    // create realm with old schema and populate
-    @autoreleasepool {
-        RLMRealm *realm = [self realmWithSingleObject:objectSchema];
-        [realm beginWriteTransaction];
-        [realm createObject:MigrationPrimaryKeyObject.className withValue:@[@1]];
-        [realm createObject:MigrationPrimaryKeyObject.className withValue:@[@2]];
-        [realm commitWriteTransaction];
-    }
-
-    // apply migration
-    [RLMRealm setSchemaVersion:1 forRealmAtPath:RLMTestRealmPath() withMigrationBlock:^(__unused RLMMigration *migration, __unused uint64_t oldSchemaVersion) { }];
-    [RLMRealm migrateRealmAtPath:RLMTestRealmPath()];
-
-    // check that column is now indexed
-    RLMRealm *realm = [self realmWithTestPath];
-    RLMAssertRealmSchemaMatchesTable(self, realm);
-    XCTAssertTrue(realm.schema[MigrationPrimaryKeyObject.className].table->has_search_index(0));
-
-    // verify that old data still exists
-    RLMResults *objects = [MigrationPrimaryKeyObject allObjectsInRealm:realm];
-    XCTAssertEqual(1, [objects[0] intCol]);
-    XCTAssertEqual(2, [objects[1] intCol]);
-}
-
-- (void)testDuplicatePrimaryKeyMigration {
-    // make the pk non-primary so that we can add duplicate values
-    RLMObjectSchema *objectSchema = [RLMObjectSchema schemaForObjectClass:MigrationPrimaryKeyObject.class];
-    objectSchema.primaryKeyProperty.isPrimary = NO;
-    objectSchema.primaryKeyProperty = nil;
-
-    // populate with values that will be invalid when the property is made primary
-    RLMRealm *realm = [self realmWithSingleObject:objectSchema];
-    [realm beginWriteTransaction];
-    [realm createObject:MigrationPrimaryKeyObject.className withValue:@[@1]];
-    [realm createObject:MigrationPrimaryKeyObject.className withValue:@[@1]];
-    [realm commitWriteTransaction];
-
-    // apply bad migration
-    [RLMRealm setSchemaVersion:1
-                forRealmAtPath:RLMTestRealmPath()
-            withMigrationBlock:^(__unused RLMMigration *migration, __unused uint64_t oldSchemaVersion) {}];
-    XCTAssertNotNil([RLMRealm migrateRealmAtPath:RLMTestRealmPath()], @"Migration should return error due to duplicate primary keys)");
-
-    // apply good migration that deletes duplicates
-    [RLMRealm setSchemaVersion:1
-                forRealmAtPath:RLMTestRealmPath()
-            withMigrationBlock:^(RLMMigration *migration, __unused uint64_t oldSchemaVersion) {
-        NSMutableSet *seen = [NSMutableSet set];
-        __block bool duplicateDeleted = false;
-        [migration enumerateObjects:@"MigrationPrimaryKeyObject" block:^(__unused RLMObject *oldObject, RLMObject *newObject) {
-           if ([seen containsObject:newObject[@"intCol"]]) {
-               duplicateDeleted = true;
-               [migration deleteObject:newObject];
-           }
-           else {
-               [seen addObject:newObject[@"intCol"]];
-           }
-        }];
-        XCTAssertEqual(true, duplicateDeleted);
-    }];
-    [RLMRealm migrateRealmAtPath:RLMTestRealmPath()];
-    RLMAssertRealmSchemaMatchesTable(self, [self realmWithTestPath]);
-
-    // make sure deletion occurred
-    XCTAssertEqual(1U, [[MigrationPrimaryKeyObject allObjectsInRealm:[RLMRealm realmWithPath:RLMTestRealmPath()]] count]);
-}
-
-- (void)testIncompleteMigrationIsRolledBack {
-    // make string an int
-    RLMObjectSchema *objectSchema = [RLMObjectSchema schemaForObjectClass:MigrationPrimaryKeyObject.class];
-    objectSchema.primaryKeyProperty.isPrimary = NO;
-    objectSchema.primaryKeyProperty = nil;
-
-    // create realm with old schema and populate
-    @autoreleasepool {
-        RLMRealm *realm = [self realmWithSingleObject:objectSchema];
-        [realm beginWriteTransaction];
-        [realm createObject:MigrationPrimaryKeyObject.className withValue:@[@1]];
-        [realm createObject:MigrationPrimaryKeyObject.className withValue:@[@1]];
-        [realm commitWriteTransaction];
-    }
-
-    // fail to apply migration
-    [RLMRealm setSchemaVersion:1
-                forRealmAtPath:RLMTestRealmPath()
-            withMigrationBlock:^(__unused RLMMigration *migration, __unused uint64_t oldSchemaVersion) {}];
-    XCTAssertNotNil([RLMRealm migrateRealmAtPath:RLMTestRealmPath()], @"Migration should return error due to duplicate primary keys)");
-
-    // should still be able to open with pre-migration schema
-    XCTAssertNoThrow([self realmWithSingleObject:objectSchema]);
-}
-
-- (void)testAddObjectDuringMigration {
-    // initialize realm
-    @autoreleasepool {
-        [RLMRealm defaultRealm];
-    }
-
-    [RLMRealm setDefaultRealmSchemaVersion:1
-                        withMigrationBlock:^(RLMMigration *migration, __unused uint64_t oldSchemaVersion) {
-        [migration createObject:StringObject.className withValue:@[@"string"]];
-    }];
-
-    // implicit migration
-    XCTAssertEqual(1U, StringObject.allObjects.count);
-}
-
-- (void)testVersionNumberCanStaySameWithNoSchemaChanges {
-    @autoreleasepool { [self realmWithTestPathAndSchema:[RLMSchema sharedSchema]]; }
-
-    [RLMRealm setSchemaVersion:0
-                forRealmAtPath:RLMTestRealmPath()
-            withMigrationBlock:^(__unused RLMMigration *migration, __unused uint64_t oldSchemaVersion) {}];
-    XCTAssertNoThrow([RLMRealm migrateRealmAtPath:RLMTestRealmPath()]);
-}
-
-- (void)testMigrationIsAppliedWhenNeeded {
-    @autoreleasepool {
-        // make string an int
-        RLMObjectSchema *objectSchema = [RLMObjectSchema schemaForObjectClass:MigrationObject.class];
-        RLMProperty *stringCol = objectSchema.properties[1];
-        stringCol.type = RLMPropertyTypeInt;
-        stringCol.objcType = 'i';
-        stringCol.optional = NO;
-
-        // create realm with old schema and populate
-        RLMRealm *realm = [self realmWithSingleObject:objectSchema];
-        [realm beginWriteTransaction];
-        [realm createObject:MigrationObject.className withValue:@[@1, @1]];
-        [realm commitWriteTransaction];
-    }
-
-    __block bool migrationApplied = false;
-    [RLMRealm setSchemaVersion:1
-                forRealmAtPath:RLMTestRealmPath()
-            withMigrationBlock:^(RLMMigration *migration, __unused uint64_t oldSchemaVersion) {
-                [migration enumerateObjects:MigrationObject.className block:^(RLMObject *, RLMObject *newObject) {
-                    newObject[@"stringCol"] = @"";
-                }];
-                migrationApplied = true;
-            }];
-
-    // migration should be applied when opening realm
-    @autoreleasepool {
-        [RLMRealm realmWithPath:RLMTestRealmPath()];
-    }
-    XCTAssertEqual(true, migrationApplied);
-
-    // applying migration at same version is no-op
-    migrationApplied = false;
-    [RLMRealm migrateRealmAtPath:RLMTestRealmPath()];
-    XCTAssertEqual(false, migrationApplied);
-
-    // test version cant go down
-    [RLMRealm setSchemaVersion:0
-                forRealmAtPath:RLMTestRealmPath()
-            withMigrationBlock:^(__unused RLMMigration *migration, __unused uint64_t oldSchemaVersion) {}];
-    XCTAssertNotNil([RLMRealm migrateRealmAtPath:RLMTestRealmPath()]);
-}
-
-- (void)testVersionNumberCanStaySameWhenAddingObjectSchema {
-    @autoreleasepool {
-        // create realm with old schema and populate
-        RLMRealm *realm = [self realmWithSingleObject:[RLMObjectSchema schemaForObjectClass:MigrationObject.class]];
-        [realm beginWriteTransaction];
-        [realm createObject:MigrationObject.className withValue:@[@1, @"1"]];
-        [realm commitWriteTransaction];
-    }
-    XCTAssertNoThrow([RLMRealm realmWithPath:RLMTestRealmPath()]);
+    config.readOnly = true;
+    RLMRealm *realm = [RLMRealm realmWithConfiguration:config error:nil];
+    objectSchema = realm.schema[@"StringObject"];
+    XCTAssertTrue(objectSchema.table->has_search_index([objectSchema.properties[0] column]));
 }
 
 - (void)testRearrangeProperties {
-    @autoreleasepool {
-        // create object in default realm
-        [[RLMRealm defaultRealm] transactionWithBlock:^{
-            [CircleObject createInDefaultRealmWithValue:@[@"data", NSNull.null]];
-        }];
+    // create object in default realm
+    [RLMRealm.defaultRealm transactionWithBlock:^{
+        [CircleObject createInDefaultRealmWithValue:@[@"data", NSNull.null]];
+    }];
 
-        // create realm with the properties reversed
-        RLMSchema *schema = [[RLMSchema sharedSchema] copy];
-        RLMObjectSchema *objectSchema = schema[@"CircleObject"];
-        objectSchema.properties = @[objectSchema.properties[1], objectSchema.properties[0]];
+    // create realm with the properties reversed
+    RLMSchema *schema = [[RLMSchema sharedSchema] copy];
+    RLMObjectSchema *objectSchema = schema[@"CircleObject"];
+    objectSchema.properties = @[objectSchema.properties[1], objectSchema.properties[0]];
 
-        RLMRealm *realm = [self realmWithTestPathAndSchema:schema];
-        [realm beginWriteTransaction];
-        [realm createObject:CircleObject.className withValue:@[NSNull.null, @"data"]];
-        [realm commitWriteTransaction];
-    }
-
-    // migration should not be requried
-    RLMRealm *realm = nil;
-    XCTAssertNoThrow(realm = [self realmWithTestPath]);
+    RLMRealm *realm = [self realmWithTestPathAndSchema:schema];
+    [realm beginWriteTransaction];
+    [realm createObject:CircleObject.className withValue:@[NSNull.null, @"data"]];
+    [realm commitWriteTransaction];
 
     // accessors should work
     CircleObject *obj = [[CircleObject allObjectsInRealm:realm] firstObject];
@@ -895,26 +466,17 @@ RLM_ARRAY_TYPE(MigrationObject);
     }
 }
 
-- (void)testMigrationDoesNotEffectOtherPaths {
-    RLMRealm *defaultRealm = RLMRealm.defaultRealm;
-    [RLMRealm migrateRealmAtPath:RLMTestRealmPath()];
-    XCTAssertEqual(defaultRealm, RLMRealm.defaultRealm);
-}
-
 - (void)testAccessorCreationForReadOnlyRealms {
     RLMClearAccessorCache();
 
     // Create a realm file with only a single table
-    @autoreleasepool {
-        RLMRealm *realm = [self realmWithSingleObject:[RLMObjectSchema schemaForObjectClass:IntObject.class]];
-        [realm beginWriteTransaction];
+    [self createTestRealmWithSchema:@[[RLMObjectSchema schemaForObjectClass:IntObject.class]] block:^(RLMRealm *realm) {
         [realm createObject:IntObject.className withValue:@[@1]];
-        [realm commitWriteTransaction];
-    }
+    }];
 
     Class intObjectAccessorClass;
     @autoreleasepool {
-        RLMRealm *realm = [RLMRealm realmWithPath:RLMTestRealmPath() readOnly:YES error:nil];
+        RLMRealm *realm = [self readOnlyRealmWithPath:RLMTestRealmPath() error:nil];
 
         intObjectAccessorClass = realm.schema[IntObject.className].accessorClass;
 
@@ -926,7 +488,7 @@ RLM_ARRAY_TYPE(MigrationObject);
     }
 
     @autoreleasepool {
-        RLMRealm *realm = [RLMRealm realmWithPath:RLMTestRealmPath() readOnly:NO error:nil];
+        RLMRealm *realm = [self realmWithTestPath];
 
         // read-write realm should have a different IntObject accessor class due
         // to that we check for RLMSchema compatibility and not for each RLMObjectSchema
@@ -942,198 +504,414 @@ RLM_ARRAY_TYPE(MigrationObject);
     RLMClearAccessorCache();
 }
 
-- (void)testAddingAndRemovingIndex {
-    RLMSchema *noIndex = [[RLMSchema alloc] init];
-    noIndex.objectSchema = @[[RLMObjectSchema schemaForObjectClass:StringObject.class]];
+#pragma mark - Migration block invocatios
 
-    RLMSchema *index = [[RLMSchema alloc] init];
-    RLMObjectSchema *objectSchema = [RLMObjectSchema schemaForObjectClass:StringObject.class];
-    [objectSchema.properties[0] setIndexed:YES];
-    index.objectSchema = @[objectSchema];
+- (void)testMigrationBlockNotCalledForIntialRealmCreation {
+    RLMRealmConfiguration *config = [RLMRealmConfiguration new];
+    config.migrationBlock = ^(__unused RLMMigration *migration, __unused uint64_t oldSchemaVersion) {
+        XCTFail(@"Migration block should not have been called");
+    };
+    XCTAssertNoThrow([RLMRealm realmWithConfiguration:config error:nil]);
+}
 
-    auto columnIsIndexed = ^(RLMRealm *realm) {
-        RLMObjectSchema *objectSchema = realm.schema[@"StringObject"];
-        return objectSchema.table->has_search_index([objectSchema.properties[0] column]);
+- (void)testMigrationBlockNotCalledWhenSchemaVersionIsUnchanged {
+    RLMRealmConfiguration *config = [RLMRealmConfiguration new];
+    config.schemaVersion = 1;
+    @autoreleasepool { XCTAssertNoThrow([RLMRealm realmWithConfiguration:config error:nil]); }
+
+    config.migrationBlock = ^(__unused RLMMigration *migration, __unused uint64_t oldSchemaVersion) {
+        XCTFail(@"Migration block should not have been called");
+    };
+    @autoreleasepool { XCTAssertNoThrow([RLMRealm realmWithConfiguration:config error:nil]); }
+    @autoreleasepool { XCTAssertNil([RLMRealm migrateRealm:config]); }
+}
+
+- (void)testMigrationBlockCalledWhenSchemaVersionHasChanged {
+    RLMRealmConfiguration *config = [RLMRealmConfiguration new];
+    config.schemaVersion = 1;
+    @autoreleasepool { XCTAssertNoThrow([RLMRealm realmWithConfiguration:config error:nil]); }
+
+    __block bool migrationCalled = false;
+    config.schemaVersion = 2;
+    config.migrationBlock = ^(__unused RLMMigration *migration, __unused uint64_t oldSchemaVersion) {
+        migrationCalled = true;
+    };
+    @autoreleasepool { XCTAssertNoThrow([RLMRealm realmWithConfiguration:config error:nil]); }
+    XCTAssertTrue(migrationCalled);
+
+    migrationCalled = false;
+    config.schemaVersion = 3;
+    @autoreleasepool { XCTAssertNil([RLMRealm migrateRealm:config]); }
+    XCTAssertTrue(migrationCalled);
+}
+
+#pragma mark - Migration Correctness
+
+- (void)testRemovingSubclass {
+    RLMObjectSchema *objectSchema = [[RLMObjectSchema alloc] initWithClassName:@"DeletedClass" objectClass:RLMObject.class properties:@[]];
+    [self createTestRealmWithSchema:@[objectSchema] block:^(RLMRealm *realm) {
+        [realm createObject:@"DeletedClass" withValue:@[]];
+    }];
+
+    // apply migration
+    RLMRealm *realm = [self migrateTestRealmWithBlock:^(RLMMigration *migration, uint64_t oldSchemaVersion) {
+        XCTAssertEqual(oldSchemaVersion, 0U, @"Initial schema version should be 0");
+
+        XCTAssertTrue([migration deleteDataForClassName:@"DeletedClass"]);
+        XCTAssertFalse([migration deleteDataForClassName:@"NoSuchClass"]);
+        XCTAssertFalse([migration deleteDataForClassName:self.nonLiteralNil]);
+
+        [migration createObject:StringObject.className withValue:@[@"migration"]];
+        XCTAssertTrue([migration deleteDataForClassName:StringObject.className]);
+    }];
+
+    XCTAssertFalse(ObjectStore::table_for_object_type(realm.group, "DeletedClass"), @"The deleted class should not have a table.");
+    XCTAssertEqual(0U, [StringObject allObjectsInRealm:realm].count);
+}
+
+- (void)testAddingPropertyAtEnd {
+    // create schema to migrate from with single string column
+    RLMObjectSchema *objectSchema = [RLMObjectSchema schemaForObjectClass:MigrationObject.class];
+    objectSchema.properties = @[objectSchema.properties[0]];
+    [self createTestRealmWithSchema:@[objectSchema] block:^(RLMRealm *realm) {
+        [realm createObject:MigrationObject.className withValue:@[@1]];
+        [realm createObject:MigrationObject.className withValue:@[@2]];
+    }];
+
+    // apply migration
+    RLMRealm *realm = [self migrateTestRealmWithBlock:^(RLMMigration *migration, uint64_t oldSchemaVersion) {
+        XCTAssertEqual(oldSchemaVersion, 0U, @"Initial schema version should be 0");
+        [migration enumerateObjects:MigrationObject.className
+                              block:^(RLMObject *oldObject, RLMObject *newObject) {
+            XCTAssertThrows(oldObject[@"stringCol"], @"stringCol should not exist on old object");
+            NSNumber *intObj;
+            XCTAssertNoThrow(intObj = oldObject[@"intCol"], @"Should be able to access intCol on oldObject");
+            XCTAssertEqualObjects(newObject[@"intCol"], oldObject[@"intCol"]);
+            NSString *stringObj = [NSString stringWithFormat:@"%@", intObj];
+            XCTAssertNoThrow(newObject[@"stringCol"] = stringObj, @"Should be able to set stringCol");
+        }];
+    }];
+
+    // verify migration
+    MigrationObject *mig1 = [MigrationObject allObjectsInRealm:realm][1];
+    XCTAssertEqual(mig1.intCol, 2, @"Int column should have value 2");
+    XCTAssertEqualObjects(mig1.stringCol, @"2", @"String column should be populated");
+}
+
+- (void)testAddingPropertyAtBeginningPreservesData {
+    // create schema to migrate from with the second and third columns from the final data
+    RLMObjectSchema *objectSchema = [RLMObjectSchema schemaForObjectClass:ThreeFieldMigrationObject.class];
+    objectSchema.properties = @[objectSchema.properties[1], objectSchema.properties[2]];
+
+    [self createTestRealmWithSchema:@[objectSchema] block:^(RLMRealm *realm) {
+        [realm createObject:ThreeFieldMigrationObject.className withValue:@[@1, @2]];
+    }];
+
+    RLMRealm *realm = [self migrateTestRealmWithBlock:^(RLMMigration *migration, uint64_t) {
+        [migration enumerateObjects:ThreeFieldMigrationObject.className
+                              block:^(RLMObject *oldObject, RLMObject *newObject) {
+            XCTAssertThrows(oldObject[@"col1"]);
+            XCTAssertEqualObjects(oldObject[@"col2"], newObject[@"col2"]);
+            XCTAssertEqualObjects(oldObject[@"col3"], newObject[@"col3"]);
+        }];
+    }];
+
+    // verify migration
+    ThreeFieldMigrationObject *mig = [ThreeFieldMigrationObject allObjectsInRealm:realm][0];
+    XCTAssertEqual(0, mig.col1);
+    XCTAssertEqual(1, mig.col2);
+    XCTAssertEqual(2, mig.col3);
+}
+
+- (void)testRemoveProperty {
+    // create schema with an extra column
+    RLMObjectSchema *objectSchema = [RLMObjectSchema schemaForObjectClass:MigrationObject.class];
+    RLMProperty *thirdProperty = [[RLMProperty alloc] initWithName:@"deletedCol" type:RLMPropertyTypeBool objectClassName:nil indexed:NO optional:NO];
+    thirdProperty.column = 2;
+    objectSchema.properties = [objectSchema.properties arrayByAddingObject:thirdProperty];
+
+    // create realm with old schema and populate
+    [self createTestRealmWithSchema:@[objectSchema] block:^(RLMRealm *realm) {
+        [realm createObject:MigrationObject.className withValue:@[@1, @"1", @YES]];
+        [realm createObject:MigrationObject.className withValue:@[@2, @"2", @NO]];
+    }];
+
+    // apply migration
+    RLMRealm *realm = [self migrateTestRealmWithBlock:^(RLMMigration *migration, uint64_t oldSchemaVersion) {
+        XCTAssertEqual(oldSchemaVersion, 0U, @"Initial schema version should be 0");
+        [migration enumerateObjects:MigrationObject.className
+                                       block:^(RLMObject *oldObject, RLMObject *newObject) {
+            XCTAssertNoThrow(oldObject[@"deletedCol"], @"Deleted column should be accessible on old object.");
+            XCTAssertThrows(newObject[@"deletedCol"], @"Deleted column should not be accessible on new object.");
+
+            XCTAssertEqualObjects(newObject[@"intCol"], oldObject[@"intCol"]);
+            XCTAssertEqualObjects(newObject[@"stringCol"], oldObject[@"stringCol"]);
+        }];
+    }];
+
+    // verify migration
+    MigrationObject *mig1 = [MigrationObject allObjectsInRealm:realm][1];
+    XCTAssertThrows(mig1[@"deletedCol"], @"Deleted column should no longer be accessible.");
+}
+
+- (void)testRemoveAndAddProperty {
+    // create schema to migrate from with single string column
+    RLMObjectSchema *objectSchema = [RLMObjectSchema schemaForObjectClass:MigrationObject.class];
+    RLMProperty *oldInt = [[RLMProperty alloc] initWithName:@"oldIntCol" type:RLMPropertyTypeInt objectClassName:nil indexed:NO optional:NO];
+    objectSchema.properties = @[oldInt, objectSchema.properties[1]];
+
+    // create realm with old schema and populate
+    [self createTestRealmWithSchema:@[objectSchema] block:^(RLMRealm *realm) {
+        [realm createObject:MigrationObject.className withValue:@[@1, @"1"]];
+        [realm createObject:MigrationObject.className withValue:@[@1, @"2"]];
+    }];
+
+    // object migration object
+    void (^migrateObjectBlock)(RLMObject *, RLMObject *) = ^(RLMObject *oldObject, RLMObject *newObject) {
+        XCTAssertNoThrow(oldObject[@"oldIntCol"], @"Deleted column should be accessible on old object.");
+        XCTAssertThrows(oldObject[@"intCol"], @"New column should not be accessible on old object.");
+        XCTAssertEqual([oldObject[@"oldIntCol"] intValue], 1, @"Deleted column value is correct.");
+        XCTAssertNoThrow(newObject[@"intCol"], @"New column is accessible on new object.");
+        XCTAssertThrows(newObject[@"oldIntCol"], @"Old column should not be accessible on old object.");
+        XCTAssertEqual([newObject[@"intCol"] intValue], 0, @"New column value is uninitialized.");
     };
 
-    // create initial file with no index
-    @autoreleasepool {
-        XCTAssertFalse(columnIsIndexed([self realmWithTestPathAndSchema:noIndex]));
-    }
+    // apply migration
+    RLMRealm *realm = [self migrateTestRealmWithBlock:^(RLMMigration *migration, uint64_t oldSchemaVersion) {
+        XCTAssertEqual(oldSchemaVersion, 0U, @"Initial schema version should be 0");
+        [migration enumerateObjects:MigrationObject.className block:migrateObjectBlock];
+    }];
 
-    // should add index when opening with indexed schema
-    @autoreleasepool {
-        XCTAssertTrue(columnIsIndexed([self realmWithTestPathAndSchema:index]));
-    }
+    // verify migration
+    MigrationObject *mig1 = [MigrationObject allObjectsInRealm:realm][1];
+    XCTAssertThrows(mig1[@"oldIntCol"], @"Deleted column should no longer be accessible.");
+}
 
-    // should remove index when opening with non-indexed schema
-    @autoreleasepool {
-        XCTAssertFalse(columnIsIndexed([self realmWithTestPathAndSchema:noIndex]));
-    }
+- (void)testChangePropertyType {
+    // make string an int
+    RLMObjectSchema *objectSchema = [RLMObjectSchema schemaForObjectClass:MigrationObject.class];
+    RLMProperty *stringCol = objectSchema.properties[1];
+    stringCol.type = RLMPropertyTypeInt;
+    stringCol.objcType = 'i';
+    stringCol.optional = NO;
 
-    // create initial file with index
-    [self deleteFiles];
-    @autoreleasepool {
-        XCTAssertTrue(columnIsIndexed([self realmWithTestPathAndSchema:index]));
-    }
+    // create realm with old schema and populate
+    [self createTestRealmWithSchema:@[objectSchema] block:^(RLMRealm *realm) {
+        [realm createObject:MigrationObject.className withValue:@[@1, @1]];
+        [realm createObject:MigrationObject.className withValue:@[@2, @2]];
+    }];
 
-    // should be able to open readonly with mismatched index schema
-    @autoreleasepool {
-        XCTAssertTrue(columnIsIndexed([RLMRealm realmWithPath:RLMTestRealmPath() readOnly:YES error:nil]));
-    }
+    // apply migration
+    RLMRealm *realm = [self migrateTestRealmWithBlock:^(RLMMigration *migration, uint64_t oldSchemaVersion) {
+        XCTAssertEqual(oldSchemaVersion, 0U, @"Initial schema version should be 0");
+        [migration enumerateObjects:MigrationObject.className
+                                       block:^(RLMObject *oldObject, RLMObject *newObject) {
+            XCTAssertEqualObjects(newObject[@"intCol"], oldObject[@"intCol"]);
+            NSNumber *intObj = oldObject[@"stringCol"];
+            XCTAssert([intObj isKindOfClass:NSNumber.class], @"Old stringCol should be int");
+            newObject[@"stringCol"] = intObj.stringValue;
+        }];
+    }];
+
+    // verify migration
+    MigrationObject *mig1 = [MigrationObject allObjectsInRealm:realm][1];
+    XCTAssertEqualObjects(mig1[@"stringCol"], @"2", @"stringCol should be string after migration.");
+}
+
+- (void)testChangeObjectLinkType {
+    // create realm with old schema and populate
+    [self createTestRealmWithSchema:RLMSchema.sharedSchema.objectSchema block:^(RLMRealm *realm) {
+        id obj = [realm createObject:MigrationObject.className withValue:@[@1, @"1"]];
+        [realm createObject:MigrationLinkObject.className withValue:@[obj, @[obj]]];
+    }];
+
+    // Make the object link property link to a different class
+    RLMRealmConfiguration *config = self.config;
+    RLMObjectSchema *objectSchema = [RLMObjectSchema schemaForObjectClass:MigrationLinkObject.class];
+    [objectSchema.properties[0] setObjectClassName:MigrationLinkObject.className];
+    config.customSchema = [self schemaWithObjects:@[objectSchema, [RLMObjectSchema schemaForObjectClass:MigrationObject.class]]];
+
+    // Apply migration
+    config.schemaVersion = 1;
+    config.migrationBlock = ^(RLMMigration *migration, uint64_t oldSchemaVersion) {
+        XCTAssertEqual(oldSchemaVersion, 0U, @"Initial schema version should be 0");
+        [migration enumerateObjects:MigrationLinkObject.className
+                                       block:^(RLMObject *oldObject, RLMObject *newObject) {
+                                           XCTAssertNotNil(oldObject[@"object"]);
+                                           XCTAssertNil(newObject[@"object"]);
+
+                                           XCTAssertEqual(1U, [oldObject[@"array"] count]);
+                                           XCTAssertEqual(1U, [newObject[@"array"] count]);
+                                       }];
+    };
+    RLMRealm *realm = [RLMRealm realmWithConfiguration:config error:nil];
+    RLMAssertRealmSchemaMatchesTable(self, realm);
+}
+
+- (void)testChangeArrayLinkType {
+    // create realm with old schema and populate
+    RLMRealmConfiguration *config = [self config];
+    [self createTestRealmWithSchema:RLMSchema.sharedSchema.objectSchema block:^(RLMRealm *realm) {
+        id obj = [realm createObject:MigrationObject.className withValue:@[@1, @"1"]];
+        [realm createObject:MigrationLinkObject.className withValue:@[obj, @[obj]]];
+    }];
+
+    // Make the array linklist property link to a different class
+    RLMObjectSchema *objectSchema = [RLMObjectSchema schemaForObjectClass:MigrationLinkObject.class];
+    [objectSchema.properties[1] setObjectClassName:MigrationLinkObject.className];
+    config.customSchema = [self schemaWithObjects:@[objectSchema, [RLMObjectSchema schemaForObjectClass:MigrationObject.class]]];
+
+    // Apply migration
+    config.schemaVersion = 1;
+    config.migrationBlock = ^(RLMMigration *migration, uint64_t oldSchemaVersion) {
+        XCTAssertEqual(oldSchemaVersion, 0U, @"Initial schema version should be 0");
+        [migration enumerateObjects:MigrationLinkObject.className
+                                       block:^(RLMObject *oldObject, RLMObject *newObject) {
+                                           XCTAssertNotNil(oldObject[@"object"]);
+                                           XCTAssertNotNil(newObject[@"object"]);
+
+                                           XCTAssertEqual(1U, [oldObject[@"array"] count]);
+                                           XCTAssertEqual(0U, [newObject[@"array"] count]);
+                                       }];
+    };
+    RLMRealm *realm = [RLMRealm realmWithConfiguration:config error:nil];
+    RLMAssertRealmSchemaMatchesTable(self, realm);
+}
+
+- (void)testMakingPropertyPrimaryPreservesValues {
+    RLMObjectSchema *objectSchema = [RLMObjectSchema schemaForObjectClass:MigrationStringPrimaryKeyObject.class];
+    objectSchema.primaryKeyProperty = nil;
+
+    [self createTestRealmWithSchema:@[objectSchema] block:^(RLMRealm *realm) {
+        [realm createObject:MigrationStringPrimaryKeyObject.className withValue:@[@"1"]];
+        [realm createObject:MigrationStringPrimaryKeyObject.className withValue:@[@"2"]];
+    }];
+
+    RLMRealm *realm = [self migrateTestRealmWithBlock:nil];
+    RLMResults *objects = [MigrationStringPrimaryKeyObject allObjectsInRealm:realm];
+    XCTAssertEqualObjects(@"1", [objects[0] stringCol]);
+    XCTAssertEqualObjects(@"2", [objects[1] stringCol]);
+}
+
+- (void)testAddingPrimaryKeyShouldRejectDuplicateValues {
+    // make the pk non-primary so that we can add duplicate values
+    RLMObjectSchema *objectSchema = [RLMObjectSchema schemaForObjectClass:MigrationPrimaryKeyObject.class];
+    objectSchema.primaryKeyProperty = nil;
+    [self createTestRealmWithSchema:@[objectSchema] block:^(RLMRealm *realm) {
+        // populate with values that will be invalid when the property is made primary
+        [realm createObject:MigrationPrimaryKeyObject.className withValue:@[@1]];
+        [realm createObject:MigrationPrimaryKeyObject.className withValue:@[@1]];
+    }];
+
+    // Fails due to duplicate values
+    [self failToMigrateTestRealmWithBlock:nil];
+
+    // apply good migration that deletes duplicates
+    RLMRealm *realm = [self migrateTestRealmWithBlock:^(RLMMigration *migration, uint64_t) {
+        NSMutableSet *seen = [NSMutableSet set];
+        __block bool duplicateDeleted = false;
+        [migration enumerateObjects:@"MigrationPrimaryKeyObject" block:^(__unused RLMObject *oldObject, RLMObject *newObject) {
+           if ([seen containsObject:newObject[@"intCol"]]) {
+               duplicateDeleted = true;
+               [migration deleteObject:newObject];
+           }
+           else {
+               [seen addObject:newObject[@"intCol"]];
+           }
+        }];
+        XCTAssertEqual(true, duplicateDeleted);
+    }];
+
+    // make sure deletion occurred
+    XCTAssertEqual(1U, [[MigrationPrimaryKeyObject allObjectsInRealm:realm] count]);
+}
+
+- (void)testIncompleteMigrationIsRolledBack {
+    RLMObjectSchema *objectSchema = [RLMObjectSchema schemaForObjectClass:MigrationPrimaryKeyObject.class];
+    objectSchema.primaryKeyProperty = nil;
+    [self createTestRealmWithSchema:@[objectSchema] block:^(RLMRealm *realm) {
+        [realm createObject:MigrationPrimaryKeyObject.className withValue:@[@1]];
+        [realm createObject:MigrationPrimaryKeyObject.className withValue:@[@1]];
+    }];
+
+    // fail to apply migration
+    [self failToMigrateTestRealmWithBlock:nil];
+
+    // should still be able to open with pre-migration schema
+    XCTAssertNoThrow([self realmWithSingleObject:objectSchema]);
+}
+
+- (void)testAddObjectDuringMigration {
+    // initialize realm
+    @autoreleasepool { [self realmWithTestPath]; }
+
+    RLMRealm *realm = [self migrateTestRealmWithBlock:^(RLMMigration * migration, uint64_t) {
+        [migration createObject:StringObject.className withValue:@[@"string"]];
+    }];
+    XCTAssertEqual(1U, [StringObject allObjectsInRealm:realm].count);
 }
 
 - (void)testEnumeratedObjectsDuringMigration {
-    // initialize realm
-    @autoreleasepool {
-        [[RLMRealm defaultRealm] transactionWithBlock:^{
-            [StringObject createInDefaultRealmWithValue:@[@"string"]];
-            [ArrayPropertyObject createInDefaultRealmWithValue:@[@"array", @[@[@"string"]], @[@[@1]]]];
+    [self createTestRealmWithClasses:@[StringObject.class, ArrayPropertyObject.class, IntObject.class] block:^(RLMRealm *realm) {
+        [StringObject createInRealm:realm withValue:@[@"string"]];
+        [ArrayPropertyObject createInRealm:realm withValue:@[@"array", @[@[@"string"]], @[@[@1]]]];
+    }];
+
+    RLMRealm *realm = [self migrateTestRealmWithBlock:^(RLMMigration *migration, uint64_t) {
+        [migration enumerateObjects:StringObject.className block:^(RLMObject *oldObject, RLMObject *newObject) {
+            XCTAssertEqualObjects([oldObject valueForKey:@"stringCol"], oldObject[@"stringCol"]);
+            [newObject setValue:@"otherString" forKey:@"stringCol"];
+            XCTAssertEqualObjects([oldObject valueForKey:@"realm"], oldObject.realm);
+            XCTAssertThrows([oldObject valueForKey:@"noSuchKey"]);
+            XCTAssertThrows([newObject setValue:@1 forKey:@"noSuchKey"]);
         }];
-    }
 
-    [RLMRealm setDefaultRealmSchemaVersion:1
-                        withMigrationBlock:^(RLMMigration *migration, __unused uint64_t oldSchemaVersion) {
-                            [migration enumerateObjects:StringObject.className block:^(RLMObject *oldObject, RLMObject *newObject) {
-                                XCTAssertEqualObjects([oldObject valueForKey:@"stringCol"], oldObject[@"stringCol"]);
-                                [newObject setValue:@"otherString" forKey:@"stringCol"];
-                                XCTAssertEqualObjects([oldObject valueForKey:@"realm"], oldObject.realm);
-                                XCTAssertThrows([oldObject valueForKey:@"noSuchKey"]);
-                                XCTAssertThrows([newObject setValue:@1 forKey:@"noSuchKey"]);
-                            }];
+        [migration enumerateObjects:ArrayPropertyObject.className block:^(RLMObject *oldObject, RLMObject *newObject) {
+            XCTAssertEqual(RLMDynamicObject.class, newObject.class);
+            XCTAssertEqual(RLMDynamicObject.class, oldObject.class);
+            XCTAssertEqual(RLMDynamicObject.class, [[oldObject[@"array"] firstObject] class]);
+            XCTAssertEqual(RLMDynamicObject.class, [[newObject[@"array"] firstObject] class]);
+        }];
+    }];
 
-                            [migration enumerateObjects:ArrayPropertyObject.className block:^(RLMObject *oldObject, RLMObject *newObject) {
-                                XCTAssertEqual(RLMDynamicObject.class, newObject.class);
-                                XCTAssertEqual(RLMDynamicObject.class, oldObject.class);
-                                XCTAssertEqual(RLMDynamicObject.class, [[oldObject[@"array"] firstObject] class]);
-                                XCTAssertEqual(RLMDynamicObject.class, [[newObject[@"array"] firstObject] class]);
-                            }];
-                        }];
-
-    // implicit migration
-    XCTAssertEqualObjects(@"otherString", [StringObject.allObjects.firstObject stringCol]);
-}
-
-- (void)testMigrationBlockNotCalledForIntialRealmCreation {
-    [RLMRealm setSchemaVersion:1
-                forRealmAtPath:RLMTestRealmPath()
-            withMigrationBlock:^(__unused RLMMigration *migration, __unused uint64_t oldSchemaVersion) {
-                XCTFail(@"Migration block should not have been called");
-            }];
-    XCTAssertNoThrow([self realmWithTestPath]);
-}
-
-- (void)testRLMNotVersionedHasCorrectValue
-{
-    XCTAssertEqual(RLMNotVersioned, std::numeric_limits<uint64_t>::max());
-}
-
-- (void)testSetSchemaVersionValidatesVersion
-{
-    RLMAssertThrowsWithReasonMatching([RLMRealm setSchemaVersion:RLMNotVersioned forRealmAtPath:RLMTestRealmPath() withMigrationBlock:nil], @"Cannot set schema version");
-    [RLMRealm setSchemaVersion:RLMNotVersioned - 1 forRealmAtPath:RLMTestRealmPath() withMigrationBlock:nil];
-}
-
-- (void)testSchemaVersionIsUsedForExplicitMigration {
-    // Create a realm requiring a migration
-    @autoreleasepool {
-        RLMObjectSchema *objectSchema = [RLMObjectSchema schemaForObjectClass:MigrationObject.class];
-        objectSchema.properties = @[objectSchema.properties[0]];
-        [self realmWithSingleObject:objectSchema];
-    }
-
-    // Migrate it with RLMRealmConfiguration
-    @autoreleasepool {
-        __block bool called = false;
-        RLMRealmConfiguration *config = [[RLMRealmConfiguration alloc] init];
-        config.schemaVersion = 1;
-        config.migrationBlock = ^(RLMMigration *, uint64_t) {
-            called = true;
-        };
-        config.path = RLMTestRealmPath();
-        XCTAssertNil([RLMRealm migrateRealm:config]);
-        XCTAssertTrue(called);
-    }
-
-    @autoreleasepool {
-        XCTAssertEqual(1U, [RLMRealm schemaVersionAtPath:RLMTestRealmPath() error:nil]);
-    }
-}
-
-- (void)testChangingColumnNullability {
-    RLMSchema *nullable = [[RLMSchema alloc] init];
-    nullable.objectSchema = @[[RLMObjectSchema schemaForObjectClass:StringObject.class]];
-
-    RLMSchema *nonnull = [[RLMSchema alloc] init];
-    RLMObjectSchema *objectSchema = [RLMObjectSchema schemaForObjectClass:StringObject.class];
-    [objectSchema.properties[0] setOptional:NO];
-    nonnull.objectSchema = @[objectSchema];
-
-    // create initial required column
-    @autoreleasepool {
-        [self realmWithTestPathAndSchema:nonnull];
-    }
-
-    // attempt to open with an optional column
-    @autoreleasepool {
-        XCTAssertThrows([self realmWithTestPathAndSchema:nullable]);
-    }
-
-    [self deleteFiles];
-
-    // create initial optional column
-    @autoreleasepool {
-        [self realmWithTestPathAndSchema:nullable];
-    }
-
-    // attempt to open with a required column
-    @autoreleasepool {
-        XCTAssertThrows([self realmWithTestPathAndSchema:nonnull]);
-    }
+    XCTAssertEqualObjects(@"otherString", [[StringObject allObjectsInRealm:realm].firstObject stringCol]);
 }
 
 - (void)testRequiredToNullableAutoMigration {
-    RLMSchema *nullable = [[RLMSchema alloc] init];
-    nullable.objectSchema = @[[RLMObjectSchema schemaForObjectClass:AllOptionalTypes.class]];
-
-    RLMSchema *nonnull = [[RLMSchema alloc] init];
     RLMObjectSchema *objectSchema = [RLMObjectSchema schemaForObjectClass:AllOptionalTypes.class];
     [objectSchema.properties setValue:@NO forKey:@"optional"];
-    nonnull.objectSchema = @[objectSchema];
 
     // create initial required column
-    @autoreleasepool {
-        RLMRealm *realm = [self realmWithTestPathAndSchema:nonnull];
-        [realm transactionWithBlock:^{
-            [AllOptionalTypes createInRealm:realm withValue:@[@1, @1, @1, @1, @"str", [@"data" dataUsingEncoding:NSUTF8StringEncoding], [NSDate dateWithTimeIntervalSince1970:1]]];
-            [AllOptionalTypes createInRealm:realm withValue:@[@2, @2, @2, @0, @"str2", [@"data2" dataUsingEncoding:NSUTF8StringEncoding], [NSDate dateWithTimeIntervalSince1970:2]]];
-        }];
-    }
+    [self createTestRealmWithSchema:@[objectSchema] block:^(RLMRealm *realm) {
+        [AllOptionalTypes createInRealm:realm withValue:@[@1, @1, @1, @1, @"str",
+                                                          [@"data" dataUsingEncoding:NSUTF8StringEncoding],
+                                                          [NSDate dateWithTimeIntervalSince1970:1]]];
+        [AllOptionalTypes createInRealm:realm withValue:@[@2, @2, @2, @0, @"str2",
+                                                          [@"data2" dataUsingEncoding:NSUTF8StringEncoding],
+                                                          [NSDate dateWithTimeIntervalSince1970:2]]];
+    }];
 
-    @autoreleasepool {
-        [RLMRealm setSchemaVersion:1 forRealmAtPath:RLMTestRealmPath() withMigrationBlock:nil];
-        RLMRealm *realm = [self realmWithTestPathAndSchema:nullable];
-        RLMResults *allObjects = [AllOptionalTypes allObjectsInRealm:realm];
-        XCTAssertEqual(2U, allObjects.count);
+    RLMRealm *realm = [self migrateTestRealmWithBlock:nil];
+    RLMResults *allObjects = [AllOptionalTypes allObjectsInRealm:realm];
+    XCTAssertEqual(2U, allObjects.count);
 
-        AllOptionalTypes *obj = allObjects[0];
-        XCTAssertEqualObjects(@1, obj.intObj);
-        XCTAssertEqualObjects(@1, obj.floatObj);
-        XCTAssertEqualObjects(@1, obj.doubleObj);
-        XCTAssertEqualObjects(@1, obj.boolObj);
-        XCTAssertEqualObjects(@"str", obj.string);
-        XCTAssertEqualObjects([@"data" dataUsingEncoding:NSUTF8StringEncoding], obj.data);
-        XCTAssertEqualObjects([NSDate dateWithTimeIntervalSince1970:1], obj.date);
+    AllOptionalTypes *obj = allObjects[0];
+    XCTAssertEqualObjects(@1, obj.intObj);
+    XCTAssertEqualObjects(@1, obj.floatObj);
+    XCTAssertEqualObjects(@1, obj.doubleObj);
+    XCTAssertEqualObjects(@1, obj.boolObj);
+    XCTAssertEqualObjects(@"str", obj.string);
+    XCTAssertEqualObjects([@"data" dataUsingEncoding:NSUTF8StringEncoding], obj.data);
+    XCTAssertEqualObjects([NSDate dateWithTimeIntervalSince1970:1], obj.date);
 
-        obj = allObjects[1];
-        XCTAssertEqualObjects(@2, obj.intObj);
-        XCTAssertEqualObjects(@2, obj.floatObj);
-        XCTAssertEqualObjects(@2, obj.doubleObj);
-        XCTAssertEqualObjects(@0, obj.boolObj);
-        XCTAssertEqualObjects(@"str2", obj.string);
-        XCTAssertEqualObjects([@"data2" dataUsingEncoding:NSUTF8StringEncoding], obj.data);
-        XCTAssertEqualObjects([NSDate dateWithTimeIntervalSince1970:2], obj.date);
-    }
+    obj = allObjects[1];
+    XCTAssertEqualObjects(@2, obj.intObj);
+    XCTAssertEqualObjects(@2, obj.floatObj);
+    XCTAssertEqualObjects(@2, obj.doubleObj);
+    XCTAssertEqualObjects(@0, obj.boolObj);
+    XCTAssertEqualObjects(@"str2", obj.string);
+    XCTAssertEqualObjects([@"data2" dataUsingEncoding:NSUTF8StringEncoding], obj.data);
+    XCTAssertEqualObjects([NSDate dateWithTimeIntervalSince1970:2], obj.date);
 }
 
 @end

--- a/Realm/Tests/RLMTestCase.m
+++ b/Realm/Tests/RLMTestCase.m
@@ -73,8 +73,10 @@ static BOOL encryptTests() {
 #endif
     [self preintializeSchema];
 
-    // Clean up any potentially lingering Realm files from previous runs
-    [NSFileManager.defaultManager removeItemAtPath:RLMRealmPathForFile(@"") error:nil];
+    if (!getenv("RLMProcessIsChild")) {
+        // Clean up any potentially lingering Realm files from previous runs
+        [NSFileManager.defaultManager removeItemAtPath:RLMRealmPathForFile(@"") error:nil];
+    }
 
     // Ensure the documents directory exists as it sometimes doesn't after
     // resetting the simulator

--- a/Realm/Tests/RLMTestCase.m
+++ b/Realm/Tests/RLMTestCase.m
@@ -21,19 +21,7 @@
 #import "RLMRealmConfiguration_Private.h"
 #import <Realm/RLMRealm_Private.h>
 #import <Realm/RLMSchema_Private.h>
-
-static NSString *documentsDir() {
-#if TARGET_OS_IPHONE
-    return NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES)[0];
-#else
-    NSString *path = NSSearchPathForDirectoriesInDomains(NSApplicationSupportDirectory, NSUserDomainMask, YES)[0];
-    return [path stringByAppendingPathComponent:[[[NSBundle mainBundle] executablePath] lastPathComponent]];
-#endif
-}
-
-NSString *RLMRealmPathForFile(NSString *fileName) {
-    return [documentsDir() stringByAppendingPathComponent:fileName];
-}
+#import <Realm/RLMRealmConfiguration_Private.h>
 
 NSString *RLMDefaultRealmPath() {
     return RLMRealmPathForFile(@"default.realm");
@@ -87,7 +75,8 @@ static BOOL encryptTests() {
 
     // Ensure the documents directory exists as it sometimes doesn't after
     // resetting the simulator
-    [NSFileManager.defaultManager createDirectoryAtPath:documentsDir() withIntermediateDirectories:YES attributes:nil error:nil];
+    [NSFileManager.defaultManager createDirectoryAtPath:RLMDefaultRealmPath().stringByDeletingLastPathComponent
+                            withIntermediateDirectories:YES attributes:nil error:nil];
 }
 
 - (void)setUp {

--- a/Realm/Tests/RLMTestCase.m
+++ b/Realm/Tests/RLMTestCase.m
@@ -73,6 +73,9 @@ static BOOL encryptTests() {
 #endif
     [self preintializeSchema];
 
+    // Clean up any potentially lingering Realm files from previous runs
+    [NSFileManager.defaultManager removeItemAtPath:RLMRealmPathForFile(@"") error:nil];
+
     // Ensure the documents directory exists as it sometimes doesn't after
     // resetting the simulator
     [NSFileManager.defaultManager createDirectoryAtPath:RLMDefaultRealmPath().stringByDeletingLastPathComponent

--- a/Realm/module.modulemap
+++ b/Realm/module.modulemap
@@ -7,7 +7,6 @@ framework module Realm {
     explicit module Private {
         header "RLMAccessor.h"
         header "RLMArray_Private.h"
-        header "RLMRealmConfiguration_Private.h"
         header "RLMListBase.h"
         header "RLMMigration_Private.h"
         header "RLMObjectSchema_Private.h"
@@ -15,12 +14,13 @@ framework module Realm {
         header "RLMObject_Private.h"
         header "RLMOptionalBase.h"
         header "RLMProperty_Private.h"
+        header "RLMRealmConfiguration_Private.h"
         header "RLMRealmUtil.h"
         header "RLMRealm_Private.h"
         header "RLMResults_Private.h"
         header "RLMSchema_Private.h"
     }
-    
+
     explicit module Dynamic {
         header "RLMRealm_Dynamic.h"
         header "RLMObjectBase_Dynamic.h"

--- a/RealmSwift-swift1.2/Migration.swift
+++ b/RealmSwift-swift1.2/Migration.swift
@@ -43,61 +43,6 @@ accessed using subscripting.
 public typealias MigrationObjectEnumerateBlock = (oldObject: MigrationObject?, newObject: MigrationObject?) -> Void
 
 /**
-Specify a schema version and an associated migration block which is applied when
-opening the default Realm with an old schema version.
-
-Before you can open an existing `Realm` which has a different on-disk schema
-from the schema defined in your object interfaces, you must provide a migration
-block which converts from the disk schema to your current object schema. At the
-minimum your migration block must initialize any properties which were added to
-existing objects without defaults and ensure uniqueness if a primary key
-property is added to an existing object.
-
-You should call this method before accessing any `Realm` instances which
-require migration. After registering your migration block, Realm will call your
-block automatically as needed.
-
-:warning: Unsuccessful migrations will throw exceptions when the migration block is applied.
-          This will happen in the following cases:
-
-          - The given `schemaVersion` is lower than the target Realm's current schema version.
-          - A new property without a default was added to an object and not initialized
-            during the migration. You are required to either supply a default value or to
-            manually populate added properties during a migration.
-
-:param: version The current schema version.
-:param: block   The block which migrates the Realm to the current version.
-*/
-@availability(*, deprecated=1, message="Use Realm(configuration:error:)")
-public func setDefaultRealmSchemaVersion(schemaVersion: UInt64, migrationBlock: MigrationBlock) {
-    RLMRealmSetSchemaVersionForPath(schemaVersion, Realm.defaultPath, accessorMigrationBlock(migrationBlock))
-}
-
-/**
-Specify a schema version and an associated migration block which is applied when
-opening a Realm at the specified path with an old schema version.
-
-Before you can open an existing `Realm` which has a different on-disk schema
-from the schema defined in your object interfaces, you must provide a migration
-block which converts from the disk schema to your current object schema. At the
-minimum your migration block must initialize any properties which were added to
-existing objects without defaults and ensure uniqueness if a primary key
-property is added to an existing object.
-
-You should call this method before accessing any `Realm` instances which
-require migration. After registering your migration block, Realm will call your
-block automatically as needed.
-
-:param: version   The current schema version.
-:param: realmPath The path of the Realms to migrate.
-:param: block     The block which migrates the Realm to the current version.
-*/
-@availability(*, deprecated=1, message="Use Realm(configuration:error:)")
-public func setSchemaVersion(schemaVersion: UInt64, realmPath: String, migrationBlock: MigrationBlock) {
-    RLMRealmSetSchemaVersionForPath(schemaVersion, realmPath, accessorMigrationBlock(migrationBlock))
-}
-
-/**
 Get the schema version for a Realm at a given path.
 :param: realmPath     Path to a Realm file.
 :param: encryptionKey Optional 64-byte encryption key for encrypted Realms.
@@ -112,31 +57,6 @@ public func schemaVersionAtPath(realmPath: String, encryptionKey: NSData? = nil,
         return nil
     }
     return version
-}
-
-/**
-Performs the registered migration block on a Realm at the given path.
-
-This method is called automatically when opening a Realm for the first time and does
-not need to be called explicitly. You can choose to call this method to control
-exactly when and how migrations are performed.
-
-:param: path          The path of the Realm to migrate.
-:param: encryptionKey Optional 64-byte encryption key for encrypted Realms.
-                      If the Realms at the given path are not encrypted, omit the argument or pass
-                      in `nil`.
-
-:returns: `nil` if the migration was successful, or an `NSError` object that describes the problem
-          that occured otherwise.
-*/
-@availability(*, deprecated=1, message="Use migrateRealm(configuration:)")
-public func migrateRealm(path: String, encryptionKey: NSData? = nil) -> NSError? {
-    let configuration = RLMRealmConfiguration.defaultConfiguration()
-    configuration.path = path
-    configuration.encryptionKey = encryptionKey
-    configuration.schemaVersion = UInt64(RLMRealmSchemaVersionForPath(path))
-    configuration.migrationBlock = RLMRealmMigrationBlockForPath(path)
-    return RLMRealm.migrateRealm(configuration)
 }
 
 /**

--- a/RealmSwift-swift1.2/Realm.swift
+++ b/RealmSwift-swift1.2/Realm.swift
@@ -61,25 +61,6 @@ public final class Realm {
     /// Indicates if this Realm contains any objects.
     public var isEmpty: Bool { return rlmRealm.isEmpty }
 
-    /**
-    The location of the default Realm as a string. Can be overridden.
-
-    `~/Library/Application Support/{bundle ID}/default.realm` on OS X.
-
-    `default.realm` in your application's documents directory on iOS.
-
-    :returns: Location of the default Realm.
-    */
-    @availability(*, deprecated=1, message="Use Configuration.defaultConfiguration")
-    public class var defaultPath: String {
-        get {
-            return Configuration.defaultConfiguration.path ?? RLMRealmConfiguration.defaultRealmPath()
-        }
-        set {
-            RLMRealmConfiguration.setDefaultPath(newValue)
-        }
-    }
-
     // MARK: Initializers
 
     /**
@@ -115,57 +96,6 @@ public final class Realm {
     */
     public convenience init(path: String) {
         self.init(RLMRealm(path: path, key: nil, readOnly: false, inMemory: false, dynamic: false, schema: nil, error: nil)!)
-    }
-
-    /**
-    Obtains a `Realm` instance with persistence to a specific file path with
-    options.
-
-    Like `init(path:)`, but with the ability to open read-only realms and get
-    errors as an `NSError` inout parameter rather than exceptions.
-
-    :warning: Read-only Realms do not support changes made to the file while the
-              `Realm` exists. This means that you cannot open a Realm as both read-only
-              and read-write at the same time. Read-only Realms should normally only be used
-              on files which cannot be opened in read-write mode, and not just for enforcing
-              correctness in code that should not need to write to the Realm.
-
-    :param: path            Path to the file you want the data saved in.
-    :param: readOnly        Bool indicating if this Realm is read-only (must use for read-only files).
-    :param: encryptionKey   64-byte key to use to encrypt the data.
-    :param: error           If an error occurs, upon return contains an `NSError` object
-                            that describes the problem. If you are not interested in
-                            possible errors, omit the argument, or pass in `nil`.
-    */
-    @availability(*, deprecated=1, message="Use Realm(configuration:error:)")
-    public convenience init?(path: String, readOnly: Bool, encryptionKey: NSData? = nil, error: NSErrorPointer = nil) {
-        if let rlmRealm = RLMRealm(path: path, key: encryptionKey, readOnly: readOnly, inMemory: false, dynamic: false, schema: nil, error: error) as RLMRealm? {
-            self.init(rlmRealm)
-        } else {
-            self.init(RLMRealm())
-            return nil
-        }
-    }
-
-    /**
-    Obtains a Realm instance for an un-persisted in-memory Realm. The identifier
-    used to create this instance can be used to access the same in-memory Realm from
-    multiple threads.
-
-    Because in-memory Realms are not persisted, you must be sure to hold on to a
-    reference to the `Realm` object returned from this for as long as you want
-    the data to last. Realm's internal cache of `Realm`s will not keep the
-    in-memory Realm alive across cycles of the run loop, so without a strong
-    reference to the `Realm` a new Realm will be created each time. Note that
-    `Object`s, `List`s, and `Results` that refer to objects persisted in a Realm have a
-    strong reference to the relevant `Realm`, as do `NotifcationToken`s.
-
-    :param: identifier A string used to identify a particular in-memory Realm.
-    */
-    @availability(*, deprecated=1, message="Use Realm(configuration:error:)")
-    public convenience init(inMemoryIdentifier: String) {
-        let configuration = Configuration(inMemoryIdentifier: inMemoryIdentifier).rlmConfiguration
-        self.init(RLMRealm(configuration: configuration, error: nil)!)
     }
 
     // MARK: Transactions
@@ -627,28 +557,6 @@ public final class Realm {
             rlmRealm.writeCopyToPath(path, error: &error)
         }
         return error
-    }
-
-    // MARK: Encryption
-
-    /**
-    Set the encryption key to use when opening Realms at a certain path.
-
-    This can be used as an alternative to explicitly passing the key to
-    `Realm(path:, encryptionKey:, readOnly:, error:)` each time a Realm instance is
-    needed. The encryption key will be used any time a Realm is opened with
-    `Realm(path:)` or `Realm()`.
-
-    If you do not want Realm to hold on to your encryption keys any longer than
-    needed, then use `Realm(path:, encryptionKey:, readOnly:, error:)` rather than this
-    method.
-
-    :param: encryptionKey 64-byte encryption key to use, or `nil` to unset.
-    :param: path          Realm path to set the encryption key for.
-    +*/
-    @availability(*, deprecated=1, message="Use Realm(configuration:error:)")
-    public class func setEncryptionKey(encryptionKey: NSData?, forPath path: String = Realm.defaultPath) {
-        RLMRealmSetEncryptionKeyForPath(encryptionKey, path)
     }
 
     // MARK: Internal

--- a/RealmSwift-swift1.2/RealmConfiguration.swift
+++ b/RealmSwift-swift1.2/RealmConfiguration.swift
@@ -55,7 +55,7 @@ extension Realm {
 
         :returns: An initialized `Configuration`.
         */
-        public init(path: String? = RLMRealmConfiguration.defaultRealmPath(),
+        public init(path: String? = RLMRealmPathForFile("default.realm"),
             inMemoryIdentifier: String? = nil,
             encryptionKey: NSData? = nil,
             readOnly: Bool = false,

--- a/RealmSwift-swift1.2/Tests/MigrationTests.swift
+++ b/RealmSwift-swift1.2/Tests/MigrationTests.swift
@@ -24,7 +24,7 @@ import Realm.Dynamic
 import Foundation
 
 private func realmWithCustomSchema(path: String, schema :RLMSchema) -> RLMRealm {
-    return RLMRealm(path: path, key: nil, readOnly: false, inMemory: false, dynamic: true, schema: schema, error: nil)!
+    return RLMRealm(path: path, key: nil, readOnly: false, inMemory: false, dynamic: true, schema: schema, error: nil)
 }
 
 private func realmWithSingleClass(path: String, objectSchema: RLMObjectSchema) -> RLMRealm {
@@ -49,7 +49,7 @@ class MigrationTests: TestCase {
     // create realm at path and test version is 0
     private func createAndTestRealmAtPath(realmPath: String) {
         autoreleasepool {
-            Realm(path: realmPath)
+            _ = Realm(path: realmPath)
             return
         }
         XCTAssertEqual(UInt64(0), schemaVersionAtPath(realmPath)!, "Initial version should be 0")
@@ -58,7 +58,7 @@ class MigrationTests: TestCase {
     // migrate realm at path and ensure migration
     private func migrateAndTestRealm(realmPath: String, shouldRun: Bool = true, schemaVersion: UInt64 = 1, autoMigration: Bool = false, block: MigrationBlock? = nil) {
         var didRun = false
-        setSchemaVersion(schemaVersion, realmPath, { migration, oldSchemaVersion in
+        let config = Realm.Configuration(path: realmPath, schemaVersion: schemaVersion, migrationBlock: { migration, oldSchemaVersion in
             if let block = block {
                 block(migration: migration, oldSchemaVersion: oldSchemaVersion)
             }
@@ -67,28 +67,37 @@ class MigrationTests: TestCase {
         })
 
         if autoMigration {
-            Realm(path: realmPath)
+            autoreleasepool {
+                _ = Realm(configuration: config)
+            }
         }
         else {
-            migrateRealm(realmPath, encryptionKey: nil)
+            migrateRealm(configuration: config)
         }
 
         XCTAssertEqual(didRun, shouldRun)
     }
 
+    private func migrateAndTestDefaultRealm(schemaVersion: UInt64 = 1, block: MigrationBlock) {
+        migrateAndTestRealm(defaultRealmPath(), schemaVersion: schemaVersion, block: block)
+        Realm.Configuration.defaultConfiguration = Realm.Configuration(path: defaultRealmPath(), schemaVersion: schemaVersion)
+    }
+
     // MARK Test cases
 
     func testSetDefaultRealmSchemaVersion() {
-        createAndTestRealmAtPath(Realm.defaultPath)
+        createAndTestRealmAtPath(defaultRealmPath())
+
         var didRun = false
-        setDefaultRealmSchemaVersion(1, { migration, oldSchemaVersion in
+        let config = Realm.Configuration(path: defaultRealmPath(), schemaVersion: 1, migrationBlock: { migration, oldSchemaVersion in
             didRun = true
-            return
         })
-        migrateRealm(Realm.defaultPath, encryptionKey: nil)
+        Realm.Configuration.defaultConfiguration = config
+
+        migrateRealm()
 
         XCTAssertEqual(didRun, true)
-        XCTAssertEqual(UInt64(1), schemaVersionAtPath(Realm.defaultPath)!)
+        XCTAssertEqual(UInt64(1), schemaVersionAtPath(defaultRealmPath())!)
     }
 
     func testSetSchemaVersion() {
@@ -100,11 +109,11 @@ class MigrationTests: TestCase {
 
     func testSchemaVersionAtPath() {
         var error : NSError? = nil
-        assertNil(schemaVersionAtPath(Realm.defaultPath, error: &error), "Version should be nil before Realm creation")
+        assertNil(schemaVersionAtPath(defaultRealmPath(), error: &error), "Version should be nil before Realm creation")
         XCTAssertNotNil(error, "Error should be set")
 
-        Realm()
-        XCTAssertEqual(UInt64(0), schemaVersionAtPath(Realm.defaultPath)!, "Initial version should be 0")
+        _ = Realm()
+        XCTAssertEqual(UInt64(0), schemaVersionAtPath(defaultRealmPath())!, "Initial version should be 0")
         assertThrows(schemaVersionAtPath("/dev/null"))
     }
 
@@ -123,19 +132,18 @@ class MigrationTests: TestCase {
 
     func testMigrationProperties() {
         let prop = RLMProperty(name: "stringCol", type: RLMPropertyType.Int, objectClassName: nil, indexed: false, optional: false)
-        autoreleasepool { () -> () in
-            realmWithSingleClassProperties(Realm.defaultPath, "SwiftStringObject", [prop])
-            return
+        autoreleasepool {
+            realmWithSingleClassProperties(defaultRealmPath(), "SwiftStringObject", [prop])
         }
 
-        migrateAndTestRealm(Realm.defaultPath, block: { migration, oldSchemaVersion in
+        migrateAndTestDefaultRealm() { migration, oldSchemaVersion in
             XCTAssertEqual(migration.oldSchema.objectSchema.count, 1)
             XCTAssertGreaterThan(migration.newSchema.objectSchema.count, 1)
             XCTAssertEqual(migration.oldSchema.objectSchema[0].properties.count, 1)
             XCTAssertEqual(migration.newSchema["SwiftStringObject"]!.properties.count, 1)
             XCTAssertEqual(migration.oldSchema["SwiftStringObject"]!.properties[0].type, PropertyType.Int)
             XCTAssertEqual(migration.newSchema["SwiftStringObject"]!["stringCol"]!.type, PropertyType.String)
-        })
+        }
     }
 
     func testEnumerate() {
@@ -143,14 +151,12 @@ class MigrationTests: TestCase {
             _ = Realm()
         }
 
-        autoreleasepool {
-            self.migrateAndTestRealm(Realm.defaultPath, block: { migration, oldSchemaVersion in
-                migration.enumerate("SwiftStringObject", { oldObj, newObj in
-                    XCTFail("No objects to enumerate")
-                })
-
-                migration.enumerate("NoSuchClass", {oldObj, newObj in}) // shouldn't throw
+        migrateAndTestDefaultRealm() { migration, oldSchemaVersion in
+            migration.enumerate("SwiftStringObject", { oldObj, newObj in
+                XCTFail("No objects to enumerate")
             })
+
+            migration.enumerate("NoSuchClass", {oldObj, newObj in}) // shouldn't throw
         }
 
         autoreleasepool {
@@ -161,20 +167,18 @@ class MigrationTests: TestCase {
             }
         }
 
-        autoreleasepool {
-            self.migrateAndTestRealm(Realm.defaultPath, schemaVersion: 2, block: { migration, oldSchemaVersion in
-                var count = 0
-                migration.enumerate("SwiftStringObject", { oldObj, newObj in
-                    XCTAssertEqual(newObj!.objectSchema.className, "SwiftStringObject")
-                    XCTAssertEqual(oldObj!.objectSchema.className, "SwiftStringObject")
-                    XCTAssertEqual(newObj!["stringCol"] as! String, "string")
-                    XCTAssertEqual(oldObj!["stringCol"] as! String, "string")
-                    self.assertThrows(oldObj!["noSuchCol"] as! String)
-                    self.assertThrows(newObj!["noSuchCol"] as! String)
-                    count++
-                })
-                XCTAssertEqual(count, 1)
+        migrateAndTestDefaultRealm(schemaVersion: 2) { migration, oldSchemaVersion in
+            var count = 0
+            migration.enumerate("SwiftStringObject", { oldObj, newObj in
+                XCTAssertEqual(newObj!.objectSchema.className, "SwiftStringObject")
+                XCTAssertEqual(oldObj!.objectSchema.className, "SwiftStringObject")
+                XCTAssertEqual((newObj!["stringCol"] as! String), "string")
+                XCTAssertEqual((oldObj!["stringCol"] as! String), "string")
+                self.assertThrows(oldObj!["noSuchCol"] as! String)
+                self.assertThrows(newObj!["noSuchCol"] as! String)
+                count++
             })
+            XCTAssertEqual(count, 1)
         }
 
         autoreleasepool {
@@ -183,15 +187,13 @@ class MigrationTests: TestCase {
             }
         }
 
-        autoreleasepool {
-            self.migrateAndTestRealm(Realm.defaultPath, schemaVersion: 3, block: { migration, oldSchemaVersion in
-                migration.enumerate("SwiftArrayPropertyObject") { oldObject, newObject in
-                    XCTAssertTrue(oldObject! as AnyObject is MigrationObject)
-                    XCTAssertTrue(newObject! as AnyObject is MigrationObject)
-                    XCTAssertTrue(oldObject!["array"]! is List<MigrationObject>)
-                    XCTAssertTrue(oldObject!["array"]! is List<MigrationObject>)
-                }
-            })
+        migrateAndTestDefaultRealm(schemaVersion: 3) { migration, oldSchemaVersion in
+            migration.enumerate("SwiftArrayPropertyObject") { oldObject, newObject in
+                XCTAssertTrue(oldObject! as AnyObject is MigrationObject)
+                XCTAssertTrue(newObject! as AnyObject is MigrationObject)
+                XCTAssertTrue(oldObject!["array"]! is List<MigrationObject>)
+                XCTAssertTrue(oldObject!["array"]! is List<MigrationObject>)
+            }
         }
     }
 
@@ -200,13 +202,13 @@ class MigrationTests: TestCase {
             _ = Realm()
         }
 
-        migrateAndTestRealm(Realm.defaultPath, block: { migration, oldSchemaVersion in
+        migrateAndTestDefaultRealm() { migration, oldSchemaVersion in
             migration.create("SwiftStringObject", value: ["string"])
             migration.create("SwiftStringObject", value: ["stringCol": "string"])
             migration.create("SwiftStringObject")
 
             self.assertThrows(migration.create("NoSuchObject", value: []))
-        })
+        }
 
         let objects = Realm().objects(SwiftStringObject)
         XCTAssertEqual(objects.count, 3)
@@ -224,7 +226,7 @@ class MigrationTests: TestCase {
             }
         }
 
-        self.migrateAndTestRealm(Realm.defaultPath, block: { migration, oldSchemaVersion in
+        migrateAndTestDefaultRealm() { migration, oldSchemaVersion in
             var deleted = false;
             migration.enumerate("SwiftStringObject", { oldObj, newObj in
                 if deleted == false {
@@ -232,44 +234,39 @@ class MigrationTests: TestCase {
                     deleted = true
                 }
             })
-        })
+        }
 
         XCTAssertEqual(Realm().objects(SwiftStringObject).count, 1)
     }
 
     func testDeleteData() {
         autoreleasepool {
-            let realm = realmWithSingleClassProperties(testRealmPath(), "DeletedClass", [])
+            let realm = realmWithSingleClassProperties(defaultRealmPath(), "DeletedClass", [])
             realm.transactionWithBlock {
                 realm.createObject("DeletedClass", withValue: [])
             }
         }
 
-        autoreleasepool {
-            setSchemaVersion(1, testRealmPath()) { migration, oldSchemaVersion in
-                XCTAssertEqual(oldSchemaVersion, 0, "Initial schema version should be 0");
+        migrateAndTestDefaultRealm() { migration, oldSchemaVersion in
+            XCTAssertEqual(oldSchemaVersion, 0, "Initial schema version should be 0");
 
-                XCTAssertTrue(migration.deleteData("DeletedClass"));
-                XCTAssertFalse(migration.deleteData("NoSuchClass"));
+            XCTAssertTrue(migration.deleteData("DeletedClass"));
+            XCTAssertFalse(migration.deleteData("NoSuchClass"));
 
-                migration.create(SwiftStringObject.className(), value: ["migration"])
-                XCTAssertTrue(migration.deleteData(SwiftStringObject.className()));
-            }
-            migrateRealm(testRealmPath())
+            migration.create(SwiftStringObject.className(), value: ["migration"])
+            XCTAssertTrue(migration.deleteData(SwiftStringObject.className()));
         }
 
-        autoreleasepool {
-            let realm = dynamicRealm(testRealmPath())
-            XCTAssertNil(realm.schema.schemaForClassName("DeletedClass"))
-            XCTAssertEqual(0, realm.allObjects("SwiftStringObject").count)
-        }
+        let realm = dynamicRealm(defaultRealmPath())
+        XCTAssertNil(realm.schema.schemaForClassName("DeletedClass"))
+        XCTAssertEqual(0, realm.allObjects("SwiftStringObject").count)
     }
 
     // test getting/setting all property types
     func testMigrationObject() {
         autoreleasepool {
             Realm().write {
-                var object = SwiftObject()
+                let object = SwiftObject()
                 object.boolCol = true
                 object.objectCol = SwiftBoolObject(value: [true])
                 object.arrayCol.append(SwiftBoolObject(value: [false]))
@@ -278,34 +275,34 @@ class MigrationTests: TestCase {
             }
         }
 
-        self.migrateAndTestRealm(Realm.defaultPath, block: { migration, oldSchemaVersion in
+        migrateAndTestDefaultRealm() { migration, oldSchemaVersion in
             var enumerated = false
             migration.enumerate("SwiftObject", { oldObj, newObj in
-                XCTAssertEqual(oldObj!["boolCol"] as! Bool, true)
-                XCTAssertEqual(newObj!["boolCol"] as! Bool, true)
-                XCTAssertEqual(oldObj!["intCol"] as! Int, 123)
-                XCTAssertEqual(newObj!["intCol"] as! Int, 123)
-                XCTAssertEqual(oldObj!["floatCol"] as! Float, 1.23 as Float)
-                XCTAssertEqual(newObj!["floatCol"] as! Float, 1.23 as Float)
-                XCTAssertEqual(oldObj!["doubleCol"] as! Double, 12.3 as Double)
-                XCTAssertEqual(newObj!["doubleCol"] as! Double, 12.3 as Double)
+                XCTAssertEqual((oldObj!["boolCol"] as! Bool), true)
+                XCTAssertEqual((newObj!["boolCol"] as! Bool), true)
+                XCTAssertEqual((oldObj!["intCol"] as! Int), 123)
+                XCTAssertEqual((newObj!["intCol"] as! Int), 123)
+                XCTAssertEqual((oldObj!["floatCol"] as! Float), 1.23 as Float)
+                XCTAssertEqual((newObj!["floatCol"] as! Float), 1.23 as Float)
+                XCTAssertEqual((oldObj!["doubleCol"] as! Double), 12.3 as Double)
+                XCTAssertEqual((newObj!["doubleCol"] as! Double), 12.3 as Double)
 
-                var binaryCol = "a".dataUsingEncoding(NSUTF8StringEncoding)!
-                XCTAssertEqual(oldObj!["binaryCol"] as! NSData, binaryCol)
-                XCTAssertEqual(newObj!["binaryCol"] as! NSData, binaryCol)
+                let binaryCol = "a".dataUsingEncoding(NSUTF8StringEncoding)!
+                XCTAssertEqual((oldObj!["binaryCol"] as! NSData), binaryCol)
+                XCTAssertEqual((newObj!["binaryCol"] as! NSData), binaryCol)
 
-                var dateCol = NSDate(timeIntervalSince1970: 1)
-                XCTAssertEqual(oldObj!["dateCol"] as! NSDate, dateCol)
-                XCTAssertEqual(newObj!["dateCol"] as! NSDate, dateCol)
+                let dateCol = NSDate(timeIntervalSince1970: 1)
+                XCTAssertEqual((oldObj!["dateCol"] as! NSDate), dateCol)
+                XCTAssertEqual((newObj!["dateCol"] as! NSDate), dateCol)
 
                 // FIXME - test that casting to SwiftBoolObject throws
-                XCTAssertEqual((oldObj!["objectCol"] as! MigrationObject)["boolCol"] as! Bool, true)
-                XCTAssertEqual((newObj!["objectCol"] as! MigrationObject)["boolCol"] as! Bool, true)
+                XCTAssertEqual(((oldObj!["objectCol"] as! MigrationObject)["boolCol"] as! Bool), true)
+                XCTAssertEqual(((newObj!["objectCol"] as! MigrationObject)["boolCol"] as! Bool), true)
 
                 XCTAssertEqual((oldObj!["arrayCol"] as! List<MigrationObject>).count, 1)
-                XCTAssertEqual((oldObj!["arrayCol"] as! List<MigrationObject>)[0]["boolCol"] as! Bool, false)
+                XCTAssertEqual(((oldObj!["arrayCol"] as! List<MigrationObject>)[0]["boolCol"] as! Bool), false)
                 XCTAssertEqual((newObj!["arrayCol"] as! List<MigrationObject>).count, 1)
-                XCTAssertEqual((newObj!["arrayCol"] as! List<MigrationObject>)[0]["boolCol"] as! Bool, false)
+                XCTAssertEqual(((newObj!["arrayCol"] as! List<MigrationObject>)[0]["boolCol"] as! Bool), false)
 
                 // edit all values
                 newObj!["boolCol"] = false
@@ -328,9 +325,9 @@ class MigrationTests: TestCase {
                 // verify list property
                 list = newObj!["arrayCol"] as! List<MigrationObject>
                 XCTAssertEqual(list.count, 3)
-                XCTAssertEqual(list[0]["boolCol"] as! Bool, true)
-                XCTAssertEqual(list[1]["boolCol"] as! Bool, false)
-                XCTAssertEqual(list[2]["boolCol"] as! Bool, true)
+                XCTAssertEqual((list[0]["boolCol"] as! Bool), true)
+                XCTAssertEqual((list[1]["boolCol"] as! Bool), false)
+                XCTAssertEqual((list[2]["boolCol"] as! Bool), true)
 
                 self.assertThrows(newObj!.valueForKey("noSuchKey"))
                 self.assertThrows(newObj!.setValue(1, forKey: "noSuchKey"))
@@ -341,7 +338,7 @@ class MigrationTests: TestCase {
                 enumerated = true
             })
             XCTAssertEqual(enumerated, true)
-        })
+        }
 
         // refresh to update realm
         Realm().refresh()

--- a/RealmSwift-swift1.2/Tests/TestCase.swift
+++ b/RealmSwift-swift1.2/Tests/TestCase.swift
@@ -43,6 +43,9 @@ class TestCase: XCTestCase {
         // re-enabled and we need it enabled for performance tests
         RLMDisableSyncToDisk()
 #endif
+        // Clean up any potentially lingering Realm files from previous runs
+        NSFileManager.defaultManager().removeItemAtPath(RLMRealmPathForFile(""), error: nil)
+        // The directory might not actually already exist, so not an error
     }
 
     override func invokeTest() {

--- a/RealmSwift-swift1.2/Tests/TestCase.swift
+++ b/RealmSwift-swift1.2/Tests/TestCase.swift
@@ -46,18 +46,18 @@ class TestCase: XCTestCase {
     }
 
     override func invokeTest() {
-        Realm.defaultPath = realmPathForFile("\(realmFilePrefix()).default.realm")
+        Realm.Configuration.defaultConfiguration = Realm.Configuration(path: realmPathForFile("\(realmFilePrefix()).default.realm"))
         NSFileManager.defaultManager().createDirectoryAtPath(realmPathForFile(""), withIntermediateDirectories: true, attributes: nil, error: nil)
 
         exceptionThrown = false
         autoreleasepool { super.invokeTest() }
 
         if exceptionThrown {
-            RLMDeallocateRealm(Realm.defaultPath)
+            RLMDeallocateRealm(defaultRealmPath())
             RLMDeallocateRealm(testRealmPath())
         }
         else {
-            XCTAssertNil(RLMGetThreadLocalCachedRealmForPath(Realm.defaultPath))
+            XCTAssertNil(RLMGetThreadLocalCachedRealmForPath(defaultRealmPath()))
             XCTAssertNil(RLMGetThreadLocalCachedRealmForPath(testRealmPath()))
         }
         deleteRealmFiles()
@@ -96,10 +96,14 @@ class TestCase: XCTestCase {
     internal func testRealmPath() -> String {
         return realmPathForFile("\(realmFilePrefix()).realm")
     }
+
+    internal func defaultRealmPath() -> String {
+        return realmPathForFile("\(realmFilePrefix()).default.realm")
+    }
 }
 
 private func realmPathForFile(fileName: String) -> String {
-    var path = Realm.defaultPath.stringByDeletingLastPathComponent
+    var path = (Realm.Configuration.defaultConfiguration.path! as NSString).stringByDeletingLastPathComponent
     if path.lastPathComponent != "testRealms" {
         path = path.stringByAppendingPathComponent("testRealms")
     }

--- a/RealmSwift-swift2.0/Migration.swift
+++ b/RealmSwift-swift2.0/Migration.swift
@@ -43,61 +43,6 @@ accessed using subscripting.
 public typealias MigrationObjectEnumerateBlock = (oldObject: MigrationObject?, newObject: MigrationObject?) -> Void
 
 /**
-Specify a schema version and an associated migration block which is applied when
-opening the default Realm with an old schema version.
-
-Before you can open an existing `Realm` which has a different on-disk schema
-from the schema defined in your object interfaces, you must provide a migration
-block which converts from the disk schema to your current object schema. At the
-minimum your migration block must initialize any properties which were added to
-existing objects without defaults and ensure uniqueness if a primary key
-property is added to an existing object.
-
-You should call this method before accessing any `Realm` instances which
-require migration. After registering your migration block, Realm will call your
-block automatically as needed.
-
-- warning: Unsuccessful migrations will throw exceptions when the migration block is applied.
-           This will happen in the following cases:
-
-           - The given `schemaVersion` is lower than the target Realm's current schema version.
-           - A new property without a default was added to an object and not initialized
-             during the migration. You are required to either supply a default value or to
-             manually populate added properties during a migration.
-
-- parameter version: The current schema version.
-- parameter block:   The block which migrates the Realm to the current version.
-*/
-@available(*, deprecated=1, message="Use Realm(configuration:error:)")
-public func setDefaultRealmSchemaVersion(schemaVersion: UInt64, migrationBlock: MigrationBlock) {
-    RLMRealmSetSchemaVersionForPath(schemaVersion, Realm.Configuration.defaultConfiguration.path, accessorMigrationBlock(migrationBlock))
-}
-
-/**
-Specify a schema version and an associated migration block which is applied when
-opening a Realm at the specified path with an old schema version.
-
-Before you can open an existing `Realm` which has a different on-disk schema
-from the schema defined in your object interfaces, you must provide a migration
-block which converts from the disk schema to your current object schema. At the
-minimum your migration block must initialize any properties which were added to
-existing objects without defaults and ensure uniqueness if a primary key
-property is added to an existing object.
-
-You should call this method before accessing any `Realm` instances which
-require migration. After registering your migration block, Realm will call your
-block automatically as needed.
-
-- parameter version:   The current schema version.
-- parameter realmPath: The path of the Realms to migrate.
-- parameter block:     The block which migrates the Realm to the current version.
-*/
-@available(*, deprecated=1, message="Use Realm(configuration:error:)")
-public func setSchemaVersion(schemaVersion: UInt64, realmPath: String, migrationBlock: MigrationBlock) {
-    RLMRealmSetSchemaVersionForPath(schemaVersion, realmPath, accessorMigrationBlock(migrationBlock))
-}
-
-/**
 Get the schema version for a Realm at a given path.
 - parameter realmPath:     Path to a Realm file.
 - parameter encryptionKey: Optional 64-byte encryption key for encrypted Realms.
@@ -113,31 +58,6 @@ public func schemaVersionAtPath(realmPath: String, encryptionKey: NSData? = nil,
         return nil
     }
     return version
-}
-
-/**
-Performs the registered migration block on a Realm at the given path.
-
-This method is called automatically when opening a Realm for the first time and does
-not need to be called explicitly. You can choose to call this method to control
-exactly when and how migrations are performed.
-
-- parameter path:          The path of the Realm to migrate.
-- parameter encryptionKey: Optional 64-byte encryption key for encrypted Realms.
-                           If the Realms at the given path are not encrypted, omit the argument or pass
-                           in `nil`.
-
-- returns: `nil` if the migration was successful, or an `NSError` object that describes the problem
-           that occured otherwise.
-*/
-@available(*, deprecated=1, message="Use migrateRealm(configuration:)")
-public func migrateRealm(path: String, encryptionKey: NSData? = nil) -> NSError? {
-    let configuration = RLMRealmConfiguration.defaultConfiguration()
-    configuration.path = path
-    configuration.encryptionKey = encryptionKey
-    configuration.schemaVersion = UInt64(RLMRealmSchemaVersionForPath(path))
-    configuration.migrationBlock = RLMRealmMigrationBlockForPath(path)
-    return RLMRealm.migrateRealm(configuration)
 }
 
 /**

--- a/RealmSwift-swift2.0/Realm.swift
+++ b/RealmSwift-swift2.0/Realm.swift
@@ -61,25 +61,6 @@ public final class Realm {
     /// Indicates if this Realm contains any objects.
     public var isEmpty: Bool { return rlmRealm.isEmpty }
 
-    /**
-    The location of the default Realm as a string. Can be overridden.
-
-    `~/Library/Application Support/{bundle ID}/default.realm` on OS X.
-
-    `default.realm` in your application's documents directory on iOS.
-
-    - returns: Location of the default Realm.
-    */
-    @available(*, deprecated=1, message="Use Realm.Configuration.defaultConfiguration")
-    public class var defaultPath: String {
-        get {
-            return Configuration.defaultConfiguration.path ?? RLMRealmConfiguration.defaultRealmPath()
-        }
-        set {
-            RLMRealmConfiguration.setDefaultPath(newValue)
-        }
-    }
-
     // MARK: Initializers
 
     /**
@@ -89,9 +70,7 @@ public final class Realm {
     - parameter configuration: The configuration to use when creating the Realm instance.
     */
     public convenience init(configuration: Configuration = Configuration.defaultConfiguration) throws {
-        let rlmConfiguration = configuration.rlmConfiguration
-        RLMRealmAddPathSettingsToConfiguration(rlmConfiguration)
-        let rlmRealm = try RLMRealm(configuration: rlmConfiguration)
+        let rlmRealm = try RLMRealm(configuration: configuration.rlmConfiguration)
         self.init(rlmRealm)
     }
 
@@ -103,50 +82,6 @@ public final class Realm {
     public convenience init(path: String) throws {
         let rlmRealm = try RLMRealm(path: path, key: nil, readOnly: false, inMemory: false, dynamic: false, schema: nil)
         self.init(rlmRealm)
-    }
-
-    /**
-    Obtains a `Realm` instance with persistence to a specific file path with
-    options.
-
-    Like `init(path:)`, but with the ability to open read-only realms and
-    encrypted realms.
-
-    - warning: Read-only Realms do not support changes made to the file while the
-               `Realm` exists. This means that you cannot open a Realm as both read-only
-               and read-write at the same time. Read-only Realms should normally only be used
-               on files which cannot be opened in read-write mode, and not just for enforcing
-               correctness in code that should not need to write to the Realm.
-
-    - parameter path:          Path to the file you want the data saved in.
-    - parameter readOnly:      Bool indicating if this Realm is read-only (must use for read-only files).
-    - parameter encryptionKey: 64-byte key to use to encrypt the data.
-    */
-    @available(*, deprecated=1, message="Use Realm(configuration:)")
-    public convenience init(path: String, readOnly: Bool, encryptionKey: NSData? = nil) throws {
-        let rlmRealm = try RLMRealm(path: path, key: encryptionKey, readOnly: readOnly, inMemory: false, dynamic: false, schema: nil)
-        self.init(rlmRealm)
-    }
-
-    /**
-    Obtains a Realm instance for an un-persisted in-memory Realm. The identifier
-    used to create this instance can be used to access the same in-memory Realm from
-    multiple threads.
-
-    Because in-memory Realms are not persisted, you must be sure to hold on to a
-    reference to the `Realm` object returned from this for as long as you want
-    the data to last. Realm's internal cache of `Realm`s will not keep the
-    in-memory Realm alive across cycles of the run loop, so without a strong
-    reference to the `Realm` a new Realm will be created each time. Note that
-    `Object`s, `List`s, and `Results` that refer to objects persisted in a Realm have a
-    strong reference to the relevant `Realm`, as do `NotifcationToken`s.
-
-    - parameter identifier: A string used to identify a particular in-memory Realm.
-    */
-    @available(*, deprecated=1, message="Use Realm(configuration:)")
-    public convenience init(inMemoryIdentifier: String) throws {
-        let configuration = Configuration(inMemoryIdentifier: inMemoryIdentifier)
-        try self.init(configuration: configuration)
     }
 
     // MARK: Transactions
@@ -594,28 +529,6 @@ public final class Realm {
         } else {
             try rlmRealm.writeCopyToPath(path)
         }
-    }
-
-    // MARK: Encryption
-
-    /**
-    Set the encryption key to use when opening Realms at a certain path.
-
-    This can be used as an alternative to explicitly passing the key to
-    `Realm(path:, encryptionKey:, readOnly:, error:)` each time a Realm instance is
-    needed. The encryption key will be used any time a Realm is opened with
-    `Realm(path:)` or `Realm()`.
-
-    If you do not want Realm to hold on to your encryption keys any longer than
-    needed, then use `Realm(path:, encryptionKey:, readOnly:, error:)` rather than this
-    method.
-
-    - parameter encryptionKey: 64-byte encryption key to use, or `nil` to unset.
-    - parameter path:          Realm path to set the encryption key for.
-    */
-    @available(*, deprecated=1, message="Use Realm(configuration:)")
-    public class func setEncryptionKey(encryptionKey: NSData?, forPath path: String = Realm.defaultPath) {
-        RLMRealmSetEncryptionKeyForPath(encryptionKey, path)
     }
 
     // MARK: Internal

--- a/RealmSwift-swift2.0/RealmConfiguration.swift
+++ b/RealmSwift-swift2.0/RealmConfiguration.swift
@@ -55,7 +55,7 @@ extension Realm {
 
         - returns: An initialized `Realm.Configuration`.
         */
-        public init(path: String? = RLMRealmConfiguration.defaultRealmPath(),
+        public init(path: String? = RLMRealmPathForFile("default.realm"),
             inMemoryIdentifier: String? = nil,
             encryptionKey: NSData? = nil,
             readOnly: Bool = false,

--- a/RealmSwift-swift2.0/Tests/MigrationTests.swift
+++ b/RealmSwift-swift2.0/Tests/MigrationTests.swift
@@ -58,7 +58,7 @@ class MigrationTests: TestCase {
     // migrate realm at path and ensure migration
     private func migrateAndTestRealm(realmPath: String, shouldRun: Bool = true, schemaVersion: UInt64 = 1, autoMigration: Bool = false, block: MigrationBlock? = nil) {
         var didRun = false
-        setSchemaVersion(schemaVersion, realmPath: realmPath, migrationBlock: { migration, oldSchemaVersion in
+        let config = Realm.Configuration(path: realmPath, schemaVersion: schemaVersion, migrationBlock: { migration, oldSchemaVersion in
             if let block = block {
                 block(migration: migration, oldSchemaVersion: oldSchemaVersion)
             }
@@ -67,28 +67,37 @@ class MigrationTests: TestCase {
         })
 
         if autoMigration {
-            _ = try! Realm(path: realmPath)
+            autoreleasepool {
+                _ = try! Realm(configuration: config)
+            }
         }
         else {
-            migrateRealm(realmPath, encryptionKey: nil)
+            migrateRealm(config)
         }
 
         XCTAssertEqual(didRun, shouldRun)
     }
 
+    private func migrateAndTestDefaultRealm(schemaVersion: UInt64 = 1, block: MigrationBlock) {
+        migrateAndTestRealm(defaultRealmPath(), schemaVersion: schemaVersion, block: block)
+        Realm.Configuration.defaultConfiguration = Realm.Configuration(path: defaultRealmPath(), schemaVersion: schemaVersion)
+    }
+
     // MARK Test cases
 
     func testSetDefaultRealmSchemaVersion() {
-        createAndTestRealmAtPath(Realm.defaultPath)
+        createAndTestRealmAtPath(defaultRealmPath())
+
         var didRun = false
-        setDefaultRealmSchemaVersion(1, migrationBlock: { migration, oldSchemaVersion in
+        let config = Realm.Configuration(path: defaultRealmPath(), schemaVersion: 1, migrationBlock: { migration, oldSchemaVersion in
             didRun = true
-            return
         })
-        migrateRealm(Realm.defaultPath, encryptionKey: nil)
+        Realm.Configuration.defaultConfiguration = config
+
+        migrateRealm()
 
         XCTAssertEqual(didRun, true)
-        XCTAssertEqual(UInt64(1), schemaVersionAtPath(Realm.defaultPath)!)
+        XCTAssertEqual(UInt64(1), schemaVersionAtPath(defaultRealmPath())!)
     }
 
     func testSetSchemaVersion() {
@@ -100,11 +109,11 @@ class MigrationTests: TestCase {
 
     func testSchemaVersionAtPath() {
         var error : NSError? = nil
-        assertNil(schemaVersionAtPath(Realm.defaultPath, error: &error), "Version should be nil before Realm creation")
+        assertNil(schemaVersionAtPath(defaultRealmPath(), error: &error), "Version should be nil before Realm creation")
         XCTAssertNotNil(error, "Error should be set")
 
         _ = try! Realm()
-        XCTAssertEqual(UInt64(0), schemaVersionAtPath(Realm.defaultPath)!, "Initial version should be 0")
+        XCTAssertEqual(UInt64(0), schemaVersionAtPath(defaultRealmPath())!, "Initial version should be 0")
         assertThrows(schemaVersionAtPath("/dev/null"))
     }
 
@@ -123,19 +132,18 @@ class MigrationTests: TestCase {
 
     func testMigrationProperties() {
         let prop = RLMProperty(name: "stringCol", type: RLMPropertyType.Int, objectClassName: nil, indexed: false, optional: false)
-        autoreleasepool { () -> () in
-            realmWithSingleClassProperties(Realm.defaultPath, className: "SwiftStringObject", properties: [prop])
-            return
+        autoreleasepool {
+            realmWithSingleClassProperties(defaultRealmPath(), className: "SwiftStringObject", properties: [prop])
         }
 
-        migrateAndTestRealm(Realm.defaultPath, block: { migration, oldSchemaVersion in
+        migrateAndTestDefaultRealm() { migration, oldSchemaVersion in
             XCTAssertEqual(migration.oldSchema.objectSchema.count, 1)
             XCTAssertGreaterThan(migration.newSchema.objectSchema.count, 1)
             XCTAssertEqual(migration.oldSchema.objectSchema[0].properties.count, 1)
             XCTAssertEqual(migration.newSchema["SwiftStringObject"]!.properties.count, 1)
             XCTAssertEqual(migration.oldSchema["SwiftStringObject"]!.properties[0].type, PropertyType.Int)
             XCTAssertEqual(migration.newSchema["SwiftStringObject"]!["stringCol"]!.type, PropertyType.String)
-        })
+        }
     }
 
     func testEnumerate() {
@@ -143,14 +151,12 @@ class MigrationTests: TestCase {
             _ = try! Realm()
         }
 
-        autoreleasepool {
-            self.migrateAndTestRealm(Realm.defaultPath, block: { migration, oldSchemaVersion in
-                migration.enumerate("SwiftStringObject", { oldObj, newObj in
-                    XCTFail("No objects to enumerate")
-                })
-
-                migration.enumerate("NoSuchClass", {oldObj, newObj in}) // shouldn't throw
+        migrateAndTestDefaultRealm() { migration, oldSchemaVersion in
+            migration.enumerate("SwiftStringObject", { oldObj, newObj in
+                XCTFail("No objects to enumerate")
             })
+
+            migration.enumerate("NoSuchClass", {oldObj, newObj in}) // shouldn't throw
         }
 
         autoreleasepool {
@@ -161,20 +167,18 @@ class MigrationTests: TestCase {
             }
         }
 
-        autoreleasepool {
-            self.migrateAndTestRealm(Realm.defaultPath, schemaVersion: 2, block: { migration, oldSchemaVersion in
-                var count = 0
-                migration.enumerate("SwiftStringObject", { oldObj, newObj in
-                    XCTAssertEqual(newObj!.objectSchema.className, "SwiftStringObject")
-                    XCTAssertEqual(oldObj!.objectSchema.className, "SwiftStringObject")
-                    XCTAssertEqual((newObj!["stringCol"] as! String), "string")
-                    XCTAssertEqual((oldObj!["stringCol"] as! String), "string")
-                    self.assertThrows(oldObj!["noSuchCol"] as! String)
-                    self.assertThrows(newObj!["noSuchCol"] as! String)
-                    count++
-                })
-                XCTAssertEqual(count, 1)
+        migrateAndTestDefaultRealm(2) { migration, oldSchemaVersion in
+            var count = 0
+            migration.enumerate("SwiftStringObject", { oldObj, newObj in
+                XCTAssertEqual(newObj!.objectSchema.className, "SwiftStringObject")
+                XCTAssertEqual(oldObj!.objectSchema.className, "SwiftStringObject")
+                XCTAssertEqual((newObj!["stringCol"] as! String), "string")
+                XCTAssertEqual((oldObj!["stringCol"] as! String), "string")
+                self.assertThrows(oldObj!["noSuchCol"] as! String)
+                self.assertThrows(newObj!["noSuchCol"] as! String)
+                count++
             })
+            XCTAssertEqual(count, 1)
         }
 
         autoreleasepool {
@@ -183,15 +187,13 @@ class MigrationTests: TestCase {
             }
         }
 
-        autoreleasepool {
-            self.migrateAndTestRealm(Realm.defaultPath, schemaVersion: 3, block: { migration, oldSchemaVersion in
-                migration.enumerate("SwiftArrayPropertyObject") { oldObject, newObject in
-                    XCTAssertTrue(oldObject! as AnyObject is MigrationObject)
-                    XCTAssertTrue(newObject! as AnyObject is MigrationObject)
-                    XCTAssertTrue(oldObject!["array"]! is List<MigrationObject>)
-                    XCTAssertTrue(oldObject!["array"]! is List<MigrationObject>)
-                }
-            })
+        migrateAndTestDefaultRealm(3) { migration, oldSchemaVersion in
+            migration.enumerate("SwiftArrayPropertyObject") { oldObject, newObject in
+                XCTAssertTrue(oldObject! as AnyObject is MigrationObject)
+                XCTAssertTrue(newObject! as AnyObject is MigrationObject)
+                XCTAssertTrue(oldObject!["array"]! is List<MigrationObject>)
+                XCTAssertTrue(oldObject!["array"]! is List<MigrationObject>)
+            }
         }
     }
 
@@ -200,13 +202,13 @@ class MigrationTests: TestCase {
             _ = try! Realm()
         }
 
-        migrateAndTestRealm(Realm.defaultPath, block: { migration, oldSchemaVersion in
+        migrateAndTestDefaultRealm() { migration, oldSchemaVersion in
             migration.create("SwiftStringObject", value: ["string"])
             migration.create("SwiftStringObject", value: ["stringCol": "string"])
             migration.create("SwiftStringObject")
 
             self.assertThrows(migration.create("NoSuchObject", value: []))
-        })
+        }
 
         let objects = try! Realm().objects(SwiftStringObject)
         XCTAssertEqual(objects.count, 3)
@@ -224,7 +226,7 @@ class MigrationTests: TestCase {
             }
         }
 
-        self.migrateAndTestRealm(Realm.defaultPath, block: { migration, oldSchemaVersion in
+        migrateAndTestDefaultRealm() { migration, oldSchemaVersion in
             var deleted = false;
             migration.enumerate("SwiftStringObject", { oldObj, newObj in
                 if deleted == false {
@@ -232,37 +234,32 @@ class MigrationTests: TestCase {
                     deleted = true
                 }
             })
-        })
+        }
 
         XCTAssertEqual(try! Realm().objects(SwiftStringObject).count, 1)
     }
 
     func testDeleteData() {
         autoreleasepool {
-            let realm = realmWithSingleClassProperties(testRealmPath(), className: "DeletedClass", properties: [])
+            let realm = realmWithSingleClassProperties(defaultRealmPath(), className: "DeletedClass", properties: [])
             try! realm.transactionWithBlock {
                 realm.createObject("DeletedClass", withValue: [])
             }
         }
 
-        autoreleasepool {
-            setSchemaVersion(1, realmPath: testRealmPath()) { migration, oldSchemaVersion in
-                XCTAssertEqual(oldSchemaVersion, 0, "Initial schema version should be 0");
+        migrateAndTestDefaultRealm() { migration, oldSchemaVersion in
+            XCTAssertEqual(oldSchemaVersion, 0, "Initial schema version should be 0");
 
-                XCTAssertTrue(migration.deleteData("DeletedClass"));
-                XCTAssertFalse(migration.deleteData("NoSuchClass"));
+            XCTAssertTrue(migration.deleteData("DeletedClass"));
+            XCTAssertFalse(migration.deleteData("NoSuchClass"));
 
-                migration.create(SwiftStringObject.className(), value: ["migration"])
-                XCTAssertTrue(migration.deleteData(SwiftStringObject.className()));
-            }
-            migrateRealm(testRealmPath())
+            migration.create(SwiftStringObject.className(), value: ["migration"])
+            XCTAssertTrue(migration.deleteData(SwiftStringObject.className()));
         }
 
-        autoreleasepool {
-            let realm = dynamicRealm(testRealmPath())
-            XCTAssertNil(realm.schema.schemaForClassName("DeletedClass"))
-            XCTAssertEqual(0, realm.allObjects("SwiftStringObject").count)
-        }
+        let realm = dynamicRealm(defaultRealmPath())
+        XCTAssertNil(realm.schema.schemaForClassName("DeletedClass"))
+        XCTAssertEqual(0, realm.allObjects("SwiftStringObject").count)
     }
 
     // test getting/setting all property types
@@ -278,7 +275,7 @@ class MigrationTests: TestCase {
             }
         }
 
-        self.migrateAndTestRealm(Realm.defaultPath, block: { migration, oldSchemaVersion in
+        migrateAndTestDefaultRealm() { migration, oldSchemaVersion in
             var enumerated = false
             migration.enumerate("SwiftObject", { oldObj, newObj in
                 XCTAssertEqual((oldObj!["boolCol"] as! Bool), true)
@@ -341,7 +338,7 @@ class MigrationTests: TestCase {
                 enumerated = true
             })
             XCTAssertEqual(enumerated, true)
-        })
+        }
 
         // refresh to update realm
         try! Realm().refresh()

--- a/RealmSwift-swift2.0/Tests/TestCase.swift
+++ b/RealmSwift-swift2.0/Tests/TestCase.swift
@@ -44,6 +44,12 @@ class TestCase: XCTestCase {
         // re-enabled and we need it enabled for performance tests
         RLMDisableSyncToDisk()
 #endif
+        do {
+            // Clean up any potentially lingering Realm files from previous runs
+            try NSFileManager.defaultManager().removeItemAtPath(RLMRealmPathForFile(""))
+        } catch {
+            // The directory might not actually already exist, so not an error
+        }
     }
 
     override func invokeTest() {

--- a/RealmSwift-swift2.0/Tests/TestCase.swift
+++ b/RealmSwift-swift2.0/Tests/TestCase.swift
@@ -46,18 +46,18 @@ class TestCase: XCTestCase {
     }
 
     override func invokeTest() {
-        Realm.defaultPath = realmPathForFile("\(realmFilePrefix()).default.realm")
+        Realm.Configuration.defaultConfiguration = Realm.Configuration(path: realmPathForFile("\(realmFilePrefix()).default.realm"))
         try! NSFileManager.defaultManager().createDirectoryAtPath(realmPathForFile(""), withIntermediateDirectories: true, attributes: nil)
 
         exceptionThrown = false
         autoreleasepool { super.invokeTest() }
 
         if exceptionThrown {
-            RLMDeallocateRealm(Realm.defaultPath)
+            RLMDeallocateRealm(defaultRealmPath())
             RLMDeallocateRealm(testRealmPath())
         }
         else {
-            XCTAssertNil(RLMGetThreadLocalCachedRealmForPath(Realm.defaultPath))
+            XCTAssertNil(RLMGetThreadLocalCachedRealmForPath(defaultRealmPath()))
             XCTAssertNil(RLMGetThreadLocalCachedRealmForPath(testRealmPath()))
         }
         deleteRealmFiles()
@@ -99,10 +99,14 @@ class TestCase: XCTestCase {
     internal func testRealmPath() -> String {
         return realmPathForFile("\(realmFilePrefix()).realm")
     }
+
+    internal func defaultRealmPath() -> String {
+        return realmPathForFile("\(realmFilePrefix()).default.realm")
+    }
 }
 
 private func realmPathForFile(fileName: String) -> String {
-    var path: NSString = (Realm.defaultPath as NSString).stringByDeletingLastPathComponent
+    var path: NSString = (Realm.Configuration.defaultConfiguration.path! as NSString).stringByDeletingLastPathComponent
     if path.lastPathComponent != "testRealms" {
         path = path.stringByAppendingPathComponent("testRealms")
     }


### PR DESCRIPTION
I ended up mostly rewriting the migration tests, since a lot of the tests simply didn't make any sense with the new way of doing things, but a large chunk of the migration functionality was sort of incidentally tested along the way in those tests (and nowhere else). The RLMRealm tests weren't as bad, but similarly required a lot of shuffling around due to tests for the removed functionality and tests for remaining things being entangled.

The changes to non-test code should all be straightforward and obvious (and the updated tests pass with none of the non-test changes other than the bug fix in migrateRealm:).

@jpsim @bdash 