### PR TITLE
[Swift] Get list of DynamicObject

### DIFF
--- a/RealmSwift-swift1.2/Object.swift
+++ b/RealmSwift-swift1.2/Object.swift
@@ -200,16 +200,16 @@ public class Object: RLMObjectBase, Equatable, Printable {
 
     Returns a List of DynamicObjects for a property name
 
-    - warning: This method is useful only in specialized circumstances
+    :warning: This method is useful only in specialized circumstances
 
-    - parameter propertyName: The name of the property to get a List<DynamicObject>
+    :param: propertyName The name of the property to get a List<DynamicObject>
 
-    - returns: A List of DynamicObjects
+    :returns: A List of DynamicObjects
 
     :nodoc:
     */
     public func dynamicList(propertyName: String) -> List<DynamicObject> {
-        return unsafeBitCast(self.listForProperty(RLMValidatedGetProperty(self, propertyName)), List<DynamicObject>.self)
+        return unsafeBitCast(listForProperty(RLMValidatedGetProperty(self, propertyName)), List<DynamicObject>.self)
     }
 
     // MARK: Private functions

--- a/RealmSwift-swift1.2/Object.swift
+++ b/RealmSwift-swift1.2/Object.swift
@@ -191,6 +191,27 @@ public class Object: RLMObjectBase, Equatable, Printable {
         }
     }
 
+    // MARK: Dynamic list
+
+    /**
+    This method is useful only in specialized circumstances, for example, when building
+    components that integrate with Realm. If you are simply building an app on Realm, it is
+    recommended to use instance variables or cast the KVC returns.
+
+    Returns a List of DynamicObjects for a property name
+
+    - warning: This method is useful only in specialized circumstances
+
+    - parameter propertyName: The name of the property to get a List<DynamicObject>
+
+    - returns: A List of DynamicObjects
+
+    :nodoc:
+    */
+    public func dynamicList(propertyName: String) -> List<DynamicObject> {
+        return unsafeBitCast(self.listForProperty(RLMValidatedGetProperty(self, propertyName)), List<DynamicObject>.self)
+    }
+
     // MARK: Private functions
 
     // FIXME: None of these functions should be exposed in the public interface.

--- a/RealmSwift-swift1.2/Tests/ObjectTests.swift
+++ b/RealmSwift-swift1.2/Tests/ObjectTests.swift
@@ -25,7 +25,7 @@ class ObjectTests: TestCase {
     // init() Tests are in ObjectCreationTests.swift
 
     // init(value:) tests are in ObjectCreationTests.swift
-    
+
     func testRealm() {
         let standalone = SwiftStringObject()
         XCTAssertNil(standalone.realm)
@@ -283,5 +283,22 @@ class ObjectTests: TestCase {
             let persistedObject = Realm().create(SwiftObject.self, value: [:])
             self.setAndTestAllTypes(setter, getter: getter, object: persistedObject)
         }
+    }
+
+    func testDynamicList() {
+        let realm = try! Realm()
+        let arrayObject = SwiftArrayPropertyObject()
+        let str1 = SwiftStringObject()
+        let str2 = SwiftStringObject()
+        arrayObject.array.appendContentsOf([str1, str2])
+        try! realm.write {
+            realm.add(arrayObject)
+        }
+        let dynamicArray = arrayObject.dynamicList("array")
+        XCTAssertEqual(dynamicArray.count, 2)
+        XCTAssertEqual(dynamicArray[0], str1)
+        XCTAssertEqual(dynamicArray[1], str2)
+        XCTAssertEqual(arrayObject.dynamicList("intArray").count, 0)
+        assertThrows(arrayObject.dynamicList("noSuchList"))
     }
 }

