### PR TITLE
Clarified doc comments for cancelTransaction

### DIFF
--- a/RealmSwift-swift1.2/Realm.swift
+++ b/RealmSwift-swift1.2/Realm.swift
@@ -168,8 +168,8 @@ public final class Realm {
     This rolls back all objects in the Realm to the state they were in at the
     beginning of the write transaction, and then ends the transaction.
 
-    This restores the data for deleted objects, but does not reinstate deleted
-    accessor objects. Any `Object`s which were added to the Realm will be
+    This restores the data for deleted objects, but does not revive invalidated
+    object instances. Any `Object`s which were added to the Realm will be
     invalidated rather than switching back to standalone objects.
     Given the following code:
 

--- a/RealmSwift-swift2.0/Realm.swift
+++ b/RealmSwift-swift2.0/Realm.swift
@@ -143,8 +143,8 @@ public final class Realm {
     This rolls back all objects in the Realm to the state they were in at the
     beginning of the write transaction, and then ends the transaction.
 
-    This restores the data for deleted objects, but does not reinstate deleted
-    accessor objects. Any `Object`s which were added to the Realm will be
+    This restores the data for deleted objects, but does not revive invalidated
+    object instances. Any `Object`s which were added to the Realm will be
     invalidated rather than switching back to standalone objects.
     Given the following code:
 


### PR DESCRIPTION
Minor change to remove the 'accessor object' terminology.