### PR TITLE
Fix a crash when a deleted LinkView is implicitly handed over for bg query updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+x.x.x Release notes (yyyy-MM-dd)
+=============================================================
+
+### API breaking changes
+
+* None.
+
+### Enhancements
+
+* None.
+
+### Bugfixes
+
+* Fix an occasional crash when a `RLMArray`/`List` which has previously been
+  filtered is deleted.
+
 0.98.0 Release notes (2016-02-04)
 =============================================================
 


### PR DESCRIPTION
See https://secure.helpscout.net/conversation/168310017/2922.

https://gist.github.com/tgoyne/fd89f097d1b44c8e3f9c reproduces the crash that this fixes, but I couldn't figure out how to make it deterministic without the non-test change. The use of addNotificationBlock is just to make it insensitive to the foibles of the optimizer and is not required to hit the bug.

This is probably better fixed in core (and in fact some core changes are needed since the post-0.96.0 changes to deleted linkview handling break this workaround), but since it's a regression from 0.97.1 IMO we need to ship a fix promptly.

@bdash @jpsim 