### PR TITLE
Add support for comparison with key paths on both sides of the operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ x.x.x Release notes (yyyy-MM-dd)
   now marked as `__attribute__((noescape))`/`@noescape`.
 * Rework the implementation of encrypted Realms to no longer interfere with
   debuggers.
+* Many forms of queries with key paths on both sides of the comparison operator
+  are now supported.
 
 ### Bugfixes
 

--- a/Realm/RLMQueryUtil.hpp
+++ b/Realm/RLMQueryUtil.hpp
@@ -27,6 +27,7 @@ namespace realm {
 }
 
 @class RLMObjectSchema;
+@class RLMProperty;
 @class RLMSchema;
 
 extern NSString * const RLMPropertiesComparisonTypeMismatchException;
@@ -36,8 +37,8 @@ extern NSString * const RLMUnsupportedTypesFoundInPropertyComparisonException;
 void RLMUpdateQueryWithPredicate(realm::Query *query, NSPredicate *predicate, RLMSchema *schema,
                                  RLMObjectSchema *objectSchema);
 
-// return column index - throw for invalid column name
-NSUInteger RLMValidatedColumnIndex(RLMObjectSchema *objectSchema, NSString *columnName);
+// return property - throw for invalid column name
+RLMProperty *RLMValidatedProperty(RLMObjectSchema *objectSchema, NSString *columnName);
 
 // validate the array of RLMSortDescriptors and convert it to a realm::SortOrder
 realm::SortOrder RLMSortOrderFromDescriptors(RLMObjectSchema *objectSchema, NSArray *descriptors);

