### PR TITLE
Add support for subqueries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,10 @@ x.x.x Release notes (yyyy-MM-dd)
   properties.
 * Indexing `BOOL`/`Bool` and `NSDate` properties are now supported.
 * Swift: Add support for indexing optional properties.
+* `NSPredicate`'s `SUBQUERY` operator is now supported. It has the following limitations:
+  * `@count` is the only operator that may be applied to the `SUBQUERY` expression.
+  * The `SUBQUERY(…).@count` expression must be compared with a constant.
+  * Correlated subqueries are not yet supported.
 
 ### Bugfixes
 

--- a/Realm.xcodeproj/project.pbxproj
+++ b/Realm.xcodeproj/project.pbxproj
@@ -100,6 +100,10 @@
 		3FDE338D19C39A87003B7DBA /* RLMSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = E88C36FF19745E5500C9963D /* RLMSupport.swift */; };
 		3FEC4A3F1BBB18D400F009C3 /* SwiftSchemaTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FEC4A3D1BBB188B00F009C3 /* SwiftSchemaTests.swift */; };
 		5D128F2A1BE984E5001F4FBF /* Realm.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 5D659ED91BE04556006515A0 /* Realm.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		5D3E1A2E1C1FC6D5002913BA /* RLMPredicateUtil.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 5D3E1A2C1C1FC6D5002913BA /* RLMPredicateUtil.hpp */; };
+		5D3E1A2F1C1FC6D5002913BA /* RLMPredicateUtil.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5D3E1A2D1C1FC6D5002913BA /* RLMPredicateUtil.mm */; };
+		5D3E1A301C1FD1CF002913BA /* RLMPredicateUtil.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5D3E1A2D1C1FC6D5002913BA /* RLMPredicateUtil.mm */; };
+		5D3E1A311C1FD1D2002913BA /* RLMPredicateUtil.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 5D3E1A2C1C1FC6D5002913BA /* RLMPredicateUtil.hpp */; };
 		5D6156EE1BE0689200A4BD3F /* Realm.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5D659ED91BE04556006515A0 /* Realm.framework */; };
 		5D6156FB1BE08E7E00A4BD3F /* PerformanceTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 3F04EA2D1992BEE400C2CE2E /* PerformanceTests.m */; };
 		5D6157051BE13CBB00A4BD3F /* strip-frameworks.sh in Resources */ = {isa = PBXBuildFile; fileRef = E81C393E1AE5CE6A00F03B56 /* strip-frameworks.sh */; };
@@ -491,6 +495,8 @@
 		3FE79FF719BA6A5900780C9A /* RLMSwiftSupport.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RLMSwiftSupport.h; sourceTree = "<group>"; };
 		3FEC4A3D1BBB188B00F009C3 /* SwiftSchemaTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwiftSchemaTests.swift; sourceTree = "<group>"; };
 		5D30B74A1B42039F00D90C5A /* RLMDefines.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RLMDefines.h; sourceTree = "<group>"; };
+		5D3E1A2C1C1FC6D5002913BA /* RLMPredicateUtil.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = RLMPredicateUtil.hpp; sourceTree = "<group>"; };
+		5D3E1A2D1C1FC6D5002913BA /* RLMPredicateUtil.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = RLMPredicateUtil.mm; sourceTree = "<group>"; };
 		5D6156F51BE077E600A4BD3F /* RLMPlatform.h.in */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = RLMPlatform.h.in; sourceTree = "<group>"; };
 		5D6156F71BE07B6B00A4BD3F /* TestHost.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = TestHost.xcconfig; sourceTree = "<group>"; };
 		5D659E6D1BE0398E006515A0 /* Base.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Base.xcconfig; sourceTree = "<group>"; };
@@ -956,6 +962,8 @@
 				C0004BEB1B8E4FCF00304BF3 /* RLMOptionalBase.h */,
 				C0004BEC1B8E4FCF00304BF3 /* RLMOptionalBase.mm */,
 				5D6156F51BE077E600A4BD3F /* RLMPlatform.h.in */,