--- a/RealmSwift-swift1.2/Tests/ObjectTests.swift
+++ b/RealmSwift-swift1.2/Tests/ObjectTests.swift
@@ -290,8 +290,7 @@ class ObjectTests: TestCase {
         let arrayObject = SwiftArrayPropertyObject()
         let str1 = SwiftStringObject()
         let str2 = SwiftStringObject()
-        arrayObject.array.append(str1)
-        arrayObject.array.append(str2)
+        arrayObject.array.extend([str1, str2])
         realm.write {
             realm.add(arrayObject)
         }

--- a/RealmSwift-swift1.2/Tests/ObjectTests.swift
+++ b/RealmSwift-swift1.2/Tests/ObjectTests.swift
@@ -25,6 +25,7 @@ class ObjectTests: TestCase {
     // init() Tests are in ObjectCreationTests.swift
 
     // init(value:) tests are in ObjectCreationTests.swift
+
     func testRealm() {
         let standalone = SwiftStringObject()
         XCTAssertNil(standalone.realm)

--- a/RealmSwift-swift1.2/Tests/ObjectTests.swift
+++ b/RealmSwift-swift1.2/Tests/ObjectTests.swift
@@ -286,12 +286,13 @@ class ObjectTests: TestCase {
     }
 
     func testDynamicList() {
-        let realm = try! Realm()
+        let realm = Realm()
         let arrayObject = SwiftArrayPropertyObject()
         let str1 = SwiftStringObject()
         let str2 = SwiftStringObject()
-        arrayObject.array.appendContentsOf([str1, str2])
-        try! realm.write {
+        arrayObject.array.append(str1)
+        arrayObject.array.append(str2)
+        realm.write {
             realm.add(arrayObject)
         }
         let dynamicArray = arrayObject.dynamicList("array")

--- a/RealmSwift-swift1.2/Tests/ObjectTests.swift
+++ b/RealmSwift-swift1.2/Tests/ObjectTests.swift
@@ -25,7 +25,6 @@ class ObjectTests: TestCase {
     // init() Tests are in ObjectCreationTests.swift
 
     // init(value:) tests are in ObjectCreationTests.swift
-
     func testRealm() {
         let standalone = SwiftStringObject()
         XCTAssertNil(standalone.realm)

--- a/RealmSwift-swift2.0/Object.swift
+++ b/RealmSwift-swift2.0/Object.swift
@@ -213,7 +213,7 @@ public class Object: RLMObjectBase {
     :nodoc:
     */
     public func dynamicList(propertyName: String) -> List<DynamicObject> {
-        return unsafeBitCast(self.listForProperty(RLMValidatedGetProperty(self, propertyName)), List<DynamicObject>.self)
+        return unsafeBitCast(listForProperty(RLMValidatedGetProperty(self, propertyName)), List<DynamicObject>.self)
     }
 
     // MARK: Equatable

--- a/RealmSwift-swift2.0/Object.swift
+++ b/RealmSwift-swift2.0/Object.swift
@@ -195,6 +195,27 @@ public class Object: RLMObjectBase {
         }
     }
 
+    // MARK: Dynamic list
+
+    /**
+    This method is useful only in specialized circumstances, for example, when building
+    components that integrate with Realm. If you are simply building an app on Realm, it is
+    recommended to use instance variables or cast the KVC returns.
+
+    Returns a List of DynamicObjects for a property name
+
+    - warning: This method is useful only in specialized circumstances
+
+    - parameter propertyName: The name of the property to get a List<DynamicObject>
+
+    - returns: A List of DynamicObjects
+
+    :nodoc:
+    */
+    public func dynamicList(propertyName: String) -> List<DynamicObject> {
+        return unsafeBitCast(self.listForProperty(RLMValidatedGetProperty(self, propertyName)), List<DynamicObject>.self)
+    }
+
     // MARK: Equatable
 
     /// Returns whether both objects are equal.

--- a/RealmSwift-swift2.0/Tests/ObjectTests.swift
+++ b/RealmSwift-swift2.0/Tests/ObjectTests.swift
@@ -288,6 +288,6 @@ class ObjectTests: TestCase {
     func testDynamicList() {
         XCTAssertEqual(SwiftArrayPropertyObject.dynamicList("array").count, 0)
         XCTAssertEqual(SwiftArrayPropertyObject.dynamicList("intArray").count, 0)
-        assertThrows(SwiftArraypropertyObject.dynamicList("noSuchList"))
+        assertThrows(SwiftArrayPropertyObject.dynamicList("noSuchList"))
     }
 }

--- a/RealmSwift-swift2.0/Tests/ObjectTests.swift
+++ b/RealmSwift-swift2.0/Tests/ObjectTests.swift
@@ -286,8 +286,19 @@ class ObjectTests: TestCase {
     }
 
     func testDynamicList() {
-        XCTAssertEqual(SwiftArrayPropertyObject.dynamicList("array").count, 0)
-        XCTAssertEqual(SwiftArrayPropertyObject.dynamicList("intArray").count, 0)
-        assertThrows(SwiftArrayPropertyObject.dynamicList("noSuchList"))
+        let realm = try! Realm()
+        let arrayObject = SwiftArrayPropertyObject()
+        let str1 = SwiftStringObject()
+        let str2 = SwiftStringObject()
+        arrayObject.array.appendContentsOf([str1, str2])
+        try! realm.write {
+            realm.add(arrayObject)
+        }
+        let dynamicArray = arrayObject.dynamicList("array")
+        XCTAssertEqual(dynamicArray.count, 2)
+        XCTAssertEqual(dynamicArray[0], str1)
+        XCTAssertEqual(dynamicArray[1], str2)
+        XCTAssertEqual(arrayObject.dynamicList("intArray").count, 0)
+        assertThrows(arrayObject.dynamicList("noSuchList"))
     }
 }

--- a/RealmSwift-swift2.0/Tests/ObjectTests.swift
+++ b/RealmSwift-swift2.0/Tests/ObjectTests.swift
@@ -284,4 +284,10 @@ class ObjectTests: TestCase {
             self.setAndTestAllTypes(setter, getter: getter, object: persistedObject)
         }
     }
+
+    func testDynamicList() {
+        XCTAssertEqual(SwiftArrayPropertyObject.dynamicList("array").count, 0)
+        XCTAssertEqual(SwiftArrayPropertyObject.dynamicList("intArray").count, 0)
+        assertThrows(SwiftArraypropertyObject.dynamicList("noSuchList"))
+    }
 }


### PR DESCRIPTION
Hey @jpsim -- this pull request implements [#2685](https://github.com/realm/realm-cocoa/issues/2685)

Wasn't sure what style you all wanted for documentation/testing so I just guestimated based on code elsewhere (sorta shooting from the hip!)

As a user I can already get this functionality myself by using an unsafeBitCast on the result of KVC, but it's nice to wrap away these types of casts so the user doesn't feel like they're doing something wrong.

Let me know what you think!