### PR TITLE
added the "is_dirty" flag

### DIFF
--- a/Realm/ObjectStore/impl/apple/external_commit_helper.cpp
+++ b/Realm/ObjectStore/impl/apple/external_commit_helper.cpp
@@ -327,6 +327,11 @@ void ExternalCommitHelper::listen()
 
 void ExternalCommitHelper::notify_others()
 {
+    std::lock_guard<std::mutex> lock(m_realms_mutex);
+    for (auto const& realm : m_realms) {
+        realm.realm->set_is_dirty(true);
+    }
+    
     notify_fd(m_notify_fd);
 }
 #endif

--- a/Realm/ObjectStore/shared_realm.cpp
+++ b/Realm/ObjectStore/shared_realm.cpp
@@ -97,6 +97,8 @@ Realm::Realm(Config config)
         throw RealmFileException(RealmFileException::Kind::FormatUpgradeRequired, m_config.path, "The Realm file format must be allowed to be upgraded "
         "in order to proceed.");
     }
+    
+    set_is_dirty(false);
 }
 
 Realm::~Realm() {
@@ -372,6 +374,8 @@ void Realm::notify()
             }
         }
     }
+    
+    set_is_dirty(false);
 }
 
 
@@ -398,6 +402,8 @@ bool Realm::refresh()
         read_group();
     }
 
+    set_is_dirty(false);
+    
     return true;
 }
 

--- a/Realm/ObjectStore/shared_realm.hpp
+++ b/Realm/ObjectStore/shared_realm.hpp
@@ -129,6 +129,13 @@ namespace realm {
         // FIXME private
         Group *read_group();
         static RealmCache s_global_cache;
+        
+    private:
+        bool m_is_dirty;
+        
+    public:
+        void set_is_dirty(bool is_dirty) { m_is_dirty = is_dirty; }
+        bool is_dirty() const { return m_is_dirty; }
     };
 
     class RealmCache

--- a/Realm/RLMRealm.h
+++ b/Realm/RLMRealm.h
@@ -307,6 +307,16 @@ typedef void(^RLMNotificationBlock)(NSString *notification, RLMRealm *realm);
 @property (nonatomic) BOOL autorefresh;
 
 /**
+ After changes from writable Realm are saved, and notifications were sent to other Realms,
+ there is a hole between sending the notifications and their processing. So, if any user's block
+ would be executed in this hole, the Realm might not contain the newest changes.
+ 
+ To prevent this, isDirty is set to YES after sending notifications and
+ then is reverted to NO after its processing.
+ */
+@property (nonatomic, readonly) BOOL isDirty;
+
+/**
  Write a compacted copy of the RLMRealm to the given path.
 
  The destination file cannot already exist.

--- a/Realm/RLMRealm.mm
+++ b/Realm/RLMRealm.mm
@@ -150,6 +150,11 @@ NSData *RLMRealmValidatedEncryptionKey(NSData *key) {
     _realm->set_auto_refresh(autorefresh);
 }
 
+- (BOOL)isDirty {
+    // YES & NO are not exactly the same as true & false
+    return _realm->is_dirty() ? YES : NO;
+}
+
 + (NSString *)writeableTemporaryPathForFile:(NSString *)fileName {
     return [NSTemporaryDirectory() stringByAppendingPathComponent:fileName];
 }

--- a/RealmSwift-swift2.0/Realm.swift
+++ b/RealmSwift-swift2.0/Realm.swift
@@ -60,6 +60,9 @@ public final class Realm {
 
     /// Indicates if this Realm contains any objects.
     public var isEmpty: Bool { return rlmRealm.isEmpty }
+    
+    /// Indicates is this Realm may not contain the most recent changes from other Realms
+    public var isDirty: Bool { return rlmRealm.isDirty }
 
     // MARK: Initializers
 


### PR DESCRIPTION
After changes are written in one Realm, and before they will be synchronized with others, the next runloop cycle might gets fired. So add "is_dirty" flag that we can check to ensure other Realms are synchronized and we can call our custom completion blocks.