+				5D3E1A2C1C1FC6D5002913BA /* RLMPredicateUtil.hpp */,
+				5D3E1A2D1C1FC6D5002913BA /* RLMPredicateUtil.mm */,
 				3F68BFCD1B558CA800D50FBD /* RLMPrefix.h */,
 				E81A1F761955FC9300FDED82 /* RLMProperty.h */,
 				E81A1F771955FC9300FDED82 /* RLMProperty.mm */,
@@ -1036,6 +1044,7 @@
 				3F0543F41C56F76700AA5322 /* cached_realm_base.hpp in Headers */,
 				5D659EA01BE04556006515A0 /* external_commit_helper.hpp in Headers */,
 				3F0543F81C56F78300AA5322 /* external_commit_helper.hpp in Headers */,
+				5D3E1A2E1C1FC6D5002913BA /* RLMPredicateUtil.hpp in Headers */,
 				5D659EA11BE04556006515A0 /* index_set.hpp in Headers */,
 				5D659EA21BE04556006515A0 /* object_schema.hpp in Headers */,
 				5D659EA31BE04556006515A0 /* object_store.hpp in Headers */,
@@ -1111,6 +1120,7 @@
 				5DD755AB1BE056DE002800DA /* RLMDefines.h in Headers */,
 				5DD755AC1BE056DE002800DA /* RLMListBase.h in Headers */,
 				5DD755AD1BE056DE002800DA /* RLMMigration.h in Headers */,
+				5D3E1A311C1FD1D2002913BA /* RLMPredicateUtil.hpp in Headers */,
 				5DD755AE1BE056DE002800DA /* RLMMigration_Private.h in Headers */,
 				5DD755AF1BE056DE002800DA /* RLMObject.h in Headers */,
 				5DD755B01BE056DE002800DA /* RLMObject_Private.h in Headers */,
@@ -1621,6 +1631,7 @@
 				5D659E921BE04556006515A0 /* RLMProperty.mm in Sources */,
 				5D659E931BE04556006515A0 /* RLMQueryUtil.mm in Sources */,
 				5D659E941BE04556006515A0 /* RLMRealm.mm in Sources */,
+				5D3E1A2F1C1FC6D5002913BA /* RLMPredicateUtil.mm in Sources */,
 				5D659E951BE04556006515A0 /* RLMRealmConfiguration.mm in Sources */,
 				5D659E961BE04556006515A0 /* RLMRealmUtil.mm in Sources */,
 				5D659E971BE04556006515A0 /* RLMResults.mm in Sources */,
@@ -1712,6 +1723,7 @@
 				5DD755901BE056DE002800DA /* RLMProperty.mm in Sources */,
 				5DD755911BE056DE002800DA /* RLMQueryUtil.mm in Sources */,
 				5DD755921BE056DE002800DA /* RLMRealm.mm in Sources */,
+				5D3E1A301C1FD1CF002913BA /* RLMPredicateUtil.mm in Sources */,
 				5DD755931BE056DE002800DA /* RLMRealmConfiguration.mm in Sources */,
 				5DD755941BE056DE002800DA /* RLMRealmUtil.mm in Sources */,
 				5DD755951BE056DE002800DA /* RLMResults.mm in Sources */,

--- a/Realm/RLMPredicateUtil.hpp
+++ b/Realm/RLMPredicateUtil.hpp
@@ -1,0 +1,36 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2015 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#import <Foundation/Foundation.h>
+
+class RLMPredicateExpressionTransformer {
+    using ExpressionVisitor = NSExpression *(*)(NSExpression *);
+
+public:
+    static NSPredicate *transform(NSPredicate *predicate, ExpressionVisitor visitor) {
+        RLMPredicateExpressionTransformer self(visitor);
+        return self.visit(predicate);
+    }
+
+private:
+    RLMPredicateExpressionTransformer(ExpressionVisitor visitor) : m_visitor(visitor) { }
+
+    NSExpression *visit(NSExpression *expression) const;
+    NSPredicate *visit(NSPredicate *predicate) const;
+
+    ExpressionVisitor m_visitor;
+};

