### PR TITLE
Fixes to Swift doc comments

### DIFF
--- a/RealmSwift-swift1.2/Aliases.swift
+++ b/RealmSwift-swift1.2/Aliases.swift
@@ -42,7 +42,7 @@ See [Realm Models](http://realm.io/docs/swift/latest/#models).
 * Data
 * Date
 
-## Array/Linked object types
+## Relationships: List (Array) and Object types
 
 * Object
 * Array

--- a/RealmSwift-swift1.2/List.swift
+++ b/RealmSwift-swift1.2/List.swift
@@ -26,7 +26,7 @@ public class ListBase: RLMListBase {
     // Printable requires a description property defined in Swift (and not obj-c),
     // and it has to be defined as @objc override, which can't be done in a
     // generic class.
-    /// Returns a human-readable description of the objects contained in the list.
+    /// Returns a human-readable description of the objects contained in the List.
     @objc public override var description: String {
         return descriptionWithMaxDepth(RLMDescriptionMaxDepth)
     }
@@ -36,14 +36,14 @@ public class ListBase: RLMListBase {
         return gsub("RLMArray <0x[a-z0-9]+>", type, _rlmArray.descriptionWithMaxDepth(depth)) ?? type
     }
 
-    /// Returns the number of objects in this list.
+    /// Returns the number of objects in this List.
     public var count: Int { return Int(_rlmArray.count) }
 }
 
 /**
 `List<T>` is the container type in Realm used to define to-many relationships.
 
-Lists hold a single `Object` subclass (`T`) which defines the "type" of the list.
+Lists hold a single `Object` subclass (`T`) which defines the "type" of the List.
 
 Lists can be filtered and sorted with the same predicates as `Results<T>`.
 
@@ -56,13 +56,13 @@ public final class List<T: Object>: ListBase {
 
     // MARK: Properties
 
-    /// The Realm the objects in this list belong to, or `nil` if the list's
-    /// owning object does not belong to a realm (the list is standalone).
+    /// The Realm the objects in this List belong to, or `nil` if the List's
+    /// owning object does not belong to a realm (the List is standalone).
     public var realm: Realm? {
         return map(_rlmArray.realm) { Realm($0) }
     }
 
-    /// Indicates if the list can no longer be accessed.
+    /// Indicates if the List can no longer be accessed.
     public var invalidated: Bool { return _rlmArray.invalidated }
 
     // MARK: Initializers
@@ -75,11 +75,11 @@ public final class List<T: Object>: ListBase {
     // MARK: Index Retrieval
 
     /**
-    Returns the index of the given object, or `nil` if the object is not in the list.
+    Returns the index of the given object, or `nil` if the object is not in the List.
 
     :param: object The object whose index is being queried.
 
-    :returns: The index of the given object, or `nil` if the object is not in the list.
+    :returns: The index of the given object, or `nil` if the object is not in the List.
     */
     public func indexOf(object: T) -> Int? {
         return notFoundToNil(_rlmArray.indexOfObject(unsafeBitCast(object, RLMObject.self)))
@@ -91,7 +91,7 @@ public final class List<T: Object>: ListBase {
 
     :param: predicate The `NSPredicate` used to filter the objects.
 
-    :returns: The index of the given object, or `nil` if no objects match.
+    :returns: The index of the first matching object, or `nil` if no objects match.
     */
     public func indexOf(predicate: NSPredicate) -> Int? {
         return notFoundToNil(_rlmArray.indexOfObjectWithPredicate(predicate))
@@ -104,7 +104,7 @@ public final class List<T: Object>: ListBase {
     :param: predicateFormat The predicate format string, optionally followed by a variable number
                             of arguments.
 
-    :returns: The index of the given object, or `nil` if no objects match.
+    :returns: The index of the first matching object, or `nil` if no objects match.
     */
     public func indexOf(predicateFormat: String, _ args: CVarArgType...) -> Int? {
         return indexOf(NSPredicate(format: predicateFormat, arguments: getVaList(args)))
@@ -133,27 +133,27 @@ public final class List<T: Object>: ListBase {
         }
     }
 
-    /// Returns the first object in the list, or `nil` if empty.
+    /// Returns the first object in the List, or `nil` if empty.
     public var first: T? { return _rlmArray.firstObject() as! T? }
 
-    /// Returns the last object in the list, or `nil` if empty.
+    /// Returns the last object in the List, or `nil` if empty.
     public var last: T? { return _rlmArray.lastObject() as! T? }
 
     // MARK: KVC
 
     /**
-    Returns an Array containing the results of invoking `valueForKey:` using key on each of the collection's objects.
+    Returns an Array containing the results of invoking `valueForKey(_:)` using key on each of the collection's objects.
 
     :param: key The name of the property.
 
-    :returns: Array containing the results of invoking `valueForKey:` using key on each of the collection's objects.
+    :returns: Array containing the results of invoking `valueForKey(_:)` using key on each of the collection's objects.
     */
     public override func valueForKey(key: String) -> AnyObject? {
         return _rlmArray.valueForKey(key)
     }
 
     /**
-    Invokes `setValue:forKey:` on each of the collection's objects using the specified value and key.
+    Invokes `setValue(_:forKey:)` on each of the collection's objects using the specified value and key.
 
     :warning: This method can only be called during a write transaction.
 
@@ -167,22 +167,22 @@ public final class List<T: Object>: ListBase {
     // MARK: Filtering
 
     /**
-    Returns `Results` containing list elements that match the given predicate.
+    Returns `Results` containing elements that match the given predicate.
 
     :param: predicateFormat The predicate format string which can accept variable arguments.
 
-    :returns: `Results` containing list elements that match the given predicate.
+    :returns: `Results` containing elements that match the given predicate.
     */
     public func filter(predicateFormat: String, _ args: CVarArgType...) -> Results<T> {
         return Results<T>(_rlmArray.objectsWithPredicate(NSPredicate(format: predicateFormat, arguments: getVaList(args))))
     }
 
     /**
-    Returns `Results` containing list elements that match the given predicate.
+    Returns `Results` containing elements that match the given predicate.
 
     :param: predicate The predicate to filter the objects.
 
-    :returns: `Results` containing list elements that match the given predicate.
+    :returns: `Results` containing elements that match the given predicate.
     */
     public func filter(predicate: NSPredicate) -> Results<T> {
         return Results<T>(_rlmArray.objectsWithPredicate(predicate))
@@ -191,12 +191,12 @@ public final class List<T: Object>: ListBase {
     // MARK: Sorting
 
     /**
-    Returns `Results` containing list elements sorted by the given property.
+    Returns `Results` containing elements sorted by the given property.
 
     :param: property  The property name to sort by.
     :param: ascending The direction to sort by.
 
-    :returns: `Results` containing list elements sorted by the given property.
+    :returns: `Results` containing elements sorted by the given property.
     */
     public func sorted(property: String, ascending: Bool = true) -> Results<T> {
         return sorted([SortDescriptor(property: property, ascending: ascending)])
@@ -270,7 +270,7 @@ public final class List<T: Object>: ListBase {
     // MARK: Mutation
 
     /**
-    Appends the given object to the end of the list. If the object is from a
+    Appends the given object to the end of the List. If the object is from a
     different Realm it is copied to the List's Realm.
 
     :warning: This method can only be called during a write transaction.
@@ -282,7 +282,7 @@ public final class List<T: Object>: ListBase {
     }
 
     /**
-    Appends the objects in the given sequence to the end of the list.
+    Appends the objects in the given sequence to the end of the List.
 
     :warning: This method can only be called during a write transaction.
 
@@ -299,7 +299,7 @@ public final class List<T: Object>: ListBase {
 
     :warning: This method can only be called during a write transaction.
     :warning: Throws an exception when called with an index smaller than zero or greater than
-              or equal to the number of objects in the list.
+              or equal to the number of objects in the List.
 
     :param: object An object.
     :param: index  The index at which to insert the object.
@@ -310,11 +310,11 @@ public final class List<T: Object>: ListBase {
     }
 
     /**
-    Removes the object at the given index from the list. Does not remove the object from the Realm.
+    Removes the object at the given index from the List. Does not remove the object from the Realm.
 
     :warning: This method can only be called during a write transaction.
     :warning: Throws an exception when called with an index smaller than zero or greater than
-              or equal to the number of objects in the list.
+              or equal to the number of objects in the List.
 
     :param: index The index at which to remove the object.
     */
@@ -324,7 +324,7 @@ public final class List<T: Object>: ListBase {
     }
 
     /**
-    Removes the last object in the list. Does not remove the object from the Realm.
+    Removes the last object in the List. Does not remove the object from the Realm.
 
     :warning: This method can only be called during a write transaction.
     */
@@ -346,9 +346,9 @@ public final class List<T: Object>: ListBase {
 
     :warning: This method can only be called during a write transaction.
     :warning: Throws an exception when called with an index smaller than zero or greater than
-              or equal to the number of objects in the list.
+              or equal to the number of objects in the List.
 
-    :param: index  The list index of the object to be replaced.
+    :param: index  The List index of the object to be replaced.
     :param: object An object to replace at the specified index.
     */
     public func replace(index: Int, object: T) {
@@ -361,7 +361,7 @@ public final class List<T: Object>: ListBase {
 
     :warning: This method can only be called during a write transaction.
     :warning: Throws an exception when called with an index smaller than zero or greater than
-              or equal to the number of objects in the list.
+              or equal to the number of objects in the List.
 
     :param: from  The index of the object to be moved.
     :param: to    The index to which the object at `from` should be moved.
@@ -373,9 +373,9 @@ public final class List<T: Object>: ListBase {
     }
 
     /**
-    Exchanges the objects in the list at given indexes.
+    Exchanges the objects in the List at given indexes.
 
-    :warning: Throws an exception when either index exceeds the bounds of the list.
+    :warning: Throws an exception when either index exceeds the bounds of the List.
     :warning: This method can only be called during a write transaction.
 
     :param: index1 The index of the object with which to replace the object at index `index2`.
@@ -391,7 +391,7 @@ public final class List<T: Object>: ListBase {
 extension List: RealmCollectionType, ExtensibleCollectionType {
     // MARK: Sequence Support
 
-    /// Returns a `GeneratorOf<T>` that yields successive elements in the list.
+    /// Returns a `GeneratorOf<T>` that yields successive elements in the List.
     public func generate() -> RLMGenerator<T> {
         return RLMGenerator(collection: _rlmArray)
     }

--- a/RealmSwift-swift1.2/Migration.swift
+++ b/RealmSwift-swift1.2/Migration.swift
@@ -34,7 +34,7 @@ public typealias MigrationBlock = (migration: Migration, oldSchemaVersion: UInt6
 public typealias MigrationObject = DynamicObject
 
 /**
-Provides both the old and new versions of an object in this Realm. Objects properties can only be
+Provides both the old and new versions of an object in this Realm. Object properties can only be
 accessed using subscripting.
 
 :param: oldObject Object in original `Realm` (read-only)
@@ -103,8 +103,8 @@ public final class Migration {
     Enumerates objects of a given type in this Realm, providing both the old and new versions of
     each object. Object properties can be accessed using subscripting.
 
-    :param: className The name of the `Object` class to enumerate.
-    :param: block     The block providing both the old and new versions of an object in this Realm.
+    :param: objectClassName The name of the `Object` class to enumerate.
+    :param: block           The block providing both the old and new versions of an object in this Realm.
     */
     public func enumerate(objectClassName: String, _ block: MigrationObjectEnumerateBlock) {
         rlmMigration.enumerateObjects(objectClassName) {
@@ -116,7 +116,7 @@ public final class Migration {
     Create an `Object` of type `className` in the Realm being migrated.
 
     :param: className The name of the `Object` class to create.
-    :param: object    The object used to populate the object. This can be any key/value coding
+    :param: value     The object used to populate the new `Object`. This can be any key/value coding
                       compliant object, or a JSON object such as those returned from the methods in
                       `NSJSONSerialization`, or an `Array` with one object for each persisted
                       property. An exception will be thrown if any required properties are not
@@ -143,9 +143,9 @@ public final class Migration {
     This deletes all objects of the given class, and if the Object subclass no longer exists in your program,
     cleans up any remaining metadata for the class in the Realm file.
 
-    :param:   name The name of the Object class to delete.
+    :param:   objectClassName The name of the Object class to delete.
 
-    :returns: whether there was any data to delete.
+    :returns: `true` if there was any data to delete.
     */
     public func deleteData(objectClassName: String) -> Bool {
         return rlmMigration.deleteDataForClassName(objectClassName)

--- a/RealmSwift-swift1.2/Object.swift
+++ b/RealmSwift-swift1.2/Object.swift
@@ -36,6 +36,7 @@ class Dog: Object {
 
 - `String`, `NSString`
 - `Int`
+- `Int8`, `Int16`, `Int32`, `Int64`
 - `Float`
 - `Double`
 - `Bool`
@@ -46,10 +47,10 @@ class Dog: Object {
 - `List<T: Object>` for to-many relationships
 
 `String`, `NSString`, `NSDate`, `NSData` and `Object` subclass properties can be
-optional. `Int`, `Float`, `Double`, `Bool` and `List` properties cannot. To store
-an optional number, instead use `RealmOptional<Int>`, `RealmOptional<Float>`,
-`RealmOptional<Double>`, or `RealmOptional<Bool>` instead, which wraps an optional
-value of the generic type.
+optional. `Int`, `Int8`, Int16`, Int32`, `Int64`, `Float`, `Double`, `Bool` 
+and `List` properties cannot. To store an optional number, instead use 
+`RealmOptional<Int>`, `RealmOptional<Float>`, `RealmOptional<Double>`, or 
+`RealmOptional<Bool>` instead, which wraps an optional value of the generic type.
 
 All property types except for `List` and `RealmOptional` *must* be declared as
 `dynamic var`. `List` and `RealmOptional` properties must be declared as
@@ -57,8 +58,7 @@ non-dynamic `let` properties.
 
 ### Querying
 
-You can gets `Results` of an Object subclass via tha `objects(_:)` free function or
-the `objects(_:)` instance method on `Realm`.
+You can gets `Results` of an Object subclass via the `objects(_:)` instance method on `Realm`.
 
 ### Relationships
 
@@ -69,7 +69,7 @@ public class Object: RLMObjectBase, Equatable, Printable {
     // MARK: Initializers
 
     /**
-    Initialize a standalone (unpersisted) Object.
+    Initialize a standalone (unpersisted) `Object`.
     Call `add(_:)` on a `Realm` to add standalone objects to a realm.
 
     :see: Realm().add(_:)
@@ -157,11 +157,11 @@ public class Object: RLMObjectBase, Equatable, Printable {
     // MARK: Inverse Relationships
 
     /**
-    Get an `Array` of objects of type `className` which have this object as the given property value. This can
+    Get an `Array` of objects of type `T` which have this object as the given property value. This can
     be used to get the inverse relationship value for `Object` and `List` properties.
-    :param: className The type of object on which the relationship to query is defined.
-    :param: property  The name of the property which defines the relationship.
-    :returns: An `Array` of objects of type `className` which have this object as their value for the `propertyName` property.
+    :param: type          The type of object on which the relationship to query is defined.
+    :param: propertyName  The name of the property which defines the relationship.
+    :returns: An `Array` of objects of type `T` which have this object as their value for the `propertyName` property.
     */
     public func linkingObjects<T: Object>(type: T.Type, forProperty propertyName: String) -> [T] {
         return RLMObjectBaseLinkingObjectsOfClass(self, T.className(), propertyName) as! [T]

--- a/RealmSwift-swift1.2/ObjectSchema.swift
+++ b/RealmSwift-swift1.2/ObjectSchema.swift
@@ -20,12 +20,12 @@ import Foundation
 import Realm
 
 /**
-This class represents Realm model object schemas persisted to Realm in a Schema.
+This class represents Realm model object schemas.
 
-When using Realm, ObjectSchema objects allow performing migrations and
+When using Realm, `ObjectSchema` objects allow performing migrations and
 introspecting the database's schema.
 
-Object schemas map to tables in the core database.
+`ObjectSchema`s map to tables in the core database.
 */
 public final class ObjectSchema: Printable {
 

--- a/RealmSwift-swift1.2/Property.swift
+++ b/RealmSwift-swift1.2/Property.swift
@@ -20,9 +20,9 @@ import Foundation
 import Realm
 
 /**
-This class represents properties persisted to Realm in an ObjectSchema.
+This class represents properties persisted to Realm in an `ObjectSchema`.
 
-When using Realm, Property objects allow performing migrations and
+When using Realm, `Property` objects allow performing migrations and
 introspecting the database's schema.
 
 These properties map to columns in the core database.
@@ -42,7 +42,7 @@ public final class Property: Printable {
     /// Whether this property is indexed.
     public var indexed: Bool { return rlmProperty.indexed }
 
-    ///  Whether this property is optional (can contain `nil` values).
+    /// Whether this property is optional (can contain `nil` values).
     public var optional: Bool { return rlmProperty.optional }
 
     /// Object class name - specify object types for `Object` and `List` properties.

--- a/RealmSwift-swift1.2/Realm.swift
+++ b/RealmSwift-swift1.2/Realm.swift
@@ -238,6 +238,8 @@ public final class Realm {
 
     :see: add(object:update:)
 
+    :warning: This method can only be called during a write transaction.
+
     :param: objects A sequence which contains objects to be added to this Realm.
     :param: update If true will try to update existing objects with the same primary key.
     */
@@ -256,6 +258,8 @@ public final class Realm {
     When 'update' is 'true', the object must have a primary key. If no objects exist in
     the Realm instance with the same primary key value, the object is inserted. Otherwise,
     the existing object is updated with any changed values.
+
+    :warning: This method can only be called during a write transaction.
 
     :param: type    The object type to create.
     :param: value   The value used to populate the object. This can be any key/value coding compliant
@@ -288,6 +292,8 @@ public final class Realm {
     the Realm instance with the same primary key value, the object is inserted. Otherwise,
     the existing object is updated with any changed values.
     
+    :warning: This method can only be called during a write transaction.
+
     :param: className   The class name of the object to create.
     :param: value       The value used to populate the object. This can be any key/value coding compliant
     object, or a JSON dictionary such as those returned from the methods in `NSJSONSerialization`,
@@ -314,6 +320,8 @@ public final class Realm {
     /**
     Deletes the given object from this Realm.
 
+    :warning: This method can only be called during a write transaction.
+
     :param: object The object to be deleted.
     */
     public func delete(object: Object) {
@@ -322,6 +330,8 @@ public final class Realm {
 
     /**
     Deletes the given objects from this Realm.
+
+    :warning: This method can only be called during a write transaction.
 
     :param: objects The objects to be deleted. This can be a `List<Object>`, `Results<Object>`,
                     or any other enumerable `SequenceType` which generates `Object`.
@@ -335,6 +345,8 @@ public final class Realm {
     /**
     Deletes the given objects from this Realm.
 
+    :warning: This method can only be called during a write transaction.
+ 
     :param: objects The objects to be deleted. Must be `List<Object>`.
 
     :nodoc:
@@ -346,6 +358,8 @@ public final class Realm {
     /**
     Deletes the given objects from this Realm.
 
+    :warning: This method can only be called during a write transaction.
+
     :param: objects The objects to be deleted. Must be `Results<Object>`.
 
     :nodoc:
@@ -356,6 +370,8 @@ public final class Realm {
 
     /**
     Deletes all objects from this Realm.
+
+    :warning: This method can only be called during a write transaction.
     */
     public func deleteAll() {
         RLMDeleteAllObjectsFromRealm(rlmRealm)

--- a/RealmSwift-swift1.2/Realm.swift
+++ b/RealmSwift-swift1.2/Realm.swift
@@ -25,7 +25,7 @@ A Realm instance (also referred to as "a realm") represents a Realm
 database.
 
 Realms can either be stored on disk (see `init(path:)`) or in
-memory (see `init(inMemoryIdentifier:)`).
+memory (see `Configuration`).
 
 Realm instances are cached internally, and constructing equivalent Realm
 objects (with the same path or identifier) produces limited overhead.
@@ -55,7 +55,7 @@ public final class Realm {
     /// The Schema used by this realm.
     public var schema: Schema { return Schema(rlmRealm.schema) }
 
-    /// Returns a `Configuration` that can be used to create this `Realm` instance.
+    /// Returns the `Configuration` that was used to create this `Realm` instance.
     public var configuration: Configuration { return Configuration.fromRLMRealmConfiguration(rlmRealm.configuration) }
 
     /// Indicates if this Realm contains any objects.
@@ -101,8 +101,17 @@ public final class Realm {
     // MARK: Transactions
 
     /**
-    Helper to perform actions contained within the given block inside a write transation.
+    Performs actions contained within the given block inside a write transation.
+	
+    Write transactions cannot be nested, and trying to execute a write transaction 
+	on a `Realm` which is already in a write transaction will throw an exception. 
+	Calls to `write` from `Realm` instances in other threads will block
+    until the current write transaction completes.
 
+    Before executing the write transaction, `write` updates the `Realm` to the 
+	latest Realm version, as if `refresh()` was called, and generates notifications 
+	if applicable. This has no effect if the `Realm` was already up to date.
+ 
     :param: block The block to be executed inside a write transaction.
     :param: error If an error occurs, upon return contains an `NSError` object
                   that describes the problem. If you are not interested in
@@ -119,7 +128,7 @@ public final class Realm {
 
     Only one write transaction can be open at a time. Write transactions cannot be
     nested, and trying to begin a write transaction on a `Realm` which is
-    already in a write transaction with throw an exception. Calls to
+    already in a write transaction will throw an exception. Calls to
     `beginWrite` from `Realm` instances in other threads will block
     until the current write transaction completes.
 
@@ -138,9 +147,8 @@ public final class Realm {
     }
 
     /**
-    Commits all writes operations in the current write transaction.
-
-    After this is called, the `Realm` reverts back to being read-only.
+    Commits all writes operations in the current write transaction, and ends
+	the transaction.
 
     Calling this when not in a write transaction will throw an exception.
     
@@ -206,8 +214,8 @@ public final class Realm {
     the Realm instance with the same primary key value, the object is inserted. Otherwise,
     the existing object is updated with any changed values.
 
-    When added, all linked (child) objects referenced by this object will also be
-    added to the Realm if they are not already in it. If the object or any linked
+    When added, all (child) relationships referenced by this object will also be
+    added to the Realm if they are not already in it. If the object or any related
     objects already belong to a different Realm an exception will be thrown. Use one
     of the `create` functions to insert a copy of a persisted object into a different
     Realm.
@@ -273,7 +281,7 @@ public final class Realm {
     components that integrate with Realm. If you are simply building an app on Realm, it is
     recommended to use the typed method `create(type:value:update:)`.
     
-    Creates or updates an object with the given class name and adds it to the `Realm` populating
+    Creates or updates an object with the given class name and adds it to the `Realm`, populating
     the object with the given value.
     
     When 'update' is 'true', the object must have a primary key. If no objects exist in
@@ -466,9 +474,13 @@ public final class Realm {
 
     If set to `true` (the default), changes made on other threads will be reflected
     in this Realm on the next cycle of the run loop after the changes are
-    committed.  If set to `false`, you must manually call -refresh on the Realm to
+    committed.  If set to `false`, you must manually call `refresh()` on the Realm to
     update it to get the latest version.
 
+    Note that on background threads, the run loop is not run by default and you will 
+	will need to manually call `refresh()` in order to update to the latest version,
+	even if `autorefresh` is set to `true`.
+	
     Even with this enabled, you can still call `refresh()` at any time to update the
     Realm before the automatic refresh would occur.
 
@@ -583,16 +595,16 @@ public enum Notification: String {
     /**
     Posted when the data in a realm has changed.
 
-    DidChange are posted after a realm has been refreshed to reflect a write transaction, i.e. when
+    DidChange is posted after a realm has been refreshed to reflect a write transaction, i.e. when
     an autorefresh occurs, `refresh()` is called, after an implicit refresh from
-    `beginWriteTransaction()`, and after a local write transaction is committed.
+    `write(_:block:)`/`beginWrite()`, and after a local write transaction is committed.
     */
     case DidChange = "RLMRealmDidChangeNotification"
 
     /**
-    Posted when a write transaction has been committed to a realm on a different thread for the same
+    Posted when a write transaction has been committed to a Realm on a different thread for the same
     file. This is not posted if `autorefresh` is enabled or if the Realm is refreshed before the
-    notifcation has a chance to run.
+    notification has a chance to run.
 
     Realms with autorefresh disabled should normally have a handler for this notification which
     calls `refresh()` after doing some work.

--- a/RealmSwift-swift1.2/RealmCollectionType.swift
+++ b/RealmSwift-swift1.2/RealmCollectionType.swift
@@ -82,7 +82,7 @@ public protocol RealmCollectionType: CollectionType, Printable {
 
     :param: predicate The `NSPredicate` used to filter the objects.
 
-    :returns: The index of the given object, or `nil` if no objects match.
+    :returns: The index of the first matching object, or `nil` if no objects match.
     */
     func indexOf(predicate: NSPredicate) -> Int?
 
@@ -93,7 +93,7 @@ public protocol RealmCollectionType: CollectionType, Printable {
     :param: predicateFormat The predicate format string, optionally followed by a variable number
     of arguments.
 
-    :returns: The index of the given object, or `nil` if no objects match.
+    :returns: The index of the first matching object, or `nil` if no objects match.
     */
     func indexOf(predicateFormat: String, _ args: CVarArgType...) -> Int?
 
@@ -200,16 +200,16 @@ public protocol RealmCollectionType: CollectionType, Printable {
     // MARK: Key-Value Coding
 
     /**
-    Returns an Array containing the results of invoking `valueForKey:` using key on each of the collection's objects.
+    Returns an Array containing the results of invoking `valueForKey(_:)` using key on each of the collection's objects.
 
     :param: key The name of the property.
 
-    :returns: Array containing the results of invoking `valueForKey:` using key on each of the collection's objects.
+    :returns: Array containing the results of invoking `valueForKey(_:)` using key on each of the collection's objects.
     */
     func valueForKey(key: String) -> AnyObject?
 
     /**
-    Invokes `setValue:forKey:` on each of the collection's objects using the specified value and key.
+    Invokes `setValue(_:forKey:)` on each of the collection's objects using the specified value and key.
 
     :warning: This method can only be called during a write transaction.
 
@@ -280,9 +280,9 @@ private final class _AnyRealmCollection<C: RealmCollectionType>: _AnyRealmCollec
     Returns the index of the first object matching the given predicate,
     or `nil` no objects match.
 
-    - parameter predicate: The `NSPredicate` used to filter the objects.
+    :param: predicate The `NSPredicate` used to filter the objects.
 
-    - returns: The index of the given object, or `nil` if no objects match.
+    :returns: The index of the first matching object, or `nil` if no objects match.
     */
     override func indexOf(predicate: NSPredicate) -> Int? { return base.indexOf(predicate) }
 
@@ -290,10 +290,10 @@ private final class _AnyRealmCollection<C: RealmCollectionType>: _AnyRealmCollec
     Returns the index of the first object matching the given predicate,
     or `nil` if no objects match.
 
-    - parameter predicateFormat: The predicate format string, optionally followed by a variable number
+    :param: predicateFormat The predicate format string, optionally followed by a variable number
     of arguments.
 
-    - returns: The index of the given object, or `nil` if no objects match.
+    :returns: The index of the first matching object, or `nil` if no objects match.
     */
     override func indexOf(predicateFormat: String, _ args: CVarArgType...) -> Int? { return base.indexOf(NSPredicate(format: predicateFormat, arguments: getVaList(args))) }
 
@@ -311,18 +311,18 @@ private final class _AnyRealmCollection<C: RealmCollectionType>: _AnyRealmCollec
     /**
     Returns `Results` containing collection elements that match the given predicate.
 
-    - parameter predicateFormat: The predicate format string which can accept variable arguments.
+    :param: predicateFormat The predicate format string which can accept variable arguments.
 
-    - returns: `Results` containing collection elements that match the given predicate.
+    :returns: `Results` containing collection elements that match the given predicate.
     */
     override func filter(predicateFormat: String, _ args: CVarArgType...) -> Results<C.Element> { return base.filter(NSPredicate(format: predicateFormat, arguments: getVaList(args))) }
 
     /**
     Returns `Results` containing collection elements that match the given predicate.
 
-    - parameter predicate: The predicate to filter the objects.
+    :param: predicate The predicate to filter the objects.
 
-    - returns: `Results` containing collection elements that match the given predicate.
+    :returns: `Results` containing collection elements that match the given predicate.
     */
     override func filter(predicate: NSPredicate) -> Results<C.Element> { return base.filter(predicate) }
 
@@ -332,19 +332,19 @@ private final class _AnyRealmCollection<C: RealmCollectionType>: _AnyRealmCollec
     /**
     Returns `Results` containing collection elements sorted by the given property.
 
-    - parameter property:  The property name to sort by.
-    - parameter ascending: The direction to sort by.
+    :param: property  The property name to sort by.
+    :param: ascending The direction to sort by.
 
-    - returns: `Results` containing collection elements sorted by the given property.
+    :returns: `Results` containing collection elements sorted by the given property.
     */
     override func sorted(property: String, ascending: Bool) -> Results<C.Element> { return base.sorted(property, ascending: ascending) }
 
     /**
     Returns `Results` with elements sorted by the given sort descriptors.
 
-    - parameter sortDescriptors: `SortDescriptor`s to sort by.
+    :param: sortDescriptors `SortDescriptor`s to sort by.
 
-    - returns: `Results` with elements sorted by the given sort descriptors.
+    :returns: `Results` with elements sorted by the given sort descriptors.
     */
     override func sorted<S: SequenceType where S.Generator.Element == SortDescriptor>(sortDescriptors: S) -> Results<C.Element> { return base.sorted(sortDescriptors) }
 
@@ -354,44 +354,44 @@ private final class _AnyRealmCollection<C: RealmCollectionType>: _AnyRealmCollec
     /**
     Returns the minimum value of the given property.
 
-    - warning: Only names of properties of a type conforming to the `MinMaxType` protocol can be used.
+    :warning: Only names of properties of a type conforming to the `MinMaxType` protocol can be used.
 
-    - parameter property: The name of a property conforming to `MinMaxType` to look for a minimum on.
+    :param: property The name of a property conforming to `MinMaxType` to look for a minimum on.
 
-    - returns: The minimum value for the property amongst objects in the collection, or `nil` if the collection is empty.
+    :returns: The minimum value for the property amongst objects in the collection, or `nil` if the collection is empty.
     */
     override func min<U: MinMaxType>(property: String) -> U? { return base.min(property) }
 
     /**
     Returns the maximum value of the given property.
 
-    - warning: Only names of properties of a type conforming to the `MinMaxType` protocol can be used.
+    :warning: Only names of properties of a type conforming to the `MinMaxType` protocol can be used.
 
-    - parameter property: The name of a property conforming to `MinMaxType` to look for a maximum on.
+    :param: property The name of a property conforming to `MinMaxType` to look for a maximum on.
 
-    - returns: The maximum value for the property amongst objects in the collection, or `nil` if the collection is empty.
+    :returns: The maximum value for the property amongst objects in the collection, or `nil` if the collection is empty.
     */
     override func max<U: MinMaxType>(property: String) -> U? { return base.max(property) }
 
     /**
     Returns the sum of the given property for objects in the collection.
 
-    - warning: Only names of properties of a type conforming to the `AddableType` protocol can be used.
+    :warning: Only names of properties of a type conforming to the `AddableType` protocol can be used.
 
-    - parameter property: The name of a property conforming to `AddableType` to calculate sum on.
+    :param: property The name of a property conforming to `AddableType` to calculate sum on.
 
-    - returns: The sum of the given property over all objects in the collection.
+    :returns: The sum of the given property over all objects in the collection.
     */
     override func sum<U: AddableType>(property: String) -> U { return base.sum(property) }
 
     /**
     Returns the average of the given property for objects in the collection.
 
-    - warning: Only names of properties of a type conforming to the `AddableType` protocol can be used.
+    :warning: Only names of properties of a type conforming to the `AddableType` protocol can be used.
 
-    - parameter property: The name of a property conforming to `AddableType` to calculate average on.
+    :param: property The name of a property conforming to `AddableType` to calculate average on.
 
-    - returns: The average of the given property over all objects in the collection, or `nil` if the collection is empty.
+    :returns: The average of the given property over all objects in the collection, or `nil` if the collection is empty.
     */
     override func average<U: AddableType>(property: String) -> U? { return base.average(property) }
 
@@ -401,9 +401,9 @@ private final class _AnyRealmCollection<C: RealmCollectionType>: _AnyRealmCollec
     /**
     Returns the object at the given `index`.
 
-    - parameter index: The index.
+    :param: index The index.
 
-    - returns: The object at the given `index`.
+    :returns: The object at the given `index`.
     */
     override subscript(index: Int) -> C.Element { return base[index as! C.Index] as! C.Element } // FIXME: it should be possible to avoid this force-casting
 
@@ -425,16 +425,16 @@ private final class _AnyRealmCollection<C: RealmCollectionType>: _AnyRealmCollec
     // MARK: Key-Value Coding
 
     /**
-    Returns an Array containing the results of invoking `valueForKey:` using key on each of the collection's objects.
+    Returns an Array containing the results of invoking `valueForKey(_:)` using key on each of the collection's objects.
 
     :param: key The name of the property.
 
-    :returns: Array containing the results of invoking `valueForKey:` using key on each of the collection's objects.
+    :returns: Array containing the results of invoking `valueForKey(_:)` using key on each of the collection's objects.
     */
     override func valueForKey(key: String) -> AnyObject? { return base.valueForKey(key) }
 
     /**
-    Invokes `setValue:forKey:` on each of the collection's objects using the specified value and key.
+    Invokes `setValue(_:forKey:)` on each of the collection's objects using the specified value and key.
 
     :warning: This method can only be called during a write transaction.
 
@@ -490,9 +490,9 @@ public final class AnyRealmCollection<T: Object>: RealmCollectionType {
     Returns the index of the first object matching the given predicate,
     or `nil` no objects match.
 
-    - parameter predicate: The `NSPredicate` used to filter the objects.
+    :param: predicate The `NSPredicate` used to filter the objects.
 
-    - returns: The index of the given object, or `nil` if no objects match.
+    :returns: The index of the first matching object, or `nil` if no objects match.
     */
     public func indexOf(predicate: NSPredicate) -> Int? { return base.indexOf(predicate) }
 
@@ -500,10 +500,10 @@ public final class AnyRealmCollection<T: Object>: RealmCollectionType {
     Returns the index of the first object matching the given predicate,
     or `nil` if no objects match.
 
-    - parameter predicateFormat: The predicate format string, optionally followed by a variable number
+    :param: predicateFormat The predicate format string, optionally followed by a variable number
     of arguments.
 
-    - returns: The index of the given object, or `nil` if no objects match.
+    :returns: The index of the first matching object, or `nil` if no objects match.
     */
     public func indexOf(predicateFormat: String, _ args: CVarArgType...) -> Int? { return base.indexOf(NSPredicate(format: predicateFormat, arguments: getVaList(args))) }
 
@@ -521,18 +521,18 @@ public final class AnyRealmCollection<T: Object>: RealmCollectionType {
     /**
     Returns `Results` containing collection elements that match the given predicate.
 
-    - parameter predicateFormat: The predicate format string which can accept variable arguments.
+    :param: predicateFormat The predicate format string which can accept variable arguments.
 
-    - returns: `Results` containing collection elements that match the given predicate.
+    :returns: `Results` containing collection elements that match the given predicate.
     */
     public func filter(predicateFormat: String, _ args: CVarArgType...) -> Results<Element> { return base.filter(NSPredicate(format: predicateFormat, arguments: getVaList(args))) }
 
     /**
     Returns `Results` containing collection elements that match the given predicate.
 
-    - parameter predicate: The predicate to filter the objects.
+    :param: predicate The predicate to filter the objects.
 
-    - returns: `Results` containing collection elements that match the given predicate.
+    :returns: `Results` containing collection elements that match the given predicate.
     */
     public func filter(predicate: NSPredicate) -> Results<Element> { return base.filter(predicate) }
 
@@ -542,19 +542,19 @@ public final class AnyRealmCollection<T: Object>: RealmCollectionType {
     /**
     Returns `Results` containing collection elements sorted by the given property.
 
-    - parameter property:  The property name to sort by.
-    - parameter ascending: The direction to sort by.
+    :param: property  The property name to sort by.
+    :param: ascending The direction to sort by.
 
-    - returns: `Results` containing collection elements sorted by the given property.
+    :returns: `Results` containing collection elements sorted by the given property.
     */
     public func sorted(property: String, ascending: Bool) -> Results<Element> { return base.sorted(property, ascending: ascending) }
 
     /**
     Returns `Results` with elements sorted by the given sort descriptors.
 
-    - parameter sortDescriptors: `SortDescriptor`s to sort by.
+    :param: sortDescriptors `SortDescriptor`s to sort by.
 
-    - returns: `Results` with elements sorted by the given sort descriptors.
+    :returns: `Results` with elements sorted by the given sort descriptors.
     */
     public func sorted<S: SequenceType where S.Generator.Element == SortDescriptor>(sortDescriptors: S) -> Results<Element> { return base.sorted(sortDescriptors) }
 
@@ -564,44 +564,44 @@ public final class AnyRealmCollection<T: Object>: RealmCollectionType {
     /**
     Returns the minimum value of the given property.
 
-    - warning: Only names of properties of a type conforming to the `MinMaxType` protocol can be used.
+    :warning: Only names of properties of a type conforming to the `MinMaxType` protocol can be used.
 
-    - parameter property: The name of a property conforming to `MinMaxType` to look for a minimum on.
+    :param: property The name of a property conforming to `MinMaxType` to look for a minimum on.
 
-    - returns: The minimum value for the property amongst objects in the collection, or `nil` if the collection is empty.
+    :returns: The minimum value for the property amongst objects in the collection, or `nil` if the collection is empty.
     */
     public func min<U: MinMaxType>(property: String) -> U? { return base.min(property) }
 
     /**
     Returns the maximum value of the given property.
 
-    - warning: Only names of properties of a type conforming to the `MinMaxType` protocol can be used.
+    :warning: Only names of properties of a type conforming to the `MinMaxType` protocol can be used.
 
-    - parameter property: The name of a property conforming to `MinMaxType` to look for a maximum on.
+    :param: property The name of a property conforming to `MinMaxType` to look for a maximum on.
 
-    - returns: The maximum value for the property amongst objects in the collection, or `nil` if the collection is empty.
+    :returns: The maximum value for the property amongst objects in the collection, or `nil` if the collection is empty.
     */
     public func max<U: MinMaxType>(property: String) -> U? { return base.max(property) }
 
     /**
     Returns the sum of the given property for objects in the collection.
 
-    - warning: Only names of properties of a type conforming to the `AddableType` protocol can be used.
+    :warning: Only names of properties of a type conforming to the `AddableType` protocol can be used.
 
-    - parameter property: The name of a property conforming to `AddableType` to calculate sum on.
+    :param: property The name of a property conforming to `AddableType` to calculate sum on.
 
-    - returns: The sum of the given property over all objects in the collection.
+    :returns: The sum of the given property over all objects in the collection.
     */
     public func sum<U: AddableType>(property: String) -> U { return base.sum(property) }
 
     /**
     Returns the average of the given property for objects in the collection.
 
-    - warning: Only names of properties of a type conforming to the `AddableType` protocol can be used.
+    :warning: Only names of properties of a type conforming to the `AddableType` protocol can be used.
 
-    - parameter property: The name of a property conforming to `AddableType` to calculate average on.
+    :param: property The name of a property conforming to `AddableType` to calculate average on.
 
-    - returns: The average of the given property over all objects in the collection, or `nil` if the collection is empty.
+    :returns: The average of the given property over all objects in the collection, or `nil` if the collection is empty.
     */
     public func average<U: AddableType>(property: String) -> U? { return base.average(property) }
 
@@ -611,9 +611,9 @@ public final class AnyRealmCollection<T: Object>: RealmCollectionType {
     /**
     Returns the object at the given `index`.
 
-    - parameter index: The index.
+    :param: index The index.
 
-    - returns: The object at the given `index`.
+    :returns: The object at the given `index`.
     */
     public subscript(index: Int) -> T { return base[index] }
 
@@ -635,16 +635,16 @@ public final class AnyRealmCollection<T: Object>: RealmCollectionType {
     // MARK: Key-Value Coding
 
     /**
-    Returns an Array containing the results of invoking `valueForKey:` using key on each of the collection's objects.
+    Returns an Array containing the results of invoking `valueForKey(_:)` using key on each of the collection's objects.
 
     :param: key The name of the property.
 
-    :returns: Array containing the results of invoking `valueForKey:` using key on each of the collection's objects.
+    :returns: Array containing the results of invoking `valueForKey(_:)` using key on each of the collection's objects.
     */
     public func valueForKey(key: String) -> AnyObject? { return base.valueForKey(key) }
 
     /**
-    Invokes `setValue:forKey:` on each of the collection's objects using the specified value and key.
+    Invokes `setValue(_:forKey:)` on each of the collection's objects using the specified value and key.
 
     :warning: This method can only be called during a write transaction.
 

--- a/RealmSwift-swift1.2/Results.swift
+++ b/RealmSwift-swift1.2/Results.swift
@@ -117,7 +117,7 @@ public final class Results<T: Object>: ResultsBase {
 
     :param: predicate The predicate to filter the objects.
 
-    :returns: The index of the given object, or `nil` if no objects match.
+    :returns: The index of the first matching object, or `nil` if no objects match.
     */
     public func indexOf(predicate: NSPredicate) -> Int? {
         return notFoundToNil(rlmResults.indexOfObjectWithPredicate(predicate))
@@ -129,7 +129,7 @@ public final class Results<T: Object>: ResultsBase {
 
     :param: predicateFormat The predicate format string which can accept variable arguments.
 
-    :returns: The index of the given object, or `nil` if no objects match.
+    :returns: The index of the first matching object, or `nil` if no objects match.
     */
     public func indexOf(predicateFormat: String, _ args: CVarArgType...) -> Int? {
         return notFoundToNil(rlmResults.indexOfObjectWithPredicate(NSPredicate(format: predicateFormat, arguments: getVaList(args))))
@@ -160,18 +160,18 @@ public final class Results<T: Object>: ResultsBase {
     // MARK: KVC
 
     /**
-    Returns an Array containing the results of invoking `valueForKey:` using key on each of the collection's objects.
+    Returns an Array containing the results of invoking `valueForKey(_:)` using key on each of the collection's objects.
 
     :param: key The name of the property.
 
-    :returns: Array containing the results of invoking `valueForKey:` using key on each of the collection's objects.
+    :returns: Array containing the results of invoking `valueForKey(_:)` using key on each of the collection's objects.
     */
     public override func valueForKey(key: String) -> AnyObject? {
         return rlmResults.valueForKey(key)
     }
 
     /**
-    Invokes `setValue:forKey:` on each of the collection's objects using the specified value and key.
+    Invokes `setValue(_:forKey:)` on each of the collection's objects using the specified value and key.
 
     :warning: This method can only be called during a write transaction.
 

--- a/RealmSwift-swift1.2/Schema.swift
+++ b/RealmSwift-swift1.2/Schema.swift
@@ -25,7 +25,7 @@ This class represents the collection of model object schemas persisted to Realm.
 When using Realm, `Schema` objects allow performing migrations and
 introspecting the database's schema.
 
-Schemas map to collections of tables in the core database.
+`Schema`s map to collections of tables in the core database.
 */
 public final class Schema: Printable {
 

--- a/RealmSwift-swift1.2/SortDescriptor.swift
+++ b/RealmSwift-swift1.2/SortDescriptor.swift
@@ -55,7 +55,7 @@ public struct SortDescriptor {
 
     // MARK: Functions
 
-    /// Returns a copy of the receiver with the sort order reversed.
+    /// Returns a copy of the `SortDescriptor` with the sort order reversed.
     public func reversed() -> SortDescriptor {
         return SortDescriptor(property: property, ascending: !ascending)
     }

--- a/RealmSwift-swift2.0/Aliases.swift
+++ b/RealmSwift-swift2.0/Aliases.swift
@@ -42,7 +42,7 @@ See [Realm Models](http://realm.io/docs/swift/latest/#models).
 * Data
 * Date
 
-## Array/Linked object types
+## Relationships: List (Array) and Object types
 
 * Object
 * Array

--- a/RealmSwift-swift2.0/List.swift
+++ b/RealmSwift-swift2.0/List.swift
@@ -26,7 +26,7 @@ public class ListBase: RLMListBase {
     // Printable requires a description property defined in Swift (and not obj-c),
     // and it has to be defined as @objc override, which can't be done in a
     // generic class.
-    /// Returns a human-readable description of the objects contained in the list.
+    /// Returns a human-readable description of the objects contained in the List.
     @objc public override var description: String {
         return descriptionWithMaxDepth(RLMDescriptionMaxDepth)
     }
@@ -36,14 +36,14 @@ public class ListBase: RLMListBase {
         return gsub("RLMArray <0x[a-z0-9]+>", template: type, string: _rlmArray.descriptionWithMaxDepth(depth)) ?? type
     }
 
-    /// Returns the number of objects in this list.
+    /// Returns the number of objects in this List.
     public var count: Int { return Int(_rlmArray.count) }
 }
 
 /**
 `List<T>` is the container type in Realm used to define to-many relationships.
 
-Lists hold a single `Object` subclass (`T`) which defines the "type" of the list.
+Lists hold a single `Object` subclass (`T`) which defines the "type" of the List.
 
 Lists can be filtered and sorted with the same predicates as `Results<T>`.
 
@@ -56,13 +56,13 @@ public final class List<T: Object>: ListBase {
 
     // MARK: Properties
 
-    /// The Realm the objects in this list belong to, or `nil` if the list's
-    /// owning object does not belong to a realm (the list is standalone).
+    /// The Realm the objects in this List belong to, or `nil` if the List's
+    /// owning object does not belong to a Realm (the List is standalone).
     public var realm: Realm? {
         return _rlmArray.realm.map { Realm($0) }
     }
 
-    /// Indicates if the list can no longer be accessed.
+    /// Indicates if the List can no longer be accessed.
     public var invalidated: Bool { return _rlmArray.invalidated }
 
     // MARK: Initializers
@@ -76,11 +76,11 @@ public final class List<T: Object>: ListBase {
     // MARK: Index Retrieval
 
     /**
-    Returns the index of the given object, or `nil` if the object is not in the list.
+    Returns the index of the given object, or `nil` if the object is not in the List.
 
     - parameter object: The object whose index is being queried.
 
-    - returns: The index of the given object, or `nil` if the object is not in the list.
+    - returns: The index of the given object, or `nil` if the object is not in the List.
     */
     public func indexOf(object: T) -> Int? {
         return notFoundToNil(_rlmArray.indexOfObject(unsafeBitCast(object, RLMObject.self)))
@@ -92,7 +92,7 @@ public final class List<T: Object>: ListBase {
 
     - parameter predicate: The `NSPredicate` used to filter the objects.
 
-    - returns: The index of the given object, or `nil` if no objects match.
+    - returns: The index of the first matching object, or `nil` if no objects match.
     */
     public func indexOf(predicate: NSPredicate) -> Int? {
         return notFoundToNil(_rlmArray.indexOfObjectWithPredicate(predicate))
@@ -105,7 +105,7 @@ public final class List<T: Object>: ListBase {
     - parameter predicateFormat: The predicate format string, optionally
                                  followed by a variable number of arguments.
 
-    - returns: The index of the given object, or `nil` if no objects match.
+    - returns: The index of the first matching object, or `nil` if no objects match.
     */
     public func indexOf(predicateFormat: String, _ args: AnyObject...) -> Int? {
         return indexOf(NSPredicate(format: predicateFormat, argumentArray: args))
@@ -134,27 +134,27 @@ public final class List<T: Object>: ListBase {
         }
     }
 
-    /// Returns the first object in the list, or `nil` if empty.
+    /// Returns the first object in the List, or `nil` if empty.
     public var first: T? { return _rlmArray.firstObject() as! T? }
 
-    /// Returns the last object in the list, or `nil` if empty.
+    /// Returns the last object in the List, or `nil` if empty.
     public var last: T? { return _rlmArray.lastObject() as! T? }
 
     // MARK: KVC
 
     /**
-    Returns an Array containing the results of invoking `valueForKey:` using key on each of the collection's objects.
+    Returns an Array containing the results of invoking `valueForKey(_:)` using key on each of the collection's objects.
 
     - parameter key: The name of the property.
 
-    - returns: Array containing the results of invoking `valueForKey:` using key on each of the collection's objects.
+    - returns: Array containing the results of invoking `valueForKey(_:)` using key on each of the collection's objects.
     */
     public override func valueForKey(key: String) -> AnyObject? {
         return _rlmArray.valueForKey(key)
     }
 
     /**
-    Invokes `setValue:forKey:` on each of the collection's objects using the specified value and key.
+    Invokes `setValue(_:forKey:)` on each of the collection's objects using the specified value and key.
 
     - warning: This method can only be called during a write transaction.
 
@@ -168,22 +168,22 @@ public final class List<T: Object>: ListBase {
     // MARK: Filtering
 
     /**
-    Returns `Results` containing list elements that match the given predicate.
+    Returns `Results` containing elements that match the given predicate.
 
     - parameter predicateFormat: The predicate format string which can accept variable arguments.
 
-    - returns: `Results` containing list elements that match the given predicate.
+    - returns: `Results` containing elements that match the given predicate.
     */
     public func filter(predicateFormat: String, _ args: AnyObject...) -> Results<T> {
         return Results<T>(_rlmArray.objectsWithPredicate(NSPredicate(format: predicateFormat, argumentArray: args)))
     }
 
     /**
-    Returns `Results` containing list elements that match the given predicate.
+    Returns `Results` containing elements that match the given predicate.
 
     - parameter predicate: The predicate to filter the objects.
 
-    - returns: `Results` containing list elements that match the given predicate.
+    - returns: `Results` containing elements that match the given predicate.
     */
     public func filter(predicate: NSPredicate) -> Results<T> {
         return Results<T>(_rlmArray.objectsWithPredicate(predicate))
@@ -192,12 +192,12 @@ public final class List<T: Object>: ListBase {
     // MARK: Sorting
 
     /**
-    Returns `Results` containing list elements sorted by the given property.
+    Returns `Results` containing elements sorted by the given property.
 
     - parameter property:  The property name to sort by.
     - parameter ascending: The direction to sort by.
 
-    - returns: `Results` containing list elements sorted by the given property.
+    - returns: `Results` containing elements sorted by the given property.
     */
     public func sorted(property: String, ascending: Bool = true) -> Results<T> {
         return sorted([SortDescriptor(property: property, ascending: ascending)])
@@ -271,7 +271,7 @@ public final class List<T: Object>: ListBase {
     // MARK: Mutation
 
     /**
-    Appends the given object to the end of the list. If the object is from a
+    Appends the given object to the end of the List. If the object is from a
     different Realm it is copied to the List's Realm.
 
     - warning: This method can only be called during a write transaction.
@@ -283,7 +283,7 @@ public final class List<T: Object>: ListBase {
     }
 
     /**
-    Appends the objects in the given sequence to the end of the list.
+    Appends the objects in the given sequence to the end of the List.
 
     - warning: This method can only be called during a write transaction.
 
@@ -300,7 +300,7 @@ public final class List<T: Object>: ListBase {
 
     - warning: This method can only be called during a write transaction.
     - warning: Throws an exception when called with an index smaller than zero
-               or greater than or equal to the number of objects in the list.
+               or greater than or equal to the number of objects in the List.
 
     - parameter object: An object.
     - parameter index:  The index at which to insert the object.
@@ -311,11 +311,11 @@ public final class List<T: Object>: ListBase {
     }
 
     /**
-    Removes the object at the given index from the list. Does not remove the object from the Realm.
+    Removes the object at the given index from the List. Does not remove the object from the Realm.
 
     - warning: This method can only be called during a write transaction.
     - warning: Throws an exception when called with an index smaller than zero
-               or greater than or equal to the number of objects in the list.
+               or greater than or equal to the number of objects in the List.
 
     - parameter index: The index at which to remove the object.
     */
@@ -325,7 +325,7 @@ public final class List<T: Object>: ListBase {
     }
 
     /**
-    Removes the last object in the list. Does not remove the object from the Realm.
+    Removes the last object in the List. Does not remove the object from the Realm.
 
     - warning: This method can only be called during a write transaction.
     */
@@ -347,9 +347,9 @@ public final class List<T: Object>: ListBase {
 
     - warning: This method can only be called during a write transaction.
     - warning: Throws an exception when called with an index smaller than zero
-               or greater than or equal to the number of objects in the list.
+               or greater than or equal to the number of objects in the List.
 
-    - parameter index:  The list index of the object to be replaced.
+    - parameter index:  The index of the object to be replaced.
     - parameter object: An object to replace at the specified index.
     */
     public func replace(index: Int, object: T) {
@@ -362,7 +362,7 @@ public final class List<T: Object>: ListBase {
 
     - warning: This method can only be called during a write transaction.
     - warning: Throws an exception when called with an index smaller than zero or greater than
-               or equal to the number of objects in the list.
+               or equal to the number of objects in the List.
 
     - parameter from:  The index of the object to be moved.
     - parameter to:    index to which the object at `from` should be moved.
@@ -374,9 +374,9 @@ public final class List<T: Object>: ListBase {
     }
 
     /**
-    Exchanges the objects in the list at given indexes.
+    Exchanges the objects in the List at given indexes.
 
-    - warning: Throws an exception when either index exceeds the bounds of the list.
+    - warning: Throws an exception when either index exceeds the bounds of the List.
     - warning: This method can only be called during a write transaction.
 
     - parameter index1: The index of the object with which to replace the object at index `index2`.
@@ -392,7 +392,7 @@ public final class List<T: Object>: ListBase {
 extension List: RealmCollectionType, RangeReplaceableCollectionType {
     // MARK: Sequence Support
 
-    /// Returns a `GeneratorOf<T>` that yields successive elements in the list.
+    /// Returns a `GeneratorOf<T>` that yields successive elements in the List.
     public func generate() -> RLMGenerator<T> {
         return RLMGenerator(collection: _rlmArray)
     }
@@ -403,7 +403,7 @@ extension List: RealmCollectionType, RangeReplaceableCollectionType {
     Replace the given `subRange` of elements with `newElements`.
 
     - parameter subRange:    The range of elements to be replaced.
-    - parameter newElements: The new elements to be inserted into the list.
+    - parameter newElements: The new elements to be inserted into the List.
     */
     public func replaceRange<C: CollectionType where C.Generator.Element == T>(subRange: Range<Int>, with newElements: C) {
         for _ in subRange {

--- a/RealmSwift-swift2.0/Migration.swift
+++ b/RealmSwift-swift2.0/Migration.swift
@@ -34,7 +34,7 @@ public typealias MigrationBlock = (migration: Migration, oldSchemaVersion: UInt6
 public typealias MigrationObject = DynamicObject
 
 /**
-Provides both the old and new versions of an object in this Realm. Objects properties can only be
+Provides both the old and new versions of an object in this Realm. Object properties can only be
 accessed using subscripting.
 
 - parameter oldObject: Object in original `Realm` (read-only).
@@ -104,8 +104,8 @@ public final class Migration {
     Enumerates objects of a given type in this Realm, providing both the old and new versions of
     each object. Object properties can be accessed using subscripting.
 
-    - parameter className: The name of the `Object` class to enumerate.
-    - parameter block:     The block providing both the old and new versions of an object in this Realm.
+    - parameter objectClassName: The name of the `Object` class to enumerate.
+    - parameter block:           The block providing both the old and new versions of an object in this Realm.
     */
     public func enumerate(objectClassName: String, _ block: MigrationObjectEnumerateBlock) {
         rlmMigration.enumerateObjects(objectClassName) {
@@ -117,7 +117,7 @@ public final class Migration {
     Create an `Object` of type `className` in the Realm being migrated.
 
     - parameter className: The name of the `Object` class to create.
-    - parameter object:    The object used to populate the object. This can be any key/value coding
+    - parameter value:     The object used to populate the new `Object`. This can be any key/value coding
                            compliant object, or a JSON object such as those returned from the methods in
                            `NSJSONSerialization`, or an `Array` with one object for each persisted
                            property. An exception will be thrown if any required properties are not
@@ -144,9 +144,9 @@ public final class Migration {
     This deletes all objects of the given class, and if the Object subclass no longer exists in your program,
     cleans up any remaining metadata for the class in the Realm file.
 
-    - parameter name: The name of the Object class to delete.
+    - parameter objectClassName: The name of the Object class to delete.
 
-    - returns: whether there was any data to delete.
+    - returns: `true` if there was any data to delete.
     */
     public func deleteData(objectClassName: String) -> Bool {
         return rlmMigration.deleteDataForClassName(objectClassName)

--- a/RealmSwift-swift2.0/Object.swift
+++ b/RealmSwift-swift2.0/Object.swift
@@ -36,6 +36,7 @@ class Dog: Object {
 
 - `String`, `NSString`
 - `Int`
+- `Int8`, `Int16`, `Int32`, `Int64`
 - `Float`
 - `Double`
 - `Bool`
@@ -46,10 +47,10 @@ class Dog: Object {
 - `List<T: Object>` for to-many relationships
 
 `String`, `NSString`, `NSDate`, `NSData` and `Object` subclass properties can be
-optional. `Int`, `Float`, `Double`, `Bool` and `List` properties cannot. To store
-an optional number, instead use `RealmOptional<Int>`, `RealmOptional<Float>`,
-`RealmOptional<Double>`, or `RealmOptional<Bool>` instead, which wraps an optional
-value of the generic type.
+optional. `Int`, `Int8`, Int16`, Int32`, `Int64`, `Float`, `Double`, `Bool` 
+and `List` properties cannot. To store an optional number, instead use 
+`RealmOptional<Int>`, `RealmOptional<Float>`, `RealmOptional<Double>`, or 
+`RealmOptional<Bool>` instead, which wraps an optional value of the generic type.
 
 All property types except for `List` and `RealmOptional` *must* be declared as
 `dynamic var`. `List` and `RealmOptional` properties must be declared as
@@ -57,8 +58,8 @@ non-dynamic `let` properties.
 
 ### Querying
 
-You can gets `Results` of an Object subclass via tha `objects(_:)` free function or
-the `objects(_:)` instance method on `Realm`.
+You can gets `Results` of an Object subclass via the `objects(_:)` instance 
+method on `Realm`.
 
 ### Relationships
 
@@ -69,7 +70,7 @@ public class Object: RLMObjectBase {
     // MARK: Initializers
 
     /**
-    Initialize a standalone (unpersisted) Object.
+    Initialize a standalone (unpersisted) `Object`.
     Call `add(_:)` on a `Realm` to add standalone objects to a realm.
 
     - see: Realm().add(_:)
@@ -158,13 +159,13 @@ public class Object: RLMObjectBase {
     // MARK: Inverse Relationships
 
     /**
-    Get an `Array` of objects of type `className` which have this object as the given property value. This can
+    Get an `Array` of objects of type `T` which have this object as the given property value. This can
     be used to get the inverse relationship value for `Object` and `List` properties.
 
-    - parameter className: The type of object on which the relationship to query is defined.
-    - parameter property:  The name of the property which defines the relationship.
+    - parameter type:          The type of object on which the relationship to query is defined.
+    - parameter propertyName:  The name of the property which defines the relationship.
 
-    - returns: An `Array` of objects of type `className` which have this object as their value for the `propertyName` property.
+    - returns: An `Array` of objects of type `T` which have this object as their value for the `propertyName` property.
     */
     public func linkingObjects<T: Object>(type: T.Type, forProperty propertyName: String) -> [T] {
         // FIXME: use T.className()

--- a/RealmSwift-swift2.0/ObjectSchema.swift
+++ b/RealmSwift-swift2.0/ObjectSchema.swift
@@ -20,12 +20,12 @@ import Foundation
 import Realm
 
 /**
-This class represents Realm model object schemas persisted to Realm in a Schema.
+This class represents Realm model object schemas.
 
-When using Realm, ObjectSchema objects allow performing migrations and
+When using Realm, `ObjectSchema` objects allow performing migrations and
 introspecting the database's schema.
 
-Object schemas map to tables in the core database.
+`ObjectSchema`s map to tables in the core database.
 */
 public final class ObjectSchema: CustomStringConvertible {
 

--- a/RealmSwift-swift2.0/Property.swift
+++ b/RealmSwift-swift2.0/Property.swift
@@ -20,9 +20,9 @@ import Foundation
 import Realm
 
 /**
-This class represents properties persisted to Realm in an ObjectSchema.
+This class represents properties persisted to Realm in an `ObjectSchema`.
 
-When using Realm, Property objects allow performing migrations and
+When using Realm, `Property` objects allow performing migrations and
 introspecting the database's schema.
 
 These properties map to columns in the core database.
@@ -42,7 +42,7 @@ public final class Property: CustomStringConvertible {
     /// Whether this property is indexed.
     public var indexed: Bool { return rlmProperty.indexed }
 
-    ///  Whether this property is optional (can contain `nil` values).
+    /// Whether this property is optional (can contain `nil` values).
     public var optional: Bool { return rlmProperty.optional }
 
     /// Object class name - specify object types for `Object` and `List` properties.

--- a/RealmSwift-swift2.0/Realm.swift
+++ b/RealmSwift-swift2.0/Realm.swift
@@ -25,7 +25,7 @@ A Realm instance (also referred to as "a realm") represents a Realm
 database.
 
 Realms can either be stored on disk (see `init(path:)`) or in
-memory (see `init(inMemoryIdentifier:)`).
+memory (see `Configuration`).
 
 Realm instances are cached internally, and constructing equivalent Realm
 objects (with the same path or identifier) produces limited overhead.
@@ -55,7 +55,7 @@ public final class Realm {
     /// The Schema used by this realm.
     public var schema: Schema { return Schema(rlmRealm.schema) }
 
-    /// Returns a `Configuration` that can be used to create this `Realm` instance.
+    /// Returns the `Configuration` that was used to create this `Realm` instance.
     public var configuration: Configuration { return Configuration.fromRLMRealmConfiguration(rlmRealm.configuration) }
 
     /// Indicates if this Realm contains any objects.
@@ -87,7 +87,16 @@ public final class Realm {
     // MARK: Transactions
 
     /**
-    Helper to perform actions contained within the given block inside a write transation.
+    Performs actions contained within the given block inside a write transation.
+	
+    Write transactions cannot be nested, and trying to execute a write transaction 
+	on a `Realm` which is already in a write transaction will throw an exception. 
+	Calls to `write` from `Realm` instances in other threads will block
+    until the current write transaction completes.
+
+    Before executing the write transaction, `write` updates the `Realm` to the 
+	latest Realm version, as if `refresh()` was called, and generates notifications 
+	if applicable. This has no effect if the `Realm` was already up to date.
 
     - parameter block: The block to be executed inside a write transaction.
     */
@@ -100,7 +109,7 @@ public final class Realm {
 
     Only one write transaction can be open at a time. Write transactions cannot be
     nested, and trying to begin a write transaction on a `Realm` which is
-    already in a write transaction with throw an exception. Calls to
+    already in a write transaction will throw an exception. Calls to
     `beginWrite` from `Realm` instances in other threads will block
     until the current write transaction completes.
 
@@ -119,9 +128,8 @@ public final class Realm {
     }
 
     /**
-    Commits all writes operations in the current write transaction.
-
-    After this is called, the `Realm` reverts back to being read-only.
+    Commits all writes operations in the current write transaction, and ends
+	the transaction.
 
     Calling this when not in a write transaction will throw an exception.
     */
@@ -181,8 +189,8 @@ public final class Realm {
     the Realm instance with the same primary key value, the object is inserted. Otherwise,
     the existing object is updated with any changed values.
 
-    When added, all linked (child) objects referenced by this object will also be
-    added to the Realm if they are not already in it. If the object or any linked
+    When added, all (child) relationships referenced by this object will also be
+    added to the Realm if they are not already in it. If the object or any related
     objects already belong to a different Realm an exception will be thrown. Use one
     of the `create` functions to insert a copy of a persisted object into a different
     Realm.
@@ -203,7 +211,7 @@ public final class Realm {
     /**
     Adds or updates objects in the given sequence to be persisted it in this Realm.
 
-    - see: add(object:update:)
+    - see: add(_:update:)
 
     - parameter objects: A sequence which contains objects to be added to this Realm.
     - parameter update: If true will try to update existing objects with the same primary key.
@@ -247,9 +255,9 @@ public final class Realm {
     /**
     This method is useful only in specialized circumstances, for example, when building
     components that integrate with Realm. If you are simply building an app on Realm, it is
-    recommended to use the typed method `create(type:value:update:)`.
+    recommended to use the typed method `create(_:value:update:)`.
 
-    Creates or updates an object with the given class name and adds it to the `Realm` populating
+    Creates or updates an object with the given class name and adds it to the `Realm`, populating
     the object with the given value.
 
     When 'update' is 'true', the object must have a primary key. If no objects exist in
@@ -384,7 +392,7 @@ public final class Realm {
     /**
     This method is useful only in specialized circumstances, for example, when building
     components that integrate with Realm. If you are simply building an app on Realm, it is
-    recommended to use the typed method `objectForPrimaryKey(type:key:)`.
+    recommended to use the typed method `objectForPrimaryKey(_:key:)`.
 
     Get a dynamic object with the given class name and primary key.
 
@@ -444,8 +452,12 @@ public final class Realm {
 
     If set to `true` (the default), changes made on other threads will be reflected
     in this Realm on the next cycle of the run loop after the changes are
-    committed.  If set to `false`, you must manually call -refresh on the Realm to
+    committed.  If set to `false`, you must manually call `refresh()` on the Realm to
     update it to get the latest version.
+	
+	Note that on background threads, the run loop is not run by default and you will 
+	will need to manually call `refresh()` in order to update to the latest version,
+	even if `autorefresh` is set to `true`.
 
     Even with this enabled, you can still call `refresh()` at any time to update the
     Realm before the automatic refresh would occur.
@@ -555,16 +567,16 @@ public enum Notification: String {
     /**
     Posted when the data in a realm has changed.
 
-    DidChange are posted after a realm has been refreshed to reflect a write transaction, i.e. when
+    DidChange is posted after a realm has been refreshed to reflect a write transaction, i.e. when
     an autorefresh occurs, `refresh()` is called, after an implicit refresh from
-    `beginWriteTransaction()`, and after a local write transaction is committed.
+    `write(_:)`/`beginWrite()`, and after a local write transaction is committed.
     */
     case DidChange = "RLMRealmDidChangeNotification"
 
     /**
-    Posted when a write transaction has been committed to a realm on a different thread for the same
+    Posted when a write transaction has been committed to a Realm on a different thread for the same
     file. This is not posted if `autorefresh` is enabled or if the Realm is refreshed before the
-    notifcation has a chance to run.
+    notification has a chance to run.
 
     Realms with autorefresh disabled should normally have a handler for this notification which
     calls `refresh()` after doing some work.

--- a/RealmSwift-swift2.0/Realm.swift
+++ b/RealmSwift-swift2.0/Realm.swift
@@ -213,6 +213,8 @@ public final class Realm {
 
     - see: add(_:update:)
 
+    - warning: This method can only be called during a write transaction.
+
     - parameter objects: A sequence which contains objects to be added to this Realm.
     - parameter update: If true will try to update existing objects with the same primary key.
     */
@@ -231,6 +233,8 @@ public final class Realm {
     When 'update' is 'true', the object must have a primary key. If no objects exist in
     the Realm instance with the same primary key value, the object is inserted. Otherwise,
     the existing object is updated with any changed values.
+
+    - warning: This method can only be called during a write transaction.
 
     - parameter type:   The object type to create.
     - parameter value:  The value used to populate the object. This can be any key/value coding compliant
@@ -264,6 +268,8 @@ public final class Realm {
     the Realm instance with the same primary key value, the object is inserted. Otherwise,
     the existing object is updated with any changed values.
 
+    - warning: This method can only be called during a write transaction.
+
     - parameter className:  The class name of the object to create.
     - parameter value:      The value used to populate the object. This can be any key/value coding compliant
     object, or a JSON dictionary such as those returned from the methods in `NSJSONSerialization`,
@@ -290,6 +296,8 @@ public final class Realm {
     /**
     Deletes the given object from this Realm.
 
+    - warning: This method can only be called during a write transaction.
+
     - parameter object: The object to be deleted.
     */
     public func delete(object: Object) {
@@ -298,6 +306,8 @@ public final class Realm {
 
     /**
     Deletes the given objects from this Realm.
+
+    - warning: This method can only be called during a write transaction.
 
     - parameter objects: The objects to be deleted. This can be a `List<Object>`, `Results<Object>`,
                          or any other enumerable SequenceType which generates Object.
@@ -311,6 +321,8 @@ public final class Realm {
     /**
     Deletes the given objects from this Realm.
 
+    - warning: This method can only be called during a write transaction.
+
     - parameter objects: The objects to be deleted. Must be `List<Object>`.
 
     :nodoc:
@@ -322,6 +334,8 @@ public final class Realm {
     /**
     Deletes the given objects from this Realm.
 
+    - warning: This method can only be called during a write transaction.
+
     - parameter objects: The objects to be deleted. Must be `Results<Object>`.
 
     :nodoc:
@@ -332,6 +346,8 @@ public final class Realm {
 
     /**
     Deletes all objects from this Realm.
+
+    - warning: This method can only be called during a write transaction.
     */
     public func deleteAll() {
         RLMDeleteAllObjectsFromRealm(rlmRealm)

--- a/RealmSwift-swift2.0/RealmCollectionType.swift
+++ b/RealmSwift-swift2.0/RealmCollectionType.swift
@@ -82,7 +82,7 @@ public protocol RealmCollectionType: CollectionType, CustomStringConvertible {
 
     - parameter predicate: The `NSPredicate` used to filter the objects.
 
-    - returns: The index of the given object, or `nil` if no objects match.
+    - returns: The index of the first matching object, or `nil` if no objects match.
     */
     func indexOf(predicate: NSPredicate) -> Int?
 
@@ -93,7 +93,7 @@ public protocol RealmCollectionType: CollectionType, CustomStringConvertible {
     - parameter predicateFormat: The predicate format string, optionally followed by a variable number
     of arguments.
 
-    - returns: The index of the given object, or `nil` if no objects match.
+    - returns: The index of the first matching object, or `nil` if no objects match.
     */
     func indexOf(predicateFormat: String, _ args: AnyObject...) -> Int?
 
@@ -191,18 +191,18 @@ public protocol RealmCollectionType: CollectionType, CustomStringConvertible {
     // MARK: Key-Value Coding
 
     /**
-    Returns an Array containing the results of invoking `valueForKey:` using key on each of the collection's objects.
+    Returns an Array containing the results of invoking `valueForKey(_:)` using key on each of the collection's objects.
 
     - parameter key: The name of the property.
 
-    - returns: Array containing the results of invoking `valueForKey:` using key on each of the collection's objects.
+    - returns: Array containing the results of invoking `valueForKey(_:)` using key on each of the collection's objects.
     */
     func valueForKey(key: String) -> AnyObject?
 
     /**
-    Invokes `setValue:forKey:` on each of the collection's objects using the specified value and key.
+    Invokes `setValue(_:forKey:)` on each of the collection's objects using the specified value and key.
 
-    :warning: This method can only be called during a write transaction.
+    - warning: This method can only be called during a write transaction.
 
     - parameter value: The object value.
     - parameter key:   The name of the property.
@@ -271,7 +271,7 @@ private final class _AnyRealmCollection<C: RealmCollectionType>: _AnyRealmCollec
 
     - parameter predicate: The `NSPredicate` used to filter the objects.
 
-    - returns: The index of the given object, or `nil` if no objects match.
+    - returns: The index of the first matching object, or `nil` if no objects match.
     */
     override func indexOf(predicate: NSPredicate) -> Int? { return base.indexOf(predicate) }
 
@@ -282,7 +282,7 @@ private final class _AnyRealmCollection<C: RealmCollectionType>: _AnyRealmCollec
     - parameter predicateFormat: The predicate format string, optionally followed by a variable number
     of arguments.
 
-    - returns: The index of the given object, or `nil` if no objects match.
+    - returns: The index of the first matching object, or `nil` if no objects match.
     */
     override func indexOf(predicateFormat: String, _ args: AnyObject...) -> Int? { return base.indexOf(NSPredicate(format: predicateFormat, argumentArray: args)) }
 
@@ -405,18 +405,18 @@ private final class _AnyRealmCollection<C: RealmCollectionType>: _AnyRealmCollec
     // MARK: Key-Value Coding
 
     /**
-    Returns an Array containing the results of invoking `valueForKey:` using key on each of the collection's objects.
+    Returns an Array containing the results of invoking `valueForKey(_:)` using key on each of the collection's objects.
 
     - parameter key: The name of the property.
 
-    - returns: Array containing the results of invoking `valueForKey:` using key on each of the collection's objects.
+    - returns: Array containing the results of invoking `valueForKey(_:)` using key on each of the collection's objects.
     */
     override func valueForKey(key: String) -> AnyObject? { return base.valueForKey(key) }
 
     /**
-    Invokes `setValue:forKey:` on each of the collection's objects using the specified value and key.
+    Invokes `setValue(_:forKey:)` on each of the collection's objects using the specified value and key.
 
-    :warning: This method can only be called during a write transaction.
+    - warning: This method can only be called during a write transaction.
 
     - parameter value: The object value.
     - parameter key:   The name of the property.
@@ -472,7 +472,7 @@ public final class AnyRealmCollection<T: Object>: RealmCollectionType {
 
     - parameter predicate: The `NSPredicate` used to filter the objects.
 
-    - returns: The index of the given object, or `nil` if no objects match.
+    - returns: The index of the first matching object, or `nil` if no objects match.
     */
     public func indexOf(predicate: NSPredicate) -> Int? { return base.indexOf(predicate) }
 
@@ -483,7 +483,7 @@ public final class AnyRealmCollection<T: Object>: RealmCollectionType {
     - parameter predicateFormat: The predicate format string, optionally followed by a variable number
     of arguments.
 
-    - returns: The index of the given object, or `nil` if no objects match.
+    - returns: The index of the first matching object, or `nil` if no objects match.
     */
     public func indexOf(predicateFormat: String, _ args: AnyObject...) -> Int? { return base.indexOf(NSPredicate(format: predicateFormat, argumentArray: args)) }
 
@@ -606,18 +606,18 @@ public final class AnyRealmCollection<T: Object>: RealmCollectionType {
     // MARK: Key-Value Coding
 
     /**
-    Returns an Array containing the results of invoking `valueForKey:` using key on each of the collection's objects.
+    Returns an Array containing the results of invoking `valueForKey(_:)` using key on each of the collection's objects.
 
     - parameter key: The name of the property.
 
-    - returns: Array containing the results of invoking `valueForKey:` using key on each of the collection's objects.
+    - returns: Array containing the results of invoking `valueForKey(_:)` using key on each of the collection's objects.
     */
     public func valueForKey(key: String) -> AnyObject? { return base.valueForKey(key) }
 
     /**
-    Invokes `setValue:forKey:` on each of the collection's objects using the specified value and key.
+    Invokes `setValue(_:forKey:)` on each of the collection's objects using the specified value and key.
 
-    :warning: This method can only be called during a write transaction.
+    - warning: This method can only be called during a write transaction.
 
     - parameter value: The object value.
     - parameter key:   The name of the property.

--- a/RealmSwift-swift2.0/Results.swift
+++ b/RealmSwift-swift2.0/Results.swift
@@ -116,7 +116,7 @@ public final class Results<T: Object>: ResultsBase {
 
     - parameter predicate: The predicate to filter the objects.
 
-    - returns: The index of the given object, or `nil` if no objects match.
+    - returns: The index of the first matching object, or `nil` if no objects match.
     */
     public func indexOf(predicate: NSPredicate) -> Int? {
         return notFoundToNil(rlmResults.indexOfObjectWithPredicate(predicate))
@@ -128,7 +128,7 @@ public final class Results<T: Object>: ResultsBase {
 
     - parameter predicateFormat: The predicate format string which can accept variable arguments.
 
-    - returns: The index of the given object, or `nil` if no objects match.
+    - returns: The index of the first matching object, or `nil` if no objects match.
     */
     public func indexOf(predicateFormat: String, _ args: AnyObject...) -> Int? {
         return notFoundToNil(rlmResults.indexOfObjectWithPredicate(NSPredicate(format: predicateFormat, argumentArray: args)))
@@ -159,18 +159,18 @@ public final class Results<T: Object>: ResultsBase {
     // MARK: KVC
 
     /**
-    Returns an Array containing the results of invoking `valueForKey:` using key on each of the collection's objects.
+    Returns an Array containing the results of invoking `valueForKey(_:)` using key on each of the collection's objects.
 
     - parameter key: The name of the property.
 
-    - returns: Array containing the results of invoking `valueForKey:` using key on each of the collection's objects.
+    - returns: Array containing the results of invoking `valueForKey(_:)` using key on each of the collection's objects.
     */
     public override func valueForKey(key: String) -> AnyObject? {
         return rlmResults.valueForKey(key)
     }
 
     /**
-    Invokes `setValue:forKey:` on each of the collection's objects using the specified value and key.
+    Invokes `setValue(_:forKey:)` on each of the collection's objects using the specified value and key.
 
     - warning: This method can only be called during a write transaction.
 

--- a/RealmSwift-swift2.0/Schema.swift
+++ b/RealmSwift-swift2.0/Schema.swift
@@ -25,7 +25,7 @@ This class represents the collection of model object schemas persisted to Realm.
 When using Realm, `Schema` objects allow performing migrations and
 introspecting the database's schema.
 
-Schemas map to collections of tables in the core database.
+`Schema`s map to collections of tables in the core database.
 */
 public final class Schema: CustomStringConvertible {
 

--- a/RealmSwift-swift2.0/SortDescriptor.swift
+++ b/RealmSwift-swift2.0/SortDescriptor.swift
@@ -55,7 +55,7 @@ public struct SortDescriptor {
 
     // MARK: Functions
 
-    /// Returns a copy of the receiver with the sort order reversed.
+    /// Returns a copy of the `SortDescriptor` with the sort order reversed.
     public func reversed() -> SortDescriptor {
         return SortDescriptor(property: property, ascending: !ascending)
     }


### PR DESCRIPTION
Most of these are fairly minor formatting changes, fixes to param names & the like. I’ve also:

* Added warnings on the Realm methods that require write transactions - as these were on each of the mutating List methods.
* Fixed some Swift 2 style comments in Swift 1 & vice versa
* Removed the reference to the free objects() function as this seems to be gone?
* Added a 'background thread' warning on autoRefresh
* Where possible, changed references to 'links' to 'relationships' in line with the Java terminology
* Added the additional Int types. 

On that last one, I’ll need confirmation about the Int8 support, as it doesn’t seem to be complete - not sure if this is an error, or it’s not meant to be supported after all.