### PR TITLE
Restore test location reporting in Swift tests

### DIFF
--- a/Configuration/RealmSwift/Tests.xcconfig
+++ b/Configuration/RealmSwift/Tests.xcconfig
@@ -4,6 +4,7 @@ INFOPLIST_FILE = RealmSwift/Tests/RealmSwiftTests-Info.plist;
 PRODUCT_NAME = $(TARGET_NAME);
 SWIFT_OBJC_BRIDGING_HEADER = RealmSwift/Tests/RealmSwiftTests-BridgingHeader.h
 SWIFT_OPTIMIZATION_LEVEL = -Onone;
+OTHER_SWIFT_FLAGS = -DREALM_XCODE_VERSION_$(XCODE_VERSION_ACTUAL);
 
 LD_RUNPATH_SEARCH_PATHS[sdk=iphone*] = $(inherited) @executable_path/Frameworks @loader_path/Frameworks;
 LD_RUNPATH_SEARCH_PATHS[sdk=appletv*] = $(inherited) @executable_path/Frameworks @loader_path/Frameworks;

--- a/RealmSwift-swift2.0/Tests/KVOTests.swift
+++ b/RealmSwift-swift2.0/Tests/KVOTests.swift
@@ -79,31 +79,33 @@ class KVOTests: TestCase {
     }
 
     func observeChange(obj: NSObject, _ key: String, _ old: AnyObject, _ new: AnyObject,
-                       _ block: () -> Void) {
+                       fileName: TestLocationString = __FILE__, lineNumber: UInt = __LINE__, _ block: () -> Void) {
         obj.addObserver(self, forKeyPath: key, options: [.Old, .New], context: nil)
         block()
         obj.removeObserver(self, forKeyPath: key)
 
-        XCTAssert(changeDictionary != nil, "Did not get a notification")
+        XCTAssert(changeDictionary != nil, "Did not get a notification", file: fileName, line: lineNumber)
         if changeDictionary == nil {
             return
         }
 
         let actualOld: AnyObject = changeDictionary![NSKeyValueChangeOldKey]!
         let actualNew: AnyObject = changeDictionary![NSKeyValueChangeNewKey]!
-        XCTAssert(actualOld.isEqual(old), "Old value: expected \(old), got \(actualOld)")
-        XCTAssert(actualNew.isEqual(new), "New value: expected \(new), got \(actualNew)")
+        XCTAssert(actualOld.isEqual(old), "Old value: expected \(old), got \(actualOld)", file: fileName,
+            line: lineNumber)
+        XCTAssert(actualNew.isEqual(new), "New value: expected \(new), got \(actualNew)", file: fileName,
+            line: lineNumber)
 
         changeDictionary = nil
     }
 
     func observeListChange(obj: NSObject, _ key: String, _ kind: NSKeyValueChange, _ indexes: NSIndexSet,
-                           _ block: () -> Void) {
+                           fileName: TestLocationString = __FILE__, lineNumber: UInt = __LINE__, _ block: () -> Void) {
         obj.addObserver(self, forKeyPath: key, options: [.Old, .New], context: nil)
         block()
         obj.removeObserver(self, forKeyPath: key)
 
-        XCTAssert(changeDictionary != nil, "Did not get a notification")
+        XCTAssert(changeDictionary != nil, "Did not get a notification", file: fileName, line: lineNumber)
         if changeDictionary == nil {
             return
         }
@@ -111,8 +113,10 @@ class KVOTests: TestCase {
         let actualKind = NSKeyValueChange(rawValue: (changeDictionary![NSKeyValueChangeKindKey] as! NSNumber)
             .unsignedLongValue)!
         let actualIndexes = changeDictionary![NSKeyValueChangeIndexesKey]! as! NSIndexSet
-        XCTAssert(actualKind == kind, "Change kind: expected \(kind), got \(actualKind)")
-        XCTAssert(actualIndexes.isEqual(indexes), "Changed indexes: expected \(indexes), got \(actualIndexes)")
+        XCTAssert(actualKind == kind, "Change kind: expected \(kind), got \(actualKind)", file: fileName,
+            line: lineNumber)
+        XCTAssert(actualIndexes.isEqual(indexes), "Changed indexes: expected \(indexes), got \(actualIndexes)",
+            file: fileName, line: lineNumber)
 
         changeDictionary = nil
     }

--- a/RealmSwift-swift2.0/Tests/TestCase.swift
+++ b/RealmSwift-swift2.0/Tests/TestCase.swift
@@ -23,6 +23,12 @@ import Realm.Dynamic
 import RealmSwift
 import XCTest
 
+#if REALM_XCODE_VERSION_0730
+    typealias TestLocationString = StaticString
+#else
+    typealias TestLocationString = String
+#endif
+
 func inMemoryRealm(inMememoryIdentifier: String) -> Realm {
     return try! Realm(configuration: Realm.Configuration(inMemoryIdentifier: inMememoryIdentifier))
 }
@@ -114,28 +120,34 @@ class TestCase: XCTestCase {
         RLMAssertThrows(self, { _ = block() } as dispatch_block_t, named, message, fileName, lineNumber)
     }
 
-    func assertSucceeds(message: String? = nil, @noescape block: () throws -> ()) {
+    func assertSucceeds(message: String? = nil, fileName: TestLocationString = __FILE__,
+                        lineNumber: UInt = __LINE__, @noescape block: () throws -> ()) {
         do {
             try block()
         } catch {
-            XCTFail("Expected no error, but instead caught <\(error)>.")
+            XCTFail("Expected no error, but instead caught <\(error)>.",
+                file: fileName, line: lineNumber)
         }
     }
 
     func assertFails<T>(expectedError: Error,  _ message: String? = nil,
+                        fileName: TestLocationString = __FILE__, lineNumber: UInt = __LINE__,
                         @noescape block: () throws -> T) {
         do {
             try block()
-            XCTFail("Expected to catch <\(expectedError)>, but no error was thrown.")
+            XCTFail("Expected to catch <\(expectedError)>, but no error was thrown.",
+                file: fileName, line: lineNumber)
         } catch expectedError {
             // Success!
         } catch {
-            XCTFail("Expected to catch <\(expectedError)>, but instead caught <\(error)>.")
+            XCTFail("Expected to catch <\(expectedError)>, but instead caught <\(error)>.",
+                file: fileName, line: lineNumber)
         }
     }
 
-    func assertNil<T>(@autoclosure block: () -> T?, _ message: String? = nil) {
-        XCTAssert(block() == nil, message ?? "")
+    func assertNil<T>(@autoclosure block: () -> T?, _ message: String? = nil,
+                      fileName: TestLocationString = __FILE__, lineNumber: UInt = __LINE__) {
+        XCTAssert(block() == nil, message ?? "", file: fileName, line: lineNumber)
     }
 
     private func realmFilePrefix() -> String {


### PR DESCRIPTION
Switch between String and StaticString based on the Xcode version.