### PR TITLE
add workaround for #3054

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ x.x.x Release notes (yyyy-MM-dd)
 * Fix crashes or incorrect results for queries that use relationship equality
   in cases where the `RLMResults` is kept alive and instances of the target class
   of the relationship are deleted.
+* Fix crash when accessing Results dependent on a deleted relationship.
 
 0.97.0 Release notes (2015-12-17)
 =============================================================

--- a/Realm/ObjectStore/results.cpp
+++ b/Realm/ObjectStore/results.cpp
@@ -146,7 +146,13 @@ void Results::update_tableview()
             m_mode = Mode::TableView;
             break;
         case Mode::TableView:
-            m_table_view.sync_if_needed();
+            try {
+                m_table_view.sync_if_needed();
+            }
+            catch (DeletedLinkView const& ex) {
+                m_mode = Mode::Empty;
+                m_table_view = TableView();
+            }
             break;
     }
 }

--- a/Realm/Tests/QueryTests.m
+++ b/Realm/Tests/QueryTests.m
@@ -1736,6 +1736,21 @@
     XCTAssertEqualObjects(@"Spot's owner", [spotQuery.firstObject name]);
 }
 
+- (void)testQueryDeleteRelationshipDependency
+{
+    RLMRealm *realm = [RLMRealm defaultRealm];
+    [realm beginWriteTransaction];
+    [ArrayOfSelfObject createInDefaultRealmWithValue:@{@"name": @"B", @"arrayProp": @[@{@"name": @"A"}]}];
+    // Make queries that depend on the relationship.
+    RLMResults *arrayProp = [[[[ArrayOfSelfObject allObjects] firstObject] arrayProp] objectsWhere:@"name = name"];
+    [[[arrayProp firstObject] arrayProp] objectsWhere:@"name = name"];
+    // Delete the object in the relationship being queried.
+    [realm deleteObject:[[ArrayOfSelfObject allObjects] firstObject]];
+    XCTAssertNil(arrayProp.firstObject, @"Should be nil and not throw");
+    XCTAssertEqual(arrayProp.count, 0U, @"Result should be empty");
+    [realm cancelWriteTransaction];
+}
+
 @end
 
 @interface NullQueryTests : QueryTests

--- a/Realm/Tests/RLMTestObjects.h
+++ b/Realm/Tests/RLMTestObjects.h
@@ -226,6 +226,15 @@ RLM_ARRAY_TYPE(DogObject)
 
 @end
 
+#pragma mark ArrayOfSelfObject
+
+RLM_ARRAY_TYPE(ArrayOfSelfObject);
+
+@interface ArrayOfSelfObject : RLMObject
+@property NSString *name;
+@property RLM_GENERIC_ARRAY(ArrayOfSelfObject) *arrayProp;
+@end
+
 #pragma mark CircleObject
 
 @interface CircleObject : RLMObject

--- a/Realm/Tests/RLMTestObjects.m
+++ b/Realm/Tests/RLMTestObjects.m
@@ -124,6 +124,11 @@
 @implementation BaseClassStringObject
 @end
 
+#pragma mark ArrayOfSelfObject
+
+@implementation ArrayOfSelfObject
+@end
+
 #pragma mark CircleObject
 
 @implementation CircleObject


### PR DESCRIPTION
This test would crash with core 0.95.5. /cc @bdash 

I'm sure the test case can be further reduced and probably even be done without adding a new test object model, but I haven't been able to do so myself.