### PR TITLE
Annotate collections with generic types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ x.x.x Release notes (yyyy-MM-dd)
 ### API breaking changes
 
 * All functionality deprecated in previous releases has been removed entirely.
+* Add generic type annotations to NSArrays and NSDictionaries in public APIs.
 
 ### Enhancements
 

--- a/Realm/RLMCollection.h
+++ b/Realm/RLMCollection.h
@@ -20,7 +20,7 @@
 
 RLM_ASSUME_NONNULL_BEGIN
 
-@class RLMRealm, RLMResults, RLMObject;
+@class RLMRealm, RLMResults, RLMObject, RLMSortDescriptor;
 
 /**
  A homogenous collection of `RLMObject`s like `RLMArray` or `RLMResults`.
@@ -139,7 +139,7 @@ RLM_ASSUME_NONNULL_BEGIN
  
  @return    An RLMResults sorted by the specified properties.
  */
-- (RLMResults *)sortedResultsUsingDescriptors:(NSArray *)properties;
+- (RLMResults *)sortedResultsUsingDescriptors:(NSArray RLM_GENERIC(RLMSortDescriptor *) *)properties;
 
 /// :nodoc:
 - (id)objectAtIndexedSubscript:(NSUInteger)index;

--- a/Realm/RLMDefines.h
+++ b/Realm/RLMDefines.h
@@ -27,10 +27,12 @@
 #pragma mark - Generics
 
 #if __has_extension(objc_generics)
+#define RLM_GENERIC(...) <__VA_ARGS__>
 #define RLM_GENERIC_COLLECTION <RLMObjectType: RLMObject *>
 #define RLM_GENERIC_RETURN <RLMObjectType>
 #define RLMObjectArgument RLMObjectType
 #else
+#define RLM_GENERIC(...)
 #define RLM_GENERIC_COLLECTION
 #define RLM_GENERIC_RETURN
 typedef id RLMObjectType;

--- a/Realm/RLMObject.h
+++ b/Realm/RLMObject.h
@@ -236,7 +236,7 @@ RLM_ASSUME_NONNULL_BEGIN
  for string and int properties.
  @return    NSArray of property names.
  */
-+ (NSArray *)indexedProperties;
++ (NSArray RLM_GENERIC(NSString *) *)indexedProperties;
 
 /**
  Implement to indicate the default values to be used for each property.
@@ -261,7 +261,7 @@ RLM_ASSUME_NONNULL_BEGIN
  
  @return    NSArray of property names to ignore.
  */
-+ (nullable NSArray *)ignoredProperties;
++ (nullable NSArray RLM_GENERIC(NSString *) *)ignoredProperties;
 
 /**
  Implement to return an array of property names that should not allow storing nil.
@@ -276,7 +276,7 @@ RLM_ASSUME_NONNULL_BEGIN
 
  @return    NSArray of property names that are required.
  */
-+ (NSArray *)requiredProperties;
++ (NSArray RLM_GENERIC(NSString *) *)requiredProperties;
 
 
 #pragma mark - Getting & Querying Objects from the Default Realm

--- a/Realm/RLMObjectSchema.h
+++ b/Realm/RLMObjectSchema.h
@@ -40,7 +40,7 @@ RLM_ASSUME_NONNULL_BEGIN
  
  @see RLMProperty
  */
