### PR TITLE
made va_list methods public

### DIFF
--- a/Realm/RLMArray.h
+++ b/Realm/RLMArray.h
@@ -228,6 +228,9 @@ RLM_ASSUME_NONNULL_BEGIN
  */
 - (NSUInteger)indexOfObjectWhere:(NSString *)predicateFormat, ...;
 
+/// :nodoc:
+- (NSUInteger)indexOfObjectWhere:(NSString *)predicateFormat args:(va_list)args;
+
 /**
  Gets the index of the first object matching the predicate.
 
@@ -245,6 +248,9 @@ RLM_ASSUME_NONNULL_BEGIN
  @return                An RLMResults of objects that match the given predicate
  */
 - (RLMResults RLM_GENERIC_RETURN*)objectsWhere:(NSString *)predicateFormat, ...;
+
+/// :nodoc:
+- (RLMResults RLM_GENERIC_RETURN*)objectsWhere:(NSString *)predicateFormat args:(va_list)args;
 
 /**
  Get objects matching the given predicate in the RLMArray.

--- a/Realm/RLMArray.mm
+++ b/Realm/RLMArray.mm
@@ -296,7 +296,7 @@ static void RLMValidateArrayBounds(__unsafe_unretained RLMArray *const ar,
 
 - (RLMResults *)objectsWhere:(NSString *)predicateFormat args:(va_list)args
 {
-    return [self objectsWithPredicate:[NSPredicate predicateWithFormat:predicateFormat arguments:args]];
+    return [self objectsWithPredicate:RLMValidatedPredicate(predicateFormat, args)];
 }
 
 - (id)valueForKeyPath:(NSString *)keyPath {
@@ -386,8 +386,7 @@ static void RLMValidateArrayBounds(__unsafe_unretained RLMArray *const ar,
 
 - (NSUInteger)indexOfObjectWhere:(NSString *)predicateFormat args:(va_list)args
 {
-    return [self indexOfObjectWithPredicate:[NSPredicate predicateWithFormat:predicateFormat
-                                                                   arguments:args]];
+    return [self indexOfObjectWithPredicate:RLMValidatedPredicate(predicateFormat, args)];
 }
 
 #pragma mark - Superclass Overrides

--- a/Realm/RLMArray.mm
+++ b/Realm/RLMArray.mm
@@ -291,8 +291,9 @@ static void RLMValidateArrayBounds(__unsafe_unretained RLMArray *const ar,
 {
     va_list args;
     va_start(args, predicateFormat);
+    RLMResults *results = [self objectsWhere:predicateFormat args:args];
     va_end(args);
-    return [self objectsWhere:predicateFormat args:args];
+    return results;
 }
 
 - (RLMResults *)objectsWhere:(NSString *)predicateFormat args:(va_list)args
@@ -382,8 +383,9 @@ static void RLMValidateArrayBounds(__unsafe_unretained RLMArray *const ar,
 {
     va_list args;
     va_start(args, predicateFormat);
+    NSUInteger index = [self indexOfObjectWhere:predicateFormat args:args];
     va_end(args);
-    return [self indexOfObjectWhere:predicateFormat args:args];
+    return index;
 }
 
 - (NSUInteger)indexOfObjectWhere:(NSString *)predicateFormat args:(va_list)args

--- a/Realm/RLMArray.mm
+++ b/Realm/RLMArray.mm
@@ -290,13 +290,14 @@ static void RLMValidateArrayBounds(__unsafe_unretained RLMArray *const ar,
 - (RLMResults *)objectsWhere:(NSString *)predicateFormat, ...
 {
     va_list args;
-    RLM_VARARG(predicateFormat, args);
+    va_start(args, predicateFormat);
+    va_end(args);
     return [self objectsWhere:predicateFormat args:args];
 }
 
 - (RLMResults *)objectsWhere:(NSString *)predicateFormat args:(va_list)args
 {
-    return [self objectsWithPredicate:RLMValidatedPredicate(predicateFormat, args)];
+    return [self objectsWithPredicate:[NSPredicate predicateWithFormat:predicateFormat arguments:args]];
 }
 
 - (id)valueForKeyPath:(NSString *)keyPath {
@@ -380,13 +381,15 @@ static void RLMValidateArrayBounds(__unsafe_unretained RLMArray *const ar,
 - (NSUInteger)indexOfObjectWhere:(NSString *)predicateFormat, ...
 {
     va_list args;
-    RLM_VARARG(predicateFormat, args);
+    va_start(args, predicateFormat);
+    va_end(args);
     return [self indexOfObjectWhere:predicateFormat args:args];
 }
 
 - (NSUInteger)indexOfObjectWhere:(NSString *)predicateFormat args:(va_list)args
 {
-    return [self indexOfObjectWithPredicate:RLMValidatedPredicate(predicateFormat, args)];
+    return [self indexOfObjectWithPredicate:[NSPredicate predicateWithFormat:predicateFormat
+                                                                   arguments:args]];
 }
 
 #pragma mark - Superclass Overrides

--- a/Realm/RLMCollection.h
+++ b/Realm/RLMCollection.h
@@ -95,6 +95,9 @@ RLM_ASSUME_NONNULL_BEGIN
  */
 - (NSUInteger)indexOfObjectWhere:(NSString *)predicateFormat, ...;
 
