### PR TITLE
Don't measure the construction of the NSPredicate in testQueryConstruction

### DIFF
--- a/RealmSwift-swift2.0/Tests/PerformanceTests.swift
+++ b/RealmSwift-swift2.0/Tests/PerformanceTests.swift
@@ -247,8 +247,8 @@ class SwiftPerformanceTests: TestCase {
 
     func testQueryConstruction() {
         let realm = realmWithTestPath()
-        let predicate = "boolCol = false and (intCol = 5 or floatCol = 1.0) and objectCol = nil and doubleCol != 7.0 " +
-                        " and stringCol IN {'a', 'b', 'c'}"
+        let predicate = NSPredicate(format: "boolCol = false and (intCol = 5 or floatCol = 1.0) and " +
+                                    "objectCol = nil and doubleCol != 7.0 and stringCol IN {'a', 'b', 'c'}")
 
         measureBlock {
             for _ in 0..<500 {


### PR DESCRIPTION
The parsing of the `NSPredicate` was moved into the benchmark loop by 2a2ae542d531a4fe6da132e8dbfdb22710989d7f, but it doesn't belong there.

This should fix #2978.