### PR TITLE
Fix +[RLMObject createInRealm:withValue:] when given an NSArray

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,9 @@ x.x.x Release notes (yyyy-MM-dd)
 * Fix a race condition between commits and opening Realm files on new threads
   that could lead to a crash.
 * Fix several crashes when opening Realm files.
+* `-[RLMObject createInRealm:withValue:]`, `-[RLMObject createOrUpdateInRealm:withValue:]`, and
+  their variants for the default Realm now always match the contents of an `NSArray` against properties
+  in the same order as they are defined in the model,.
 
 0.96.2 Release notes (2015-10-26)
 =============================================================

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@ x.x.x Release notes (yyyy-MM-dd)
 * Fix several crashes when opening Realm files.
 * `-[RLMObject createInRealm:withValue:]`, `-[RLMObject createOrUpdateInRealm:withValue:]`, and
   their variants for the default Realm now always match the contents of an `NSArray` against properties
-  in the same order as they are defined in the model,.
+  in the same order as they are defined in the model.
 
 0.96.2 Release notes (2015-10-26)
 =============================================================

--- a/Realm/RLMObjectSchema.mm
+++ b/Realm/RLMObjectSchema.mm
@@ -39,6 +39,7 @@ using namespace realm;
 @implementation RLMObjectSchema {
     // table accessor optimization
     realm::TableRef _table;
+    NSArray *_propertiesInDeclaredOrder;
 }
 
 - (instancetype)initWithClassName:(NSString *)objectClassName objectClass:(Class)objectClass properties:(NSArray *)properties {
@@ -67,6 +68,7 @@ using namespace realm;
         }
     }
     _propertiesByName = map;
+    _propertiesInDeclaredOrder = nil;
 }
 
 - (void)setPrimaryKeyProperty:(RLMProperty *)primaryKeyProperty {
@@ -97,6 +99,10 @@ using namespace realm;
         props = [[RLMObjectSchema propertiesForClass:cls isSwift:isSwift] arrayByAddingObjectsFromArray:props];
         cls = superClass;
         superClass = class_getSuperclass(superClass);
+    }
+    NSUInteger index = 0;
+    for (RLMProperty *prop in props) {
+        prop.declarationIndex = index++;
     }
     schema.properties = props;
 
@@ -378,6 +384,17 @@ using namespace realm;
         return NSOrderedSame;
     }];
     // No need to update the dictionary
+}
+
+- (NSArray *)propertiesInDeclaredOrder {
+    if (!_propertiesInDeclaredOrder) {
+        _propertiesInDeclaredOrder = [_properties sortedArrayUsingComparator:^NSComparisonResult(RLMProperty *p1, RLMProperty *p2) {
+            if (p1.declarationIndex < p2.declarationIndex) return NSOrderedAscending;
+            if (p1.declarationIndex > p2.declarationIndex) return NSOrderedDescending;
+            return NSOrderedSame;
+        }];
+    }
+    return _propertiesInDeclaredOrder;
 }
 
 @end

--- a/Realm/RLMObjectSchema_Private.h
+++ b/Realm/RLMObjectSchema_Private.h
@@ -37,6 +37,8 @@ RLM_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, readwrite) RLMProperty *primaryKeyProperty;
 
+@property (nonatomic, readonly) NSArray RLM_GENERIC(RLMProperty *) *propertiesInDeclaredOrder;
+
 // The Realm retains its object schemas, so they need to not retain the Realm
 @property (nonatomic, unsafe_unretained, nullable) RLMRealm *realm;
 // returns a cached or new schema for a given object class

