### PR TITLE
Fix a crash when constructing a dynamic object from a Swift type with a RealmOptional property

### DIFF
--- a/Realm/RLMObjectBase.mm
+++ b/Realm/RLMObjectBase.mm
@@ -438,6 +438,9 @@ Class RLMObjectUtilClass(BOOL isSwift) {
 + (void)initializeListProperty:(__unused RLMObjectBase *)object property:(__unused RLMProperty *)property array:(__unused RLMArray *)array {
 }
 
++ (void)initializeOptionalProperty:(__unused RLMObjectBase *)object property:(__unused RLMProperty *)property {
+}
+
 + (NSDictionary *)getOptionalProperties:(__unused id)obj {
     return nil;
 }

--- a/Realm/RLMObjectStore.mm
+++ b/Realm/RLMObjectStore.mm
@@ -102,10 +102,8 @@ void RLMInitializeSwiftAccessorGenerics(__unsafe_unretained RLMObjectBase *const
                                                                      key:prop.name
                                                             parentSchema:object->_objectSchema];
             [RLMObjectUtilClass(YES) initializeListProperty:object property:prop array:array];
-        } else if (auto ivar = prop.swiftIvar) {
-            auto optional = static_cast<RLMOptionalBase *>(object_getIvar(object, ivar));
-            optional.object = object;
-            optional.property = prop;
+        } else if (prop.swiftIvar) {
+            [RLMObjectUtilClass(YES) initializeOptionalProperty:object property:prop];
         }
     }
 }

--- a/Realm/RLMObject_Private.h
+++ b/Realm/RLMObject_Private.h
@@ -78,6 +78,7 @@ FOUNDATION_EXTERN const NSUInteger RLMDescriptionMaxDepth;
 
 + (NSArray *)getGenericListPropertyNames:(id)obj;
 + (void)initializeListProperty:(RLMObjectBase *)object property:(RLMProperty *)property array:(RLMArray *)array;
++ (void)initializeOptionalProperty:(RLMObjectBase *)object property:(RLMProperty *)property;
 
 + (NSDictionary *)getOptionalProperties:(id)obj;
 + (NSArray *)requiredPropertiesForClass:(Class)cls;

--- a/RealmSwift-swift1.2/Object.swift
+++ b/RealmSwift-swift1.2/Object.swift
@@ -179,6 +179,8 @@ public class Object: RLMObjectBase, Equatable, Printable {
             if property.type == .Array {
                 return self.listForProperty(property)
             }
+            // No special logic is needed for optional numbers here because the NSNumber returned by RLMDynamicGet
+            // is better for callers than the RealmOptional that optionalForProperty would give us.
             return RLMDynamicGet(self, property)
         }
         set(value) {

--- a/RealmSwift-swift1.2/Object.swift
+++ b/RealmSwift-swift1.2/Object.swift
@@ -335,7 +335,9 @@ public class ObjectUtil: NSObject {
     }
 
     @objc private class func initializeOptionalProperty(object: RLMObjectBase, property: RLMProperty) {
-        (object as! Object).optionalForProperty(property).object = object
+        let optional = (object as! Object).optionalForProperty(property)
+        optional.property = property
+        optional.object = object
     }
 
     @objc private class func getOptionalProperties(object: AnyObject) -> NSDictionary {

--- a/RealmSwift-swift1.2/Tests/MigrationTests.swift
+++ b/RealmSwift-swift1.2/Tests/MigrationTests.swift
@@ -192,7 +192,57 @@ class MigrationTests: TestCase {
                 XCTAssertTrue(oldObject! as AnyObject is MigrationObject)
                 XCTAssertTrue(newObject! as AnyObject is MigrationObject)
                 XCTAssertTrue(oldObject!["array"]! is List<MigrationObject>)
-                XCTAssertTrue(oldObject!["array"]! is List<MigrationObject>)
+                XCTAssertTrue(newObject!["array"]! is List<MigrationObject>)
+            }
+        }
+
+        autoreleasepool {
+            Realm().write {
+                let soo = SwiftOptionalObject()
+                soo.optNSStringCol = "NSString"
+                soo.optStringCol = "String"
+                soo.optBinaryCol = NSData()
+                soo.optDateCol = NSDate()
+                soo.optIntCol.value = 1
+                soo.optInt8Col.value = 2
+                soo.optInt16Col.value = 3
+                soo.optInt32Col.value = 4
+                soo.optInt64Col.value = 5
+                soo.optFloatCol.value = 6.1
+                soo.optDoubleCol.value = 7.2
+                soo.optBoolCol.value = true
+                Realm().add(soo)
+            }
+        }
+
+        migrateAndTestDefaultRealm(schemaVersion: 4) { migration, oldSchemaVersion in
+            migration.enumerate("SwiftOptionalObject") { oldObject, newObject in
+                XCTAssertTrue(oldObject! as AnyObject is MigrationObject)
+                XCTAssertTrue(newObject! as AnyObject is MigrationObject)
+                XCTAssertTrue(oldObject!["optNSStringCol"]! is NSString)
+                XCTAssertTrue(newObject!["optNSStringCol"]! is NSString)
+                XCTAssertTrue(oldObject!["optStringCol"]! is String)
+                XCTAssertTrue(newObject!["optStringCol"]! is String)
+                XCTAssertTrue(oldObject!["optBinaryCol"]! is NSData)
+                XCTAssertTrue(newObject!["optBinaryCol"]! is NSData)
+                XCTAssertTrue(oldObject!["optDateCol"]! is NSDate)
+                XCTAssertTrue(newObject!["optDateCol"]! is NSDate)
+                XCTAssertTrue(oldObject!["optIntCol"]! is Int)
+                XCTAssertTrue(newObject!["optIntCol"]! is Int)
+                XCTAssertTrue(oldObject!["optInt8Col"]! is Int)
+                XCTAssertTrue(newObject!["optInt8Col"]! is Int)
+                XCTAssertTrue(oldObject!["optInt16Col"]! is Int)
+                XCTAssertTrue(newObject!["optInt16Col"]! is Int)
+                XCTAssertTrue(oldObject!["optInt32Col"]! is Int)
+                XCTAssertTrue(newObject!["optInt32Col"]! is Int)
+                XCTAssertTrue(oldObject!["optInt64Col"]! is Int)
+                XCTAssertTrue(newObject!["optInt64Col"]! is Int)
+                XCTAssertTrue(oldObject!["optFloatCol"]! is Float)
+                XCTAssertTrue(newObject!["optFloatCol"]! is Float)
+                XCTAssertTrue(oldObject!["optDoubleCol"]! is Double)
+                XCTAssertTrue(newObject!["optDoubleCol"]! is Double)
+                XCTAssertTrue(oldObject!["optBoolCol"]! is Bool)
+                XCTAssertTrue(newObject!["optBoolCol"]! is Bool)
             }
         }
     }

