### PR TITLE
Port most of RLMResults's functionality to realm::Results

### DIFF
--- a/Realm.xcodeproj/project.pbxproj
+++ b/Realm.xcodeproj/project.pbxproj
@@ -41,6 +41,9 @@
 		29EDB8E41A7708E700458D80 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = E8839B2D19E31FD90047B1A8 /* main.m */; };
 		3F1F47821B9612B300CD99A3 /* KVOTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 3F0F029D1B6FFE610046A4D5 /* KVOTests.mm */; };
 		3F1F47831B9656B900CD99A3 /* KVOTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 3F0F029D1B6FFE610046A4D5 /* KVOTests.mm */; };
+		3F75566B1BE94CCC0058BC7E /* results.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3F7556691BE94CCC0058BC7E /* results.cpp */; };
+		3F75566C1BE94CCC0058BC7E /* results.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 3F75566A1BE94CCC0058BC7E /* results.hpp */; };
+		3F75566D1BE94CEA0058BC7E /* results.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3F7556691BE94CCC0058BC7E /* results.cpp */; };
 		3F8DCA7519930FCB0008BD7F /* SwiftTestObjects.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8F8D90B196CB8DD00475368 /* SwiftTestObjects.swift */; };
 		3F8DCA7619930FCB0008BD7F /* SwiftArrayPropertyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E82FA60A195632F20043A3C3 /* SwiftArrayPropertyTests.swift */; };
 		3F8DCA7719930FCB0008BD7F /* SwiftArrayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E82FA60B195632F20043A3C3 /* SwiftArrayTests.swift */; };
@@ -427,6 +430,8 @@
 		3F62BA9E1BA0AB9000A4CEB2 /* binding_context.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = binding_context.hpp; path = ObjectStore/binding_context.hpp; sourceTree = "<group>"; };
 		3F68BFCD1B558CA800D50FBD /* RLMPrefix.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RLMPrefix.h; sourceTree = "<group>"; };
 		3F6B89AE19EF40BA004E8EA8 /* librealm-ios.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = "librealm-ios.a"; path = "../core/librealm-ios.a"; sourceTree = "<group>"; };
+		3F7556691BE94CCC0058BC7E /* results.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = results.cpp; path = ObjectStore/results.cpp; sourceTree = "<group>"; };
+		3F75566A1BE94CCC0058BC7E /* results.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = results.hpp; path = ObjectStore/results.hpp; sourceTree = "<group>"; };
 		3FAE25511B8CEBBE00D01405 /* object_store.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = object_store.cpp; path = ObjectStore/object_store.cpp; sourceTree = "<group>"; };
 		3FAE25521B8CEBBE00D01405 /* object_store.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = object_store.hpp; path = ObjectStore/object_store.hpp; sourceTree = "<group>"; };
 		3FAE25531B8CEBBE00D01405 /* shared_realm.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = shared_realm.cpp; path = ObjectStore/shared_realm.cpp; sourceTree = "<group>"; };
@@ -626,6 +631,8 @@
 				3FAE25511B8CEBBE00D01405 /* object_store.cpp */,
 				3FAE25521B8CEBBE00D01405 /* object_store.hpp */,
 				3FAE25571B8CEBBE00D01405 /* property.hpp */,
+				3F7556691BE94CCC0058BC7E /* results.cpp */,
+				3F75566A1BE94CCC0058BC7E /* results.hpp */,
 				3FE556421B9A43E5002A1129 /* schema.cpp */,
 				3FE556431B9A43E5002A1129 /* schema.hpp */,
 				3FAE25531B8CEBBE00D01405 /* shared_realm.cpp */,
@@ -971,6 +978,7 @@
 				5D659EA31BE04556006515A0 /* object_store.hpp in Headers */,
 				5D659EA41BE04556006515A0 /* property.hpp in Headers */,
 				5D659EA51BE04556006515A0 /* Realm.h in Headers */,
+				3F75566C1BE94CCC0058BC7E /* results.hpp in Headers */,
 				5D659EA71BE04556006515A0 /* RLMAccessor.h in Headers */,
 				5D659EA81BE04556006515A0 /* RLMAnalytics.hpp in Headers */,
 				5D659EA91BE04556006515A0 /* RLMArray.h in Headers */,
@@ -1470,6 +1478,7 @@
 				5D659E821BE04556006515A0 /* index_set.cpp in Sources */,
 				5D659E831BE04556006515A0 /* object_schema.cpp in Sources */,
 				5D659E841BE04556006515A0 /* object_store.cpp in Sources */,
+				3F75566B1BE94CCC0058BC7E /* results.cpp in Sources */,
 				5D659E851BE04556006515A0 /* RLMAccessor.mm in Sources */,
 				5D659E861BE04556006515A0 /* RLMAnalytics.mm in Sources */,
 				5D659E871BE04556006515A0 /* RLMArray.mm in Sources */,
@@ -1555,6 +1564,7 @@
 				5DD755801BE056DE002800DA /* index_set.cpp in Sources */,
 				5DD755811BE056DE002800DA /* object_schema.cpp in Sources */,
 				5DD755821BE056DE002800DA /* object_store.cpp in Sources */,
+				3F75566D1BE94CEA0058BC7E /* results.cpp in Sources */,
 				5DD755831BE056DE002800DA /* RLMAccessor.mm in Sources */,
 				5DD755841BE056DE002800DA /* RLMAnalytics.mm in Sources */,
 				5DD755851BE056DE002800DA /* RLMArray.mm in Sources */,

--- a/Realm/ObjectStore/object_store.cpp
+++ b/Realm/ObjectStore/object_store.cpp
@@ -30,6 +30,7 @@
 
 using namespace realm;
 
+namespace {
 const char * const c_metadataTableName = "metadata";
 const char * const c_versionColumnName = "version";
 const size_t c_versionColumnIndex = 0;
@@ -42,8 +43,8 @@ const size_t c_primaryKeyPropertyNameColumnIndex =  1;
 
 const size_t c_zeroRowIndex = 0;
 
-const std::string c_object_table_prefix = "class_";
-const size_t c_object_table_prefix_length = c_object_table_prefix.length();
+const char c_object_table_prefix[] = "class_";
+}
 
 const uint64_t ObjectStore::NotVersioned = std::numeric_limits<uint64_t>::max();
 
@@ -119,15 +120,15 @@ void ObjectStore::set_primary_key_for_object(Group *group, StringData object_typ
     }
 }
 
