### PR TITLE
fix invalid Swift docs

### DIFF
--- a/RealmSwift-swift2.0/Object.swift
+++ b/RealmSwift-swift2.0/Object.swift
@@ -221,9 +221,14 @@ public class Object: RLMObjectBase {
 
     // MARK: Equatable
 
-    /// Returns whether both objects are equal.
-    /// Objects are considered equal when they are both from the same Realm
-    /// and point to the same underlying object in the database.
+    /**
+    Returns whether both objects are equal.
+
+    Objects are considered equal when they are both from the same Realm and point to the same
+    underlying object in the database.
+
+    - parameter object: Object to compare for equality.
+    */
     public override func isEqual(object: AnyObject?) -> Bool {
         return RLMObjectBaseAreEqual(self as RLMObjectBase?, object as? RLMObjectBase)
     }

--- a/RealmSwift-swift2.0/ObjectSchema.swift
+++ b/RealmSwift-swift2.0/ObjectSchema.swift
@@ -73,7 +73,11 @@ public final class ObjectSchema: CustomStringConvertible {
 
 extension ObjectSchema: Equatable {}
 
+// swiftlint:disable valid_docs
+
 /// Returns whether the two object schemas are equal.
 public func == (lhs: ObjectSchema, rhs: ObjectSchema) -> Bool {
     return lhs.rlmObjectSchema.isEqualToObjectSchema(rhs.rlmObjectSchema)
 }
+
+// swiftlint:enable valid_docs

--- a/RealmSwift-swift2.0/Property.swift
+++ b/RealmSwift-swift2.0/Property.swift
@@ -62,7 +62,11 @@ public final class Property: CustomStringConvertible {
 
 extension Property: Equatable {}
 
+// swiftlint:disable valid_docs
+
 /// Returns whether the two properties are equal.
 public func == (lhs: Property, rhs: Property) -> Bool {
     return lhs.rlmProperty.isEqualToProperty(rhs.rlmProperty)
 }
+
+// swiftlint:enable valid_docs

--- a/RealmSwift-swift2.0/Realm.swift
+++ b/RealmSwift-swift2.0/Realm.swift
@@ -68,6 +68,8 @@ public final class Realm {
     which can be changed by setting `Realm.Configuration.defaultConfiguration`.
 
     - parameter configuration: The configuration to use when creating the Realm instance.
+
+    - throws: An NSError if the Realm could not be initialized.
     */
     public convenience init(configuration: Configuration = Configuration.defaultConfiguration) throws {
         let rlmRealm = try RLMRealm(configuration: configuration.rlmConfiguration)
@@ -78,6 +80,8 @@ public final class Realm {
     Obtains a Realm instance persisted at the specified file path.
 
     - parameter path: Path to the realm file.
+
+    - throws: An NSError if the Realm could not be initialized.
     */
     public convenience init(path: String) throws {
         var configuration = Configuration.defaultConfiguration
@@ -100,6 +104,8 @@ public final class Realm {
 	if applicable. This has no effect if the `Realm` was already up to date.
 
     - parameter block: The block to be executed inside a write transaction.
+
+    - throws: An NSError if the transaction could not be written.
     */
     public func write(@noescape block: (() -> Void)) throws {
         try rlmRealm.transactionWithBlock(block)
@@ -133,6 +139,8 @@ public final class Realm {
 	the transaction.
 
     Calling this when not in a write transaction will throw an exception.
+
+    - throws: An NSError if the transaction could not be written.
     */
     public func commitWrite() throws {
         try rlmRealm.commitWriteTransaction()
@@ -555,6 +563,8 @@ public final class Realm {
 
     - parameter path:          Path to save the Realm to.
     - parameter encryptionKey: Optional 64-byte encryption key to encrypt the new file with.
+
+    - throws: An NSError if the copy could not be written.
     */
     public func writeCopyToPath(path: String, encryptionKey: NSData? = nil) throws {
         if let encryptionKey = encryptionKey {
@@ -576,10 +586,14 @@ public final class Realm {
 
 extension Realm: Equatable { }
 
+// swiftlint:disable valid_docs
+
 /// Returns whether the two realms are equal.
 public func == (lhs: Realm, rhs: Realm) -> Bool {
     return lhs.rlmRealm == rhs.rlmRealm
 }
+
+// swiftlint:enable valid_docs
 
 // MARK: Notifications
 

--- a/RealmSwift-swift2.0/RealmCollectionType.swift
+++ b/RealmSwift-swift2.0/RealmCollectionType.swift
@@ -30,6 +30,8 @@ public final class RLMGenerator<T: Object>: GeneratorType {
         generatorBase = NSFastGenerator(collection)
     }
 
+    // swiftlint:disable valid_docs
+
     /// Advance to the next element and return it, or `nil` if no next element
     /// exists.
     public func next() -> T? {
@@ -39,6 +41,8 @@ public final class RLMGenerator<T: Object>: GeneratorType {
         }
         return accessor
     }
+
+    // swiftlint:enable valid_docs
 }
 
 /**

--- a/RealmSwift-swift2.0/RealmConfiguration.swift
+++ b/RealmSwift-swift2.0/RealmConfiguration.swift
@@ -59,8 +59,6 @@ extension Realm {
         - parameter schemaVersion:      The current schema version.
         - parameter migrationBlock:     The block which migrates the Realm to the current version.
         - parameter objectTypes:        The subset of `Object` subclasses persisted in the Realm.
-
-        - returns: An initialized `Realm.Configuration`.
         */
         public init(path: String? = RLMRealmPathForFile("default.realm"),
             inMemoryIdentifier: String? = nil,

--- a/RealmSwift-swift2.0/Schema.swift
+++ b/RealmSwift-swift2.0/Schema.swift
@@ -63,7 +63,11 @@ public final class Schema: CustomStringConvertible {
 
 extension Schema: Equatable {}
 
+// swiftlint:disable valid_docs
+
 /// Returns whether the two schemas are equal.
 public func == (lhs: Schema, rhs: Schema) -> Bool {
     return lhs.rlmSchema.isEqualToSchema(rhs.rlmSchema)
 }
+
+// swiftlint:enable valid_docs

--- a/RealmSwift-swift2.0/SortDescriptor.swift
+++ b/RealmSwift-swift2.0/SortDescriptor.swift
@@ -75,11 +75,15 @@ extension SortDescriptor: CustomStringConvertible {
 
 extension SortDescriptor: Equatable {}
 
+// swiftlint:disable valid_docs
+
 /// Returns whether the two sort descriptors are equal.
 public func == (lhs: SortDescriptor, rhs: SortDescriptor) -> Bool {
     return lhs.property == rhs.property &&
         lhs.ascending == lhs.ascending
 }
+
+// swiftlint:enable valid_docs
 
 // MARK: StringLiteralConvertible
 

--- a/RealmSwift-swift2.0/Tests/ObjectTests.swift
+++ b/RealmSwift-swift2.0/Tests/ObjectTests.swift
@@ -228,7 +228,7 @@ class ObjectTests: TestCase {
         XCTAssertEqual((getter(object, "arrayCol") as! List<DynamicObject>).first!, boolObject)
     }
 
-    /// Yields a read-write migration `SwiftObject` to the given block
+    // Yields a read-write migration `SwiftObject` to the given block
     private func withMigrationObject(block: ((MigrationObject, Migration) -> ())) {
         autoreleasepool {
             let realm = self.realmWithTestPath()
@@ -252,11 +252,11 @@ class ObjectTests: TestCase {
     }
 
     func testSetValueForKey() {
-        let setter : (Object, AnyObject?, String) -> () = { object, value, key in
+        let setter: (Object, AnyObject?, String) -> () = { object, value, key in
             object.setValue(value, forKey: key)
             return
         }
-        let getter : (Object, String) -> (AnyObject?) = { object, key in
+        let getter: (Object, String) -> (AnyObject?) = { object, key in
             object.valueForKey(key)
         }
 
@@ -273,11 +273,11 @@ class ObjectTests: TestCase {
     }
 
     func testSubscript() {
-        let setter : (Object, AnyObject?, String) -> () = { object, value, key in
+        let setter: (Object, AnyObject?, String) -> () = { object, value, key in
             object[key] = value
             return
         }
-        let getter : (Object, String) -> (AnyObject?) = { object, key in
+        let getter: (Object, String) -> (AnyObject?) = { object, key in
             object[key]
         }
 


### PR DESCRIPTION
some Swift docs:

- were missing parameter definitions
- were missing throws documentation
- had superfluous returns documentation
- were using documentation incompatible with SwiftLint's valid docs rule

After these changes, SwiftLint runs successfully as of [0.5.3](https://github.com/realm/SwiftLint/releases/tag/0.5.3).

/cc @bdash @tgoyne 