### PR TITLE
[Podspec] add header files from ObjectStore's impl directory

### DIFF
--- a/Realm.podspec
+++ b/Realm.podspec
@@ -60,6 +60,8 @@ Pod::Spec.new do |s|
   s.subspec 'Headers' do |s|
     s.source_files          = 'include/**/*.{h,hpp}'
     s.public_header_files   = public_header_files
-    s.private_header_files  = 'include/Realm/*{Accessor,RealmUtil,ListBase,ObjectStore,Private}.h', 'include/Realm/ObjectStore/*.hpp'
+    s.private_header_files  = 'include/Realm/*{Accessor,RealmUtil,ListBase,ObjectStore,Private}.h',
+                              'include/Realm/ObjectStore/*.hpp',
+                              'include/Realm/ObjectStore/impl/*.hpp'
   end
 end


### PR DESCRIPTION
Realm doesn't compile with CocoaPods without this (see https://ci.realm.io/job/Cocoa%20Installation%20Examples/12/). /cc @bdash 