--- a/RealmSwift-swift2.0/Object.swift
+++ b/RealmSwift-swift2.0/Object.swift
@@ -184,6 +184,8 @@ public class Object: RLMObjectBase {
             if property.type == .Array {
                 return self.listForProperty(property)
             }
+            // No special logic is needed for optional numbers here because the NSNumber returned by RLMDynamicGet
+            // is better for callers than the RealmOptional that optionalForProperty would give us.
             return RLMDynamicGet(self, property)
         }
         set(value) {

--- a/RealmSwift-swift2.0/Object.swift
+++ b/RealmSwift-swift2.0/Object.swift
@@ -333,7 +333,9 @@ public class ObjectUtil: NSObject {
     }
 
     @objc private class func initializeOptionalProperty(object: RLMObjectBase, property: RLMProperty) {
-        (object as! Object).optionalForProperty(property).object = object
+        let optional = (object as! Object).optionalForProperty(property)
+        optional.property = property
+        optional.object = object
     }
 
     @objc private class func getOptionalProperties(object: AnyObject) -> NSDictionary {

--- a/RealmSwift-swift2.0/Object.swift
+++ b/RealmSwift-swift2.0/Object.swift
@@ -250,6 +250,11 @@ public class Object: RLMObjectBase {
     internal func listForProperty(prop: RLMProperty) -> RLMListBase {
         return object_getIvar(self, prop.swiftIvar) as! RLMListBase
     }
+
+    // Helper for getting the optional object for a property
+    internal func optionalForProperty(prop: RLMProperty) -> RLMOptionalBase {
+        return object_getIvar(self, prop.swiftIvar) as! RLMOptionalBase
+    }
 }
 
 
@@ -258,6 +263,7 @@ public class Object: RLMObjectBase {
 /// :nodoc:
 public final class DynamicObject: Object {
     private var listProperties = [String: List<DynamicObject>]()
+    private var optionalProperties = [String: RLMOptionalBase]()
 
     // Override to create List<DynamicObject> on access
     internal override func listForProperty(prop: RLMProperty) -> RLMListBase {
@@ -267,6 +273,17 @@ public final class DynamicObject: Object {
         let list = List<DynamicObject>()
         listProperties[prop.name] = list
         return list
+    }
+
+    // Override to create RealmOptional on access
+    internal override func optionalForProperty(prop: RLMProperty) -> RLMOptionalBase {
+        if let optional = optionalProperties[prop.name] {
+            return optional
+        }
+        let optional = RLMOptionalBase()
+        optional.property = prop
+        optionalProperties[prop.name] = optional
+        return optional
     }
 
     /// :nodoc:
@@ -313,6 +330,10 @@ public class ObjectUtil: NSObject {
 
     @objc private class func initializeListProperty(object: RLMObjectBase, property: RLMProperty, array: RLMArray) {
         (object as! Object).listForProperty(property)._rlmArray = array
+    }
+
+    @objc private class func initializeOptionalProperty(object: RLMObjectBase, property: RLMProperty) {
+        (object as! Object).optionalForProperty(property).object = object
     }
 
     @objc private class func getOptionalProperties(object: AnyObject) -> NSDictionary {

--- a/RealmSwift-swift2.0/Tests/MigrationTests.swift
+++ b/RealmSwift-swift2.0/Tests/MigrationTests.swift
@@ -192,7 +192,57 @@ class MigrationTests: TestCase {
                 XCTAssertTrue(oldObject! as AnyObject is MigrationObject)
                 XCTAssertTrue(newObject! as AnyObject is MigrationObject)
                 XCTAssertTrue(oldObject!["array"]! is List<MigrationObject>)
-                XCTAssertTrue(oldObject!["array"]! is List<MigrationObject>)
+                XCTAssertTrue(newObject!["array"]! is List<MigrationObject>)
+            }
+        }
+
+        autoreleasepool {
+            try! Realm().write {
+                let soo = SwiftOptionalObject()
+                soo.optNSStringCol = "NSString"
+                soo.optStringCol = "String"
+                soo.optBinaryCol = NSData()
+                soo.optDateCol = NSDate()
+                soo.optIntCol.value = 1
+                soo.optInt8Col.value = 2
+                soo.optInt16Col.value = 3
+                soo.optInt32Col.value = 4
+                soo.optInt64Col.value = 5
+                soo.optFloatCol.value = 6.1
+                soo.optDoubleCol.value = 7.2
+                soo.optBoolCol.value = true
+                try! Realm().add(soo)
+            }
+        }
+
+        migrateAndTestDefaultRealm(4) { migration, oldSchemaVersion in
+            migration.enumerate("SwiftOptionalObject") { oldObject, newObject in
+                XCTAssertTrue(oldObject! as AnyObject is MigrationObject)
+                XCTAssertTrue(newObject! as AnyObject is MigrationObject)
+                XCTAssertTrue(oldObject!["optNSStringCol"]! is NSString)
+                XCTAssertTrue(newObject!["optNSStringCol"]! is NSString)
+                XCTAssertTrue(oldObject!["optStringCol"]! is String)
+                XCTAssertTrue(newObject!["optStringCol"]! is String)
+                XCTAssertTrue(oldObject!["optBinaryCol"]! is NSData)
+                XCTAssertTrue(newObject!["optBinaryCol"]! is NSData)
+                XCTAssertTrue(oldObject!["optDateCol"]! is NSDate)
+                XCTAssertTrue(newObject!["optDateCol"]! is NSDate)
+                XCTAssertTrue(oldObject!["optIntCol"]! is Int)
+                XCTAssertTrue(newObject!["optIntCol"]! is Int)
+                XCTAssertTrue(oldObject!["optInt8Col"]! is Int)
+                XCTAssertTrue(newObject!["optInt8Col"]! is Int)
+                XCTAssertTrue(oldObject!["optInt16Col"]! is Int)
+                XCTAssertTrue(newObject!["optInt16Col"]! is Int)
+                XCTAssertTrue(oldObject!["optInt32Col"]! is Int)
+                XCTAssertTrue(newObject!["optInt32Col"]! is Int)
+                XCTAssertTrue(oldObject!["optInt64Col"]! is Int)
+                XCTAssertTrue(newObject!["optInt64Col"]! is Int)
+                XCTAssertTrue(oldObject!["optFloatCol"]! is Float)
+                XCTAssertTrue(newObject!["optFloatCol"]! is Float)
+                XCTAssertTrue(oldObject!["optDoubleCol"]! is Double)
+                XCTAssertTrue(newObject!["optDoubleCol"]! is Double)
+                XCTAssertTrue(oldObject!["optBoolCol"]! is Bool)
+                XCTAssertTrue(newObject!["optBoolCol"]! is Bool)
             }
         }
     }


### PR DESCRIPTION
Fixes #2859.

Needs:
- [x] Don't break existing tests.
- [x] New tests for #2859 
