### PR TITLE
[CONTRIBUTING] Add guidelines about the format of commit messages

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,6 +43,21 @@ $(which git && git --version)
 
 We love contributions to Realm! If you'd like to contribute code, documentation, or any other improvements, please [file a Pull Request](https://github.com/realm/realm-cocoa/pulls) on our GitHub repository. Make sure to accept our [CLA](#CLA) and to follow our [style guide](https://github.com/realm/realm-cocoa/wiki/Objective-C-Style-Guide).
 
+### Commit Messages
+
+Although we don’t enforce a strict format for commit messages, we prefer that you follow the guidelines below, which are common among open source projects. Following these guidelines helps with the review process, searching commit logs and documentation of implementation details. At a high level, the contents of the commit message should convey the rationale of the change, without delving into much detail. For example, `setter names were not set right` leaves the reviewer wondering about which bits and why they weren’t “right”. In contrast, `[RLMProperty] Correctly capitalize setterName` conveys almost all there is to the change.
+
+Below are some guidelines about the format of the commit message itself:
+
+* Separate the commit message into a single-line title and a separate body that describes the change.
+* Make the title concise to be easily read within a commit log.
+* In changes that are restricted to a specific part of the code, include a [tag] at the start of the line in square brackets — for example, `[RLMArray] …`, `[scripts] …` or  `[Podspec] …`. This tag helps email filters and searches for post-commit reviews.
+* Make the body concise, while including the complete reasoning. Unless required to understand the change, additional code examples or other details should be left to the pull request.
+* If the commit fixes a bug, include the number of the issue in the message.
+* Use the first person present tense - for example "Fix …" instead of "Fixes …" or "Fixed …".
+* For text formatting and spelling, follow the same rules as documentation and in-code comments — for example, the use of capitalization and periods.
+* If the commit is a bug fix on top of another recently committed change, or a revert or reapply of a patch, include the Git revision number of the prior related commit, e.g. `Revert abcd3fg because it caused #1234`.
+
 ### CLA
 
 Realm welcomes all contributions! The only requirement we have is that, like many other projects, we need to have a [Contributor License Agreement](https://en.wikipedia.org/wiki/Contributor_License_Agreement) (CLA) in place before we can accept any external code. Our own CLA is a modified version of the Apache Software Foundation’s CLA.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,7 +51,6 @@ Below are some guidelines about the format of the commit message itself:
 
 * Separate the commit message into a single-line title and a separate body that describes the change.
 * Make the title concise to be easily read within a commit log.
-* In changes that are restricted to a specific part of the code, include a [tag] at the start of the line in square brackets — for example, `[RLMArray] …`, `[scripts] …` or  `[Podspec] …`. This tag helps email filters and searches for post-commit reviews.
 * Make the body concise, while including the complete reasoning. Unless required to understand the change, additional code examples or other details should be left to the pull request.
 * If the commit fixes a bug, include the number of the issue in the message.
 * Use the first person present tense - for example "Fix …" instead of "Fixes …" or "Fixed …".


### PR DESCRIPTION
Based on https://swift.org/contributing/#commit-messages with minor adaptions.