### PR TITLE
Fixes to Objective-C doc comments

### DIFF
--- a/Realm/RLMArray.h
+++ b/Realm/RLMArray.h
@@ -90,7 +90,7 @@ RLM_ASSUME_NONNULL_BEGIN
 
  @param index   The index to look up.
 
- @return An RLMObject of the class contained by this RLMArray.
+ @return An RLMObject of the type contained in this RLMArray.
  */
 - (RLMObjectType)objectAtIndex:(NSUInteger)index;
 
@@ -99,7 +99,7 @@ RLM_ASSUME_NONNULL_BEGIN
 
  Returns `nil` if called on an empty RLMArray.
 
- @return An RLMObject of the class contained by this RLMArray.
+ @return An RLMObject of the type contained in this RLMArray.
  */
 - (nullable RLMObjectType)firstObject;
 
@@ -108,7 +108,7 @@ RLM_ASSUME_NONNULL_BEGIN
 
  Returns `nil` if called on an empty RLMArray.
 
- @return An RLMObject of the class contained by this RLMArray.
+ @return An RLMObject of the type contained in this RLMArray.
  */
 - (nullable RLMObjectType)lastObject;
 
@@ -121,7 +121,7 @@ RLM_ASSUME_NONNULL_BEGIN
 
  @warning This method can only be called during a write transaction.
 
- @param object  An RLMObject of the class contained by this RLMArray.
+ @param object  An RLMObject of the type contained in this RLMArray.
  */
 - (void)addObject:(RLMObjectArgument)object;
 
@@ -138,11 +138,11 @@ RLM_ASSUME_NONNULL_BEGIN
 /**
  Inserts an object at the given index.
 
- Throws an exception when called with an index greater than the number of objects in this RLMArray.
+ Throws an exception when the index exceeds the bounds of this RLMArray.
 
  @warning This method can only be called during a write transaction.
 
- @param anObject  An object (of the same type as returned from the objectClassName selector).
+ @param anObject  An RLMObject of the type contained in this RLMArray.
  @param index   The array index at which the object is inserted.
  */
 - (void)insertObject:(RLMObjectArgument)anObject atIndex:(NSUInteger)index;
@@ -150,7 +150,7 @@ RLM_ASSUME_NONNULL_BEGIN
 /**
  Removes an object at a given index.
 
- Throws an exception when called with an index greater than the number of objects in this RLMArray.
+ Throws an exception when the index exceeds the bounds of this RLMArray.
 
  @warning This method can only be called during a write transaction.
 
@@ -175,7 +175,7 @@ RLM_ASSUME_NONNULL_BEGIN
 /**
  Replaces an object at the given index with a new object.
 
- Throws an exception when called with an index greater than the number of objects in this RLMArray.
+ Throws an exception when the index exceeds the bounds of this RLMArray.
 
  @warning This method can only be called during a write transaction.
 
@@ -187,8 +187,7 @@ RLM_ASSUME_NONNULL_BEGIN
 /**
  Moves the object at the given source index to the given destination index.
 
- Throws an exception when called with an index greater than or equal to the
- number of objects in this RLMArray.
+ Throws an exception when the index exceeds the bounds of this RLMArray.
 
  @warning This method can only be called during a write transaction.
 

--- a/Realm/RLMCollection.h
+++ b/Realm/RLMCollection.h
@@ -53,7 +53,7 @@ RLM_ASSUME_NONNULL_BEGIN
  
  @param index   The index to look up.
  
- @return An RLMObject of the class contained by this RLMCollection.
+ @return An RLMObject of the type contained in this RLMCollection.
  */
 - (id)objectAtIndex:(NSUInteger)index;
 
@@ -62,7 +62,7 @@ RLM_ASSUME_NONNULL_BEGIN
  
  Returns `nil` if called on an empty RLMCollection.
  
- @return An RLMObject of the class contained by this RLMCollection.
+ @return An RLMObject of the type contained in this RLMCollection.
  */
 - (nullable id)firstObject;
 
