### PR TITLE
Add support for predicates of the form "%@ IN collection"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ x.x.x Release notes (yyyy-MM-dd)
 * Aggregate operations (`ANY`, `NONE`, `@count`, `SUBQUERY`, etc.) are now supported for key paths
   that begin with an object relationship so long as there is a `RLMArray`/`List` property at some
   point in a key path.
+* Predicates of the form `%@ IN arrayProperty` are now supported.
 
 ### Bugfixes
 

--- a/Realm/RLMQueryUtil.mm
+++ b/Realm/RLMQueryUtil.mm
@@ -930,7 +930,7 @@ void update_query_with_value_expression(RLMSchema *schema,
         return;
     }
 
-    // turn IN into ored together ==
+    // turn "key.path IN collection" into ored together ==. "collection IN key.path" is handled elsewhere.
     if (pred.predicateOperatorType == NSInPredicateOperatorType) {
         process_or_group(query, value, [&](id item) {
             id normalized = value_from_constant_expression_or_value(item);
@@ -1117,9 +1117,21 @@ void update_query_with_predicate(NSPredicate *predicate, RLMSchema *schema,
         }
 
         if (compp.predicateOperatorType == NSBetweenPredicateOperatorType || compp.predicateOperatorType == NSInPredicateOperatorType) {
-            // Inserting an array via %@ gives NSConstantValueExpressionType, but
-            // including it directly gives NSAggregateExpressionType
-            if (exp1Type != NSKeyPathExpressionType || (exp2Type != NSAggregateExpressionType && exp2Type != NSConstantValueExpressionType)) {
+            // Inserting an array via %@ gives NSConstantValueExpressionType, but including it directly gives NSAggregateExpressionType
+            if (exp1Type == NSKeyPathExpressionType && (exp2Type == NSAggregateExpressionType || exp2Type == NSConstantValueExpressionType)) {
+                // "key.path IN %@", "key.path IN {…}", "key.path BETWEEN %@", or "key.path BETWEEN {…}".
+                exp2Type = NSConstantValueExpressionType;
+            }
+            else if (compp.predicateOperatorType == NSInPredicateOperatorType && exp1Type == NSConstantValueExpressionType && exp2Type == NSKeyPathExpressionType) {
+                // "%@ IN key.path" is equivalent to "ANY key.path IN %@". Rewrite the former into the latter.
+                NSExpression *keyPath = [NSExpression expressionForKeyPath:compp.rightExpression.keyPath];
+                NSExpression *constantValue = [NSExpression expressionForConstantValue:compp.leftExpression.constantValue];
+                compp = [NSComparisonPredicate predicateWithLeftExpression:keyPath rightExpression:constantValue
+                                                                  modifier:NSAnyPredicateModifier type:NSEqualToPredicateOperatorType options:0];
+                exp1Type = NSKeyPathExpressionType;
+                exp2Type = NSConstantValueExpressionType;
+            }
+            else {
                 if (compp.predicateOperatorType == NSBetweenPredicateOperatorType) {
                     @throw RLMPredicateException(@"Invalid predicate",
                                                  @"Predicate with BETWEEN operator must compare a KeyPath with an aggregate with two values");
@@ -1129,7 +1141,6 @@ void update_query_with_predicate(NSPredicate *predicate, RLMSchema *schema,
                                                  @"Predicate with IN operator must compare a KeyPath with an aggregate");
                 }
             }
-            exp2Type = NSConstantValueExpressionType;
         }
 
         if (exp1Type == NSKeyPathExpressionType && exp2Type == NSKeyPathExpressionType) {

--- a/Realm/RLMQueryUtil.mm
+++ b/Realm/RLMQueryUtil.mm
@@ -1124,9 +1124,7 @@ void update_query_with_predicate(NSPredicate *predicate, RLMSchema *schema,
             }
             else if (compp.predicateOperatorType == NSInPredicateOperatorType && exp1Type == NSConstantValueExpressionType && exp2Type == NSKeyPathExpressionType) {
                 // "%@ IN key.path" is equivalent to "ANY key.path IN %@". Rewrite the former into the latter.
-                NSExpression *keyPath = [NSExpression expressionForKeyPath:compp.rightExpression.keyPath];
-                NSExpression *constantValue = [NSExpression expressionForConstantValue:compp.leftExpression.constantValue];
-                compp = [NSComparisonPredicate predicateWithLeftExpression:keyPath rightExpression:constantValue
+                compp = [NSComparisonPredicate predicateWithLeftExpression:compp.rightExpression rightExpression:compp.leftExpression
                                                                   modifier:NSAnyPredicateModifier type:NSEqualToPredicateOperatorType options:0];
                 exp1Type = NSKeyPathExpressionType;
                 exp2Type = NSConstantValueExpressionType;

--- a/Realm/Tests/QueryTests.m
+++ b/Realm/Tests/QueryTests.m
@@ -1521,6 +1521,7 @@
 
     ArrayPropertyObject *arr = [ArrayPropertyObject createInRealm:realm withValue:@[@"name", @[], @[]]];
     [arr.array addObject:[StringObject createInRealm:realm withValue:@[@"value"]]];
+    StringObject *otherStringObject = [StringObject createInRealm:realm withValue:@[@"some other value"]];
     [realm commitWriteTransaction];
 
 
@@ -1533,6 +1534,10 @@
     RLMAssertCount(ArrayPropertyObject, 1U, @"ANY array IN %@", [StringObject objectsWhere:@"stringCol = 'value'"]);
     RLMAssertCount(ArrayPropertyObject, 1U, @"NONE array IN %@", [StringObject objectsWhere:@"stringCol = 'missing'"]);
     RLMAssertCount(ArrayPropertyObject, 0U, @"NONE array IN %@", [StringObject objectsWhere:@"stringCol = 'value'"]);
+
+    StringObject *stringObject = [[StringObject allObjectsInRealm:realm] firstObject];
+    RLMAssertCount(ArrayPropertyObject, 1U, @"%@ IN array", stringObject);
+    RLMAssertCount(ArrayPropertyObject, 0U, @"%@ IN array", otherStringObject);
 }
 
 - (void)testQueryChaining {


### PR DESCRIPTION
Rewrite `%@ IN collection` to the equivalent `ANY collection = %@` since that form is already supported.

Fixes #1550.