### PR TITLE
Fix warnings when building via CocoaPods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ x.x.x Release notes (yyyy-MM-dd)
   previously been queried.
 * Fix a crash when deleting an object containing an `RLMArray`/`List` with
   active notification blocks.
+* Fix duplicate file warnings when building via CocoaPods.
 
 0.98.0 Release notes (2016-02-04)
 =============================================================

--- a/Realm.podspec
+++ b/Realm.podspec
@@ -39,19 +39,11 @@ Pod::Spec.new do |s|
                               'include/Realm/RLMObjectBase_Dynamic.h'
 
                               # Realm.Private module
-  private_header_files      = 'include/Realm/RLMAccessor.h',
-                              'include/Realm/RLMArray_Private.h',
+  private_header_files      = 'include/Realm/*_Private.h',
+                              'include/Realm/RLMAccessor.h',
                               'include/Realm/RLMListBase.h',
-                              'include/Realm/RLMMigration_Private.h',
-                              'include/Realm/RLMObjectSchema_Private.h',
                               'include/Realm/RLMObjectStore.h',
-                              'include/Realm/RLMObject_Private.h',
-                              'include/Realm/RLMOptionalBase.h',
-                              'include/Realm/RLMProperty_Private.h',
-                              'include/Realm/RLMRealmConfiguration_Private.h',
-                              'include/Realm/RLMRealm_Private.h',
-                              'include/Realm/RLMResults_Private.h',
-                              'include/Realm/RLMSchema_Private.h'
+                              'include/Realm/RLMOptionalBase.h'
 
   source_files              = 'Realm/*.{m,mm}',
                               'Realm/ObjectStore/*.cpp',

--- a/Realm.podspec
+++ b/Realm.podspec
@@ -33,21 +33,30 @@ Pod::Spec.new do |s|
                               'include/Realm/RLMResults.h',
                               'include/Realm/RLMSchema.h',
                               'include/Realm/Realm.h',
+
+                              # Realm.Dynamic module
                               'include/Realm/RLMRealm_Dynamic.h',
                               'include/Realm/RLMObjectBase_Dynamic.h'
 
-  private_header_files      = 'include/Realm/*{Accessor,RealmUtil,ListBase,ObjectStore,Private,SwiftSupport}.h',
-                              'include/realm.hpp',
-                              'include/realm/realm_nmmintrin.h',
-                              'include/realm/util/*.h',
-                              'include/realm/**/*.hpp',
-                              'include/Realm/**/*.hpp'
+                              # Realm.Private module
+  private_header_files      = 'include/Realm/RLMAccessor.h',
+                              'include/Realm/RLMArray_Private.h',
+                              'include/Realm/RLMListBase.h',
+                              'include/Realm/RLMMigration_Private.h',
+                              'include/Realm/RLMObjectSchema_Private.h',
+                              'include/Realm/RLMObjectStore.h',
+                              'include/Realm/RLMObject_Private.h',
+                              'include/Realm/RLMOptionalBase.h',
+                              'include/Realm/RLMProperty_Private.h',
+                              'include/Realm/RLMRealmConfiguration_Private.h',
+                              'include/Realm/RLMRealm_Private.h',
+                              'include/Realm/RLMResults_Private.h',
+                              'include/Realm/RLMSchema_Private.h'
 
   source_files              = 'Realm/*.{m,mm}',
                               'Realm/ObjectStore/*.cpp',
                               'Realm/ObjectStore/impl/*.cpp',
                               'Realm/ObjectStore/impl/apple/*.cpp'
-
 
   s.module_map              = 'Realm/module.modulemap'
   s.compiler_flags          = "-DREALM_HAVE_CONFIG -DREALM_COCOA_VERSION='@\"#{s.version}\"' -D__ASSERTMACROS__"
@@ -58,9 +67,9 @@ Pod::Spec.new do |s|
   s.pod_target_xcconfig     = { 'CLANG_CXX_LANGUAGE_STANDARD' => 'compiler-default',
                                 'OTHER_CPLUSPLUSFLAGS' => '-std=c++1y $(inherited)',
                                 'APPLICATION_EXTENSION_API_ONLY' => 'YES',
-                                'HEADER_SEARCH_PATHS' => '"${PODS_ROOT}/Realm/include"',
-                                'USER_HEADER_SEARCH_PATHS' => '"${PODS_ROOT}/Realm/include/Realm/"' }
-  s.preserve_paths          = %w(build.sh)
+                                'HEADER_SEARCH_PATHS' => '"${PODS_ROOT}/Realm/include/core"',
+                                'USER_HEADER_SEARCH_PATHS' => '"${PODS_ROOT}/Realm/include" "${PODS_ROOT}/Realm/include/Realm"' }
+  s.preserve_paths          = %w(build.sh include)
 
   s.ios.deployment_target   = '7.0'
   s.ios.vendored_library    = 'core/librealm-ios.a'

