### PR TITLE
Fix an issue Swift optional properties no longer ignored

### DIFF
--- a/Realm/RLMObjectSchema.mm
+++ b/Realm/RLMObjectSchema.mm
@@ -204,6 +204,9 @@ using namespace realm;
             property.optional = false;
         }
         [optionalProperties enumerateKeysAndObjectsUsingBlock:^(NSString *propertyName, NSNumber *propertyType, __unused BOOL *stop) {
+            if ([ignoredProperties containsObject:propertyName]) {
+                return;
+            }
             NSUInteger existing = [propArray indexOfObjectPassingTest:^BOOL(RLMProperty *obj, __unused NSUInteger idx, __unused BOOL *stop) {
                 return [obj.name isEqualToString:propertyName];
             }];

--- a/RealmSwift-swift1.2/Tests/ObjectCreationTests.swift
+++ b/RealmSwift-swift1.2/Tests/ObjectCreationTests.swift
@@ -184,6 +184,15 @@ class ObjectCreationTests: TestCase {
         }
     }
 
+    func testCreateWithOptionalIgnoredProperties() {
+        let realm = Realm()
+        realm.write {
+            let object = realm.create(SwiftOptionalIgnoredPropertiesObject)
+            let properties = object.objectSchema.properties
+            XCTAssertEqual(properties, [])
+        }
+    }
+
     func testCreateWithDictionary() {
         // dictionary with all values specified
         let baselineValues =

--- a/RealmSwift-swift1.2/Tests/SwiftTestObjects.swift
+++ b/RealmSwift-swift1.2/Tests/SwiftTestObjects.swift
@@ -116,6 +116,24 @@ class SwiftOptionalDefaultValuesObject: Object {
     }
 }
 
+class SwiftOptionalIgnoredPropertiesObject: Object {
+    dynamic var optNSStringCol: NSString? = "A"
+    dynamic var optStringCol: String? = "B"
+    dynamic var optBinaryCol: NSData? = "C".dataUsingEncoding(NSUTF8StringEncoding)
+    dynamic var optDateCol: NSDate? = NSDate(timeIntervalSince1970: 10)
+    dynamic var optObjectCol: SwiftBoolObject? = SwiftBoolObject(value: [true])
+
+    override class func ignoredProperties() -> [String] {
+        return [
+            "optNSStringCol",
+            "optStringCol",
+            "optBinaryCol",
+            "optDateCol",
+            "optObjectCol"
+        ]
+    }
+}
+
 
 class SwiftDogObject: Object {
     dynamic var dogName = ""

--- a/RealmSwift-swift2.0/Tests/ObjectCreationTests.swift
+++ b/RealmSwift-swift2.0/Tests/ObjectCreationTests.swift
@@ -183,6 +183,15 @@ class ObjectCreationTests: TestCase {
         }
     }
 
+    func testCreateWithOptionalIgnoredProperties() {
+        let realm = try! Realm()
+        try! realm.write {
+            let object = realm.create(SwiftOptionalIgnoredPropertiesObject)
+            let properties = object.objectSchema.properties
+            XCTAssertEqual(properties, [])
+        }
+    }
+
     func testCreateWithDictionary() {
         // dictionary with all values specified
         let baselineValues =

--- a/RealmSwift-swift2.0/Tests/SwiftTestObjects.swift
+++ b/RealmSwift-swift2.0/Tests/SwiftTestObjects.swift
@@ -116,6 +116,24 @@ class SwiftOptionalDefaultValuesObject: Object {
     }
 }
 
+class SwiftOptionalIgnoredPropertiesObject: Object {
+    dynamic var optNSStringCol: NSString? = "A"
+    dynamic var optStringCol: String? = "B"
+    dynamic var optBinaryCol: NSData? = "C".dataUsingEncoding(NSUTF8StringEncoding)
+    dynamic var optDateCol: NSDate? = NSDate(timeIntervalSince1970: 10)
+    dynamic var optObjectCol: SwiftBoolObject? = SwiftBoolObject(value: [true])
+
+    override class func ignoredProperties() -> [String] {
+        return [
+            "optNSStringCol",
+            "optStringCol",
+            "optBinaryCol",
+            "optDateCol",
+            "optObjectCol"
+        ]
+    }
+}
+
 
 
 class SwiftDogObject: Object {


### PR DESCRIPTION
This PR to fix the problem that the properties would be added to the schema even marked as ignored if the properties are optional.

It will happen only on Swift optional properties. 

Related issue: https://github.com/realm/realm-cocoa/issues/2732