### PR TITLE
Removed some unused declarations

### DIFF
--- a/Realm/RLMAccessor.h
+++ b/Realm/RLMAccessor.h
@@ -20,7 +20,7 @@
 
 #import <Realm/RLMDefines.h>
 
-@class RLMObjectSchema, RLMProperty, RLMObjectBase, RLMRealm, RLMProperty;
+@class RLMObjectSchema, RLMProperty, RLMObjectBase, RLMProperty;
 
 #ifdef __cplusplus
 typedef NSUInteger RLMCreationOptions;

--- a/Realm/RLMRealmUtil.hpp
+++ b/Realm/RLMRealmUtil.hpp
@@ -39,14 +39,4 @@ void RLMClearRealmCache();
 // for all cached realms on the current thread
 void RLMInstallUncaughtExceptionHandler();
 
-@interface RLMNotifier : NSObject
-// listens to changes to the realm's file and notifies it when they occur
-// does not retain the Realm
-- (instancetype)initWithRealm:(RLMRealm *)realm error:(NSError **)error;
-// stop listening for changes
-- (void)stop;
-// notify other Realm instances for the same path that a change has occurred
-- (void)notifyOtherRealms;
-@end
-
 std::unique_ptr<realm::RealmDelegate> RLMCreateRealmDelegate(RLMRealm *realm);

--- a/Realm/RLMRealm_Private.h
+++ b/Realm/RLMRealm_Private.h
@@ -18,7 +18,7 @@
 
 #import <Realm/RLMRealm.h>
 
-@class RLMFastEnumerator, RLMNotifier;
+@class RLMFastEnumerator;
 
 // Disable syncing files to disk. Cannot be re-enabled. Use only for tests.
 FOUNDATION_EXTERN void RLMDisableSyncToDisk();

--- a/Realm/RLMRealm_Private.hpp
+++ b/Realm/RLMRealm_Private.hpp
@@ -20,9 +20,7 @@
 #import "RLMUtil.hpp"
 #import "shared_realm.hpp"
 
-#import <realm/link_view.hpp>
 #import <realm/group.hpp>
-#import <pthread.h>
 
 namespace realm {
     class Group;

--- a/Realm/RLMSchema_Private.hpp
+++ b/Realm/RLMSchema_Private.hpp
@@ -19,7 +19,6 @@
 #import "RLMSchema_Private.h"
 
 #import <memory>
-#import <vector>
 
 namespace realm {
     class Schema;

--- a/Realm/RLMSwiftSupport.h
+++ b/Realm/RLMSwiftSupport.h
@@ -18,8 +18,6 @@
 
 #import <Foundation/Foundation.h>
 
-@class RLMArray;
-
 @interface RLMSwiftSupport : NSObject
 
 + (BOOL)isSwiftClassName:(NSString *)className;

--- a/Realm/RLMUtil.hpp
+++ b/Realm/RLMUtil.hpp
@@ -28,8 +28,6 @@
 
 @class RLMObjectSchema;
 @class RLMProperty;
-@class RLMRealm;
-@class RLMSchema;
 @protocol RLMFastEnumerable;
 
 __attribute__((format(NSString, 1, 2)))


### PR DESCRIPTION
`RLMNotifier` was still declared despite being removed. Remove it, and some imports and forward declarations that are no longer necessary.