### PR TITLE
Add casts to suppress spurious warnings about values outside of the range of the enum

### DIFF
--- a/Realm/Tests/ObjectTests.m
+++ b/Realm/Tests/ObjectTests.m
@@ -646,7 +646,8 @@ RLM_ARRAY_TYPE(PrimaryEmployeeObject);
 
     [realm beginWriteTransaction];
     NSDate *date = ({
-        NSDateComponents *components = [[NSCalendar currentCalendar] components:NSCalendarUnitMonth|NSCalendarUnitYear|NSCalendarUnitDay fromDate:NSDate.date];
+        NSCalendarUnit units = (NSCalendarUnit)(NSCalendarUnitMonth | NSCalendarUnitYear | NSCalendarUnitDay);
+        NSDateComponents *components = [[NSCalendar currentCalendar] components:units fromDate:NSDate.date];
         components.calendar = [NSCalendar currentCalendar];
         components.year += 50000;
         components.date;

--- a/Realm/Tests/RLMAssertions.h
+++ b/Realm/Tests/RLMAssertions.h
@@ -42,8 +42,8 @@
 #define RLMPrimitiveAssertMatches(self, expression, regexString, format...) \
 ({ \
     NSString *string = (expression); \
-    NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern: regexString options: 0 error:nil]; \
-    if ([regex numberOfMatchesInString:string options:0 range:NSMakeRange(0, string.length)] == 0) { \
+    NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:regexString options:(NSRegularExpressionOptions)0 error:nil]; \
+    if ([regex numberOfMatchesInString:string options:(NSMatchingOptions)0 range:NSMakeRange(0, string.length)] == 0) { \
         _XCTRegisterFailure(self, [_XCTFailureDescription(_XCTAssertion_True, 0, @#expression @" (EXPR_STRING) matches " @#regexString) stringByReplacingOccurrencesOfString:@"EXPR_STRING" withString:string ?: @"<nil>"], format); \
     } \
 })


### PR DESCRIPTION
The warnings are being emitted for two option enums that have no explicit "none" member, and for `NSCalendar`'s misuse of an option enum as an argument type where it expects the multiple options to be combined.

/cc @jpsim @tgoyne 
