### PR TITLE
Ensure that RLMFastEnumerator initializes our Swift generics machinery for the accessor objects it creates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ x.x.x Release notes (yyyy-MM-dd)
 * Use of KVC collection operators on Swift collection types no longer throws an exception.
 * Fix reporting of inWriteTransaction in notifications triggered by
   `beginWriteTransaction`.
+* The contents of `List` and `Optional` properties are now correctly preserved when copying
+  a Swift object from one Realm to another.
 
 0.98.1 Release notes (2016-02-10)
 =============================================================

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ x.x.x Release notes (yyyy-MM-dd)
 * Fix reporting of inWriteTransaction in notifications triggered by
   `beginWriteTransaction`.
 * The contents of `List` and `Optional` properties are now correctly preserved when copying
-  a Swift object from one Realm to another.
+  a Swift object from one Realm to another, and performing other operations that result in a
+  Swift object graph being recursively traversed from Objective-C.
 
 0.98.1 Release notes (2016-02-10)
 =============================================================

--- a/Realm/RLMResults.mm
+++ b/Realm/RLMResults.mm
@@ -136,6 +136,7 @@ static const int RLMEnumerationBufferSize = 16;
         else if (_tableView.is_row_attached(index)) {
             accessor->_row = (*_objectSchema.table)[_tableView.get_source_ndx(index)];
         }
+        RLMInitializeSwiftAccessorGenerics(accessor);
         _strongBuffer[batchCount] = accessor;
         batchCount++;
     }

--- a/RealmSwift-swift2.0/Tests/ObjectCreationTests.swift
+++ b/RealmSwift-swift2.0/Tests/ObjectCreationTests.swift
@@ -388,17 +388,23 @@ class ObjectCreationTests: TestCase {
             "arrayCol": [SwiftBoolObject(value: [true]), SwiftBoolObject()] as AnyObject,
         ]
 
-        realmWithTestPath().beginWrite()
-        let otherRealmObject = realmWithTestPath().create(SwiftListOfSwiftObject.self, value: ["array": [SwiftObject(value: values), SwiftObject(value: values)]])
-        try! realmWithTestPath().commitWrite()
+        let realmA = realmWithTestPath()
+        let realmB = try! Realm()
 
-        try! Realm().beginWrite()
-        let object = try! Realm().create(SwiftListOfSwiftObject.self, value: otherRealmObject)
-        try! Realm().commitWrite()
+        var realmAObject: SwiftListOfSwiftObject!
+        try! realmA.write {
+            let array = [SwiftObject(value: values), SwiftObject(value: values)]
+            realmAObject = realmA.create(SwiftListOfSwiftObject.self, value: ["array": array])
+        }
 
-        XCTAssertNotEqual(otherRealmObject, object)
-        XCTAssertEqual(object.array.count,2)
-        for swiftObject in object.array {
+        var realmBObject: SwiftListOfSwiftObject!
+        try! realmB.write {
+            realmBObject = realmB.create(SwiftListOfSwiftObject.self, value: realmAObject)
+        }
+
+        XCTAssertNotEqual(realmAObject, realmBObject)
+        XCTAssertEqual(realmBObject.array.count, 2)
+        for swiftObject in realmBObject.array {
             verifySwiftObjectWithDictionaryLiteral(swiftObject, dictionary: values, boolObjectValue: true,
                 boolObjectListValues: [true, false])
         }

--- a/RealmSwift-swift2.0/Tests/ObjectCreationTests.swift
+++ b/RealmSwift-swift2.0/Tests/ObjectCreationTests.swift
@@ -375,6 +375,35 @@ class ObjectCreationTests: TestCase {
             boolObjectListValues: [true, false])
     }
 
+    func testCreateWithDeeplyNestedObjectsFromAnotherRealm() {
+        let values = [
+            "boolCol": true as NSNumber,
+            "intCol": 1 as NSNumber,
+            "floatCol": 1.1 as NSNumber,
+            "doubleCol": 11.1 as NSNumber,
+            "stringCol": "b" as NSString,
+            "binaryCol": "b".dataUsingEncoding(NSUTF8StringEncoding)! as NSData,
+            "dateCol": NSDate(timeIntervalSince1970: 2) as NSDate,
+            "objectCol": SwiftBoolObject(value: [true]) as AnyObject,
+            "arrayCol": [SwiftBoolObject(value: [true]), SwiftBoolObject()] as AnyObject,
+        ]
+
+        realmWithTestPath().beginWrite()
+        let otherRealmObject = realmWithTestPath().create(SwiftListOfSwiftObject.self, value: ["array": [SwiftObject(value: values), SwiftObject(value: values)]])
+        try! realmWithTestPath().commitWrite()
+
+        try! Realm().beginWrite()
+        let object = try! Realm().create(SwiftListOfSwiftObject.self, value: otherRealmObject)
+        try! Realm().commitWrite()
+
+        XCTAssertNotEqual(otherRealmObject, object)
+        XCTAssertEqual(object.array.count,2)
+        for swiftObject in object.array {
+            verifySwiftObjectWithDictionaryLiteral(swiftObject, dictionary: values, boolObjectValue: true,
+                boolObjectListValues: [true, false])
+        }
+    }
+
     func testUpdateWithObjectsFromAnotherRealm() {
         realmWithTestPath().beginWrite()
         let otherRealmObject = realmWithTestPath().create(SwiftLinkToPrimaryStringObject.self,


### PR DESCRIPTION
Fixes #2905.