### PR TITLE
Call TableView::clear() with RemoveMode::unordered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,9 @@ x.x.x Release notes (yyyy-MM-dd)
 
 ### Bugfixes
 
-* None.
+* Fix poor performance when calling `-[RLMRealm deleteObjects:]` on an
+  `RLMResults` which filtered the objects when there are other classes linking
+  to the type of the deleted objects.
 
 0.96.3 Release notes (2015-12-04)
 =============================================================

--- a/Realm/ObjectStore/results.cpp
+++ b/Realm/ObjectStore/results.cpp
@@ -277,7 +277,7 @@ void Results::clear()
         case Mode::TableView:
             validate_write();
             update_tableview();
-            m_table_view.clear();
+            m_table_view.clear(RemoveMode::unordered);
             break;
     }
 }

--- a/Realm/Tests/KVOTests.mm
+++ b/Realm/Tests/KVOTests.mm
@@ -1613,7 +1613,6 @@ public:
     }
 }
 
-#if 0 // FIXME: this hits an assertion failure in core
 - (void)testInsertNewTables {
     KVOObject *obj = [self createObject];
 
@@ -1631,6 +1630,5 @@ public:
         AssertChanged(r, @NO, @YES);
     }
 }
-#endif
 @end
 

--- a/build.sh
+++ b/build.sh
@@ -14,7 +14,7 @@ set -o pipefail
 set -e
 
 # You can override the version of the core library
-: ${REALM_CORE_VERSION:=0.95.4} # set to "current" to always use the current build
+: ${REALM_CORE_VERSION:=0.95.5} # set to "current" to always use the current build
 
 # You can override the xcmode used
 : ${XCMODE:=xcodebuild} # must be one of: xcodebuild (default), xcpretty, xctool


### PR DESCRIPTION
By default it now does an ordered removal, which doesn't actually work with links.

The `TransactLogObserver` changes are to make it always assume unordered removal since it's currently being incorrectly reported as ordered, and we now never use ordered.

It'd be nice to have a test which actually hits the problematic conditions for ordered removal, but that'll probably take a while to write.

@jpsim @bdash 