### PR TITLE
Fixes issue where KVC fails while copying a Swift object with nested relationships from one Realm to another

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ x.x.x Release notes (yyyy-MM-dd)
 * Fix incorrect search results for some queries on integer properties.
 * Add error-checking for nil realm parameters in many methods such as
   `+[RLMObject allObjectsInRealm:]`.
+* Fix failure to copy tertiary or deeper linked objects while copying a Swift object from one Realm to another.
 
 0.96.2 Release notes (2015-10-26)
 =============================================================

--- a/Realm.xcodeproj/xcshareddata/xcschemes/Realm.xcscheme
+++ b/Realm.xcodeproj/xcshareddata/xcschemes/Realm.xcscheme
@@ -52,6 +52,16 @@
                ReferencedContainer = "container:Realm.xcodeproj">
             </BuildableReference>
          </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "5D660FD71BE98C7C0021E04F"
+               BuildableName = "RealmSwift Tests.xctest"
+               BlueprintName = "RealmSwift Tests"
+               ReferencedContainer = "container:Realm.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
       <MacroExpansion>
          <BuildableReference

--- a/Realm.xcodeproj/xcshareddata/xcschemes/Realm.xcscheme
+++ b/Realm.xcodeproj/xcshareddata/xcschemes/Realm.xcscheme
@@ -52,16 +52,6 @@
                ReferencedContainer = "container:Realm.xcodeproj">
             </BuildableReference>
          </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "5D660FD71BE98C7C0021E04F"
-               BuildableName = "RealmSwift Tests.xctest"
-               BlueprintName = "RealmSwift Tests"
-               ReferencedContainer = "container:Realm.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
       </Testables>
       <MacroExpansion>
          <BuildableReference

--- a/Realm/RLMObjectBase.mm
+++ b/Realm/RLMObjectBase.mm
@@ -148,9 +148,10 @@ static id RLMValidatedObjectForProperty(id obj, RLMProperty *prop, RLMSchema *sc
     return [super valueForKey:key];
 }
 
-// Generic Swift properties can't be dynamic, so KVO doesn't work for them by default
+// Generic Swift properties can't be dynamic, so KVC doesn't work for them by default
 - (id)valueForUndefinedKey:(NSString *)key {
     if (Ivar ivar = _objectSchema[key].swiftIvar) {
+        RLMInitializeSwiftAccessorGenericsForProperty(self,key);
         return RLMCoerceToNil(object_getIvar(self, ivar));
     }
     return [super valueForUndefinedKey:key];

--- a/Realm/RLMObjectStore.h
+++ b/Realm/RLMObjectStore.h
@@ -80,6 +80,7 @@ RLMObjectBase *RLMCreateObjectInRealmWithValue(RLMRealm *realm, NSString *classN
 
 // switch List<> properties from being backed by standalone RLMArrays to RLMArrayLinkView
 void RLMInitializeSwiftAccessorGenerics(RLMObjectBase *object);
+void RLMInitializeSwiftAccessorGenericsForProperty(RLMObjectBase *object, NSString *propName);
 
 #ifdef __cplusplus
 }

--- a/Realm/RLMObjectStore.mm
+++ b/Realm/RLMObjectStore.mm
@@ -135,11 +135,8 @@ void RLMInitializeSwiftAccessorGenericsForProperty(__unsafe_unretained RLMObject
                                                                      key:prop.name
                                                             parentSchema:object->_objectSchema];
             [RLMObjectUtilClass(YES) initializeListProperty:object property:prop array:array];
-        }
-        else if (auto ivar = prop.swiftIvar) {
-            auto optional = static_cast<RLMOptionalBase *>(object_getIvar(object, ivar));
-            optional.object = object;
-            optional.property = prop;
+        } else if (prop.swiftIvar) {
+            [RLMObjectUtilClass(YES) initializeOptionalProperty:object property:prop];
         }
     }
 }

--- a/RealmSwift-swift1.2/Tests/ObjectCreationTests.swift
+++ b/RealmSwift-swift1.2/Tests/ObjectCreationTests.swift
@@ -354,6 +354,36 @@ class ObjectCreationTests: TestCase {
         verifySwiftObjectWithDictionaryLiteral(object, dictionary: values, boolObjectValue: true, boolObjectListValues: [true, false])
     }
 