+/// :nodoc:
+- (NSUInteger)indexOfObjectWhere:(NSString *)predicateFormat args:(va_list)args;
+
 /**
  Gets the index of the first object matching the predicate.
  
@@ -112,6 +115,9 @@ RLM_ASSUME_NONNULL_BEGIN
  @return    An RLMResults of objects that match the given predicate
  */
 - (RLMResults *)objectsWhere:(NSString *)predicateFormat, ...;
+
+/// :nodoc:
+- (RLMResults *)objectsWhere:(NSString *)predicateFormat args:(va_list)args;
 
 /**
  Get objects matching the given predicate in the RLMCollection.

--- a/Realm/RLMObject.h
+++ b/Realm/RLMObject.h
@@ -297,6 +297,9 @@ RLM_ASSUME_NONNULL_BEGIN
  */
 + (RLMResults *)objectsWhere:(NSString *)predicateFormat, ...;
 
+/// :nodoc:
++ (RLMResults *)objectsWhere:(NSString *)predicateFormat args:(va_list)args;
+
 
 /**
  Get objects matching the given predicate for this type from the default Realm.
@@ -342,6 +345,9 @@ RLM_ASSUME_NONNULL_BEGIN
  @return    An RLMResults of objects of the subclass type in the specified Realm that match the given predicate
  */
 + (RLMResults *)objectsInRealm:(RLMRealm *)realm where:(NSString *)predicateFormat, ...;
