### PR TITLE
Don't invoke 'sh build.sh binary-has-bitcode' unless we're building with Xcode > 6

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -160,9 +160,14 @@ build_combined() {
     # Combine ar archives
     LIPO_OUTPUT="$out_path/$product_name/$module_name"
     xcrun lipo -create "$simulator_path/$binary_path" "$os_path/$binary_path" -output "$LIPO_OUTPUT"
-    if [[ "$destination" != "" ]] && [[ "$config" == "Release" ]]; then
+
+    if [[ $(xcode_major_version) != "6" && "$destination" != "" && "$config" == "Release" ]]; then
         sh build.sh binary-has-bitcode "$LIPO_OUTPUT"
     fi
+}
+
+xcode_major_version() {
+    xcodebuild -version | awk '/Xcode / { print $2 }' | cut -d '.' -f 1
 }
 
 xc_work_around_rdar_23055637() {
@@ -830,7 +835,7 @@ case "$COMMAND" in
             exit 0
         fi
         # Work around rdar://21826157 by checking for bitcode in thin binaries
-        
+
         # Get architectures for binary
         archs="$(lipo -info "$BINARY" | rev | cut -d ':' -f1 | rev)"
 

--- a/build.sh
+++ b/build.sh
@@ -161,13 +161,9 @@ build_combined() {
     LIPO_OUTPUT="$out_path/$product_name/$module_name"
     xcrun lipo -create "$simulator_path/$binary_path" "$os_path/$binary_path" -output "$LIPO_OUTPUT"
 
-    if [[ $(xcode_major_version) != "6" && "$destination" != "" && "$config" == "Release" ]]; then
+    if [[ $REALM_SWIFT_VERSION != '1.2' && "$destination" != "" && "$config" == "Release" ]]; then
         sh build.sh binary-has-bitcode "$LIPO_OUTPUT"
     fi
-}
-
-xcode_major_version() {
-    xcodebuild -version | awk '/Xcode / { print $2 }' | cut -d '.' -f 1
 }
 
 xc_work_around_rdar_23055637() {


### PR DESCRIPTION
Xcode 6 doesn't support bitcode so there's no reason to try to verify that the binary we produced contains it.