-std::string ObjectStore::object_type_for_table_name(const std::string &table_name) {
-    if (table_name.size() >= c_object_table_prefix_length && table_name.compare(0, c_object_table_prefix_length, c_object_table_prefix) == 0) {
-        return table_name.substr(c_object_table_prefix_length, table_name.length() - c_object_table_prefix_length);
+StringData ObjectStore::object_type_for_table_name(StringData table_name) {
+    if (table_name.begins_with(c_object_table_prefix)) {
+        return table_name.substr(sizeof(c_object_table_prefix) - 1);
     }
-    return std::string();
+    return StringData();
 }
 
-std::string ObjectStore::table_name_for_object_type(const std::string &object_type) {
-    return c_object_table_prefix + object_type;
+std::string ObjectStore::table_name_for_object_type(StringData object_type) {
+    return std::string(c_object_table_prefix) + object_type.data();
 }
 
 TableRef ObjectStore::table_for_object_type(Group *group, StringData object_type) {
@@ -138,7 +139,7 @@ ConstTableRef ObjectStore::table_for_object_type(const Group *group, StringData 
     return group->get_table(table_name_for_object_type(object_type));
 }
 
-TableRef ObjectStore::table_for_object_type_create_if_needed(Group *group, const StringData &object_type, bool &created) {
+TableRef ObjectStore::table_for_object_type_create_if_needed(Group *group, StringData object_type, bool &created) {
     return group->get_or_add_table(table_name_for_object_type(object_type), &created);
 }
 
@@ -491,7 +492,7 @@ void ObjectStore::validate_primary_column_uniqueness(const Group *group, Schema 
     }
 }
 
-void ObjectStore::delete_data_for_object(Group *group, const StringData &object_type) {
+void ObjectStore::delete_data_for_object(Group *group, StringData object_type) {
     TableRef table = table_for_object_type(group, object_type);
     if (table) {
         group->remove_table(table->get_index_in_group());

--- a/Realm/ObjectStore/object_store.cpp
+++ b/Realm/ObjectStore/object_store.cpp
@@ -524,7 +524,7 @@ DuplicatePrimaryKeyValueException::DuplicatePrimaryKeyValueException(std::string
     m_object_type(object_type), m_property(property)
 {
     m_what = "Primary key property '" + property.name + "' has duplicate values after migration.";
-};
+}
 
 
 SchemaValidationException::SchemaValidationException(std::vector<ObjectSchemaValidationException> const& errors) :

--- a/Realm/ObjectStore/object_store.hpp
+++ b/Realm/ObjectStore/object_store.hpp
@@ -68,10 +68,13 @@ namespace realm {
         static Schema schema_from_group(const Group *group);
 
         // deletes the table for the given type
-        static void delete_data_for_object(Group *group, const StringData &object_type);
+        static void delete_data_for_object(Group *group, StringData object_type);
 
         // indicates if this group contains any objects
         static bool is_empty(const Group *group);
+
+        static std::string table_name_for_object_type(StringData class_name);
+        static StringData object_type_for_table_name(StringData table_name);
 
     private:
         // set a new schema version
@@ -102,9 +105,7 @@ namespace realm {
         // must be in write transaction to set
         static void set_primary_key_for_object(Group *group, StringData object_type, StringData primary_key);
 
-        static TableRef table_for_object_type_create_if_needed(Group *group, const StringData &object_type, bool &created);
-        static std::string table_name_for_object_type(const std::string &class_name);
-        static std::string object_type_for_table_name(const std::string &table_name);
+        static TableRef table_for_object_type_create_if_needed(Group *group, StringData object_type, bool &created);
 
         // returns if any indexes were changed
         static bool update_indexes(Group *group, Schema &schema);

--- a/Realm/ObjectStore/results.cpp
+++ b/Realm/ObjectStore/results.cpp
@@ -17,42 +17,288 @@
 ////////////////////////////////////////////////////////////////////////////
 
 #include "results.hpp"
-#import <stdexcept>
+
+#include <stdexcept>
 
 using namespace realm;
 
-Results::Results(SharedRealm &r, ObjectSchema &o, Query q, SortOrder s) :
-    realm(r), object_schema(o), backing_query(q), table_view(backing_query.find_all())
+Results::Results(SharedRealm r, Query q, SortOrder s)
+: m_realm(std::move(r))
+, m_query(std::move(q))
+, m_table(m_query.get_table().get())
+, m_sort(std::move(s))
+, m_mode(Mode::Query)
 {
-    setSort(std::move(s));
+}
+
+Results::Results(SharedRealm r, Table& table)
+: m_realm(std::move(r))
+, m_table(&table)
+, m_mode(Mode::Table)
+{
+}
+
+void Results::validate_read() const
+{
+    if (m_realm && !m_realm->check_thread())
+        throw Error::IncorrectThread;
+    if (m_table && !m_table->is_attached())
+        throw Error::Invalidated;
+}
+
+void Results::validate_write() const
+{
+    validate_read();
+    if (!m_realm || !m_realm->is_in_transaction())
+        throw Error::NotInWrite;
 }
 
 size_t Results::size()
 {
-    verify_attached();
-    return table_view.size();
-}
-
-void Results::setSort(SortOrder s)
-{
-    sort_order = std::make_unique<SortOrder>(std::move(s));
-    table_view.sort(sort_order->columnIndices, sort_order->ascending);
-}
-
-Row Results::get(std::size_t row_ndx)
-{
-    verify_attached();
-    if (row_ndx >= table_view.size()) {
-        throw std::out_of_range(std::string("Index ") + std::to_string(row_ndx) + " is outside of range 0..." +
-                               std::to_string(table_view.size()) + ".");
+    validate_read();
+    switch (m_mode) {
+        case Mode::Empty: return 0;
+        case Mode::Table: return m_table->size();
+        case Mode::Query: return m_query.count();
+        case Mode::TableView:
+            update_tableview();
+            return m_table_view.size();
     }
-    return table_view.get(row_ndx);
 }
 
-void Results::verify_attached()
+RowExpr Results::get(size_t row_ndx)
 {
-    if (!table_view.is_attached()) {
-        throw std::runtime_error("Tableview is not attached");
+    validate_read();
+    switch (m_mode) {
+        case Mode::Empty: break;
+        case Mode::Table:
+            if (row_ndx < m_table->size())
+                return m_table->get(row_ndx);
+            break;
+        case Mode::Query:
+        case Mode::TableView:
+            update_tableview();
+            if (row_ndx < m_table_view.size())
+                return m_table_view.get(row_ndx);
+            break;
     }
-    table_view.sync_if_needed();
+
+    throw Error::OutOfBoundsIndex;
+}
+
+util::Optional<RowExpr> Results::first()
+{
+    validate_read();
+    switch (m_mode) {
+        case Mode::Empty:
+            return none;
+        case Mode::Table:
+            return m_table->size() == 0 ? util::none : util::Optional<RowExpr>(m_table->front());
+        case Mode::Query:
+            update_tableview();
+            [[clang::fallthrough]];
+        case Mode::TableView:
+            return m_table_view.size() == 0 ? util::none : util::Optional<RowExpr>(m_table_view.front());
+    }
+}
+
+util::Optional<RowExpr> Results::last()
+{
+    validate_read();
+    switch (m_mode) {
+        case Mode::Empty:
+            return none;
+        case Mode::Table:
+            return m_table->size() == 0 ? util::none : util::Optional<RowExpr>(m_table->back());
+        case Mode::Query:
+            update_tableview();
+            [[clang::fallthrough]];
+        case Mode::TableView:
+            return m_table_view.size() == 0 ? util::none : util::Optional<RowExpr>(m_table_view.back());
+    }
+}
+
+void Results::update_tableview()
+{
+    validate_read();
+    switch (m_mode) {
+        case Mode::Empty:
+        case Mode::Table:
+            return;
+        case Mode::Query:
+            m_table_view = m_query.find_all();
+            if (m_sort) {
+                m_table_view.sort(m_sort.columnIndices, m_sort.ascending);
+            }
+            m_mode = Mode::TableView;
+            break;
+        case Mode::TableView:
+            m_table_view.sync_if_needed();
+            break;
+    }
+}
+
+size_t Results::index_of(Row const& row)
+{
+    validate_read();
+    if (!row) {
+        throw Error::DetachedAccessor;
+    }
+    if (m_table && row.get_table() != m_table) {
+        throw Error::IncorrectTable;
+    }
+    return index_of(row.get_index());
+}
+
+size_t Results::index_of(size_t row_ndx)
+{
+    validate_read();
+    switch (m_mode) {
+        case Mode::Empty:
+            return not_found;
+        case Mode::Table:
+            return row_ndx;
+        case Mode::Query:
+            if (!m_sort)
+                return m_query.count(row_ndx, row_ndx + 1) ? m_query.count(0, row_ndx) : not_found;
+            [[clang::fallthrough]];
+        case Mode::TableView:
+            update_tableview();
+            return m_table_view.find_by_source_ndx(row_ndx);
+    }
+
+}
+
+template<typename Int, typename Float, typename Double, typename DateTime>
+util::Optional<Mixed> Results::aggregate(size_t column, bool return_none_for_empty,
+                                         Int agg_int, Float agg_float,
+                                         Double agg_double, DateTime agg_datetime)
+{
+    validate_read();
+    if (!m_table)
+        return none;
+    if (column > m_table->get_column_count())
+        throw Error::OutOfBoundsIndex;
+
+    auto do_agg = [&](auto const& getter) -> util::Optional<Mixed> {
+        switch (m_mode) {
+            case Mode::Empty:
+                return none;
+            case Mode::Table:
+                if (return_none_for_empty && m_table->size() == 0)
+                    return none;
+                return util::Optional<Mixed>(getter(*m_table));
+            case Mode::Query:
+            case Mode::TableView:
+                update_tableview();
+                if (return_none_for_empty && m_table_view.size() == 0)
+                    return none;
+                return util::Optional<Mixed>(getter(m_table_view));
+        }
+    };
+
+    switch (m_table->get_column_type(column))
+    {
+        case type_DateTime: return do_agg(agg_datetime);
+        case type_Double: return do_agg(agg_double);
+        case type_Float: return do_agg(agg_float);
+        case type_Int: return do_agg(agg_int);
+        default:
+            throw Error::UnsupportedColumnType;
+    }
+}
+
+util::Optional<Mixed> Results::max(size_t column)
+{
+    return aggregate(column, true,
+                     [=](auto const& table) { return table.maximum_int(column); },
+                     [=](auto const& table) { return table.maximum_float(column); },
+                     [=](auto const& table) { return table.maximum_double(column); },
+                     [=](auto const& table) { return table.maximum_datetime(column); });
+}
+
+util::Optional<Mixed> Results::min(size_t column)
+{
+    return aggregate(column, true,
+                     [=](auto const& table) { return table.minimum_int(column); },
+                     [=](auto const& table) { return table.minimum_float(column); },
+                     [=](auto const& table) { return table.minimum_double(column); },
+                     [=](auto const& table) { return table.minimum_datetime(column); });
+}
+
+util::Optional<Mixed> Results::sum(size_t column)
+{
+    return aggregate(column, false,
+                     [=](auto const& table) { return table.sum_int(column); },
+                     [=](auto const& table) { return table.sum_float(column); },
+                     [=](auto const& table) { return table.sum_double(column); },
+                     [=](auto const&) -> util::None { throw Error::UnsupportedColumnType; });
+}
+
+util::Optional<Mixed> Results::average(size_t column)
+{
+    return aggregate(column, true,
+                     [=](auto const& table) { return table.average_int(column); },
+                     [=](auto const& table) { return table.average_float(column); },
+                     [=](auto const& table) { return table.average_double(column); },
+                     [=](auto const&) -> util::None { throw Error::UnsupportedColumnType; });
+}
+
+void Results::clear()
+{
+    switch (m_mode) {
+        case Mode::Empty:
+            return;
+        case Mode::Table:
+            validate_write();
+            m_table->clear();
+            break;
+        case Mode::Query:
+            // Not using Query:remove() because bulding the tableview and
+            // clearing it is actually significantly faster
+        case Mode::TableView:
+            validate_write();
+            update_tableview();
+            m_table_view.clear();
+            break;
+    }
+}
+
+Query Results::get_query() const
+{
+    validate_read();
+    switch (m_mode) {
+        case Mode::Empty:
+        case Mode::Query:
+        case Mode::TableView:
+            return m_query;
+        case Mode::Table:
+            return m_table->where();
+    }
+}
+
+TableView Results::get_tableview()
+{
+    validate_read();
+    switch (m_mode) {
+        case Mode::Empty:
+            return {};
+        case Mode::Query:
+        case Mode::TableView:
+            update_tableview();
+            return m_table_view;
+        case Mode::Table:
+            return m_table->where().find_all();
+    }
+    REALM_UNREACHABLE();
+}
+
+Results Results::sort(realm::SortOrder&& sort) const
+{
+    return Results(m_realm, get_query(), std::move(sort));
+}
+
+Results Results::filter(Query&& q) const
+{
+    return Results(m_realm, get_query().and_query(q), get_sort());
 }

--- a/Realm/ObjectStore/results.cpp
+++ b/Realm/ObjectStore/results.cpp
@@ -160,7 +160,9 @@ size_t Results::index_of(Row const& row)
         throw DetatchedAccessorException{};
     }
     if (m_table && row.get_table() != m_table) {
-        throw IncorrectTableException{m_table, row.get_table()};
+        throw IncorrectTableException{
+            ObjectStore::object_type_for_table_name(m_table->get_name()),
+            ObjectStore::object_type_for_table_name(row.get_table()->get_name())};
     }
     return index_of(row.get_index());
 }
@@ -308,6 +310,11 @@ TableView Results::get_tableview()
             return m_table->where().find_all();
     }
     REALM_UNREACHABLE();
+}
+
+StringData Results::get_object_type() const noexcept
+{
+    return ObjectStore::object_type_for_table_name(m_table->get_name());
 }
 
 Results Results::sort(realm::SortOrder&& sort) const

--- a/Realm/ObjectStore/results.cpp
+++ b/Realm/ObjectStore/results.cpp
@@ -106,12 +106,12 @@ util::Optional<RowExpr> Results::first()
         case Mode::Empty:
             return none;
         case Mode::Table:
-            return m_table->size() == 0 ? util::none : util::Optional<RowExpr>(m_table->front());
+            return m_table->size() == 0 ? util::none : util::make_optional(m_table->front());
         case Mode::Query:
             update_tableview();
             REALM_FALLTHROUGH;
         case Mode::TableView:
-            return m_table_view.size() == 0 ? util::none : util::Optional<RowExpr>(m_table_view.front());
+            return m_table_view.size() == 0 ? util::none : util::make_optional(m_table_view.front());
     }
     REALM_UNREACHABLE();
 }
@@ -123,12 +123,12 @@ util::Optional<RowExpr> Results::last()
         case Mode::Empty:
             return none;
         case Mode::Table:
-            return m_table->size() == 0 ? util::none : util::Optional<RowExpr>(m_table->back());
+            return m_table->size() == 0 ? util::none : util::make_optional(m_table->back());
         case Mode::Query:
             update_tableview();
             REALM_FALLTHROUGH;
         case Mode::TableView:
-            return m_table_view.size() == 0 ? util::none : util::Optional<RowExpr>(m_table_view.back());
+            return m_table_view.size() == 0 ? util::none : util::make_optional(m_table_view.back());
     }
     REALM_UNREACHABLE();
 }

--- a/Realm/ObjectStore/results.cpp
+++ b/Realm/ObjectStore/results.cpp
@@ -272,7 +272,7 @@ void Results::clear()
             m_table->clear();
             break;
         case Mode::Query:
-            // Not using Query:remove() because bulding the tableview and
+            // Not using Query:remove() because building the tableview and
             // clearing it is actually significantly faster
         case Mode::TableView:
             validate_write();

--- a/Realm/ObjectStore/results.cpp
+++ b/Realm/ObjectStore/results.cpp
@@ -324,7 +324,7 @@ Results Results::sort(realm::SortOrder&& sort) const
 
 Results Results::filter(Query&& q) const
 {
-    return Results(m_realm, get_query().and_query(q), get_sort());
+    return Results(m_realm, get_query().and_query(std::move(q)), get_sort());
 }
 
 Results::UnsupportedColumnTypeException::UnsupportedColumnTypeException(size_t column, const Table* table) {

--- a/Realm/ObjectStore/results.cpp
+++ b/Realm/ObjectStore/results.cpp
@@ -1,0 +1,58 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2015 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+#include "results.hpp"
+#import <stdexcept>
+
+using namespace realm;
+
+Results::Results(SharedRealm &r, ObjectSchema &o, Query q, SortOrder s) :
+    realm(r), object_schema(o), backing_query(q), table_view(backing_query.find_all())
+{
+    setSort(std::move(s));
+}
+
+size_t Results::size()
+{
+    verify_attached();
+    return table_view.size();
+}
+
+void Results::setSort(SortOrder s)
+{
+    sort_order = std::make_unique<SortOrder>(std::move(s));
+    table_view.sort(sort_order->columnIndices, sort_order->ascending);
+}
+
+Row Results::get(std::size_t row_ndx)
+{
+    verify_attached();
+    if (row_ndx >= table_view.size()) {
+        throw std::out_of_range(std::string("Index ") + std::to_string(row_ndx) + " is outside of range 0..." +
+                               std::to_string(table_view.size()) + ".");
+    }
+    return table_view.get(row_ndx);
+}
+
+void Results::verify_attached()
+{
+    if (!table_view.is_attached()) {
+        throw std::runtime_error("Tableview is not attached");
+    }
+    table_view.sync_if_needed();
+}

--- a/Realm/ObjectStore/results.hpp
+++ b/Realm/ObjectStore/results.hpp
@@ -65,6 +65,9 @@ public:
     // Get a tableview containing the same rows as this Results
     TableView get_tableview();
 
+    // Get the object type which will be returned by get()
+    StringData get_object_type() const noexcept;
+
     // Get the size of this results
     // Can be either O(1) or O(N) depending on the state of things
     size_t size();
@@ -128,8 +131,8 @@ public:
 
     // The input Row object belongs to a different table
     struct IncorrectTableException {
-        const Table* expected;
-        const Table* actual;
+        StringData expected;
+        StringData actual;
     };
 
     // The requested aggregate operation is not supported for the column type

--- a/Realm/ObjectStore/results.hpp
+++ b/Realm/ObjectStore/results.hpp
@@ -19,35 +19,140 @@
 #ifndef REALM_RESULTS_HPP
 #define REALM_RESULTS_HPP
 
-#import "shared_realm.hpp"
-#import <realm/table_view.hpp>
+#include "shared_realm.hpp"
+
+#include <realm/table_view.hpp>
+#include <realm/table.hpp>
+#include <realm/util/optional.hpp>
 
 namespace realm {
-    struct SortOrder {
-        std::vector<size_t> columnIndices;
-        std::vector<bool> ascending;
+template<typename T> class BasicRowExpr;
+using RowExpr = BasicRowExpr<Table>;
+class Mixed;
 
-        explicit operator bool() const {
-            return !columnIndices.empty();
-        }
+struct SortOrder {
+    std::vector<size_t> columnIndices;
+    std::vector<bool> ascending;
+
+    explicit operator bool() const
+    {
+        return !columnIndices.empty();
+    }
+};
+
+class Results {
+public:
+    // Results can be either be backed by nothing, a thin wrapper around a table,
+    // or a wrapper around a query and a sort order which creates and updates
+    // the tableview as needed
+    Results() = default;
+    Results(SharedRealm r, Table& table);
+    Results(SharedRealm r, Query q, SortOrder s = {});
+
+    // Results is copyable and moveable
+    Results(Results const&) = default;
+    Results(Results&&) = default;
+    Results& operator=(Results const&) = default;
+    Results& operator=(Results&&) = default;
+
+    // Get a query which will match the same rows as is contained in this Results
+    // Returned query will not be valid if the current mode is Empty
+    Query get_query() const;
+
+    // Get the currently applied sort order for this Results
+    SortOrder const& get_sort() const noexcept { return m_sort; }
+
+    // Get a tableview containing the same rows as this Results
+    TableView get_tableview();
+
+    // Get the size of this results
+    // Can be either O(1) or O(N) depending on the state of things
+    size_t size();
+
+    // Get the row accessor for the given index
+    // Throws OutOfBoundsIndex if index >= size()
+    RowExpr get(size_t index);
+
+    // Get a row accessor for the first/last row, or none if the results are empty
+    // More efficient than calling size()+get()
+    util::Optional<RowExpr> first();
+    util::Optional<RowExpr> last();
+
+    // Get the first index of the given row in this results, or not_found
+    // Throws DetachedAccessor if row is not attached
+    // Throws IncorrectTable if row belongs to a different table
+    size_t index_of(size_t row_ndx);
+    size_t index_of(Row const& row);
+
+    // Delete all of the rows in this Results from the Realm
+    // size() will always be zero afterwards
+    // Throws NotInWrite
+    void clear();
+
+    // Create a new Results by further filtering or sorting this Results
+    Results filter(Query&& q) const;
+    Results sort(SortOrder&& sort) const;
+
+    // Get the min/max/average/sum of the given column
+    // All but sum() returns none when there are zero matching rows
+    // sum() returns 0, except for when it returns none
+    // Throws UnsupportedColumnType for sum/average on datetime or non-numeric column
+    // Throws OutOfBoundsIndex for an out-of-bounds column
+    util::Optional<Mixed> max(size_t column);
+    util::Optional<Mixed> min(size_t column);
+    util::Optional<Mixed> average(size_t column);
+    util::Optional<Mixed> sum(size_t column);
+
+    enum class Mode {
+        Empty, // Backed by nothing (for missing tables)
+        Table, // Backed directly by a Table
+        Query, // Backed by a query that has not yet been turned into a TableView
+        TableView // Backed by a TableView created from a Query
+    };
+    // Get the currrent mode of the Results
+    // Ideally this would not be public but it's needed for some KVO stuff
+    Mode get_mode() const { return m_mode; }
+
+    // All errors thrown by Results are one of the following error codes
+    // Invalidated and IncorrectThread can be thrown by all non-noexcept functions
+    // Other errors are thrown only where indicated
+    enum class Error {
+        // The Results object has been invalidated (due to the Realm being invalidated)
+        Invalidated,
+        // The Results object is being accessed from the wrong thread
+        IncorrectThread,
+        // The containing Realm is not in a write transaction
+        NotInWrite,
+
+        // The input index parameter was out of bounds
+        OutOfBoundsIndex,
+        // The input Row object belongs to a different table
+        IncorrectTable,
+        // The input Row object is not attached
+        DetachedAccessor,
+        // The requested aggregate operation is not supported for the column type
+        UnsupportedColumnType
     };
 
-    static SortOrder s_defaultSort = {{}, {}};
+private:
+    SharedRealm m_realm;
+    Query m_query;
+    TableView m_table_view;
+    Table* m_table = nullptr;
+    SortOrder m_sort;
 
-    struct Results {
-        Results(SharedRealm &r, ObjectSchema &o, Query q, SortOrder s = s_defaultSort);
-        size_t size();
-        Row get(std::size_t row_ndx);
-        void verify_attached();
+    Mode m_mode = Mode::Empty;
 
-        SharedRealm realm;
-        ObjectSchema &object_schema;
-        Query backing_query;
-        TableView table_view;
-        std::unique_ptr<SortOrder> sort_order;
+    void validate_read() const;
+    void validate_write() const;
 
-        void setSort(SortOrder s);
-    };
+    void update_tableview();
+
+    template<typename Int, typename Float, typename Double, typename DateTime>
+    util::Optional<Mixed> aggregate(size_t column, bool return_none_for_empty,
+                                    Int agg_int, Float agg_float,
+                                    Double agg_double, DateTime agg_datetime);
+};
 }
 
 #endif /* REALM_RESULTS_HPP */

--- a/Realm/ObjectStore/results.hpp
+++ b/Realm/ObjectStore/results.hpp
@@ -70,7 +70,7 @@ public:
     size_t size();
 
     // Get the row accessor for the given index
-    // Throws OutOfBoundsIndex if index >= size()
+    // Throws OutOfBoundsIndexException if index >= size()
     RowExpr get(size_t index);
 
     // Get a row accessor for the first/last row, or none if the results are empty
@@ -79,14 +79,14 @@ public:
     util::Optional<RowExpr> last();
 
     // Get the first index of the given row in this results, or not_found
-    // Throws DetachedAccessor if row is not attached
-    // Throws IncorrectTable if row belongs to a different table
+    // Throws DetachedAccessorException if row is not attached
+    // Throws IncorrectTableException if row belongs to a different table
     size_t index_of(size_t row_ndx);
     size_t index_of(Row const& row);
 
     // Delete all of the rows in this Results from the Realm
     // size() will always be zero afterwards
-    // Throws NotInWrite
+    // Throws InvalidTransactionException if not in a write transaction
     void clear();
 
     // Create a new Results by further filtering or sorting this Results
@@ -96,8 +96,8 @@ public:
     // Get the min/max/average/sum of the given column
     // All but sum() returns none when there are zero matching rows
     // sum() returns 0, except for when it returns none
-    // Throws UnsupportedColumnType for sum/average on datetime or non-numeric column
-    // Throws OutOfBoundsIndex for an out-of-bounds column
+    // Throws UnsupportedColumnTypeException for sum/average on datetime or non-numeric column
+    // Throws OutOfBoundsIndexException for an out-of-bounds column
     util::Optional<Mixed> max(size_t column);
     util::Optional<Mixed> min(size_t column);
     util::Optional<Mixed> average(size_t column);
@@ -113,25 +113,32 @@ public:
     // Ideally this would not be public but it's needed for some KVO stuff
     Mode get_mode() const { return m_mode; }
 
-    // All errors thrown by Results are one of the following error codes
-    // Invalidated and IncorrectThread can be thrown by all non-noexcept functions
-    // Other errors are thrown only where indicated
-    enum class Error {
-        // The Results object has been invalidated (due to the Realm being invalidated)
-        Invalidated,
-        // The Results object is being accessed from the wrong thread
-        IncorrectThread,
-        // The containing Realm is not in a write transaction
-        NotInWrite,
+    // The Results object has been invalidated (due to the Realm being invalidated)
+    // All non-noexcept functions can throw this
+    struct InvalidatedException {};
 
-        // The input index parameter was out of bounds
-        OutOfBoundsIndex,
-        // The input Row object belongs to a different table
-        IncorrectTable,
-        // The input Row object is not attached
-        DetachedAccessor,
-        // The requested aggregate operation is not supported for the column type
-        UnsupportedColumnType
+    // The input index parameter was out of bounds
+    struct OutOfBoundsIndexException {
+        size_t requested;
+        size_t valid_count;
+    };
+
+    // The input Row object is not attached
+    struct DetatchedAccessorException { };
+
+    // The input Row object belongs to a different table
+    struct IncorrectTableException {
+        const Table* expected;
+        const Table* actual;
+    };
+
+    // The requested aggregate operation is not supported for the column type
+    struct UnsupportedColumnTypeException {
+        size_t column_index;
+        StringData column_name;
+        DataType column_type;
+
+        UnsupportedColumnTypeException(size_t column, const Table* table);
     };
 
 private:

--- a/Realm/ObjectStore/results.hpp
+++ b/Realm/ObjectStore/results.hpp
@@ -1,0 +1,53 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2015 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+#ifndef REALM_RESULTS_HPP
+#define REALM_RESULTS_HPP
+
+#import "shared_realm.hpp"
+#import <realm/table_view.hpp>
+
+namespace realm {
+    struct SortOrder {
+        std::vector<size_t> columnIndices;
+        std::vector<bool> ascending;
+
+        explicit operator bool() const {
+            return !columnIndices.empty();
+        }
+    };
+
+    static SortOrder s_defaultSort = {{}, {}};
+
+    struct Results {
+        Results(SharedRealm &r, ObjectSchema &o, Query q, SortOrder s = s_defaultSort);
+        size_t size();
+        Row get(std::size_t row_ndx);
+        void verify_attached();
+
+        SharedRealm realm;
+        ObjectSchema &object_schema;
+        Query backing_query;
+        TableView table_view;
+        std::unique_ptr<SortOrder> sort_order;
+
+        void setSort(SortOrder s);
+    };
+}
+
+#endif /* REALM_RESULTS_HPP */

--- a/Realm/ObjectStore/shared_realm.cpp
+++ b/Realm/ObjectStore/shared_realm.cpp
@@ -47,6 +47,8 @@ Realm::Config::Config(const Config& c)
     }
 }
 
+Realm::Config::Config() = default;
+Realm::Config::Config(Config&&) = default;
 Realm::Config::~Config() = default;
 
 Realm::Config& Realm::Config::operator=(realm::Realm::Config const& c)

--- a/Realm/ObjectStore/shared_realm.cpp
+++ b/Realm/ObjectStore/shared_realm.cpp
@@ -230,9 +230,14 @@ static void check_read_write(Realm *realm)
     }
 }
 
+bool Realm::check_thread() const noexcept
+{
+    return m_thread_id == std::this_thread::get_id();
+}
+
 void Realm::verify_thread() const
 {
-    if (m_thread_id != std::this_thread::get_id()) {
+    if (!check_thread()) {
         throw IncorrectThreadException("Realm accessed from incorrect thread.");
     }
 }

--- a/Realm/ObjectStore/shared_realm.cpp
+++ b/Realm/ObjectStore/shared_realm.cpp
@@ -230,15 +230,17 @@ static void check_read_write(Realm *realm)
     }
 }
 
-bool Realm::check_thread() const noexcept
-{
-    return m_thread_id == std::this_thread::get_id();
-}
-
 void Realm::verify_thread() const
 {
-    if (!check_thread()) {
-        throw IncorrectThreadException("Realm accessed from incorrect thread.");
+    if (m_thread_id != std::this_thread::get_id()) {
+        throw IncorrectThreadException();
+    }
+}
+
+void Realm::verify_in_write() const
+{
+    if (!is_in_transaction()) {
+        throw InvalidTransactionException("Cannot modify persisted objects outside of a write transaction.");
     }
 }
 

--- a/Realm/ObjectStore/shared_realm.hpp
+++ b/Realm/ObjectStore/shared_realm.hpp
@@ -56,8 +56,8 @@ namespace realm {
 
             MigrationFunction migration_function;
 
-            Config() = default;
-            Config(Config&&) = default;
+            Config();
+            Config(Config&&);
             Config(const Config& c);
             ~Config();
 

--- a/Realm/ObjectStore/shared_realm.hpp
+++ b/Realm/ObjectStore/shared_realm.hpp
@@ -98,8 +98,8 @@ namespace realm {
         bool compact();
 
         std::thread::id thread_id() const { return m_thread_id; }
-        bool check_thread() const noexcept;
         void verify_thread() const;
+        void verify_in_write() const;
 
         ~Realm();
 
@@ -141,11 +141,9 @@ namespace realm {
         std::mutex m_mutex;
     };
 
-    class RealmFileException : public std::runtime_error
-    {
-      public:
-        enum class Kind
-        {
+    class RealmFileException : public std::runtime_error {
+    public:
+        enum class Kind {
             /** Thrown for any I/O related exception scenarios when a realm is opened. */
             AccessError,
             /** Thrown if the user does not have permission to open or create
@@ -163,31 +161,27 @@ namespace realm {
         RealmFileException(Kind kind, std::string message) : std::runtime_error(message), m_kind(kind) {}
         Kind kind() const { return m_kind; }
         
-      private:
+    private:
         Kind m_kind;
     };
 
-    class MismatchedConfigException : public std::runtime_error
-    {
-      public:
+    class MismatchedConfigException : public std::runtime_error {
+    public:
         MismatchedConfigException(std::string message) : std::runtime_error(message) {}
     };
 
-    class InvalidTransactionException : public std::runtime_error
-    {
-      public:
+    class InvalidTransactionException : public std::runtime_error {
+    public:
         InvalidTransactionException(std::string message) : std::runtime_error(message) {}
     };
 
-    class IncorrectThreadException : public std::runtime_error
-    {
-      public:
-        IncorrectThreadException(std::string message) : std::runtime_error(message) {}
+    class IncorrectThreadException : public std::runtime_error {
+    public:
+        IncorrectThreadException() : std::runtime_error("Realm accessed from incorrect thread.") {}
     };
 
-    class UnitializedRealmException : public std::runtime_error
-    {
-      public:
+    class UnitializedRealmException : public std::runtime_error {
+    public:
         UnitializedRealmException(std::string message) : std::runtime_error(message) {}
     };
 }

--- a/Realm/ObjectStore/shared_realm.hpp
+++ b/Realm/ObjectStore/shared_realm.hpp
@@ -19,7 +19,6 @@
 #ifndef REALM_REALM_HPP
 #define REALM_REALM_HPP
 
-#include <map>
 #include <memory>
 #include <thread>
 #include <vector>
@@ -99,6 +98,7 @@ namespace realm {
         bool compact();
 
         std::thread::id thread_id() const { return m_thread_id; }
+        bool check_thread() const noexcept;
         void verify_thread() const;
 
         ~Realm();

--- a/Realm/ObjectStore/shared_realm.hpp
+++ b/Realm/ObjectStore/shared_realm.hpp
@@ -101,6 +101,10 @@ namespace realm {
         void verify_thread() const;
         void verify_in_write() const;
 
+        // Close this Realm and remove it from the cache. Continuing to use a
+        // Realm after closing it will produce undefined behavior.
+        void close();
+
         ~Realm();
 
       private:

--- a/Realm/RLMAccessor.mm
+++ b/Realm/RLMAccessor.mm
@@ -380,35 +380,7 @@ static inline void RLMSetValue(__unsafe_unretained RLMObjectBase *const obj, NSU
 // any getter/setter
 static inline id RLMGetAnyProperty(__unsafe_unretained RLMObjectBase *const obj, NSUInteger col_ndx) {
     RLMVerifyAttached(obj);
-
-    realm::Mixed mixed = obj->_row.get_mixed(col_ndx);
-    switch (mixed.get_type()) {
-        case RLMPropertyTypeString:
-            return RLMStringDataToNSString(mixed.get_string());
-        case RLMPropertyTypeInt: {
-            return @(mixed.get_int());
-        case RLMPropertyTypeFloat:
-            return @(mixed.get_float());
-        case RLMPropertyTypeDouble:
-            return @(mixed.get_double());
-        case RLMPropertyTypeBool:
-            return @(mixed.get_bool());
-        case RLMPropertyTypeDate:
-            return RLMDateTimeToNSDate(mixed.get_datetime());
-        case RLMPropertyTypeData: {
-            realm::BinaryData bd = mixed.get_binary();
-            return RLMBinaryDataToNSData(bd);
-        }
-        case RLMPropertyTypeArray:
-            @throw [NSException exceptionWithName:@"RLMNotImplementedException"
-                                           reason:@"RLMArray not yet supported" userInfo:nil];
-
-            // for links and other unsupported types throw
-        case RLMPropertyTypeObject:
-        default:
-            @throw RLMException(@"Invalid data type for RLMPropertyTypeAny property.");
-        }
-    }
+    return RLMMixedToObjc(obj->_row.get_mixed(col_ndx));
 }
 static inline void RLMSetValue(__unsafe_unretained RLMObjectBase *const obj, NSUInteger col_ndx, __unsafe_unretained id val) {
     RLMVerifyInWriteTransaction(obj);

--- a/Realm/RLMArrayLinkView.mm
+++ b/Realm/RLMArrayLinkView.mm
@@ -396,9 +396,8 @@ static void RLMInsertObject(RLMArrayLinkView *ar, RLMObject *object, NSUInteger 
     auto results = realm::Results(_realm->_realm,
                                   _backingLinkView->get_target_table().where(_backingLinkView),
                                   RLMSortOrderFromDescriptors(_realm.schema[_objectClassName], properties));
-    return [RLMResults resultsWithObjectClassName:self.objectClassName
-                                            realm:_realm
-                                          results:std::move(results)];
+    return [RLMResults resultsWithObjectSchema:_realm.schema[self.objectClassName]
+                                       results:std::move(results)];
 }
 
 - (RLMResults *)objectsWithPredicate:(NSPredicate *)predicate {
@@ -406,9 +405,8 @@ static void RLMInsertObject(RLMArrayLinkView *ar, RLMObject *object, NSUInteger 
 
     realm::Query query = _backingLinkView->get_target_table().where(_backingLinkView);
     RLMUpdateQueryWithPredicate(&query, predicate, _realm.schema, _realm.schema[self.objectClassName]);
-    return [RLMResults resultsWithObjectClassName:self.objectClassName
-                                            realm:_realm
-                                          results:realm::Results(_realm->_realm, std::move(query))];
+    return [RLMResults resultsWithObjectSchema:_realm.schema[self.objectClassName]
+                                       results:realm::Results(_realm->_realm, std::move(query))];
 }
 
 - (NSUInteger)indexOfObjectWithPredicate:(NSPredicate *)predicate {

--- a/Realm/RLMArrayLinkView.mm
+++ b/Realm/RLMArrayLinkView.mm
@@ -28,6 +28,8 @@
 #import "RLMSchema.h"
 #import "RLMUtil.hpp"
 
+#import "results.hpp"
+
 #import <realm/table_view.hpp>
 #import <objc/runtime.h>
 
@@ -391,12 +393,12 @@ static void RLMInsertObject(RLMArrayLinkView *ar, RLMObject *object, NSUInteger 
 - (RLMResults *)sortedResultsUsingDescriptors:(NSArray *)properties {
     RLMLinkViewArrayValidateAttached(self);
 
-    auto query = std::make_unique<realm::Query>(_backingLinkView->get_target_table().where(_backingLinkView));
+    auto results = realm::Results(_realm->_realm,
+                                  _backingLinkView->get_target_table().where(_backingLinkView),
+                                  RLMSortOrderFromDescriptors(_realm.schema[_objectClassName], properties));
     return [RLMResults resultsWithObjectClassName:self.objectClassName
-                                            query:move(query)
-                                             sort:RLMSortOrderFromDescriptors(_realm.schema[_objectClassName], properties)
-                                            realm:_realm];
-
+                                            realm:_realm
+                                          results:std::move(results)];
 }
 
 - (RLMResults *)objectsWithPredicate:(NSPredicate *)predicate {
@@ -405,8 +407,8 @@ static void RLMInsertObject(RLMArrayLinkView *ar, RLMObject *object, NSUInteger 
     realm::Query query = _backingLinkView->get_target_table().where(_backingLinkView);
     RLMUpdateQueryWithPredicate(&query, predicate, _realm.schema, _realm.schema[self.objectClassName]);
     return [RLMResults resultsWithObjectClassName:self.objectClassName
-                                            query:std::make_unique<realm::Query>(query)
-                                            realm:_realm];
+                                            realm:_realm
+                                          results:realm::Results(_realm->_realm, std::move(query))];
 }
 
 - (NSUInteger)indexOfObjectWithPredicate:(NSPredicate *)predicate {

--- a/Realm/RLMArray_Private.hpp
+++ b/Realm/RLMArray_Private.hpp
@@ -84,8 +84,7 @@ void RLMEnsureArrayObservationInfo(std::unique_ptr<RLMObservationInfo>& info, NS
 // RLMResults private methods
 //
 @interface RLMResults () <RLMFastEnumerable>
-+ (instancetype)resultsWithObjectClassName:(NSString *)objectClassName
-                                     realm:(RLMRealm *)realm
++ (instancetype)resultsWithObjectSchema:(RLMObjectSchema *)objectSchema
                                    results:(realm::Results)results;
 
 - (void)deleteObjectsFromRealm;

--- a/Realm/RLMArray_Private.hpp
+++ b/Realm/RLMArray_Private.hpp
@@ -24,8 +24,9 @@
 
 namespace realm {
     class LinkView;
-    class Query;
+    class Results;
     class TableView;
+    struct SortOrder;
 
     namespace util {
         template<typename T> class bind_ptr;
@@ -36,15 +37,6 @@ namespace realm {
 @class RLMObjectBase;
 @class RLMObjectSchema;
 class RLMObservationInfo;
-
-struct RLMSortOrder {
-    std::vector<size_t> columnIndices;
-    std::vector<bool> ascending;
-
-    explicit operator bool() const {
-        return !columnIndices.empty();
-    }
-};
 
 @protocol RLMFastEnumerable
 @property (nonatomic, readonly) RLMRealm *realm;
@@ -93,35 +85,10 @@ void RLMEnsureArrayObservationInfo(std::unique_ptr<RLMObservationInfo>& info, NS
 //
 @interface RLMResults () <RLMFastEnumerable>
 + (instancetype)resultsWithObjectClassName:(NSString *)objectClassName
-                                     query:(std::unique_ptr<realm::Query>)query
-                                     realm:(RLMRealm *)realm;
-
-+ (instancetype)resultsWithObjectClassName:(NSString *)objectClassName
-                                     query:(std::unique_ptr<realm::Query>)query
-                                      view:(realm::TableView &&)view
-                                     realm:(RLMRealm *)realm;
-
-+ (instancetype)resultsWithObjectClassName:(NSString *)objectClassName
-                                     query:(std::unique_ptr<realm::Query>)query
-                                      sort:(RLMSortOrder)sorter
-                                     realm:(RLMRealm *)realm;
+                                     realm:(RLMRealm *)realm
+                                   results:(realm::Results)results;
 
 - (void)deleteObjectsFromRealm;
-@end
-
-//
-// RLMResults subclass used when a TableView can't be created - this is used
-// for readonly realms where we can't create an underlying table class for a
-// type, and we need to return a functional RLMResults instance which is always empty.
-//
-@interface RLMEmptyResults : RLMResults
-+ (instancetype)emptyResultsWithObjectClassName:(NSString *)objectClassName
-                                          realm:(RLMRealm *)realm;
-@end
-
-// RLMResults backed by a realm::Table directly rather than using a TableView
-@interface RLMTableResults : RLMResults
-+ (RLMResults *)tableResultsWithObjectSchema:(RLMObjectSchema *)objectSchema realm:(RLMRealm *)realm;
 @end
 
 // An object which encapulates the shared logic for fast-enumerating RLMArray

--- a/Realm/RLMObjectStore.h
+++ b/Realm/RLMObjectStore.h
@@ -77,14 +77,23 @@ RLMObjectBase *RLMCreateObjectInRealmWithValue(RLMRealm *realm, NSString *classN
 // Accessor Creation
 //
 
-// Create accessors
-RLMObjectBase *RLMCreateObjectAccessor(RLMRealm *realm,
-                                       RLMObjectSchema *objectSchema,
-                                       NSUInteger index) NS_RETURNS_RETAINED;
 
 // switch List<> properties from being backed by standalone RLMArrays to RLMArrayLinkView
 void RLMInitializeSwiftAccessorGenerics(RLMObjectBase *object);
 
 #ifdef __cplusplus
 }
+
+namespace realm {
+    class Table;
+    template<typename T> class BasicRowExpr;
+    using RowExpr = BasicRowExpr<Table>;
+}
+// Create accessors
+RLMObjectBase *RLMCreateObjectAccessor(RLMRealm *realm,
+                                       RLMObjectSchema *objectSchema,
+                                       NSUInteger index) NS_RETURNS_RETAINED;
+RLMObjectBase *RLMCreateObjectAccessor(RLMRealm *realm,
+                                       RLMObjectSchema *objectSchema,
+                                       realm::RowExpr row) NS_RETURNS_RETAINED;
 #endif

--- a/Realm/RLMObjectStore.mm
+++ b/Realm/RLMObjectStore.mm
@@ -458,7 +458,7 @@ RLMResults *RLMGetObjects(RLMRealm *realm, NSString *objectClassName, NSPredicat
     if (!objectSchema.table) {
         // read-only realms may be missing tables since we can't add any
         // missing ones on init
-        return [RLMResults resultsWithObjectClassName:objectClassName realm:realm results:{}];
+        return [RLMResults resultsWithObjectSchema:objectSchema results:{}];
     }
 
     if (predicate) {
@@ -466,14 +466,12 @@ RLMResults *RLMGetObjects(RLMRealm *realm, NSString *objectClassName, NSPredicat
         RLMUpdateQueryWithPredicate(&query, predicate, realm.schema, objectSchema);
 
         // create and populate array
-        return [RLMResults resultsWithObjectClassName:objectClassName
-                                                realm:realm
-                                              results:realm::Results(realm->_realm, std::move(query))];
+        return [RLMResults resultsWithObjectSchema:objectSchema
+                                           results:realm::Results(realm->_realm, std::move(query))];
     }
 
-    return [RLMResults resultsWithObjectClassName:objectClassName
-                                            realm:realm
-                                          results:realm::Results(realm->_realm, *objectSchema.table)];
+    return [RLMResults resultsWithObjectSchema:objectSchema
+                                       results:realm::Results(realm->_realm, *objectSchema.table)];
 }
 
 id RLMGetObject(RLMRealm *realm, NSString *objectClassName, id key) {

--- a/Realm/RLMObjectStore.mm
+++ b/Realm/RLMObjectStore.mm
@@ -519,7 +519,7 @@ id RLMGetObject(RLMRealm *realm, NSString *objectClassName, id key) {
         return nil;
     }
 
-    return RLMCreateObjectAccessor(realm, objectSchema, (*objectSchema.table)[row]);
+    return RLMCreateObjectAccessor(realm, objectSchema, row);
 }
 
 RLMObjectBase *RLMCreateObjectAccessor(__unsafe_unretained RLMRealm *const realm,

--- a/Realm/RLMQueryUtil.hpp
+++ b/Realm/RLMQueryUtil.hpp
@@ -21,14 +21,13 @@
 
 namespace realm {
     class Query;
+    struct SortOrder;
     class Table;
     class TableView;
 }
 
 @class RLMObjectSchema;
 @class RLMSchema;
-
-struct RLMSortOrder;
 
 extern NSString * const RLMPropertiesComparisonTypeMismatchException;
 extern NSString * const RLMUnsupportedTypesFoundInPropertyComparisonException;
@@ -40,8 +39,8 @@ void RLMUpdateQueryWithPredicate(realm::Query *query, NSPredicate *predicate, RL
 // return column index - throw for invalid column name
 NSUInteger RLMValidatedColumnIndex(RLMObjectSchema *objectSchema, NSString *columnName);
 
-// validate the array of RLMSortDescriptors and convert it to an RLMSortOrder
-RLMSortOrder RLMSortOrderFromDescriptors(RLMObjectSchema *objectSchema, NSArray *descriptors);
+// validate the array of RLMSortDescriptors and convert it to a realm::SortOrder
+realm::SortOrder RLMSortOrderFromDescriptors(RLMObjectSchema *objectSchema, NSArray *descriptors);
 
 // This macro validates predicate format with optional arguments
 #define RLM_VARARG(PREDICATE_FORMAT, ARGS) \

--- a/Realm/RLMQueryUtil.mm
+++ b/Realm/RLMQueryUtil.mm
@@ -25,7 +25,10 @@
 #import "RLMSchema_Private.h"
 #import "RLMUtil.hpp"
 
+#import "results.hpp"
+
 #include <realm.hpp>
+
 using namespace realm;
 
 NSString * const RLMPropertiesComparisonTypeMismatchException = @"RLMPropertiesComparisonTypeMismatchException";
@@ -1081,8 +1084,8 @@ void RLMUpdateQueryWithPredicate(realm::Query *query, NSPredicate *predicate, RL
                     (int)validateMessage.size(), validateMessage.c_str());
 }
 
-RLMSortOrder RLMSortOrderFromDescriptors(RLMObjectSchema *objectSchema, NSArray *descriptors) {
-    RLMSortOrder sort;
+realm::SortOrder RLMSortOrderFromDescriptors(RLMObjectSchema *objectSchema, NSArray *descriptors) {
+    realm::SortOrder sort;
     sort.columnIndices.reserve(descriptors.count);
     sort.ascending.reserve(descriptors.count);
 

--- a/Realm/RLMRealm.mm
+++ b/Realm/RLMRealm.mm
@@ -488,6 +488,8 @@ static void CheckReadWrite(RLMRealm *realm, NSString *msg=@"Cannot write to a re
               "transaction and all pending changes have been rolled back.");
     }
 
+    [self detachAllEnumerators];
+
     for (RLMObjectSchema *objectSchema in _schema.objectSchema) {
         for (RLMObservationInfo *info : objectSchema->_observedObjects) {
             info->willChange(RLMInvalidatedKey);

--- a/Realm/RLMResults.mm
+++ b/Realm/RLMResults.mm
@@ -251,7 +251,7 @@ static inline void RLMResultsValidateInWriteTransaction(__unsafe_unretained RLMR
     RLMUpdateQueryWithPredicate(&query, predicate, _realm.schema, _objectSchema);
     size_t index = query.find();
     if (index == realm::not_found) {
-        return (NSUInteger)NSNotFound;
+        return NSNotFound;
     }
     return _results.index_of(index);
 }

--- a/Realm/RLMUtil.hpp
+++ b/Realm/RLMUtil.hpp
@@ -26,6 +26,10 @@
 #import <realm/string_data.hpp>
 #import <realm/util/file.hpp>
 
+namespace realm {
+    class Mixed;
+}
+
 @class RLMObjectSchema;
 @class RLMProperty;
 @protocol RLMFastEnumerable;
@@ -160,3 +164,5 @@ static inline realm::DateTime RLMDateTimeForNSDate(__unsafe_unretained NSDate *c
 static inline NSUInteger RLMConvertNotFound(size_t index) {
     return index == realm::not_found ? NSNotFound : index;
 }
+
+id RLMMixedToObjc(realm::Mixed const& value);

--- a/Realm/RLMUtil.mm
+++ b/Realm/RLMUtil.mm
@@ -27,6 +27,8 @@
 #import "RLMSchema_Private.h"
 #import "RLMSwiftSupport.h"
 
+#import <realm/mixed.hpp>
+
 #include <sys/sysctl.h>
 #include <sys/types.h>
 
@@ -326,4 +328,29 @@ BOOL RLMIsDebuggerAttached()
     }
 
     return (info.kp_proc.p_flag & P_TRACED) != 0;
+}
+
+id RLMMixedToObjc(realm::Mixed const& mixed) {
+    switch (mixed.get_type()) {
+        case realm::type_String:
+            return RLMStringDataToNSString(mixed.get_string());
+        case realm::type_Int: {
+            return @(mixed.get_int());
+        case realm::type_Float:
+            return @(mixed.get_float());
+        case realm::type_Double:
+            return @(mixed.get_double());
+        case realm::type_Bool:
+            return @(mixed.get_bool());
+        case realm::type_DateTime:
+            return RLMDateTimeToNSDate(mixed.get_datetime());
+        case realm::type_Binary: {
+            return RLMBinaryDataToNSData(mixed.get_binary());
+        }
+        case realm::type_Link:
+        case realm::type_LinkList:
+        default:
+            @throw RLMException(@"Invalid data type for RLMPropertyTypeAny property.");
+        }
+    }
 }

--- a/Realm/Tests/KVOTests.mm
+++ b/Realm/Tests/KVOTests.mm
@@ -1226,6 +1226,20 @@ public:
     AssertIndexChange(NSKeyValueChangeRemoval, ([NSIndexSet indexSetWithIndexesInRange:{0, 3}]));
 }
 
+- (void)testDeleteObjectsInArrayViaTableViewClear {
+    KVOLinkObject2 *obj = [self createLinkObject];
+    KVOLinkObject2 *obj2 = [self createLinkObject];
+    [obj.array addObject:obj.obj];
+    [obj.array addObject:obj.obj];
+    [obj.array addObject:obj2.obj];
+
+    KVORecorder r(self, obj, @"array");
+    RLMResults *results = [KVOLinkObject1 objectsInRealm:self.realm where:@"TRUEPREDICATE"];
+    [results lastObject];
+    [self.realm deleteObjects:results];
+    AssertIndexChange(NSKeyValueChangeRemoval, ([NSIndexSet indexSetWithIndexesInRange:{0, 3}]));
+}
+
 - (void)testDeleteObjectsInArrayViaQueryClear {
     KVOLinkObject2 *obj = [self createLinkObject];
     KVOLinkObject2 *obj2 = [self createLinkObject];

--- a/Realm/Tests/PerformanceTests.m
+++ b/Realm/Tests/PerformanceTests.m
@@ -42,7 +42,12 @@ static RLMRealm *s_smallRealm, *s_mediumRealm, *s_largeRealm;
 
 + (void)tearDown {
     s_smallRealm = s_mediumRealm = s_largeRealm = nil;
+    [RLMRealm resetRealmState];
     [super tearDown];
+}
+
+- (void)resetRealmState {
+    // Do nothing, as we need to keep our in-memory realms around between tests
 }
 
 - (void)measureBlock:(void (^)(void))block {

--- a/Realm/Tests/RLMTestCase.m
+++ b/Realm/Tests/RLMTestCase.m
@@ -129,11 +129,15 @@ static BOOL encryptTests() {
 
 - (void)deleteFiles {
     // Clear cache
-    [RLMRealm resetRealmState];
+    [self resetRealmState];
 
     // Delete Realm files
     [self deleteRealmFileAtPath:RLMDefaultRealmPath()];
     [self deleteRealmFileAtPath:RLMTestRealmPath()];
+}
+
+- (void)resetRealmState {
+    [RLMRealm resetRealmState];
 }
 
 - (void)deleteRealmFileAtPath:(NSString *)path

--- a/Realm/Tests/RealmTests.mm
+++ b/Realm/Tests/RealmTests.mm
@@ -1048,7 +1048,14 @@ extern "C" {
     XCTAssertEqual(results, [results sortedResultsUsingProperty:@"intCol" ascending:YES]);
     XCTAssertThrows([results objectAtIndex:0]);
     XCTAssertEqual(NSNotFound, [results indexOfObject:self.nonLiteralNil]);
+    XCTAssertEqual(NSNotFound, [results indexOfObjectWhere:@"intCol = 5"]);
     XCTAssertNoThrow([realm deleteObjects:results]);
+    XCTAssertNil([results maxOfProperty:@"intCol"]);
+    XCTAssertNil([results minOfProperty:@"intCol"]);
+    XCTAssertNil([results averageOfProperty:@"intCol"]);
+    XCTAssertNil([results sumOfProperty:@"intCol"]);
+    XCTAssertNil([results firstObject]);
+    XCTAssertNil([results lastObject]);
     for (__unused id obj in results) {
         XCTFail(@"Got an item in empty results");
     }

--- a/Realm/Tests/RealmTests.mm
+++ b/Realm/Tests/RealmTests.mm
@@ -895,24 +895,20 @@ extern "C" {
 - (void)testRefreshCreatesAReadTransaction
 {
     RLMRealm *realm = [RLMRealm defaultRealm];
-    dispatch_queue_t queue = dispatch_queue_create("background", 0);
-    dispatch_group_t group = dispatch_group_create();
 
-    dispatch_group_async(group, queue, ^{
+    [self dispatchAsyncAndWait:^{
         [RLMRealm.defaultRealm transactionWithBlock:^{
             [IntObject createInDefaultRealmWithValue:@[@1]];
         }];
-    });
-    dispatch_group_wait(group, DISPATCH_TIME_FOREVER);
+    }];
 
     XCTAssertTrue([realm refresh]);
 
-    dispatch_group_async(group, queue, ^{
+    [self dispatchAsyncAndWait:^{
         [RLMRealm.defaultRealm transactionWithBlock:^{
             [IntObject createInDefaultRealmWithValue:@[@1]];
         }];
-    });
-    dispatch_group_wait(group, DISPATCH_TIME_FOREVER);
+    }];
 
     // refresh above should have created a read transaction, so realm should
     // still only see one object

--- a/Realm/Tests/ResultsTests.m
+++ b/Realm/Tests/ResultsTests.m
@@ -72,6 +72,54 @@
     XCTAssertNil(objects[0], @"Object should have been released");
 }
 
+- (void)testFirst {
+    XCTAssertNil(IntObject.allObjects.firstObject);
+    XCTAssertNil([IntObject objectsWhere:@"intCol > 5"].firstObject);
+
+    RLMRealm *realm = [RLMRealm defaultRealm];
+    [realm beginWriteTransaction];
+    [IntObject createInDefaultRealmWithValue:@[@10]];
+    [IntObject createInDefaultRealmWithValue:@[@20]];
+    [realm commitWriteTransaction];
+
+    XCTAssertEqual(10, [IntObject.allObjects.firstObject intCol]);
+    XCTAssertEqual(10, [[IntObject objectsWhere:@"intCol > 5"].firstObject intCol]);
+    XCTAssertEqual(20, [[IntObject objectsWhere:@"intCol > 10"].firstObject intCol]);
+}
+
+- (void)testLast {
+    XCTAssertNil(IntObject.allObjects.lastObject);
+    XCTAssertNil([IntObject objectsWhere:@"intCol > 5"].lastObject);
+
+    RLMRealm *realm = [RLMRealm defaultRealm];
+    [realm beginWriteTransaction];
+    [IntObject createInDefaultRealmWithValue:@[@20]];
+    [IntObject createInDefaultRealmWithValue:@[@10]];
+    [realm commitWriteTransaction];
+
+    XCTAssertEqual(10, [IntObject.allObjects.lastObject intCol]);
+    XCTAssertEqual(10, [[IntObject objectsWhere:@"intCol > 5"].lastObject intCol]);
+    XCTAssertEqual(20, [[IntObject objectsWhere:@"intCol > 10"].lastObject intCol]);
+}
+
+- (void)testSubscript {
+    RLMAssertThrowsWithReasonMatching([IntObject allObjects][0], @"0.*less than 0");
+    RLMAssertThrowsWithReasonMatching([IntObject objectsWhere:@"intCol > 5"][0], @"0.*less than 0");
+
+    RLMRealm *realm = [RLMRealm defaultRealm];
+    [realm beginWriteTransaction];
+    [IntObject createInDefaultRealmWithValue:@[@10]];
+    [IntObject createInDefaultRealmWithValue:@[@20]];
+    [realm commitWriteTransaction];
+
+    XCTAssertEqual(10, [IntObject.allObjects[0] intCol]);
+    XCTAssertEqual(10, [[IntObject objectsWhere:@"intCol > 5"][0] intCol]);
+    XCTAssertEqual(20, [[IntObject objectsWhere:@"intCol > 10"][0] intCol]);
+
+    RLMAssertThrowsWithReasonMatching([IntObject allObjects][2], @"2.*less than 2");
+    RLMAssertThrowsWithReasonMatching([IntObject objectsWhere:@"intCol > 5"][2], @"2.*less than 2");
+}
+
 - (void)testValueForKey {
     RLMRealm *realm = self.realmWithTestPath;
 
@@ -94,18 +142,28 @@
     [AggregateObject createInRealm:realm withValue:@[@0, @1.2f, @0.0, @YES, dateMinInput]];
     [AggregateObject createInRealm:realm withValue:@[@0, @1.2f, @0.0, @YES, dateMinInput]];
 
-    XCTAssertEqualObjects([[AggregateObject allObjectsInRealm:realm] valueForKey:@"intCol"], (@[@0, @1, @0, @1, @0, @1, @0, @1, @0, @0]));
-    XCTAssertTrue([[[[AggregateObject allObjectsInRealm:realm] valueForKey:@"self"] firstObject] isEqualToObject:[AggregateObject allObjectsInRealm:realm].firstObject]);
-    XCTAssertTrue([[[[AggregateObject allObjectsInRealm:realm] valueForKey:@"self"] lastObject] isEqualToObject:[AggregateObject allObjectsInRealm:realm].lastObject]);
+    XCTAssertEqualObjects([[AggregateObject allObjectsInRealm:realm] valueForKey:@"intCol"],
+                          (@[@0, @1, @0, @1, @0, @1, @0, @1, @0, @0]));
+    XCTAssertTrue([[[[AggregateObject allObjectsInRealm:realm] valueForKey:@"self"] firstObject]
+                   isEqualToObject:[AggregateObject allObjectsInRealm:realm].firstObject]);
+    XCTAssertTrue([[[[AggregateObject allObjectsInRealm:realm] valueForKey:@"self"] lastObject]
+                   isEqualToObject:[AggregateObject allObjectsInRealm:realm].lastObject]);
 
-    XCTAssertEqualObjects([[AggregateObject objectsInRealm:realm where:@"intCol != 1"] valueForKey:@"intCol"], (@[@0, @0, @0, @0, @0, @0]));
-    XCTAssertTrue([[[[AggregateObject objectsInRealm:realm where:@"intCol != 1"] valueForKey:@"self"] firstObject] isEqualToObject:[AggregateObject objectsInRealm:realm where:@"intCol != 1"].firstObject]);
-    XCTAssertTrue([[[[AggregateObject objectsInRealm:realm where:@"intCol != 1"] valueForKey:@"self"] lastObject] isEqualToObject:[AggregateObject objectsInRealm:realm where:@"intCol != 1"].lastObject]);
+    XCTAssertEqualObjects([[AggregateObject objectsInRealm:realm where:@"intCol != 1"] valueForKey:@"intCol"],
+                          (@[@0, @0, @0, @0, @0, @0]));
+    XCTAssertTrue([[[[AggregateObject objectsInRealm:realm where:@"intCol != 1"] valueForKey:@"self"] firstObject]
+                   isEqualToObject:[AggregateObject objectsInRealm:realm where:@"intCol != 1"].firstObject]);
+    XCTAssertTrue([[[[AggregateObject objectsInRealm:realm where:@"intCol != 1"] valueForKey:@"self"] lastObject]
+                   isEqualToObject:[AggregateObject objectsInRealm:realm where:@"intCol != 1"].lastObject]);
 
     [realm commitWriteTransaction];
 
-    XCTAssertEqualObjects([[AggregateObject allObjectsInRealm:realm] valueForKey:@"intCol"], (@[@0, @1, @0, @1, @0, @1, @0, @1, @0, @0]));
-    XCTAssertEqualObjects([[AggregateObject objectsInRealm:realm where:@"intCol != 1"] valueForKey:@"intCol"], (@[@0, @0, @0, @0, @0, @0]));
+    XCTAssertEqualObjects([[AggregateObject allObjectsInRealm:realm] valueForKey:@"intCol"],
+                          (@[@0, @1, @0, @1, @0, @1, @0, @1, @0, @0]));
+    XCTAssertEqualObjects([[AggregateObject objectsInRealm:realm where:@"intCol != 1"] valueForKey:@"intCol"],
+                          (@[@0, @0, @0, @0, @0, @0]));
+
+    XCTAssertThrows([[AggregateObject allObjectsInRealm:realm] valueForKey:@"invalid"]);
 }
 
 - (void)testSetValueForKey {
@@ -129,15 +187,21 @@
     [AggregateObject createInRealm:realm withValue:@[@0, @1.2f, @0.0, @YES, dateMinInput]];
 
     [[AggregateObject allObjectsInRealm:realm] setValue:@25 forKey:@"intCol"];
-    XCTAssertEqualObjects([[AggregateObject allObjectsInRealm:realm] valueForKey:@"intCol"], (@[@25, @25, @25, @25, @25, @25, @25, @25, @25, @25]));
+    XCTAssertEqualObjects([[AggregateObject allObjectsInRealm:realm] valueForKey:@"intCol"],
+                          (@[@25, @25, @25, @25, @25, @25, @25, @25, @25, @25]));
 
     [[AggregateObject objectsInRealm:realm where:@"floatCol > 1"] setValue:@10 forKey:@"intCol"];
-    XCTAssertEqualObjects([[AggregateObject objectsInRealm:realm where:@"floatCol > 1"] valueForKey:@"intCol"], (@[@10, @10, @10, @10, @10, @10]));
+    XCTAssertEqualObjects([[AggregateObject objectsInRealm:realm where:@"floatCol > 1"] valueForKey:@"intCol"],
+                          (@[@10, @10, @10, @10, @10, @10]));
+
+    XCTAssertThrows([[AggregateObject allObjectsInRealm:realm] valueForKey:@"invalid"]);
 
     [realm commitWriteTransaction];
 
-    XCTAssertThrows([[AggregateObject allObjectsInRealm:realm] setValue:@25 forKey:@"intCol"]);
-    XCTAssertThrows([[AggregateObject objectsInRealm:realm where:@"floatCol > 1"] setValue:@10 forKey:@"intCol"]);
+    RLMAssertThrowsWithReasonMatching([[AggregateObject allObjectsInRealm:realm] setValue:@25 forKey:@"intCol"],
+                                      @"write transaction");
+    RLMAssertThrowsWithReasonMatching([[AggregateObject objectsInRealm:realm where:@"floatCol > 1"] setValue:@10 forKey:@"intCol"],
+                                      @"write transaction");
 }
 
 - (void)testObjectAggregate
@@ -194,12 +258,12 @@
     XCTAssertEqualWithAccuracy([allArray sumOfProperty:@"doubleCol"].doubleValue, 10.0, 0.1f);
 
     // Test invalid column name
-    XCTAssertThrows([yesArray sumOfProperty:@"foo"]);
-    XCTAssertThrows([allArray sumOfProperty:@"foo"]);
+    RLMAssertThrowsWithReasonMatching([yesArray sumOfProperty:@"foo"], @"foo.*AggregateObject");
+    RLMAssertThrowsWithReasonMatching([allArray sumOfProperty:@"foo"], @"foo.*AggregateObject");
 
     // Test operation not supported
-    XCTAssertThrows([yesArray sumOfProperty:@"boolCol"]);
-    XCTAssertThrows([allArray sumOfProperty:@"foo"]);
+    RLMAssertThrowsWithReasonMatching([yesArray sumOfProperty:@"boolCol"], @"sum.*bool");
+    RLMAssertThrowsWithReasonMatching([allArray sumOfProperty:@"boolCol"], @"sum.*bool");
 
 
     // Average ::::::::::::::::::::::::::::::::::::::::::::::
@@ -219,12 +283,12 @@
     XCTAssertEqualWithAccuracy([allArray averageOfProperty:@"doubleCol"].doubleValue, 1.0, 0.1f);
 
     // Test invalid column name
-    XCTAssertThrows([yesArray averageOfProperty:@"foo"]);
-    XCTAssertThrows([allArray averageOfProperty:@"foo"]);
+    RLMAssertThrowsWithReasonMatching([yesArray averageOfProperty:@"foo"], @"foo.*AggregateObject");
+    RLMAssertThrowsWithReasonMatching([allArray averageOfProperty:@"foo"], @"foo.*AggregateObject");
 
     // Test operation not supported
-    XCTAssertThrows([yesArray averageOfProperty:@"boolCol"]);
-    XCTAssertThrows([allArray averageOfProperty:@"boolCol"]);
+    RLMAssertThrowsWithReasonMatching([yesArray averageOfProperty:@"boolCol"], @"average.*bool");
+    RLMAssertThrowsWithReasonMatching([allArray averageOfProperty:@"boolCol"], @"average.*bool");
 
     // MIN ::::::::::::::::::::::::::::::::::::::::::::::
     // Test int min
@@ -248,12 +312,12 @@
     XCTAssertEqualObjects(dateMinInput, [allArray minOfProperty:@"dateCol"]);
 
     // Test invalid column name
-    XCTAssertThrows([yesArray minOfProperty:@"foo"]);
-    XCTAssertThrows([allArray minOfProperty:@"foo"]);
+    RLMAssertThrowsWithReasonMatching([yesArray minOfProperty:@"foo"], @"foo.*AggregateObject");
+    RLMAssertThrowsWithReasonMatching([allArray minOfProperty:@"foo"], @"foo.*AggregateObject");
 
     // Test operation not supported
-    XCTAssertThrows([yesArray minOfProperty:@"boolCol"]);
-    XCTAssertThrows([allArray minOfProperty:@"boolCol"]);
+    RLMAssertThrowsWithReasonMatching([yesArray minOfProperty:@"boolCol"], @"min.*bool");
+    RLMAssertThrowsWithReasonMatching([allArray minOfProperty:@"boolCol"], @"min.*bool");
 
     // MAX ::::::::::::::::::::::::::::::::::::::::::::::
     // Test int max
@@ -277,12 +341,12 @@
     XCTAssertEqualObjects(dateMaxInput, [allArray maxOfProperty:@"dateCol"]);
 
     // Test invalid column name
-    XCTAssertThrows([yesArray maxOfProperty:@"foo"]);
-    XCTAssertThrows([allArray maxOfProperty:@"foo"]);
+    RLMAssertThrowsWithReasonMatching([yesArray maxOfProperty:@"foo"], @"foo.*AggregateObject");
+    RLMAssertThrowsWithReasonMatching([allArray maxOfProperty:@"foo"], @"foo.*AggregateObject");
 
     // Test operation not supported
-    XCTAssertThrows([yesArray maxOfProperty:@"boolCol"]);
-    XCTAssertThrows([allArray maxOfProperty:@"boolCol"]);
+    RLMAssertThrowsWithReasonMatching([yesArray maxOfProperty:@"boolCol"], @"max.*bool");
+    RLMAssertThrowsWithReasonMatching([allArray maxOfProperty:@"boolCol"], @"max.*bool");
 }
 
 - (void)testArrayDescription
@@ -330,16 +394,33 @@
     XCTAssertEqual(1U, [results indexOfObject:po3]);
     XCTAssertEqual((NSUInteger)NSNotFound, [results indexOfObject:po2]);
     XCTAssertEqual((NSUInteger)NSNotFound, [results indexOfObject:standalone]);
-    XCTAssertThrows([results indexOfObject:so]);
-    XCTAssertThrows([results indexOfObject:deletedObject]);
+    RLMAssertThrowsWithReasonMatching([results indexOfObject:so], @"StringObject.*EmployeeObject");
+    RLMAssertThrowsWithReasonMatching([results indexOfObject:deletedObject], @"Object has been invalidated");
+
+    [results lastObject]; // Force to tableview mode
+    XCTAssertEqual(0U, [results indexOfObject:po1]);
+    XCTAssertEqual(1U, [results indexOfObject:po3]);
+    XCTAssertEqual((NSUInteger)NSNotFound, [results indexOfObject:po2]);
+    XCTAssertEqual((NSUInteger)NSNotFound, [results indexOfObject:standalone]);
+    RLMAssertThrowsWithReasonMatching([results indexOfObject:so], @"StringObject.*EmployeeObject");
+    RLMAssertThrowsWithReasonMatching([results indexOfObject:deletedObject], @"Object has been invalidated");
+
+    // reverse order from sort
+    results = [[EmployeeObject objectsWhere:@"hired = YES"] sortedResultsUsingProperty:@"age" ascending:YES];
+    XCTAssertEqual(1U, [results indexOfObject:po1]);
+    XCTAssertEqual(0U, [results indexOfObject:po3]);
+    XCTAssertEqual((NSUInteger)NSNotFound, [results indexOfObject:po2]);
+    XCTAssertEqual((NSUInteger)NSNotFound, [results indexOfObject:standalone]);
+    RLMAssertThrowsWithReasonMatching([results indexOfObject:so], @"StringObject.*EmployeeObject");
+    RLMAssertThrowsWithReasonMatching([results indexOfObject:deletedObject], @"Object has been invalidated");
 
     results = [EmployeeObject allObjects];
     XCTAssertEqual(0U, [results indexOfObject:po1]);
     XCTAssertEqual(1U, [results indexOfObject:po2]);
     XCTAssertEqual(2U, [results indexOfObject:po3]);
     XCTAssertEqual((NSUInteger)NSNotFound, [results indexOfObject:standalone]);
-    XCTAssertThrows([results indexOfObject:so]);
-    XCTAssertThrows([results indexOfObject:deletedObject]);
+    RLMAssertThrowsWithReasonMatching([results indexOfObject:so], @"StringObject.*EmployeeObject");
+    RLMAssertThrowsWithReasonMatching([results indexOfObject:deletedObject], @"Object has been invalidated");
 }
 
 - (void)testIndexOfObjectWhere
@@ -428,25 +509,6 @@
     XCTAssertEqual(40, [(EmployeeObject *)sortedName[0] age]);
 }
 
-- (void)testSortingDoesNotEagerlyCreateView {
-    RLMRealm *realm = [RLMRealm defaultRealm];
-
-    [realm beginWriteTransaction];
-    [EmployeeObject createInRealm:realm withValue:@{@"name": @"A",  @"age": @20, @"hired": @YES}];
-    [EmployeeObject createInRealm:realm withValue:@{@"name": @"B", @"age": @30, @"hired": @NO}];
-    [EmployeeObject createInRealm:realm withValue:@{@"name": @"C", @"age": @40, @"hired": @YES}];
-    [realm commitWriteTransaction];
-
-    RLMResults *sortedAge = [[EmployeeObject allObjects] sortedResultsUsingProperty:@"age" ascending:YES];
-    RLMResults *sortedName = [sortedAge sortedResultsUsingProperty:@"name" ascending:NO];
-    RLMResults *filtered = [sortedName objectsWhere:@"age > 0"];
-
-    Ivar ivar = class_getInstanceVariable(sortedAge.class, "_viewCreated");
-    XCTAssertFalse((bool)object_getIvar(sortedAge, ivar));
-    XCTAssertFalse((bool)object_getIvar(sortedName, ivar));
-    XCTAssertFalse((bool)object_getIvar(filtered, ivar));
-}
-
 - (void)testRerunningSortedQuery {
     RLMRealm *realm = [RLMRealm defaultRealm];
 
@@ -511,27 +573,6 @@ static vm_size_t get_resident_size() {
     XCTAssert(get_resident_size() < size * 2);
 }
 
-- (void)testCrossThreadAccess
-{
-    RLMRealm *realm = self.realmWithTestPath;
-
-    [realm beginWriteTransaction];
-    [StringObject createInRealm:realm withValue:@[@"name1"]];
-    [StringObject createInRealm:realm withValue:@[@"name2"]];
-    [realm commitWriteTransaction];
-
-    RLMResults *results = [StringObject allObjects];
-    RLMResults *queryResults = [StringObject objectsWhere:@"stringCol = 'name1'"];
-    XCTAssertNoThrow([results lastObject]);
-    XCTAssertNoThrow([queryResults lastObject]);
-
-    // Using dispatch_async to ensure it actually lands on another thread
-    [self dispatchAsyncAndWait:^{
-        XCTAssertThrows([results lastObject]);
-        XCTAssertThrows([queryResults lastObject]);
-    }];
-}
-
 - (void)testDeleteAllObjects
 {
     RLMRealm *realm = self.realmWithTestPath;
@@ -542,7 +583,7 @@ static vm_size_t get_resident_size() {
     [realm commitWriteTransaction];
 
     RLMResults *results = [StringObject objectsInRealm:realm where:@"stringCol = 'name1'"];
-    XCTAssertThrows([realm deleteObjects:results]);
+    RLMAssertThrowsWithReasonMatching([realm deleteObjects:results], @"write transaction");
     [realm beginWriteTransaction];
     [realm deleteObjects:results];
     [realm commitWriteTransaction];
@@ -550,7 +591,7 @@ static vm_size_t get_resident_size() {
     XCTAssertEqual(1U, [StringObject allObjectsInRealm:realm].count);
 
     results = [StringObject allObjectsInRealm:realm];
-    XCTAssertThrows([realm deleteObjects:results]);
+    RLMAssertThrowsWithReasonMatching([realm deleteObjects:results], @"write transaction");
     [realm beginWriteTransaction];
     [realm deleteObjects:results];
     [realm commitWriteTransaction];
@@ -628,6 +669,154 @@ static vm_size_t get_resident_size() {
     }
 
     XCTAssertEqual(enumeratedCount, count);
+}
+
+- (void)testCallInvalidateDuringEnumeration {
+    RLMRealm *realm = self.realmWithTestPath;
+    const int count = 40;
+
+    [realm beginWriteTransaction];
+    for (int i = 0; i < count; ++i) {
+        [IntObject createInRealm:realm withValue:@[@(0)]];
+    }
+    [realm commitWriteTransaction];
+
+    int enumeratedCount = 0;
+    @try {
+        for (__unused IntObject *io in [IntObject objectsInRealm:realm where:@"intCol = 0"]) {
+            ++enumeratedCount;
+            [realm invalidate];
+        }
+        XCTFail(@"Should have thrown an exception");
+    }
+    @catch (NSException *e) {
+        XCTAssertEqualObjects(e.reason, @"Collection is no longer valid");
+    }
+    XCTAssertEqual(16, enumeratedCount);
+
+    // Also test with the enumeration done within a write transaction
+    [realm beginWriteTransaction];
+    enumeratedCount = 0;
+    @try {
+        for (__unused IntObject *io in [IntObject objectsInRealm:realm where:@"intCol = 0"]) {
+            ++enumeratedCount;
+            [realm invalidate];
+        }
+        XCTFail(@"Should have thrown an exception");
+    }
+    @catch (NSException *e) {
+        XCTAssertEqualObjects(e.reason, @"Collection is no longer valid");
+    }
+    XCTAssertEqual(16, enumeratedCount);
+}
+
+- (void)testBeginWriteTransactionDuringEnumeration {
+    RLMRealm *realm = self.realmWithTestPath;
+    const int count = 40;
+
+    [realm beginWriteTransaction];
+    for (int i = 0; i < count; ++i) {
+        [IntObject createInRealm:realm withValue:@[@(0)]];
+    }
+    [realm commitWriteTransaction];
+
+    for (IntObject *io in [IntObject objectsInRealm:realm where:@"intCol = 0"]) {
+        [realm beginWriteTransaction];
+        io.intCol = 1;
+        [realm commitWriteTransaction];
+    }
+
+    XCTAssertEqual(40U, [IntObject objectsInRealm:realm where:@"intCol = 1"].count);
+}
+
+- (void)testAllMethodsCheckThread {
+    RLMRealm *realm = [RLMRealm defaultRealm];
+    [realm transactionWithBlock:^{
+        [IntObject createInDefaultRealmWithValue:@[@0]];
+    }];
+
+    RLMResults *results = [IntObject allObjects];
+    XCTAssertNoThrow([results objectAtIndex:0]);
+    XCTAssertNoThrow([results firstObject]);
+    XCTAssertNoThrow([results lastObject]);
+    XCTAssertNoThrow([results indexOfObject:[IntObject allObjects].firstObject]);
+    XCTAssertNoThrow([results indexOfObjectWhere:@"intCol = 0"]);
+    XCTAssertNoThrow([results indexOfObjectWithPredicate:[NSPredicate predicateWithFormat:@"intCol = 0"]]);
+    XCTAssertNoThrow([results objectsWhere:@"intCol = 0"]);
+    XCTAssertNoThrow([results objectsWithPredicate:[NSPredicate predicateWithFormat:@"intCol = 0"]]);
+    XCTAssertNoThrow([results sortedResultsUsingProperty:@"intCol" ascending:YES]);
+    XCTAssertNoThrow([results sortedResultsUsingDescriptors:@[[RLMSortDescriptor sortDescriptorWithProperty:@"intCol" ascending:YES]]]);
+    XCTAssertNoThrow([results minOfProperty:@"intCol"]);
+    XCTAssertNoThrow([results maxOfProperty:@"intCol"]);
+    XCTAssertNoThrow([results sumOfProperty:@"intCol"]);
+    XCTAssertNoThrow([results averageOfProperty:@"intCol"]);
+    XCTAssertNoThrow(results[0]);
+    XCTAssertNoThrow([results valueForKey:@"intCol"]);
+
+    [self dispatchAsyncAndWait:^{
+        XCTAssertThrows([results objectAtIndex:0]);
+        XCTAssertThrows([results firstObject]);
+        XCTAssertThrows([results lastObject]);
+        XCTAssertThrows([results indexOfObject:[IntObject allObjects].firstObject]);
+        XCTAssertThrows([results indexOfObjectWhere:@"intCol = 0"]);
+        XCTAssertThrows([results indexOfObjectWithPredicate:[NSPredicate predicateWithFormat:@"intCol = 0"]]);
+        XCTAssertThrows([results objectsWhere:@"intCol = 0"]);
+        XCTAssertThrows([results objectsWithPredicate:[NSPredicate predicateWithFormat:@"intCol = 0"]]);
+        XCTAssertThrows([results sortedResultsUsingProperty:@"intCol" ascending:YES]);
+        XCTAssertThrows([results sortedResultsUsingDescriptors:@[[RLMSortDescriptor sortDescriptorWithProperty:@"intCol" ascending:YES]]]);
+        XCTAssertThrows([results minOfProperty:@"intCol"]);
+        XCTAssertThrows([results maxOfProperty:@"intCol"]);
+        XCTAssertThrows([results sumOfProperty:@"intCol"]);
+        XCTAssertThrows([results averageOfProperty:@"intCol"]);
+        XCTAssertThrows(results[0]);
+        XCTAssertThrows([results valueForKey:@"intCol"]);
+    }];
+}
+
+- (void)testAllMethodsCheckForInvalidation {
+    RLMRealm *realm = [RLMRealm defaultRealm];
+    [realm transactionWithBlock:^{
+        [IntObject createInDefaultRealmWithValue:@[@0]];
+    }];
+
+    RLMResults *results = [IntObject allObjects];
+    XCTAssertNoThrow([results objectAtIndex:0]);
+    XCTAssertNoThrow([results firstObject]);
+    XCTAssertNoThrow([results lastObject]);
+    XCTAssertNoThrow([results indexOfObject:[IntObject allObjects].firstObject]);
+    XCTAssertNoThrow([results indexOfObjectWhere:@"intCol = 0"]);
+    XCTAssertNoThrow([results indexOfObjectWithPredicate:[NSPredicate predicateWithFormat:@"intCol = 0"]]);
+    XCTAssertNoThrow([results objectsWhere:@"intCol = 0"]);
+    XCTAssertNoThrow([results objectsWithPredicate:[NSPredicate predicateWithFormat:@"intCol = 0"]]);
+    XCTAssertNoThrow([results sortedResultsUsingProperty:@"intCol" ascending:YES]);
+    XCTAssertNoThrow([results sortedResultsUsingDescriptors:@[[RLMSortDescriptor sortDescriptorWithProperty:@"intCol" ascending:YES]]]);
+    XCTAssertNoThrow([results minOfProperty:@"intCol"]);
+    XCTAssertNoThrow([results maxOfProperty:@"intCol"]);
+    XCTAssertNoThrow([results sumOfProperty:@"intCol"]);
+    XCTAssertNoThrow([results averageOfProperty:@"intCol"]);
+    XCTAssertNoThrow(results[0]);
+    XCTAssertNoThrow([results valueForKey:@"intCol"]);
+    XCTAssertNoThrow({for (__unused id obj in results);});
+
+    [realm invalidate];
+
+    XCTAssertThrows([results objectAtIndex:0]);
+    XCTAssertThrows([results firstObject]);
+    XCTAssertThrows([results lastObject]);
+    XCTAssertThrows([results indexOfObject:[IntObject allObjects].firstObject]);
+    XCTAssertThrows([results indexOfObjectWhere:@"intCol = 0"]);
+    XCTAssertThrows([results indexOfObjectWithPredicate:[NSPredicate predicateWithFormat:@"intCol = 0"]]);
+    XCTAssertThrows([results objectsWhere:@"intCol = 0"]);
+    XCTAssertThrows([results objectsWithPredicate:[NSPredicate predicateWithFormat:@"intCol = 0"]]);
+    XCTAssertThrows([results sortedResultsUsingProperty:@"intCol" ascending:YES]);
+    XCTAssertThrows([results sortedResultsUsingDescriptors:@[[RLMSortDescriptor sortDescriptorWithProperty:@"intCol" ascending:YES]]]);
+    XCTAssertThrows([results minOfProperty:@"intCol"]);
+    XCTAssertThrows([results maxOfProperty:@"intCol"]);
+    XCTAssertThrows([results sumOfProperty:@"intCol"]);
+    XCTAssertThrows([results averageOfProperty:@"intCol"]);
+    XCTAssertThrows(results[0]);
+    XCTAssertThrows([results valueForKey:@"intCol"]);
+    XCTAssertThrows({for (__unused id obj in results);});
 }
 
 @end

--- a/RealmSwift-swift1.2/Tests/TestCase.swift
+++ b/RealmSwift-swift1.2/Tests/TestCase.swift
@@ -55,16 +55,12 @@ class TestCase: XCTestCase {
         exceptionThrown = false
         autoreleasepool { super.invokeTest() }
 
-        if exceptionThrown {
-            RLMDeallocateRealm(defaultRealmPath())
-            RLMDeallocateRealm(testRealmPath())
-        }
-        else {
+        if !exceptionThrown {
             XCTAssertFalse(RLMHasCachedRealmForPath(defaultRealmPath()))
             XCTAssertFalse(RLMHasCachedRealmForPath(testRealmPath()))
         }
-        deleteRealmFiles()
         RLMRealm.resetRealmState()
+        deleteRealmFiles()
     }
 
     func dispatchSyncNewThread(block: dispatch_block_t) {

--- a/RealmSwift-swift1.2/Tests/TestUtils.h
+++ b/RealmSwift-swift1.2/Tests/TestUtils.h
@@ -24,9 +24,5 @@ FOUNDATION_EXTERN void RLMAssertThrows(XCTestCase *self,
                                        NSString *name, NSString *message,
                                        NSString *fileName, NSUInteger lineNumber);
 
-// Forcibly deallocate the RLMRealm for the given path on the main thread
-// Will cause crashes if it's alive for a reason other than being leaked by RLMAssertThrows
-FOUNDATION_EXTERN void RLMDeallocateRealm(NSString *path);
-
 FOUNDATION_EXTERN bool RLMHasCachedRealmForPath(NSString *path);
 

--- a/RealmSwift-swift1.2/Tests/TestUtils.mm
+++ b/RealmSwift-swift1.2/Tests/TestUtils.mm
@@ -59,23 +59,6 @@ void RLMAssertThrows(XCTestCase *self, dispatch_block_t block, NSString *name, N
     }
 }
 
-void RLMDeallocateRealm(NSString *path) {
-    __weak RLMRealm *realm;
-
-    @autoreleasepool {
-        realm = RLMGetThreadLocalCachedRealmForPath(path.UTF8String);
-    }
-
-    while (true) {
-        @autoreleasepool {
-            if (!realm) {
-                return;
-            }
-        }
-        CFRelease((__bridge void *)realm);
-    }
-}
-
 bool RLMHasCachedRealmForPath(NSString *path) {
     return RLMGetAnyCachedRealmForPath(path.UTF8String);
 }

--- a/RealmSwift-swift2.0/Tests/PerformanceTests.swift
+++ b/RealmSwift-swift2.0/Tests/PerformanceTests.swift
@@ -62,6 +62,10 @@ class SwiftPerformanceTests: TestCase {
         super.tearDown()
     }
 
+    override func resetRealmState() {
+        // Do nothing, as we need to keep our in-memory realms around between tests
+    }
+
     override func measureBlock(block: (() -> Void)) {
         super.measureBlock {
             autoreleasepool {

--- a/RealmSwift-swift2.0/Tests/TestCase.swift
+++ b/RealmSwift-swift2.0/Tests/TestCase.swift
@@ -52,6 +52,11 @@ class TestCase: XCTestCase {
         }
     }
 
+    override class func tearDown() {
+        RLMRealm.resetRealmState()
+        super.tearDown()
+    }
+
     override func invokeTest() {
         testDir = RLMRealmPathForFile(realmFilePrefix())
 
@@ -72,7 +77,7 @@ class TestCase: XCTestCase {
             XCTAssertFalse(RLMHasCachedRealmForPath(testRealmPath()))
         }
 
-        RLMRealm.resetRealmState()
+        resetRealmState()
 
         do {
             try NSFileManager.defaultManager().removeItemAtPath(testDir)
@@ -86,6 +91,10 @@ class TestCase: XCTestCase {
             XCTAssertNotEqual(url.pathExtension, "realm", "Lingering realm file at \(parentDir)/\(url)")
             assert(url.pathExtension != "realm")
         }
+    }
+
+    func resetRealmState() {
+        RLMRealm.resetRealmState()
     }
 
     func dispatchSyncNewThread(block: dispatch_block_t) {

--- a/RealmSwift-swift2.0/Tests/TestCase.swift
+++ b/RealmSwift-swift2.0/Tests/TestCase.swift
@@ -67,14 +67,12 @@ class TestCase: XCTestCase {
         exceptionThrown = false
         autoreleasepool { super.invokeTest() }
 
-        if exceptionThrown {
-            RLMDeallocateRealm(defaultRealmPath())
-            RLMDeallocateRealm(testRealmPath())
-        }
-        else {
+        if !exceptionThrown {
             XCTAssertFalse(RLMHasCachedRealmForPath(defaultRealmPath()))
             XCTAssertFalse(RLMHasCachedRealmForPath(testRealmPath()))
         }
+
+        RLMRealm.resetRealmState()
 
         do {
             try NSFileManager.defaultManager().removeItemAtPath(testDir)
@@ -88,8 +86,6 @@ class TestCase: XCTestCase {
             XCTAssertNotEqual(url.pathExtension, "realm", "Lingering realm file at \(parentDir)/\(url)")
             assert(url.pathExtension != "realm")
         }
-
-        RLMRealm.resetRealmState()
     }
 
     func dispatchSyncNewThread(block: dispatch_block_t) {

--- a/RealmSwift-swift2.0/Tests/TestUtils.h
+++ b/RealmSwift-swift2.0/Tests/TestUtils.h
@@ -24,9 +24,5 @@ FOUNDATION_EXTERN void RLMAssertThrows(XCTestCase *self,
                                        NSString *name, NSString *message,
                                        NSString *fileName, NSUInteger lineNumber);
 
-// Forcibly deallocate the RLMRealm for the given path on the main thread
-// Will cause crashes if it's alive for a reason other than being leaked by RLMAssertThrows
-FOUNDATION_EXTERN void RLMDeallocateRealm(NSString *path);
-
 FOUNDATION_EXTERN bool RLMHasCachedRealmForPath(NSString *path);
 

--- a/RealmSwift-swift2.0/Tests/TestUtils.mm
+++ b/RealmSwift-swift2.0/Tests/TestUtils.mm
@@ -59,23 +59,6 @@ void RLMAssertThrows(XCTestCase *self, dispatch_block_t block, NSString *name, N
     }
 }
 
-void RLMDeallocateRealm(NSString *path) {
-    __weak RLMRealm *realm;
-
-    @autoreleasepool {
-        realm = RLMGetThreadLocalCachedRealmForPath(path.UTF8String);
-    }
-
-    while (true) {
-        @autoreleasepool {
-            if (!realm) {
-                return;
-            }
-        }
-        CFRelease((__bridge void *)realm);
-    }
-}
-
 bool RLMHasCachedRealmForPath(NSString *path) {
     return RLMGetAnyCachedRealmForPath(path.UTF8String);
 }


### PR DESCRIPTION
Everything but `-description` and the fast enumeration stuff is now a fairly thin wrapper around the objectstore Results class. I'd like to port `RLMFastEnumerator` to the object store in the future, but it's awkward to do so while not yet using the objectstore List class, and it's not needed for the async query stuff, which the rest of the stuff is a prereq for.

Shouldn't be any end-user visible functional changes.

