### PR TITLE
[Script] Avoid code signing bcsymbolmap files

### DIFF
--- a/scripts/strip-frameworks.sh
+++ b/scripts/strip-frameworks.sh
@@ -35,6 +35,14 @@ code_sign() {
   /usr/bin/codesign --force --sign ${EXPANDED_CODE_SIGN_IDENTITY} --preserve-metadata=identifier,entitlements "$1"
 }
 
+if [ "$ACTION" = "install" ]; then
+  echo "Copy .bcsymbolmap files to .xcarchive"
+  find . -name '*.bcsymbolmap' -type f -exec mv {} "${CONFIGURATION_BUILD_DIR}" \;
+else
+  # Delete *.bcsymbolmap files from framework bundle unless archiving
+  find . -name '*.bcsymbolmap' -type f -exec rm -rf "{}" +\;
+fi
+
 echo "Stripping frameworks"
 cd "${BUILT_PRODUCTS_DIR}/${FRAMEWORKS_FOLDER_PATH}"
 
@@ -60,11 +68,3 @@ for file in $(find . -type f -perm +111); do
     fi
   fi
 done
-
-if [ "$ACTION" = "install" ]; then
-  echo "Copy .bcsymbolmap files to .xcarchive"
-  find . -name '*.bcsymbolmap' -type f -exec mv {} "${CONFIGURATION_BUILD_DIR}" \;
-else
-  # Delete *.bcsymbolmap files from framework bundle unless archiving
-  find . -name '*.bcsymbolmap' -type f -exec rm -rf "{}" +\;
-fi


### PR DESCRIPTION
Move copying bcsymbolmap files to before the code signing.
Because these files to be erased or being moved, problems are occurred if they are signed.

Fixes https://github.com/realm/realm-cocoa/issues/2968

cc @bdash @jpsim 