### PR TITLE
Use the path of the file which actually failed to open in error messages

### DIFF
--- a/Realm/ObjectStore/shared_realm.cpp
+++ b/Realm/ObjectStore/shared_realm.cpp
@@ -73,18 +73,22 @@ Realm::Realm(Config config)
         }
     }
     catch (util::File::PermissionDenied const& ex) {
-        throw RealmFileException(RealmFileException::Kind::PermissionDenied, "Unable to open a realm at path '" + m_config.path +
-                             "'. Please use a path where your app has " + (m_config.read_only ? "read" : "read-write") + " permissions.");
+        throw RealmFileException(RealmFileException::Kind::PermissionDenied, ex.get_path(),
+                                 "Unable to open a realm at path '" + ex.get_path() +
+                                 "'. Please use a path where your app has " + (m_config.read_only ? "read" : "read-write") + " permissions.");
     }
     catch (util::File::Exists const& ex) {
-        throw RealmFileException(RealmFileException::Kind::Exists, "Unable to open a realm at path '" + m_config.path + "'");
+        throw RealmFileException(RealmFileException::Kind::Exists, ex.get_path(),
+                                 "File at path '" + ex.get_path() + "' already exists.");
     }
     catch (util::File::AccessError const& ex) {
-        throw RealmFileException(RealmFileException::Kind::AccessError, "Unable to open a realm at path '" + m_config.path + "'");
+        throw RealmFileException(RealmFileException::Kind::AccessError, ex.get_path(),
+                                 "Unable to open a realm at path '" + ex.get_path() + "'");
     }
-    catch (IncompatibleLockFile const&) {
-        throw RealmFileException(RealmFileException::Kind::IncompatibleLockFile, "Realm file is currently open in another process "
-        "which cannot share access with this process. All processes sharing a single file must be the same architecture.");
+    catch (IncompatibleLockFile const& ex) {
+        throw RealmFileException(RealmFileException::Kind::IncompatibleLockFile, m_config.path,
+                                 "Realm file is currently open in another process "
+                                 "which cannot share access with this process. All processes sharing a single file must be the same architecture.");
     }
 }
 

--- a/Realm/ObjectStore/shared_realm.hpp
+++ b/Realm/ObjectStore/shared_realm.hpp
@@ -151,7 +151,7 @@ namespace realm {
             /** Thrown if the user does not have permission to open or create
              the specified file in the specified access mode when the realm is opened. */
             PermissionDenied,
-            /** Thrown if no_create was specified and the file did already exist when the realm is opened. */
+            /** Thrown if create_Always was specified and the file did already exist when the realm is opened. */
             Exists,
             /** Thrown if no_create was specified and the file was not found when the realm is opened. */
             NotFound,
@@ -160,11 +160,14 @@ namespace realm {
              architecture mismatch. */
             IncompatibleLockFile,
         };
-        RealmFileException(Kind kind, std::string message) : std::runtime_error(message), m_kind(kind) {}
+        RealmFileException(Kind kind, std::string path, std::string message) :
+            std::runtime_error(std::move(message)), m_kind(kind), m_path(std::move(path)) {}
         Kind kind() const { return m_kind; }
+        const std::string& path() const { return m_path; }
         
       private:
         Kind m_kind;
+        std::string m_path;
     };
 
     class MismatchedConfigException : public std::runtime_error

--- a/Realm/RLMRealm.mm
+++ b/Realm/RLMRealm.mm
@@ -244,7 +244,8 @@ static void RLMRealmSetSchemaAndAlign(RLMRealm *realm, RLMSchema *targetSchema) 
                                  "architecture. For sharing files between the Realm "
                                  "Browser and an iOS simulator, this means that you "
                                  "must use a 64-bit simulator.";
-                RLMSetErrorOrThrow(RLMMakeError(RLMErrorIncompatibleLockFile, File::PermissionDenied(err.UTF8String, "FIXME: ex.get_path()")), outError);
+                RLMSetErrorOrThrow(RLMMakeError(RLMErrorIncompatibleLockFile,
+                                                File::PermissionDenied(err.UTF8String, ex.path())), outError);
                 break;
             }
             case RealmFileException::Kind::Exists:

--- a/Realm/RLMUtil.hpp
+++ b/Realm/RLMUtil.hpp
@@ -30,12 +30,17 @@
 @class RLMProperty;
 @protocol RLMFastEnumerable;
 
+namespace realm {
+    class RealmFileException;
+}
+
 __attribute__((format(NSString, 1, 2)))
 NSException *RLMException(NSString *fmt, ...);
 NSException *RLMException(std::exception const& exception);
 
 NSError *RLMMakeError(RLMError code, std::exception const& exception);
 NSError *RLMMakeError(RLMError code, const realm::util::File::AccessError&);
+NSError *RLMMakeError(RLMError code, const realm::RealmFileException&);
 NSError *RLMMakeError(std::system_error const& exception);
 NSError *RLMMakeError(NSException *exception);
 

--- a/Realm/RLMUtil.mm
+++ b/Realm/RLMUtil.mm
@@ -271,6 +271,14 @@ NSError *RLMMakeError(RLMError code, const realm::util::File::AccessError& excep
                                       @"Error Code": @(code)}];
 }
 
+NSError *RLMMakeError(RLMError code, const realm::RealmFileException& exception) {
+    return [NSError errorWithDomain:RLMErrorDomain
+                               code:code
+                           userInfo:@{NSLocalizedDescriptionKey: @(exception.what()),
+                                      NSFilePathErrorKey: @(exception.path().c_str()),
+                                      @"Error Code": @(code)}];
+}
+
 NSError *RLMMakeError(std::system_error const& exception) {
     return [NSError errorWithDomain:RLMErrorDomain
                                code:exception.code().value()


### PR DESCRIPTION
This was done before the object store changes and was missed when those were updated.