### PR TITLE
Throw an exception when notifications blocks are added outside of a run loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ x.x.x Release notes (yyyy-MM-dd)
 
 * All functionality deprecated in previous releases has been removed entirely.
 * Add generic type annotations to NSArrays and NSDictionaries in public APIs.
+* Adding a Realm notification block on a thread not currently running from
+  within a run loop throws an exception rather than silently never calling the
+  notification block.
 
 ### Enhancements
 

--- a/Realm/RLMRealm.h
+++ b/Realm/RLMRealm.h
@@ -133,6 +133,12 @@ typedef void(^RLMNotificationBlock)(NSString *notification, RLMRealm *realm);
 /**
  Add a notification handler for changes in this RLMRealm.
 
+ Notification handlers are called after each write transaction is committed,
+ either on the current thread or other threads. The block is called on the same
+ thread as they were added on, and can only be added on threads which are
+ currently within a run loop. Unless you are specifically creating and running a
+ run loop on a background thread, this normally will only be the main thread.
+
  The block has the following definition:
 
      typedef void(^RLMNotificationBlock)(NSString *notification, RLMRealm *realm);

--- a/Realm/RLMRealm.mm
+++ b/Realm/RLMRealm.mm
@@ -395,6 +395,9 @@ static void CheckReadWrite(RLMRealm *realm, NSString *msg=@"Cannot write to a re
     if (!block) {
         @throw RLMException(@"The notification block should not be nil");
     }
+    if (!RLMIsInRunLoop()) {
+        @throw RLMException(@"Can only add notification blocks from within runloops.");
+    }
 
     _realm->read_group();
 

--- a/Realm/RLMUtil.hpp
+++ b/Realm/RLMUtil.hpp
@@ -63,6 +63,8 @@ void RLMCollectionSetValueForKey(id<RLMFastEnumerable> collection, NSString *key
 
 BOOL RLMIsDebuggerAttached();
 
+BOOL RLMIsInRunLoop();
+
 // C version of isKindOfClass
 static inline BOOL RLMIsKindOfClass(Class class1, Class class2) {
     while (class1) {

--- a/Realm/RLMUtil.mm
+++ b/Realm/RLMUtil.mm
@@ -332,6 +332,14 @@ BOOL RLMIsDebuggerAttached()
     return (info.kp_proc.p_flag & P_TRACED) != 0;
 }
 
+BOOL RLMIsInRunLoop() {
+    if (auto mode = CFRunLoopCopyCurrentMode(CFRunLoopGetCurrent())) {
+        CFRelease(mode);
+        return true;
+    }
+    return false;
+}
+
 id RLMMixedToObjc(realm::Mixed const& mixed) {
     switch (mixed.get_type()) {
         case realm::type_String:

--- a/Realm/Tests/RLMMultiProcessTestCase.m
+++ b/Realm/Tests/RLMMultiProcessTestCase.m
@@ -73,6 +73,14 @@
     [super setUp];
 }
 
+- (void)invokeTest {
+    CFRunLoopPerformBlock(CFRunLoopGetCurrent(), kCFRunLoopDefaultMode, ^{
+        [super invokeTest];
+        CFRunLoopStop(CFRunLoopGetCurrent());
+    });
+    CFRunLoopRun();
+}
+
 - (void)deleteFiles {
     // Only the parent should delete files in setUp/tearDown
     if (self.isParent) {

--- a/RealmSwift-swift1.2/Realm.swift
+++ b/RealmSwift-swift1.2/Realm.swift
@@ -458,6 +458,13 @@ public final class Realm {
     /**
     Add a notification handler for changes in this Realm.
 
+    Notification handlers are called after each write transaction is committed,
+    either on the current thread or other threads. The block is called on the
+    same thread as they were added on, and can only be added on threads which
+    are currently within a run loop. Unless you are specifically creating and
+    running a run loop on a background thread, this normally will only be the
+    main thread.
+
     :param: block A block which is called to process Realm notifications.
                   It receives the following parameters:
 

--- a/RealmSwift-swift2.0/Realm.swift
+++ b/RealmSwift-swift2.0/Realm.swift
@@ -433,6 +433,13 @@ public final class Realm {
     /**
     Add a notification handler for changes in this Realm.
 
+    Notification handlers are called after each write transaction is committed,
+    either on the current thread or other threads. The block is called on the
+    same thread as they were added on, and can only be added on threads which
+    are currently within a run loop. Unless you are specifically creating and
+    running a run loop on a background thread, this normally will only be the
+    main thread.
+
     - parameter block: A block which is called to process Realm notifications.
                        It receives the following parameters:
 


### PR DESCRIPTION
The notification will never actually be called unless the user manually runs a run loop on the same thread afterwards, which is unlikely to be what the user actually expects.