### PR TITLE
Minor fix to give better error message for misspelled keypath operators.

### DIFF
--- a/Realm/RLMQueryUtil.mm
+++ b/Realm/RLMQueryUtil.mm
@@ -848,7 +848,7 @@ NSString *get_collection_operation_name_from_key_path(NSString *keyPath, NSStrin
         @throw RLMPredicateException(@"Invalid key path", @"'%@' is not a valid key path'", keyPath);
     }
 
-    if ([keyPath characterAtIndex:at.location - 1] != '.') {
+    if (at.location == 0 || [keyPath characterAtIndex:at.location - 1] != '.') {
         @throw RLMPredicateException(@"Invalid key path", @"'%@' is not a valid key path'", keyPath);
     }
 

--- a/Realm/Tests/QueryTests.m
+++ b/Realm/Tests/QueryTests.m
@@ -550,6 +550,9 @@
     XCTAssertThrows([realm objects:className where:@","], @"comma");
     XCTAssertThrows([realm objects:className where:@"()"], @"parens");
 
+    // Misspelled keypath (should be %K)
+    RLMAssertThrowsWithReasonMatching([realm objects:className where:@"@K == YES"], @"'@K' is not a valid key path'");
+
     // not a link column
     RLMAssertThrowsWithReasonMatching([realm objects:className where:@"age.age == 25"], @"'age' is not a link .* 'PersonObject'");
     XCTAssertThrows([realm objects:className where:@"age.age.age == 25"]);


### PR DESCRIPTION
This gives a better error message for misspelled keypath operators (and in general accidental use of `@` outside of collection operators). It used to just crash.