### PR TITLE
Make partial schema initialization more robust

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ x.x.x Release notes (yyyy-MM-dd)
 * The `ANY` / `SOME` / `NONE` qualifiers are now required in comparisons involving a key path that
   traverse a `RLMArray`/`List` property. Previously they were only required if the first key in the
   key path was an `RLMArray`/`List` property.
+* Fix several scenarios where the default schema would be initialized
+  incorrectly if the first Realm opened used a restricted class subset (via
+  `objectClasses`/`objectTypes`).
 
 0.98.1 Release notes (2016-02-10)
 =============================================================

--- a/Realm/RLMAccessor.h
+++ b/Realm/RLMAccessor.h
@@ -60,6 +60,5 @@ void RLMReplaceClassNameMethod(Class accessorClass, NSString *className);
 
 // Replace sharedSchema method for the given class
 void RLMReplaceSharedSchemaMethod(Class accessorClass, RLMObjectSchema * __nullable schema);
-void RLMReplaceSharedSchemaMethodWithBlock(Class accessorClass, RLMObjectSchema *(^method)(Class));
 
 RLM_ASSUME_NONNULL_END

--- a/Realm/RLMObjectBase.mm
+++ b/Realm/RLMObjectBase.mm
@@ -185,7 +185,7 @@ static id RLMValidatedObjectForProperty(id obj, RLMProperty *prop, RLMSchema *sc
 
 // overridden at runtime per-class for performance
 + (RLMObjectSchema *)sharedSchema {
-    return RLMSchema.sharedSchema[self.className];
+    return [RLMSchema sharedSchemaForClass:self.class];
 }
 
 - (NSString *)description

--- a/Realm/RLMProperty.mm
+++ b/Realm/RLMProperty.mm
@@ -162,7 +162,7 @@ BOOL RLMPropertyTypeIsNumeric(RLMPropertyType propertyType) {
                                                           encoding:NSUTF8StringEncoding];
 
                 Class cls = [RLMSchema classForString:_objectClassName];
-                if (!RLMIsObjectSubclass(cls)) {
+                if (!cls) {
                     @throw RLMException(@"'%@' is not supported as an RLMArray object type. RLMArrays can only contain instances of RLMObject subclasses. See https://realm.io/docs/objc/latest/#to-many for more information.", self.objectClassName);
                 }
             }
@@ -202,7 +202,7 @@ BOOL RLMPropertyTypeIsNumeric(RLMPropertyType propertyType) {
 
                 // verify type
                 Class cls = [RLMSchema classForString:className];
-                if (!RLMIsObjectSubclass(cls)) {
+                if (!cls) {
                     @throw RLMException(@"'%@' is not supported as an RLMObject property. All properties must be primitives, NSString, NSDate, NSData, RLMArray, or subclasses of RLMObject. See https://realm.io/docs/objc/latest/api/Classes/RLMObject.html for more information.", className);
                 }
 

--- a/Realm/RLMSchema.mm
+++ b/Realm/RLMSchema.mm
@@ -313,8 +313,10 @@ static void RLMRegisterClassLocalNames(Class *classes, NSUInteger count) {
 
 - (NSString *)description {
     NSMutableString *objectSchemaString = [NSMutableString string];
-    for (RLMObjectSchema *objectSchema in self.objectSchema) {
-        [objectSchemaString appendFormat:@"\t%@\n", [objectSchema.description stringByReplacingOccurrencesOfString:@"\n" withString:@"\n\t"]];
+    NSArray *sort = @[[NSSortDescriptor sortDescriptorWithKey:@"className" ascending:YES]];
+    for (RLMObjectSchema *objectSchema in [self.objectSchema sortedArrayUsingDescriptors:sort]) {
+        [objectSchemaString appendFormat:@"\t%@\n",
+         [objectSchema.description stringByReplacingOccurrencesOfString:@"\n" withString:@"\n\t"]];
     }
     return [NSString stringWithFormat:@"Schema {\n%@}", objectSchemaString];
 }

--- a/Realm/RLMSchema.mm
+++ b/Realm/RLMSchema.mm
@@ -43,45 +43,99 @@ const uint64_t RLMNotVersioned = realm::ObjectStore::NotVersioned;
 @property (nonatomic, readwrite) NSMutableDictionary *objectSchemaByName;
 @end
 
-static RLMSchema *s_sharedSchema;
-static RLMSchema *s_partialSharedSchema = [[RLMSchema alloc] init];
+static RLMSchema *s_sharedSchema = [[RLMSchema alloc] init];
 static NSMutableDictionary *s_localNameToClass = [[NSMutableDictionary alloc] init];
+static NSMutableDictionary *s_privateObjectSubclasses = [[NSMutableDictionary alloc] init];
 
-@implementation RLMSchema
+static enum class SharedSchemaState {
+    Uninitialized,
+    Initializing,
+    Initialized
+} s_sharedSchemaState = SharedSchemaState::Uninitialized;
 
-+ (instancetype)schemaWithObjectClasses:(NSArray *)classes {
-    NSUInteger count = classes.count;
-    auto classArray = std::make_unique<__unsafe_unretained Class[]>(count);
-    [classes getObjects:classArray.get() range:NSMakeRange(0, count)];
-    [self registerClasses:classArray.get() count:count];
-
-    RLMSchema *schema = [[self alloc] init];
-    NSMutableArray *schemas = [NSMutableArray arrayWithCapacity:count];
-    for (Class cls in classes) {
-        if (!RLMIsObjectSubclass(cls)) {
-            @throw RLMException(@"Can't add non-Object type '%@' to a schema.", cls);
-        }
-        [schemas addObject:[cls sharedSchema]];
+// Caller must @synchronize on s_localNameToClass
+static RLMObjectSchema *RLMRegisterClass(Class cls) {
+    if (RLMObjectSchema *schema = s_privateObjectSubclasses[[cls className]]) {
+        return schema;
     }
-    schema.objectSchema = schemas;
 
-    NSMutableArray *errors = [NSMutableArray new];
-    // Verify that all of the targets of links are included in the class list
-    for (RLMObjectSchema *objectSchema in schema->_objectSchema) {
-        for (RLMProperty *prop in objectSchema.properties) {
-            if (prop.type != RLMPropertyTypeObject && prop.type != RLMPropertyTypeArray) {
-                continue;
-            }
-            if (!schema->_objectSchemaByName[prop.objectClassName]) {
-                [errors addObject:[NSString stringWithFormat:@"- '%@.%@' links to class '%@', which is missing from the list of classes to persist", objectSchema.className, prop.name, prop.objectClassName]];
-            }
-        }
-    }
-    if (errors.count) {
-        @throw RLMException(@"Invalid class subset list:\n%@", [errors componentsJoinedByString:@"\n"]);
+    auto prevState = s_sharedSchemaState;
+    s_sharedSchemaState = SharedSchemaState::Initializing;
+    RLMObjectSchema *schema = [RLMObjectSchema schemaForObjectClass:cls];
+    s_sharedSchemaState = prevState;
+
+    // set standalone class on shared shema for standalone object creation
+    schema.standaloneClass = RLMStandaloneAccessorClassForObjectClass(schema.objectClass, schema);
+
+    // override sharedSchema classs methods for performance
+    RLMReplaceSharedSchemaMethod(cls, schema);
+
+    s_privateObjectSubclasses[schema.className] = schema;
+    if ([cls shouldIncludeInDefaultSchema]) {
+        s_sharedSchema.objectSchemaByName[schema.className] = schema;
     }
 
     return schema;
+}
+
+// Caller must @synchronize on s_localNameToClass
+static void RLMRegisterClassLocalNames(Class *classes, NSUInteger count) {
+    for (NSUInteger i = 0; i < count; i++) {
+        Class cls = classes[i];
+
+        if (!RLMIsObjectSubclass(cls) || RLMIsGeneratedClass(cls)) {
+            continue;
+        }
+
+        NSString *className = NSStringFromClass(cls);
+        if ([RLMSwiftSupport isSwiftClassName:className]) {
+            className = [RLMSwiftSupport demangleClassName:className];
+        }
+        // NSStringFromClass demangles the names for top-level Swift classes
+        // but not for nested classes. _T indicates it's a Swift symbol, t
+        // indicates it's a type, and C indicates it's a class.
+        else if ([className hasPrefix:@"_TtC"]) {
+            @throw RLMException(@"RLMObject subclasses cannot be nested within other declarations. Please move %@ to global scope.", className);
+        }
+
+        if (Class existingClass = s_localNameToClass[className]) {
+            if (existingClass != cls) {
+                @throw RLMException(@"RLMObject subclasses with the same name cannot be included twice in the same target. "
+                                    @"Please make sure '%@' is only linked once to your current target.", className);
+            }
+            continue;
+        }
+
+        s_localNameToClass[className] = cls;
+        RLMReplaceClassNameMethod(cls, className);
+    }
+}
+
+@implementation RLMSchema {
+    NSArray *_objectSchema;
+}
+
+- (instancetype)init {
+    self = [super init];
+    if (self) {
+        _objectSchemaByName = [[NSMutableDictionary alloc] init];
+    }
+    return self;
+}
+
+- (NSArray *)objectSchema {
+    if (!_objectSchema) {
+        _objectSchema = [_objectSchemaByName allValues];
+    }
+    return _objectSchema;
+}
+
+- (void)setObjectSchema:(NSArray *)objectSchema {
+    _objectSchema = objectSchema;
+    _objectSchemaByName = [NSMutableDictionary dictionaryWithCapacity:objectSchema.count];
+    for (RLMObjectSchema *object in objectSchema) {
+        [_objectSchemaByName setObject:object forKey:object.className];
+    }
 }
 
 - (RLMObjectSchema *)schemaForClassName:(NSString *)className {
@@ -96,119 +150,100 @@ static NSMutableDictionary *s_localNameToClass = [[NSMutableDictionary alloc] in
     return schema;
 }
 
-- (void)setObjectSchema:(NSArray *)objectSchema {
-    _objectSchema = objectSchema;
-    _objectSchemaByName = [NSMutableDictionary dictionaryWithCapacity:objectSchema.count];
-    for (RLMObjectSchema *object in objectSchema) {
-        [(NSMutableDictionary *)_objectSchemaByName setObject:object forKey:object.className];
++ (instancetype)schemaWithObjectClasses:(NSArray *)classes {
+    NSUInteger count = classes.count;
+    auto classArray = std::make_unique<__unsafe_unretained Class[]>(count);
+    [classes getObjects:classArray.get() range:NSMakeRange(0, count)];
+
+    RLMSchema *schema = [[self alloc] init];
+    @synchronized(s_localNameToClass) {
+        RLMRegisterClassLocalNames(classArray.get(), count);
+
+        schema->_objectSchemaByName = [NSMutableDictionary dictionaryWithCapacity:count];
+        for (Class cls in classes) {
+            if (!RLMIsObjectSubclass(cls)) {
+                @throw RLMException(@"Can't add non-Object type '%@' to a schema.", cls);
+            }
+            schema->_objectSchemaByName[[cls className]] = RLMRegisterClass(cls);
+        }
+    }
+
+    NSMutableArray *errors = [NSMutableArray new];
+    // Verify that all of the targets of links are included in the class list
+    [schema->_objectSchemaByName enumerateKeysAndObjectsUsingBlock:^(id, RLMObjectSchema *objectSchema, BOOL *) {
+        for (RLMProperty *prop in objectSchema.properties) {
+            if (prop.type != RLMPropertyTypeObject && prop.type != RLMPropertyTypeArray) {
+                continue;
+            }
+            if (!schema->_objectSchemaByName[prop.objectClassName]) {
+                [errors addObject:[NSString stringWithFormat:@"- '%@.%@' links to class '%@', which is missing from the list of classes to persist", objectSchema.className, prop.name, prop.objectClassName]];
+            }
+        }
+    }];
+    if (errors.count) {
+        @throw RLMException(@"Invalid class subset list:\n%@", [errors componentsJoinedByString:@"\n"]);
+    }
+
+    return schema;
+}
+
++ (RLMObjectSchema *)sharedSchemaForClass:(Class)cls {
+    @synchronized(s_localNameToClass) {
+        // We create instancse of Swift objects during schema init, and they
+        // obviously need to not also try to initialize the schema
+        if (s_sharedSchemaState == SharedSchemaState::Initializing) {
+            return nil;
+        }
+
+        RLMRegisterClassLocalNames(&cls, 1);
+        return RLMRegisterClass(cls);
     }
 }
 
 + (instancetype)partialSharedSchema {
-    return s_partialSharedSchema;
-}
-
-+ (void)registerClasses:(Class *)classes count:(NSUInteger)count {
-    auto newClasses = [NSMutableArray new];
-    auto threadID = pthread_mach_thread_np(pthread_self());
-
-    @synchronized(s_localNameToClass) {
-        // first create class to name mapping so we can do array validation
-        // when creating object schema
-        for (NSUInteger i = 0; i < count; i++) {
-            Class cls = classes[i];
-
-            if (!RLMIsObjectSubclass(cls) || RLMIsGeneratedClass(cls)) {
-                continue;
-            }
-
-            NSString *className = NSStringFromClass(cls);
-            if ([RLMSwiftSupport isSwiftClassName:className]) {
-                className = [RLMSwiftSupport demangleClassName:className];
-            }
-            // NSStringFromClass demangles the names for top-level Swift classes
-            // but not for nested classes. _T indicates it's a Swift symbol, t
-            // indicates it's a type, and C indicates it's a class.
-            else if ([className hasPrefix:@"_TtC"]) {
-                @throw RLMException(@"RLMObject subclasses cannot be nested within other declarations. Please move %@ to global scope.", className);
-            }
-
-            if (Class existingClass = s_localNameToClass[className]) {
-                if (existingClass != cls) {
-                    @throw RLMException(@"RLMObject subclasses with the same name cannot be included twice in the same target. "
-                                        @"Please make sure '%@' is only linked once to your current target.", className);
-                }
-                continue;
-            }
-
-            s_localNameToClass[className] = cls;
-            [newClasses addObject:cls];
-
-            RLMReplaceClassNameMethod(cls, className);
-            // override sharedSchema class method to return nil to avoid topo-sort issues when on this thread
-            // (i.e. while during schema initialization), but wait on other threads until schema initialization is done,
-            // then return the just-initialized schema
-            RLMReplaceSharedSchemaMethodWithBlock(cls, ^RLMObjectSchema *(Class cls) {
-                if (threadID == pthread_mach_thread_np(pthread_self())) {
-                    return nil;
-                }
-                @synchronized(s_localNameToClass) {
-                    return [cls sharedSchema];
-                }
-            });
-        }
-
-        NSMutableArray *schemas = [NSMutableArray arrayWithCapacity:newClasses.count];
-        for (Class cls in newClasses) {
-            RLMObjectSchema *schema = [RLMObjectSchema schemaForObjectClass:cls];
-
-            // set standalone class on shared shema for standalone object creation
-            schema.standaloneClass = RLMStandaloneAccessorClassForObjectClass(schema.objectClass, schema);
-
-            // override sharedSchema classs methods for performance
-            RLMReplaceSharedSchemaMethod(cls, schema);
-
-            if ([cls shouldIncludeInDefaultSchema]) {
-                [schemas addObject:schema];
-            }
-        }
-
-        // protected by the @synchronized around s_localNameToClass
-        s_partialSharedSchema.objectSchema = [[s_partialSharedSchema objectSchema] arrayByAddingObjectsFromArray:schemas] ?: schemas;
-    }
+    return s_sharedSchema;
 }
 
 // schema based on runtime objects
 + (instancetype)sharedSchema {
-    static mach_port_t threadID;
-    if (pthread_mach_thread_np(pthread_self()) == threadID) {
-        @throw RLMException(@"Illegal recursive call of +[%@ %@]. Note: Properties of Swift `Object` classes must not be prepopulated with queried results from a Realm.", self, NSStringFromSelector(_cmd));
+    @synchronized(s_localNameToClass) {
+        if (s_sharedSchemaState == SharedSchemaState::Initialized) {
+            // Init was done on a different thread while we were waiting for
+            // the @synchronized
+            return s_sharedSchema;
+        }
+
+        if (s_sharedSchemaState == SharedSchemaState::Initializing) {
+            @throw RLMException(@"Illegal recursive call of +[%@ %@]. Note: Properties of Swift `Object` classes must not be prepopulated with queried results from a Realm.", self, NSStringFromSelector(_cmd));
+        }
+
+        s_sharedSchemaState = SharedSchemaState::Initializing;
+        try {
+            // Make sure we've discovered all classes
+            {
+                unsigned int numClasses;
+                std::unique_ptr<__unsafe_unretained Class[], decltype(&free)> classes(objc_copyClassList(&numClasses), &free);
+                RLMRegisterClassLocalNames(classes.get(), numClasses);
+            }
+
+            [s_localNameToClass enumerateKeysAndObjectsUsingBlock:^(NSString *, Class cls, BOOL *) {
+                RLMRegisterClass(cls);
+            }];
+        }
+        catch (...) {
+            s_sharedSchemaState = SharedSchemaState::Uninitialized;
+            throw;
+        }
+
+        // Replace this method with one that doesn't need to acquire a lock
+        Class metaClass = objc_getMetaClass(class_getName(self));
+        IMP imp = imp_implementationWithBlock(^{ return s_sharedSchema; });
+        class_replaceMethod(metaClass, @selector(sharedSchema), imp, "@@:");
+
+        s_sharedSchemaState = SharedSchemaState::Initialized;
     }
-    static std::once_flag onceFlag;
-    std::call_once(onceFlag, [&](){
-        threadID = pthread_mach_thread_np(pthread_self());
-        RLMSchema *schema = [[RLMSchema alloc] init];
 
-        unsigned int numClasses;
-        std::unique_ptr<__unsafe_unretained Class[], decltype(&free)> classes(objc_copyClassList(&numClasses), &free);
-        [self registerClasses:classes.get() count:numClasses];
-
-        // set class array
-        schema.objectSchema = s_partialSharedSchema.objectSchema;
-
-        // set shared schema
-        s_sharedSchema = schema;
-
-        threadID = 0;
-    });
     return s_sharedSchema;
-}
-
-// schema based on tables in a realm
-+ (instancetype)dynamicSchemaFromRealm:(RLMRealm *)realm {
-    // generate object schema and class mapping for all tables in the realm
-    Schema objectStoreSchema = ObjectStore::schema_from_group(realm.group);
-    return [self dynamicSchemaFromObjectStoreSchema:objectStoreSchema];
 }
 
 // schema based on tables in a realm
@@ -230,35 +265,50 @@ static NSMutableDictionary *s_localNameToClass = [[NSMutableDictionary alloc] in
     if (Class cls = s_localNameToClass[className]) {
         return cls;
     }
-    return NSClassFromString(className);
+
+    if (Class cls = NSClassFromString(className)) {
+        return RLMIsObjectSubclass(cls) ? cls : nil;
+    }
+
+    // className might be the local name of a Swift class we haven't registered
+    // yet, so scan them all then recheck
+    {
+        unsigned int numClasses;
+        std::unique_ptr<__unsafe_unretained Class[], decltype(&free)> classes(objc_copyClassList(&numClasses), &free);
+        RLMRegisterClassLocalNames(classes.get(), numClasses);
+    }
+
+    return s_localNameToClass[className];
 }
 
 - (id)copyWithZone:(NSZone *)zone {
     RLMSchema *schema = [[RLMSchema allocWithZone:zone] init];
-    schema.objectSchema = [[NSArray allocWithZone:zone] initWithArray:self.objectSchema copyItems:YES];
+    schema->_objectSchemaByName = [[NSMutableDictionary allocWithZone:zone]
+                                   initWithDictionary:_objectSchemaByName copyItems:YES];
     return schema;
 }
 
 - (instancetype)shallowCopy {
     RLMSchema *schema = [[RLMSchema alloc] init];
-    NSMutableArray *objectSchema = [NSMutableArray arrayWithCapacity:_objectSchema.count];
-    for (RLMObjectSchema *schema in _objectSchema) {
-        [objectSchema addObject:[schema shallowCopy]];
-    }
-    schema.objectSchema = objectSchema;
+    schema->_objectSchemaByName = [[NSMutableDictionary alloc] initWithCapacity:_objectSchemaByName.count];
+    [_objectSchemaByName enumerateKeysAndObjectsUsingBlock:^(NSString *name, RLMObjectSchema *objectSchema, BOOL *) {
+        schema->_objectSchemaByName[name] = [objectSchema shallowCopy];
+    }];
     return schema;
 }
 
 - (BOOL)isEqualToSchema:(RLMSchema *)schema {
-    if (_objectSchema.count != schema.objectSchema.count) {
+    if (_objectSchemaByName.count != schema->_objectSchemaByName.count) {
         return NO;
     }
-    for (RLMObjectSchema *objectSchema in schema.objectSchema) {
-        if (![_objectSchemaByName[objectSchema.className] isEqualToObjectSchema:objectSchema]) {
-            return NO;
+    __block BOOL matches = YES;
+    [_objectSchemaByName enumerateKeysAndObjectsUsingBlock:^(NSString *name, RLMObjectSchema *objectSchema, BOOL *stop) {
+        if (![schema->_objectSchemaByName[name] isEqualToObjectSchema:objectSchema]) {
+            *stop = YES;
+            matches = NO;
         }
-    }
-    return YES;
+    }];
+    return matches;
 }
 
 - (NSString *)description {
@@ -271,10 +321,10 @@ static NSMutableDictionary *s_localNameToClass = [[NSMutableDictionary alloc] in
 
 - (std::unique_ptr<Schema>)objectStoreCopy {
     std::vector<realm::ObjectSchema> schema;
-    schema.reserve(_objectSchema.count);
-    for (RLMObjectSchema *objectSchema in _objectSchema) {
+    schema.reserve(_objectSchemaByName.count);
+    [_objectSchemaByName enumerateKeysAndObjectsUsingBlock:[&](NSString *, RLMObjectSchema *objectSchema, BOOL *) {
         schema.push_back(objectSchema.objectStoreCopy);
-    }
+    }];
     return std::make_unique<realm::Schema>(std::move(schema));
 }
 

--- a/Realm/RLMSchema_Private.h
+++ b/Realm/RLMSchema_Private.h
@@ -49,14 +49,13 @@ RLM_ASSUME_NONNULL_BEGIN
 // schema based upon all currently registered object classes
 + (instancetype)partialSharedSchema;
 
-// schema based on tables in a Realm
-+ (instancetype)dynamicSchemaFromRealm:(RLMRealm *)realm;
-
 // class for string
 + (nullable Class)classForString:(NSString *)className;
 
 // shallow copy for reusing schema properties accross the same Realm on multiple threads
 - (instancetype)shallowCopy;
+
++ (RLMObjectSchema *)sharedSchemaForClass:(Class)cls;
 
 @end
 

--- a/Realm/Tests/SchemaTests.mm
+++ b/Realm/Tests/SchemaTests.mm
@@ -337,8 +337,6 @@ RLM_ARRAY_TYPE(SchemaTestClassSecondChild)
     RLMSchema *schema = [[RLMSchema alloc] init];
     schema.objectSchema = objectSchema;
 
-#   define OptionalString @"\t\t\toptional = YES;\n"
-
     XCTAssertEqualObjects(schema.description, @"Schema {\n"
                                               @"\tAllTypesObject {\n"
                                               @"\t\tboolCol {\n"
@@ -374,21 +372,21 @@ RLM_ARRAY_TYPE(SchemaTestClassSecondChild)
                                               @"\t\t\tobjectClassName = (null);\n"
                                               @"\t\t\tindexed = NO;\n"
                                               @"\t\t\tisPrimary = NO;\n"
-                                              OptionalString
+                                              @"\t\t\toptional = YES;\n"
                                               @"\t\t}\n"
                                               @"\t\tbinaryCol {\n"
                                               @"\t\t\ttype = data;\n"
                                               @"\t\t\tobjectClassName = (null);\n"
                                               @"\t\t\tindexed = NO;\n"
                                               @"\t\t\tisPrimary = NO;\n"
-                                              OptionalString
+                                              @"\t\t\toptional = YES;\n"
                                               @"\t\t}\n"
                                               @"\t\tdateCol {\n"
                                               @"\t\t\ttype = date;\n"
                                               @"\t\t\tobjectClassName = (null);\n"
                                               @"\t\t\tindexed = NO;\n"
                                               @"\t\t\tisPrimary = NO;\n"
-                                              OptionalString
+                                              @"\t\t\toptional = YES;\n"
                                               @"\t\t}\n"
                                               @"\t\tcBoolCol {\n"
                                               @"\t\t\ttype = bool;\n"
@@ -419,15 +417,6 @@ RLM_ARRAY_TYPE(SchemaTestClassSecondChild)
                                               @"\t\t\toptional = YES;\n"
                                               @"\t\t}\n"
                                               @"\t}\n"
-                                              @"\tStringObject {\n"
-                                              @"\t\tstringCol {\n"
-                                              @"\t\t\ttype = string;\n"
-                                              @"\t\t\tobjectClassName = (null);\n"
-                                              @"\t\t\tindexed = NO;\n"
-                                              @"\t\t\tisPrimary = NO;\n"
-                                              OptionalString
-                                              @"\t\t}\n"
-                                              @"\t}\n"
                                               @"\tIntObject {\n"
                                               @"\t\tintCol {\n"
                                               @"\t\t\ttype = int;\n"
@@ -437,9 +426,17 @@ RLM_ARRAY_TYPE(SchemaTestClassSecondChild)
                                               @"\t\t\toptional = NO;\n"
                                               @"\t\t}\n"
                                               @"\t}\n"
+                                              @"\tStringObject {\n"
+                                              @"\t\tstringCol {\n"
+                                              @"\t\t\ttype = string;\n"
+                                              @"\t\t\tobjectClassName = (null);\n"
+                                              @"\t\t\tindexed = NO;\n"
+                                              @"\t\t\tisPrimary = NO;\n"
+                                              @"\t\t\toptional = YES;\n"
+                                              @"\t\t}\n"
+                                              @"\t}\n"
                                               @"}");
 
-#undef OptionalString
 }
 
 - (void)testClassWithDuplicateProperties

--- a/Realm/Tests/Swift1.2/Swift-Tests-Bridging-Header.h
+++ b/Realm/Tests/Swift1.2/Swift-Tests-Bridging-Header.h
@@ -20,6 +20,3 @@
 #import "RLMMultiProcessTestCase.h"
 #import "TestUtils.h"
 
-@interface RLMSchema (Private)
-+ (void)registerClasses:(const Class[])classes count:(NSUInteger)count;
-@end

--- a/Realm/Tests/Swift2.0/Swift-Tests-Bridging-Header.h
+++ b/Realm/Tests/Swift2.0/Swift-Tests-Bridging-Header.h
@@ -19,7 +19,3 @@
 #import "RLMTestObjects.h"
 #import "RLMMultiProcessTestCase.h"
 #import "TestUtils.h"
-
-@interface RLMSchema (Private)
-+ (void)registerClasses:(const Class[])classes count:(NSUInteger)count;
-@end

--- a/Realm/Tests/Swift2.0/SwiftSchemaTests.swift
+++ b/Realm/Tests/Swift2.0/SwiftSchemaTests.swift
@@ -24,6 +24,15 @@ class InitLinkedToClass: RLMObject {
     dynamic var value = SwiftIntObject(value: [0])
 }
 
+class IgnoredLinkPropertyObject : RLMObject {
+    dynamic var value = 0
+    var obj = SwiftIntObject()
+
+    override class func ignoredProperties() -> [String] {
+        return ["obj"]
+    }
+}
+
 class SwiftRecursingSchemaTestObject : RLMObject {
     dynamic var propertyWithIllegalDefaultValue: SwiftIntObject? = {
         if mayAccessSchema {
@@ -51,11 +60,51 @@ class SwiftSchemaTests: RLMMultiProcessTestCase {
             return
         }
 
-        // registerClasses:count: happens to initialize the schemas in the same
-        // order as the classes appear in the array, so this initializes the
-        // schema for `InitLinkedToClass` before `IntObject` to verify that
-        // `initWithValue:` does not throw in that scenario
-        RLMSchema.registerClasses([InitLinkedToClass.self, SwiftIntObject.self], count: 2)
+        let config = RLMRealmConfiguration.defaultConfiguration()
+        config.objectClasses = [IgnoredLinkPropertyObject.self]
+        config.inMemoryIdentifier = __FUNCTION__
+        let r = try! RLMRealm(configuration: config)
+        try! r.transactionWithBlock {
+            IgnoredLinkPropertyObject.createInRealm(r, withValue: [1])
+        }
+    }
+
+    func testCreateStandaloneObjectWhichCreatesAnotherClassDuringSchemaInit() {
+        if isParent {
+            XCTAssertEqual(0, runChildAndWait(), "Tests in child process failed")
+            return
+        }
+
+        // Should not throw (or crash) despite creating an object with an
+        // unintialized schema during schema init
+        let _ = InitLinkedToClass()
+    }
+
+    func testCreateStandaloneObjectWithLinkPropertyWithoutSharedSchemaInitialized() {
+        if isParent {
+            XCTAssertEqual(0, runChildAndWait(), "Tests in child process failed")
+            return
+        }
+
+        // This is different from the above test in that it links to an
+        // unintialized type rather than creating one
+        let _ = SwiftCompanyObject()
+    }
+
+    func testInitStandaloneObjectNotInClassSubsetDuringSchemaInit() {
+        if isParent {
+            XCTAssertEqual(0, runChildAndWait(), "Tests in child process failed")
+            return
+        }
+
+        let config = RLMRealmConfiguration.defaultConfiguration()
+        config.objectClasses = [IgnoredLinkPropertyObject.self]
+        config.inMemoryIdentifier = __FUNCTION__
+        let _ = try! RLMRealm(configuration: config)
+        let r = try! RLMRealm(configuration: RLMRealmConfiguration.defaultConfiguration())
+        try! r.transactionWithBlock {
+            IgnoredLinkPropertyObject.createInRealm(r, withValue: [1])
+        }
     }
 
     func testPreventsDeadLocks() {


### PR DESCRIPTION
Make it so that creating a standalone object only initializing the entire shared schema if it needs to in order to validate link/array properties, and otherwise only initialize that class's schema.

Fix a case where triggering initialization of the shared schema during partial schema init would result in the classes used in the partial schema not appearing in the shared schema.

Fix creating standalone instances of subclasses when the parent class has been used in a partial schema and the shared schema has not been initialized.

Fix some probably innocuous data races.

Reduce the number of calls to class_replaceMethod() during schema init.

Fixes #3200.