### PR TITLE
Add `warn_unused_result` attributes to `addNotificationBlock` methods.

### DIFF
--- a/Realm/RLMArray.h
+++ b/Realm/RLMArray.h
@@ -303,7 +303,7 @@ RLM_ASSUME_NONNULL_BEGIN
  @param block The block to be called each time the array changes.
  @return A token which must be held for as long as you want notifications to be delivered.
  */
-- (RLMNotificationToken *)addNotificationBlock:(void (^)(RLMArray RLM_GENERIC_RETURN *array, NSError *))block;
+- (RLMNotificationToken *)addNotificationBlock:(void (^)(RLMArray RLM_GENERIC_RETURN *array, NSError *))block RLM_WARN_UNUSED_RESULT;
 
 #pragma mark - Unavailable Methods
 

--- a/Realm/RLMCollection.h
+++ b/Realm/RLMCollection.h
@@ -177,7 +177,7 @@ RLM_ASSUME_NONNULL_BEGIN
  @param block The block to be called each time the collection changes.
  @return A token which must be held for as long as you want notifications to be delivered.
  */
-- (RLMNotificationToken *)addNotificationBlock:(void (^)(id<RLMCollection> collection))block;
+- (RLMNotificationToken *)addNotificationBlock:(void (^)(id<RLMCollection> collection))block RLM_WARN_UNUSED_RESULT;
 
 @end
 

--- a/Realm/RLMDefines.h
+++ b/Realm/RLMDefines.h
@@ -78,6 +78,14 @@ typedef RLMObject * RLMObjectArgument;
 #  define RLM_NOESCAPE
 #endif
 
+#pragma mark - Unused Result
+
+#if __has_attribute(warn_unused_result)
+#  define RLM_WARN_UNUSED_RESULT __attribute__((warn_unused_result))
+#else
+#  define RLM_WARN_UNUSED_RESULT
+#endif
+
 #pragma mark - Swift Availability
 
 #if defined(NS_SWIFT_UNAVAILABLE)

--- a/Realm/RLMRealm.h
+++ b/Realm/RLMRealm.h
@@ -154,7 +154,7 @@ typedef void (^RLMNotificationBlock)(NSString *notification, RLMRealm *realm);
  @return A token object which must be stored as long as you wish to continue
          receiving change notifications.
  */
-- (RLMNotificationToken *)addNotificationBlock:(RLMNotificationBlock)block;
+- (RLMNotificationToken *)addNotificationBlock:(RLMNotificationBlock)block RLM_WARN_UNUSED_RESULT;
 
 /**
  Remove a previously registered notification handler using the token returned

--- a/Realm/RLMResults.h
+++ b/Realm/RLMResults.h
@@ -201,7 +201,7 @@ RLM_ASSUME_NONNULL_BEGIN
  @param block The block to be called with the evaluated results.
  @return A token which must be held for as long as you want query results to be delivered.
  */
-- (RLMNotificationToken *)addNotificationBlock:(void (^)(RLMResults RLM_GENERIC_RETURN *__nullable results, NSError *__nullable error))block;
+- (RLMNotificationToken *)addNotificationBlock:(void (^)(RLMResults RLM_GENERIC_RETURN *__nullable results, NSError *__nullable error))block RLM_WARN_UNUSED_RESULT;
 
 #pragma mark - Aggregating Property Values
 

--- a/RealmSwift-swift2.0/List.swift
+++ b/RealmSwift-swift2.0/List.swift
@@ -414,6 +414,7 @@ public final class List<T: Object>: ListBase {
     - parameter block: The block to be called each time the list changes.
     - returns: A token which must be held for as long as you want notifications to be delivered.
     */
+    @warn_unused_result(message="You must hold on to the NotificationToken returned from addNotificationBlock")
     public func addNotificationBlock(block: (List<T>) -> ()) -> NotificationToken {
         return _rlmArray.addNotificationBlock { _, _ in block(self) }
     }

--- a/RealmSwift-swift2.0/Realm.swift
+++ b/RealmSwift-swift2.0/Realm.swift
@@ -458,6 +458,7 @@ public final class Realm {
     - returns: A notification token which can later be passed to `removeNotification(_:)`
                to remove this notification.
     */
+    @warn_unused_result(message="You must hold on to the NotificationToken returned from addNotificationBlock")
     public func addNotificationBlock(block: NotificationBlock) -> NotificationToken {
         return rlmRealm.addNotificationBlock(rlmNotificationBlockFromNotificationBlock(block))
     }

--- a/RealmSwift-swift2.0/RealmCollectionType.swift
+++ b/RealmSwift-swift2.0/RealmCollectionType.swift
@@ -729,6 +729,7 @@ public final class AnyRealmCollection<T: Object>: RealmCollectionType {
     - parameter block: The block to be called each time the collection changes.
     - returns: A token which must be held for as long as you want notifications to be delivered.
     */
+    @warn_unused_result(message="You must hold on to the NotificationToken returned from addNotificationBlock")
     public func addNotificationBlock(block: (AnyRealmCollection<Element>?, NSError?) -> ()) -> NotificationToken {
         return base._addNotificationBlock(block)
     }

--- a/RealmSwift-swift2.0/Results.swift
+++ b/RealmSwift-swift2.0/Results.swift
@@ -351,6 +351,7 @@ public final class Results<T: Object>: ResultsBase {
      - parameter block: The block to be called with the evaluated results.
      - returns: A token which must be held for as long as you want query results to be delivered.
      */
+    @warn_unused_result(message="You must hold on to the NotificationToken returned from addNotificationBlock")
     public func addNotificationBlock(block: (Results<T>?, NSError?) -> ()) -> NotificationToken {
         return rlmResults.addNotificationBlock { results, error in
             if results != nil {


### PR DESCRIPTION
It allows noticing that does not hold the `NotifiationToken` before execution.

<img width="931" alt="screen shot 2016-02-23 at 08 34 44" src="https://cloud.githubusercontent.com/assets/40610/13236539/663ee178-da08-11e5-900a-8bf1ea5b3a12.png">

@jpsim @mrackwitz  