+
+/// :nodoc:
++ (RLMResults *)objectsInRealm:(RLMRealm *)realm where:(NSString *)predicateFormat args:(va_list)args;
 
 /**
  Get objects matching the given predicate for this type from the specified Realm.

--- a/Realm/RLMObject.mm
+++ b/Realm/RLMObject.mm
@@ -105,22 +105,24 @@
 
 + (RLMResults *)objectsWhere:(NSString *)predicateFormat, ... {
     va_list args;
-    RLM_VARARG(predicateFormat, args);
+    va_start(args, predicateFormat);
+    va_end(args);
     return [self objectsWhere:predicateFormat args:args];
 }
 
 + (RLMResults *)objectsWhere:(NSString *)predicateFormat args:(va_list)args {
-    return [self objectsWithPredicate:RLMValidatedPredicate(predicateFormat, args)];
+    return [self objectsWithPredicate:[NSPredicate predicateWithFormat:predicateFormat arguments:args]];
 }
 
 + (RLMResults *)objectsInRealm:(RLMRealm *)realm where:(NSString *)predicateFormat, ... {
     va_list args;
-    RLM_VARARG(predicateFormat, args);
+    va_start(args, predicateFormat);
+    va_end(args);
     return [self objectsInRealm:realm where:predicateFormat args:args];
 }
 
 + (RLMResults *)objectsInRealm:(RLMRealm *)realm where:(NSString *)predicateFormat args:(va_list)args {
-    return [self objectsInRealm:realm withPredicate:RLMValidatedPredicate(predicateFormat, args)];
+    return [self objectsInRealm:realm withPredicate:[NSPredicate predicateWithFormat:predicateFormat arguments:args]];
 }
 
 + (RLMResults *)objectsWithPredicate:(NSPredicate *)predicate {

--- a/Realm/RLMObject.mm
+++ b/Realm/RLMObject.mm
@@ -110,7 +110,7 @@
 }
 
 + (RLMResults *)objectsWhere:(NSString *)predicateFormat args:(va_list)args {
-    return [self objectsWithPredicate:[NSPredicate predicateWithFormat:predicateFormat arguments:args]];
+    return [self objectsWithPredicate:RLMValidatedPredicate(predicateFormat, args)];
 }
 
 + (RLMResults *)objectsInRealm:(RLMRealm *)realm where:(NSString *)predicateFormat, ... {
@@ -120,7 +120,7 @@
 }
 
 + (RLMResults *)objectsInRealm:(RLMRealm *)realm where:(NSString *)predicateFormat args:(va_list)args {
-    return [self objectsInRealm:realm withPredicate:[NSPredicate predicateWithFormat:predicateFormat arguments:args]];
+    return [self objectsInRealm:realm withPredicate:RLMValidatedPredicate(predicateFormat, args)];
 }
 
 + (RLMResults *)objectsWithPredicate:(NSPredicate *)predicate {

--- a/Realm/RLMObject.mm
+++ b/Realm/RLMObject.mm
@@ -106,8 +106,9 @@
 + (RLMResults *)objectsWhere:(NSString *)predicateFormat, ... {
     va_list args;
     va_start(args, predicateFormat);
+    RLMResults *results = [self objectsWhere:predicateFormat args:args];
     va_end(args);
-    return [self objectsWhere:predicateFormat args:args];
+    return results;
 }
 
 + (RLMResults *)objectsWhere:(NSString *)predicateFormat args:(va_list)args {
@@ -117,8 +118,9 @@
 + (RLMResults *)objectsInRealm:(RLMRealm *)realm where:(NSString *)predicateFormat, ... {
     va_list args;
     va_start(args, predicateFormat);
+    RLMResults *results = [self objectsInRealm:realm where:predicateFormat args:args];
     va_end(args);
-    return [self objectsInRealm:realm where:predicateFormat args:args];
+    return results;
 }
 
 + (RLMResults *)objectsInRealm:(RLMRealm *)realm where:(NSString *)predicateFormat args:(va_list)args {

--- a/Realm/RLMQueryUtil.hpp
+++ b/Realm/RLMQueryUtil.hpp
@@ -17,6 +17,7 @@
 ////////////////////////////////////////////////////////////////////////////
 
 #import <Foundation/Foundation.h>
+#import "RLMConstants.h"
 #import <vector>
 
 namespace realm {
@@ -46,8 +47,7 @@ realm::SortOrder RLMSortOrderFromDescriptors(RLMObjectSchema *objectSchema, NSAr
 // This macro validates predicate format with optional arguments
 #define RLM_VARARG(PREDICATE_FORMAT, ARGS) \
 va_start(ARGS, PREDICATE_FORMAT);          \
-va_end(ARGS);                              \
-if (PREDICATE_FORMAT && ![PREDICATE_FORMAT isKindOfClass:[NSString class]]) {         \
-    NSString *reason = @"predicate must be an NSString with optional format va_list"; \
-    [NSException exceptionWithName:RLMExceptionName reason:reason userInfo:nil];       \
-}
+va_end(ARGS);
+
+// return predicate - throw for invalid format
+NSPredicate *RLMValidatedPredicate(id predicateFormat, va_list args);

--- a/Realm/RLMQueryUtil.hpp
+++ b/Realm/RLMQueryUtil.hpp
@@ -17,7 +17,6 @@
 ////////////////////////////////////////////////////////////////////////////
 
 #import <Foundation/Foundation.h>
-#import "RLMConstants.h"
 #import <vector>
 
 namespace realm {
@@ -43,11 +42,3 @@ RLMProperty *RLMValidatedProperty(RLMObjectSchema *objectSchema, NSString *colum
 
 // validate the array of RLMSortDescriptors and convert it to a realm::SortOrder
 realm::SortOrder RLMSortOrderFromDescriptors(RLMObjectSchema *objectSchema, NSArray *descriptors);
-
-// This macro validates predicate format with optional arguments
-#define RLM_VARARG(PREDICATE_FORMAT, ARGS) \
-va_start(ARGS, PREDICATE_FORMAT);          \
-va_end(ARGS);
-
-// return predicate - throw for invalid format
-NSPredicate *RLMValidatedPredicate(id predicateFormat, va_list args);

--- a/Realm/RLMQueryUtil.mm
+++ b/Realm/RLMQueryUtil.mm
@@ -71,6 +71,14 @@ RLMProperty *RLMValidatedProperty(RLMObjectSchema *desc, NSString *columnName) {
     return prop;
 }
 
+NSPredicate *RLMValidatedPredicate(id predicateFormat, va_list args) {
+    if (predicateFormat && ![predicateFormat isKindOfClass:[NSString class]]) {
+        NSString *reason = @"predicate must be an NSString with optional format va_list";
+        @throw [NSException exceptionWithName:RLMExceptionName reason:reason userInfo:nil];
+    }
+    return [NSPredicate predicateWithFormat:predicateFormat arguments:args];
+}
+
 namespace {
 
 // FIXME: TrueExpression and FalseExpression should be supported by core in some way

--- a/Realm/RLMQueryUtil.mm
+++ b/Realm/RLMQueryUtil.mm
@@ -71,14 +71,6 @@ RLMProperty *RLMValidatedProperty(RLMObjectSchema *desc, NSString *columnName) {
     return prop;
 }
 
-NSPredicate *RLMValidatedPredicate(id predicateFormat, va_list args) {
-    if (predicateFormat && ![predicateFormat isKindOfClass:[NSString class]]) {
-        NSString *reason = @"predicate must be an NSString with optional format va_list";
-        @throw [NSException exceptionWithName:RLMExceptionName reason:reason userInfo:nil];
-    }
-    return [NSPredicate predicateWithFormat:predicateFormat arguments:args];
-}
-
 namespace {
 
 // FIXME: TrueExpression and FalseExpression should be supported by core in some way

--- a/Realm/RLMRealm.mm
+++ b/Realm/RLMRealm.mm
@@ -629,8 +629,9 @@ static void CheckReadWrite(RLMRealm *realm, NSString *msg=@"Cannot write to a re
 - (RLMResults *)objects:(NSString *)objectClassName where:(NSString *)predicateFormat, ... {
     va_list args;
     va_start(args, predicateFormat);
+    RLMResults *results = [self objects:objectClassName where:predicateFormat args:args];
     va_end(args);
-    return [self objects:objectClassName where:predicateFormat args:args];
+    return results;
 }
 
 - (RLMResults *)objects:(NSString *)objectClassName where:(NSString *)predicateFormat args:(va_list)args {

--- a/Realm/RLMRealm.mm
+++ b/Realm/RLMRealm.mm
@@ -628,12 +628,13 @@ static void CheckReadWrite(RLMRealm *realm, NSString *msg=@"Cannot write to a re
 
 - (RLMResults *)objects:(NSString *)objectClassName where:(NSString *)predicateFormat, ... {
     va_list args;
-    RLM_VARARG(predicateFormat, args);
+    va_start(args, predicateFormat);
+    va_end(args);
     return [self objects:objectClassName where:predicateFormat args:args];
 }
 
 - (RLMResults *)objects:(NSString *)objectClassName where:(NSString *)predicateFormat args:(va_list)args {
-    return [self objects:objectClassName withPredicate:RLMValidatedPredicate(predicateFormat, args)];
+    return [self objects:objectClassName withPredicate:[NSPredicate predicateWithFormat:predicateFormat arguments:args]];
 }
 
 - (RLMResults *)objects:(NSString *)objectClassName withPredicate:(NSPredicate *)predicate {

--- a/Realm/RLMRealm.mm
+++ b/Realm/RLMRealm.mm
@@ -633,7 +633,7 @@ static void CheckReadWrite(RLMRealm *realm, NSString *msg=@"Cannot write to a re
 }
 
 - (RLMResults *)objects:(NSString *)objectClassName where:(NSString *)predicateFormat args:(va_list)args {
-    return [self objects:objectClassName withPredicate:[NSPredicate predicateWithFormat:predicateFormat arguments:args]];
+    return [self objects:objectClassName withPredicate:RLMValidatedPredicate(predicateFormat, args)];
 }
 
 - (RLMResults *)objects:(NSString *)objectClassName withPredicate:(NSPredicate *)predicate {

--- a/Realm/RLMResults.h
+++ b/Realm/RLMResults.h
@@ -104,6 +104,9 @@ RLM_ASSUME_NONNULL_BEGIN
  */
 - (NSUInteger)indexOfObjectWhere:(NSString *)predicateFormat, ...;
 