--- a/Realm/ObjectStore/impl/apple/cached_realm.cpp
+++ b/Realm/ObjectStore/impl/apple/cached_realm.cpp
@@ -16,7 +16,7 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-#include "cached_realm.hpp"
+#include "impl/cached_realm.hpp"
 
 #include "shared_realm.hpp"
 

--- a/Realm/ObjectStore/impl/apple/external_commit_helper.cpp
+++ b/Realm/ObjectStore/impl/apple/external_commit_helper.cpp
@@ -16,7 +16,7 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-#include "external_commit_helper.hpp"
+#include "impl/external_commit_helper.hpp"
 
 #include "impl/realm_coordinator.hpp"
 

--- a/Realm/ObjectStore/impl/async_query.cpp
+++ b/Realm/ObjectStore/impl/async_query.cpp
@@ -16,9 +16,9 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-#include "async_query.hpp"
+#include "impl/async_query.hpp"
 
-#include "realm_coordinator.hpp"
+#include "impl/realm_coordinator.hpp"
 #include "results.hpp"
 
 using namespace realm;

--- a/Realm/ObjectStore/impl/realm_coordinator.cpp
+++ b/Realm/ObjectStore/impl/realm_coordinator.cpp
@@ -21,9 +21,9 @@
 #include "impl/async_query.hpp"
 #include "impl/cached_realm.hpp"
 #include "impl/external_commit_helper.hpp"
+#include "impl/transact_log_handler.hpp"
 #include "object_store.hpp"
 #include "schema.hpp"
-#include "transact_log_handler.hpp"
 
 #include <realm/commit_log.hpp>
 #include <realm/group_shared.hpp>

--- a/Realm/ObjectStore/impl/transact_log_handler.cpp
+++ b/Realm/ObjectStore/impl/transact_log_handler.cpp
@@ -16,7 +16,7 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-#include "transact_log_handler.hpp"
+#include "impl/transact_log_handler.hpp"
 
 #include "binding_context.hpp"
 

--- a/Realm/ObjectStore/results.cpp
+++ b/Realm/ObjectStore/results.cpp
@@ -18,9 +18,9 @@
 
 #include "results.hpp"
 
-#include "async_query.hpp"
+#include "impl/async_query.hpp"
+#include "impl/realm_coordinator.hpp"
 #include "object_store.hpp"
-#include "realm_coordinator.hpp"
 
 #include <stdexcept>
 

--- a/Realm/RLMResults.mm
+++ b/Realm/RLMResults.mm
@@ -30,7 +30,7 @@
 #import "RLMUtil.hpp"
 
 #import "results.hpp"
-#import "external_commit_helper.hpp"
+#import "impl/external_commit_helper.hpp"
 
 #import <objc/runtime.h>
 #import <objc/message.h>

--- a/build.sh
+++ b/build.sh
@@ -889,25 +889,19 @@ case "$COMMAND" in
         done
 
         if [[ "$2" != "swift" ]]; then
-          # CocoaPods doesn't support multiple header_mappings_dir, so combine
-          # both sets of headers into a single directory
           rm -rf include
-          # Create uppercase `Realm` header directory for a case-sensitive filesystem.
-          # Both `Realm` and `realm` directories are required.
-          if [ ! -e core/include/Realm ]; then
-            cp -R core/include/realm core/include/Realm
-          fi
-          cp -R core/include include
-          mkdir -p include/Realm/impl/apple
-          cp Realm/*.{h,hpp} include/Realm
-          cp Realm/ObjectStore/*.hpp include/Realm
-          cp Realm/ObjectStore/impl/*.hpp include/Realm/impl
-          cp Realm/ObjectStore/impl/apple/*.hpp include/Realm/impl/apple
-          # Create lowercase `realm` header directory for a case-sensitive filesystem.
-          if [ ! -e include/realm ]; then
-            cp -R include/Realm include/realm
-          fi
-          touch include/Realm/RLMPlatform.h
+          mkdir -p include
+          mv core/include include/core
+
+          mkdir -p include/impl/apple
+          cp Realm/*.hpp include
+          cp Realm/ObjectStore/*.hpp include
+          cp Realm/ObjectStore/impl/*.hpp include/impl
+          cp Realm/ObjectStore/impl/apple/*.hpp include/impl/apple
+
+          mkdir -p include/Realm
+          touch Realm/RLMPlatform.h
+          cp Realm/*.h include/Realm
         else
           echo "let swiftLanguageVersion = \"$(get_swift_version)\"" > RealmSwift/SwiftVersion.swift
         fi


### PR DESCRIPTION
Only include headers needed for the Realm.Private module in private_header_files and just preserve_path the assembled include directory. This makes it not copy a whole bunch of files into the framework which don't need to be copied, and in some cases were generating warnings due to headers with the same file name at different paths.

This requires fixing all of the objectstore include paths to not rely on Xcode's header mapping stuff, which needed to be done anyway.

Also put the core headers in a different directory from the obj-c headers to remove the need to do convoluted things to handle case-sensitive filesystems.

Fixes #3178.