### PR TITLE
test Carthage installation examples from source

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,7 @@ build/
 
 # unless supporting rvm < 1.11.0 or doing something fancy, ignore this:
 .rvmrc
+
+## Carthage
+# Cartfiles are ignored because they're generated on demand in the installation examples
+Cartfile

--- a/.gitignore
+++ b/.gitignore
@@ -98,3 +98,4 @@ build/
 ## Carthage
 # Cartfiles are ignored because they're generated on demand in the installation examples
 Cartfile
+Carthage

--- a/examples/installation/build.sh
+++ b/examples/installation/build.sh
@@ -57,8 +57,7 @@ xctest() {
     elif [[ $NAME == Carthage* ]]; then
         (
             cd "$DIRECTORY";
-            : ${sha:=master}
-            echo "github \"realm/realm-cocoa\" \"$sha\"" > Cartfile
+            echo "github \"realm/realm-cocoa\" \"${sha:-master}\"" > Cartfile
             carthage update
         )
     elif [[ $LANG == swift* ]]; then

--- a/examples/installation/build.sh
+++ b/examples/installation/build.sh
@@ -55,7 +55,12 @@ xctest() {
     if [[ $NAME == CocoaPods* ]]; then
         pod install --project-directory="$DIRECTORY"
     elif [[ $NAME == Carthage* ]]; then
-        (cd "$DIRECTORY"; carthage update)
+        (
+            cd "$DIRECTORY";
+            : ${sha:=master}
+            echo "github \"realm/realm-cocoa\" \"$sha\"" > Cartfile
+            carthage update
+        )
     elif [[ $LANG == swift* ]]; then
         download_zip_if_needed swift
     else

--- a/examples/installation/build.sh
+++ b/examples/installation/build.sh
@@ -56,8 +56,12 @@ xctest() {
         pod install --project-directory="$DIRECTORY"
     elif [[ $NAME == Carthage* ]]; then
         (
-            cd "$DIRECTORY";
-            echo "github \"realm/realm-cocoa\" \"${sha:-master}\"" > Cartfile
+            cd "$DIRECTORY"
+            if [ -n "$REALM_BUILD_USING_LATEST_RELEASE" ]; then
+                echo "github \"realm/realm-cocoa\"" > Cartfile
+            else
+                echo "github \"realm/realm-cocoa\" \"${sha:-master}\"" > Cartfile
+            fi
             carthage update
         )
     elif [[ $LANG == swift* ]]; then

--- a/examples/installation/ios/objc/CarthageExample/Cartfile
+++ b/examples/installation/ios/objc/CarthageExample/Cartfile
@@ -1,1 +1,0 @@
-github "realm/realm-cocoa"

--- a/examples/installation/ios/swift-1.2/CarthageExample/Cartfile
+++ b/examples/installation/ios/swift-1.2/CarthageExample/Cartfile
@@ -1,1 +1,0 @@
-github "realm/realm-cocoa"

--- a/examples/installation/ios/swift-2.1/CarthageExample/Cartfile
+++ b/examples/installation/ios/swift-2.1/CarthageExample/Cartfile
@@ -1,1 +1,0 @@
-github "realm/realm-cocoa"

--- a/examples/installation/osx/objc/CarthageExample/Cartfile
+++ b/examples/installation/osx/objc/CarthageExample/Cartfile
@@ -1,1 +1,0 @@
-github "realm/realm-cocoa"

--- a/examples/installation/osx/swift-1.2/CarthageExample/Cartfile
+++ b/examples/installation/osx/swift-1.2/CarthageExample/Cartfile
@@ -1,1 +1,0 @@
-github "realm/realm-cocoa"

--- a/examples/installation/osx/swift-2.1/CarthageExample/Cartfile
+++ b/examples/installation/osx/swift-2.1/CarthageExample/Cartfile
@@ -1,1 +1,0 @@
-github "realm/realm-cocoa"


### PR DESCRIPTION
we couldn't do this before because we didn't support building Realm Swift from source, relying instead on testing the last prebuilt binaries uploaded to GitHub releases.

/cc @bdash 