### PR TITLE
[build.sh] Print stderr when curl fails

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -282,8 +282,15 @@ download_core() {
     CORE_TMP_TAR="${TMP_DIR}/core-${REALM_CORE_VERSION}.tar.bz2.tmp"
     CORE_TAR="${TMP_DIR}/core-${REALM_CORE_VERSION}.tar.bz2"
     if [ ! -f "${CORE_TAR}" ]; then
-        curl -f -L -s "https://static.realm.io/downloads/core/realm-core-${REALM_CORE_VERSION}.tar.bz2" -o "${CORE_TMP_TAR}" ||
-          (echo "Downloading core failed. Please try again once you have an Internet connection." && exit 1)
+        local CORE_URL="https://static.realm.io/downloads/core/realm-core-${REALM_CORE_VERSION}.tar.bz2"
+        set +e # temporarily disable immediate exit
+        local ERROR # sweeps the exit code unless declared separately
+        ERROR=$(curl -fsSL "$CORE_URL" -o "${CORE_TMP_TAR}" 2>&1 >/dev/null)
+        if [[ $? -ne 0 ]]; then
+            echo "Downloading core failed:\n${ERROR}"
+            exit 1
+        fi
+        set -e # re-enable flag
         mv "${CORE_TMP_TAR}" "${CORE_TAR}"
     fi
 

--- a/build.sh
+++ b/build.sh
@@ -285,7 +285,7 @@ download_core() {
         local CORE_URL="https://static.realm.io/downloads/core/realm-core-${REALM_CORE_VERSION}.tar.bz2"
         set +e # temporarily disable immediate exit
         local ERROR # sweeps the exit code unless declared separately
-        ERROR=$(curl -fsSL "$CORE_URL" -o "${CORE_TMP_TAR}" 2>&1 >/dev/null)
+        ERROR=$(curl --fail --silent --show-error --location "$CORE_URL" --output "${CORE_TMP_TAR}" 2>&1 >/dev/null)
         if [[ $? -ne 0 ]]; then
             echo "Downloading core failed:\n${ERROR}"
             exit 1


### PR DESCRIPTION
Fixes #3023.

The used CURL options are the following for reference:
-f: (HTTP) Fail silently (no output at all) on server errors.
-s: Silent or quiet mode.
-S: When used with -s it makes curl show an error message if it fails.
-L: Follow redirects.
-o: Write output to given path