### PR TITLE
[Swift] Fix crash when using optional Int16/Int32/Int64 properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ x.x.x Release notes (yyyy-MM-dd)
 
 * Support assigning `Results` to `List` properties via KVC.
 * Honor the schema version set in the configuration in `+[RLMRealm migrateRealm:]`.
+* Fix crash when using optional Int16/Int32/Int64 properties in Swift.
 
 0.96.0 Release notes (2015-10-14)
 =============================================================

--- a/RealmSwift-swift1.2/Optional.swift
+++ b/RealmSwift-swift1.2/Optional.swift
@@ -39,10 +39,29 @@ public final class RealmOptional<T: RealmOptionalType> : RLMOptionalBase {
     /// The value this optional represents.
     public var value: T? {
         get {
+            if T.self is Int16.Type {
+                return map((underlyingValue as! NSNumber?)?.longValue) { Int16($0) } as! T?
+            } else if T.self is Int32.Type {
+                return map((underlyingValue as! NSNumber?)?.longValue) { Int32($0) } as! T?
+            } else if T.self is Int64.Type {
+                return map((underlyingValue as! NSNumber?)?.longLongValue) { Int64($0) } as! T?
+            }
             return underlyingValue as! T?
         }
         set {
-            self.underlyingValue = newValue as! AnyObject?
+            if let unwrappedValue = newValue {
+                if let int64Value = unwrappedValue as? Int64 {
+                    underlyingValue = NSNumber(longLong: int64Value)
+                } else if let int32Value = unwrappedValue as? Int32 {
+                    underlyingValue = NSNumber(long: Int(int32Value))
+                } else if let int16Value = unwrappedValue as? Int16 {
+                    underlyingValue = NSNumber(long: Int(int16Value))
+                } else {
+                    underlyingValue = unwrappedValue as! AnyObject
+                }
+            } else {
+                underlyingValue = nil
+            }
         }
     }
 

--- a/RealmSwift-swift1.2/Optional.swift
+++ b/RealmSwift-swift1.2/Optional.swift
@@ -35,7 +35,7 @@ declared as `dynamic` in Swift, such as `Int`s, `Float`, `Double`, and `Bool`.
 It encapsulates a value in its `value` property, which is the only way to mutate
 a `RealmOptional` property on an `Object`.
 */
-public final class RealmOptional<T: RealmOptionalType> : RLMOptionalBase {
+public final class RealmOptional<T: RealmOptionalType>: RLMOptionalBase {
     /// The value this optional represents.
     public var value: T? {
         get {

--- a/RealmSwift-swift1.2/Optional.swift
+++ b/RealmSwift-swift1.2/Optional.swift
@@ -28,6 +28,32 @@ extension Float: RealmOptionalType {}
 extension Double: RealmOptionalType {}
 extension Bool: RealmOptionalType {}
 
+// Not all RealmOptionalType's can be cast to AnyObject, so handle casting logic here.
+private func realmOptionalToAnyObject<T: RealmOptionalType>(value: T?) -> AnyObject? {
+    if let anyObjectValue: AnyObject = value as? AnyObject {
+        return anyObjectValue
+    } else if let int16Value = value as? Int16 {
+        return NSNumber(long: Int(int16Value))
+    } else if let int32Value = value as? Int32 {
+        return NSNumber(long: Int(int32Value))
+    } else if let int64Value = value as? Int64 {
+        return NSNumber(longLong: int64Value)
+    }
+    return nil
+}
+
+// Not all RealmOptionalType's can be cast from AnyObject, so handle casting logic here.
+private func anyObjectToRealmOptional<T: RealmOptionalType>(anyObject: AnyObject?) -> T? {
+    if T.self is Int16.Type {
+        return ((anyObject as! NSNumber?)?.longValue).map { Int16($0) } as! T?
+    } else if T.self is Int32.Type {
+        return ((anyObject as! NSNumber?)?.longValue).map { Int32($0) } as! T?
+    } else if T.self is Int64.Type {
+        return (anyObject as! NSNumber?)?.longLongValue as! T?
+    }
+    return anyObject as! T?
+}
+
 /**
 A `RealmOptional` represents a optional value for types that can't be directly
 declared as `dynamic` in Swift, such as `Int`s, `Float`, `Double`, and `Bool`.
@@ -39,29 +65,10 @@ public final class RealmOptional<T: RealmOptionalType>: RLMOptionalBase {
     /// The value this optional represents.
     public var value: T? {
         get {
-            if T.self is Int16.Type {
-                return map((underlyingValue as! NSNumber?)?.longValue) { Int16($0) } as! T?
-            } else if T.self is Int32.Type {
-                return map((underlyingValue as! NSNumber?)?.longValue) { Int32($0) } as! T?
-            } else if T.self is Int64.Type {
-                return map((underlyingValue as! NSNumber?)?.longLongValue) { Int64($0) } as! T?
-            }
-            return underlyingValue as! T?
+            return anyObjectToRealmOptional(underlyingValue)
         }
         set {
-            if let unwrappedValue = newValue {
-                if let int64Value = unwrappedValue as? Int64 {
-                    underlyingValue = NSNumber(longLong: int64Value)
-                } else if let int32Value = unwrappedValue as? Int32 {
-                    underlyingValue = NSNumber(long: Int(int32Value))
-                } else if let int16Value = unwrappedValue as? Int16 {
-                    underlyingValue = NSNumber(long: Int(int16Value))
-                } else {
-                    underlyingValue = unwrappedValue as! AnyObject
-                }
-            } else {
-                underlyingValue = nil
-            }
+            underlyingValue = realmOptionalToAnyObject(newValue)
         }
     }
 

--- a/RealmSwift-swift1.2/Tests/ObjectAccessorTests.swift
+++ b/RealmSwift-swift1.2/Tests/ObjectAccessorTests.swift
@@ -269,7 +269,7 @@ class ObjectAccessorTests: TestCase {
         object.optInt16Col.value = Int16.max
         XCTAssertEqual(object.optInt16Col.value!, Int16.max)
         object.optInt16Col.value = nil
-        XCTAssertNil(object.optInt16Col.value)
+        XCTAssert(object.optInt16Col.value == nil)
 
         object.optInt32Col.value = Int32.min
         XCTAssertEqual(object.optInt32Col.value!, Int32.min)
@@ -278,7 +278,7 @@ class ObjectAccessorTests: TestCase {
         object.optInt32Col.value = Int32.max
         XCTAssertEqual(object.optInt32Col.value!, Int32.max)
         object.optInt32Col.value = nil
-        XCTAssertNil(object.optInt32Col.value)
+        XCTAssert(object.optInt32Col.value == nil)
 
         object.optInt64Col.value = Int64.min
         XCTAssertEqual(object.optInt64Col.value!, Int64.min)
@@ -287,7 +287,7 @@ class ObjectAccessorTests: TestCase {
         object.optInt64Col.value = Int64.max
         XCTAssertEqual(object.optInt64Col.value!, Int64.max)
         object.optInt64Col.value = nil
-        XCTAssertNil(object.optInt64Col.value)
+        XCTAssert(object.optInt64Col.value == nil)
 
         object.optFloatCol.value = -FLT_MAX
         XCTAssertEqual(object.optFloatCol.value!, -FLT_MAX)

--- a/RealmSwift-swift1.2/Tests/ObjectAccessorTests.swift
+++ b/RealmSwift-swift1.2/Tests/ObjectAccessorTests.swift
@@ -262,6 +262,33 @@ class ObjectAccessorTests: TestCase {
         object.optIntCol.value = nil
         XCTAssertNil(object.optIntCol.value)
 
+        object.optInt16Col.value = -1
+        XCTAssertEqual(object.optInt16Col.value!, -1)
+        object.optInt16Col.value = 0
+        XCTAssertEqual(object.optInt16Col.value!, 0)
+        object.optInt16Col.value = 1
+        XCTAssertEqual(object.optInt16Col.value!, 1)
+        object.optInt16Col.value = nil
+        XCTAssert(object.optInt16Col.value == nil)
+
+        object.optInt32Col.value = -1
+        XCTAssertEqual(object.optInt32Col.value!, -1)
+        object.optInt32Col.value = 0
+        XCTAssertEqual(object.optInt32Col.value!, 0)
+        object.optInt32Col.value = 1
+        XCTAssertEqual(object.optInt32Col.value!, 1)
+        object.optInt32Col.value = nil
+        XCTAssert(object.optInt32Col.value == nil)
+
+        object.optInt64Col.value = -1
+        XCTAssertEqual(object.optInt64Col.value!, -1)
+        object.optInt64Col.value = 0
+        XCTAssertEqual(object.optInt64Col.value!, 0)
+        object.optInt64Col.value = 1
+        XCTAssertEqual(object.optInt64Col.value!, 1)
+        object.optInt64Col.value = nil
+        XCTAssert(object.optInt64Col.value == nil)
+
         object.optFloatCol.value = 20
         XCTAssertEqual(object.optFloatCol.value!, 20 as Float)
         object.optFloatCol.value = 20.2

--- a/RealmSwift-swift1.2/Tests/ObjectAccessorTests.swift
+++ b/RealmSwift-swift1.2/Tests/ObjectAccessorTests.swift
@@ -253,57 +253,57 @@ class ObjectAccessorTests: TestCase {
         object.optDateCol = nil
         XCTAssertNil(object.optDateCol)
 
-        object.optIntCol.value = -1
-        XCTAssertEqual(object.optIntCol.value!, -1)
+        object.optIntCol.value = Int.min
+        XCTAssertEqual(object.optIntCol.value!, Int.min)
         object.optIntCol.value = 0
         XCTAssertEqual(object.optIntCol.value!, 0)
-        object.optIntCol.value = 1
-        XCTAssertEqual(object.optIntCol.value!, 1)
+        object.optIntCol.value = Int.max
+        XCTAssertEqual(object.optIntCol.value!, Int.max)
         object.optIntCol.value = nil
         XCTAssertNil(object.optIntCol.value)
 
-        object.optInt16Col.value = -1
-        XCTAssertEqual(object.optInt16Col.value!, -1)
+        object.optInt16Col.value = Int16.min
+        XCTAssertEqual(object.optInt16Col.value!, Int16.min)
         object.optInt16Col.value = 0
         XCTAssertEqual(object.optInt16Col.value!, 0)
-        object.optInt16Col.value = 1
-        XCTAssertEqual(object.optInt16Col.value!, 1)
+        object.optInt16Col.value = Int16.max
+        XCTAssertEqual(object.optInt16Col.value!, Int16.max)
         object.optInt16Col.value = nil
-        XCTAssert(object.optInt16Col.value == nil)
+        XCTAssertNil(object.optInt16Col.value)
 
-        object.optInt32Col.value = -1
-        XCTAssertEqual(object.optInt32Col.value!, -1)
+        object.optInt32Col.value = Int32.min
+        XCTAssertEqual(object.optInt32Col.value!, Int32.min)
         object.optInt32Col.value = 0
         XCTAssertEqual(object.optInt32Col.value!, 0)
-        object.optInt32Col.value = 1
-        XCTAssertEqual(object.optInt32Col.value!, 1)
+        object.optInt32Col.value = Int32.max
+        XCTAssertEqual(object.optInt32Col.value!, Int32.max)
         object.optInt32Col.value = nil
-        XCTAssert(object.optInt32Col.value == nil)
+        XCTAssertNil(object.optInt32Col.value)
 
-        object.optInt64Col.value = -1
-        XCTAssertEqual(object.optInt64Col.value!, -1)
+        object.optInt64Col.value = Int64.min
+        XCTAssertEqual(object.optInt64Col.value!, Int64.min)
         object.optInt64Col.value = 0
         XCTAssertEqual(object.optInt64Col.value!, 0)
-        object.optInt64Col.value = 1
-        XCTAssertEqual(object.optInt64Col.value!, 1)
+        object.optInt64Col.value = Int64.max
+        XCTAssertEqual(object.optInt64Col.value!, Int64.max)
         object.optInt64Col.value = nil
-        XCTAssert(object.optInt64Col.value == nil)
+        XCTAssertNil(object.optInt64Col.value)
 
-        object.optFloatCol.value = 20
-        XCTAssertEqual(object.optFloatCol.value!, 20 as Float)
-        object.optFloatCol.value = 20.2
-        XCTAssertEqual(object.optFloatCol.value!, 20.2 as Float)
-        object.optFloatCol.value = 16777217
-        XCTAssertEqual(Double(object.optFloatCol.value!), 16777216.0 as Double)
+        object.optFloatCol.value = -FLT_MAX
+        XCTAssertEqual(object.optFloatCol.value!, -FLT_MAX)
+        object.optFloatCol.value = 0
+        XCTAssertEqual(object.optFloatCol.value!, 0)
+        object.optFloatCol.value = FLT_MAX
+        XCTAssertEqual(object.optFloatCol.value!, FLT_MAX)
         object.optFloatCol.value = nil
         XCTAssertNil(object.optFloatCol.value)
 
-        object.optDoubleCol.value = 20
-        XCTAssertEqual(object.optDoubleCol.value!, 20)
-        object.optDoubleCol.value = 20.2
-        XCTAssertEqual(object.optDoubleCol.value!, 20.2)
-        object.optDoubleCol.value = 16777217
-        XCTAssertEqual(object.optDoubleCol.value!, 16777217)
+        object.optDoubleCol.value = -DBL_MAX
+        XCTAssertEqual(object.optDoubleCol.value!, -DBL_MAX)
+        object.optDoubleCol.value = 0
+        XCTAssertEqual(object.optDoubleCol.value!, 0)
+        object.optDoubleCol.value = DBL_MAX
+        XCTAssertEqual(object.optDoubleCol.value!, DBL_MAX)
         object.optDoubleCol.value = nil
         XCTAssertNil(object.optDoubleCol.value)
 

--- a/RealmSwift-swift1.2/Tests/ObjectCreationTests.swift
+++ b/RealmSwift-swift1.2/Tests/ObjectCreationTests.swift
@@ -468,6 +468,9 @@ class ObjectCreationTests: TestCase {
         }
         XCTAssert(object.optBoolCol.value == (get("optBoolCol") as! Bool?))
         XCTAssert(object.optIntCol.value == (get("optIntCol") as! Int?))
+        XCTAssert(object.optInt16Col.value == (get("optInt16Col") as! Int16?))
+        XCTAssert(object.optInt32Col.value == (get("optInt32Col") as! Int32?))
+        XCTAssert(object.optInt64Col.value == (get("optInt64Col") as! Int64?))
         XCTAssert(object.optFloatCol.value == (get("optFloatCol") as! Float?))
         XCTAssert(object.optDoubleCol.value == (get("optDoubleCol") as! Double?))
         XCTAssert(object.optStringCol == (get("optStringCol") as! String?))

--- a/RealmSwift-swift1.2/Tests/SwiftTestObjects.swift
+++ b/RealmSwift-swift1.2/Tests/SwiftTestObjects.swift
@@ -65,6 +65,9 @@ class SwiftOptionalObject: Object {
     dynamic var optBinaryCol: NSData?
     dynamic var optDateCol: NSDate?
     let optIntCol = RealmOptional<Int>()
+    let optInt16Col = RealmOptional<Int16>()
+    let optInt32Col = RealmOptional<Int32>()
+    let optInt64Col = RealmOptional<Int64>()
     let optFloatCol = RealmOptional<Float>()
     let optDoubleCol = RealmOptional<Double>()
     let optBoolCol = RealmOptional<Bool>()
@@ -87,6 +90,9 @@ class SwiftOptionalDefaultValuesObject: Object {
     dynamic var optBinaryCol: NSData? = "C".dataUsingEncoding(NSUTF8StringEncoding)
     dynamic var optDateCol: NSDate? = NSDate(timeIntervalSince1970: 10)
     let optIntCol = RealmOptional<Int>()
+    let optInt16Col = RealmOptional<Int16>()
+    let optInt32Col = RealmOptional<Int32>()
+    let optInt64Col = RealmOptional<Int64>()
     let optFloatCol = RealmOptional<Float>()
     let optDoubleCol = RealmOptional<Double>()
     let optBoolCol = RealmOptional<Bool>()
@@ -100,6 +106,9 @@ class SwiftOptionalDefaultValuesObject: Object {
             "optBinaryCol" : "C".dataUsingEncoding(NSUTF8StringEncoding)! as NSData,
             "optDateCol" : NSDate(timeIntervalSince1970: 10),
             "optIntCol" : NSNull(),
+            "optInt16Col" : NSNull(),
+            "optInt32Col" : NSNull(),
+            "optInt64Col" : NSNull(),
             "optFloatCol" : NSNull(),
             "optDoubleCol" : NSNull(),
             "optBoolCol" : NSNull()

--- a/RealmSwift-swift2.0/Optional.swift
+++ b/RealmSwift-swift2.0/Optional.swift
@@ -35,14 +35,26 @@ declared as `dynamic` in Swift, such as `Int`s, `Float`, `Double`, and `Bool`.
 It encapsulates a value in its `value` property, which is the only way to mutate
 a `RealmOptional` property on an `Object`.
 */
-public final class RealmOptional<T: RealmOptionalType> : RLMOptionalBase {
+public final class RealmOptional<T: RealmOptionalType>: RLMOptionalBase {
     /// The value this optional represents.
     public var value: T? {
         get {
             return underlyingValue as! T?
         }
         set {
-            self.underlyingValue = newValue as! AnyObject?
+            guard let unwrappedValue = newValue else {
+                underlyingValue = nil
+                return
+            }
+            if let int64Value = unwrappedValue as? Int64 {
+                underlyingValue = NSNumber(longLong: int64Value)
+            } else if let int32Value = unwrappedValue as? Int32 {
+                underlyingValue = NSNumber(long: Int(int32Value))
+            } else if let int16Value = unwrappedValue as? Int16 {
+                underlyingValue = NSNumber(long: Int(int16Value))
+            } else {
+                underlyingValue = unwrappedValue as! AnyObject
+            }
         }
     }
 

--- a/RealmSwift-swift2.0/Optional.swift
+++ b/RealmSwift-swift2.0/Optional.swift
@@ -39,6 +39,13 @@ public final class RealmOptional<T: RealmOptionalType>: RLMOptionalBase {
     /// The value this optional represents.
     public var value: T? {
         get {
+            if T.self is Int16.Type {
+                return ((underlyingValue as! NSNumber?)?.longValue).map { Int16($0) } as! T?
+            } else if T.self is Int32.Type {
+                return ((underlyingValue as! NSNumber?)?.longValue).map { Int32($0) } as! T?
+            } else if T.self is Int64.Type {
+                return ((underlyingValue as! NSNumber?)?.longLongValue).map { Int64($0) } as! T?
+            }
             return underlyingValue as! T?
         }
         set {

--- a/RealmSwift-swift2.0/Optional.swift
+++ b/RealmSwift-swift2.0/Optional.swift
@@ -28,6 +28,32 @@ extension Float: RealmOptionalType {}
 extension Double: RealmOptionalType {}
 extension Bool: RealmOptionalType {}
 
+// Not all RealmOptionalType's can be cast to AnyObject, so handle casting logic here.
+private func realmOptionalToAnyObject<T: RealmOptionalType>(value: T?) -> AnyObject? {
+    if let anyObjectValue: AnyObject = value as? AnyObject {
+        return anyObjectValue
+    } else if let int16Value = value as? Int16 {
+        return NSNumber(long: Int(int16Value))
+    } else if let int32Value = value as? Int32 {
+        return NSNumber(long: Int(int32Value))
+    } else if let int64Value = value as? Int64 {
+        return NSNumber(longLong: int64Value)
+    }
+    return nil
+}
+
+// Not all RealmOptionalType's can be cast from AnyObject, so handle casting logic here.
+private func anyObjectToRealmOptional<T: RealmOptionalType>(anyObject: AnyObject?) -> T? {
+    if T.self is Int16.Type {
+        return ((anyObject as! NSNumber?)?.longValue).map { Int16($0) } as! T?
+    } else if T.self is Int32.Type {
+        return ((anyObject as! NSNumber?)?.longValue).map { Int32($0) } as! T?
+    } else if T.self is Int64.Type {
+        return (anyObject as! NSNumber?)?.longLongValue as! T?
+    }
+    return anyObject as! T?
+}
+
 /**
 A `RealmOptional` represents a optional value for types that can't be directly
 declared as `dynamic` in Swift, such as `Int`s, `Float`, `Double`, and `Bool`.
@@ -39,29 +65,10 @@ public final class RealmOptional<T: RealmOptionalType>: RLMOptionalBase {
     /// The value this optional represents.
     public var value: T? {
         get {
-            if T.self is Int16.Type {
-                return ((underlyingValue as! NSNumber?)?.longValue).map { Int16($0) } as! T?
-            } else if T.self is Int32.Type {
-                return ((underlyingValue as! NSNumber?)?.longValue).map { Int32($0) } as! T?
-            } else if T.self is Int64.Type {
-                return ((underlyingValue as! NSNumber?)?.longLongValue).map { Int64($0) } as! T?
-            }
-            return underlyingValue as! T?
+            return anyObjectToRealmOptional(underlyingValue)
         }
         set {
-            guard let unwrappedValue = newValue else {
-                underlyingValue = nil
-                return
-            }
-            if let int64Value = unwrappedValue as? Int64 {
-                underlyingValue = NSNumber(longLong: int64Value)
-            } else if let int32Value = unwrappedValue as? Int32 {
-                underlyingValue = NSNumber(long: Int(int32Value))
-            } else if let int16Value = unwrappedValue as? Int16 {
-                underlyingValue = NSNumber(long: Int(int16Value))
-            } else {
-                underlyingValue = unwrappedValue as! AnyObject
-            }
+            underlyingValue = realmOptionalToAnyObject(newValue)
         }
     }
 

--- a/RealmSwift-swift2.0/Tests/ObjectAccessorTests.swift
+++ b/RealmSwift-swift2.0/Tests/ObjectAccessorTests.swift
@@ -254,57 +254,57 @@ class ObjectAccessorTests: TestCase {
         object.optDateCol = nil
         XCTAssertNil(object.optDateCol)
 
-        object.optIntCol.value = -1
-        XCTAssertEqual(object.optIntCol.value!, -1)
+        object.optIntCol.value = Int.min
+        XCTAssertEqual(object.optIntCol.value!, Int.min)
         object.optIntCol.value = 0
         XCTAssertEqual(object.optIntCol.value!, 0)
-        object.optIntCol.value = 1
-        XCTAssertEqual(object.optIntCol.value!, 1)
+        object.optIntCol.value = Int.max
+        XCTAssertEqual(object.optIntCol.value!, Int.max)
         object.optIntCol.value = nil
         XCTAssertNil(object.optIntCol.value)
 
-        object.optInt16Col.value = -1
-        XCTAssertEqual(object.optInt16Col.value!, -1)
+        object.optInt16Col.value = Int16.min
+        XCTAssertEqual(object.optInt16Col.value!, Int16.min)
         object.optInt16Col.value = 0
         XCTAssertEqual(object.optInt16Col.value!, 0)
-        object.optInt16Col.value = 1
-        XCTAssertEqual(object.optInt16Col.value!, 1)
+        object.optInt16Col.value = Int16.max
+        XCTAssertEqual(object.optInt16Col.value!, Int16.max)
         object.optInt16Col.value = nil
         XCTAssertNil(object.optInt16Col.value)
 
-        object.optInt32Col.value = -1
-        XCTAssertEqual(object.optInt32Col.value!, -1)
+        object.optInt32Col.value = Int32.min
+        XCTAssertEqual(object.optInt32Col.value!, Int32.min)
         object.optInt32Col.value = 0
         XCTAssertEqual(object.optInt32Col.value!, 0)
-        object.optInt32Col.value = 1
-        XCTAssertEqual(object.optInt32Col.value!, 1)
+        object.optInt32Col.value = Int32.max
+        XCTAssertEqual(object.optInt32Col.value!, Int32.max)
         object.optInt32Col.value = nil
         XCTAssertNil(object.optInt32Col.value)
 
-        object.optInt64Col.value = -1
-        XCTAssertEqual(object.optInt64Col.value!, -1)
+        object.optInt64Col.value = Int64.min
+        XCTAssertEqual(object.optInt64Col.value!, Int64.min)
         object.optInt64Col.value = 0
         XCTAssertEqual(object.optInt64Col.value!, 0)
-        object.optInt64Col.value = 1
-        XCTAssertEqual(object.optInt64Col.value!, 1)
+        object.optInt64Col.value = Int64.max
+        XCTAssertEqual(object.optInt64Col.value!, Int64.max)
         object.optInt64Col.value = nil
         XCTAssertNil(object.optInt64Col.value)
 
-        object.optFloatCol.value = 20
-        XCTAssertEqual(object.optFloatCol.value!, 20 as Float)
-        object.optFloatCol.value = 20.2
-        XCTAssertEqual(object.optFloatCol.value!, 20.2 as Float)
-        object.optFloatCol.value = 16777217
-        XCTAssertEqual(Double(object.optFloatCol.value!), 16777216.0 as Double)
+        object.optFloatCol.value = -FLT_MAX
+        XCTAssertEqual(object.optFloatCol.value!, -FLT_MAX)
+        object.optFloatCol.value = 0
+        XCTAssertEqual(object.optFloatCol.value!, 0)
+        object.optFloatCol.value = FLT_MAX
+        XCTAssertEqual(object.optFloatCol.value!, FLT_MAX)
         object.optFloatCol.value = nil
         XCTAssertNil(object.optFloatCol.value)
 
-        object.optDoubleCol.value = 20
-        XCTAssertEqual(object.optDoubleCol.value!, 20)
-        object.optDoubleCol.value = 20.2
-        XCTAssertEqual(object.optDoubleCol.value!, 20.2)
-        object.optDoubleCol.value = 16777217
-        XCTAssertEqual(object.optDoubleCol.value!, 16777217)
+        object.optDoubleCol.value = -DBL_MAX
+        XCTAssertEqual(object.optDoubleCol.value!, -DBL_MAX)
+        object.optDoubleCol.value = 0
+        XCTAssertEqual(object.optDoubleCol.value!, 0)
+        object.optDoubleCol.value = DBL_MAX
+        XCTAssertEqual(object.optDoubleCol.value!, DBL_MAX)
         object.optDoubleCol.value = nil
         XCTAssertNil(object.optDoubleCol.value)
 

--- a/RealmSwift-swift2.0/Tests/ObjectAccessorTests.swift
+++ b/RealmSwift-swift2.0/Tests/ObjectAccessorTests.swift
@@ -263,6 +263,33 @@ class ObjectAccessorTests: TestCase {
         object.optIntCol.value = nil
         XCTAssertNil(object.optIntCol.value)
 
+        object.optInt16Col.value = -1
+        XCTAssertEqual(object.optInt16Col.value!, -1)
+        object.optInt16Col.value = 0
+        XCTAssertEqual(object.optInt16Col.value!, 0)
+        object.optInt16Col.value = 1
+        XCTAssertEqual(object.optInt16Col.value!, 1)
+        object.optInt16Col.value = nil
+        XCTAssertNil(object.optInt16Col.value)
+
+        object.optInt32Col.value = -1
+        XCTAssertEqual(object.optInt32Col.value!, -1)
+        object.optInt32Col.value = 0
+        XCTAssertEqual(object.optInt32Col.value!, 0)
+        object.optInt32Col.value = 1
+        XCTAssertEqual(object.optInt32Col.value!, 1)
+        object.optInt32Col.value = nil
+        XCTAssertNil(object.optInt32Col.value)
+
+        object.optInt64Col.value = -1
+        XCTAssertEqual(object.optInt64Col.value!, -1)
+        object.optInt64Col.value = 0
+        XCTAssertEqual(object.optInt64Col.value!, 0)
+        object.optInt64Col.value = 1
+        XCTAssertEqual(object.optInt64Col.value!, 1)
+        object.optInt64Col.value = nil
+        XCTAssertNil(object.optInt64Col.value)
+
         object.optFloatCol.value = 20
         XCTAssertEqual(object.optFloatCol.value!, 20 as Float)
         object.optFloatCol.value = 20.2

--- a/RealmSwift-swift2.0/Tests/ObjectCreationTests.swift
+++ b/RealmSwift-swift2.0/Tests/ObjectCreationTests.swift
@@ -446,6 +446,9 @@ class ObjectCreationTests: TestCase {
     private func verifySwiftOptionalObjectWithDictionaryLiteral(object: SwiftOptionalDefaultValuesObject, dictionary: [String:AnyObject], boolObjectValue: Bool?) {
         XCTAssertEqual(object.optBoolCol.value, (dictionary["optBoolCol"] as! Bool?))
         XCTAssertEqual(object.optIntCol.value, (dictionary["optIntCol"] as! Int?))
+        XCTAssertEqual(object.optInt16Col.value, (dictionary["optInt16Col"] as! Int16?))
+        XCTAssertEqual(object.optInt32Col.value, (dictionary["optInt32Col"] as! Int32?))
+        XCTAssertEqual(object.optInt64Col.value, (dictionary["optInt64Col"] as! Int64?))
         XCTAssertEqual(object.optFloatCol.value, (dictionary["optFloatCol"] as! Float?))
         XCTAssertEqual(object.optDoubleCol.value, (dictionary["optDoubleCol"] as! Double?))
         XCTAssertEqual(object.optStringCol, (dictionary["optStringCol"] as! String?))

--- a/RealmSwift-swift2.0/Tests/ObjectCreationTests.swift
+++ b/RealmSwift-swift2.0/Tests/ObjectCreationTests.swift
@@ -446,9 +446,9 @@ class ObjectCreationTests: TestCase {
     private func verifySwiftOptionalObjectWithDictionaryLiteral(object: SwiftOptionalDefaultValuesObject, dictionary: [String:AnyObject], boolObjectValue: Bool?) {
         XCTAssertEqual(object.optBoolCol.value, (dictionary["optBoolCol"] as! Bool?))
         XCTAssertEqual(object.optIntCol.value, (dictionary["optIntCol"] as! Int?))
-        XCTAssertEqual(object.optInt16Col.value, (dictionary["optInt16Col"] as! Int16?))
-        XCTAssertEqual(object.optInt32Col.value, (dictionary["optInt32Col"] as! Int32?))
-        XCTAssertEqual(object.optInt64Col.value, (dictionary["optInt64Col"] as! Int64?))
+        XCTAssertEqual(object.optInt16Col.value, ((dictionary["optInt16Col"] as! NSNumber?)?.longValue).map({Int16($0)}))
+        XCTAssertEqual(object.optInt32Col.value, ((dictionary["optInt32Col"] as! NSNumber?)?.longValue).map({Int32($0)}))
+        XCTAssertEqual(object.optInt64Col.value, (dictionary["optInt64Col"] as! NSNumber?)?.longLongValue)
         XCTAssertEqual(object.optFloatCol.value, (dictionary["optFloatCol"] as! Float?))
         XCTAssertEqual(object.optDoubleCol.value, (dictionary["optDoubleCol"] as! Double?))
         XCTAssertEqual(object.optStringCol, (dictionary["optStringCol"] as! String?))

--- a/RealmSwift-swift2.0/Tests/SwiftTestObjects.swift
+++ b/RealmSwift-swift2.0/Tests/SwiftTestObjects.swift
@@ -65,6 +65,9 @@ class SwiftOptionalObject: Object {
     dynamic var optBinaryCol: NSData?
     dynamic var optDateCol: NSDate?
     let optIntCol = RealmOptional<Int>()
+    let optInt16Col = RealmOptional<Int16>()
+    let optInt32Col = RealmOptional<Int32>()
+    let optInt64Col = RealmOptional<Int64>()
     let optFloatCol = RealmOptional<Float>()
     let optDoubleCol = RealmOptional<Double>()
     let optBoolCol = RealmOptional<Bool>()
@@ -87,6 +90,9 @@ class SwiftOptionalDefaultValuesObject: Object {
     dynamic var optBinaryCol: NSData? = "C".dataUsingEncoding(NSUTF8StringEncoding)
     dynamic var optDateCol: NSDate? = NSDate(timeIntervalSince1970: 10)
     let optIntCol = RealmOptional<Int>(1)
+    let optInt16Col = RealmOptional<Int16>(1)
+    let optInt32Col = RealmOptional<Int32>(1)
+    let optInt64Col = RealmOptional<Int64>(1)
     let optFloatCol = RealmOptional<Float>(2.2)
     let optDoubleCol = RealmOptional<Double>(3.3)
     let optBoolCol = RealmOptional<Bool>(true)
@@ -100,6 +106,9 @@ class SwiftOptionalDefaultValuesObject: Object {
             "optBinaryCol" : "C".dataUsingEncoding(NSUTF8StringEncoding)! as NSData,
             "optDateCol" : NSDate(timeIntervalSince1970: 10),
             "optIntCol" : 1,
+            "optInt16Col" : 1,
+            "optInt32Col" : 1,
+            "optInt64Col" : 1,
             "optFloatCol" : 2.2 as Float,
             "optDoubleCol" : 3.3,
             "optBoolCol" : true,


### PR DESCRIPTION
Fixes #2681. /cc @bdash @tgoyne 