### PR TITLE
Remove the exception TLS slot workaround in Swift tests

### DIFF
--- a/RealmSwift-swift2.0/Tests/TestUtils.mm
+++ b/RealmSwift-swift2.0/Tests/TestUtils.mm
@@ -30,15 +30,6 @@ static void initializeSharedSchema() {
     [RLMSchema sharedSchema];
 }
 
-// Thread-local storage is used to store information about in-flight exceptions.
-// Something (no idea what) is using up all of the TLS slots, so creating the
-// TLS slot on-demand is failing. Work around this by throwing an exception very
-// early in startup to pre-allocate the main thread's exception TLS key.
-__attribute((constructor))
-static void allocateExceptionPthreadKey() {
-    try { throw 0; } catch (int) { }
-}
-
 void RLMAssertThrows(XCTestCase *self, dispatch_block_t block, NSString *name, NSString *message, NSString *fileName, NSUInteger lineNumber) {
     BOOL didThrow = NO;
     @try {


### PR DESCRIPTION
https://github.com/realm/realm-core/pull/1339 fixed the leak of TLS slots in debug builds, so it's no longer needed.