### PR TITLE
Specifying strong attribute to `underlyingValue` to avoid warning

### DIFF
--- a/Realm/RLMOptionalBase.h
+++ b/Realm/RLMOptionalBase.h
@@ -29,6 +29,6 @@
 
 @property (nonatomic, unsafe_unretained) RLMProperty *property;
 
-@property (nonatomic) id underlyingValue;
+@property (nonatomic, strong) id underlyingValue;
 
 @end


### PR DESCRIPTION
Hi!

I am having troubles with RLMOptionalBase. It has no specific attributes for the `underlyingValue` property, so Xcode is showing a warning:

:warning: `error: no 'assign', 'retain', or 'copy' attribute is specified - 'assign' is assumed`

As I have `Treat warnings as errors` set to YES, it is not letting me compile my project.

Appart from that, I think `assign` is not the correct assumption in this case. As Travis corroborates:
```
default property attribute 'assign' not appropriate for non-GC object [-Werror,-Wobjc-property-no-attribute]
```

Which is also making Travis not to pass