### PR TITLE
Enabled support for embedding the Swift source code inside alternate project.

### DIFF
--- a/Realm/RLMAnalytics.mm
+++ b/Realm/RLMAnalytics.mm
@@ -169,7 +169,7 @@ static NSDictionary *RLMAnalyticsPayload() {
     }
 
     NSString *osVersionString = [[NSProcessInfo processInfo] operatingSystemVersionString];
-    BOOL isSwift = NSClassFromString(@"RealmSwift.ObjectUtil") != nil;
+    BOOL isSwift = NSClassFromString(@"RealmSwiftObjectUtil") != nil;
 
     static NSString *kUnknownString = @"unknown";
     NSString *hashedMACAddress = RLMMACAddress() ?: kUnknownString;

--- a/Realm/RLMObjectBase.mm
+++ b/Realm/RLMObjectBase.mm
@@ -429,7 +429,7 @@ id RLMValidatedValueForProperty(id object, NSString *key, NSString *className) {
 
 Class RLMObjectUtilClass(BOOL isSwift) {
     static Class objectUtilObjc = [RLMObjectUtil class];
-    static Class objectUtilSwift = NSClassFromString(@"RealmSwift.ObjectUtil");
+    static Class objectUtilSwift = NSClassFromString(@"RealmSwiftObjectUtil");
     return isSwift && objectUtilSwift ? objectUtilSwift : objectUtilObjc;
 }
 

--- a/Realm/RLMObjectStore.mm
+++ b/Realm/RLMObjectStore.mm
@@ -96,7 +96,7 @@ void RLMInitializeSwiftAccessorGenerics(__unsafe_unretained RLMObjectBase *const
         return;
     }
 
-    static Class s_swiftObjectClass = NSClassFromString(@"RealmSwift.Object");
+    static Class s_swiftObjectClass = NSClassFromString(@"RealmSwiftObject");
     if (![object isKindOfClass:s_swiftObjectClass]) {
         return; // Is a Swift class using the obj-c API
     }

--- a/RealmSwift-swift1.2/Object.swift
+++ b/RealmSwift-swift1.2/Object.swift
@@ -64,6 +64,7 @@ You can gets `Results` of an Object subclass via the `objects(_:)` instance meth
 
 See our [Cocoa guide](http://realm.io/docs/cocoa) for more details.
 */
+@objc(RealmSwiftObject)
 public class Object: RLMObjectBase, Equatable, Printable {
 
     // MARK: Initializers
@@ -299,6 +300,7 @@ public final class DynamicObject: Object {
 
 /// :nodoc:
 /// Internal class. Do not use directly.
+@objc(RealmSwiftObjectUtil)
 public class ObjectUtil: NSObject {
     @objc private class func ignoredPropertiesForClass(type: AnyClass) -> NSArray? {
         if let type = type as? Object.Type {

--- a/RealmSwift-swift2.0/Object.swift
+++ b/RealmSwift-swift2.0/Object.swift
@@ -65,6 +65,7 @@ method on `Realm`.
 
 See our [Cocoa guide](http://realm.io/docs/cocoa) for more details.
 */
+@objc(RealmSwiftObject)
 public class Object: RLMObjectBase {
 
     // MARK: Initializers
@@ -305,6 +306,7 @@ public final class DynamicObject: Object {
 
 /// :nodoc:
 /// Internal class. Do not use directly.
+@objc(RealmSwiftObjectUtil)
 public class ObjectUtil: NSObject {
     @objc private class func ignoredPropertiesForClass(type: AnyClass) -> NSArray? {
         if let type = type as? Object.Type {


### PR DESCRIPTION
This allows a user to link the static Realm framework and then add a direct reference to the RealmSwift code. The RealmSwift code no long needs to be in a project named "RealmSwift". This use case is currently unsupported by the Realm team, however, this code will address the issue with no side effects on the existing code. The benefit is that this method will allow targeting iOS 7 using RealmSwift (since there no longer needs to be a dynamic framework embedded in the app).

Related discussion: https://github.com/realm/realm-cocoa/issues/2962