### PR TITLE
Fix race conditions when an RLMRealm is deallocated from the wrong thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ x.x.x Release notes (yyyy-MM-dd)
 
 * Fix incorrect results or crashes when using `-[RLMResults setValue:forKey:]`
   on an RLMResults which was filtered on the key being set.
+* Fix crashes when an RLMRealm is deallocated from the wrong thread.
 
 0.97.0 Release notes (2015-12-17)
 =============================================================

--- a/Realm/ObjectStore/impl/apple/external_commit_helper.cpp
+++ b/Realm/ObjectStore/impl/apple/external_commit_helper.cpp
@@ -268,7 +268,7 @@ void ExternalCommitHelper::add_realm(realm::Realm* realm)
     };
     ctx.release = [](const void* info) {
         auto ptr = static_cast<RefCountedWeakPointer*>(const_cast<void*>(info));
-        if (ptr->ref_count.fetch_add(-1, std::memory_order_relaxed) == 1) {
+        if (ptr->ref_count.fetch_add(-1, std::memory_order_acq_rel) == 1) {
             delete ptr;
         }
     };

--- a/Realm/ObjectStore/impl/apple/external_commit_helper.cpp
+++ b/Realm/ObjectStore/impl/apple/external_commit_helper.cpp
@@ -249,11 +249,28 @@ void ExternalCommitHelper::add_realm(realm::Realm* realm)
 {
     std::lock_guard<std::mutex> lock(m_realms_mutex);
 
+    struct RefCountedWeakPointer {
+        std::weak_ptr<Realm> realm;
+        std::atomic<size_t> ref_count = {1};
+    };
+
     // Create the runloop source
     CFRunLoopSourceContext ctx{};
-    ctx.info = realm;
+    ctx.info = new RefCountedWeakPointer{realm->shared_from_this()};
     ctx.perform = [](void* info) {
-        static_cast<Realm*>(info)->notify();
+        if (auto realm = static_cast<RefCountedWeakPointer*>(info)->realm.lock()) {
+            realm->notify();
+        }
+    };
+    ctx.retain = [](const void* info) {
+        static_cast<RefCountedWeakPointer*>(const_cast<void*>(info))->ref_count.fetch_add(1, std::memory_order_relaxed);
+        return info;
+    };
+    ctx.release = [](const void* info) {
+        auto ptr = static_cast<RefCountedWeakPointer*>(const_cast<void*>(info));
+        if (ptr->ref_count.fetch_add(-1, std::memory_order_relaxed) == 1) {
+            delete ptr;
+        }
     };
 
     CFRunLoopRef runloop = CFRunLoopGetCurrent();


### PR DESCRIPTION
The runloop notification source needs to hold a strong reference while the block is running and a zeroing weak reference the rest of the time to handle `CFRunLoopSourceInvalidate()` being called from a different thread.

Similarly, RLMNotificationHelper needs a zeroing weak reference to the RLMRealm because the SharedRealm can outlive the RLMRealm and then crash when it tries to deliver a notification to the RLMRealm. The reads of the weak pointer are in autoreleasepools because ARC autoreleases pointers when acquiring a strong reference to a weak pointer.

Fixes #3013.