+    func testCreateWithDeeplyNestedObjectsFromAnotherRealm() {
+        let values = [
+            "boolCol": true as NSNumber,
+            "intCol": 1 as NSNumber,
+            "floatCol": 1.1 as NSNumber,
+            "doubleCol": 11.1 as NSNumber,
+            "stringCol": "b" as NSString,
+            "binaryCol": "b".dataUsingEncoding(NSUTF8StringEncoding)! as NSData,
+            "dateCol": NSDate(timeIntervalSince1970: 2) as NSDate,
+            "objectCol": SwiftBoolObject(value: [true]) as AnyObject,
+            "arrayCol": [SwiftBoolObject(value: [true]), SwiftBoolObject()] as AnyObject,
+        ]
+
+        realmWithTestPath().beginWrite()
+        let otherRealmObjectValue = ["array": [SwiftObject(value: values), SwiftObject(value: values)]]
+        let otherRealmObject = realmWithTestPath().create(SwiftListOfSwiftObject.self, value: otherRealmObjectValue)
+        try! realmWithTestPath().commitWrite()
+
+        try! Realm().beginWrite()
+        let object = try! Realm().create(SwiftListOfSwiftObject.self, value: otherRealmObject)
+        try! Realm().commitWrite()
+
+        XCTAssertNotEqual(otherRealmObject, object)
+        XCTAssertEqual(object.array.count, 2)
+        for swiftObject in object.array {
+            verifySwiftObjectWithDictionaryLiteral(swiftObject, dictionary: values, boolObjectValue: true,
+                boolObjectListValues: [true, false])
+        }
+    }
+
     func testUpdateWithObjectsFromAnotherRealm() {
         realmWithTestPath().beginWrite()
         let otherRealmObject = realmWithTestPath().create(SwiftLinkToPrimaryStringObject.self, value: ["primary", NSNull(), [["2", 2], ["4", 4]]])

--- a/RealmSwift-swift1.2/Tests/ObjectCreationTests.swift
+++ b/RealmSwift-swift1.2/Tests/ObjectCreationTests.swift
@@ -370,11 +370,11 @@ class ObjectCreationTests: TestCase {
         realmWithTestPath().beginWrite()
         let otherRealmObjectValue = ["array": [SwiftObject(value: values), SwiftObject(value: values)]]
         let otherRealmObject = realmWithTestPath().create(SwiftListOfSwiftObject.self, value: otherRealmObjectValue)
-        try! realmWithTestPath().commitWrite()
+        realmWithTestPath().commitWrite()
 
-        try! Realm().beginWrite()
-        let object = try! Realm().create(SwiftListOfSwiftObject.self, value: otherRealmObject)
-        try! Realm().commitWrite()
+        Realm().beginWrite()
+        let object = Realm().create(SwiftListOfSwiftObject.self, value: otherRealmObject)
+        Realm().commitWrite()
 
         XCTAssertNotEqual(otherRealmObject, object)
         XCTAssertEqual(object.array.count, 2)

--- a/RealmSwift-swift2.0/Tests/ObjectCreationTests.swift
+++ b/RealmSwift-swift2.0/Tests/ObjectCreationTests.swift
@@ -374,6 +374,35 @@ class ObjectCreationTests: TestCase {
         verifySwiftObjectWithDictionaryLiteral(object, dictionary: values, boolObjectValue: true,
             boolObjectListValues: [true, false])
     }
+    
+    func testCreateWithDeeplyNestedObjectsFromAnotherRealm() {
+        let values = [
+            "boolCol": true as NSNumber,
+            "intCol": 1 as NSNumber,
+            "floatCol": 1.1 as NSNumber,
+            "doubleCol": 11.1 as NSNumber,
+            "stringCol": "b" as NSString,
+            "binaryCol": "b".dataUsingEncoding(NSUTF8StringEncoding)! as NSData,
+            "dateCol": NSDate(timeIntervalSince1970: 2) as NSDate,
+            "objectCol": SwiftBoolObject(value: [true]) as AnyObject,
+            "arrayCol": [SwiftBoolObject(value: [true]), SwiftBoolObject()] as AnyObject,
+        ]
+        
+        realmWithTestPath().beginWrite()
+        let otherRealmObject = realmWithTestPath().create(SwiftListOfSwiftObject.self, value: ["array": [SwiftObject(value: values),SwiftObject(value: values)]])
+        try! realmWithTestPath().commitWrite()
+        
+        try! Realm().beginWrite()
+        let object = try! Realm().create(SwiftListOfSwiftObject.self, value: otherRealmObject)
+        try! Realm().commitWrite()
+        
+        XCTAssertNotEqual(otherRealmObject, object)
+        XCTAssertEqual(object.array.count,2)
+        for swiftObject in object.array {
+            verifySwiftObjectWithDictionaryLiteral(swiftObject, dictionary: values, boolObjectValue: true,
+                boolObjectListValues: [true, false])
+        }
+    }
 
     func testUpdateWithObjectsFromAnotherRealm() {
         realmWithTestPath().beginWrite()

--- a/RealmSwift-swift2.0/Tests/ObjectCreationTests.swift
+++ b/RealmSwift-swift2.0/Tests/ObjectCreationTests.swift
@@ -374,7 +374,7 @@ class ObjectCreationTests: TestCase {
         verifySwiftObjectWithDictionaryLiteral(object, dictionary: values, boolObjectValue: true,
             boolObjectListValues: [true, false])
     }
-    
+
     func testCreateWithDeeplyNestedObjectsFromAnotherRealm() {
         let values = [
             "boolCol": true as NSNumber,
@@ -387,17 +387,18 @@ class ObjectCreationTests: TestCase {
             "objectCol": SwiftBoolObject(value: [true]) as AnyObject,
             "arrayCol": [SwiftBoolObject(value: [true]), SwiftBoolObject()] as AnyObject,
         ]
-        
+
         realmWithTestPath().beginWrite()
-        let otherRealmObject = realmWithTestPath().create(SwiftListOfSwiftObject.self, value: ["array": [SwiftObject(value: values),SwiftObject(value: values)]])
+        let otherRealmObjectValue = ["array": [SwiftObject(value: values), SwiftObject(value: values)]]
+        let otherRealmObject = realmWithTestPath().create(SwiftListOfSwiftObject.self, value: otherRealmObjectValue)
         try! realmWithTestPath().commitWrite()
-        
+
         try! Realm().beginWrite()
         let object = try! Realm().create(SwiftListOfSwiftObject.self, value: otherRealmObject)
         try! Realm().commitWrite()
-        
+
         XCTAssertNotEqual(otherRealmObject, object)
-        XCTAssertEqual(object.array.count,2)
+        XCTAssertEqual(object.array.count, 2)
         for swiftObject in object.array {
             verifySwiftObjectWithDictionaryLiteral(swiftObject, dictionary: values, boolObjectValue: true,
                 boolObjectListValues: [true, false])


### PR DESCRIPTION
Without initializing the underlying ivar for a list property on an object contained within a list on its parent object, KVC will simply return a blank list.

Fixes: https://github.com/realm/realm-cocoa/issues/2754#issuecomment-159322825