### PR TITLE
Pull a bunch of incidental changes from the ObjectStore repo

### DIFF
--- a/Realm/ObjectStore/impl/transact_log_handler.cpp
+++ b/Realm/ObjectStore/impl/transact_log_handler.cpp
@@ -421,10 +421,10 @@ public:
     bool set_link(size_t col, size_t row, size_t, size_t) { return mark_dirty(row, col); }
     bool set_null(size_t col, size_t row) { return mark_dirty(row, col); }
     bool nullify_link(size_t col, size_t row, size_t) { return mark_dirty(row, col); }
-    bool insert_substring(size_t col, size_t row, size_t, StringData) { return mark_dirty(row, col); }
-    bool erase_substring(size_t col, size_t row, size_t, size_t) { return mark_dirty(row, col); }
     bool set_int_unique(size_t col, size_t row, int_fast64_t) { return mark_dirty(row, col); }
     bool set_string_unique(size_t col, size_t row, StringData) { return mark_dirty(row, col); }
+    bool insert_substring(size_t col, size_t row, size_t, StringData) { return mark_dirty(row, col); }
+    bool erase_substring(size_t col, size_t row, size_t, size_t) { return mark_dirty(row, col); }
 };
 } // anonymous namespace
 

--- a/Realm/ObjectStore/impl/transact_log_handler.hpp
+++ b/Realm/ObjectStore/impl/transact_log_handler.hpp
@@ -28,20 +28,20 @@ namespace _impl {
 namespace transaction {
 // Advance the read transaction version, with change notifications sent to delegate
 // Must not be called from within a write transaction.
-void advance(SharedGroup& sg, ClientHistory& history, BindingContext* delegate);
+void advance(SharedGroup& sg, ClientHistory& history, BindingContext* binding_context);
 
 // Begin a write transaction
 // If the read transaction version is not up to date, will first advance to the
 // most recent read transaction and sent notifications to delegate
-void begin(SharedGroup& sg, ClientHistory& history, BindingContext* delegate,
+void begin(SharedGroup& sg, ClientHistory& history, BindingContext* binding_context,
            bool validate_schema_changes=true);
 
 // Commit a write transaction
-void commit(SharedGroup& sg, ClientHistory& history, BindingContext* delegate);
+void commit(SharedGroup& sg, ClientHistory& history, BindingContext* binding_context);
 
 // Cancel a write transaction and roll back all changes, with change notifications
 // for reverting to the old values sent to delegate
-void cancel(SharedGroup& sg, ClientHistory& history, BindingContext* delegate);
+void cancel(SharedGroup& sg, ClientHistory& history, BindingContext* binding_context);
 } // namespace transaction
 } // namespace _impl
 } // namespace realm

--- a/Realm/ObjectStore/index_set.hpp
+++ b/Realm/ObjectStore/index_set.hpp
@@ -19,6 +19,7 @@
 #ifndef REALM_INDEX_SET_HPP
 #define REALM_INDEX_SET_HPP
 
