### PR TITLE
Make RLMException a little less awkward to use

### DIFF
--- a/Realm/RLMAccessor.mm
+++ b/Realm/RLMAccessor.mm
@@ -69,8 +69,7 @@ static inline void RLMSetValueUnique(__unsafe_unretained RLMObjectBase *const ob
         return;
     }
     if (row != realm::not_found) {
-        NSString *reason = [NSString stringWithFormat:@"Can't set primary key property '%@' to existing value '%lld'.", propName, val];
-        @throw RLMException(reason);
+        @throw RLMException(@"Can't set primary key property '%@' to existing value '%lld'.", propName, val);
     }
     obj->_row.set_int(colIndex, val);
 }
@@ -128,8 +127,7 @@ static inline void RLMSetValueUnique(__unsafe_unretained RLMObjectBase *const ob
         return;
     }
     if (row != realm::not_found) {
-        NSString *reason = [NSString stringWithFormat:@"Can't set primary key property '%@' to existing value '%@'.", propName, val];
-        @throw RLMException(reason);
+        @throw RLMException(@"Can't set primary key property '%@' to existing value '%@'.", propName, val);
     }
     try {
         obj->_row.set_string(colIndex, str);
@@ -233,9 +231,8 @@ static inline void RLMSetValue(__unsafe_unretained RLMObjectBase *const obj, NSU
         RLMObjectSchema *valSchema = val->_objectSchema;
         RLMObjectSchema *objSchema = obj->_objectSchema;
         if (![[objSchema.properties[colIndex] objectClassName] isEqualToString:valSchema.className]) {
-            NSString *reason = [NSString stringWithFormat:@"Can't set object of type '%@' to property of type '%@'",
-                                valSchema.className, [objSchema.properties[colIndex] objectClassName]];
-            @throw RLMException(reason);
+            @throw RLMException(@"Can't set object of type '%@' to property of type '%@'",
+                                valSchema.className, [objSchema.properties[colIndex] objectClassName]);
         }
         RLMObjectBase *link = RLMGetLinkedObjectForValue(obj->_realm, valSchema.className, val, RLMCreationOptionsPromoteStandalone);
         obj->_row.set_link(colIndex, link->_row.get_index());
@@ -308,8 +305,7 @@ static inline void RLMSetValueUnique(__unsafe_unretained RLMObjectBase *const ob
         return;
     }
     if (row != realm::not_found) {
-        NSString *reason = [NSString stringWithFormat:@"Can't set primary key property '%@' to existing value '%@'.", propName, intObject];
-        @throw RLMException(reason);
+        @throw RLMException(@"Can't set primary key property '%@' to existing value '%@'.", propName, intObject);
     }
 
     if (intObject) {
@@ -454,7 +450,7 @@ static inline void RLMSetValue(__unsafe_unretained RLMObjectBase *const obj, NSU
                 return;
         }
     }
-    @throw RLMException([NSString stringWithFormat:@"Inserting invalid object of class %@ for an RLMPropertyTypeAny property (%@).", [val class], [obj->_objectSchema.properties[col_ndx] name]]);
+    @throw RLMException(@"Inserting invalid object of class %@ for an RLMPropertyTypeAny property (%@).", [val class], [obj->_objectSchema.properties[col_ndx] name]);
 }
 
 // dynamic getter with column closure
@@ -839,13 +835,13 @@ void RLMDynamicValidatedSet(RLMObjectBase *obj, NSString *propName, id val) {
     RLMObjectSchema *schema = obj->_objectSchema;
     RLMProperty *prop = schema[propName];
     if (!prop) {
-        @throw RLMException([NSString stringWithFormat:@"Invalid property name `%@` for class `%@`.", propName, obj->_objectSchema.className]);
+        @throw RLMException(@"Invalid property name `%@` for class `%@`.", propName, obj->_objectSchema.className);
     }
     if (prop.isPrimary) {
-        @throw RLMException([NSString stringWithFormat:@"Primary key can't be changed to '%@' after an object is inserted.", val]);
+        @throw RLMException(@"Primary key can't be changed to '%@' after an object is inserted.", val);
     }
     if (!RLMIsObjectValidForProperty(val, prop)) {
-        @throw RLMException([NSString stringWithFormat:@"Invalid property value `%@` for property `%@` of class `%@`", val, propName, obj->_objectSchema.className]);
+        @throw RLMException(@"Invalid property value `%@` for property `%@` of class `%@`", val, propName, obj->_objectSchema.className);
     }
 
     RLMWrapSetter(obj, prop.name, [&] {
@@ -940,7 +936,7 @@ void RLMDynamicSet(__unsafe_unretained RLMObjectBase *const obj, __unsafe_unreta
 RLMProperty *RLMValidatedGetProperty(__unsafe_unretained RLMObjectBase *const obj, __unsafe_unretained NSString *const propName) {
     RLMProperty *prop = obj->_objectSchema[propName];
     if (!prop) {
-        @throw RLMException([NSString stringWithFormat:@"Invalid property name `%@` for class `%@`.", propName, obj->_objectSchema.className]);
+        @throw RLMException(@"Invalid property name `%@` for class `%@`.", propName, obj->_objectSchema.className);
     }
     return prop;
 }

--- a/Realm/RLMAccessor.mm
+++ b/Realm/RLMAccessor.mm
@@ -842,7 +842,7 @@ void RLMDynamicValidatedSet(RLMObjectBase *obj, NSString *propName, id val) {
         @throw RLMException([NSString stringWithFormat:@"Invalid property name `%@` for class `%@`.", propName, obj->_objectSchema.className]);
     }
     if (prop.isPrimary) {
-        @throw RLMException(@"Primary key can't be changed to '%@' after an object is inserted.", val);
+        @throw RLMException([NSString stringWithFormat:@"Primary key can't be changed to '%@' after an object is inserted.", val]);
     }
     if (!RLMIsObjectValidForProperty(val, prop)) {
         @throw RLMException([NSString stringWithFormat:@"Invalid property value `%@` for property `%@` of class `%@`", val, propName, obj->_objectSchema.className]);

--- a/Realm/RLMArray.mm
+++ b/Realm/RLMArray.mm
@@ -136,8 +136,7 @@ static void RLMValidateMatchingObjectType(RLMArray *array, RLMObject *object) {
         @throw RLMException(@"Object must not be nil");
     }
     if (![array->_objectClassName isEqualToString:object->_objectSchema.className]) {
-        NSString *message = [NSString stringWithFormat:@"Object type '%@' does not match RLMArray type '%@'.", object->_objectSchema.className, array->_objectClassName];
-        @throw RLMException(message);
+        @throw RLMException(@"Object type '%@' does not match RLMArray type '%@'.", object->_objectSchema.className, array->_objectClassName);
     }
 }
 
@@ -145,8 +144,8 @@ static void RLMValidateArrayBounds(__unsafe_unretained RLMArray *const ar,
                                    NSUInteger index, bool allowOnePastEnd=false) {
     NSUInteger max = ar->_backingArray.count + allowOnePastEnd;
     if (index >= max) {
-        @throw RLMException([NSString stringWithFormat:@"Index %llu is out of bounds (must be less than %llu).",
-                             (unsigned long long)index, (unsigned long long)max]);
+        @throw RLMException(@"Index %llu is out of bounds (must be less than %llu).",
+                            (unsigned long long)index, (unsigned long long)max);
     }
 }
 

--- a/Realm/RLMArrayLinkView.mm
+++ b/Realm/RLMArrayLinkView.mm
@@ -59,9 +59,8 @@
 void RLMValidateArrayObservationKey(__unsafe_unretained NSString *const keyPath,
                                     __unsafe_unretained RLMArray *const array) {
     if (![keyPath isEqualToString:RLMInvalidatedKey]) {
-        NSString *err = [NSString stringWithFormat:@"[<%@ %p> addObserver:forKeyPath:options:context:] is not supported. Key path: %@",
-                         [array class], array, keyPath];
-        @throw RLMException(err);
+        @throw RLMException(@"[<%@ %p> addObserver:forKeyPath:options:context:] is not supported. Key path: %@",
+                            [array class], array, keyPath);
     }
 }
 
@@ -97,12 +96,12 @@ static inline void RLMLinkViewArrayValidateInWriteTransaction(__unsafe_unretaine
 }
 static inline void RLMValidateObjectClass(__unsafe_unretained RLMObjectBase *const obj, __unsafe_unretained NSString *const expected) {
     if (!obj) {
-        @throw RLMException([NSString stringWithFormat:@"Cannot add `nil` to RLMArray<%@>", expected]);
+        @throw RLMException(@"Cannot add `nil` to RLMArray<%@>", expected);
     }
 
     NSString *objectClassName = obj->_objectSchema.className;
     if (![objectClassName isEqualToString:expected]) {
-        @throw RLMException([NSString stringWithFormat:@"Cannot add object of type '%@' to RLMArray<%@>", objectClassName, expected]);
+        @throw RLMException(@"Cannot add object of type '%@' to RLMArray<%@>", objectClassName, expected);
     }
 }
 
@@ -185,8 +184,8 @@ static void RLMValidateArrayBounds(__unsafe_unretained RLMArrayLinkView *const a
                                    NSUInteger index, bool allowOnePastEnd=false) {
     NSUInteger max = ar->_backingLinkView->size() + allowOnePastEnd;
     if (index >= max) {
-        @throw RLMException([NSString stringWithFormat:@"Index %llu is out of bounds (must be less than %llu).",
-                             (unsigned long long)index, (unsigned long long)max]);
+        @throw RLMException(@"Index %llu is out of bounds (must be less than %llu).",
+                             (unsigned long long)index, (unsigned long long)max);
     }
 }
 
@@ -343,8 +342,8 @@ static void RLMInsertObject(RLMArrayLinkView *ar, RLMObject *object, NSUInteger 
 
     // check that object types align
     if (![_objectClassName isEqualToString:object->_objectSchema.className]) {
-        @throw RLMException([NSString stringWithFormat:@"Object of type (%@) does not match RLMArray type (%@)",
-                             object->_objectSchema.className, _objectClassName]);
+        @throw RLMException(@"Object of type (%@) does not match RLMArray type (%@)",
+                            object->_objectSchema.className, _objectClassName);
     }
 
     // if different tables then no match

--- a/Realm/RLMArrayLinkView.mm
+++ b/Realm/RLMArrayLinkView.mm
@@ -97,12 +97,12 @@ static inline void RLMLinkViewArrayValidateInWriteTransaction(__unsafe_unretaine
 }
 static inline void RLMValidateObjectClass(__unsafe_unretained RLMObjectBase *const obj, __unsafe_unretained NSString *const expected) {
     if (!obj) {
-        @throw RLMException(@"Object is `nil`", @{@"expected class" : expected});
+        @throw RLMException([NSString stringWithFormat:@"Cannot add `nil` to RLMArray<%@>", expected]);
     }
 
     NSString *objectClassName = obj->_objectSchema.className;
     if (![objectClassName isEqualToString:expected]) {
-        @throw RLMException(@"Object type is incorrect.", @{@"expected class" : expected, @"actual class" : objectClassName});
+        @throw RLMException([NSString stringWithFormat:@"Cannot add object of type '%@' to RLMArray<%@>", objectClassName, expected]);
     }
 }
 

--- a/Realm/RLMObjectBase.mm
+++ b/Realm/RLMObjectBase.mm
@@ -77,7 +77,7 @@ static id RLMValidatedObjectForProperty(id obj, RLMProperty *prop, RLMSchema *sc
     }
 
     // if not convertible to prop throw
-    @throw RLMException([NSString stringWithFormat:@"Invalid value '%@' for property '%@'", obj, prop.name]);
+    @throw RLMException(@"Invalid value '%@' for property '%@'", obj, prop.name);
 }
 
 - (instancetype)initWithValue:(id)value schema:(RLMSchema *)schema {
@@ -332,11 +332,11 @@ NSArray *RLMObjectBaseLinkingObjectsOfClass(RLMObjectBase *object, NSString *cla
     RLMObjectSchema *schema = object->_realm.schema[className];
     RLMProperty *prop = schema[property];
     if (!prop) {
-        @throw RLMException([NSString stringWithFormat:@"Invalid property '%@'", property]);
+        @throw RLMException(@"Invalid property '%@'", property);
     }
 
     if (![prop.objectClassName isEqualToString:object->_objectSchema.className]) {
-        @throw RLMException([NSString stringWithFormat:@"Property '%@' of '%@' expected to be an RLMObject or RLMArray property pointing to type '%@'", property, className, object->_objectSchema.className]);
+        @throw RLMException(@"Property '%@' of '%@' expected to be an RLMObject or RLMArray property pointing to type '%@'", property, className, object->_objectSchema.className);
     }
 
     Table *table = schema.table;
@@ -412,8 +412,8 @@ id RLMValidatedValueForProperty(id object, NSString *key, NSString *className) {
     }
     @catch (NSException *e) {
         if ([e.name isEqualToString:NSUndefinedKeyException]) {
-            @throw RLMException([NSString stringWithFormat:@"Invalid value '%@' to initialize object of type '%@': missing key '%@'",
-                                 object, className, key]);
+            @throw RLMException(@"Invalid value '%@' to initialize object of type '%@': missing key '%@'",
+                                object, className, key);
         }
         @throw;
     }

--- a/Realm/RLMObjectSchema.mm
+++ b/Realm/RLMObjectSchema.mm
@@ -109,9 +109,9 @@ using namespace realm;
         }]];
 
         if (duplicatePropertyNames.count == 1) {
-            @throw RLMException([NSString stringWithFormat:@"Property '%@' is declared multiple times in the class hierarchy of '%@'", duplicatePropertyNames.allObjects.firstObject, className]);
+            @throw RLMException(@"Property '%@' is declared multiple times in the class hierarchy of '%@'", duplicatePropertyNames.allObjects.firstObject, className);
         } else {
-            @throw RLMException([NSString stringWithFormat:@"Object '%@' has properties that are declared multiple times in its class hierarchy: '%@'", className, [duplicatePropertyNames.allObjects componentsJoinedByString:@"', '"]]);
+            @throw RLMException(@"Object '%@' has properties that are declared multiple times in its class hierarchy: '%@'", className, [duplicatePropertyNames.allObjects componentsJoinedByString:@"', '"]);
         }
     }
 
@@ -125,9 +125,7 @@ using namespace realm;
         }
 
         if (!schema.primaryKeyProperty) {
-            NSString *message = [NSString stringWithFormat:@"Primary key property '%@' does not exist on object '%@'",
-                                 primaryKey, className];
-            @throw RLMException(message);
+            @throw RLMException(@"Primary key property '%@' does not exist on object '%@'", primaryKey, className);
         }
         if (schema.primaryKeyProperty.type != RLMPropertyTypeInt && schema.primaryKeyProperty.type != RLMPropertyTypeString) {
             @throw RLMException(@"Only 'string' and 'int' properties can be designated the primary key");
@@ -141,7 +139,7 @@ using namespace realm;
             if (prop.type == RLMPropertyTypeAny && isSwift) {
                 error = [error stringByAppendingString:@"\nIf this is a 'String?' property, it must be declared as 'NSString?' instead."];
             }
-            @throw RLMException(error);
+            @throw RLMException(@"%@", error);
         }
     }
 
@@ -230,9 +228,8 @@ using namespace realm;
         for (RLMProperty *property in propArray) {
             bool required = [requiredProperties containsObject:property.name];
             if (required && property.type == RLMPropertyTypeObject) {
-                NSString *error = [NSString stringWithFormat:@"Object properties cannot be made required, " \
-                                                              "but '+[%@ requiredProperties]' included '%@'", objectClass, property.name];
-                @throw RLMException(error);
+                @throw RLMException(@"Object properties cannot be made required, "
+                                    "but '+[%@ requiredProperties]' included '%@'", objectClass, property.name);
             }
             property.optional &= !required;
         }
@@ -240,8 +237,7 @@ using namespace realm;
 
     for (RLMProperty *property in propArray) {
         if (!property.optional && property.type == RLMPropertyTypeObject) { // remove if/when core supports required link columns
-            NSString *message = [NSString stringWithFormat:@"The `%@.%@` property must be marked as being optional.", [objectClass className], property.name];
-            @throw RLMException(message);
+            @throw RLMException(@"The `%@.%@` property must be marked as being optional.", [objectClass className], property.name);
         }
     }
 
@@ -361,8 +357,7 @@ using namespace realm;
         NSString *primaryKeyString = [NSString stringWithUTF8String:objectSchema.primary_key.c_str()];
         schema.primaryKeyProperty = schema[primaryKeyString];
         if (!schema.primaryKeyProperty) {
-            NSString *reason = [NSString stringWithFormat:@"No property matching primary key '%@'", primaryKeyString];
-            @throw RLMException(reason);
+            @throw RLMException(@"No property matching primary key '%@'", primaryKeyString);
         }
     }
 

