### PR TITLE
Remove Realm::m_in_transaction and use the value from the SharedGroup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ x.x.x Release notes (yyyy-MM-dd)
   properties to a class.
 * Fix potential errors when cancelling a write transaction which modified
   multiple `RLMArray`/`List` properties.
+* Report the correct value for inWriteTransaction after attempting to commit a
+  write transaction fails.
 
 0.98.2 Release notes (2016-02-18)
 =============================================================

--- a/Realm/ObjectStore/shared_realm.hpp
+++ b/Realm/ObjectStore/shared_realm.hpp
@@ -92,7 +92,7 @@ namespace realm {
         void begin_transaction();
         void commit_transaction();
         void cancel_transaction();
-        bool is_in_transaction() const { return m_in_transaction; }
+        bool is_in_transaction() const noexcept;
         bool is_in_read_transaction() const { return !!m_group; }
 
         bool refresh();
@@ -143,7 +143,6 @@ namespace realm {
       private:
         Config m_config;
         std::thread::id m_thread_id = std::this_thread::get_id();
-        bool m_in_transaction = false;
         bool m_auto_refresh = true;
 
         std::unique_ptr<ClientHistory> m_history;


### PR DESCRIPTION
Depends on #3250.

No changelog entry because while it should make the specific symptoms seen in #3122 impossible, it's not obvious that it actually fixes any bugs.