### PR TITLE
Use the right Swift ObjectUtil class depending on parent class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ x.x.x Release notes (yyyy-MM-dd)
 
 ### Bugfixes
 
-* None.
+* Using Realm Objective-C from Swift while having Realm Swift linked no longer causes that the
+  declared `ignoredProperties` are not taken into account.
 
 0.98.2 Release notes (2016-02-18)
 =============================================================

--- a/Realm/RLMObjectBase.mm
+++ b/Realm/RLMObjectBase.mm
@@ -188,6 +188,10 @@ static id RLMValidatedObjectForProperty(id obj, RLMProperty *prop, RLMSchema *sc
     return [RLMSchema sharedSchemaForClass:self.class];
 }
 
++ (Class)objectUtilClass:(BOOL)isSwift {
+    return RLMObjectUtilClass(isSwift);
+}
+
 - (NSString *)description
 {
     if (self.isInvalidated) {

--- a/Realm/RLMObjectSchema.mm
+++ b/Realm/RLMObjectSchema.mm
@@ -154,7 +154,7 @@ using namespace realm;
 }
 
 + (NSArray *)propertiesForClass:(Class)objectClass isSwift:(bool)isSwiftClass {
-    Class objectUtil = RLMObjectUtilClass(isSwiftClass);
+    Class objectUtil = [objectClass objectUtilClass:isSwiftClass];
     NSArray *ignoredProperties = [objectUtil ignoredPropertiesForClass:objectClass];
 
     // For Swift classes we need an instance of the object when parsing properties

--- a/Realm/RLMObject_Private.h
+++ b/Realm/RLMObject_Private.h
@@ -38,6 +38,9 @@
 // shared schema for this class
 + (RLMObjectSchema *)sharedSchema;
 
+// provide injection point for alternative Swift object util class
++ (Class)objectUtilClass:(BOOL)isSwift;
+
 @end
 
 @interface RLMDynamicObject : RLMObject

--- a/Realm/Tests/RLMTestObjects.m
+++ b/Realm/Tests/RLMTestObjects.m
@@ -17,6 +17,7 @@
 ////////////////////////////////////////////////////////////////////////////
 
 #import "RLMTestObjects.h"
+#import <Realm/RLMObject_Private.h>
 
 #pragma mark - Abstract Objects
 #pragma mark -
@@ -196,6 +197,7 @@
 #pragma mark FakeObject
 
 @implementation FakeObject
++ (Class)objectUtilClass:(BOOL)isSwift { return RLMObjectUtilClass(isSwift); }
 + (NSArray *)ignoredProperties { return nil; }
 + (NSArray *)indexedProperties { return nil; }
 + (NSString *)primaryKey { return nil; }

--- a/RealmSwift-swift2.0/Object.swift
+++ b/RealmSwift-swift2.0/Object.swift
@@ -129,6 +129,15 @@ public class Object: RLMObjectBase {
     public final var className: String { return "" }
     #endif
 
+    /**
+    WARNING: This is an internal helper method not intended for public use.
+    :nodoc:
+    */
+    public override class func objectUtilClass(isSwift: Bool) -> AnyClass {
+        return ObjectUtil.self
+    }
+
+
     // MARK: Object Customization
 
     /**

--- a/RealmSwift-swift2.0/Tests/ObjectSchemaInitializationTests.swift
+++ b/RealmSwift-swift2.0/Tests/ObjectSchemaInitializationTests.swift
@@ -196,7 +196,8 @@ class ObjectSchemaInitializationTests: TestCase {
 }
 
 class SwiftFakeObject: NSObject {
-    dynamic class func primaryKey() -> String! { return nil }
+    dynamic class func objectUtilClass(isSwift: Bool) -> AnyClass { return ObjectUtil.self }
+    dynamic class func primaryKey() -> String? { return nil }
     dynamic class func ignoredProperties() -> [String] { return [] }
     dynamic class func indexedProperties() -> [String] { return [] }
 }


### PR DESCRIPTION
`RealmSwiftObjectUtil` doesn't support `RLMObject` classes (and shouldn't from my understanding). That can cause that just linking Realm Swift screws up `RLMObject` model definitions from Swift as seen in #3097.
This introduces the protocol `ObjectProtocol` implemented by RealmSwiftObject and SwiftFakeObject  and tests for the conformance to that as a workaround to allow invalid test classes.
/c @jpsim @tgoyne