### PR TITLE
fix CocoaPods installation examples

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -631,9 +631,8 @@ case "$COMMAND" in
 
     "verify-cocoapods")
         cd examples/installation
-        # FIXME: tests are duplicated to work around https://github.com/realm/realm-cocoa/issues/2701
-        sh build.sh test-ios-objc-cocoapods || sh build.sh test-ios-objc-cocoapods || exit 1
-        sh build.sh test-ios-swift-cocoapods || sh build.sh test-ios-swift-cocoapods || exit 1
+        sh build.sh test-ios-objc-cocoapods || exit 1
+        sh build.sh test-ios-swift-cocoapods || exit 1
         ;;
 
     "verify-osx-encryption")

--- a/examples/installation/build.sh
+++ b/examples/installation/build.sh
@@ -45,10 +45,6 @@ xctest() {
     DIRECTORY="$PLATFORM/$LANG/$NAME"
     PROJECT="$DIRECTORY/$NAME.xcodeproj"
     WORKSPACE="$DIRECTORY/$NAME.xcworkspace"
-    CMD="-project $PROJECT"
-    if [ -d $WORKSPACE ]; then
-        CMD="-workspace $WORKSPACE"
-    fi
     if [[ $PLATFORM == ios ]]; then
         sh "$(dirname "$0")/../../scripts/reset-simulators.sh"
     fi
@@ -72,6 +68,10 @@ xctest() {
     DESTINATION=""
     if [[ $PLATFORM == ios ]]; then
         DESTINATION="-destination id=$(xcrun simctl list devices | grep -v unavailable | grep -m 1 -o '[0-9A-F\-]\{36\}')"
+    fi
+    CMD="-project $PROJECT"
+    if [ -d $WORKSPACE ]; then
+        CMD="-workspace $WORKSPACE"
     fi
     xcodebuild $CMD -scheme $NAME clean build test $DESTINATION
 }


### PR DESCRIPTION
by checking if there's a workspace after running pod install.

So it turns out that CocoaPods *doesn't* fail to install Realm on the first try, but rather that we were testing our installation examples incorrectly.