### PR TITLE
[build.sh] Fix fail to install via CocoaPods on case-sensitive filesystem

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -798,6 +798,10 @@ case "$COMMAND" in
           cp Realm/ObjectStore/*.hpp include/Realm
           cp Realm/ObjectStore/impl/*.hpp include/Realm
           cp Realm/ObjectStore/impl/apple/*.hpp include/Realm
+          # Create lowercase `realm` header directory for a case-sensitive filesystem.
+          if [ ! -e include/realm ]; then
+            cp -R include/Realm include/realm
+          fi
           touch include/Realm/RLMPlatform.h
         fi
         ;;


### PR DESCRIPTION
Create `core/include/Realm` directory after copying ObjectStore headers.
Because cannot find ObjectStore related headers on case-sensitive filesystem.

On `0.96.3` and `master`, fail to install via CocoaPods due to the following error:

```
/Pods/Realm/Realm/ObjectStore/object_store_exceptions.cpp:19:10: 'object_store_exceptions.hpp' file not found
```

@jpsim @bdash 