### PR TITLE
Bool and NSDate properties can be indexed.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ x.x.x Release notes (yyyy-MM-dd)
   of the specified path was not found when a copy should be written. 
 * Greatly improve performance when deleting objects with one or more indexed
   properties.
+* Indexing `BOOL`/`Bool` and `NSDate` properties are now supported.
 
 ### Bugfixes
 

--- a/Realm/ObjectStore/property.hpp
+++ b/Realm/ObjectStore/property.hpp
@@ -51,6 +51,7 @@ namespace realm {
         std::string object_type;
         bool is_primary = false;
         bool is_indexed = false;
+        bool is_indexable() const { return type == PropertyTypeInt || type == PropertyTypeBool || type == PropertyTypeString || type == PropertyTypeDate; }
         bool is_nullable = false;
 
         size_t table_column = -1;

--- a/Realm/ObjectStore/schema.cpp
+++ b/Realm/ObjectStore/schema.cpp
@@ -89,7 +89,7 @@ void Schema::validate() const
 
             // check indexable
             if (prop.is_indexed) {
-                if (prop.type != PropertyTypeString && prop.type != PropertyTypeInt) {
+                if (!prop.is_indexable()) {
                     exceptions.emplace_back(PropertyTypeNotIndexableException(object.name, prop));
                 }
             }

--- a/Realm/Tests/ObjectTests.m
+++ b/Realm/Tests/ObjectTests.m
@@ -67,14 +67,23 @@
 
 
 @interface IndexedObject : RLMObject
-@property NSString *name;
-@property NSInteger age;
+@property NSString *stringCol;
+@property NSInteger integerCol;
+@property int intCol;
+@property long longCol;
+@property long long longlongCol;
+@property BOOL boolCol;
+@property NSDate *dateCol;
+
+@property float floatCol;
+@property double doubleCol;
+@property NSData *dataCol;
 @end
 
 @implementation IndexedObject
 + (NSArray *)indexedProperties
 {
-    return @[@"name"];
+    return @[@"stringCol", @"integerCol", @"intCol", @"longCol", @"longlongCol", @"boolCol", @"dateCol"];
 }
 @end
 
@@ -1492,11 +1501,37 @@ RLM_ARRAY_TYPE(PrimaryEmployeeObject);
 
 - (void)testIndex
 {
-    RLMProperty *nameProperty = [[RLMRealm defaultRealm] schema][IndexedObject.className][@"name"];
-    XCTAssertTrue(nameProperty.indexed, @"indexed property should have an index");
+    RLMSchema *schema = [RLMRealm defaultRealm].schema;
+
+    RLMProperty *stringProperty = schema[IndexedObject.className][@"stringCol"];
+    XCTAssertTrue(stringProperty.indexed, @"indexed property should have an index");
+
+    RLMProperty *integerProperty = schema[IndexedObject.className][@"integerCol"];
+    XCTAssertTrue(integerProperty.indexed, @"indexed property should have an index");
+
+    RLMProperty *intProperty = schema[IndexedObject.className][@"intCol"];
+    XCTAssertTrue(intProperty.indexed, @"indexed property should have an index");
+
+    RLMProperty *longProperty = schema[IndexedObject.className][@"longCol"];
+    XCTAssertTrue(longProperty.indexed, @"indexed property should have an index");
+
+    RLMProperty *longlongProperty = schema[IndexedObject.className][@"longlongCol"];
+    XCTAssertTrue(longlongProperty.indexed, @"indexed property should have an index");
+
+    RLMProperty *boolProperty = schema[IndexedObject.className][@"boolCol"];
+    XCTAssertTrue(boolProperty.indexed, @"indexed property should have an index");
+
+    RLMProperty *dateProperty = schema[IndexedObject.className][@"dateCol"];
+    XCTAssertTrue(dateProperty.indexed, @"indexed property should have an index");
     
-    RLMProperty *ageProperty = [[RLMRealm defaultRealm] schema][IndexedObject.className][@"age"];
-    XCTAssertFalse(ageProperty.indexed, @"non-indexed property shouldn't have an index");
+    RLMProperty *floatProperty = schema[IndexedObject.className][@"floatCol"];
+    XCTAssertFalse(floatProperty.indexed, @"non-indexed property shouldn't have an index");
+
+    RLMProperty *doubleProperty = schema[IndexedObject.className][@"doubleCol"];
+    XCTAssertFalse(doubleProperty.indexed, @"non-indexed property shouldn't have an index");
+
+    RLMProperty *dataProperty = schema[IndexedObject.className][@"dataCol"];
+    XCTAssertFalse(dataProperty.indexed, @"non-indexed property shouldn't have an index");
 }
 
 - (void)testRetainedRealmObjectUnknownKey

--- a/RealmSwift-swift1.2/Tests/ObjectSchemaInitializationTests.swift
+++ b/RealmSwift-swift1.2/Tests/ObjectSchemaInitializationTests.swift
@@ -144,6 +144,17 @@ class ObjectSchemaInitializationTests: TestCase {
 
     func testIndexedProperties() {
         XCTAssertTrue(SwiftIndexedPropertiesObject().objectSchema["stringCol"]!.indexed)
+        XCTAssertTrue(SwiftIndexedPropertiesObject().objectSchema["intCol"]!.indexed)
+        XCTAssertTrue(SwiftIndexedPropertiesObject().objectSchema["int8Col"]!.indexed)
+        XCTAssertTrue(SwiftIndexedPropertiesObject().objectSchema["int16Col"]!.indexed)
+        XCTAssertTrue(SwiftIndexedPropertiesObject().objectSchema["int32Col"]!.indexed)
+        XCTAssertTrue(SwiftIndexedPropertiesObject().objectSchema["int64Col"]!.indexed)
+        XCTAssertTrue(SwiftIndexedPropertiesObject().objectSchema["boolCol"]!.indexed)
+        XCTAssertTrue(SwiftIndexedPropertiesObject().objectSchema["dateCol"]!.indexed)
+
+        XCTAssertFalse(SwiftIndexedPropertiesObject().objectSchema["floatCol"]!.indexed)
+        XCTAssertFalse(SwiftIndexedPropertiesObject().objectSchema["doubleCol"]!.indexed)
+        XCTAssertFalse(SwiftIndexedPropertiesObject().objectSchema["dataCol"]!.indexed)
 
         let unindexibleSchema = RLMObjectSchema(forObjectClass: SwiftObjectWithUnindexibleProperties.self)
         for propName in SwiftObjectWithUnindexibleProperties.indexedProperties() {

--- a/RealmSwift-swift1.2/Tests/ObjectTests.swift
+++ b/RealmSwift-swift1.2/Tests/ObjectTests.swift
@@ -98,8 +98,21 @@ class ObjectTests: TestCase {
 
     func testIndexedProperties() {
         XCTAssertEqual(Object.indexedProperties(), [], "indexed properties should default to []")
-        XCTAssertEqual(SwiftIndexedPropertiesObject.indexedProperties().count, 1)
-        XCTAssertTrue(SwiftIndexedPropertiesObject().objectSchema["stringCol"]!.indexed)
+        XCTAssertEqual(SwiftIndexedPropertiesObject.indexedProperties().count, 8)
+
+        let objectSchema = SwiftIndexedPropertiesObject().objectSchema
+        XCTAssertTrue(objectSchema["stringCol"]!.indexed)
+        XCTAssertTrue(objectSchema["intCol"]!.indexed)
+        XCTAssertTrue(objectSchema["int8Col"]!.indexed)
+        XCTAssertTrue(objectSchema["int16Col"]!.indexed)
+        XCTAssertTrue(objectSchema["int32Col"]!.indexed)
+        XCTAssertTrue(objectSchema["int64Col"]!.indexed)
+        XCTAssertTrue(objectSchema["boolCol"]!.indexed)
+        XCTAssertTrue(objectSchema["dateCol"]!.indexed)
+
+        XCTAssertFalse(objectSchema["floatCol"]!.indexed)
+        XCTAssertFalse(objectSchema["doubleCol"]!.indexed)
+        XCTAssertFalse(objectSchema["dataCol"]!.indexed)
     }
 
     func testLinkingObjects() {

--- a/RealmSwift-swift1.2/Tests/SwiftTestObjects.swift
+++ b/RealmSwift-swift1.2/Tests/SwiftTestObjects.swift
@@ -238,8 +238,18 @@ class SwiftPrimaryStringObject: Object {
 class SwiftIndexedPropertiesObject: Object {
     dynamic var stringCol = ""
     dynamic var intCol = 0
+    dynamic var int8Col: Int8 = 0
+    dynamic var int16Col: Int16 = 0
+    dynamic var int32Col: Int32 = 0
+    dynamic var int64Col: Int64 = 0
+    dynamic var boolCol = false
+    dynamic var dateCol = NSDate()
+
+    dynamic var floatCol: Float = 0.0
+    dynamic var doubleCol: Double = 0.0
+    dynamic var dataCol = NSData()
 
     override class func indexedProperties() -> [String] {
-        return ["stringCol"] // Add "intCol" when integer indexing is supported
+        return ["stringCol", "intCol", "int8Col", "int16Col", "int32Col", "int64Col", "boolCol", "dateCol"]
     }
 }

--- a/RealmSwift-swift2.0/Tests/ObjectSchemaInitializationTests.swift
+++ b/RealmSwift-swift2.0/Tests/ObjectSchemaInitializationTests.swift
@@ -151,6 +151,17 @@ class ObjectSchemaInitializationTests: TestCase {
 
     func testIndexedProperties() {
         XCTAssertTrue(SwiftIndexedPropertiesObject().objectSchema["stringCol"]!.indexed)
+        XCTAssertTrue(SwiftIndexedPropertiesObject().objectSchema["intCol"]!.indexed)
+        XCTAssertTrue(SwiftIndexedPropertiesObject().objectSchema["int8Col"]!.indexed)
+        XCTAssertTrue(SwiftIndexedPropertiesObject().objectSchema["int16Col"]!.indexed)
+        XCTAssertTrue(SwiftIndexedPropertiesObject().objectSchema["int32Col"]!.indexed)
+        XCTAssertTrue(SwiftIndexedPropertiesObject().objectSchema["int64Col"]!.indexed)
+        XCTAssertTrue(SwiftIndexedPropertiesObject().objectSchema["boolCol"]!.indexed)
+        XCTAssertTrue(SwiftIndexedPropertiesObject().objectSchema["dateCol"]!.indexed)
+
+        XCTAssertFalse(SwiftIndexedPropertiesObject().objectSchema["floatCol"]!.indexed)
+        XCTAssertFalse(SwiftIndexedPropertiesObject().objectSchema["doubleCol"]!.indexed)
+        XCTAssertFalse(SwiftIndexedPropertiesObject().objectSchema["dataCol"]!.indexed)
 
         let unindexibleSchema = RLMObjectSchema(forObjectClass: SwiftObjectWithUnindexibleProperties.self)
         for propName in SwiftObjectWithUnindexibleProperties.indexedProperties() {

--- a/RealmSwift-swift2.0/Tests/ObjectTests.swift
+++ b/RealmSwift-swift2.0/Tests/ObjectTests.swift
@@ -102,8 +102,21 @@ class ObjectTests: TestCase {
 
     func testIndexedProperties() {
         XCTAssertEqual(Object.indexedProperties(), [], "indexed properties should default to []")
-        XCTAssertEqual(SwiftIndexedPropertiesObject.indexedProperties().count, 1)
-        XCTAssertTrue(SwiftIndexedPropertiesObject().objectSchema["stringCol"]!.indexed)
+        XCTAssertEqual(SwiftIndexedPropertiesObject.indexedProperties().count, 8)
+
+        let objectSchema = SwiftIndexedPropertiesObject().objectSchema
+        XCTAssertTrue(objectSchema["stringCol"]!.indexed)
+        XCTAssertTrue(objectSchema["intCol"]!.indexed)
+        XCTAssertTrue(objectSchema["int8Col"]!.indexed)
+        XCTAssertTrue(objectSchema["int16Col"]!.indexed)
+        XCTAssertTrue(objectSchema["int32Col"]!.indexed)
+        XCTAssertTrue(objectSchema["int64Col"]!.indexed)
+        XCTAssertTrue(objectSchema["boolCol"]!.indexed)
+        XCTAssertTrue(objectSchema["dateCol"]!.indexed)
+
+        XCTAssertFalse(objectSchema["floatCol"]!.indexed)
+        XCTAssertFalse(objectSchema["doubleCol"]!.indexed)
+        XCTAssertFalse(objectSchema["dataCol"]!.indexed)
     }
 
     func testLinkingObjects() {

--- a/RealmSwift-swift2.0/Tests/SwiftTestObjects.swift
+++ b/RealmSwift-swift2.0/Tests/SwiftTestObjects.swift
@@ -239,8 +239,18 @@ class SwiftPrimaryStringObject: Object {
 class SwiftIndexedPropertiesObject: Object {
     dynamic var stringCol = ""
     dynamic var intCol = 0
+    dynamic var int8Col: Int8 = 0
+    dynamic var int16Col: Int16 = 0
+    dynamic var int32Col: Int32 = 0
+    dynamic var int64Col: Int64 = 0
+    dynamic var boolCol = false
+    dynamic var dateCol = NSDate()
+
+    dynamic var floatCol: Float = 0.0
+    dynamic var doubleCol: Double = 0.0
+    dynamic var dataCol = NSData()
 
     override class func indexedProperties() -> [String] {
-        return ["stringCol"] // Add "intCol" when integer indexing is supported
+        return ["stringCol", "intCol", "int8Col", "int16Col", "int32Col", "int64Col", "boolCol", "dateCol"]
     }
 }


### PR DESCRIPTION
Core supports indexing Bool and NSDate properties.
realm-java also supports indexing Bool and NSDate properties.
It is better to align the specification with realm-java.

Also, indexing of Bool and NSDate had been supported implicitly in v0.96. v0.97 breaks this behavior.

cc @tgoyne @jpsim 