### PR TITLE
Use `carthage archive` command to create Carthage release zip

### DIFF
--- a/scripts/github_release.rb
+++ b/scripts/github_release.rb
@@ -16,19 +16,9 @@ SWIFT_ZIP = BUILD + "realm-swift-#{VERSION}.zip"
 CARTHAGE_ZIP = BUILD + 'Carthage.framework.zip'
 
 puts 'Creating Carthage release zip'
-Dir.mktmpdir do |tmp|
-  Dir.chdir(tmp) do
-    FileUtils.mkdir_p %w(Carthage/Build/Mac Carthage/Build/iOS Carthage/Build/watchOS)
-    system('unzip', SWIFT_ZIP.to_path, :out=>"/dev/null")
-    FileUtils.rm_f CARTHAGE_ZIP
-
-    FileUtils.mv(%W(realm-swift-#{VERSION}/ios/swift-2.1/Realm.framework realm-swift-#{VERSION}/ios/swift-2.1/RealmSwift.framework), 'Carthage/Build/iOS')
-    FileUtils.mv(%W(realm-swift-#{VERSION}/osx/swift-2.1/Realm.framework realm-swift-#{VERSION}/osx/swift-2.1/RealmSwift.framework), 'Carthage/Build/Mac')
-    FileUtils.mv(%W(realm-swift-#{VERSION}/watchos/Realm.framework realm-swift-#{VERSION}/watchos/RealmSwift.framework), 'Carthage/Build/watchOS')
-
-    system('zip', '--symlinks', '-r', CARTHAGE_ZIP.to_path, 'Carthage', :out=>"/dev/null")
-  end
-end
+system('carthage', 'build', '--no-skip-current')
+system('carthage', 'archive', 'Realm', '--output', CARTHAGE_ZIP.to_path)
+system('carthage', 'archive', 'RealmSwift', '--output', CARTHAGE_ZIP.to_path)
 
 REPOSITORY = 'realm/realm-cocoa'
 


### PR DESCRIPTION
Fixes https://github.com/realm/realm-cocoa/issues/2766

This PR makes archive include `bcsymbolmap` and `dSYM` files. The size of archive increase 25MB to 45MB due to `dSYM` files.

cc/ @jpsim @bdash 

**BEFORE**
```
Carthage
└── Build
    ├── Mac
    │   ├── Realm.framework
    │   └── RealmSwift.framework
    ├── iOS
    │   ├── Realm.framework
    │   └── RealmSwift.framework
    └── watchOS
        ├── Realm.framework
        └── RealmSwift.framework
```

**AFTER**
```
Carthage
└── Build
    ├── Mac
    │   ├── Realm.framework
    │   ├── Realm.framework.dSYM
    │   ├── RealmSwift.framework
    │   └── RealmSwift.framework.dSYM
    ├── iOS
    │   ├── 25D72A15-BFBB-3AD3-B3B4-5CE712BEF4E3.bcsymbolmap
    │   ├── 726DB844-0F93-3704-B40D-AA2FF42E44B6.bcsymbolmap
    │   ├── AC49FB7B-F645-378F-A502-B09ADADDF1F6.bcsymbolmap
    │   ├── F99B1C70-ACE1-3D93-8F0C-AFAE7B8B2F31.bcsymbolmap
    │   ├── Realm.framework
    │   ├── Realm.framework.dSYM
    │   ├── RealmSwift.framework
    │   └── RealmSwift.framework.dSYM
    └── watchOS
        ├── 4482C77E-EB60-3DE8-AAF8-3C0C007982D8.bcsymbolmap
        ├── 86E6E2DF-8A3C-3C76-B8CE-6470C38C23AC.bcsymbolmap
        ├── Realm.framework
        ├── Realm.framework.dSYM
        ├── RealmSwift.framework
        └── RealmSwift.framework.dSYM
```