+/// :nodoc:
+- (NSUInteger)indexOfObjectWhere:(NSString *)predicateFormat args:(va_list)args;
+
 /**
  Gets the index of the first object matching the predicate.
 
@@ -121,6 +124,9 @@ RLM_ASSUME_NONNULL_BEGIN
  @return                An RLMResults of objects that match the given predicate
  */
 - (RLMResults RLM_GENERIC_RETURN*)objectsWhere:(NSString *)predicateFormat, ...;
+
+/// :nodoc:
+- (RLMResults RLM_GENERIC_RETURN*)objectsWhere:(NSString *)predicateFormat args:(va_list)args;
 
 /**
  Get objects matching the given predicate in the RLMResults.

--- a/Realm/RLMResults.mm
+++ b/Realm/RLMResults.mm
@@ -245,8 +245,7 @@ static inline void RLMResultsValidateInWriteTransaction(__unsafe_unretained RLMR
 }
 
 - (NSUInteger)indexOfObjectWhere:(NSString *)predicateFormat args:(va_list)args {
-    return [self indexOfObjectWithPredicate:[NSPredicate predicateWithFormat:predicateFormat
-                                                                   arguments:args]];
+    return [self indexOfObjectWithPredicate:RLMValidatedPredicate(predicateFormat, args)];
 }
 
 - (NSUInteger)indexOfObjectWithPredicate:(NSPredicate *)predicate {
@@ -385,7 +384,7 @@ static inline void RLMResultsValidateInWriteTransaction(__unsafe_unretained RLMR
 }
 
 - (RLMResults *)objectsWhere:(NSString *)predicateFormat args:(va_list)args {
-    return [self objectsWithPredicate:[NSPredicate predicateWithFormat:predicateFormat arguments:args]];
+    return [self objectsWithPredicate:RLMValidatedPredicate(predicateFormat, args)];
 }
 
 - (RLMResults *)objectsWithPredicate:(NSPredicate *)predicate {

--- a/Realm/RLMResults.mm
+++ b/Realm/RLMResults.mm
@@ -240,12 +240,14 @@ static inline void RLMResultsValidateInWriteTransaction(__unsafe_unretained RLMR
 
 - (NSUInteger)indexOfObjectWhere:(NSString *)predicateFormat, ... {
     va_list args;
-    RLM_VARARG(predicateFormat, args);
+    va_start(args, predicateFormat);
+    va_end(args);
     return [self indexOfObjectWhere:predicateFormat args:args];
 }
 
 - (NSUInteger)indexOfObjectWhere:(NSString *)predicateFormat args:(va_list)args {
-    return [self indexOfObjectWithPredicate:RLMValidatedPredicate(predicateFormat, args)];
+    return [self indexOfObjectWithPredicate:[NSPredicate predicateWithFormat:predicateFormat
+                                                                   arguments:args]];
 }
 
 - (NSUInteger)indexOfObjectWithPredicate:(NSPredicate *)predicate {
@@ -379,12 +381,13 @@ static inline void RLMResultsValidateInWriteTransaction(__unsafe_unretained RLMR
 
 - (RLMResults *)objectsWhere:(NSString *)predicateFormat, ... {
     va_list args;
-    RLM_VARARG(predicateFormat, args);
+    va_start(args, predicateFormat);
+    va_end(args);
     return [self objectsWhere:predicateFormat args:args];
 }
 
 - (RLMResults *)objectsWhere:(NSString *)predicateFormat args:(va_list)args {
-    return [self objectsWithPredicate:RLMValidatedPredicate(predicateFormat, args)];
+    return [self objectsWithPredicate:[NSPredicate predicateWithFormat:predicateFormat arguments:args]];
 }
 
 - (RLMResults *)objectsWithPredicate:(NSPredicate *)predicate {

--- a/Realm/RLMResults.mm
+++ b/Realm/RLMResults.mm
@@ -241,8 +241,9 @@ static inline void RLMResultsValidateInWriteTransaction(__unsafe_unretained RLMR
 - (NSUInteger)indexOfObjectWhere:(NSString *)predicateFormat, ... {
     va_list args;
     va_start(args, predicateFormat);
+    NSUInteger index = [self indexOfObjectWhere:predicateFormat args:args];
     va_end(args);
-    return [self indexOfObjectWhere:predicateFormat args:args];
+    return index;
 }
 
 - (NSUInteger)indexOfObjectWhere:(NSString *)predicateFormat args:(va_list)args {
@@ -382,8 +383,9 @@ static inline void RLMResultsValidateInWriteTransaction(__unsafe_unretained RLMR
 - (RLMResults *)objectsWhere:(NSString *)predicateFormat, ... {
     va_list args;
     va_start(args, predicateFormat);
+    RLMResults *results = [self objectsWhere:predicateFormat args:args];
     va_end(args);
-    return [self objectsWhere:predicateFormat args:args];
+    return results;
 }
 
 - (RLMResults *)objectsWhere:(NSString *)predicateFormat args:(va_list)args {


### PR DESCRIPTION
to allow other variadic methods to forward their arguments and to mirror what's done in Foundation APIs.

This addresses #2934. I've marked the methods as `:nodoc:` so they won't be included in our HTML documentation because I don't think they should be.