### PR TITLE
[Podspec] Explicitly set the REALM_SWIFT_VERSION

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -320,6 +320,7 @@ case "$COMMAND" in
 esac
 export CONFIGURATION
 
+: ${REALM_SWIFT_VERSION:=1.2}
 source "$(dirname "$0")/scripts/swift-version.sh"
 
 case "$COMMAND" in


### PR DESCRIPTION
Instead of automatically determining it in the script via `scripts/swift-version.sh`, which would fail if the wrong Xcode version is selected globally via `xcode-select`.
Fixes #2941.
/c @bdash @jpsim