### PR TITLE
Read-only Realm should be opened even in immutable directory

### DIFF
--- a/Realm/ObjectStore/shared_realm.cpp
+++ b/Realm/ObjectStore/shared_realm.cpp
@@ -153,11 +153,15 @@ SharedRealm Realm::get_shared_realm(Config config)
         // FIXME - need to validate that schemas match
         realm->m_config.schema = std::make_unique<Schema>(*existing->m_config.schema);
 
-        realm->m_notifier = existing->m_notifier;
-        realm->m_notifier->add_realm(realm.get());
+        if (!realm->m_config.read_only) {
+            realm->m_notifier = existing->m_notifier;
+            realm->m_notifier->add_realm(realm.get());
+        }
     }
     else {
-        realm->m_notifier = std::make_shared<ExternalCommitHelper>(realm.get());
+        if (!realm->m_config.read_only) {
+            realm->m_notifier = std::make_shared<ExternalCommitHelper>(realm.get());
+        }
 
         // otherwise get the schema from the group
         realm->m_config.schema = std::make_unique<Schema>(ObjectStore::schema_from_group(realm->read_group()));


### PR DESCRIPTION
Realm files in an app bundle should be opened if marked as read-only.
However, to open Realm in an app bundle will fail due to try to create a `*.note` file in a bundle.

This behavior introduced from the following commit:
https://github.com/realm/realm-cocoa/commit/9cfaa500a96482752c2536282644585ebef4c68f

This test (opening read-only Realm in app bundle) hits https://github.com/realm/realm-cocoa/blob/master/Realm/ObjectStore/impl/apple/external_commit_helper.cpp#L117 then throws exception.

cc @tgoyne @jpsim 