### PR TITLE
[scripts] Initialize REALM_SWIFT_VERSION from branch

### DIFF
--- a/scripts/swift-version.sh
+++ b/scripts/swift-version.sh
@@ -30,6 +30,9 @@ find_xcode_for_swift() {
     return 1
 }
 
+# If version is not set, try to initialize it from the current branch for names like 'swift-1.2'
+: ${REALM_SWIFT_VERSION:=$(git symbolic-ref --short HEAD 2>/dev/null | sed -E 's/(swift-([0-9]+\.[0-9]+))|.*/\2/g')}
+
 if [[ "$REALM_SWIFT_VERSION" ]]; then
     find_xcode_for_swift $REALM_SWIFT_VERSION
 else


### PR DESCRIPTION
This ensures that on these branches, always the right source version is used instead of automatically determining it further down the script, which fails if the wrong Xcode version is selected globally via `xcode-select`.
This could be done explicitly on each branch, but that would cause that these branches diverge from master through a human-initiated action vs. just automatic commits by CI and could be easily forgotten for new such branches in the future.
Fixes #2941. Supersedes #2952.