### PR TITLE
Crash called "indexOfObject" method to RLMResults made ​​from RLMArrayy, when the object wasn't found.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 * Fix a crash when deleting an object containing an `RLMArray`/`List` with
   active notification blocks.
 * Fix duplicate file warnings when building via CocoaPods.
+* Fix crash or incorrect results when calling `indexOfObject:` on an
+  `RLMResults` derived from an `RLMArray`.
 
 0.98.0 Release notes (2016-02-04)
 =============================================================

--- a/Realm/ObjectStore/results.cpp
+++ b/Realm/ObjectStore/results.cpp
@@ -201,9 +201,6 @@ size_t Results::index_of(size_t row_ndx)
         case Mode::Table:
             return row_ndx;
         case Mode::Query:
-            if (!m_sort)
-                return m_query.count(row_ndx, row_ndx + 1) ? m_query.count(0, row_ndx) : not_found;
-            REALM_FALLTHROUGH;
         case Mode::TableView:
             update_tableview();
             return m_table_view.find_by_source_ndx(row_ndx);

--- a/Realm/Tests/ArrayPropertyTests.m
+++ b/Realm/Tests/ArrayPropertyTests.m
@@ -446,6 +446,10 @@
 
     // invalid object
     XCTAssertThrows([company.employees indexOfObject:(EmployeeObject *)company]);
+
+    RLMResults *employees = [company.employees objectsWhere:@"age = %@", @40];
+    XCTAssertEqual(0U, [employees indexOfObject:po1]);
+    XCTAssertEqual((NSUInteger)NSNotFound, [employees indexOfObject:po3]);
 }
 
 - (void)testIndexOfObjectWhere


### PR DESCRIPTION
The crash was occurred by hitting assertion with the following message:
```
query.cpp:692: [realm-core-0.96.0] Assertion failed: tv_index < m_view->size() [2, 2]
```

This regression is introduced by aadd905
This crash was occurred at from `v0.97.0` to `master`.

If the object was found, it won't crash.
This crash doesn't occur in `RLMResults` generated from `RLMObject`.

```
RLMResults *employees = [company.employees objectsWhere:@"age = %@", @40];
XCTAssertEqual(0U, [employees indexOfObject:po1]); // No crash
XCTAssertEqual((NSUInteger)NSNotFound, [employees indexOfObject:po3]); // Crash
```

CC/ @tgoyne @jpsim 

Complete stack trace is:

