### PR TITLE
Fix the path to the core static library that CocoaPods uses

### DIFF
--- a/Realm.podspec
+++ b/Realm.podspec
@@ -50,7 +50,7 @@ Pod::Spec.new do |s|
   s.preserve_paths          = %w(build.sh)
 
   s.ios.deployment_target   = '7.0'
-  s.ios.vendored_library    = 'core/librealm-ios-no-bitcode.a'
+  s.ios.vendored_library    = 'core/librealm-ios.a'
 
   s.osx.deployment_target   = '10.9'
   s.osx.vendored_library    = 'core/librealm-osx.a'


### PR DESCRIPTION
It was set to `librealm-ios-no-bitcode.a` prior to `build.sh` picking up the automatic selection of bitcode or no-bitcode library based on the Xcode version. Now that `build.sh` contains that logic, `librealm-ios-no-bitcode.a` does not exist after `build.sh cocoapods-setup` completes.