### PR TITLE
Remove testNotificationsForChangesWhileSuspended

### DIFF
--- a/Realm/Tests/InterprocessTests.m
+++ b/Realm/Tests/InterprocessTests.m
@@ -303,29 +303,4 @@
     }
 }
 
-- (void)testNotificationsForChangesWhileSuspended {
-    RLMRealm *realm = RLMRealm.defaultRealm;
-    if (self.isParent) {
-        // Launch the child and wait for it to make a commit to signal that it's done launching
-        NSTask *child = [self childTask];
-        [self waitForNotification:RLMRealmDidChangeNotification realm:realm block:^{
-            [child launch];
-        }];
-
-        // Suspend it, make a commit, then resume it
-        [child suspend];
-        [realm transactionWithBlock:^{}];
-        [child resume];
-
-        // blocks forever if the child doesn't get notified
-        [child waitUntilExit];
-    }
-    else {
-        // Tell the parent we've launched
-        [realm transactionWithBlock:^{}];
-        // Wait for a commit notification from the parent
-        [self waitForNotification:RLMRealmDidChangeNotification realm:realm block:^{}];
-    }
-}
-
 @end


### PR DESCRIPTION
Because -[NSTask suspend] is asynchronous and there doesn't seem to be a
reliable way to check this programmatically, and this spuriously fails on CI on
a regular basis.

The intent of this test is also tested elsewhere in the interprocess tests.

Resolves #2119. /cc @tgoyne 