+#include <cstdlib>
 #include <vector>
 
 namespace realm {

--- a/Realm/ObjectStore/object_schema.cpp
+++ b/Realm/ObjectStore/object_schema.cpp
@@ -28,6 +28,14 @@ using namespace realm;
 
 ObjectSchema::~ObjectSchema() = default;
 
+ObjectSchema::ObjectSchema(std::string name, std::string primary_key, std::initializer_list<Property> properties)
+: name(std::move(name))
+, properties(properties)
+, primary_key(std::move(primary_key))
+{
+    set_primary_key_property();
+}
+
 ObjectSchema::ObjectSchema(const Group *group, const std::string &name) : name(name) {
     ConstTableRef table = ObjectStore::table_for_object_type(group, name);
 
@@ -50,13 +58,7 @@ ObjectSchema::ObjectSchema(const Group *group, const std::string &name) : name(n
     }
 
     primary_key = realm::ObjectStore::get_primary_key_for_object(group, name);
-    if (primary_key.length()) {
-        auto primary_key_prop = primary_key_property();
-        if (!primary_key_prop) {
-            throw InvalidPrimaryKeyException(name, primary_key);
-        }
-        primary_key_prop->is_primary = true;
-    }
+    set_primary_key_property();
 }
 
 Property *ObjectSchema::property_for_name(StringData name) {
@@ -70,4 +72,15 @@ Property *ObjectSchema::property_for_name(StringData name) {
 
 const Property *ObjectSchema::property_for_name(StringData name) const {
     return const_cast<ObjectSchema *>(this)->property_for_name(name);
+}
+
+void ObjectSchema::set_primary_key_property()
+{
+    if (primary_key.length()) {
+        auto primary_key_prop = primary_key_property();
+        if (!primary_key_prop) {
+            throw InvalidPrimaryKeyException(name, primary_key);
+        }
+        primary_key_prop->is_primary = true;
+    }
 }

--- a/Realm/ObjectStore/object_schema.hpp
+++ b/Realm/ObjectStore/object_schema.hpp
@@ -31,6 +31,7 @@ namespace realm {
     class ObjectSchema {
     public:
         ObjectSchema() = default;
+        ObjectSchema(std::string name, std::string primary_key, std::initializer_list<Property> properties);
         ~ObjectSchema();
 
         // create object schema from existing table
@@ -49,6 +50,9 @@ namespace realm {
         const Property *primary_key_property() const {
             return property_for_name(primary_key);
         }
+
+    private:
+        void set_primary_key_property();
     };
 }
 

--- a/Realm/ObjectStore/object_store.cpp
+++ b/Realm/ObjectStore/object_store.cpp
@@ -319,11 +319,14 @@ void ObjectStore::create_tables(Group *group, Schema &target_schema, bool update
                     case PropertyTypeObject:
                     case PropertyTypeArray: {
                         TableRef link_table = ObjectStore::table_for_object_type(group, target_prop.object_type);
+                        REALM_ASSERT(link_table);
                         target_prop.table_column = table->add_column_link(DataType(target_prop.type), target_prop.name, *link_table);
                         break;
                     }
                     default:
-                        target_prop.table_column = table->add_column(DataType(target_prop.type), target_prop.name, target_prop.is_nullable);
+                        target_prop.table_column = table->add_column(DataType(target_prop.type),
+                                                                     target_prop.name,
+                                                                     target_prop.is_nullable);
                         break;
                 }
             }

--- a/Realm/ObjectStore/property.hpp
+++ b/Realm/ObjectStore/property.hpp
@@ -53,7 +53,7 @@ namespace realm {
         bool is_indexed = false;
         bool is_nullable = false;
 
-        size_t table_column;
+        size_t table_column = -1;
         bool requires_index() const { return is_primary || is_indexed; }
     };
 

--- a/Realm/ObjectStore/schema.hpp
+++ b/Realm/ObjectStore/schema.hpp
@@ -19,6 +19,7 @@
 #ifndef REALM_SCHEMA_HPP
 #define REALM_SCHEMA_HPP
 
+#include <string>
 #include <vector>
 
 namespace realm {

--- a/Realm/ObjectStore/schema.hpp
+++ b/Realm/ObjectStore/schema.hpp
@@ -30,6 +30,7 @@ private:
 public:
     // Create a schema from a vector of ObjectSchema
     Schema(base types);
+    Schema(std::initializer_list<ObjectSchema> types) : Schema(base(types)) { }
 
     // find an ObjectSchema by name
     iterator find(std::string const& name);

--- a/Realm/ObjectStore/shared_realm.cpp
+++ b/Realm/ObjectStore/shared_realm.cpp
@@ -86,7 +86,7 @@ Realm::Realm(Config config)
     }
     catch (util::File::NotFound const& ex) {
         throw RealmFileException(RealmFileException::Kind::NotFound, ex.get_path(),
-                                 "File at path '" + ex.get_path() + "' does not exists.");
+                                 "File at path '" + ex.get_path() + "' does not exist.");
     }
     catch (util::File::AccessError const& ex) {
         throw RealmFileException(RealmFileException::Kind::AccessError, ex.get_path(),

--- a/Realm/ObjectStore/shared_realm.cpp
+++ b/Realm/ObjectStore/shared_realm.cpp
@@ -98,8 +98,9 @@ Realm::Realm(Config config)
                                  "which cannot share access with this process. All processes sharing a single file must be the same architecture.");
     }
     catch (FileFormatUpgradeRequired const& ex) {
-        throw RealmFileException(RealmFileException::Kind::FormatUpgradeRequired, m_config.path, "The Realm file format must be allowed to be upgraded "
-        "in order to proceed.");
+        throw RealmFileException(RealmFileException::Kind::FormatUpgradeRequired, m_config.path,
+                                 "The Realm file format must be allowed to be upgraded "
+                                 "in order to proceed.");
     }
 }
 

--- a/Realm/ObjectStore/shared_realm.hpp
+++ b/Realm/ObjectStore/shared_realm.hpp
@@ -19,11 +19,12 @@
 #ifndef REALM_REALM_HPP
 #define REALM_REALM_HPP
 
+#include "object_store.hpp"
+
 #include <memory>
+#include <mutex>
 #include <thread>
 #include <vector>
-
-#include "object_store.hpp"
 
 namespace realm {
     class ClientHistory;
@@ -168,7 +169,7 @@ namespace realm {
             std::runtime_error(std::move(message)), m_kind(kind), m_path(std::move(path)) {}
         Kind kind() const { return m_kind; }
         const std::string& path() const { return m_path; }
-        
+
     private:
         Kind m_kind;
         std::string m_path;

--- a/build.sh
+++ b/build.sh
@@ -385,7 +385,7 @@ case "$COMMAND" in
         # objectstore repo
         git rev-list --reverse $commit..HEAD -- Realm/ObjectStore \
             | xargs -I@ git format-patch --stdout @^! Realm/ObjectStore \
-            | git -C $path am -p 3
+            | git -C $path am -p 3 --directory src
         ;;
 
     "pull-object-store-changes")
@@ -396,7 +396,7 @@ case "$COMMAND" in
             exit 1
         fi
 
-        git -C $path format-patch --stdout $commit..HEAD | git am --directory Realm/ObjectStore
+        git -C $path format-patch --stdout $commit..HEAD | git am -p 2 --directory Realm/ObjectStore
         ;;
 
     ######################################


### PR DESCRIPTION
There are a bunch of little non-functional differences between the two copies of the code that made diffing them pointlessly annoying. This brings them back into sync except for where the differences are related to actual functional changes.