### PR TITLE
added 'import Foundation' to Swift template

### DIFF
--- a/plugin/Templates/file_templates/Realm Model Object.xctemplate/Swift/___FILEBASENAME___.swift
+++ b/plugin/Templates/file_templates/Realm Model Object.xctemplate/Swift/___FILEBASENAME___.swift
@@ -6,6 +6,7 @@
 //___COPYRIGHT___
 //
 
+import Foundation
 import RealmSwift
 
 class ___FILEBASENAMEASIDENTIFIER___: Object {


### PR DESCRIPTION
Otherwise you’ll get “'dynamic' attribute used without importing module 'Foundation'”