### PR TITLE
Copy bcsymbolmap files to build products folder when archiving

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -101,6 +101,10 @@ xc() {
     fi
 }
 
+copy_bcsymbolmap() {
+    find "$1" -name '*.bcsymbolmap' -type f -exec cp {} "$2" \;
+}
+
 build_ios_combined() {
     local scheme="$1"
     local module_name="$2"
@@ -124,6 +128,9 @@ build_ios_combined() {
     if [ -d $iphonesimulator_path/Modules/$module_name.swiftmodule ]; then
       cp $iphonesimulator_path/Modules/$module_name.swiftmodule/* $iphoneos_path/Modules/$module_name.swiftmodule/
     fi
+    
+    # Copy *.bcsymbolmap to .framework for submitting app with bitcode
+    copy_bcsymbolmap "$build_products_path/$config-iphoneos$scope_suffix" "$iphoneos_path"
 
     # Retrieve build products
     clean_retrieve $iphoneos_path $out_path $product_name
@@ -154,6 +161,9 @@ build_watchos_combined() {
     if [ -d $watchsimulator_path/Modules/$module_name.swiftmodule ]; then
       cp $watchsimulator_path/Modules/$module_name.swiftmodule/* $watchos_path/Modules/$module_name.swiftmodule/
     fi
+    
+    # Copy *.bcsymbolmap
+    copy_bcsymbolmap "$build_products_path/$config-watchos$scope_suffix" "$watchos_path"
 
     # Retrieve build products
     clean_retrieve $watchos_path $out_path $product_name

--- a/scripts/strip-frameworks.sh
+++ b/scripts/strip-frameworks.sh
@@ -60,3 +60,12 @@ for file in $(find . -type f -perm +111); do
     fi
   fi
 done
+
+if [ "$ACTION" = "install" ]; then
+  echo "Copy .bcsymbolmap files to .xcarchive"
+  mv Realm.framework/*.bcsymbolmap RealmSwift.framework/*.bcsymbolmap "${CONFIGURATION_BUILD_DIR}"
+else
+  # Delete *.bcsymbolmap files from framework bundle unless archiving
+  rm -f Realm.framework/*.bcsymbolmap
+  rm -f RealmSwift.framework/*.bcsymbolmap
+fi

--- a/scripts/strip-frameworks.sh
+++ b/scripts/strip-frameworks.sh
@@ -63,9 +63,8 @@ done
 
 if [ "$ACTION" = "install" ]; then
   echo "Copy .bcsymbolmap files to .xcarchive"
-  mv Realm.framework/*.bcsymbolmap RealmSwift.framework/*.bcsymbolmap "${CONFIGURATION_BUILD_DIR}"
+  find . -name '*.bcsymbolmap' -type f -exec mv {} "${CONFIGURATION_BUILD_DIR}" \;
 else
   # Delete *.bcsymbolmap files from framework bundle unless archiving
-  rm -f Realm.framework/*.bcsymbolmap
-  rm -f RealmSwift.framework/*.bcsymbolmap
+  find . -name '*.bcsymbolmap' -type f -exec rm -rf "{}" +\;
 fi


### PR DESCRIPTION
`*.bcsymbolmap` files are necessary to submit an app with including debug symbols. If there are no those files, following error occurs unless uncheck "include app symbols ..."

![untitled](https://cloud.githubusercontent.com/assets/40610/10799433/2189cfd0-7df0-11e5-8cf2-42d8dceffe7e.png)

```
The archive did not contain 
<DVTFilePath:0x7f91ea526720:'...xcarchive/BCSymbolMaps/....bcsymbolmap'> as expected.
```

This PR makes it include the `*.bcsymbolmap` files to the each framework bundles. Those files are moved to an app bundle when archiving.

See also:
[Missing BCSymbolMap for AppStore Submission - Xcode7B5](https://forums.developer.apple.com/thread/14729)

/cc @jpsim @mrackwitz 