@@ -71,7 +71,7 @@ RLM_ASSUME_NONNULL_BEGIN
  
  Returns `nil` if called on an empty RLMCollection.
  
- @return An RLMObject of the class contained by this RLMCollection.
+ @return An RLMObject of the type contained in this RLMCollection.
  */
 - (nullable id)lastObject;
 

--- a/Realm/RLMMigration.h
+++ b/Realm/RLMMigration.h
@@ -26,7 +26,7 @@ RLM_ASSUME_NONNULL_BEGIN
 @class RLMObject;
 
 /**
-Provides both the old and new versions of an object in this Realm. Objects properties can only be
+Provides both the old and new versions of an object in this Realm. Object properties can only be
 accessed using keyed subscripting.
 
 @param oldObject Object in original RLMRealm (read-only).

--- a/Realm/RLMObject.h
+++ b/Realm/RLMObject.h
@@ -371,12 +371,12 @@ RLM_ASSUME_NONNULL_BEGIN
 
 /**
  Get an `NSArray` of objects of type `className` which have this object as the given property value. This can
- be used to get the inverse relatshionship value for `RLMObject` and `RLMArray` properties.
+ be used to get the inverse relationship value for `RLMObject` and `RLMArray` properties.
 
  @param className   The type of object on which the relationship to query is defined.
  @param property    The name of the property which defines the relationship.
 
- @return    An NSArray of objects of type `className` which have this object as thier value for the `property` property.
+ @return    An NSArray of objects of type `className` which have this object as their value for the `property` property.
  */
 - (NSArray *)linkingObjectsOfClass:(NSString *)className forProperty:(NSString *)property;
 
@@ -406,7 +406,7 @@ RLM_ASSUME_NONNULL_BEGIN
 /**
  Properties on RLMObjects of type RLMArray must have an associated type. A type is associated
  with an RLMArray property by defining a protocol for the object type which the RLMArray will
- hold. To define an protocol for an object you can use the macro RLM_ARRAY_TYPE:
+ hold. To define the protocol for an object you can use the macro RLM_ARRAY_TYPE:
  
      RLM_ARRAY_TYPE(ObjectType)
      ...

--- a/Realm/RLMObjectBase_Dynamic.h
+++ b/Realm/RLMObjectBase_Dynamic.h
@@ -51,7 +51,7 @@ FOUNDATION_EXTERN RLMObjectSchema *RLMObjectBaseObjectSchema(RLMObjectBase *obje
  @param className	The type of object on which the relationship to query is defined.
  @param property	The name of the property which defines the relationship.
  
- @return An NSArray of objects of type `className` which have this object as thier value for the `property` property.
+ @return An NSArray of objects of type `className` which have this object as their value for the `property` property.
  */
 FOUNDATION_EXTERN NSArray *RLMObjectBaseLinkingObjectsOfClass(RLMObjectBase *object, NSString *className, NSString *property);
 

--- a/Realm/RLMObjectSchema.h
+++ b/Realm/RLMObjectSchema.h
@@ -24,7 +24,7 @@ RLM_ASSUME_NONNULL_BEGIN
 @class RLMProperty;
 
 /**
- This class represents Realm model object schemas persisted to Realm in an RLMSchema.
+ This class represents Realm model object schemas.
 
  When using Realm, RLMObjectSchema objects allow performing migrations and
  introspecting the database's schema.

--- a/Realm/RLMResults.h
+++ b/Realm/RLMResults.h
@@ -59,7 +59,7 @@ RLM_ASSUME_NONNULL_BEGIN
 
  @param index   The index to look up.
 
- @return An RLMObject of the class contained by this RLMResults.
+ @return An RLMObject of the type contained in this RLMResults.
  */
 - (RLMObjectType)objectAtIndex:(NSUInteger)index;
 
@@ -68,7 +68,7 @@ RLM_ASSUME_NONNULL_BEGIN
 
  Returns `nil` if called on an empty RLMResults.
 
- @return An RLMObject of the class contained by this RLMResults.
+ @return An RLMObject of the type contained in this RLMResults.
  */
 - (nullable RLMObjectType)firstObject;
 
