### PR TITLE
Fix reporting of the Target OS Type when building with older iOS SDKs.

### DIFF
--- a/Realm/RLMAnalytics.mm
+++ b/Realm/RLMAnalytics.mm
@@ -189,10 +189,10 @@ static NSDictionary *RLMAnalyticsPayload() {
                      @"Binding": @"cocoa",
                      @"Language": isSwift ? @"swift" : @"objc",
                      @"Realm Version": REALM_COCOA_VERSION,
-#if TARGET_OS_IOS
-                     @"Target OS Type": @"ios",
-#elif TARGET_OS_WATCH
+#if TARGET_OS_WATCH
                      @"Target OS Type": @"watchos",
+#elif TARGET_OS_IPHONE
+                     @"Target OS Type": @"ios",
 #else
                      @"Target OS Type": @"osx",
 #endif


### PR DESCRIPTION
`TARGET_OS_IOS` is new in iOS 9.0, so builds made with older iOS SDKs were reported as targeting OS X. Switch to using `TARGET_OS_IPHONE` instead.

/cc @jpsim @timanglade 