### PR TITLE
Fix reporting of inWriteTransaction in notifications triggered by beginWrite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ x.x.x Release notes (yyyy-MM-dd)
 ### Bugfixes
 
 * Use of KVC collection operators on Swift collection types no longer throws an exception.
+* Fix reporting of inWriteTransaction in notifications triggered by
+  `beginWriteTransaction`.
 
 0.98.1 Release notes (2016-02-10)
 =============================================================

--- a/Realm/ObjectStore/shared_realm.cpp
+++ b/Realm/ObjectStore/shared_realm.cpp
@@ -294,8 +294,14 @@ void Realm::begin_transaction()
     // make sure we have a read transaction
     read_group();
 
-    transaction::begin(*m_shared_group, *m_history, m_binding_context.get());
     m_in_transaction = true;
+    try {
+        transaction::begin(*m_shared_group, *m_history, m_binding_context.get());
+    }
+    catch (...) {
+        m_in_transaction = false;
+        throw;
+    }
 }
 
 void Realm::commit_transaction()

--- a/Realm/RLMRealm.mm
+++ b/Realm/RLMRealm.mm
@@ -591,10 +591,6 @@ static void CheckReadWrite(RLMRealm *realm, NSString *msg=@"Cannot write to a re
     }
 }
 
-- (void)notify {
-    _realm->notify();
-}
-
 - (BOOL)refresh {
     return _realm->refresh();
 }

--- a/Realm/RLMRealm_Private.h
+++ b/Realm/RLMRealm_Private.h
@@ -78,7 +78,6 @@ void RLMRealmTranslateException(NSError **error);
 - (void)detachAllEnumerators;
 
 - (void)sendNotifications:(NSString *)notification;
-- (void)notify;
 - (void)verifyThread;
 - (void)verifyNotificationsAreSupported;
 


### PR DESCRIPTION
Set m_in_transaction before calling `promote_to_write()`, and set it back to false if that throws rather than setting it afterwards, so that notifications called due to the implicit `advance_read()` see the correct value.

Also includes some uninteresting tests that hit a few of the previously uncovered bits of `realm::Realm`.

May fix #3199.