### PR TITLE
Report changes made via addOrUpdate/createOrUpdate to KVO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,9 @@ x.x.x Release notes (yyyy-MM-dd)
 
 ### Bugfixes
 
-* None.
+* Properly report changes made by adding an object to a Realm with
+  addOrUpdate:/createOrUpdate: to KVO observers for existing objects with that
+  primary key.
 
 0.98.3 Release notes (2016-02-26)
 =============================================================

--- a/Realm/RLMAccessor.mm
+++ b/Realm/RLMAccessor.mm
@@ -787,93 +787,93 @@ void RLMDynamicValidatedSet(RLMObjectBase *obj, NSString *propName, id val) {
         @throw RLMException(@"Invalid property value `%@` for property `%@` of class `%@`", val, propName, obj->_objectSchema.className);
     }
 
-    RLMWrapSetter(obj, prop.name, [&] {
-        RLMDynamicSet(obj, prop, RLMCoerceToNil(val), RLMCreationOptionsPromoteStandalone);
-    });
+    RLMDynamicSet(obj, prop, RLMCoerceToNil(val), RLMCreationOptionsPromoteStandalone);
 }
 
 void RLMDynamicSet(__unsafe_unretained RLMObjectBase *const obj, __unsafe_unretained RLMProperty *const prop,
                    __unsafe_unretained id const val, RLMCreationOptions creationOptions) {
     NSUInteger col = prop.column;
-    switch (accessorCodeForType(prop.objcType, prop.type)) {
-        case RLMAccessorCodeByte:
-        case RLMAccessorCodeShort:
-        case RLMAccessorCodeInt:
-        case RLMAccessorCodeLong:
-        case RLMAccessorCodeLongLong:
-            if (prop.isPrimary) {
-                RLMSetValueUnique(obj, col, prop.name, [val longLongValue]);
-            }
-            else {
-                RLMSetValue(obj, col, [val longLongValue]);
-            }
-            break;
-        case RLMAccessorCodeFloat:
-            RLMSetValue(obj, col, [val floatValue]);
-            break;
-        case RLMAccessorCodeDouble:
-            RLMSetValue(obj, col, [val doubleValue]);
-            break;
-        case RLMAccessorCodeBool:
-            RLMSetValue(obj, col, [val boolValue]);
-            break;
-        case RLMAccessorCodeIntObject:
-            if (prop.isPrimary) {
-                RLMSetValueUnique(obj, col, prop.name, (NSNumber<RLMInt> *)val);
-            }
-            else {
-                RLMSetValue(obj, col, (NSNumber<RLMInt> *)val);
-            }
-            break;
-        case RLMAccessorCodeFloatObject:
-            RLMSetValue(obj, col, (NSNumber<RLMFloat> *)val);
-            break;
-        case RLMAccessorCodeDoubleObject:
-            RLMSetValue(obj, col, (NSNumber<RLMDouble> *)val);
-            break;
-        case RLMAccessorCodeBoolObject:
-            RLMSetValue(obj, col, (NSNumber<RLMBool> *)val);
-            break;
-        case RLMAccessorCodeString:
-            if (prop.isPrimary) {
-                RLMSetValueUnique(obj, col, prop.name, (NSString *)val);
-            }
-            else {
-                RLMSetValue(obj, col, (NSString *)val);
-            }
-            break;
-        case RLMAccessorCodeDate:
-            RLMSetValue(obj, col, (NSDate *)val);
-            break;
-        case RLMAccessorCodeData:
-            RLMSetValue(obj, col, (NSData *)val);
-            break;
-        case RLMAccessorCodeLink: {
-            if (!val || val == NSNull.null) {
-                RLMSetValue(obj, col, (RLMObjectBase *)nil);
-            }
-            else {
-                RLMSetValue(obj, col, RLMGetLinkedObjectForValue(obj->_realm, prop.objectClassName, val, creationOptions));
-            }
-            break;
-        }
-        case RLMAccessorCodeArray:
-            if (!val || val == NSNull.null) {
-                RLMSetValue(obj, col, (id<NSFastEnumeration>)nil);
-            }
-            else {
-                id<NSFastEnumeration> rawLinks = val;
-                NSMutableArray *links = [NSMutableArray array];
-                for (id rawLink in rawLinks) {
-                    [links addObject:RLMGetLinkedObjectForValue(obj->_realm, prop.objectClassName, rawLink, creationOptions)];
+    RLMWrapSetter(obj, prop.name, [&] {
+        switch (accessorCodeForType(prop.objcType, prop.type)) {
+            case RLMAccessorCodeByte:
+            case RLMAccessorCodeShort:
+            case RLMAccessorCodeInt:
+            case RLMAccessorCodeLong:
+            case RLMAccessorCodeLongLong:
+                if (prop.isPrimary) {
+                    RLMSetValueUnique(obj, col, prop.name, [val longLongValue]);
                 }
-                RLMSetValue(obj, col, links);
+                else {
+                    RLMSetValue(obj, col, [val longLongValue]);
+                }
+                break;
+            case RLMAccessorCodeFloat:
+                RLMSetValue(obj, col, [val floatValue]);
+                break;
+            case RLMAccessorCodeDouble:
+                RLMSetValue(obj, col, [val doubleValue]);
+                break;
+            case RLMAccessorCodeBool:
+                RLMSetValue(obj, col, [val boolValue]);
+                break;
+            case RLMAccessorCodeIntObject:
+                if (prop.isPrimary) {
+                    RLMSetValueUnique(obj, col, prop.name, (NSNumber<RLMInt> *)val);
+                }
+                else {
+                    RLMSetValue(obj, col, (NSNumber<RLMInt> *)val);
+                }
+                break;
+            case RLMAccessorCodeFloatObject:
+                RLMSetValue(obj, col, (NSNumber<RLMFloat> *)val);
+                break;
+            case RLMAccessorCodeDoubleObject:
+                RLMSetValue(obj, col, (NSNumber<RLMDouble> *)val);
+                break;
+            case RLMAccessorCodeBoolObject:
+                RLMSetValue(obj, col, (NSNumber<RLMBool> *)val);
+                break;
+            case RLMAccessorCodeString:
+                if (prop.isPrimary) {
+                    RLMSetValueUnique(obj, col, prop.name, (NSString *)val);
+                }
+                else {
+                    RLMSetValue(obj, col, (NSString *)val);
+                }
+                break;
+            case RLMAccessorCodeDate:
+                RLMSetValue(obj, col, (NSDate *)val);
+                break;
+            case RLMAccessorCodeData:
+                RLMSetValue(obj, col, (NSData *)val);
+                break;
+            case RLMAccessorCodeLink: {
+                if (!val || val == NSNull.null) {
+                    RLMSetValue(obj, col, (RLMObjectBase *)nil);
+                }
+                else {
+                    RLMSetValue(obj, col, RLMGetLinkedObjectForValue(obj->_realm, prop.objectClassName, val, creationOptions));
+                }
+                break;
             }
-            break;
-        case RLMAccessorCodeAny:
-            RLMSetValue(obj, col, val);
-            break;
-    }
+            case RLMAccessorCodeArray:
+                if (!val || val == NSNull.null) {
+                    RLMSetValue(obj, col, (id<NSFastEnumeration>)nil);
+                }
+                else {
+                    id<NSFastEnumeration> rawLinks = val;
+                    NSMutableArray *links = [NSMutableArray array];
+                    for (id rawLink in rawLinks) {
+                        [links addObject:RLMGetLinkedObjectForValue(obj->_realm, prop.objectClassName, rawLink, creationOptions)];
+                    }
+                    RLMSetValue(obj, col, links);
+                }
+                break;
+            case RLMAccessorCodeAny:
+                RLMSetValue(obj, col, val);
+                break;
+        }
+    });
 }
 
 RLMProperty *RLMValidatedGetProperty(__unsafe_unretained RLMObjectBase *const obj, __unsafe_unretained NSString *const propName) {

--- a/Realm/RLMOptionalBase.mm
+++ b/Realm/RLMOptionalBase.mm
@@ -45,15 +45,15 @@
 }
 
 - (void)setUnderlyingValue:(id)underlyingValue {
-    NSString *propertyName = _property.name;
-    [_object willChangeValueForKey:propertyName];
     if ((_object && _object->_realm) || _object.isInvalidated) {
         RLMDynamicSet(_object, _property, underlyingValue, RLMCreationOptionsNone);
     }
     else {
+        NSString *propertyName = _property.name;
+        [_object willChangeValueForKey:propertyName];
         _standaloneValue = underlyingValue;
+        [_object didChangeValueForKey:propertyName];
     }
-    [_object didChangeValueForKey:propertyName];
 }
 
 - (BOOL)isKindOfClass:(Class)aClass {

--- a/Realm/Tests/KVOTests.mm
+++ b/Realm/Tests/KVOTests.mm
@@ -1285,6 +1285,28 @@ public:
     // ignored properties do not notify other accessors for the same row
 }
 
+- (void)testAddOrUpdate {
+    KVOObject *obj = [self createObject];
+    KVOObject *obj2 = [[KVOObject alloc] initWithValue:obj];
+
+    KVORecorder r(self, obj, @"boolCol");
+    obj2.boolCol = true;
+    XCTAssertTrue(r.empty());
+    [self.realm addOrUpdateObject:obj2];
+    AssertChanged(r, @NO, @YES);
+}
+
+- (void)testCreateOrUpdate {
+    KVOObject *obj = [self createObject];
+    KVOObject *obj2 = [[KVOObject alloc] initWithValue:obj];
+
+    KVORecorder r(self, obj, @"boolCol");
+    obj2.boolCol = true;
+    XCTAssertTrue(r.empty());
+    [KVOObject createOrUpdateInRealm:self.realm withValue:obj2];
+    AssertChanged(r, @NO, @YES);
+}
+
 // The following tests aren't really multiple-accessor-specific, but they're
 // conceptually similar and don't make sense in the multiple realm instances case
 - (void)testCancelWriteTransactionWhileObservingNewObject {

--- a/RealmSwift-swift2.0/Tests/KVOTests.swift
+++ b/RealmSwift-swift2.0/Tests/KVOTests.swift
@@ -246,21 +246,21 @@ class KVOTests: TestCase {
             obj.arrayCol.removeAll()
         }
 
-        observeChange(obj, "optIntCol", NSNull(), 10) { obj.optIntCol.value = 10 }
-        observeChange(obj, "optFloatCol", NSNull(), 10) { obj.optFloatCol.value = 10 }
-        observeChange(obj, "optDoubleCol", NSNull(), 10) { obj.optDoubleCol.value = 10 }
-        observeChange(obj, "optBoolCol", NSNull(), true) { obj.optBoolCol.value = true }
-        observeChange(obj, "optStringCol", NSNull(), "abc") { obj.optStringCol = "abc" }
-        observeChange(obj, "optBinaryCol", NSNull(), data) { obj.optBinaryCol = data }
-        observeChange(obj, "optDateCol", NSNull(), date) { obj.optDateCol = date }
+        observeChange(obs, "optIntCol", NSNull(), 10) { obj.optIntCol.value = 10 }
+        observeChange(obs, "optFloatCol", NSNull(), 10) { obj.optFloatCol.value = 10 }
+        observeChange(obs, "optDoubleCol", NSNull(), 10) { obj.optDoubleCol.value = 10 }
+        observeChange(obs, "optBoolCol", NSNull(), true) { obj.optBoolCol.value = true }
+        observeChange(obs, "optStringCol", NSNull(), "abc") { obj.optStringCol = "abc" }
+        observeChange(obs, "optBinaryCol", NSNull(), data) { obj.optBinaryCol = data }
+        observeChange(obs, "optDateCol", NSNull(), date) { obj.optDateCol = date }
 
-        observeChange(obj, "optIntCol", 10, NSNull()) { obj.optIntCol.value = nil }
-        observeChange(obj, "optFloatCol", 10, NSNull()) { obj.optFloatCol.value = nil }
-        observeChange(obj, "optDoubleCol", 10, NSNull()) { obj.optDoubleCol.value = nil }
-        observeChange(obj, "optBoolCol", true, NSNull()) { obj.optBoolCol.value = nil }
-        observeChange(obj, "optStringCol", "abc", NSNull()) { obj.optStringCol = nil }
-        observeChange(obj, "optBinaryCol", data, NSNull()) { obj.optBinaryCol = nil }
-        observeChange(obj, "optDateCol", date, NSNull()) { obj.optDateCol = nil }
+        observeChange(obs, "optIntCol", 10, NSNull()) { obj.optIntCol.value = nil }
+        observeChange(obs, "optFloatCol", 10, NSNull()) { obj.optFloatCol.value = nil }
+        observeChange(obs, "optDoubleCol", 10, NSNull()) { obj.optDoubleCol.value = nil }
+        observeChange(obs, "optBoolCol", true, NSNull()) { obj.optBoolCol.value = nil }
+        observeChange(obs, "optStringCol", "abc", NSNull()) { obj.optStringCol = nil }
+        observeChange(obs, "optBinaryCol", data, NSNull()) { obj.optBinaryCol = nil }
+        observeChange(obs, "optDateCol", date, NSNull()) { obj.optDateCol = nil }
 
         observeChange(obs, "invalidated", false, true) {
             self.realm.delete(obj)


### PR DESCRIPTION
And fix a similar issue where modifying a RealmOptional property did not notify other accessors for the same row of the change.

Fixes #3292.