### PR TITLE
Validate schema changes made from other processes

### DIFF
--- a/Realm/ObjectStore/impl/transact_log_handler.cpp
+++ b/Realm/ObjectStore/impl/transact_log_handler.cpp
@@ -27,7 +27,110 @@
 using namespace realm;
 
 namespace {
-class TransactLogHandler {
+// A transaction log handler that just validates that all operations made are
+// onces supported by the object store
+class TransactLogValidator {
+    // Index of currently selected table
+    size_t m_current_table = 0;
+
+    // Tables which were created during the transaction being processed, which
+    // can have columns inserted without a schema version bump
+    std::vector<size_t> m_new_tables;
+
+    REALM_NORETURN
+    REALM_NOINLINE
+    void schema_error()
+    {
+        throw std::runtime_error("Schema mismatch detected: another process has modified the Realm file's schema in an incompatible way");
+    }
+
+    bool schema_error_unless_new_table()
+    {
+        if (std::find(begin(m_new_tables), end(m_new_tables), m_current_table) == end(m_new_tables)) {
+            schema_error();
+        }
+        return true;
+    }
+
+protected:
+    size_t current_table() const noexcept { return m_current_table; }
+
+public:
+    // Schema changes which don't involve a change in the schema version are
+    // allowed
+    bool add_search_index(size_t) { return true; }
+    bool remove_search_index(size_t) { return true; }
+
+    // Creating entirely new tables without a schema version bump is allowed, so
+    // we need to track if new columns are being added to a new table or an
+    // existing one
+    bool insert_group_level_table(size_t table_ndx, size_t, StringData)
+    {
+        m_new_tables.push_back(table_ndx);
+        return true;
+    }
+    bool insert_column(size_t, DataType, StringData, bool) { return schema_error_unless_new_table(); }
+    bool insert_link_column(size_t, DataType, StringData, size_t, size_t) { return schema_error_unless_new_table(); }
+    bool add_primary_key(size_t) { return schema_error_unless_new_table(); }
+    bool set_link_type(size_t, LinkType) { return schema_error_unless_new_table(); }
+
+    // Removing or renaming things while a Realm is open is never supported
+    bool erase_group_level_table(size_t, size_t) { schema_error(); }
+    bool rename_group_level_table(size_t, StringData) { schema_error(); }
+    bool erase_column(size_t) { schema_error(); }
+    bool erase_link_column(size_t, size_t, size_t) { schema_error(); }
+    bool rename_column(size_t, StringData) { schema_error(); }
+    bool remove_primary_key() { schema_error(); }
+    bool move_column(size_t, size_t) { schema_error(); }
+    bool move_group_level_table(size_t, size_t) { schema_error(); }
+
+    bool select_descriptor(int levels, const size_t*)
+    {
+        // subtables not supported
+        return levels == 0;
+    }
+
+    bool select_table(size_t group_level_ndx, int, const size_t*) noexcept
+    {
+        m_current_table = group_level_ndx;
+        return true;
+    }
+
+    bool select_link_list(size_t, size_t, size_t) { return true; }
+
+    // Non-schema changes are all allowed
+    void parse_complete() { }
+    bool insert_empty_rows(size_t, size_t, size_t, bool) { return true; }
+    bool erase_rows(size_t, size_t, size_t, bool) { return true; }
+    bool swap_rows(size_t, size_t) { return true; }
+    bool clear_table() noexcept { return true; }
+    bool link_list_set(size_t, size_t) { return true; }
+    bool link_list_insert(size_t, size_t) { return true; }
+    bool link_list_erase(size_t) { return true; }
+    bool link_list_nullify(size_t) { return true; }
+    bool link_list_clear(size_t) { return true; }
+    bool link_list_move(size_t, size_t) { return true; }
+    bool link_list_swap(size_t, size_t) { return true; }
+    bool set_int(size_t, size_t, int_fast64_t) { return true; }
+    bool set_bool(size_t, size_t, bool) { return true; }
+    bool set_float(size_t, size_t, float) { return true; }
+    bool set_double(size_t, size_t, double) { return true; }
+    bool set_string(size_t, size_t, StringData) { return true; }
+    bool set_binary(size_t, size_t, BinaryData) { return true; }
+    bool set_date_time(size_t, size_t, DateTime) { return true; }
+    bool set_table(size_t, size_t) { return true; }
+    bool set_mixed(size_t, size_t, const Mixed&) { return true; }
+    bool set_link(size_t, size_t, size_t, size_t) { return true; }
+    bool set_null(size_t, size_t) { return true; }
+    bool nullify_link(size_t, size_t, size_t) { return true; }
+    bool insert_substring(size_t, size_t, size_t, StringData) { return true; }
+    bool erase_substring(size_t, size_t, size_t, size_t) { return true; }
+    bool optimize_table() { return true; }
+};
+
+// Extends TransactLogValidator to also track changes and report it to the
+// binding context if any properties are being observed
+class TransactLogObserver : public TransactLogValidator {
     using ColumnInfo = BindingContext::ColumnInfo;
     using ObserverState = BindingContext::ObserverState;
 
@@ -36,10 +139,8 @@ class TransactLogHandler {
     // Userdata pointers for rows which have been deleted
     std::vector<void *> invalidated;
     // Delegate to send change information to
-    BindingContext* m_delegate;
+    BindingContext* m_context;
 
-    // Index of currently selected table
-    size_t m_current_table = 0;
     // Change information for the currently selected LinkList, if any
     ColumnInfo* m_active_linklist = nullptr;
 
@@ -71,8 +172,8 @@ class TransactLogHandler {
     // Mark the given row/col as needing notifications sent
     bool mark_dirty(size_t row_ndx, size_t col_ndx)
     {
-        auto it = lower_bound(begin(m_observers), end(m_observers), ObserverState{m_current_table, row_ndx, nullptr});
-        if (it != end(m_observers) && it->table_ndx == m_current_table && it->row_ndx == row_ndx) {
+        auto it = lower_bound(begin(m_observers), end(m_observers), ObserverState{current_table(), row_ndx, nullptr});
+        if (it != end(m_observers) && it->table_ndx == current_table() && it->row_ndx == row_ndx) {
             get_change(*it, col_ndx).changed = true;
         }
         return true;
@@ -93,9 +194,11 @@ class TransactLogHandler {
         throw std::runtime_error("Schema mismatch detected: another process has modified the Realm file's schema in an incompatible way");
     }
 
+    // Throw an exception if the currently modified table already existed before
+    // the current set of modifications
     bool schema_error_unless_new_table()
     {
-        if (std::find(begin(m_new_tables), end(m_new_tables), m_current_table) == end(m_new_tables)) {
+        if (std::find(begin(m_new_tables), end(m_new_tables), current_table()) == end(m_new_tables)) {
             schema_error();
         }
         return true;
@@ -103,69 +206,55 @@ class TransactLogHandler {
 
 public:
     template<typename Func>
-    TransactLogHandler(BindingContext* delegate, SharedGroup& sg, Func&& func)
-    : m_delegate(delegate)
+    TransactLogObserver(BindingContext* context, SharedGroup& sg, Func&& func, bool validate_schema_changes)
+    : m_context(context)
     {
-        if (!delegate) {
-            func();
+        if (!context) {
+            if (validate_schema_changes) {
+                // The handler functions are non-virtual, so the parent class's
+                // versions are called if we don't need to track changes to observed
+                // objects
+                func(static_cast<TransactLogValidator&>(*this));
+            }
+            else {
+                func();
+            }
             return;
         }
 
-        m_observers = delegate->get_observed_rows();
+        m_observers = context->get_observed_rows();
         if (m_observers.empty()) {
             auto old_version = sg.get_version_of_current_transaction();
-            func();
+            if (validate_schema_changes) {
+                func(static_cast<TransactLogValidator&>(*this));
+            }
+            else {
+                func();
+            }
             if (old_version != sg.get_version_of_current_transaction()) {
-                delegate->did_change({}, {});
+                context->did_change({}, {});
             }
             return;
         }
 
         func(*this);
-        delegate->did_change(m_observers, invalidated);
+        context->did_change(m_observers, invalidated);
     }
 
     // Called at the end of the transaction log immediately before the version
     // is advanced
     void parse_complete()
     {
-        m_delegate->will_change(m_observers, invalidated);
+        m_context->will_change(m_observers, invalidated);
     }
 
-    // Schema changes which don't involve a change in the schema version are
-    // allowed
-    bool add_search_index(size_t) { return true; }
-    bool remove_search_index(size_t) { return true; }
-
-    // Creating entirely new tables without a schema version bump is allowed, so
-    // we need to track if new columns are being added to a new table or an
-    // existing one
-    bool insert_group_level_table(size_t table_ndx, size_t, StringData)
+    bool insert_group_level_table(size_t table_ndx, size_t prior_size, StringData name)
     {
         for (auto& observer : m_observers) {
             if (observer.table_ndx >= table_ndx)
                 ++observer.table_ndx;
         }
-        m_new_tables.push_back(table_ndx);
-        return true;
-    }
-
-    bool insert_column(size_t, DataType, StringData, bool) { return schema_error_unless_new_table(); }
-    bool insert_link_column(size_t, DataType, StringData, size_t, size_t) { return schema_error_unless_new_table(); }
-    bool add_primary_key(size_t) { return schema_error_unless_new_table(); }
-    bool set_link_type(size_t, LinkType) { return schema_error_unless_new_table(); }
-
-    // Schema changes which are never allowed while a file is open
-    bool erase_group_level_table(size_t, size_t) { schema_error(); }
-    bool rename_group_level_table(size_t, StringData) { schema_error(); }
-    bool erase_column(size_t) { schema_error(); }
-    bool erase_link_column(size_t, size_t, size_t) { schema_error(); }
-    bool rename_column(size_t, StringData) { schema_error(); }
-    bool remove_primary_key() { schema_error(); }
-
-    bool select_table(size_t group_level_ndx, int, const size_t*) noexcept
-    {
-        m_current_table = group_level_ndx;
+        TransactLogValidator::insert_group_level_table(table_ndx, prior_size, name);
         return true;
     }
 
@@ -179,7 +268,7 @@ public:
     {
         for (size_t i = 0; i < m_observers.size(); ++i) {
             auto& o = m_observers[i];
-            if (o.table_ndx == m_current_table) {
+            if (o.table_ndx == current_table()) {
                 if (o.row_ndx == row_ndx) {
                     invalidate(&o);
                     --i;
@@ -199,7 +288,7 @@ public:
     {
         for (size_t i = 0; i < m_observers.size(); ) {
             auto& o = m_observers[i];
-            if (o.table_ndx == m_current_table) {
+            if (o.table_ndx == current_table()) {
                 invalidate(&o);
             }
             else {
@@ -213,7 +302,7 @@ public:
     {
         m_active_linklist = nullptr;
         for (auto& o : m_observers) {
-            if (o.table_ndx == m_current_table && o.row_ndx == row) {
+            if (o.table_ndx == current_table() && o.row_ndx == row) {
                 m_active_linklist = &get_change(o, col);
                 break;
             }
@@ -342,47 +431,41 @@ public:
     bool nullify_link(size_t col, size_t row, size_t) { return mark_dirty(row, col); }
     bool insert_substring(size_t col, size_t row, size_t, StringData) { return mark_dirty(row, col); }
     bool erase_substring(size_t col, size_t row, size_t, size_t) { return mark_dirty(row, col); }
-
-    // Doesn't change any data
-    bool optimize_table() { return true; }
-
-    // Used for subtables, which we currently don't support
-    bool select_descriptor(int, const size_t*) { return false; }
-
-    // Not implemented
-    bool swap_rows(size_t, size_t) { return false; }
-    bool move_column(size_t, size_t) { return false; }
-    bool move_group_level_table(size_t, size_t) { return false; }
 };
 } // anonymous namespace
 
 namespace realm {
 namespace _impl {
 namespace transaction {
-void advance(SharedGroup& sg, ClientHistory& history, BindingContext* delegate) {
-    TransactLogHandler(delegate, sg, [&](auto&&... args) {
+void advance(SharedGroup& sg, ClientHistory& history, BindingContext* context)
+{
+    TransactLogObserver(context, sg, [&](auto&&... args) {
         LangBindHelper::advance_read(sg, history, std::move(args)...);
-    });
+    }, true);
 }
 
-void begin(SharedGroup& sg, ClientHistory& history, BindingContext* delegate) {
-    TransactLogHandler(delegate, sg, [&](auto&&... args) {
+void begin(SharedGroup& sg, ClientHistory& history, BindingContext* context,
+           bool validate_schema_changes)
+{
+    TransactLogObserver(context, sg, [&](auto&&... args) {
         LangBindHelper::promote_to_write(sg, history, std::move(args)...);
-    });
+    }, validate_schema_changes);
 }
 
-void commit(SharedGroup& sg, ClientHistory&, BindingContext* delegate) {
+void commit(SharedGroup& sg, ClientHistory&, BindingContext* context)
+{
     LangBindHelper::commit_and_continue_as_read(sg);
 
-    if (delegate) {
-        delegate->did_change({}, {});
+    if (context) {
+        context->did_change({}, {});
     }
 }
 
-void cancel(SharedGroup& sg, ClientHistory& history, BindingContext* delegate) {
-    TransactLogHandler(delegate, sg, [&](auto&&... args) {
+void cancel(SharedGroup& sg, ClientHistory& history, BindingContext* context)
+{
+    TransactLogObserver(context, sg, [&](auto&&... args) {
         LangBindHelper::rollback_and_continue_as_read(sg, history, std::move(args)...);
-    });
+    }, false);
 }
 
 } // namespace transaction

--- a/Realm/ObjectStore/impl/transact_log_handler.cpp
+++ b/Realm/ObjectStore/impl/transact_log_handler.cpp
@@ -44,6 +44,8 @@ class TransactLogValidator {
         throw std::runtime_error("Schema mismatch detected: another process has modified the Realm file's schema in an incompatible way");
     }
 
+    // Throw an exception if the currently modified table already existed before
+    // the current set of modifications
     bool schema_error_unless_new_table()
     {
         if (std::find(begin(m_new_tables), end(m_new_tables), m_current_table) == end(m_new_tables)) {
@@ -185,23 +187,6 @@ class TransactLogObserver : public TransactLogValidator {
     {
         invalidated.push_back(o->info);
         m_observers.erase(m_observers.begin() + (o - &m_observers[0]));
-    }
-
-    REALM_NORETURN
-    REALM_NOINLINE
-    void schema_error()
-    {
-        throw std::runtime_error("Schema mismatch detected: another process has modified the Realm file's schema in an incompatible way");
-    }
-
-    // Throw an exception if the currently modified table already existed before
-    // the current set of modifications
-    bool schema_error_unless_new_table()
-    {
-        if (std::find(begin(m_new_tables), end(m_new_tables), current_table()) == end(m_new_tables)) {
-            schema_error();
-        }
-        return true;
     }
 
 public:

--- a/Realm/ObjectStore/impl/transact_log_handler.cpp
+++ b/Realm/ObjectStore/impl/transact_log_handler.cpp
@@ -28,7 +28,7 @@ using namespace realm;
 
 namespace {
 // A transaction log handler that just validates that all operations made are
-// onces supported by the object store
+// ones supported by the object store
 class TransactLogValidator {
     // Index of currently selected table
     size_t m_current_table = 0;

--- a/Realm/ObjectStore/impl/transact_log_handler.cpp
+++ b/Realm/ObjectStore/impl/transact_log_handler.cpp
@@ -68,6 +68,11 @@ public:
     // existing one
     bool insert_group_level_table(size_t table_ndx, size_t, StringData)
     {
+        // Shift any previously added tables after the new one
+        for (auto& table : m_new_tables) {
+            if (table >= table_ndx)
+                ++table;
+        }
         m_new_tables.push_back(table_ndx);
         return true;
     }

--- a/Realm/ObjectStore/impl/transact_log_handler.hpp
+++ b/Realm/ObjectStore/impl/transact_log_handler.hpp
@@ -33,7 +33,8 @@ void advance(SharedGroup& sg, ClientHistory& history, BindingContext* delegate);
 // Begin a write transaction
 // If the read transaction version is not up to date, will first advance to the
 // most recent read transaction and sent notifications to delegate
-void begin(SharedGroup& sg, ClientHistory& history, BindingContext* delegate);
+void begin(SharedGroup& sg, ClientHistory& history, BindingContext* delegate,
+           bool validate_schema_changes=true);
 
 // Commit a write transaction
 void commit(SharedGroup& sg, ClientHistory& history, BindingContext* delegate);

--- a/Realm/ObjectStore/shared_realm.cpp
+++ b/Realm/ObjectStore/shared_realm.cpp
@@ -193,7 +193,11 @@ void Realm::update_schema(std::unique_ptr<Schema> schema, uint64_t version)
         return;
     }
 
-    begin_transaction();
+    read_group();
+    transaction::begin(*m_shared_group, *m_history, m_binding_context.get(),
+                       /* error on schema changes */ false);
+    m_in_transaction = true;
+
     struct WriteTransactionGuard {
         Realm& realm;
         ~WriteTransactionGuard() {

--- a/Realm/Tests/KVOTests.mm
+++ b/Realm/Tests/KVOTests.mm
@@ -26,6 +26,8 @@
 #import "RLMRealm_Private.hpp"
 #import "RLMSchema_Private.h"
 
+#import <realm/group.hpp>
+
 #import <atomic>
 #import <memory>
 #import <vector>
@@ -1610,5 +1612,25 @@ public:
         AssertChanged(r, @NO, @YES);
     }
 }
+
+#if 0 // FIXME: this hits an assertion failure in core
+- (void)testInsertNewTables {
+    KVOObject *obj = [self createObject];
+
+    {
+        KVORecorder r(self, obj, @"boolCol");
+
+        // Add tables before the observed one so that the observed one's index changes
+        realm::Group *group = self.realm->_realm->read_group();
+        realm::TableRef table1 = group->insert_table(5, "new table");
+        realm::TableRef table2 = group->insert_table(0, "new table 2");
+        table1->add_column(realm::type_Int, "col");
+        table2->add_column(realm::type_Int, "col");
+
+        obj.boolCol = YES;
+        AssertChanged(r, @NO, @YES);
+    }
+}
+#endif
 @end
 

--- a/Realm/Tests/SchemaTests.mm
+++ b/Realm/Tests/SchemaTests.mm
@@ -574,6 +574,139 @@ RLM_ARRAY_TYPE(SchemaTestClassSecondChild)
     [realm cancelWriteTransaction];
     dispatch_group_wait(group, DISPATCH_TIME_FOREVER);
 }
+
+- (void)testOpeningFileWithDifferentClassSubsetsInDifferentProcesses {
+    if (!self.isParent) {
+        RLMRealmConfiguration *config = [RLMRealmConfiguration defaultConfiguration];
+        config.objectClasses = @[StringObject.class];
+
+        RLMRealm *realm = [RLMRealm realmWithConfiguration:config error:nil];
+        XCTAssertEqual(1U, realm.schema.objectSchema.count);
+
+        // Verify that the StringObject table actually exists
+        [realm beginWriteTransaction];
+        [StringObject createInRealm:realm withValue:@[@""]];
+        [realm commitWriteTransaction];
+        return;
+    }
+
+    RLMRealmConfiguration *config = [RLMRealmConfiguration defaultConfiguration];
+    config.objectClasses = @[IntObject.class];
+
+    RLMRealm *realm = [RLMRealm realmWithConfiguration:config error:nil];
+    realm.autorefresh = false;
+    XCTAssertEqual(1U, realm.schema.objectSchema.count);
+
+    [realm beginWriteTransaction];
+    [IntObject createInRealm:realm withValue:@[@1]];
+    [realm commitWriteTransaction];
+
+    RLMRunChildAndWait();
+
+    // Should be able to advance over the transaction creating a new table and
+    // inserting a row into it
+    XCTAssertNoThrow([realm refresh]);
+
+    // Verify that the IntObject table didn't break
+    XCTAssertEqual(1, [[IntObject allObjectsInRealm:realm].firstObject intCol]);
+    [realm beginWriteTransaction];
+    [IntObject createInRealm:realm withValue:@[@2]];
+
+    // StringObject still isn't usable in this process since it isn't in the
+    // class subset
+    XCTAssertThrows([StringObject createInRealm:realm withValue:@[@""]]);
+    [realm commitWriteTransaction];
+}
+
+- (void)testAddingIndexToExistingColumnInBackgroundProcess {
+    if (!self.isParent) {
+        RLMSchema *schema = [RLMSchema schemaWithObjectClasses:@[IntObject.class]];
+        schema.objectSchema[0].properties[0].indexed = YES;
+
+        RLMRealmConfiguration *config = [RLMRealmConfiguration defaultConfiguration];
+        config.customSchema = schema;
+        [RLMRealm realmWithConfiguration:config error:nil];
+        return;
+    }
+
+    RLMRealmConfiguration *config = [RLMRealmConfiguration defaultConfiguration];
+    config.objectClasses = @[IntObject.class];
+
+    RLMRealm *realm = [RLMRealm realmWithConfiguration:config error:nil];
+    realm.autorefresh = false;
+    XCTAssertEqual(1U, realm.schema.objectSchema.count);
+
+    // Insert a value to ensure stuff actually happens when the index is added/removed
+    [realm beginWriteTransaction];
+    [IntObject createInRealm:realm withValue:@[@1]];
+    [realm commitWriteTransaction];
+
+    RLMRunChildAndWait();
+
+    // Should accept the index change
+    XCTAssertNoThrow([realm refresh]);
+}
+
+- (void)testRemovingIndexFromExistingColumnInBackgroundProcess {
+    if (!self.isParent) {
+        RLMSchema *schema = [RLMSchema schemaWithObjectClasses:@[IndexedStringObject.class]];
+        schema.objectSchema[0].properties[0].indexed = NO;
+
+        RLMRealmConfiguration *config = [RLMRealmConfiguration defaultConfiguration];
+        config.customSchema = schema;
+        [RLMRealm realmWithConfiguration:config error:nil];
+        return;
+    }
+
+    RLMRealmConfiguration *config = [RLMRealmConfiguration defaultConfiguration];
+    config.objectClasses = @[IndexedStringObject.class];
+
+    RLMRealm *realm = [RLMRealm realmWithConfiguration:config error:nil];
+    realm.autorefresh = false;
+    XCTAssertEqual(1U, realm.schema.objectSchema.count);
+
+    // Insert a value to ensure stuff actually happens when the index is added/removed
+    [realm beginWriteTransaction];
+    [IndexedStringObject createInRealm:realm withValue:@[@"1"]];
+    [realm commitWriteTransaction];
+
+    RLMRunChildAndWait();
+
+    // Should accept the index change
+    XCTAssertNoThrow([realm refresh]);
+}
+
+- (void)testMigratingToLaterVersionInBackgroundProcess {
+    if (!self.isParent) {
+        RLMSchema *schema = [RLMSchema schemaWithObjectClasses:@[IntObject.class]];
+        schema.objectSchema[0].properties[0].type = RLMPropertyTypeFloat;
+
+        RLMRealmConfiguration *config = [RLMRealmConfiguration defaultConfiguration];
+        config.customSchema = schema;
+        config.schemaVersion = 1;
+        [RLMRealm realmWithConfiguration:config error:nil];
+        return;
+    }
+
+    RLMRealmConfiguration *config = [RLMRealmConfiguration defaultConfiguration];
+    config.objectClasses = @[IntObject.class];
+
+    RLMRealm *realm = [RLMRealm realmWithConfiguration:config error:nil];
+    realm.autorefresh = false;
+    [realm beginWriteTransaction];
+    [IntObject createInRealm:realm withValue:@[@1]];
+    [realm commitWriteTransaction];
+
+    RLMRunChildAndWait();
+
+    // Should fail to refresh since we can't use later versions of the file due
+    // to the schema change
+    XCTAssertThrows([realm refresh]);
+    XCTAssertThrows([realm beginWriteTransaction]);
+
+    // Should have been left in a sensible state after the errors
+    XCTAssertEqual(1, [[IntObject allObjectsInRealm:realm].firstObject intCol]);
+}
 #endif
 
 @end

--- a/Realm/Tests/SchemaTests.mm
+++ b/Realm/Tests/SchemaTests.mm
@@ -621,7 +621,9 @@ RLM_ARRAY_TYPE(SchemaTestClassSecondChild)
 - (void)testAddingIndexToExistingColumnInBackgroundProcess {
     if (!self.isParent) {
         RLMSchema *schema = [RLMSchema schemaWithObjectClasses:@[IntObject.class]];
-        schema.objectSchema[0].properties[0].indexed = YES;
+        RLMObjectSchema *objectSchema = schema.objectSchema[0];
+        RLMProperty *prop = objectSchema.properties[0];
+        prop.indexed = YES;
 
         RLMRealmConfiguration *config = [RLMRealmConfiguration defaultConfiguration];
         config.customSchema = schema;
@@ -650,7 +652,9 @@ RLM_ARRAY_TYPE(SchemaTestClassSecondChild)
 - (void)testRemovingIndexFromExistingColumnInBackgroundProcess {
     if (!self.isParent) {
         RLMSchema *schema = [RLMSchema schemaWithObjectClasses:@[IndexedStringObject.class]];
-        schema.objectSchema[0].properties[0].indexed = NO;
+        RLMObjectSchema *objectSchema = schema.objectSchema[0];
+        RLMProperty *prop = objectSchema.properties[0];
+        prop.indexed = NO;
 
         RLMRealmConfiguration *config = [RLMRealmConfiguration defaultConfiguration];
         config.customSchema = schema;
@@ -679,7 +683,9 @@ RLM_ARRAY_TYPE(SchemaTestClassSecondChild)
 - (void)testMigratingToLaterVersionInBackgroundProcess {
     if (!self.isParent) {
         RLMSchema *schema = [RLMSchema schemaWithObjectClasses:@[IntObject.class]];
-        schema.objectSchema[0].properties[0].type = RLMPropertyTypeFloat;
+        RLMObjectSchema *objectSchema = schema.objectSchema[0];
+        RLMProperty *prop = objectSchema.properties[0];
+        prop.type = RLMPropertyTypeFloat;
 
         RLMRealmConfiguration *config = [RLMRealmConfiguration defaultConfiguration];
         config.customSchema = schema;


### PR DESCRIPTION
When multiple processes are sharing a single Realm file, they can potentially have different schema definitions that may or may not be compatible. This makes differences which do not require a schema version bump (i.e. one process having more or fewer tables than another process or disagreements about whether a property is indexed) explicitly supported, and throws an exception when incompatible schemas are encountered rather than crashing or silently corrupting data.