### PR TITLE
Fix race condition in multiprocess schema init

### DIFF
--- a/Realm/ObjectStore/object_store.hpp
+++ b/Realm/ObjectStore/object_store.hpp
@@ -52,12 +52,11 @@ namespace realm {
         static bool needs_update(Schema const& old_schema, Schema const& schema);
         
         // updates a Realm from old_schema to the given target schema, creating and updating tables as needed
-        // returns if any changes were made
         // passed in target schema is updated with the correct column mapping
         // optionally runs migration function if schema is out of date
         // NOTE: must be performed within a write transaction
         typedef std::function<void(Group *, Schema &)> MigrationFunction;
-        static bool update_realm_with_schema(Group *group, Schema const& old_schema, uint64_t version,
+        static void update_realm_with_schema(Group *group, Schema const& old_schema, uint64_t version,
                                              Schema &schema, MigrationFunction migration);
 
         // get a table for an object type
@@ -86,11 +85,11 @@ namespace realm {
         // create any metadata tables that don't already exist
         // must be in write transaction to set
         // returns true if it actually did anything
-        static bool create_metadata_tables(Group *group);
+        static void create_metadata_tables(Group *group);
 
         // set references to tables on targetSchema and create/update any missing or out-of-date tables
         // if update existing is true, updates existing tables, otherwise only adds and initializes new tables
-        static bool create_tables(realm::Group *group, Schema &target_schema, bool update_existing);
+        static void create_tables(realm::Group *group, Schema &target_schema, bool update_existing);
 
         // verify a target schema against an expected schema, setting the table_column property on each schema object
         // updates the column mapping on the target_schema

--- a/Realm/ObjectStore/shared_realm.cpp
+++ b/Realm/ObjectStore/shared_realm.cpp
@@ -176,7 +176,7 @@ SharedRealm Realm::get_shared_realm(Config config)
     return realm;
 }
 
-bool Realm::update_schema(std::unique_ptr<Schema> schema, uint64_t version)
+void Realm::update_schema(std::unique_ptr<Schema> schema, uint64_t version)
 {
     schema->validate();
 
@@ -186,7 +186,7 @@ bool Realm::update_schema(std::unique_ptr<Schema> schema, uint64_t version)
         ObjectStore::verify_schema(*m_config.schema, *schema, m_config.read_only);
         m_config.schema = std::move(schema);
         m_config.schema_version = version;
-        return false;
+        return;
     }
 
     begin_transaction();
@@ -225,11 +225,10 @@ bool Realm::update_schema(std::unique_ptr<Schema> schema, uint64_t version)
         m_config.schema = std::move(schema);
         m_config.schema_version = version;
 
-        bool changed = ObjectStore::update_realm_with_schema(read_group(), *old_config.schema,
-                                                             version, *m_config.schema,
-                                                             migration_function);
+        ObjectStore::update_realm_with_schema(read_group(), *old_config.schema,
+                                              version, *m_config.schema,
+                                              migration_function);
         commit_transaction();
-        return changed;
     }
     catch (...) {
         m_config.schema = std::move(old_config.schema);

--- a/Realm/ObjectStore/shared_realm.hpp
+++ b/Realm/ObjectStore/shared_realm.hpp
@@ -77,8 +77,7 @@ namespace realm {
         // updating indexes as necessary. Uses the existing migration function
         // on the Config, and the resulting Schema and version with updated
         // column mappings are set on the realms config upon success.
-        // returns if any changes were made
-        bool update_schema(std::unique_ptr<Schema> schema, uint64_t version);
+        void update_schema(std::unique_ptr<Schema> schema, uint64_t version);
 
         static uint64_t get_schema_version(Config const& config);
 

--- a/Realm/Tests/SchemaTests.mm
+++ b/Realm/Tests/SchemaTests.mm
@@ -23,8 +23,8 @@
 #import "RLMAccessor.h"
 #import "RLMObjectSchema_Private.hpp"
 #import "RLMProperty_Private.h"
+#import "RLMRealmConfiguration_Private.h"
 #import "RLMRealm_Dynamic.h"
-#import "RLMSchema_Private.h"
 #import "RLMSchema_Private.h"
 
 #import <algorithm>
@@ -485,7 +485,7 @@ RLM_ARRAY_TYPE(SchemaTestClassSecondChild)
         return;
     }
 
-    RLMRealmConfiguration *config = [RLMRealmConfiguration new];
+    RLMRealmConfiguration *config = [RLMRealmConfiguration defaultConfiguration];
 
     // Verify that opening with class subsets without the shared schema being
     // initialized works
@@ -517,6 +517,61 @@ RLM_ARRAY_TYPE(SchemaTestClassSecondChild)
         XCTAssertEqual(realm.schema.objectSchema.count,
                        [NSSet setWithArray:[realm.schema.objectSchema valueForKey:@"className"]].count);
     }
+}
+
+- (void)testMultipleProcessesTryingToInitializeSchema {
+    RLMRealm *syncRealm = [self realmWithTestPath];
+
+    if (!self.isParent) {
+        RLMSchema *schema = [RLMSchema schemaWithObjectClasses:@[IntObject.class]];
+        schema.objectSchema[0].properties[0].type = RLMPropertyTypeFloat;
+
+        RLMRealmConfiguration *config = [RLMRealmConfiguration defaultConfiguration];
+        config.customSchema = schema;
+        config.schemaVersion = 1;
+
+        [syncRealm transactionWithBlock:^{
+            [StringObject createInRealm:syncRealm withValue:@[@""]];
+        }];
+
+        [RLMRealm realmWithConfiguration:config error:nil];
+        return;
+    }
+
+    RLMRealmConfiguration *config = [RLMRealmConfiguration defaultConfiguration];
+    config.objectClasses = @[IntObject.class];
+    RLMRealm *realm = [RLMRealm realmWithConfiguration:config error:nil];
+
+    // Hold a write transaction to prevent the child processes from performing
+    // the migration immediately
+    [realm beginWriteTransaction];
+
+    // Spawn a bunch of child processes which will all try to perform the migration
+    dispatch_group_t group = dispatch_group_create();
+    for (int i = 0; i < 5; ++i) {
+        dispatch_group_async(group, dispatch_get_global_queue(0, 0), ^{
+            RLMRunChildAndWait();
+        });
+    }
+
+    // Wait for all five to be immediately before the point where they will try
+    // to perform the migration. There's inherently a race condition here in
+    // as in theory all but one process could be suspended immediately after
+    // committing the signalling commit and then not get woken up until after
+    // the migration is complete, but in practice it won't happen and we can't
+    // wait for someone to be waiting on a mutex.
+    XCTestExpectation *notificationFired = [self expectationWithDescription:@"notification fired"];
+    RLMNotificationToken *token = [syncRealm addNotificationBlock:^(NSString *, RLMRealm *) {
+        if ([StringObject allObjectsInRealm:syncRealm].count == 5) {
+            [notificationFired fulfill];
+        }
+    }];
+    [self waitForExpectationsWithTimeout:10.0 handler:nil];
+    [realm removeNotification:token];
+
+    // Release the write transaction and let them run
+    [realm cancelWriteTransaction];
+    dispatch_group_wait(group, DISPATCH_TIME_FOREVER);
 }
 #endif
 

--- a/Realm/Tests/SchemaTests.mm
+++ b/Realm/Tests/SchemaTests.mm
@@ -524,7 +524,8 @@ RLM_ARRAY_TYPE(SchemaTestClassSecondChild)
 
     if (!self.isParent) {
         RLMSchema *schema = [RLMSchema schemaWithObjectClasses:@[IntObject.class]];
-        schema.objectSchema[0].properties[0].type = RLMPropertyTypeFloat;
+        RLMProperty *prop = ((NSArray *)[schema.objectSchema[0] properties])[0];
+        prop.type = RLMPropertyTypeFloat;
 
         RLMRealmConfiguration *config = [RLMRealmConfiguration defaultConfiguration];
         config.customSchema = schema;


### PR DESCRIPTION
If the schema was initialized by a different process between when the old schema was read and the write transaction was began, the schema init code would see the updated schema version but not re-read the schema, resulting in it thinking that a migration was required when the schema actually matched.

No changelog entry since we haven't shipped a release since when this was broken.