### PR TITLE
Not throw and allow registering notification blocks on a thread without a runloop in special case

### DIFF
--- a/Realm/RLMRealm.mm
+++ b/Realm/RLMRealm.mm
@@ -395,7 +395,8 @@ static void CheckReadWrite(RLMRealm *realm, NSString *msg=@"Cannot write to a re
     if (!block) {
         @throw RLMException(@"The notification block should not be nil");
     }
-    if (!RLMIsInRunLoop()) {
+    if (!RLMIsInRunLoop() &&
+        _realm->thread_id() != std::this_thread::get_id()) {
         @throw RLMException(@"Can only add notification blocks from within runloops.");
     }
 


### PR DESCRIPTION
Not throw and allow registering notification blocks on a thread without a runloop as long as we are on the same thread as the transaction, since the calling of the block won't occur via the named pipe.

This is a strange use-case but came up with `RBQFetchedResultsController` via `RBQRealmNotificationManager`: https://github.com/Roobiq/RBQFetchedResultsController/issues/52

`RBQRealmNotificationManager` registers a notification block on the same thread as the transaction, which is probably not a common use-case beyond a component like this.