### PR TITLE
Allow aggregate operations to be used on key paths that start with a unary relationship

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ x.x.x Release notes (yyyy-MM-dd)
 
 ### Enhancements
 
-* None.
+* Aggregate operations (`ANY`, `NONE`, `@count`, `SUBQUERY`, etc.) are now supported for key paths
+  that begin with an object relationship so long as there is a `RLMArray`/`List` property at some
+  point in a key path.
 
 ### Bugfixes
 
@@ -18,6 +20,9 @@ x.x.x Release notes (yyyy-MM-dd)
   a Swift object from one Realm to another, and performing other operations that result in a
   Swift object graph being recursively traversed from Objective-C.
 * Fix a deadlock when queries are performed within a Realm notification block.
+* The `ANY` / `SOME` / `NONE` qualifiers are now required in comparisons involving a key path that
+  traverse a `RLMArray`/`List` property. Previously they were only required if the first key in the
+  key path was an `RLMArray`/`List` property.
 
 0.98.1 Release notes (2016-02-10)
 =============================================================

--- a/Realm/RLMQueryUtil.mm
+++ b/Realm/RLMQueryUtil.mm
@@ -739,7 +739,7 @@ ColumnReference column_reference_from_key_path(RLMSchema *schema, RLMObjectSchem
                                      @"Aggregate operations can only be used on key paths that include an array property");
     } else if (!isAggregate && keyPathContainsToManyRelationship) {
         @throw RLMPredicateException(@"Invalid predicate",
-                                     @"Aggregate operations must be used on key paths that include an array property");
+                                     @"Key paths that include an array property must use aggregate operations");
     }
 
     return ColumnReference(property, indexes);

--- a/Realm/Tests/QueryTests.m
+++ b/Realm/Tests/QueryTests.m
@@ -311,8 +311,8 @@
 
     XCTAssertThrows([LinkToAllTypesObject objectsWhere:@"allTypesCol.longCol = 'a'"], @"Wrong data type should throw");
 
-    RLMAssertThrowsWithReasonMatching([ArrayPropertyObject objectsWhere:@"intArray.intCol > 5"], @"Aggregate operations must be used.*array property");
-    RLMAssertThrowsWithReasonMatching([LinkToCompanyObject objectsWhere:@"company.employees.age > 5"], @"Aggregate operations must be used.*array property");
+    RLMAssertThrowsWithReasonMatching([ArrayPropertyObject objectsWhere:@"intArray.intCol > 5"], @"Key paths.*array property.*aggregate operations");
+    RLMAssertThrowsWithReasonMatching([LinkToCompanyObject objectsWhere:@"company.employees.age > 5"], @"Key paths.*array property.*aggregate operations");
 
     RLMAssertThrowsWithReasonMatching([LinkToAllTypesObject objectsWhere:@"allTypesCol.intCol = allTypesCol.doubleCol"], @"Property type mismatch");
 }

--- a/Realm/Tests/QueryTests.m
+++ b/Realm/Tests/QueryTests.m
@@ -148,10 +148,14 @@
     // These are things which are valid predicates, but which we do not support
 
     // Aggregate operators on non-arrays
-    XCTAssertThrows([PersonObject objectsWhere:@"ANY age > 5"]);
-    XCTAssertThrows([PersonObject objectsWhere:@"ALL age > 5"]);
-    XCTAssertThrows([PersonObject objectsWhere:@"SOME age > 5"]);
-    XCTAssertThrows([PersonObject objectsWhere:@"NONE age > 5"]);
+    RLMAssertThrowsWithReasonMatching([PersonObject objectsWhere:@"ANY age > 5"], @"Aggregate operations can only.*array property");
+    RLMAssertThrowsWithReasonMatching([PersonObject objectsWhere:@"ALL age > 5"], @"ALL modifier not supported");
+    RLMAssertThrowsWithReasonMatching([PersonObject objectsWhere:@"SOME age > 5"], @"Aggregate operations can only.*array property");
+    RLMAssertThrowsWithReasonMatching([PersonObject objectsWhere:@"NONE age > 5"], @"Aggregate operations can only.*array property");
+    RLMAssertThrowsWithReasonMatching([PersonLinkObject objectsWhere:@"ANY person.age > 5"], @"Aggregate operations can only.*array property");
+    RLMAssertThrowsWithReasonMatching([PersonLinkObject objectsWhere:@"ALL person.age > 5"], @"ALL modifier not supported");
+    RLMAssertThrowsWithReasonMatching([PersonLinkObject objectsWhere:@"SOME person.age > 5"], @"Aggregate operations can only.*array property");
+    RLMAssertThrowsWithReasonMatching([PersonLinkObject objectsWhere:@"NONE person.age > 5"], @"Aggregate operations can only.*array property");
 
     // nil on LHS of comparison with nullable property
     XCTAssertThrows([AllOptionalTypes objectsWhere:@"nil = boolObj"]);
