### PR TITLE
Update existing TableViews in first() and last()

### DIFF
--- a/Realm/ObjectStore/results.cpp
+++ b/Realm/ObjectStore/results.cpp
@@ -108,9 +108,8 @@ util::Optional<RowExpr> Results::first()
         case Mode::Table:
             return m_table->size() == 0 ? util::none : util::make_optional(m_table->front());
         case Mode::Query:
-            update_tableview();
-            REALM_FALLTHROUGH;
         case Mode::TableView:
+            update_tableview();
             return m_table_view.size() == 0 ? util::none : util::make_optional(m_table_view.front());
     }
     REALM_UNREACHABLE();
@@ -125,9 +124,8 @@ util::Optional<RowExpr> Results::last()
         case Mode::Table:
             return m_table->size() == 0 ? util::none : util::make_optional(m_table->back());
         case Mode::Query:
-            update_tableview();
-            REALM_FALLTHROUGH;
         case Mode::TableView:
+            update_tableview();
             return m_table_view.size() == 0 ? util::none : util::make_optional(m_table_view.back());
     }
     REALM_UNREACHABLE();

--- a/Realm/Tests/ResultsTests.m
+++ b/Realm/Tests/ResultsTests.m
@@ -541,6 +541,32 @@
     XCTAssertEqual(30, [(EmployeeObject *)filtered[1] age]);
 }
 
+- (void)testLiveUpdateFirst {
+    RLMRealm *realm = self.realmWithTestPath;
+    [realm beginWriteTransaction];
+    [IntObject createInRealm:realm withValue:@[@0]];
+
+    RLMResults *objects = [IntObject objectsInRealm:realm where:@"intCol = 0"];
+    XCTAssertNotNil([objects firstObject]);
+    [objects.firstObject setIntCol:1];
+    XCTAssertNil([objects firstObject]);
+
+    [realm cancelWriteTransaction];
+}
+
+- (void)testLiveUpdateLast {
+    RLMRealm *realm = self.realmWithTestPath;
+    [realm beginWriteTransaction];
+    [IntObject createInRealm:realm withValue:@[@0]];
+
+    RLMResults *objects = [IntObject objectsInRealm:realm where:@"intCol = 0"];
+    XCTAssertNotNil([objects lastObject]);
+    [objects.lastObject setIntCol:1];
+    XCTAssertNil([objects lastObject]);
+
+    [realm cancelWriteTransaction];
+}
+
 static vm_size_t get_resident_size() {
     struct task_basic_info info;
     mach_msg_type_number_t size = sizeof(info);


### PR DESCRIPTION
The call to update_tableview() was in the wrong place, resulting in it creating the table view, but not updating an existing one. No changelog entry since it has not been shipped in a release.