--- a/Realm/RLMQueryUtil.mm
+++ b/Realm/RLMQueryUtil.mm
@@ -691,7 +691,7 @@ void add_constraint_to_query(realm::Query &query, RLMPropertyType type,
 ColumnReference column_reference_from_key_path(RLMSchema *schema, RLMObjectSchema *desc,
                                                NSString *keyPath, bool isAggregate)
 {
-    std::vector<NSUInteger> indexes;
+    std::vector<size_t> indexes;
     RLMProperty *prop = nil;
 
     NSString *prevPath = nil;

--- a/Realm/RLMResults.mm
+++ b/Realm/RLMResults.mm
@@ -23,7 +23,7 @@
 #import "RLMObjectStore.h"
 #import "RLMObject_Private.hpp"
 #import "RLMObservation.hpp"
-#import "RLMProperty.h"
+#import "RLMProperty_Private.h"
 #import "RLMQueryUtil.hpp"
 #import "RLMRealm_Private.hpp"
 #import "RLMSchema_Private.h"
@@ -335,7 +335,7 @@ static inline void RLMResultsValidateInWriteTransaction(__unsafe_unretained RLMR
 }
 
 - (id)aggregate:(NSString *)property method:(util::Optional<Mixed> (Results::*)(size_t))method methodName:(NSString *)methodName {
-    size_t column = RLMValidatedColumnIndex(_objectSchema, property);
+    size_t column = RLMValidatedProperty(_objectSchema, property).column;
     auto value = translateErrors([&] { return (_results.*method)(column); }, methodName);
     if (!value) {
         return nil;

--- a/Realm/Tests/QueryTests.m
+++ b/Realm/Tests/QueryTests.m
@@ -1168,6 +1168,14 @@
     XCTAssertEqual(([OwnerObject objectsInRealm:realm where:@"dog.dogName = 'Harvie' and name = 'Tim'"].count), 1U);
     XCTAssertEqual(([OwnerObject objectsInRealm:realm where:@"dog.dogName = 'Harvie' and name = 'Jim'"].count), 0U);
 
+    [self makeDogWithName:@"Rex" owner:@"Rex"];
+    XCTAssertEqual(([OwnerObject objectsInRealm:realm where:@"dog.dogName = name"].count), 1U);
+    XCTAssertEqual(([OwnerObject objectsInRealm:realm where:@"name = dog.dogName"].count), 1U);
+    XCTAssertEqual(([OwnerObject objectsInRealm:realm where:@"dog.dogName != name"].count), 3U);
+    XCTAssertEqual(([OwnerObject objectsInRealm:realm where:@"name != dog.dogName"].count), 3U);
+    XCTAssertEqual(([OwnerObject objectsInRealm:realm where:@"dog.dogName == dog.dogName"].count), 4U);
+    XCTAssertEqual(([OwnerObject objectsInRealm:realm where:@"dog.dogName != dog.dogName"].count), 0U);
+
     // test invalid operators
     XCTAssertThrows([realm objects:[OwnerObject className] where:@"dog.dogName > 'Harvie'"], @"Invalid operator should throw");
 }
@@ -1266,6 +1274,8 @@
     XCTAssertThrows([LinkToAllTypesObject objectsWhere:@"allTypesCol.longCol = 'a'"], @"Wrong data type should throw");
 
     XCTAssertThrows([LinkToAllTypesObject objectsWhere:@"intArray.intCol > 5"], @"RLMArray query without ANY modifier should throw");
+
+    RLMAssertThrowsWithReasonMatching([LinkToAllTypesObject objectsWhere:@"allTypesCol.intCol = allTypesCol.doubleCol"], @"Property type mismatch");
 }
 
 
@@ -1970,7 +1980,7 @@
     XCTAssertEqual(1U, ([IntegerArrayPropertyObject objectsWhere:@"1 >  array.@count"].count));
 
     // We do not yet handle collection operations with a keypath on the other side of the comparison.
-    RLMAssertThrowsWithReasonMatching(([IntegerArrayPropertyObject objectsWhere:@"array.@count != number"]), @"'array.@count' not found in object");
+    RLMAssertThrowsWithReasonMatching(([IntegerArrayPropertyObject objectsWhere:@"array.@count != number"]), @"aggregate operations may only be compared with constants");
 
     RLMAssertThrowsWithReasonMatching(([IntegerArrayPropertyObject objectsWhere:@"array.@count.foo.bar != 0"]), @"single level key");
     RLMAssertThrowsWithReasonMatching(([IntegerArrayPropertyObject objectsWhere:@"array.@count.intCol > 0"]), @"@count does not have any properties");
@@ -2016,7 +2026,7 @@
     XCTAssertEqual(1U, ([IntegerArrayPropertyObject objectsWhere:@"array.@avg.intCol > 50"].count));
 
     // We do not yet handle collection operations with a keypath on the other side of the comparison.
-    RLMAssertThrowsWithReasonMatching(([IntegerArrayPropertyObject objectsWhere:@"array.@min.intCol == number"]), @"'array.@min.intCol' not found in object");
+    RLMAssertThrowsWithReasonMatching(([IntegerArrayPropertyObject objectsWhere:@"array.@min.intCol == number"]), @"aggregate operations may only be compared with constants");
 
     RLMAssertThrowsWithReasonMatching(([IntegerArrayPropertyObject objectsWhere:@"array.@min.intCol.foo.bar == 1.23"]), @"single level key");
     RLMAssertThrowsWithReasonMatching(([IntegerArrayPropertyObject objectsWhere:@"array.@max.intCol.foo.bar == 1.23"]), @"single level key");

--- a/Realm/Tests/RLMAssertions.h
+++ b/Realm/Tests/RLMAssertions.h
@@ -51,5 +51,7 @@
 #define RLMAssertThrowsWithReasonMatching(expression, regex, ...) \
 ({ \
     NSException *exception = RLMAssertThrows(expression, __VA_ARGS__); \
-    RLMAssertMatches(exception.reason, regex, __VA_ARGS__); \
+    if (exception) { \
+        RLMAssertMatches(exception.reason, regex, __VA_ARGS__); \
+    } \
 })


### PR DESCRIPTION
Adds support for comparisons of the form `class.unary OP property`, `class.unary OP class.unary`, and `class.many.@AGG.property OP property`, where `unary` is a unary relationship, and `many` is an `RLMArray` / `List` relationship.

The following are not part of this pull request:
* `ANY` / `SOME` / `ALL` / `NONE` with key paths on both sides of the operator.
* `class.many.@AGG.property OP class.many.@AGG.property`.
* `IN` with key paths on both sides.
* `BETWEEN` with key paths on both sides.

Depends on realm/realm-core#1360.