### PR TITLE
Fix test-ios-static with XCMODE=xcpretty

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -178,7 +178,7 @@ xcrealm_work_around_rdar_23055637() {
     # xcodebuild times out waiting for the iOS simulator to launch if it takes > 120 seconds for the tests to
     # build (<http://openradar.appspot.com/23055637>). Work around this by having the test phases intentionally
     # exit after they finish building the first time, then run the tests for real.
-    REALM_EXIT_AFTER_BUILDING_TESTS=YES xcrealm "$1" || true
+    ( REALM_EXIT_AFTER_BUILDING_TESTS=YES xcrealm "$1" ) || true
     xcrealm "$1"
 }
 


### PR DESCRIPTION
Update `xcrealm_work_around_rdar_23055637` to invoke the expected-to-fail build in a subshell so we can ignore its exit status in all cases.

This should also fix the releasability tests as they invoke `test-iso-static` with `XCMODE=xcpretty`.

/cc @jpsim @tgoyne 