-@property (nonatomic, readonly, copy) NSArray *properties;
+@property (nonatomic, readonly, copy) NSArray RLM_GENERIC(RLMProperty *) *properties;
 
 /**
  The name of the class this schema describes.

--- a/Realm/RLMObjectSchema.mm
+++ b/Realm/RLMObjectSchema.mm
@@ -32,7 +32,7 @@ using namespace realm;
 
 // private properties
 @interface RLMObjectSchema ()
-@property (nonatomic, readwrite) NSDictionary *propertiesByName;
+@property (nonatomic, readwrite) NSDictionary RLM_GENERIC(id, RLMProperty *) *propertiesByName;
 @property (nonatomic, readwrite, assign) NSString *className;
 @end
 
@@ -199,7 +199,7 @@ using namespace realm;
         }
     }
 
-    if (NSDictionary *optionalProperties = [objectUtil getOptionalProperties:swiftObjectInstance]) {
+    if (auto optionalProperties = [objectUtil getOptionalProperties:swiftObjectInstance]) {
         for (RLMProperty *property in propArray) {
             property.optional = false;
         }
@@ -226,7 +226,7 @@ using namespace realm;
             }
         }];
     }
-    if (NSArray *requiredProperties = [objectUtil requiredPropertiesForClass:objectClass]) {
+    if (auto requiredProperties = [objectUtil requiredPropertiesForClass:objectClass]) {
         for (RLMProperty *property in propArray) {
             bool required = [requiredProperties containsObject:property.name];
             if (required && property.type == RLMPropertyTypeObject) {

--- a/Realm/RLMObjectSchema_Private.h
+++ b/Realm/RLMObjectSchema_Private.h
@@ -27,7 +27,7 @@ RLM_ASSUME_NONNULL_BEGIN
 @interface RLMObjectSchema ()
 
 // writable redecleration
-@property (nonatomic, readwrite, copy) NSArray *properties;
+@property (nonatomic, readwrite, copy) NSArray RLM_GENERIC(RLMProperty *) *properties;
 @property (nonatomic, readwrite, assign) bool isSwiftClass;
 
 // class used for this object schema

--- a/Realm/RLMObject_Private.h
+++ b/Realm/RLMObject_Private.h
@@ -73,13 +73,13 @@ FOUNDATION_EXTERN const NSUInteger RLMDescriptionMaxDepth;
 @class RLMProperty, RLMArray;
 @interface RLMObjectUtil : NSObject
 
-+ (NSArray *)ignoredPropertiesForClass:(Class)cls;
-+ (NSArray *)indexedPropertiesForClass:(Class)cls;
++ (NSArray RLM_GENERIC(NSString *) *)ignoredPropertiesForClass:(Class)cls;
++ (NSArray RLM_GENERIC(NSString *) *)indexedPropertiesForClass:(Class)cls;
 
-+ (NSArray *)getGenericListPropertyNames:(id)obj;
++ (NSArray RLM_GENERIC(NSString *) *)getGenericListPropertyNames:(id)obj;
 + (void)initializeListProperty:(RLMObjectBase *)object property:(RLMProperty *)property array:(RLMArray *)array;
 
-+ (NSDictionary *)getOptionalProperties:(id)obj;
-+ (NSArray *)requiredPropertiesForClass:(Class)cls;
++ (NSDictionary RLM_GENERIC(NSString *, NSNumber *) *)getOptionalProperties:(id)obj;
++ (NSArray RLM_GENERIC(NSString *) *)requiredPropertiesForClass:(Class)cls;
 
 @end

--- a/Realm/RLMObservation.hpp
+++ b/Realm/RLMObservation.hpp
@@ -20,6 +20,8 @@
 
 #import "binding_context.hpp"
 
+#import <Realm/RLMDefines.h>
+
 #import <realm/link_view.hpp> // required by row.hpp
 #import <realm/row.hpp>
 
@@ -141,6 +143,6 @@ void RLMClearTable(RLMObjectSchema *realm);
 // invoke the block, sending notifications for cascading deletes/link nullifications
 void RLMTrackDeletions(RLMRealm *realm, dispatch_block_t block);
 
-std::vector<realm::BindingContext::ObserverState> RLMGetObservedRows(NSArray *schema);
+std::vector<realm::BindingContext::ObserverState> RLMGetObservedRows(NSArray RLM_GENERIC(RLMObjectSchema *) *schema);
 void RLMWillChange(std::vector<realm::BindingContext::ObserverState> const& observed, std::vector<void *> const& invalidated);
 void RLMDidChange(std::vector<realm::BindingContext::ObserverState> const& observed, std::vector<void *> const& invalidated);

--- a/Realm/RLMObservation.mm
+++ b/Realm/RLMObservation.mm
@@ -408,7 +408,7 @@ void forEach(realm::BindingContext::ObserverState const& state, Func&& func) {
 }
 }
 
-std::vector<realm::BindingContext::ObserverState> RLMGetObservedRows(NSArray *schema) {
+std::vector<realm::BindingContext::ObserverState> RLMGetObservedRows(NSArray RLM_GENERIC(RLMObjectSchema *) *schema) {
     std::vector<realm::BindingContext::ObserverState> observers;
     for (RLMObjectSchema *objectSchema in schema) {
         for (auto info : objectSchema->_observedObjects) {

--- a/Realm/RLMSchema.h
+++ b/Realm/RLMSchema.h
@@ -41,7 +41,7 @@ RLM_ASSUME_NONNULL_BEGIN
 
  @see RLMObjectSchema
  */
-@property (nonatomic, readonly, copy) NSArray *objectSchema;
+@property (nonatomic, readonly, copy) NSArray RLM_GENERIC(RLMObjectSchema *) *objectSchema;
 
 #pragma mark - Methods
 

--- a/Realm/RLMSchema_Private.h
+++ b/Realm/RLMSchema_Private.h
@@ -39,9 +39,9 @@ RLM_ASSUME_NONNULL_BEGIN
 
  @return An `RLMSchema` containing only the given classes.
  */
-+ (instancetype)schemaWithObjectClasses:(NSArray *)classes;
++ (instancetype)schemaWithObjectClasses:(NSArray RLM_GENERIC(Class) *)classes;
 
-@property (nonatomic, readwrite, copy) NSArray *objectSchema;
+@property (nonatomic, readwrite, copy) NSArray RLM_GENERIC(RLMObjectSchema *) *objectSchema;
 
 // schema based on runtime objects
 + (instancetype)sharedSchema;