```
query.cpp:692: [realm-core-0.96.0] Assertion failed: tv_index < m_view->size() [2, 2]
0   Realm                               0x0000000117077546 _ZN5realm4util18terminate_internalERNSt3__118basic_stringstreamIcNS1_11char_traitsIcEENS1_9allocatorIcEEEE + 40
1   Realm                               0x0000000116e7866c _ZN5realm4util9terminateIJmmEEEvPKcS3_lDpT_ + 1596
2   Realm                               0x000000011714b5d9 _ZNK5realm5Query14peek_tableviewEm + 201
3   Realm                               0x000000011714c532 _ZNK5realm5Query5countEmmm + 154
4   Realm                               0x0000000116ed1e81 _ZN5realm7Results8index_ofEm + 177
5   Realm                               0x0000000116ed1db8 _ZN5realm7Results8index_ofERKNS_8BasicRowINS_5TableEEE + 408
6   Realm                               0x000000011703865f _ZZ28-[RLMResults indexOfObject:]ENK3$_5clEv + 63
7   Realm                               0x0000000117034cd6 _ZL15translateErrorsIZ28-[RLMResults indexOfObject:]E3$_5EDaOT_P8NSString + 38
8   Realm                               0x0000000117034c6f -[RLMResults indexOfObject:] + 207
9   Tests                               0x00000001164acd28 -[ArrayPropertyTests testIndexOfObject] + 21784
10  CoreFoundation                      0x000000010ae171cc __invoking___ + 140
11  CoreFoundation                      0x000000010ae1701e -[NSInvocation invoke] + 286
12  XCTest                              0x00000001130a8080 __24-[XCTestCase invokeTest]_block_invoke_2 + 159
13  XCTest                              0x00000001130dbb14 -[XCTestContext performInScope:] + 184
14  XCTest                              0x00000001130a7fd0 -[XCTestCase invokeTest] + 169
15  Tests                               0x0000000116ac48a8 -[RLMTestCase invokeTest] + 312
16  XCTest                              0x00000001130a846b -[XCTestCase performTest:] + 443
17  XCTest                              0x00000001130a6131 -[XCTestSuite performTest:] + 377
18  XCTest                              0x00000001130a6131 -[XCTestSuite performTest:] + 377
19  XCTest                              0x0000000113093181 __25-[XCTestDriver _runSuite]_block_invoke + 51
20  XCTest                              0x00000001130b3b5b -[XCTestObservationCenter _observeTestExecutionForBlock:] + 615
21  XCTest                              0x00000001130930cd -[XCTestDriver _runSuite] + 408
22  XCTest                              0x0000000113093e2c -[XCTestDriver _checkForTestManager] + 263
23  XCTest                              0x00000001130dce99 _XCTestMain + 628
24  CoreFoundation                      0x000000010ae54a1c __CFRUNLOOP_IS_CALLING_OUT_TO_A_BLOCK__ + 12
25  CoreFoundation                      0x000000010ae4a6a5 __CFRunLoopDoBlocks + 341
26  CoreFoundation                      0x000000010ae49e02 __CFRunLoopRun + 850
27  CoreFoundation                      0x000000010ae49828 CFRunLoopRunSpecific + 488
28  GraphicsServices                    0x000000010c2a5ad2 GSEventRunModal + 161
29  UIKit                               0x000000010900e610 UIApplicationMain + 171
30  TestHost                            0x0000000108f67f5f main + 111
31  libdyld.dylib                       0x000000010f6d692d start + 1
IMPORTANT: if you see this error, please send this log to help@realm.io.
query.cpp:692: [realm-core-0.96.0] Assertion failed: tv_index < m_view->size() [2, 2]
0   Realm                               0x0000000117077546 _ZN5realm4util18terminate_internalERNSt3__118basic_stringstreamIcNS1_11char_traitsIcEENS1_9allocatorIcEEEE + 40
1   Realm                               0x0000000116e7866c _ZN5realm4util9terminateIJmmEEEvPKcS3_lDpT_ + 1596
2   Realm                               0x000000011714b5d9 _ZNK5realm5Query14peek_tableviewEm + 201
3   Realm                               0x000000011714c532 _ZNK5realm5Query5countEmmm + 154
4   Realm                               0x0000000116ed1e81 _ZN5realm7Results8index_ofEm + 177
5   Realm                               0x0000000116ed1db8 _ZN5realm7Results8index_ofERKNS_8BasicRowINS_5TableEEE + 408
6   Realm                               0x000000011703865f _ZZ28-[RLMResults indexOfObject:]ENK3$_5clEv + 63
7   Realm                               0x0000000117034cd6 _ZL15translateErrorsIZ28-[RLMResults indexOfObject:]E3$_5EDaOT_P8NSString + 38
8   Realm                               0x0000000117034c6f -[RLMResults indexOfObject:] + 207
9   Tests                               0x00000001164acd28 -[ArrayPropertyTests testIndexOfObject] + 21784
10  CoreFoundation                      0x000000010ae171cc __invoking___ + 140
11  CoreFoundation                      0x000000010ae1701e -[NSInvocation invoke] + 286
12  XCTest                              0x00000001130a8080 __24-[XCTestCase invokeTest]_block_invoke_2 + 159
13  XCTest                              0x00000001130dbb14 -[XCTestContext performInScope:] + 184
14  XCTest                              0x00000001130a7fd0 -[XCTestCase invokeTest] + 169
15  Tests                               0x0000000116ac48a8 -[RLMTestCase invokeTest] + 312
16  XCTest                              0x00000001130a846b -[XCTestCase performTest:] + 443
17  XCTest                              0x00000001130a6131 -[XCTestSuite performTest:] + 377
18  XCTest                              0x00000001130a6131 -[XCTestSuite performTest:] + 377
19  XCTest                              0x0000000113093181 __25-[XCTestDriver _runSuite]_block_invoke + 51
20  XCTest                              0x00000001130b3b5b -[XCTestObservationCenter _observeTestExecutionForBlock:] + 615
21  XCTest                              0x00000001130930cd -[XCTestDriver _runSuite] + 408
22  XCTest                              0x0000000113093e2c -[XCTestDriver _checkForTestManager] + 263
23  XCTest                              0x00000001130dce99 _XCTestMain + 628
24  CoreFoundation                      0x000000010ae54a1c __CFRUNLOOP_IS_CALLING_OUT_TO_A_BLOCK__ + 12
25  CoreFoundation                      0x000000010ae4a6a5 __CFRunLoopDoBlocks + 341
26  CoreFoundation                      0x000000010ae49e02 __CFRunLoopRun + 850
27  CoreFoundation                      0x000000010ae49828 CFRunLoopRunSpecific + 488
28  GraphicsServices                    0x000000010c2a5ad2 GSEventRunModal + 161
29  UIKit                               0x000000010900e610 UIApplicationMain + 171
30  TestHost                            0x0000000108f67f5f main + 111
31  libdyld.dylib                       0x000000010f6d692d start + 1
```