### PR TITLE
enable PR CI builds on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,35 @@
+language: objective-c
+osx_image: xcode7.2
+branches:
+  only: master
+script: placeholder # workaround for https://github.com/travis-ci/travis-ci/issues/4681
+matrix:
+  include:
+    - script: ./build.sh verify-swiftlint
+      env: JOB=verify-swiftlint
+      before_install: brew install swiftlint
+    - script: ./build.sh verify-docs
+      env: JOB=verify-docs
+      before_install: gem install jazzy
+    - script: ./build.sh verify-osx-swift
+      env: JOB=verify-osx-swift
+    - script: ./build.sh test-tvos
+      env: JOB=test-tvos
+    - script: ./build.sh verify-osx
+      env: JOB=verify-osx
+    - script: ./build.sh test-ios-swift
+      env: JOB=test-ios-swift
+    - script: ./build.sh test-ios-static
+      env: JOB=test-ios-static
+
+    ############################################################################
+    # These jobs pass but are disabled because they occasionally make Travis
+    # exceed its maximum of 50 minutes in aggregate for matrix builds.
+    ############################################################################
+
+    # - script: ./build.sh verify-ios-dynamic
+    #   env: JOB=verify-ios-dynamic
+  exclude:
+    - script: placeholder # workaround for https://github.com/travis-ci/travis-ci/issues/4681
+notifications:
+  email: false

--- a/build.sh
+++ b/build.sh
@@ -413,7 +413,7 @@ case "$COMMAND" in
 
         SWIFT_VERSION_FILE="RealmSwift/SwiftVersion.swift"
         CONTENTS="let swiftLanguageVersion = \"$version\""
-        if ! grep -q "$CONTENTS" "$SWIFT_VERSION_FILE"; then
+        if [ ! -f "$SWIFT_VERSION_FILE" ] || ! grep -q "$CONTENTS" "$SWIFT_VERSION_FILE"; then
             echo "$CONTENTS" > "$SWIFT_VERSION_FILE"
         fi
 


### PR DESCRIPTION
This will serve as a backup in case our main CI setup is experiencing
difficulties.

It will also allow non-Realm employees to see the results of some

I've only ported a subset of our standard CI PR matrix here because:

  1. Travis limits their matrix builds to 50 minutes *in aggregate*
  2. Some of our standard CI PR matrix jobs require dependencies not available
     to Travis, like codesigning certificates and provisioning profiles.

The downside to integrating this is that we'll have yet another file to update
when making changes to our build system or CI setup.

This commit also avoids grepping on RealmSwift/SwiftVersion.swift when the file
doesn't exist, preventing a warning from being printed.

/cc @tgoyne @bdash @mrackwitz 