### PR TITLE
Fix memory leak when using Object(value:) for subclasses with List/RealmOptional properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ x.x.x Release notes (yyyy-MM-dd)
 * Fix a potential crash when deleting all objects of a class.
 * Fix performance problems when creating large numbers of objects with
   `RLMArray`/`List` properties.
+* Fix memory leak when using Object(value:) for subclasses with
+  `List` or `RealmOptional` properties.
 
 0.96.2 Release notes (2015-10-26)
 =============================================================


### PR DESCRIPTION
Calling `[self init]` from `[RLMObjectBase initWithValue:schema:]` ends up
calling a second non-convenience Swift initializer on the object, which means
that all of the properties get initialized a second time and the old values are
leaked.

Closes #2882.