--- a/Realm/RLMObjectStore.mm
+++ b/Realm/RLMObjectStore.mm
@@ -164,7 +164,7 @@ void RLMUpdateRealmToSchemaVersion(RLMRealm *realm, uint64_t newVersion, RLMSche
                 NSError *error = migrationBlock();
                 if (error) {
                     [realm cancelWriteTransaction];
-                    @throw RLMException(error.description);
+                    @throw RLMException(@"%@", error.description);
                 }
             }
             migrationCalled = true;
@@ -281,11 +281,10 @@ void RLMAddObjectToRealm(__unsafe_unretained RLMObjectBase *const object,
     NSString *objectClassName = object->_objectSchema.className;
     RLMObjectSchema *schema = [realm.schema schemaForClassName:objectClassName];
     if (!schema) {
-        NSString *message = [NSString stringWithFormat:@"Object type '%@' is not persisted in the Realm. "
-                                  @"If using a custom `objectClasses` / `obejctTypes` array in your configuration, "
-                                  @"add `%@` to the list of `objectClasses` / `objectTypes`.",
-                                  objectClassName, objectClassName];
-        @throw RLMException(message);
+        @throw RLMException(@"Object type '%@' is not persisted in the Realm. "
+                            @"If using a custom `objectClasses` / `obejctTypes` array in your configuration, "
+                            @"add `%@` to the list of `objectClasses` / `objectTypes`.",
+                            objectClassName, objectClassName);
     }
     object->_objectSchema = schema;
     object->_realm = realm;
@@ -318,8 +317,8 @@ void RLMAddObjectToRealm(__unsafe_unretained RLMObjectBase *const object,
 
         // FIXME: Add condition to check for Mixed once it can support a nil value.
         if (!value && !prop.optional) {
-            @throw RLMException([NSString stringWithFormat:@"No value or default value specified for property '%@' in '%@'",
-                                 prop.name, schema.className]);
+            @throw RLMException(@"No value or default value specified for property '%@' in '%@'",
+                                prop.name, schema.className);
         }
 
         // set in table with out validation
@@ -395,7 +394,7 @@ static void RLMValidateValueForProperty(__unsafe_unretained id const obj,
         case RLMPropertyTypeData:
         case RLMPropertyTypeAny:
             if (!RLMIsObjectValidForProperty(obj, prop)) {
-                @throw RLMException([NSString stringWithFormat:@"Invalid value '%@' for property '%@'", obj, prop.name]);
+                @throw RLMException(@"Invalid value '%@' for property '%@'", obj, prop.name);
             }
             break;
         case RLMPropertyTypeObject:
@@ -406,7 +405,7 @@ static void RLMValidateValueForProperty(__unsafe_unretained id const obj,
         case RLMPropertyTypeArray: {
             if (obj != nil && obj != NSNull.null) {
                 if (![obj conformsToProtocol:@protocol(NSFastEnumeration)]) {
-                    @throw  RLMException([NSString stringWithFormat:@"Array property value (%@) is not enumerable.", obj]);
+                    @throw  RLMException(@"Array property value (%@) is not enumerable.", obj);
                 }
                 if (validateNested) {
                     id<NSFastEnumeration> array = obj;
@@ -470,11 +469,10 @@ RLMObjectBase *RLMCreateObjectInRealmWithValue(RLMRealm *realm, NSString *classN
     RLMSchema *schema = realm.schema;
     RLMObjectSchema *objectSchema = [realm.schema schemaForClassName:className];
     if (!objectSchema) {
-        NSString *message = [NSString stringWithFormat:@"Object type '%@' is not persisted in the Realm. "
+        @throw RLMException(@"Object type '%@' is not persisted in the Realm. "
                              @"If using a custom `objectClasses` / `obejctTypes` array in your configuration, "
                              @"add `%@` to the list of `objectClasses` / `objectTypes`.",
-                             className, className];
-        @throw RLMException(message);
+                             className, className);
     }
     RLMObjectBase *object = [[objectSchema.accessorClass alloc] initWithRealm:realm schema:objectSchema];
 
@@ -528,7 +526,7 @@ RLMObjectBase *RLMCreateObjectInRealmWithValue(RLMRealm *realm, NSString *classN
                 }
             }
             else if (created && !prop.optional) {
-                @throw RLMException([NSString stringWithFormat:@"Property '%@' of object of type '%@' cannot be nil.", prop.name, objectSchema.className]);
+                @throw RLMException(@"Property '%@' of object of type '%@' cannot be nil.", prop.name, objectSchema.className);
             }
         }
     }
@@ -596,8 +594,7 @@ id RLMGetObject(RLMRealm *realm, NSString *objectClassName, id key) {
 
     RLMProperty *primaryProperty = objectSchema.primaryKeyProperty;
     if (!primaryProperty) {
-        NSString *msg = [NSString stringWithFormat:@"%@ does not have a primary key", objectClassName];
-        @throw RLMException(msg);
+        @throw RLMException(@"%@ does not have a primary key", objectClassName);
     }
 
     if (!objectSchema.table) {
@@ -615,7 +612,7 @@ id RLMGetObject(RLMRealm *realm, NSString *objectClassName, id key) {
             row = objectSchema.table->find_first_string(primaryProperty.column, RLMStringDataWithNSString(str));
         }
         else {
-            @throw RLMException([NSString stringWithFormat:@"Invalid value '%@' for primary key", key]);
+            @throw RLMException(@"Invalid value '%@' for primary key", key);
         }
     }
     else {
@@ -627,7 +624,7 @@ id RLMGetObject(RLMRealm *realm, NSString *objectClassName, id key) {
             row = objectSchema.table->find_first_null(primaryProperty.column);
         }
         else {
-            @throw RLMException([NSString stringWithFormat:@"Invalid value '%@' for primary key", key]);
+            @throw RLMException(@"Invalid value '%@' for primary key", key);
         }
     }
 

--- a/Realm/RLMProperty.mm
+++ b/Realm/RLMProperty.mm
@@ -161,7 +161,7 @@ BOOL RLMPropertyTypeIsNumeric(RLMPropertyType propertyType) {
 
                 Class cls = [RLMSchema classForString:_objectClassName];
                 if (!RLMIsObjectSubclass(cls)) {
-                    @throw RLMException([NSString stringWithFormat:@"'%@' is not supported as an RLMArray object type. RLMArrays can only contain instances of RLMObject subclasses. See http://realm.io/docs/objc/#to-many for more information.", self.objectClassName]);
+                    @throw RLMException(@"'%@' is not supported as an RLMArray object type. RLMArrays can only contain instances of RLMObject subclasses. See http://realm.io/docs/objc/#to-many for more information.", self.objectClassName);
                 }
             }
             else if (strncmp(code, numberPrefix, numberPrefixLen) == 0) {
@@ -183,13 +183,13 @@ BOOL RLMPropertyTypeIsNumeric(RLMPropertyType propertyType) {
                     _type = RLMPropertyTypeBool;
                 }
                 else {
-                    NSString *message = [NSString stringWithFormat:@"'%@' is not supported as an NSNumber object type. NSNumbers can only be RLMInt, RLMFloat, RLMDouble, and RLMBool at the moment. "
-                                                                   @"See http://realm.io/docs/objc/ for more information.", numberType];
-                    @throw RLMException(message);
+                    @throw RLMException(@"'%@' is not supported as an NSNumber object type. "
+                                        @"NSNumbers can only be RLMInt, RLMFloat, RLMDouble, and RLMBool at the moment. "
+                                        @"See http://realm.io/docs/objc/ for more information.", numberType);
                 }
             }
             else if (strcmp(code, "@\"NSNumber\"") == 0) {
-                @throw RLMException([NSString stringWithFormat:@"NSNumber properties require a protocol defining the contained type - example: NSNumber<RLMInt>."]);
+                @throw RLMException(@"NSNumber properties require a protocol defining the contained type - example: NSNumber<RLMInt>.");
             }
             else if (strcmp(code, "@\"RLMArray\"") == 0) {
                 @throw RLMException(@"RLMArray properties require a protocol defining the contained type - example: RLMArray<Person>.");
@@ -201,7 +201,7 @@ BOOL RLMPropertyTypeIsNumeric(RLMPropertyType propertyType) {
                 // verify type
                 Class cls = [RLMSchema classForString:className];
                 if (!RLMIsObjectSubclass(cls)) {
-                    @throw RLMException([NSString stringWithFormat:@"'%@' is not supported as an RLMObject property. All properties must be primitives, NSString, NSDate, NSData, RLMArray, or subclasses of RLMObject. See http://realm.io/docs/objc/api/Classes/RLMObject.html for more information.", className]);
+                    @throw RLMException(@"'%@' is not supported as an RLMObject property. All properties must be primitives, NSString, NSDate, NSData, RLMArray, or subclasses of RLMObject. See http://realm.io/docs/objc/api/Classes/RLMObject.html for more information.", className);
                 }
 
                 _type = RLMPropertyTypeObject;
@@ -288,14 +288,13 @@ BOOL RLMPropertyTypeIsNumeric(RLMPropertyType propertyType) {
                 _objcRawType = @"@\"NSNumber<RLMBool>\"";
                 break;
             default:
-                @throw RLMException([NSString stringWithFormat:@"Can't persist NSNumber of type '%s': only integers, floats, doubles, and bools are currently supported.", numberType]);
+                @throw RLMException(@"Can't persist NSNumber of type '%s': only integers, floats, doubles, and bools are currently supported.", numberType);
         }
     }
 
     if (![self setTypeFromRawType]) {
-        NSString *reason = [NSString stringWithFormat:@"Can't persist property '%@' with incompatible type. "
-                            "Add to ignoredPropertyNames: method to ignore.", self.name];
-        @throw RLMException(reason);
+        @throw RLMException(@"Can't persist property '%@' with incompatible type. "
+                            "Add to ignoredPropertyNames: method to ignore.", self.name);
     }
 
     // convert type for any swift property types (which are parsed as Any)
@@ -335,9 +334,8 @@ BOOL RLMPropertyTypeIsNumeric(RLMPropertyType propertyType) {
     }
 
     if (![self setTypeFromRawType]) {
-        NSString *reason = [NSString stringWithFormat:@"Can't persist property '%@' with incompatible type. "
-                             "Add to ignoredPropertyNames: method to ignore.", self.name];
-        @throw RLMException(reason);
+        @throw RLMException(@"Can't persist property '%@' with incompatible type. "
+                             "Add to ignoredPropertyNames: method to ignore.", self.name);
     }
 
     // update getter/setter names

--- a/Realm/RLMRealm.mm
+++ b/Realm/RLMRealm.mm
@@ -384,16 +384,16 @@ static id RLMAutorelease(id value) {
     RLMRealm *realm = RLMGetThreadLocalCachedRealmForPath(path);
     if (realm) {
         if (realm->_readOnly != readOnly) {
-            @throw RLMException(@"Realm at path already opened with different read permissions", @{@"path":realm.path});
+            @throw RLMException([NSString stringWithFormat:@"Realm at path '%@' already opened with different read permissions", path]);
         }
         if (realm->_inMemory != inMemory) {
-            @throw RLMException(@"Realm at path already opened with different inMemory settings", @{@"path":realm.path});
+            @throw RLMException([NSString stringWithFormat:@"Realm at path '%@' already opened with different inMemory settings", path]);
         }
         if (realm->_dynamic != dynamic) {
-            @throw RLMException(@"Realm at path already opened with different dynamic settings", @{@"path":realm.path});
+            @throw RLMException([NSString stringWithFormat:@"Realm at path '%@' already opened with different dynamic settings", path]);
         }
         if (realm->_encryptionKey != key && (!key || ![realm->_encryptionKey isEqualToData:key])) {
-            @throw RLMException(@"Realm at path already opened with different encryption key", @{@"path":realm.path});
+            @throw RLMException([NSString stringWithFormat:@"Realm at path '%@' already opened with different encryption key", path]);
         }
         return RLMAutorelease(realm);
     }

--- a/Realm/RLMRealm.mm
+++ b/Realm/RLMRealm.mm
@@ -384,16 +384,16 @@ static id RLMAutorelease(id value) {
     RLMRealm *realm = RLMGetThreadLocalCachedRealmForPath(path);
     if (realm) {
         if (realm->_readOnly != readOnly) {
-            @throw RLMException([NSString stringWithFormat:@"Realm at path '%@' already opened with different read permissions", path]);
+            @throw RLMException(@"Realm at path '%@' already opened with different read permissions", path);
         }
         if (realm->_inMemory != inMemory) {
-            @throw RLMException([NSString stringWithFormat:@"Realm at path '%@' already opened with different inMemory settings", path]);
+            @throw RLMException(@"Realm at path '%@' already opened with different inMemory settings", path);
         }
         if (realm->_dynamic != dynamic) {
-            @throw RLMException([NSString stringWithFormat:@"Realm at path '%@' already opened with different dynamic settings", path]);
+            @throw RLMException(@"Realm at path '%@' already opened with different dynamic settings", path);
         }
         if (realm->_encryptionKey != key && (!key || ![realm->_encryptionKey isEqualToData:key])) {
-            @throw RLMException([NSString stringWithFormat:@"Realm at path '%@' already opened with different encryption key", path]);
+            @throw RLMException(@"Realm at path '%@' already opened with different encryption key", path);
         }
         return RLMAutorelease(realm);
     }
@@ -504,7 +504,7 @@ void RLMRealmSetEncryptionKeyForPath(NSData *encryptionKey, NSString *path) {
 
 static void CheckReadWrite(RLMRealm *realm, NSString *msg=@"Cannot write to a read-only Realm") {
     if (realm->_readOnly) {
-        @throw RLMException(msg);
+        @throw RLMException(@"%@", msg);
     }
 }
 
@@ -796,8 +796,8 @@ static void CheckReadWrite(RLMRealm *realm, NSString *msg=@"Cannot write to a re
 - (void)addObjects:(id<NSFastEnumeration>)array {
     for (RLMObject *obj in array) {
         if (![obj isKindOfClass:[RLMObject class]]) {
-            NSString *msg = [NSString stringWithFormat:@"Cannot insert objects of type %@ with addObjects:. Only RLMObjects are supported.", NSStringFromClass(obj.class)];
-            @throw RLMException(msg);
+            @throw RLMException(@"Cannot insert objects of type %@ with addObjects:. Only RLMObjects are supported.",
+                                NSStringFromClass(obj.class));
         }
         [self addObject:obj];
     }
@@ -806,8 +806,7 @@ static void CheckReadWrite(RLMRealm *realm, NSString *msg=@"Cannot write to a re
 - (void)addOrUpdateObject:(RLMObject *)object {
     // verify primary key
     if (!object.objectSchema.primaryKeyProperty) {
-        NSString *reason = [NSString stringWithFormat:@"'%@' does not have a primary key and can not be updated", object.objectSchema.className];
-        @throw RLMException(reason);
+        @throw RLMException(@"'%@' does not have a primary key and can not be updated", object.objectSchema.className);
     }
 
     RLMAddObjectToRealm(object, self, true);

--- a/Realm/RLMRealmConfiguration.mm
+++ b/Realm/RLMRealmConfiguration.mm
@@ -174,7 +174,7 @@ static NSString * const c_defaultRealmFileName = @"default.realm";
 
 - (void)setSchemaVersion:(uint64_t)schemaVersion {
     if ((_schemaVersion = schemaVersion) == RLMNotVersioned) {
-        @throw RLMException([NSString stringWithFormat:@"Cannot set schema version to %llu (RLMNotVersioned)", RLMNotVersioned]);
+        @throw RLMException(@"Cannot set schema version to %llu (RLMNotVersioned)", RLMNotVersioned);
     }
 }
 
@@ -190,6 +190,6 @@ static NSString * const c_defaultRealmFileName = @"default.realm";
 
 void RLMRealmConfigurationUsePerPath(SEL callingMethod) {
     if (s_configurationUsage.exchange(RLMRealmConfigurationUsagePerPath) == RLMRealmConfigurationUsageConfiguration) {
-        @throw RLMException([NSString stringWithFormat:@"Cannot call %@ after setting a default configuration.", NSStringFromSelector(callingMethod)]);
+        @throw RLMException(@"Cannot call %@ after setting a default configuration.", NSStringFromSelector(callingMethod));
     }
 }

--- a/Realm/RLMRealmUtil.mm
+++ b/Realm/RLMRealmUtil.mm
@@ -80,7 +80,7 @@ void RLMInstallUncaughtExceptionHandler() {
 // Convert an error code to either an NSError or an exception
 static id handleError(int err, NSError **error) {
     if (!error) {
-        @throw RLMException(@(strerror(err)));
+        @throw RLMException(@"%@", @(strerror(err)));
     }
     *error = [NSError errorWithDomain:NSPOSIXErrorDomain code:err userInfo:nil];
     return nil;

--- a/Realm/RLMResults.mm
+++ b/Realm/RLMResults.mm
@@ -281,7 +281,7 @@ static inline void RLMResultsValidateInWriteTransaction(__unsafe_unretained RLMR
     RLMResultsValidate(self);
 
     if (index >= self.count) {
-        @throw RLMException([NSString stringWithFormat:@"Index %@ is out of bounds.", @(index)]);
+        @throw RLMException(@"Index %@ is out of bounds.", @(index));
     }
     return RLMCreateObjectAccessor(_realm, _objectSchema, [self indexInSource:index]);
 }
@@ -317,8 +317,7 @@ static inline void RLMResultsValidateInWriteTransaction(__unsafe_unretained RLMR
 
     // check that object types align
     if (object->_row.get_table() != &_backingView.get_parent()) {
-        NSString *message = [NSString stringWithFormat:@"Object type '%@' does not match RLMResults type '%@'.", object->_objectSchema.className, _objectClassName];
-        @throw RLMException(message);
+        @throw RLMException(@"Object type '%@' does not match RLMResults type '%@'.", object->_objectSchema.className, _objectClassName);
     }
 
     size_t object_ndx = object->_row.get_index();
@@ -581,8 +580,7 @@ static NSNumber *averageOfProperty(TableType const& table, RLMRealm *realm, NSSt
 
     // check that object types align
     if (object->_row.get_table() != _table) {
-        NSString *message = [NSString stringWithFormat:@"Object type '%@' does not match RLMResults type '%@'.", object->_objectSchema.className, _objectClassName];
-        @throw RLMException(message);
+        @throw RLMException(@"Object type '%@' does not match RLMResults type '%@'.", object->_objectSchema.className, _objectClassName);
     }
 
     return RLMConvertNotFound(object->_row.get_index());
@@ -665,7 +663,7 @@ static NSNumber *averageOfProperty(TableType const& table, RLMRealm *realm, NSSt
 }
 
 - (id)objectAtIndex:(NSUInteger)index {
-    @throw RLMException([NSString stringWithFormat:@"Index %@ is out of bounds.", @(index)]);
+    @throw RLMException(@"Index %@ is out of bounds.", @(index));
 }
 
 - (id)valueForKey:(NSString *)key {

--- a/Realm/RLMResults.mm
+++ b/Realm/RLMResults.mm
@@ -281,7 +281,7 @@ static inline void RLMResultsValidateInWriteTransaction(__unsafe_unretained RLMR
     RLMResultsValidate(self);
 
     if (index >= self.count) {
-        @throw RLMException(@"Index is out of bounds.", @{@"index": @(index)});
+        @throw RLMException([NSString stringWithFormat:@"Index %@ is out of bounds.", @(index)]);
     }
     return RLMCreateObjectAccessor(_realm, _objectSchema, [self indexInSource:index]);
 }
@@ -665,7 +665,7 @@ static NSNumber *averageOfProperty(TableType const& table, RLMRealm *realm, NSSt
 }
 
 - (id)objectAtIndex:(NSUInteger)index {
-    @throw RLMException(@"Index is out of bounds.", @{@"index": @(index)});
+    @throw RLMException([NSString stringWithFormat:@"Index %@ is out of bounds.", @(index)]);
 }
 
 - (id)valueForKey:(NSString *)key {

--- a/Realm/RLMSchema.mm
+++ b/Realm/RLMSchema.mm
@@ -56,7 +56,7 @@ static NSMutableDictionary *s_localNameToClass = [[NSMutableDictionary alloc] in
     NSMutableArray *schemas = [NSMutableArray arrayWithCapacity:count];
     for (Class cls in classes) {
         if (!RLMIsObjectSubclass(cls)) {
-            @throw RLMException([NSString stringWithFormat:@"Can't add non-Object type '%@' to a schema.", cls]);
+            @throw RLMException(@"Can't add non-Object type '%@' to a schema.", cls);
         }
         [schemas addObject:[cls sharedSchema]];
     }
@@ -75,7 +75,7 @@ static NSMutableDictionary *s_localNameToClass = [[NSMutableDictionary alloc] in
         }
     }
     if (errors.count) {
-        @throw RLMException([@"Invalid class subset list:\n" stringByAppendingString:[errors componentsJoinedByString:@"\n"]]);
+        @throw RLMException(@"Invalid class subset list:\n%@", [errors componentsJoinedByString:@"\n"]);
     }
 
     return schema;
@@ -88,8 +88,7 @@ static NSMutableDictionary *s_localNameToClass = [[NSMutableDictionary alloc] in
 - (RLMObjectSchema *)objectForKeyedSubscript:(__unsafe_unretained id<NSCopying> const)className {
     RLMObjectSchema *schema = _objectSchemaByName[className];
     if (!schema) {
-        NSString *message = [NSString stringWithFormat:@"Object type '%@' not persisted in Realm", className];
-        @throw RLMException(message);
+        @throw RLMException(@"Object type '%@' not persisted in Realm", className);
     }
     return schema;
 }
@@ -128,14 +127,13 @@ static NSMutableDictionary *s_localNameToClass = [[NSMutableDictionary alloc] in
             // but not for nested classes. _T indicates it's a Swift symbol, t
             // indicates it's a type, and C indicates it's a class.
             else if ([className hasPrefix:@"_TtC"]) {
-                NSString *message = [NSString stringWithFormat:@"RLMObject subclasses cannot be nested within other declarations. Please move %@ to global scope.", className];
-                @throw RLMException(message);
+                @throw RLMException(@"RLMObject subclasses cannot be nested within other declarations. Please move %@ to global scope.", className);
             }
 
             if (Class existingClass = s_localNameToClass[className]) {
                 if (existingClass != cls) {
-                    NSString *message = [NSString stringWithFormat:@"RLMObject subclasses with the same name cannot be included twice in the same target. Please make sure '%@' is only linked once to your current target.", className];
-                    @throw RLMException(message);
+                    @throw RLMException(@"RLMObject subclasses with the same name cannot be included twice in the same target. "
+                                        @"Please make sure '%@' is only linked once to your current target.", className);
                 }
                 continue;
             }

--- a/Realm/RLMUtil.hpp
+++ b/Realm/RLMUtil.hpp
@@ -32,7 +32,8 @@
 @class RLMSchema;
 @protocol RLMFastEnumerable;
 
-NSException *RLMException(NSString *message);
+__attribute__((format(NSString, 1, 2)))
+NSException *RLMException(NSString *fmt, ...);
 NSException *RLMException(std::exception const& exception);
 
 NSError *RLMMakeError(RLMError code, std::exception const& exception);

--- a/Realm/RLMUtil.hpp
+++ b/Realm/RLMUtil.hpp
@@ -32,7 +32,7 @@
 @class RLMSchema;
 @protocol RLMFastEnumerable;
 
-NSException *RLMException(NSString *message, NSDictionary *userInfo = nil);
+NSException *RLMException(NSString *message);
 NSException *RLMException(std::exception const& exception);
 
 NSError *RLMMakeError(RLMError code, std::exception const& exception);

--- a/Realm/RLMUtil.mm
+++ b/Realm/RLMUtil.mm
@@ -241,14 +241,10 @@ void RLMCollectionSetValueForKey(id<RLMFastEnumerable> collection, NSString *key
 }
 
 
-NSException *RLMException(NSString *reason, NSDictionary *userInfo) {
-    NSMutableDictionary *info = [NSMutableDictionary dictionaryWithDictionary:userInfo];
-    [info addEntriesFromDictionary:@{
-                                     RLMRealmVersionKey : REALM_COCOA_VERSION,
-                                     RLMRealmCoreVersionKey : @REALM_VERSION
-                                     }];
-
-    return [NSException exceptionWithName:RLMExceptionName reason:reason userInfo:info];
+NSException *RLMException(NSString *reason) {
+    return [NSException exceptionWithName:RLMExceptionName reason:reason
+                                 userInfo:@{RLMRealmVersionKey: REALM_COCOA_VERSION,
+                                            RLMRealmCoreVersionKey: @REALM_VERSION}];
 }
 
 NSException *RLMException(std::exception const& exception) {
@@ -281,7 +277,7 @@ void RLMSetErrorOrThrow(NSError *error, NSError **outError) {
         *outError = error;
     }
     else {
-        @throw RLMException(error.localizedDescription, error.userInfo);
+        @throw RLMException(error.localizedDescription);
     }
 }
 

--- a/Realm/RLMUtil.mm
+++ b/Realm/RLMUtil.mm
@@ -241,14 +241,19 @@ void RLMCollectionSetValueForKey(id<RLMFastEnumerable> collection, NSString *key
 }
 
 
-NSException *RLMException(NSString *reason) {
-    return [NSException exceptionWithName:RLMExceptionName reason:reason
-                                 userInfo:@{RLMRealmVersionKey: REALM_COCOA_VERSION,
-                                            RLMRealmCoreVersionKey: @REALM_VERSION}];
+NSException *RLMException(NSString *fmt, ...) {
+    va_list args;
+    va_start(args, fmt);
+    NSException *e = [NSException exceptionWithName:RLMExceptionName
+                                             reason:[[NSString alloc] initWithFormat:fmt arguments:args]
+                                           userInfo:@{RLMRealmVersionKey: REALM_COCOA_VERSION,
+                                                      RLMRealmCoreVersionKey: @REALM_VERSION}];
+    va_end(args);
+    return e;
 }
 
 NSException *RLMException(std::exception const& exception) {
-    return RLMException(@(exception.what()));
+    return RLMException(@"%@", @(exception.what()));
 }
 
 NSError *RLMMakeError(RLMError code, std::exception const& exception) {
@@ -277,7 +282,7 @@ void RLMSetErrorOrThrow(NSError *error, NSError **outError) {
         *outError = error;
     }
     else {
-        @throw RLMException(error.localizedDescription);
+        @throw RLMException(@"%@", error.localizedDescription);
     }
 }
 

--- a/Realm/Tests/UtilTests.mm
+++ b/Realm/Tests/UtilTests.mm
@@ -33,7 +33,7 @@ static BOOL RLMEqualExceptions(NSException *actual, NSException *expected) { \
 @implementation UtilTests
 
 - (void)testRLMExceptionWithReasonAndUserInfo {
-    NSString *reason = @"Reason";
+    NSString *const reason = @"Reason";
     NSDictionary *expectedUserInfo = @{
                                        RLMRealmVersionKey : REALM_COCOA_VERSION,
                                        RLMRealmCoreVersionKey : @REALM_VERSION,

--- a/Realm/Tests/UtilTests.mm
+++ b/Realm/Tests/UtilTests.mm
@@ -34,21 +34,13 @@ static BOOL RLMEqualExceptions(NSException *actual, NSException *expected) { \
 
 - (void)testRLMExceptionWithReasonAndUserInfo {
     NSString *reason = @"Reason";
-    NSDictionary *userInfo = @{ @"key" : @"value" };
     NSDictionary *expectedUserInfo = @{
                                        RLMRealmVersionKey : REALM_COCOA_VERSION,
                                        RLMRealmCoreVersionKey : @REALM_VERSION,
                                        };
 
-    XCTAssertTrue(RLMEqualExceptions(RLMException(reason), [NSException exceptionWithName:RLMExceptionName reason:reason userInfo:expectedUserInfo]));
-    XCTAssertTrue(RLMEqualExceptions(RLMException(reason, nil), [NSException exceptionWithName:RLMExceptionName reason:reason userInfo:expectedUserInfo]));
-
-    expectedUserInfo = @{
-                         @"key" : @"value",
-                         RLMRealmVersionKey : REALM_COCOA_VERSION,
-                         RLMRealmCoreVersionKey : @REALM_VERSION,
-                         };
-    XCTAssertTrue(RLMEqualExceptions(RLMException(reason, userInfo), [NSException exceptionWithName:RLMExceptionName reason:reason userInfo:expectedUserInfo]));
+    XCTAssertTrue(RLMEqualExceptions(RLMException(reason),
+                                     [NSException exceptionWithName:RLMExceptionName reason:reason userInfo:expectedUserInfo]));
 }
 
 - (void)testRLMExceptionWithCPlusPlusException {
@@ -58,7 +50,8 @@ static BOOL RLMEqualExceptions(NSException *actual, NSException *expected) { \
                                        RLMRealmCoreVersionKey : @REALM_VERSION,
                                        };
 
-    XCTAssertTrue(RLMEqualExceptions(RLMException(exception), [NSException exceptionWithName:RLMExceptionName reason:@"Reason" userInfo:expectedUserInfo]));
+    XCTAssertTrue(RLMEqualExceptions(RLMException(exception),
+                                     [NSException exceptionWithName:RLMExceptionName reason:@"Reason" userInfo:expectedUserInfo]));
 }
 
 - (void)testRLMMakeError {
@@ -69,7 +62,8 @@ static BOOL RLMEqualExceptions(NSException *actual, NSException *expected) { \
                                        @"Error Code" : @(code),
                                        };
 
-    XCTAssertEqualObjects(RLMMakeError(code, exception), ([NSError errorWithDomain:RLMErrorDomain code:code userInfo:expectedUserInfo]));
+    XCTAssertEqualObjects(RLMMakeError(code, exception),
+                          [NSError errorWithDomain:RLMErrorDomain code:code userInfo:expectedUserInfo]);
 }
 
 - (void)testRLMSetErrorOrThrowWithNilErrorPointer {


### PR DESCRIPTION
Remove the error-specific userInfo from all exceptions (there were only a few left) and move the relevant information to the exception message, since it's quite clear that no one actually looks at the userInfo.

Make RLMException take varargs and perform string formatting since nearly every usage of it was of the form `RLMException([NSString stringWithFormat:...])` (or something equivalent split over more lines), which was needlessly verbose.