### PR TITLE
Add `@noescape` attribute to `write(_:)` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ x.x.x Release notes (yyyy-MM-dd)
 ### Enhancements
 
 * Queries are no longer limited to 16 levels of grouping.
+* The block parameter of `-[RLMRealm transactionWithBlock:]`/`Realm.write(_:)` is 
+  now marked as `__attribute__((noescape))`/`@noescape`.
 
 ### Bugfixes
 

--- a/Realm/RLMRealm.h
+++ b/Realm/RLMRealm.h
@@ -244,7 +244,7 @@ typedef void(^RLMNotificationBlock)(NSString *notification, RLMRealm *realm);
 /**
  Helper to perform a block within a transaction.
  */
-- (void)transactionWithBlock:(void(^)(void))block RLM_SWIFT_UNAVAILABLE("");
+- (void)transactionWithBlock:(RLM_NOESCAPE void(^)(void))block RLM_SWIFT_UNAVAILABLE("");
 
 /**
  Helper to perform a block within a transaction.
@@ -256,7 +256,7 @@ typedef void(^RLMNotificationBlock)(NSString *notification, RLMRealm *realm);
 
  @return Whether the transaction succeeded.
  */
-- (BOOL)transactionWithBlock:(void(^)(void))block error:(NSError **)error;
+- (BOOL)transactionWithBlock:(RLM_NOESCAPE void(^)(void))block error:(NSError **)error;
 
 /**
  Update an `RLMRealm` and outstanding objects to point to the most recent data for this `RLMRealm`.

--- a/RealmSwift-swift1.2/Realm.swift
+++ b/RealmSwift-swift1.2/Realm.swift
@@ -110,7 +110,7 @@ public final class Realm {
     
     :returns: Whether the transaction succeeded.
     */
-    public func write(error: NSErrorPointer = nil, block: (() -> Void)) -> Bool {
+    public func write(error: NSErrorPointer = nil, @noescape block: (() -> Void)) -> Bool {
         return rlmRealm.transactionWithBlock(block, error: error)
     }
 

--- a/RealmSwift-swift2.0/Realm.swift
+++ b/RealmSwift-swift2.0/Realm.swift
@@ -91,7 +91,7 @@ public final class Realm {
 
     - parameter block: The block to be executed inside a write transaction.
     */
-    public func write(block: (() -> Void)) throws {
+    public func write(@noescape block: (() -> Void)) throws {
         try rlmRealm.transactionWithBlock(block)
     }
 


### PR DESCRIPTION
Because the closure will not be stored anywhere and executed synchronously.
Also, we can use an implicit `self`, saving us from typing `self`.

cc/ @jpsim @mrackwitz 