### PR TITLE
Add support index optional properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ x.x.x Release notes (yyyy-MM-dd)
 * Greatly improve performance when deleting objects with one or more indexed
   properties.
 * Indexing `BOOL`/`Bool` and `NSDate` properties are now supported.
+* Swift: Add support for indexing optional properties.
 
 ### Bugfixes
 

--- a/Realm/RLMObjectSchema.mm
+++ b/Realm/RLMObjectSchema.mm
@@ -223,7 +223,10 @@ using namespace realm;
             }
             if (auto type = RLMCoerceToNil(propertyType)) {
                 if (existing == NSNotFound) {
-                    property = [[RLMProperty alloc] initSwiftOptionalPropertyWithName:propertyName ivar:class_getInstanceVariable(objectClass, propertyName.UTF8String) propertyType:RLMPropertyType(type.intValue)];
+                    property = [[RLMProperty alloc] initSwiftOptionalPropertyWithName:propertyName
+                                                                              indexed:[indexed containsObject:propertyName]
+                                                                                 ivar:class_getInstanceVariable(objectClass, propertyName.UTF8String)
+                                                                         propertyType:RLMPropertyType(type.intValue)];
                     [propArray addObject:property];
                 }
                 else {

--- a/Realm/RLMProperty.mm
+++ b/Realm/RLMProperty.mm
@@ -375,6 +375,7 @@ BOOL RLMPropertyTypeIsNumeric(RLMPropertyType propertyType) {
 }
 
 - (instancetype)initSwiftOptionalPropertyWithName:(NSString *)name
+                                          indexed:(BOOL)indexed
                                              ivar:(Ivar)ivar
                                      propertyType:(RLMPropertyType)propertyType {
     self = [super init];
@@ -384,6 +385,7 @@ BOOL RLMPropertyTypeIsNumeric(RLMPropertyType propertyType) {
 
     _name = name;
     _type = propertyType;
+    _indexed = indexed;
     _objcType = '@';
     _swiftIvar = ivar;
     _optional = true;

--- a/Realm/RLMProperty_Private.h
+++ b/Realm/RLMProperty_Private.h
@@ -42,6 +42,7 @@ FOUNDATION_EXTERN BOOL RLMPropertyTypeIsNumeric(RLMPropertyType propertyType);
                               objectClassName:(NSString *)objectClassName;
 
 - (instancetype)initSwiftOptionalPropertyWithName:(NSString *)name
+                                          indexed:(BOOL)indexed
                                              ivar:(Ivar)ivar
                                      propertyType:(RLMPropertyType)propertyType;
 

--- a/Realm/Tests/ObjectTests.m
+++ b/Realm/Tests/ObjectTests.m
@@ -74,16 +74,20 @@
 @property long long longlongCol;
 @property BOOL boolCol;
 @property NSDate *dateCol;
+@property NSNumber<RLMInt> *optionalIntCol;
+@property NSNumber<RLMBool> *optionalBoolCol;
 
 @property float floatCol;
 @property double doubleCol;
 @property NSData *dataCol;
+@property NSNumber<RLMFloat> *optionalFloatCol;
+@property NSNumber<RLMDouble> *optionalDoubleCol;
 @end
 
 @implementation IndexedObject
 + (NSArray *)indexedProperties
 {
-    return @[@"stringCol", @"integerCol", @"intCol", @"longCol", @"longlongCol", @"boolCol", @"dateCol"];
+    return @[@"stringCol", @"integerCol", @"intCol", @"longCol", @"longlongCol", @"boolCol", @"dateCol", @"optionalIntCol", @"optionalBoolCol"];
 }
 @end
 
@@ -1523,6 +1527,12 @@ RLM_ARRAY_TYPE(PrimaryEmployeeObject);
 
     RLMProperty *dateProperty = schema[IndexedObject.className][@"dateCol"];
     XCTAssertTrue(dateProperty.indexed, @"indexed property should have an index");
+
+    RLMProperty *optionalIntProperty = schema[IndexedObject.className][@"optionalIntCol"];
+    XCTAssertTrue(optionalIntProperty.indexed, @"indexed property should have an index");
+
+    RLMProperty *optionalBoolProperty = schema[IndexedObject.className][@"optionalBoolCol"];
+    XCTAssertTrue(optionalBoolProperty.indexed, @"indexed property should have an index");
     
     RLMProperty *floatProperty = schema[IndexedObject.className][@"floatCol"];
     XCTAssertFalse(floatProperty.indexed, @"non-indexed property shouldn't have an index");
@@ -1532,6 +1542,12 @@ RLM_ARRAY_TYPE(PrimaryEmployeeObject);
 
     RLMProperty *dataProperty = schema[IndexedObject.className][@"dataCol"];
     XCTAssertFalse(dataProperty.indexed, @"non-indexed property shouldn't have an index");
+
+    RLMProperty *optionalFloatProperty = schema[IndexedObject.className][@"optionalFloatCol"];
+    XCTAssertFalse(optionalFloatProperty.indexed, @"non-indexed property shouldn't have an index");
+
+    RLMProperty *optionalDoubleProperty = schema[IndexedObject.className][@"optionalDoubleCol"];
+    XCTAssertFalse(optionalDoubleProperty.indexed, @"non-indexed property shouldn't have an index");
 }
 
 - (void)testRetainedRealmObjectUnknownKey

--- a/RealmSwift-swift1.2/Tests/ObjectTests.swift
+++ b/RealmSwift-swift1.2/Tests/ObjectTests.swift
@@ -115,6 +115,23 @@ class ObjectTests: TestCase {
         XCTAssertFalse(objectSchema["dataCol"]!.indexed)
     }
 
+    func testIndexedOptionalProperties() {
+        XCTAssertEqual(Object.indexedProperties(), [], "indexed properties should default to []")
+        XCTAssertEqual(SwiftIndexedOptinalPropertiesObject.indexedProperties().count, 8)
+        XCTAssertTrue(SwiftIndexedOptinalPropertiesObject().objectSchema["optionalStringCol"]!.indexed)
+        XCTAssertTrue(SwiftIndexedOptinalPropertiesObject().objectSchema["optionalDateCol"]!.indexed)
+        XCTAssertTrue(SwiftIndexedOptinalPropertiesObject().objectSchema["optionalBoolCol"]!.indexed)
+        XCTAssertTrue(SwiftIndexedOptinalPropertiesObject().objectSchema["optionalIntCol"]!.indexed)
+        XCTAssertTrue(SwiftIndexedOptinalPropertiesObject().objectSchema["optionalInt8Col"]!.indexed)
+        XCTAssertTrue(SwiftIndexedOptinalPropertiesObject().objectSchema["optionalInt16Col"]!.indexed)
+        XCTAssertTrue(SwiftIndexedOptinalPropertiesObject().objectSchema["optionalInt32Col"]!.indexed)
+        XCTAssertTrue(SwiftIndexedOptinalPropertiesObject().objectSchema["optionalInt64Col"]!.indexed)
+
+        XCTAssertFalse(SwiftIndexedOptinalPropertiesObject().objectSchema["optionalDataCol"]!.indexed)
+        XCTAssertFalse(SwiftIndexedOptinalPropertiesObject().objectSchema["optionalFloatCol"]!.indexed)
+        XCTAssertFalse(SwiftIndexedOptinalPropertiesObject().objectSchema["optionalDoubleCol"]!.indexed)
+    }
+
     func testLinkingObjects() {
         let realm = Realm()
         let object = SwiftEmployeeObject()

--- a/RealmSwift-swift1.2/Tests/SwiftTestObjects.swift
+++ b/RealmSwift-swift1.2/Tests/SwiftTestObjects.swift
@@ -253,3 +253,23 @@ class SwiftIndexedPropertiesObject: Object {
         return ["stringCol", "intCol", "int8Col", "int16Col", "int32Col", "int64Col", "boolCol", "dateCol"]
     }
 }
+
+class SwiftIndexedOptinalPropertiesObject: Object {
+    dynamic var optionalStringCol: String? = ""
+    let optionalIntCol = RealmOptional<Int>()
+    let optionalInt8Col = RealmOptional<Int8>()
+    let optionalInt16Col = RealmOptional<Int16>()
+    let optionalInt32Col = RealmOptional<Int32>()
+    let optionalInt64Col = RealmOptional<Int64>()
+    let optionalBoolCol = RealmOptional<Bool>()
+    dynamic var optionalDateCol: NSDate? = NSDate()
+
+    let optionalFloatCol = RealmOptional<Float>()
+    let optionalDoubleCol = RealmOptional<Double>()
+    dynamic var optionalDataCol: NSData? = NSData()
+
+    override class func indexedProperties() -> [String] {
+        return ["optionalStringCol", "optionalIntCol", "optionalInt8Col", "optionalInt16Col",
+            "optionalInt32Col", "optionalInt64Col", "optionalBoolCol", "optionalDateCol"]
+    }
+}

--- a/RealmSwift-swift2.0/Tests/ObjectTests.swift
+++ b/RealmSwift-swift2.0/Tests/ObjectTests.swift
@@ -119,6 +119,23 @@ class ObjectTests: TestCase {
         XCTAssertFalse(objectSchema["dataCol"]!.indexed)
     }
 
+    func testIndexedOptionalProperties() {
+        XCTAssertEqual(Object.indexedProperties(), [], "indexed properties should default to []")
+        XCTAssertEqual(SwiftIndexedOptinalPropertiesObject.indexedProperties().count, 8)
+        XCTAssertTrue(SwiftIndexedOptinalPropertiesObject().objectSchema["optionalStringCol"]!.indexed)
+        XCTAssertTrue(SwiftIndexedOptinalPropertiesObject().objectSchema["optionalDateCol"]!.indexed)
+        XCTAssertTrue(SwiftIndexedOptinalPropertiesObject().objectSchema["optionalBoolCol"]!.indexed)
+        XCTAssertTrue(SwiftIndexedOptinalPropertiesObject().objectSchema["optionalIntCol"]!.indexed)
+        XCTAssertTrue(SwiftIndexedOptinalPropertiesObject().objectSchema["optionalInt8Col"]!.indexed)
+        XCTAssertTrue(SwiftIndexedOptinalPropertiesObject().objectSchema["optionalInt16Col"]!.indexed)
+        XCTAssertTrue(SwiftIndexedOptinalPropertiesObject().objectSchema["optionalInt32Col"]!.indexed)
+        XCTAssertTrue(SwiftIndexedOptinalPropertiesObject().objectSchema["optionalInt64Col"]!.indexed)
+
+        XCTAssertFalse(SwiftIndexedOptinalPropertiesObject().objectSchema["optionalDataCol"]!.indexed)
+        XCTAssertFalse(SwiftIndexedOptinalPropertiesObject().objectSchema["optionalFloatCol"]!.indexed)
+        XCTAssertFalse(SwiftIndexedOptinalPropertiesObject().objectSchema["optionalDoubleCol"]!.indexed)
+    }
+
     func testLinkingObjects() {
         let realm = try! Realm()
         let object = SwiftEmployeeObject()

--- a/RealmSwift-swift2.0/Tests/SwiftTestObjects.swift
+++ b/RealmSwift-swift2.0/Tests/SwiftTestObjects.swift
@@ -254,3 +254,23 @@ class SwiftIndexedPropertiesObject: Object {
         return ["stringCol", "intCol", "int8Col", "int16Col", "int32Col", "int64Col", "boolCol", "dateCol"]
     }
 }
+
+class SwiftIndexedOptinalPropertiesObject: Object {
+    dynamic var optionalStringCol: String? = ""
+    let optionalIntCol = RealmOptional<Int>()
+    let optionalInt8Col = RealmOptional<Int8>()
+    let optionalInt16Col = RealmOptional<Int16>()
+    let optionalInt32Col = RealmOptional<Int32>()
+    let optionalInt64Col = RealmOptional<Int64>()
+    let optionalBoolCol = RealmOptional<Bool>()
+    dynamic var optionalDateCol: NSDate? = NSDate()
+
+    let optionalFloatCol = RealmOptional<Float>()
+    let optionalDoubleCol = RealmOptional<Double>()
+    dynamic var optionalDataCol: NSData? = NSData()
+
+    override class func indexedProperties() -> [String] {
+        return ["optionalStringCol", "optionalIntCol", "optionalInt8Col", "optionalInt16Col",
+            "optionalInt32Col", "optionalInt64Col", "optionalBoolCol", "optionalDateCol"]
+    }
+}


### PR DESCRIPTION
This PR depends on https://github.com/realm/realm-cocoa/pull/3081

The main change is https://github.com/realm/realm-cocoa/commit/1ceebde2a723e767ef611c90e4f8d70c94611598.

realm-java supports indexing nullable properties.
This change aligns the specification between realm-java and realm-cocoa.

CC @jpsim @tgoyne 



