### PR TITLE
[RLMSchema] Fail instead dead-lock in +sharedSchema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ x.x.x Release notes (yyyy-MM-dd)
 * Many forms of queries with key paths on both sides of the comparison operator
   are now supported.
 * Add support for KVC collection operators in `RLMResults` and `RLMArray`.
+* Fail instead of deadlocking in `+[RLMRealm sharedSchema]`, if a Swift property is initialized
+  to a computed value, which attempts to open a Realm on its own.
 
 ### Bugfixes
 

--- a/Realm.xcodeproj/project.pbxproj
+++ b/Realm.xcodeproj/project.pbxproj
@@ -49,6 +49,8 @@
 		02AFB4671A80343600E11938 /* ResultsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 02AFB4621A80343600E11938 /* ResultsTests.m */; };
 		02AFB4681A80343600E11938 /* ResultsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 02AFB4621A80343600E11938 /* ResultsTests.m */; };
 		02E334C31A5F41C7009F8810 /* DynamicTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E81A1FBA1955FE0100FDED82 /* DynamicTests.m */; };
+		297FBEFB1C19F696009D1118 /* RLMTestCaseUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 297FBEFA1C19F696009D1118 /* RLMTestCaseUtils.swift */; };
+		297FBEFF1C19F844009D1118 /* TestUtils.mm in Sources */ = {isa = PBXBuildFile; fileRef = 297FBEFE1C19F844009D1118 /* TestUtils.mm */; };
 		29EDB8E41A7708E700458D80 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = E8839B2D19E31FD90047B1A8 /* main.m */; };
 		3F1F47821B9612B300CD99A3 /* KVOTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 3F0F029D1B6FFE610046A4D5 /* KVOTests.mm */; };
 		3F1F47831B9656B900CD99A3 /* KVOTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 3F0F029D1B6FFE610046A4D5 /* KVOTests.mm */; };