--- a/Realm/RLMPredicateUtil.hpp
+++ b/Realm/RLMPredicateUtil.hpp
@@ -17,20 +17,5 @@
 
 #import <Foundation/Foundation.h>
 
-class RLMPredicateExpressionTransformer {
-    using ExpressionVisitor = NSExpression *(*)(NSExpression *);
-
-public:
-    static NSPredicate *transform(NSPredicate *predicate, ExpressionVisitor visitor) {
-        RLMPredicateExpressionTransformer self(visitor);
-        return self.visit(predicate);
-    }
-
-private:
-    RLMPredicateExpressionTransformer(ExpressionVisitor visitor) : m_visitor(visitor) { }
-
-    NSExpression *visit(NSExpression *expression) const;
-    NSPredicate *visit(NSPredicate *predicate) const;
-
-    ExpressionVisitor m_visitor;
-};
+using ExpressionVisitor = NSExpression *(*)(NSExpression *);
+NSPredicate *transformPredicate(NSPredicate *, ExpressionVisitor);

--- a/Realm/RLMPredicateUtil.mm
+++ b/Realm/RLMPredicateUtil.mm
@@ -17,6 +17,27 @@
 
 #import "RLMPredicateUtil.hpp"
 
+// NSConditionalExpressionType is new in OS X 10.11 and iOS 9.0
+#if defined(__MAC_OS_X_VERSION_MIN_REQUIRED)
+#define CONDITIONAL_EXPRESSION_DECLARED (__MAC_OS_X_VERSION_MIN_REQUIRED >= 101100)
+#elif defined(__IPHONE_OS_VERSION_MIN_REQUIRED)
+#define CONDITIONAL_EXPRESSION_DECLARED (__IPHONE_OS_VERSION_MIN_REQUIRED >= 90000)
+#else
+#define CONDITIONAL_EXPRESSION_DECLARED 0
+#endif
+
+#if !CONDITIONAL_EXPRESSION_DECLARED
+
+#define NSConditionalExpressionType 20
+
+@interface NSExpression (NewIn1011And90)
++ (NSExpression *)expressionForConditional:(NSPredicate *)predicate trueExpression:(NSExpression *)trueExpression falseExpression:(NSExpression *)falseExpression;
+- (NSExpression *)trueExpression;
+- (NSExpression *)falseExpression;
+@end
+
+#endif
+
 NSExpression *RLMPredicateExpressionTransformer::visit(NSExpression *expression) const {
     expression = m_visitor(expression);
 

--- a/Realm/RLMQueryUtil.mm
+++ b/Realm/RLMQueryUtil.mm
@@ -1015,7 +1015,7 @@ void update_query_with_subquery_expression(RLMSchema *schema, RLMObjectSchema *o
 
     // Eliminate references to the iteration variable in the subquery.
     NSPredicate *subqueryPredicate = [subqueryExpression.predicate predicateWithSubstitutionVariables:@{ subqueryExpression.variable : [NSExpression expressionForEvaluatedObject] }];
-    subqueryPredicate = RLMPredicateExpressionTransformer::transform(subqueryPredicate, simplify_self_value_for_key_path_function_expression);
+    subqueryPredicate = transformPredicate(subqueryPredicate, simplify_self_value_for_key_path_function_expression);
 
     Query subquery = collectionMemberObjectSchema.table->where();
     RLMUpdateQueryWithPredicate(&subquery, subqueryPredicate, schema, collectionMemberObjectSchema);

--- a/Realm/RLMQueryUtil.mm
+++ b/Realm/RLMQueryUtil.mm
@@ -1001,7 +1001,7 @@ NSExpression *simplify_self_value_for_key_path_function_expression(NSExpression 
     if (expression.expressionType == NSFunctionExpressionType
         && expression.operand.expressionType == NSEvaluatedObjectExpressionType
         && [expression.function isEqualToString:@"valueForKeyPath:"]) {
-        if (NSString *keyPath = expression.arguments.firstObject.keyPath) {
+        if (NSString *keyPath = [expression.arguments.firstObject keyPath]) {
             return [NSExpression expressionForKeyPath:keyPath];
         }
     }

--- a/Realm/RLMQueryUtil.mm
+++ b/Realm/RLMQueryUtil.mm
@@ -86,14 +86,20 @@ struct TrueExpression : realm::Expression {
     }
     void set_table(const Table*) override {}
     const Table* get_table() const override { return nullptr; }
-    std::unique_ptr<Expression> clone(QueryNodeHandoverPatches*) const override { return nullptr; }
+    std::unique_ptr<Expression> clone(QueryNodeHandoverPatches*) const override
+    {
+        return std::unique_ptr<Expression>(new TrueExpression(*this));
+    }
 };
 
 struct FalseExpression : realm::Expression {
     size_t find_first(size_t, size_t) const override { return realm::not_found; }
     void set_table(const Table*) override {}
     const Table* get_table() const override { return nullptr; }
-    std::unique_ptr<Expression> clone(QueryNodeHandoverPatches*) const override { return nullptr; }
+    std::unique_ptr<Expression> clone(QueryNodeHandoverPatches*) const override
+    {
+        return std::unique_ptr<Expression>(new FalseExpression(*this));
+    }
 };
 
 NSString *operatorName(NSPredicateOperatorType operatorType)

--- a/Realm/RLMQueryUtil.mm
+++ b/Realm/RLMQueryUtil.mm
@@ -86,12 +86,14 @@ struct TrueExpression : realm::Expression {
     }
     void set_table(const Table*) override {}
     const Table* get_table() const override { return nullptr; }
+    std::unique_ptr<Expression> clone(QueryNodeHandoverPatches*) const override { return nullptr; }
 };
 
 struct FalseExpression : realm::Expression {
     size_t find_first(size_t, size_t) const override { return realm::not_found; }
     void set_table(const Table*) override {}
     const Table* get_table() const override { return nullptr; }
+    std::unique_ptr<Expression> clone(QueryNodeHandoverPatches*) const override { return nullptr; }
 };
 
 NSString *operatorName(NSPredicateOperatorType operatorType)
@@ -501,7 +503,7 @@ void add_link_constraint_to_query(realm::Query & query,
     }
 
     if (!obj->_row.is_attached()) {
-        query.and_query(new FalseExpression);
+        query.and_query(std::unique_ptr<Expression>(new FalseExpression));
         return;
     }
 
@@ -564,7 +566,7 @@ void process_or_group(Query &query, id array, Func&& func) {
         // Queries can't be empty, so if there's zero things in the OR group
         // validation will fail. Work around this by adding an expression which
         // will never find any rows in a table.
-        query.and_query(new FalseExpression);
+        query.and_query(std::unique_ptr<Expression>(new FalseExpression));
     }
 
     query.end_group();
@@ -1033,7 +1035,7 @@ void update_query_with_predicate(NSPredicate *predicate, RLMSchema *schema,
                     query.end_group();
                 } else {
                     // NSCompoundPredicate's documentation states that an AND predicate with no subpredicates evaluates to TRUE.
-                    query.and_query(new TrueExpression);
+                    query.and_query(std::unique_ptr<Expression>(new TrueExpression));
                 }
                 break;
 
@@ -1124,9 +1126,9 @@ void update_query_with_predicate(NSPredicate *predicate, RLMSchema *schema,
         }
     }
     else if ([predicate isEqual:[NSPredicate predicateWithValue:YES]]) {
-        query.and_query(new TrueExpression);
+        query.and_query(std::unique_ptr<Expression>(new TrueExpression));
     } else if ([predicate isEqual:[NSPredicate predicateWithValue:NO]]) {
-        query.and_query(new FalseExpression);
+        query.and_query(std::unique_ptr<Expression>(new FalseExpression));
     }
     else {
         // invalid predicate type

--- a/Realm/RLMQueryUtil.mm
+++ b/Realm/RLMQueryUtil.mm
@@ -1124,9 +1124,14 @@ void update_query_with_predicate(NSPredicate *predicate, RLMSchema *schema,
             // Inserting an array via %@ gives NSConstantValueExpressionType, but
             // including it directly gives NSAggregateExpressionType
             if (exp1Type != NSKeyPathExpressionType || (exp2Type != NSAggregateExpressionType && exp2Type != NSConstantValueExpressionType)) {
-                @throw RLMPredicateException(@"Invalid predicate",
-                                             @"Predicate with %s operator must compare a KeyPath with an aggregate with two values",
-                                             compp.predicateOperatorType == NSBetweenPredicateOperatorType ? "BETWEEN" : "IN");
+                if (compp.predicateOperatorType == NSBetweenPredicateOperatorType) {
+                    @throw RLMPredicateException(@"Invalid predicate",
+                                                 @"Predicate with BETWEEN operator must compare a KeyPath with an aggregate with two values");
+                }
+                else if (compp.predicateOperatorType == NSInPredicateOperatorType) {
+                    @throw RLMPredicateException(@"Invalid predicate",
+                                                 @"Predicate with IN operator must compare a KeyPath with an aggregate");
+                }
             }
             exp2Type = NSConstantValueExpressionType;
         }

--- a/Realm/Tests/QueryTests.m
+++ b/Realm/Tests/QueryTests.m
@@ -1765,8 +1765,8 @@
                                                         @{@"name": @"Tim",  @"age": @60, @"hired": @NO}]]];
     [realm commitWriteTransaction];
 
