### PR TITLE
Fix queries involving links to objects that are then deleted or moved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,8 +27,8 @@ x.x.x Release notes (yyyy-MM-dd)
   million objects in the Realm.
 * Fix errors when opening encrypted Realm files created with writeCopyToPath.
 * Fix crashes or incorrect results for queries that use relationship equality
-  in cases where the `RLMResults` is kept alive and the target table of the
-  relationship has rows reordered or deleted.
+  in cases where the `RLMResults` is kept alive and instances of the target class
+  of the relationship are deleted.
 
 0.97.0 Release notes (2015-12-17)
 =============================================================

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ x.x.x Release notes (yyyy-MM-dd)
 * Fix a crash when adding a new property to an existing class with over a
   million objects in the Realm.
 * Fix errors when opening encrypted Realm files created with writeCopyToPath.
+* Fix crashes or incorrect results for queries that use relationship equality
+  in cases where the `RLMResults` is kept alive and the target table of the
+  relationship has rows reordered or deleted.
 
 0.97.0 Release notes (2015-12-17)
 =============================================================


### PR DESCRIPTION
Update to accommodate `Query::links_to` taking a row accessor rather than a row index.

Fixes #1803.

This requires a new core release that includes realm/realm-core#1397.

/cc @jpsim @tgoyne 