@@ -307,7 +311,8 @@
 
     XCTAssertThrows([LinkToAllTypesObject objectsWhere:@"allTypesCol.longCol = 'a'"], @"Wrong data type should throw");
 
-    XCTAssertThrows([LinkToAllTypesObject objectsWhere:@"intArray.intCol > 5"], @"RLMArray query without ANY modifier should throw");
+    RLMAssertThrowsWithReasonMatching([ArrayPropertyObject objectsWhere:@"intArray.intCol > 5"], @"Aggregate operations must be used.*array property");
+    RLMAssertThrowsWithReasonMatching([LinkToCompanyObject objectsWhere:@"company.employees.age > 5"], @"Aggregate operations must be used.*array property");
 
     RLMAssertThrowsWithReasonMatching([LinkToAllTypesObject objectsWhere:@"allTypesCol.intCol = allTypesCol.doubleCol"], @"Property type mismatch");
 }
@@ -1774,18 +1779,24 @@
     RLMRealm *realm = [RLMRealm defaultRealm];
 
     [realm beginWriteTransaction];
-    [CompanyObject createInRealm:realm
-                       withValue:@[@"first company", @[@{@"name": @"John", @"age": @30, @"hired": @NO},
-                                                       @{@"name": @"Jill",  @"age": @40, @"hired": @YES},
-                                                       @{@"name": @"Joe",  @"age": @40, @"hired": @YES}]]];
-    [CompanyObject createInRealm:realm
-                       withValue:@[@"second company", @[@{@"name": @"Bill", @"age": @35, @"hired": @YES},
-                                                        @{@"name": @"Don",  @"age": @45, @"hired": @NO},
-                                                        @{@"name": @"Tim",  @"age": @60, @"hired": @NO}]]];
+    CompanyObject *first = [CompanyObject createInRealm:realm
+                                              withValue:@[@"first company", @[@{@"name": @"John", @"age": @30, @"hired": @NO},
+                                                                              @{@"name": @"Jill",  @"age": @40, @"hired": @YES},
+                                                                              @{@"name": @"Joe",  @"age": @40, @"hired": @YES}]]];
+    CompanyObject *second = [CompanyObject createInRealm:realm
+                                               withValue:@[@"second company", @[@{@"name": @"Bill", @"age": @35, @"hired": @YES},
+                                                                                @{@"name": @"Don",  @"age": @45, @"hired": @NO},
+                                                                                @{@"name": @"Tim",  @"age": @60, @"hired": @NO}]]];
+
+    [LinkToCompanyObject createInRealm:realm withValue:@[ first ]];
+    [LinkToCompanyObject createInRealm:realm withValue:@[ second ]];
     [realm commitWriteTransaction];
 
     RLMAssertCount(CompanyObject, 1U, @"SUBQUERY(employees, $employee, $employee.age > 30 AND $employee.hired = FALSE).@count > 0");
     RLMAssertCount(CompanyObject, 2U, @"SUBQUERY(employees, $employee, $employee.age < 30 AND $employee.hired = TRUE).@count == 0");
+
+    RLMAssertCount(LinkToCompanyObject, 1U, @"SUBQUERY(company.employees, $employee, $employee.age > 30 AND $employee.hired = FALSE).@count > 0");
+    RLMAssertCount(LinkToCompanyObject, 2U, @"SUBQUERY(company.employees, $employee, $employee.age < 30 AND $employee.hired = TRUE).@count == 0");
 }
 
 @end

--- a/Realm/Tests/RLMTestObjects.h
+++ b/Realm/Tests/RLMTestObjects.h
@@ -167,6 +167,14 @@ RLM_ARRAY_TYPE(EmployeeObject)
 
 @end
 
+#pragma mark LinkToCompanyObject
+
+@interface LinkToCompanyObject : RLMObject
+
+@property CompanyObject *company;
+
+@end
+
 #pragma mark DogObject
 
 @interface DogObject : RLMObject

--- a/Realm/Tests/RLMTestObjects.m
+++ b/Realm/Tests/RLMTestObjects.m
@@ -96,6 +96,11 @@
 @implementation CompanyObject
 @end
 
+#pragma mark LinkToCompanyObject
+
+@implementation LinkToCompanyObject
+@end
+
 #pragma mark DogObject
 
 @implementation DogObject


### PR DESCRIPTION
The constraint is now that the key path must traverse a to-many relationship, but it is no longer required to be the first key in the path.

This allows for the following queries that were formerly rejected:

    ANY company.employees.age > 30
    company.employees.@avg.age > 30
    SUBQUERY(company.employees, $e, $e.age > 30).@count > 0

Fixes #2955.