### PR TITLE
Have Swift collection types forward valueForKeyPath to the underlying Objective-C type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+x.x.x Release notes (yyyy-MM-dd)
+=============================================================
+
+### API breaking changes
+
+* None.
+
+### Enhancements
+
+* None.
+
+### Bugfixes
+
+* Use of KVC collection operators on Swift collection types no longer throws an exception.
+
 0.98.1 Release notes (2016-02-10)
 =============================================================
 
@@ -10,7 +25,6 @@
 * Fix duplicate file warnings when building via CocoaPods.
 * Fix crash or incorrect results when calling `indexOfObject:` on an
   `RLMResults` derived from an `RLMArray`.
-* Use of KVC collection operators on Swift collection types no longer throws an exception.
 
 0.98.0 Release notes (2016-02-04)
 =============================================================

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Fix duplicate file warnings when building via CocoaPods.
 * Fix crash or incorrect results when calling `indexOfObject:` on an
   `RLMResults` derived from an `RLMArray`.
+* Use of KVC collection operators on Swift collection types no longer throws an exception.
 
 0.98.0 Release notes (2016-02-04)
 =============================================================

--- a/RealmSwift-swift2.0/List.swift
+++ b/RealmSwift-swift2.0/List.swift
@@ -153,11 +153,13 @@ public final class List<T: Object>: ListBase {
     }
 
     /**
-     Returns an Array containing the results of invoking `valueForKeyPath(_:)` using keyPath on each of the collection's objects.
+     Returns an Array containing the results of invoking `valueForKeyPath(_:)` using keyPath on each of the
+     collection's objects.
 
      - parameter keyPath: The key path to the property.
 
-     - returns: Array containing the results of invoking `valueForKeyPath(_:)` using keyPath on each of the collection's objects.
+     - returns: Array containing the results of invoking `valueForKeyPath(_:)` using keyPath on each of the
+     collection's objects.
      */
     public override func valueForKeyPath(keyPath: String) -> AnyObject? {
         return _rlmArray.valueForKeyPath(keyPath)

--- a/RealmSwift-swift2.0/List.swift
+++ b/RealmSwift-swift2.0/List.swift
@@ -153,6 +153,17 @@ public final class List<T: Object>: ListBase {
     }
 
     /**
+     Returns an Array containing the results of invoking `valueForKeyPath(_:)` using keyPath on each of the collection's objects.
+
+     - parameter keyPath: The key path to the property.
+
+     - returns: Array containing the results of invoking `valueForKeyPath(_:)` using keyPath on each of the collection's objects.
+     */
+    public override func valueForKeyPath(keyPath: String) -> AnyObject? {
+        return _rlmArray.valueForKeyPath(keyPath)
+    }
+
+    /**
     Invokes `setValue(_:forKey:)` on each of the collection's objects using the specified value and key.
 
     - warning: This method can only be called during a write transaction.

--- a/RealmSwift-swift2.0/RealmCollectionType.swift
+++ b/RealmSwift-swift2.0/RealmCollectionType.swift
@@ -202,6 +202,15 @@ public protocol RealmCollectionType: CollectionType, CustomStringConvertible {
     func valueForKey(key: String) -> AnyObject?
 
     /**
+     Returns an Array containing the results of invoking `valueForKeyPath(_:)` using keyPath on each of the collection's objects.
+
+     - parameter keyPath: The key path to the property.
+
+     - returns: Array containing the results of invoking `valueForKeyPath(_:)` using keyPath on each of the collection's objects.
+     */
+    func valueForKeyPath(keyPath: String) -> AnyObject?
+
+    /**
     Invokes `setValue(_:forKey:)` on each of the collection's objects using the specified value and key.
 
     - warning: This method can only be called during a write transaction.
@@ -240,6 +249,7 @@ private class _AnyRealmCollectionBase<T: Object>: RealmCollectionType {
     var startIndex: Int { fatalError() }
     var endIndex: Int { fatalError() }
     func valueForKey(key: String) -> AnyObject? { fatalError() }
+    func valueForKeyPath(keyPath: String) -> AnyObject? { fatalError() }
     func setValue(value: AnyObject?, forKey key: String) { fatalError() }
     func _addNotificationBlock(block: (AnyRealmCollection<Element>?, NSError?) -> ()) -> NotificationToken {
         fatalError()
@@ -449,6 +459,7 @@ private final class _AnyRealmCollection<C: RealmCollectionType>: _AnyRealmCollec
     - returns: Array containing the results of invoking `valueForKey(_:)` using key on each of the collection's objects.
     */
     override func valueForKey(key: String) -> AnyObject? { return base.valueForKey(key) }
+    override func valueForKeyPath(keyPath: String) -> AnyObject? { return base.valueForKeyPath(keyPath) }
 
     /**
     Invokes `setValue(_:forKey:)` on each of the collection's objects using the specified value and key.
@@ -670,6 +681,7 @@ public final class AnyRealmCollection<T: Object>: RealmCollectionType {
     - returns: Array containing the results of invoking `valueForKey(_:)` using key on each of the collection's objects.
     */
     public func valueForKey(key: String) -> AnyObject? { return base.valueForKey(key) }
+    public func valueForKeyPath(keyPath: String) -> AnyObject? { return base.valueForKeyPath(keyPath) }
 
     /**
     Invokes `setValue(_:forKey:)` on each of the collection's objects using the specified value and key.

--- a/RealmSwift-swift2.0/RealmCollectionType.swift
+++ b/RealmSwift-swift2.0/RealmCollectionType.swift
@@ -202,11 +202,13 @@ public protocol RealmCollectionType: CollectionType, CustomStringConvertible {
     func valueForKey(key: String) -> AnyObject?
 
     /**
-     Returns an Array containing the results of invoking `valueForKeyPath(_:)` using keyPath on each of the collection's objects.
+     Returns an Array containing the results of invoking `valueForKeyPath(_:)` using keyPath on each of the
+     collection's objects.
 
      - parameter keyPath: The key path to the property.
 
-     - returns: Array containing the results of invoking `valueForKeyPath(_:)` using keyPath on each of the collection's objects.
+     - returns: Array containing the results of invoking `valueForKeyPath(_:)` using keyPath on each of the
+     collection's objects.
      */
     func valueForKeyPath(keyPath: String) -> AnyObject?
 
@@ -459,6 +461,16 @@ private final class _AnyRealmCollection<C: RealmCollectionType>: _AnyRealmCollec
     - returns: Array containing the results of invoking `valueForKey(_:)` using key on each of the collection's objects.
     */
     override func valueForKey(key: String) -> AnyObject? { return base.valueForKey(key) }
+
+    /**
+     Returns an Array containing the results of invoking `valueForKeyPath(_:)` using keyPath on each of the
+     collection's objects.
+
+     - parameter keyPath: The key path to the property.
+
+     - returns: Array containing the results of invoking `valueForKeyPath(_:)` using keyPath on each of the
+       collection's objects.
+     */
     override func valueForKeyPath(keyPath: String) -> AnyObject? { return base.valueForKeyPath(keyPath) }
 
     /**
@@ -681,6 +693,16 @@ public final class AnyRealmCollection<T: Object>: RealmCollectionType {
     - returns: Array containing the results of invoking `valueForKey(_:)` using key on each of the collection's objects.
     */
     public func valueForKey(key: String) -> AnyObject? { return base.valueForKey(key) }
+
+    /**
+     Returns an Array containing the results of invoking `valueForKeyPath(_:)` using keyPath on each of the
+     collection's objects.
+
+     - parameter keyPath: The key path to the property.
+
+     - returns: Array containing the results of invoking `valueForKeyPath(_:)` using keyPath on each of the
+     collection's objects.
+     */
     public func valueForKeyPath(keyPath: String) -> AnyObject? { return base.valueForKeyPath(keyPath) }
 
     /**

--- a/RealmSwift-swift2.0/Results.swift
+++ b/RealmSwift-swift2.0/Results.swift
@@ -192,6 +192,17 @@ public final class Results<T: Object>: ResultsBase {
     }
 
     /**
+     Returns an Array containing the results of invoking `valueForKeyPath(_:)` using keyPath on each of the collection's objects.
+
+     - parameter keyPath: The key path to the property.
+
+     - returns: Array containing the results of invoking `valueForKeyPath(_:)` using keyPath on each of the collection's objects.
+     */
+    public override func valueForKeyPath(keyPath: String) -> AnyObject? {
+        return rlmResults.valueForKeyPath(keyPath)
+    }
+
+    /**
     Invokes `setValue(_:forKey:)` on each of the collection's objects using the specified value and key.
 
     - warning: This method can only be called during a write transaction.

--- a/RealmSwift-swift2.0/Results.swift
+++ b/RealmSwift-swift2.0/Results.swift
@@ -192,11 +192,13 @@ public final class Results<T: Object>: ResultsBase {
     }
 
     /**
-     Returns an Array containing the results of invoking `valueForKeyPath(_:)` using keyPath on each of the collection's objects.
+     Returns an Array containing the results of invoking `valueForKeyPath(_:)` using keyPath on each of the
+     collection's objects.
 
      - parameter keyPath: The key path to the property.
 
-     - returns: Array containing the results of invoking `valueForKeyPath(_:)` using keyPath on each of the collection's objects.
+     - returns: Array containing the results of invoking `valueForKeyPath(_:)` using keyPath on each of the
+     collection's objects.
      */
     public override func valueForKeyPath(keyPath: String) -> AnyObject? {
         return rlmResults.valueForKeyPath(keyPath)

--- a/RealmSwift-swift2.0/Tests/RealmCollectionTypeTests.swift
+++ b/RealmSwift-swift2.0/Tests/RealmCollectionTypeTests.swift
@@ -323,6 +323,17 @@ class RealmCollectionTypeTests: TestCase {
         token.stop()
         realm.beginWrite()
     }
+
+    func testValueForKeyPath() {
+        XCTAssertEqual(["1", "2"], self.collection.valueForKeyPath("@unionOfObjects.stringCol") as! NSArray?)
+
+        let collection = getAggregateableCollection()
+        XCTAssertEqual(3, collection.valueForKeyPath("@count")?.longValue)
+        XCTAssertEqual(3, collection.valueForKeyPath("@max.intCol")?.longValue)
+        XCTAssertEqual(1, collection.valueForKeyPath("@min.intCol")?.longValue)
+        XCTAssertEqual(6, collection.valueForKeyPath("@sum.intCol")?.longValue)
+        XCTAssertEqual(2.0, collection.valueForKeyPath("@avg.intCol")?.doubleValue)
+    }
 }
 
 // MARK: Results


### PR DESCRIPTION
This allows key paths containing collection operators to be handled correctly, rather than throwing an unrecognized selector exception.

Fixes #3115.