@@ -420,6 +422,9 @@
 		02E334C21A5F3C45009F8810 /* module.modulemap */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.module-map"; path = module.modulemap; sourceTree = "<group>"; };
 		02E334C41A5F4923009F8810 /* RLMRealm_Private.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = RLMRealm_Private.hpp; sourceTree = "<group>"; };
 		26F3CA681986CC86004623E1 /* SwiftPropertyTypeTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwiftPropertyTypeTest.swift; sourceTree = "<group>"; };
+		297FBEFA1C19F696009D1118 /* RLMTestCaseUtils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RLMTestCaseUtils.swift; sourceTree = "<group>"; };
+		297FBEFD1C19F844009D1118 /* TestUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TestUtils.h; path = Realm/Tests/TestUtils.h; sourceTree = SOURCE_ROOT; };
+		297FBEFE1C19F844009D1118 /* TestUtils.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = TestUtils.mm; path = Realm/Tests/TestUtils.mm; sourceTree = SOURCE_ROOT; };
 		29EDB8D71A7703C500458D80 /* RLMObjectStore.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RLMObjectStore.h; sourceTree = "<group>"; };
 		29EDB8E01A77070200458D80 /* RLMRealm_Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RLMRealm_Private.h; sourceTree = "<group>"; };
 		29EDB8E51A7710B700458D80 /* RLMResults_Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RLMResults_Private.h; sourceTree = "<group>"; };
@@ -776,6 +781,7 @@
 		E81A1FC81955FE0100FDED82 /* Swift */ = {
 			isa = PBXGroup;
 			children = (
+				297FBEFA1C19F696009D1118 /* RLMTestCaseUtils.swift */,
 				0217D7B819CD0ACD00DE5C32 /* Swift-Tests-Bridging-Header.h */,
 				E82FA60A195632F20043A3C3 /* SwiftArrayPropertyTests.swift */,
 				E82FA60B195632F20043A3C3 /* SwiftArrayTests.swift */,
@@ -788,6 +794,8 @@
 				3FEC4A3D1BBB188B00F009C3 /* SwiftSchemaTests.swift */,
 				E8F8D90B196CB8DD00475368 /* SwiftTestObjects.swift */,
 				E891759A197A1B600068ACC6 /* SwiftUnicodeTests.swift */,
+				297FBEFD1C19F844009D1118 /* TestUtils.h */,
+				297FBEFE1C19F844009D1118 /* TestUtils.mm */,
 			);
 			path = Swift;
 			sourceTree = "<group>";
@@ -1694,12 +1702,14 @@
 				E81A1FEE1955FE0100FDED82 /* RLMTestCase.m in Sources */,
 				028481EF19CD032C0097A416 /* RLMTestObjects.m in Sources */,
 				0207AB89195DFA15007EFB12 /* SchemaTests.mm in Sources */,
+				297FBEFB1C19F696009D1118 /* RLMTestCaseUtils.swift in Sources */,
 				3FB4FA1819F5D2740020D53B /* SwiftArrayPropertyTests.swift in Sources */,
 				3FB4FA1919F5D2740020D53B /* SwiftArrayTests.swift in Sources */,
 				3FB4FA1A19F5D2740020D53B /* SwiftDynamicTests.swift in Sources */,
 				3FB4FA1B19F5D2740020D53B /* SwiftLinkTests.swift in Sources */,
 				3FB4FA1C19F5D2740020D53B /* SwiftMixedTests.swift in Sources */,
 				3FB4FA1D19F5D2740020D53B /* SwiftObjectInterfaceTests.swift in Sources */,
+				297FBEFF1C19F844009D1118 /* TestUtils.mm in Sources */,
 				3FB4FA1E19F5D2740020D53B /* SwiftPropertyTypeTest.swift in Sources */,
 				3FB4FA1F19F5D2740020D53B /* SwiftRealmTests.swift in Sources */,
 				3FEC4A3F1BBB18D400F009C3 /* SwiftSchemaTests.swift in Sources */,

--- a/Realm/Tests/Swift1.2/RLMTestCaseUtils.swift
+++ b/Realm/Tests/Swift1.2/RLMTestCaseUtils.swift
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////
 //
-// Copyright 2014 Realm Inc.
+// Copyright 2015 Realm Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,10 +16,9 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-#import "RLMTestObjects.h"
-#import "RLMMultiProcessTestCase.h"
-#import "TestUtils.h"
-
-@interface RLMSchema (Private)
-+ (void)registerClasses:(const Class[])classes count:(NSUInteger)count;
-@end
+extension RLMTestCase {
+    func assertThrowsWithReasonMatching<T>(@autoclosure(escaping) block: () -> T, _ regexString: String,
+        _ message: String? = nil, fileName: String = __FILE__, lineNumber: UInt = __LINE__) {
+            RLMAssertThrowsWithReasonMatchingSwift(self, { _ = block() } as dispatch_block_t, regexString, message, fileName, lineNumber)
+    }
+}

--- a/Realm/Tests/Swift2.0/RLMTestCaseUtils.swift
+++ b/Realm/Tests/Swift2.0/RLMTestCaseUtils.swift
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////
 //
-// Copyright 2014 Realm Inc.
+// Copyright 2015 Realm Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,10 +16,9 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-#import "RLMTestObjects.h"
-#import "RLMMultiProcessTestCase.h"
-#import "TestUtils.h"
-
-@interface RLMSchema (Private)
-+ (void)registerClasses:(const Class[])classes count:(NSUInteger)count;
-@end
+extension RLMTestCase {
+    func assertThrowsWithReasonMatching<T>(@autoclosure(escaping) block: () -> T, _ regexString: String,
+        _ message: String? = nil, fileName: String = __FILE__, lineNumber: UInt = __LINE__) {
+            RLMAssertThrowsWithReasonMatchingSwift(self, { _ = block() } as dispatch_block_t, regexString, message, fileName, lineNumber)
+    }
+}

--- a/Realm/Tests/Swift2.0/Swift-Tests-Bridging-Header.h
+++ b/Realm/Tests/Swift2.0/Swift-Tests-Bridging-Header.h
@@ -18,6 +18,7 @@
 
 #import "RLMTestObjects.h"
 #import "RLMMultiProcessTestCase.h"
+#import "TestUtils.h"
 
 @interface RLMSchema (Private)
 + (void)registerClasses:(const Class[])classes count:(NSUInteger)count;

--- a/Realm/Tests/TestUtils.h
+++ b/Realm/Tests/TestUtils.h
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////
 //
-// Copyright 2014 Realm Inc.
+// Copyright 2015 Realm Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,10 +16,12 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-#import "RLMTestObjects.h"
-#import "RLMMultiProcessTestCase.h"
-#import "TestUtils.h"
+#import <Foundation/Foundation.h>
+#import <XCTest/XCTestCase.h>
 
-@interface RLMSchema (Private)
-+ (void)registerClasses:(const Class[])classes count:(NSUInteger)count;
-@end
+FOUNDATION_EXTERN void RLMAssertThrowsWithReasonMatchingSwift(XCTestCase *self,
+                                                              __attribute__((noescape)) dispatch_block_t block,
+                                                              NSString *regexString,
+                                                              NSString *message,
+                                                              NSString *fileName,
+                                                              NSUInteger lineNumber);

--- a/Realm/Tests/TestUtils.mm
+++ b/Realm/Tests/TestUtils.mm
@@ -1,0 +1,45 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2015 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+#import "TestUtils.h"
+
+#import <Realm/Realm.h>
+#import <Realm/RLMRealmUtil.hpp>
+#import <Realm/RLMSchema_Private.h>
+
+void RLMAssertThrowsWithReasonMatchingSwift(XCTestCase *self, dispatch_block_t block, NSString *regexString, NSString *message, NSString *fileName, NSUInteger lineNumber) {
+    BOOL didThrow = NO;
+    @try {
+        block();
+    }
+    @catch (NSException *e) {
+        didThrow = YES;
+        NSString *reason = e.reason;
+        NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:regexString options:(NSRegularExpressionOptions)0 error:nil];
+        if ([regex numberOfMatchesInString:reason options:(NSMatchingOptions)0 range:NSMakeRange(0, reason.length)] == 0) {
+            NSString *msg = [NSString stringWithFormat:@"The given expression threw an exception with reason '%@', but expected to match '%@'",
+                             reason, regexString];
+            [self recordFailureWithDescription:msg inFile:fileName atLine:lineNumber expected:NO];
+        }
+    }
+    if (!didThrow) {
+        NSString *prefix = @"The given expression failed to throw an exception";
+        message = message ? [NSString stringWithFormat:@"%@ (%@)",  prefix, message] : prefix;
+        [self recordFailureWithDescription:message inFile:fileName atLine:lineNumber expected:NO];
+    }
+}


### PR DESCRIPTION
If a Swift property is initialized to a computed value, which attempts to open a Realm, e.g. to query for a given object, this can led to recursion while initializing the runtime schema, because Swift objects have to be initialized.
Fixes #2868.

Note: Because that affects only the `sharedSchema` and there is no API to reset those, I had to base the test on `RLMMultiProcessTestCase`, which makes this nearly impossible to debug. Because that behavior is only present for Swift object classes, this had to be done in a Swift test, which required to make a test assert to catch and check exceptions available to those as well.