### PR TITLE
improve config error when missing path+identifier

### DIFF
--- a/RealmSwift-swift1.2/RealmConfiguration.swift
+++ b/RealmSwift-swift1.2/RealmConfiguration.swift
@@ -147,10 +147,12 @@ extension Realm {
 
         internal var rlmConfiguration: RLMRealmConfiguration {
             let configuration = RLMRealmConfiguration()
-            if self.path != nil {
+            if path != nil {
                 configuration.path = self.path
-            } else {
+            } else if inMemoryIdentifier != nil {
                 configuration.inMemoryIdentifier = self.inMemoryIdentifier
+            } else {
+                fatalError("A Realm Configuration must specify a path or an in-memory identifier.")
             }
             configuration.encryptionKey = self.encryptionKey
             configuration.readOnly = self.readOnly

--- a/RealmSwift-swift2.0/RealmConfiguration.swift
+++ b/RealmSwift-swift2.0/RealmConfiguration.swift
@@ -141,8 +141,10 @@ extension Realm {
             let configuration = RLMRealmConfiguration()
             if path != nil {
                 configuration.path = self.path
-            } else {
+            } else if inMemoryIdentifier != nil {
                 configuration.inMemoryIdentifier = self.inMemoryIdentifier
+            } else {
+                fatalError("A Realm Configuration must specify a path or an in-memory identifier.")
             }
             configuration.encryptionKey = self.encryptionKey
             configuration.readOnly = self.readOnly


### PR DESCRIPTION
this would previously throw an Objective-C runtime exception: 'In-memory identifier must not be empty' which wasn't always clear, such as #2976. /cc @bdash 