### PR TITLE
Fix using -[RLMResults setValue:forKey:] on a key used in the query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,8 @@ x.x.x Release notes (yyyy-MM-dd)
 
 ### Bugfixes
 
-* None.
+* Fix incorrect results or crashes when using `-[RLMResults setValue:forKey:]`
+  on an RLMResults which was filtered on the key being set.
 
 0.97.0 Release notes (2015-12-17)
 =============================================================

--- a/Realm/RLMUtil.mm
+++ b/Realm/RLMUtil.mm
@@ -28,6 +28,7 @@
 #import "RLMSwiftSupport.h"
 
 #import <realm/mixed.hpp>
+#import <realm/table_view.hpp>
 
 #include <sys/sysctl.h>
 #include <sys/types.h>
@@ -225,18 +226,16 @@ NSArray *RLMCollectionValueForKey(id<RLMFastEnumerable> collection, NSString *ke
 }
 
 void RLMCollectionSetValueForKey(id<RLMFastEnumerable> collection, NSString *key, id value) {
-    size_t count = collection.count;
-    if (count == 0) {
+    realm::TableView tv = [collection tableView];
+    if (tv.size() == 0) {
         return;
     }
 
     RLMRealm *realm = collection.realm;
     RLMObjectSchema *objectSchema = collection.objectSchema;
     RLMObjectBase *accessor = [[objectSchema.accessorClass alloc] initWithRealm:realm schema:objectSchema];
-    realm::Table *table = objectSchema.table;
-    for (size_t i = 0; i < count; i++) {
-        size_t rowIndex = [collection indexInSource:i];
-        accessor->_row = (*table)[rowIndex];
+    for (size_t i = 0; i < tv.size(); i++) {
+        accessor->_row = tv[i];
         RLMInitializeSwiftAccessorGenerics(accessor);
         [accessor setValue:value forKey:key];
     }

--- a/Realm/Tests/ResultsTests.m
+++ b/Realm/Tests/ResultsTests.m
@@ -196,6 +196,10 @@
 
     XCTAssertThrows([[AggregateObject allObjectsInRealm:realm] valueForKey:@"invalid"]);
 
+    [[AggregateObject objectsInRealm:realm where:@"intCol != 5"] setValue:@5 forKey:@"intCol"];
+    XCTAssertEqualObjects([[AggregateObject allObjectsInRealm:realm] valueForKey:@"intCol"],
+                          (@[@5, @5, @5, @5, @5, @5, @5, @5, @5, @5]));
+
     [realm commitWriteTransaction];
 
     RLMAssertThrowsWithReasonMatching([[AggregateObject allObjectsInRealm:realm] setValue:@25 forKey:@"intCol"],


### PR DESCRIPTION
This was broken by aadd90501c70fc09e17d04e5f25fd7b732e6a9cc, which indirectly made it so that indexInSource: brings the Results back in to sync. Changing that back would be difficult, so just directly iterate over a frozen tableview instead.

Also adds a test to ensure this usage will continue to work in the future.

Fixes #3028.