--- a/Realm/Tests/Swift2.0/SwiftDynamicTests.swift
+++ b/Realm/Tests/Swift2.0/SwiftDynamicTests.swift
@@ -42,8 +42,8 @@ class SwiftDynamicTests: RLMTestCase {
         let dynSchema = dyrealm.schema[SwiftDynamicObject.className()]
         XCTAssertNotNil(dynSchema, "Should be able to get object schema dynamically")
         XCTAssertEqual(dynSchema.properties.count, Int(2))
-        XCTAssertEqual(dynSchema.properties[0].name!, "stringCol")
-        XCTAssertEqual((dynSchema.properties[1] as! RLMProperty).type, RLMPropertyType.Int)
+        XCTAssertEqual(dynSchema.properties[0].name, "stringCol")
+        XCTAssertEqual(dynSchema.properties[1].type, RLMPropertyType.Int)
 
         // verify object type
         let array = SwiftDynamicObject.allObjectsInRealm(dyrealm)
@@ -88,8 +88,8 @@ class SwiftDynamicTests: RLMTestCase {
         let dynSchema = dyrealm.schema[DynamicObject.className()]
         XCTAssertNotNil(dynSchema, "Should be able to get object schema dynamically")
         XCTAssertTrue(dynSchema.properties.count == 2)
-        XCTAssertTrue(dynSchema.properties[0].name! == "stringCol")
-        XCTAssertTrue((dynSchema.properties[1] as! RLMProperty).type == RLMPropertyType.Int)
+        XCTAssertTrue(dynSchema.properties[0].name == "stringCol")
+        XCTAssertTrue(dynSchema.properties[1].type == RLMPropertyType.Int)
 
         // verify object type
         let array = DynamicObject.allObjectsInRealm(dyrealm)
@@ -164,13 +164,13 @@ class SwiftDynamicTests: RLMTestCase {
 
         let schema = dyrealm.schema[AllTypesObject.className()]
         for idx in 0..<10 {
-            let prop = schema.properties[idx] as! RLMProperty
+            let prop = schema.properties[idx]
             XCTAssertTrue(obj1[idx].isEqual((array[0] as! RLMObject)[prop.name]))
             XCTAssertTrue(obj2[idx].isEqual((array[1] as! RLMObject)[prop.name]))
         }
 
         // check sub object type
-        XCTAssertTrue((schema.properties[10] as! RLMProperty).objectClassName! == "StringObject")
+        XCTAssertTrue(schema.properties[10].objectClassName! == "StringObject")
 
         // check object equality
         XCTAssertNil((array[0] as! RLMObject)["objectCol"], "object should be nil")

--- a/Realm/Tests/Swift2.0/SwiftTestObjects.swift
+++ b/Realm/Tests/Swift2.0/SwiftTestObjects.swift
@@ -114,7 +114,7 @@ class SwiftIgnoredPropertiesObject: RLMObject {
     dynamic var runtimeProperty: AnyObject?
     dynamic var readOnlyProperty: Int { return 0 }
 
-    override class func ignoredProperties() -> [AnyObject]? {
+    override class func ignoredProperties() -> [String]? {
         return ["runtimeProperty"]
     }
 }

--- a/RealmSwift-swift2.0/ObjectSchema.swift
+++ b/RealmSwift-swift2.0/ObjectSchema.swift
@@ -35,7 +35,7 @@ public final class ObjectSchema: CustomStringConvertible {
 
     /// Array of persisted `Property` objects for an object.
     public var properties: [Property] {
-        return (rlmObjectSchema.properties as! [RLMProperty]).map { Property($0) }
+        return rlmObjectSchema.properties.map { Property($0) }
     }
 
     /// The name of the class this schema describes.

--- a/RealmSwift-swift2.0/Tests/ObjectSchemaInitializationTests.swift
+++ b/RealmSwift-swift2.0/Tests/ObjectSchemaInitializationTests.swift
@@ -151,13 +151,10 @@ class ObjectSchemaInitializationTests: TestCase {
         let schema = RLMObjectSchema(forObjectClass: SwiftOptionalObject.self)
 
         for prop in schema.properties {
-            XCTAssertTrue((prop as! RLMProperty).optional)
+            XCTAssertTrue(prop.optional)
         }
 
-        let types = Set(schema.properties.map { prop in
-            (prop as! RLMProperty).type
-        })
-
+        let types = Set(schema.properties.map { $0.type })
         XCTAssertEqual(types, Set([.String, .String, .Data, .Date, .Object, .Int, .Float, .Double, .Bool]))
     }
 


### PR DESCRIPTION
I got annoyed at the lack of autocomplete and added generic type annotations to (almost) all of the NSArrays and NSDictionaries in headers and property declarations. This is marked as a breaking change as Swift code using the obj-c API has to be updated in a few places to compile.