### PR TITLE
Fix crashes when manually refreshing during fast enumeration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ x.x.x Release notes (yyyy-MM-dd)
 
 ### Bugfixes
 
-* None.
+* Fix crashes or incorrect results when calling `-[RLMRealm refresh]` during
+  fast enumeration.
 
 0.96.2 Release notes (2015-10-26)
 =============================================================

--- a/Realm/RLMRealm.mm
+++ b/Realm/RLMRealm.mm
@@ -443,13 +443,6 @@ static void CheckReadWrite(RLMRealm *realm, NSString *msg=@"Cannot write to a re
     catch (std::exception &ex) {
         @throw RLMException(ex);
     }
-
-    // notify any collections currently being enumerated that they need
-    // to switch to enumerating a copy as the data may change on them
-    for (RLMFastEnumerator *enumerator in _collectionEnumerators) {
-        [enumerator detach];
-    }
-    _collectionEnumerators = nil;
 }
 
 - (void)commitWriteTransaction {
@@ -736,6 +729,13 @@ static void CheckReadWrite(RLMRealm *realm, NSString *msg=@"Cannot write to a re
 
 - (void)unregisterEnumerator:(RLMFastEnumerator *)enumerator {
     [_collectionEnumerators removeObject:enumerator];
+}
+
+- (void)detachAllEnumerators {
+    for (RLMFastEnumerator *enumerator in _collectionEnumerators) {
+        [enumerator detach];
+    }
+    _collectionEnumerators = nil;
 }
 
 @end

--- a/Realm/RLMRealmUtil.mm
+++ b/Realm/RLMRealmUtil.mm
@@ -97,6 +97,7 @@ public:
     }
 
     std::vector<ObserverState> get_observed_rows() override {
+        [_realm detachAllEnumerators];
         return RLMGetObservedRows(_realm.schema.objectSchema);
     }
 

--- a/Realm/RLMRealm_Private.h
+++ b/Realm/RLMRealm_Private.h
@@ -71,6 +71,7 @@ FOUNDATION_EXTERN NSData *RLMRealmValidatedEncryptionKey(NSData *key);
 
 - (void)registerEnumerator:(RLMFastEnumerator *)enumerator;
 - (void)unregisterEnumerator:(RLMFastEnumerator *)enumerator;
+- (void)detachAllEnumerators;
 
 - (void)sendNotifications:(NSString *)notification;
 - (void)notify;


### PR DESCRIPTION
The enumerator was not being detached before the read transaction was advanced, which could lead to assertion failures or incorrect results.