### PR TITLE
Remove testRealmCreationUncached baseline from the new iOS devices

### DIFF
--- a/Realm.xcodeproj/xcshareddata/xcbaselines/3F8DCA5619930F550008BD7F.xcbaseline/02FEA37F-2419-44D8-B00E-E0A4939BEDDB.plist
+++ b/Realm.xcodeproj/xcshareddata/xcbaselines/3F8DCA5619930F550008BD7F.xcbaseline/02FEA37F-2419-44D8-B00E-E0A4939BEDDB.plist
@@ -238,18 +238,6 @@
 					<string>Local Baseline</string>
 				</dict>
 			</dict>
-			<key>testRealmCreationUncached</key>
-			<dict>
-				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
-				<dict>
-					<key>baselineAverage</key>
-					<real>4.95</real>
-					<key>baselineIntegrationDisplayName</key>
-					<string>Local Baseline</string>
-					<key>maxStandardDeviation</key>
-					<real>0.15</real>
-				</dict>
-			</dict>
 			<key>testSortingAllObjects</key>
 			<dict>
 				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>

--- a/Realm.xcodeproj/xcshareddata/xcbaselines/3F8DCA5619930F550008BD7F.xcbaseline/A4B676B6-55C6-4B74-8D3F-AC3B2CFE23C4.plist
+++ b/Realm.xcodeproj/xcshareddata/xcbaselines/3F8DCA5619930F550008BD7F.xcbaseline/A4B676B6-55C6-4B74-8D3F-AC3B2CFE23C4.plist
@@ -238,16 +238,6 @@
 					<string>Local Baseline</string>
 				</dict>
 			</dict>
-			<key>testRealmCreationUncached</key>
-			<dict>
-				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
-				<dict>
-					<key>baselineAverage</key>
-					<real>5.2</real>
-					<key>baselineIntegrationDisplayName</key>
-					<string>Local Baseline</string>
-				</dict>
-			</dict>
 			<key>testSortingAllObjects</key>
 			<dict>
 				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>

--- a/RealmSwift.xcodeproj/xcshareddata/xcbaselines/02B822551A532100007F28A5.xcbaseline/B87A7896-8B70-4814-B20D-7CD723D62868.plist
+++ b/RealmSwift.xcodeproj/xcshareddata/xcbaselines/02B822551A532100007F28A5.xcbaseline/B87A7896-8B70-4814-B20D-7CD723D62868.plist
@@ -236,16 +236,6 @@
 					<string>Oct 9, 2015, 5:58:23 PM</string>
 				</dict>
 			</dict>
-			<key>testRealmCreationUncached()</key>
-			<dict>
-				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
-				<dict>
-					<key>baselineAverage</key>
-					<real>5.228</real>
-					<key>baselineIntegrationDisplayName</key>
-					<string>Oct 9, 2015, 5:58:23 PM</string>
-				</dict>
-			</dict>
 			<key>testSortingAllObjects()</key>
 			<dict>
 				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>


### PR DESCRIPTION
`testRealmCreationUncached` is slow and has high variance, causing frequent failures on CI. Removing the baseline allows the test to be run locally while avoiding the sporadic failures on CI.

/cc @tgoyne 