-    XCTAssertEqual(1U, [CompanyObject objectsWhere:@"SUBQUERY(employees, $employee, $employee.age > 30 AND $employee.hired = FALSE).@count > 0"].count);
-    XCTAssertEqual(2U, [CompanyObject objectsWhere:@"SUBQUERY(employees, $employee, $employee.age < 30 AND $employee.hired = TRUE).@count == 0"].count);
+    RLMAssertCount(CompanyObject, 1U, @"SUBQUERY(employees, $employee, $employee.age > 30 AND $employee.hired = FALSE).@count > 0");
+    RLMAssertCount(CompanyObject, 2U, @"SUBQUERY(employees, $employee, $employee.age < 30 AND $employee.hired = TRUE).@count == 0");
 }
 
 @end

--- a/Realm/Tests/QueryTests.m
+++ b/Realm/Tests/QueryTests.m
@@ -183,6 +183,7 @@
     // Unsupported variants of subqueries.
     RLMAssertThrowsWithReasonMatching(([ArrayOfAllTypesObject objectsWhere:@"SUBQUERY(array, $obj, $obj.intCol = 5).@count == array.@count"]), @"SUBQUERY.*compared with a constant number");
     RLMAssertThrowsWithReasonMatching(([ArrayOfAllTypesObject objectsWhere:@"SUBQUERY(array, $obj, $obj.intCol = 5) == 0"]), @"SUBQUERY.*immediately followed by .@count");
+    RLMAssertThrowsWithReasonMatching(([ArrayOfAllTypesObject objectsWhere:@"SELF IN SUBQUERY(array, $obj, $obj.intCol = 5)"]), @"Predicate with IN operator must compare.*aggregate$");
 
     // block-based predicate
     NSPredicate *pred = [NSPredicate predicateWithBlock:^BOOL (__unused id obj, __unused NSDictionary *bindings) {

--- a/build.sh
+++ b/build.sh
@@ -14,7 +14,7 @@ set -o pipefail
 set -e
 
 # You can override the version of the core library
-: ${REALM_CORE_VERSION:=0.95.9} # set to "current" to always use the current build
+: ${REALM_CORE_VERSION:=0.96.0} # set to "current" to always use the current build
 
 # You can override the xcmode used
 : ${XCMODE:=xcodebuild} # must be one of: xcodebuild (default), xcpretty, xctool


### PR DESCRIPTION
Expressions that compare the count of a subquery against a constant value are supported. Comparing against non-constant values is not yet supported, nor is comparing anything but the count of the subquery.

This depends on realm/realm-core#1405 and cannot be merged until we're using a core release that contains that change.