### PR TITLE
Split SchemaValidationException into two of SchemaValidationException and SchemaMismatchException

### DIFF
--- a/Realm/ObjectStore/object_store.cpp
+++ b/Realm/ObjectStore/object_store.cpp
@@ -168,7 +168,7 @@ void ObjectStore::verify_schema(Schema const& actual_schema, Schema& target_sche
         errors.insert(errors.end(), more_errors.begin(), more_errors.end());
     }
     if (errors.size()) {
-        throw SchemaValidationException(errors);
+        throw SchemaMismatchException(errors);
     }
 }
 
@@ -513,9 +513,17 @@ DuplicatePrimaryKeyValueException::DuplicatePrimaryKeyValueException(std::string
     m_what = "Primary key property '" + property.name + "' has duplicate values after migration.";
 }
 
-
 SchemaValidationException::SchemaValidationException(std::vector<ObjectSchemaValidationException> const& errors) :
     m_validation_errors(errors)
+{
+    m_what = "Schema validation failed due to the following errors: ";
+    for (auto const& error : errors) {
+        m_what += std::string("\n- ") + error.what();
+    }
+}
+
+SchemaMismatchException::SchemaMismatchException(std::vector<ObjectSchemaValidationException> const& errors) :
+m_validation_errors(errors)
 {
     m_what ="Migration is required due to the following errors: ";
     for (auto const& error : errors) {

--- a/Realm/ObjectStore/object_store.hpp
+++ b/Realm/ObjectStore/object_store.hpp
@@ -156,6 +156,14 @@ namespace realm {
         std::vector<ObjectSchemaValidationException> m_validation_errors;
     };
 
+    class SchemaMismatchException : public ObjectStoreException {
+    public:
+        SchemaMismatchException(std::vector<ObjectSchemaValidationException> const& errors);
+        std::vector<ObjectSchemaValidationException> const& validation_errors() const { return m_validation_errors; }
+    private:
+        std::vector<ObjectSchemaValidationException> m_validation_errors;
+    };
+
     class ObjectSchemaValidationException : public ObjectStoreException {
       public:
         ObjectSchemaValidationException(std::string const& object_type) : m_object_type(object_type) {}


### PR DESCRIPTION
Because SchemaValidationException is thrown both cases that a schema definition is incorrect and that two schema definitions are mismatched.
In the former case, the migration does not solve the problem. But the exception message shows "Migration is required..."

*e.g.* An exception that says "migration is retuired" when define the following model class
```
@interface TestObject : RLMObject
@property NSData *data;
@end

@implementation TestObject
+ (NSArray<NSString *> *)indexedProperties {
    return @[@"data"];
}
@end

*** Terminating app due to uncaught exception 'RLMException', reason: 'Migration is required due to the following errors: 
- Can't index property TestObject.data: indexing a property of type 'data' is currently not supported'
```

Therefore the latter as SchemaMismatchException, to distinguish between the two cases. 
Also, the message of SchemaValidationException is changed to "Schema validation is failed...".

CC @tgoyne @bdash 

