### PR TITLE
Have github_release.rb fail if any of the carthage commands it runs fail

### DIFF
--- a/scripts/github_release.rb
+++ b/scripts/github_release.rb
@@ -16,9 +16,9 @@ SWIFT_ZIP = BUILD + "realm-swift-#{VERSION}.zip"
 CARTHAGE_ZIP = BUILD + 'Carthage.framework.zip'
 
 puts 'Creating Carthage release zip'
-system('carthage', 'build', '--no-skip-current')
-system('carthage', 'archive', 'Realm', '--output', CARTHAGE_ZIP.to_path)
-system('carthage', 'archive', 'RealmSwift', '--output', CARTHAGE_ZIP.to_path)
+system('carthage', 'build', '--no-skip-current', '-v') || exit(1)
+system('carthage', 'archive', 'Realm', '--output', CARTHAGE_ZIP.to_path) || exit(1)
+system('carthage', 'archive', 'RealmSwift', '--output', CARTHAGE_ZIP.to_path) || exit(1)
 
 REPOSITORY = 'realm/realm-cocoa'
 

--- a/scripts/github_release.rb
+++ b/scripts/github_release.rb
@@ -16,7 +16,7 @@ SWIFT_ZIP = BUILD + "realm-swift-#{VERSION}.zip"
 CARTHAGE_ZIP = BUILD + 'Carthage.framework.zip'
 
 puts 'Creating Carthage release zip'
-system('carthage', 'build', '--no-skip-current', '-v') || exit(1)
+system('carthage', 'build', '--no-skip-current') || exit(1)
 system('carthage', 'archive', 'Realm', '--output', CARTHAGE_ZIP.to_path) || exit(1)
 system('carthage', 'archive', 'RealmSwift', '--output', CARTHAGE_ZIP.to_path) || exit(1)
 


### PR DESCRIPTION
Continuing on after failures can result in an incomplete Carthage.framework.zip being uploaded for the release.

/cc @jpsim @kishikawakatsumi 