--- a/Realm/RLMObjectStore.mm
+++ b/Realm/RLMObjectStore.mm
@@ -378,7 +378,7 @@ RLMObjectBase *RLMCreateObjectInRealmWithValue(RLMRealm *realm, NSString *classN
         object->_row = (*objectSchema.table)[RLMCreateOrGetRowForObject(objectSchema, primaryGetter, createOrUpdate, created)];
 
         // populate
-        NSArray *props = objectSchema.properties;
+        NSArray *props = objectSchema.propertiesInDeclaredOrder;
         for (NSUInteger i = 0; i < array.count; i++) {
             RLMProperty *prop = props[i];
             // skip primary key when updating since it doesn't change

--- a/Realm/RLMProperty.mm
+++ b/Realm/RLMProperty.mm
@@ -396,6 +396,7 @@ BOOL RLMPropertyTypeIsNumeric(RLMPropertyType propertyType) {
     prop->_isPrimary = _isPrimary;
     prop->_swiftIvar = _swiftIvar;
     prop->_optional = _optional;
+    prop->_declarationIndex = _declarationIndex;
 
     return prop;
 }

--- a/Realm/RLMProperty_Private.h
+++ b/Realm/RLMProperty_Private.h
@@ -57,6 +57,7 @@ FOUNDATION_EXTERN BOOL RLMPropertyTypeIsNumeric(RLMPropertyType propertyType);
 @property (nonatomic, copy) NSString *objcRawType;
 @property (nonatomic, assign) BOOL isPrimary;
 @property (nonatomic, assign) Ivar swiftIvar;
+@property (nonatomic, assign) NSUInteger declarationIndex;
 
 // getter and setter names
 @property (nonatomic, copy) NSString *getterName;

--- a/Realm/Tests/MigrationTests.mm
+++ b/Realm/Tests/MigrationTests.mm
@@ -435,7 +435,10 @@ RLM_ARRAY_TYPE(MigrationObject);
 
     RLMRealm *realm = [self realmWithTestPathAndSchema:schema];
     [realm beginWriteTransaction];
-    [realm createObject:CircleObject.className withValue:@[NSNull.null, @"data"]];
+    [realm createObject:CircleObject.className withValue:@[@"data", NSNull.null]];
+
+    // -createObject:withValue: takes values in the order the properties were declared.
+    RLMAssertThrowsWithReasonMatching(([realm createObject:CircleObject.className withValue:@[NSNull.null, @"data"]]), @"object of type 'CircleObject'");
     [realm commitWriteTransaction];
 
     // accessors should work
@@ -464,6 +467,13 @@ RLM_ARRAY_TYPE(MigrationObject);
     for (NSUInteger i = 0; i < properties.count; i++) {
         XCTAssertEqual([properties[i] column], i);
     }
+
+    [realm beginWriteTransaction];
+    [realm createObject:CircleObject.className withValue:@[@"data", NSNull.null]];
+
+    // -createObject:withValue: takes values in the order the properties were declared.
+    RLMAssertThrowsWithReasonMatching(([realm createObject:CircleObject.className withValue:@[NSNull.null, @"data"]]), @"object of type 'CircleObject'");
+    [realm commitWriteTransaction];
 }
 
 - (void)testAccessorCreationForReadOnlyRealms {

--- a/Realm/Tests/MigrationTests.mm
+++ b/Realm/Tests/MigrationTests.mm
@@ -638,6 +638,7 @@ RLM_ARRAY_TYPE(MigrationObject);
     RLMObjectSchema *objectSchema = [RLMObjectSchema schemaForObjectClass:MigrationObject.class];
     RLMProperty *thirdProperty = [[RLMProperty alloc] initWithName:@"deletedCol" type:RLMPropertyTypeBool objectClassName:nil indexed:NO optional:NO];
     thirdProperty.column = 2;
+    thirdProperty.declarationIndex = 2;
     objectSchema.properties = [objectSchema.properties arrayByAddingObject:thirdProperty];
 
     // create realm with old schema and populate


### PR DESCRIPTION
It now matches values in the array with properties in the order that the properties are declared. This is the documented behavior.

We had been matching values in the order that the properties were stored in the Realm file. This order often matched the declared order, but isn't guaranteed to.

Fixes #2697.

I need to figure out how to write a test for this.