### PR TITLE
Fix core library name in the podspec

### DIFF
--- a/Realm.podspec
+++ b/Realm.podspec
@@ -67,7 +67,7 @@ Pod::Spec.new do |s|
   s.ios.vendored_library    = 'core/librealm-ios.a'
 
   s.osx.deployment_target   = '10.9'
-  s.osx.vendored_library    = 'core/librealm-osx.a'
+  s.osx.vendored_library    = 'core/librealm-macosx.a'
 
   if s.respond_to?(:watchos)
     s.watchos.deployment_target = '2.0'

--- a/build.sh
+++ b/build.sh
@@ -872,7 +872,6 @@ case "$COMMAND" in
     "cocoapods-setup")
         if [[ "$2" != "swift" ]]; then
             sh build.sh download-core
-            mv core/librealm.a core/librealm-osx.a
             if [[ "$REALM_SWIFT_VERSION" = "1.2" ]]; then
                 echo 'Installing for Xcode 6.'
                 mv core/librealm-ios-no-bitcode.a core/librealm-ios.a


### PR DESCRIPTION
0.96.2 changed the name of the core library for OS X, and while there's a symlink from the old to the new name, CocoaPods deletes the actual library and leaves just the symlink, which isn't very useful.