### PR TITLE
fix tvOS Swift packaging

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -473,6 +473,7 @@ case "$COMMAND" in
         ;;
 
     "tvos-swift")
+        sh build.sh tvos
         build_combined RealmSwift RealmSwift appletvos appletvsimulator
         exit 0
         ;;


### PR DESCRIPTION
Otherwise get this when running `sh build.sh package-tvos-swift`:

```
	zip warning: name not matched: Realm.framework
  adding: RealmSwift.framework/ (stored 0%)
  adding: RealmSwift.framework/071A9353-A9D3-3243-91A9-BD46CD7EF709.bcsymbolmap (deflated 87%)
  adding: RealmSwift.framework/_CodeSignature/ (stored 0%)
  adding: RealmSwift.framework/_CodeSignature/CodeResources (deflated 76%)
  adding: RealmSwift.framework/B621124F-2946-3BFE-AE58-DC93B8A77465.bcsymbolmap (deflated 88%)
  adding: RealmSwift.framework/Headers/ (stored 0%)
  adding: RealmSwift.framework/Headers/RealmSwift-Swift.h (deflated 74%)
  adding: RealmSwift.framework/Info.plist (deflated 29%)
  adding: RealmSwift.framework/Modules/ (stored 0%)
  adding: RealmSwift.framework/Modules/module.modulemap (deflated 17%)
  adding: RealmSwift.framework/Modules/RealmSwift.swiftmodule/ (stored 0%)
  adding: RealmSwift.framework/Modules/RealmSwift.swiftmodule/arm64.swiftdoc (deflated 80%)
  adding: RealmSwift.framework/Modules/RealmSwift.swiftmodule/arm64.swiftmodule (deflated 67%)
  adding: RealmSwift.framework/Modules/RealmSwift.swiftmodule/x86_64.swiftdoc (deflated 80%)
  adding: RealmSwift.framework/Modules/RealmSwift.swiftmodule/x86_64.swiftmodule (deflated 67%)
  adding: RealmSwift.framework/RealmSwift (deflated 64%)
```