### PR TITLE
Improve shared schema initialization performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ x.x.x Release notes (yyyy-MM-dd)
 
 ### Enhancements
 
-* None.
+* Initializing the shared schema is 3x faster.
 
 ### Bugfixes
 

--- a/Realm/RLMAccessor.mm
+++ b/Realm/RLMAccessor.mm
@@ -760,8 +760,6 @@ static Class RLMCreateAccessorClass(Class objectClass,
         }
     }
 
-    // implement className for accessor to return base className
-    RLMReplaceClassNameMethod(accClass, schema.className);
     RLMMarkClassAsGenerated(accClass);
 
     return accClass;

--- a/Realm/RLMAccessor.mm
+++ b/Realm/RLMAccessor.mm
@@ -689,14 +689,14 @@ static RLMAccessorCode accessorCodeForType(char objcTypeCode, RLMPropertyType rl
 // implement the class method className on accessors to return the className of the
 // base object
 void RLMReplaceClassNameMethod(Class accessorClass, NSString *className) {
-    Class metaClass = objc_getMetaClass(class_getName(accessorClass));
+    Class metaClass = object_getClass(accessorClass);
     IMP imp = imp_implementationWithBlock(^(Class){ return className; });
     class_addMethod(metaClass, @selector(className), imp, "@@:");
 }
 
 // implement the shared schema method
 void RLMReplaceSharedSchemaMethod(Class accessorClass, RLMObjectSchema *schema) {
-    Class metaClass = objc_getMetaClass(class_getName(accessorClass));
+    Class metaClass = object_getClass(accessorClass);
     IMP imp = imp_implementationWithBlock(^(Class cls) {
         // This can be called on a subclass of the class that we overrode it on
         // if that class hasn't been initialized yet

--- a/Realm/RLMAccessor.mm
+++ b/Realm/RLMAccessor.mm
@@ -686,12 +686,6 @@ static RLMAccessorCode accessorCodeForType(char objcTypeCode, RLMPropertyType rl
     }
 }
 
-static void RLMReplaceShouldIncludeInDefaultSchemaMethod(Class cls, bool shouldInclude) {
-    Class metaClass = objc_getMetaClass(class_getName(cls));
-    IMP imp = imp_implementationWithBlock(^(Class){ return shouldInclude; });
-    class_addMethod(metaClass, @selector(shouldIncludeInDefaultSchema), imp, "b@:");
-}
-
 // implement the class method className on accessors to return the className of the
 // base object
 void RLMReplaceClassNameMethod(Class accessorClass, NSString *className) {
@@ -768,7 +762,6 @@ static Class RLMCreateAccessorClass(Class objectClass,
 
     // implement className for accessor to return base className
     RLMReplaceClassNameMethod(accClass, schema.className);
-    RLMReplaceShouldIncludeInDefaultSchemaMethod(accClass, false);
     RLMMarkClassAsGenerated(accClass);
 
     return accClass;

--- a/Realm/Tests/SchemaTests.mm
+++ b/Realm/Tests/SchemaTests.mm
@@ -208,6 +208,15 @@ RLM_ARRAY_TYPE(SchemaTestClassSecondChild)
             objectSchema.standaloneClass = RLMStandaloneAccessorClassForObjectClass(objectSchema.objectClass, objectSchema);
         }
 
+        for (Class cls : testClasses) {
+            NSString *className = NSStringFromClass(cls);
+
+            // Restore the className method
+            Class metaClass = object_getClass(cls);
+            IMP imp = imp_implementationWithBlock(^{ return className; });
+            class_replaceMethod(metaClass, @selector(className), imp, "@:");
+        }
+
         // Verify that each class has the correct properties and className
         // for generated subclasses
         checkSchema(schema, @"SchemaTestClassBase", @{@"baseCol": @"IntObject"});
@@ -222,14 +231,6 @@ RLM_ARRAY_TYPE(SchemaTestClassSecondChild)
                                                       @"secondChild": @"SchemaTestClassSecondChild",
                                                       @"secondChildArray": @"SchemaTestClassSecondChild"});
 
-        for (Class cls : testClasses) {
-            NSString *className = NSStringFromClass(cls);
-
-            // Restore the className method
-            Class metaClass = object_getClass(cls);
-            IMP imp = imp_implementationWithBlock(^{ return className; });
-            class_replaceMethod(metaClass, @selector(className), imp, "@:");
-        }
 
         // Test creating objects of each class
         [self deleteFiles];

--- a/Realm/Tests/SchemaTests.mm
+++ b/Realm/Tests/SchemaTests.mm
@@ -190,8 +190,7 @@ RLM_ARRAY_TYPE(SchemaTestClassSecondChild)
         for (Class cls : testClasses) {
             // Ensure that the className method isn't used during schema init
             // as it may not be overriden yet
-            NSString *className = NSStringFromClass(cls);
-            Class metaClass = objc_getMetaClass(className.UTF8String);
+            Class metaClass = object_getClass(cls);
             IMP imp = imp_implementationWithBlock(^{ return nil; });
             class_replaceMethod(metaClass, @selector(className), imp, "@:");
         }
@@ -227,7 +226,7 @@ RLM_ARRAY_TYPE(SchemaTestClassSecondChild)
             NSString *className = NSStringFromClass(cls);
 
             // Restore the className method
-            Class metaClass = objc_getMetaClass(className.UTF8String);
+            Class metaClass = object_getClass(cls);
             IMP imp = imp_implementationWithBlock(^{ return className; });
             class_replaceMethod(metaClass, @selector(className), imp, "@:");
         }


### PR DESCRIPTION
On iOS 9.2, the time spent below `+[RLMSchema sharedSchema]` on the first call is dominated by the time that the Objective-C runtime spends flushing method caches as a result of calls to `class_addMethod` and `class_replaceMethod`. By eliminating several of these calls per accessor class we can take a significant chunk out of the cost of schema initialization. We do this by:

* No longer overriding `+shouldIncludeInDefaultSchema:` on generated accessor classes. It's no longer necessary as marking the class as generated has the same effect of excluding the class from the default schema.
* No longer overriding `+className` on accessor classes. `+[RLMObjectBase className]` now uses a map from `Class` to class name as an optimization rather than per-class overrides of the method. This is around 50% slower per invocation of `+className` than the previous approach, but this overhead should be dominated by any work performed by the caller.

On a user-supplied application this sequence of changes reduces the time spent below `+[RLMSchema sharedSchema]` during launch by 2/3 (on an iPad Air running iOS 9.2.1).

iOS 9.3 appears to have optimized the method cache flushing performed by `class_addMethod` to be dramatically faster. Once that version is the predominant version of iOS for users of Realm we may want to reconsider the approach to `+className` as the tradeoffs involved will be different.

Fixes #3230.