@@ -77,7 +77,7 @@ RLM_ASSUME_NONNULL_BEGIN
 
  Returns `nil` if called on an empty RLMResults.
 
- @return An RLMObject of the class contained by this RLMResults.
+ @return An RLMObject of the type contained in this RLMResults.
  */
 - (nullable RLMObjectType)lastObject;
 

--- a/Realm/RLMSchema.h
+++ b/Realm/RLMSchema.h
@@ -36,7 +36,7 @@ RLM_ASSUME_NONNULL_BEGIN
 #pragma mark - Properties
 
 /**
- An NSArray containing RLMObjectSchema's for all object types in this Realm. Meant
+ An NSArray containing RLMObjectSchemas for all object types in this Realm. Meant
  to be used during migrations for dynamic introspection.
 
  @see RLMObjectSchema
@@ -56,8 +56,8 @@ RLM_ASSUME_NONNULL_BEGIN
 - (nullable RLMObjectSchema *)schemaForClassName:(NSString *)className;
 
 /**
- Look up an RLMObjectSchema for the given class name in this Realm. Throws if there
- is no object of type className in this RLMSchema instance.
+ Look up an RLMObjectSchema for the given class name in this Realm. Throws 
+ an exception if there is no object of type className in this RLMSchema instance.
 
  @param className   The object class name.
  @return            RLMObjectSchema for the given class in this Realm.
@@ -67,7 +67,7 @@ RLM_ASSUME_NONNULL_BEGIN
 - (RLMObjectSchema *)objectForKeyedSubscript:(id <NSCopying>)className;
 
 /**
- Returns YES if schema are equal
+ Returns YES if equal to schema
  */
 - (BOOL)isEqualToSchema:(RLMSchema *)schema;
 

--- a/RealmSwift-swift1.2/Realm.swift
+++ b/RealmSwift-swift1.2/Realm.swift
@@ -163,7 +163,7 @@ public final class Realm {
     }
 
     /**
-    Revert all writes made in the current write transaction and end the transaction.
+    Reverts all writes made in the current write transaction and end the transaction.
 
     This rolls back all objects in the Realm to the state they were in at the
     beginning of the write transaction, and then ends the transaction.
@@ -493,9 +493,9 @@ public final class Realm {
     committed.  If set to `false`, you must manually call `refresh()` on the Realm to
     update it to get the latest version.
 
-    Note that on background threads, the run loop is not run by default and you will 
-	will need to manually call `refresh()` in order to update to the latest version,
-	even if `autorefresh` is set to `true`.
+    Note that by default, background threads do not have an active run loop and you 
+    will need to manually call `refresh()` in order to update to the latest version,
+    even if `autorefresh` is set to `true`.
 	
     Even with this enabled, you can still call `refresh()` at any time to update the
     Realm before the automatic refresh would occur.

--- a/RealmSwift-swift2.0/Realm.swift
+++ b/RealmSwift-swift2.0/Realm.swift
@@ -138,7 +138,7 @@ public final class Realm {
     }
 
     /**
-    Revert all writes made in the current write transaction and end the transaction.
+    Reverts all writes made in the current write transaction and end the transaction.
 
     This rolls back all objects in the Realm to the state they were in at the
     beginning of the write transaction, and then ends the transaction.
@@ -467,10 +467,10 @@ public final class Realm {
     in this Realm on the next cycle of the run loop after the changes are
     committed.  If set to `false`, you must manually call `refresh()` on the Realm to
     update it to get the latest version.
-
-	Note that on background threads, the run loop is not run by default and you will
-	will need to manually call `refresh()` in order to update to the latest version,
-	even if `autorefresh` is set to `true`.
+	
+    Note that by default, background threads do not have an active run loop and you 
+    will need to manually call `refresh()` in order to update to the latest version,
+    even if `autorefresh` is set to `true`.
 
     Even with this enabled, you can still call `refresh()` at any time to update the
     Realm before the automatic refresh would occur.


### PR DESCRIPTION
I applied the same changes made to the Swift comments where appropriate; other than that it was just a few minor typos etc.