### PR TITLE
Work around Xcode 7.2.1 failing to run tests in the iOS simulator for unknown reasons

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -171,6 +171,9 @@ xc_work_around_rdar_23055637() {
     # build (<http://openradar.appspot.com/23055637>). Work around this by having the test phases intentionally
     # exit after they finish building the first time, then run the tests for real.
     ( REALM_EXIT_AFTER_BUILDING_TESTS=YES xc "$1" ) || true
+    # Xcode 7.2.1 fails to run tests in the iOS simulator for unknown reasons. Resetting the simulator here works
+    # around this issue.
+    sh build.sh prelaunch-simulator
     xc "$1"
 }
 

--- a/scripts/reset-simulators.sh
+++ b/scripts/reset-simulators.sh
@@ -27,6 +27,13 @@ done
             continue
         fi
 
+        if [[ $LINE =~ "--" ]]; then
+            # Reset the last seen device so we won't consider devices with the same name to be duplicates
+            # if they appear in different sections.
+            previous_device=""
+            continue
+        fi
+
         regex='^(.*) [(]([0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12})[)]'
         if [[ $LINE =~ $regex ]]; then
             device="${BASH_REMATCH[1]}"


### PR DESCRIPTION
Resetting the simulator between the two xcodebuild invocations in the workaround for <rdar://problem/23055637> works around the new issue.