### PR TITLE
remove Swift casts of RLMObjectSchema

### DIFF
--- a/RealmSwift-swift2.0/Migration.swift
+++ b/RealmSwift-swift2.0/Migration.swift
@@ -166,18 +166,14 @@ internal func accessorMigrationBlock(migrationBlock: MigrationBlock) -> RLMMigra
     return { migration, oldVersion in
         // set all accessor classes to MigrationObject
         for objectSchema in migration.oldSchema.objectSchema {
-            if let objectSchema = objectSchema as? RLMObjectSchema {
-                objectSchema.accessorClass = MigrationObject.self
-                // isSwiftClass is always `false` for object schema generated
-                // from the table, but we need to pretend it's from a swift class
-                // (even if it isn't) for the accessors to be initialized correctly.
-                objectSchema.isSwiftClass = true
-            }
+            objectSchema.accessorClass = MigrationObject.self
+            // isSwiftClass is always `false` for object schema generated
+            // from the table, but we need to pretend it's from a swift class
+            // (even if it isn't) for the accessors to be initialized correctly.
+            objectSchema.isSwiftClass = true
         }
         for objectSchema in migration.newSchema.objectSchema {
-            if let objectSchema = objectSchema as? RLMObjectSchema {
-                objectSchema.accessorClass = MigrationObject.self
-            }
+            objectSchema.accessorClass = MigrationObject.self
         }
 
         // run migration

--- a/RealmSwift-swift2.0/Schema.swift
+++ b/RealmSwift-swift2.0/Schema.swift
@@ -36,7 +36,7 @@ public final class Schema: CustomStringConvertible {
     /// `ObjectSchema`s for all object types in this Realm. Meant
     /// to be used during migrations for dynamic introspection.
     public var objectSchema: [ObjectSchema] {
-        return (rlmSchema.objectSchema as! [RLMObjectSchema]).map { ObjectSchema($0) }
+        return rlmSchema.objectSchema.map(ObjectSchema.init)
     }
 
     /// Returns a human-readable description of the object schemas contained in this schema.


### PR DESCRIPTION
these are no longer necessary now that those APIs in Objective-C use generics. /cc @tgoyne 