### PR TITLE
Mark all required initializers as NS_DESIGNATED_INITIALIZER

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ x.x.x Release notes (yyyy-MM-dd)
 
 ### Bugfixes
 
-* None.
+* Mark further initializers in Objective-C as NS_DESIGNATED_INITIALIZER to prevent that these aren't
+  correctly defined in Swift Object subclasses, which don't qualify for auto-inheriting the required initializers.
 
 0.98.5 Release notes (2016-03-14)
 =============================================================

--- a/Realm/RLMObject.mm
+++ b/Realm/RLMObject.mm
@@ -41,6 +41,14 @@
     return [super init];
 }
 
+- (instancetype)initWithValue:(id)value schema:(RLMSchema *)schema {
+    return [super initWithValue:value schema:schema];
+}
+
+- (instancetype)initWithRealm:(__unsafe_unretained RLMRealm *const)realm
+                       schema:(__unsafe_unretained RLMObjectSchema *const)schema {
+    return [super initWithRealm:realm schema:schema];
+}
 
 #pragma mark - Convenience Initializers
 

--- a/Realm/RLMObject.mm
+++ b/Realm/RLMObject.mm
@@ -35,9 +35,14 @@
 // synthesized in RLMObjectBase
 @dynamic invalidated, realm, objectSchema;
 
+#pragma mark - Designated Initializers
+
 - (instancetype)init {
     return [super init];
 }
+
+
+#pragma mark - Convenience Initializers
 
 - (instancetype)initWithValue:(id)value {
     [self.class sharedSchema]; // ensure this class' objectSchema is loaded in the partialSharedSchema
@@ -48,6 +53,8 @@
 - (instancetype)initWithObject:(id)object {
     return [self initWithValue:object];
 }
+
+#pragma mark - Class-based Object Creation
 
 + (instancetype)createInDefaultRealmWithValue:(id)value {
     return (RLMObject *)RLMCreateObjectInRealmWithValue([RLMRealm defaultRealm], [self className], value, false);
@@ -87,6 +94,8 @@
     return [self createOrUpdateInRealm:realm withValue:object];
 }
 
+#pragma mark - Subscripting
+
 - (id)objectForKeyedSubscript:(NSString *)key {
     return RLMObjectBaseObjectForKeyedSubscript(self, key);
 }
@@ -94,6 +103,8 @@
 - (void)setObject:(id)obj forKeyedSubscript:(NSString *)key {
     RLMObjectBaseSetObjectForKeyedSubscript(self, key, obj);
 }
+
+#pragma mark - Getting & Querying
 
 + (RLMResults *)allObjects {
     return RLMGetObjects(RLMRealm.defaultRealm, self.className, nil);
@@ -143,6 +154,8 @@
     return RLMGetObject(realm, self.className, primaryKey);
 }
 
+#pragma mark - Other Instance Methods
+
 - (NSArray *)linkingObjectsOfClass:(NSString *)className forProperty:(NSString *)property {
     return RLMObjectBaseLinkingObjectsOfClass(self, className, property);
 }
@@ -154,6 +167,8 @@
 + (NSString *)className {
     return [super className];
 }
+
+#pragma mark - Default values for schema definition
 
 + (NSArray *)indexedProperties {
     return @[];

--- a/Realm/RLMObjectBase.h
+++ b/Realm/RLMObjectBase.h
@@ -30,7 +30,7 @@ RLM_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, readonly, getter = isInvalidated) BOOL invalidated;
 
-- (instancetype)init;
+- (instancetype)init NS_DESIGNATED_INITIALIZER;
 
 + (NSString *)className;
 

--- a/Realm/RLMObject_Private.h
+++ b/Realm/RLMObject_Private.h
@@ -29,17 +29,28 @@
 }
 
 // standalone initializer
-- (instancetype)initWithValue:(id)value schema:(RLMSchema *)schema;
+- (instancetype)initWithValue:(id)value schema:(RLMSchema *)schema NS_DESIGNATED_INITIALIZER;
 
 // live accessor initializer
 - (instancetype)initWithRealm:(__unsafe_unretained RLMRealm *const)realm
-                       schema:(__unsafe_unretained RLMObjectSchema *const)schema;
+                       schema:(__unsafe_unretained RLMObjectSchema *const)schema NS_DESIGNATED_INITIALIZER;
 
 // shared schema for this class
 + (RLMObjectSchema *)sharedSchema;
 
 // provide injection point for alternative Swift object util class
 + (Class)objectUtilClass:(BOOL)isSwift;
+
+@end
+
+@interface RLMObject ()
+
+// standalone initializer
+- (instancetype)initWithValue:(id)value schema:(RLMSchema *)schema NS_DESIGNATED_INITIALIZER;
+
+// live accessor initializer
+- (instancetype)initWithRealm:(__unsafe_unretained RLMRealm *const)realm
+                       schema:(__unsafe_unretained RLMObjectSchema *const)schema NS_DESIGNATED_INITIALIZER;
 
 @end
 

--- a/Realm/Tests/RLMTestObjects.h
+++ b/Realm/Tests/RLMTestObjects.h
@@ -313,6 +313,12 @@ RLM_ARRAY_TYPE(CircleObject);
 @interface NumberDefaultsObject : NumberObject
 @end
 
+#pragma mark CustomInitializerObject
+
+@interface CustomInitializerObject : RLMObject
+@property NSString *stringCol;
+@end
+
 #pragma mark FakeObject
 
 @interface FakeObject : NSObject

--- a/Realm/Tests/RLMTestObjects.m
+++ b/Realm/Tests/RLMTestObjects.m
@@ -194,6 +194,20 @@
 }
 @end
 
+#pragma mark CustomInitializerObject
+
+@implementation CustomInitializerObject
+
+- (instancetype)init {
+    self = [super init];
+    if (self) {
+        self.stringCol = @"test";
+    }
+    return self;
+}
+
+@end
+
 #pragma mark FakeObject
 
 @implementation FakeObject

--- a/RealmSwift-swift2.0/Object.swift
+++ b/RealmSwift-swift2.0/Object.swift
@@ -76,7 +76,7 @@ public class Object: RLMObjectBase {
 
     - see: Realm().add(_:)
     */
-    public required override init() {
+    public override required init() {
         super.init()
     }
 
@@ -250,7 +250,7 @@ public class Object: RLMObjectBase {
     WARNING: This is an internal initializer not intended for public use.
     :nodoc:
     */
-    public override init(realm: RLMRealm, schema: RLMObjectSchema) {
+    public override required init(realm: RLMRealm, schema: RLMObjectSchema) {
         super.init(realm: realm, schema: schema)
     }
 
@@ -258,7 +258,7 @@ public class Object: RLMObjectBase {
     WARNING: This is an internal initializer not intended for public use.
     :nodoc:
     */
-    public override init(value: AnyObject, schema: RLMSchema) {
+    public override required init(value: AnyObject, schema: RLMSchema) {
         super.init(value: value, schema: schema)
     }
 

--- a/RealmSwift-swift2.0/Tests/ObjectTests.swift
+++ b/RealmSwift-swift2.0/Tests/ObjectTests.swift
@@ -58,6 +58,15 @@ class ObjectTests: TestCase {
         )
     }
 
+    func testObjectSchemaForObjectWithConvenienceInitializer() {
+        let object = SwiftConvenienceInitializerObject(stringCol: "abc")
+        let schema = object.objectSchema
+        XCTAssert(schema as AnyObject is ObjectSchema)
+        XCTAssert(schema.properties as AnyObject is [Property])
+        XCTAssertEqual(schema.className, "SwiftConvenienceInitializerObject")
+        XCTAssertEqual(schema.properties.map { $0.name }, ["stringCol"])
+    }
+
     func testInvalidated() {
         let object = SwiftObject()
         XCTAssertFalse(object.invalidated)

--- a/RealmSwift-swift2.0/Tests/RealmCollectionTypeTests.swift
+++ b/RealmSwift-swift2.0/Tests/RealmCollectionTypeTests.swift
@@ -397,6 +397,22 @@ class ResultsTests: RealmCollectionTypeTests {
     }
 }
 
+class ResultsWithCustomInitializerTest: TestCase {
+    func testValueForKey() {
+        let realm = realmWithTestPath()
+        try! realm.write {
+            realm.add(SwiftCustomInitializerObject(stringVal: "A"))
+        }
+
+        let collection = realm.objects(SwiftCustomInitializerObject)
+        let expected = collection.map { $0.stringCol }
+        let actual = collection.valueForKey("stringCol") as! [String]!
+        XCTAssertEqual(expected, actual)
+
+        XCTAssertEqual(collection.map { $0 }, collection.valueForKey("self") as! [SwiftStringObject])
+    }
+}
+
 class ResultsFromTableTests: ResultsTests {
     override func collectionBase() -> Results<SwiftStringObject> {
         return realmWithTestPath().objects(SwiftStringObject)

--- a/RealmSwift-swift2.0/Tests/SwiftTestObjects.swift
+++ b/RealmSwift-swift2.0/Tests/SwiftTestObjects.swift
@@ -286,4 +286,14 @@ class SwiftCustomInitializerObject: Object {
         stringCol = ""
         super.init()
     }
+
+    required init(realm: RLMRealm, schema: RLMObjectSchema) {
+        stringCol = ""
+        super.init(realm: realm, schema: schema)
+    }
+
+    required init(value: AnyObject, schema: RLMSchema) {
+        stringCol = ""
+        super.init(value: value, schema: schema)
+    }
 }

--- a/RealmSwift-swift2.0/Tests/SwiftTestObjects.swift
+++ b/RealmSwift-swift2.0/Tests/SwiftTestObjects.swift
@@ -18,6 +18,7 @@
 
 import Foundation
 import RealmSwift
+import Realm
 
 class SwiftStringObject: Object {
     dynamic var stringCol = ""
@@ -270,5 +271,19 @@ class SwiftIndexedOptinalPropertiesObject: Object {
     override class func indexedProperties() -> [String] {
         return ["optionalStringCol", "optionalIntCol", "optionalInt8Col", "optionalInt16Col",
             "optionalInt32Col", "optionalInt64Col", "optionalBoolCol", "optionalDateCol"]
+    }
+}
+
+class SwiftCustomInitializerObject: Object {
+    dynamic var stringCol: String
+
+    init(stringVal: String) {
+        stringCol = stringVal
+        super.init()
+    }
+
+    required init() {
+        stringCol = ""
+        super.init()
     }
 }

--- a/RealmSwift-swift2.0/Tests/SwiftTestObjects.swift
+++ b/RealmSwift-swift2.0/Tests/SwiftTestObjects.swift
@@ -297,3 +297,12 @@ class SwiftCustomInitializerObject: Object {
         super.init(value: value, schema: schema)
     }
 }
+
+class SwiftConvenienceInitializerObject: Object {
+    dynamic var stringCol = ""
+
+    convenience init(stringCol: String) {
+        self.init()
+        self.stringCol = stringCol
+    }
+}


### PR DESCRIPTION
This is a follow up to investigations I did for #3185.

Even though something in that direction was brought up before by @kishikawakatsumi with #2514, which was finally rejected, I think what we currently have is problematic.

As seen in the second commit, it is currently possible to define an `Object` subclass, overwriting all initializers, which are declared as required, which perfectly compiles, whose object schema validates, but which can't be used universally at runtime as it e.g. fails when trying to access `valueForKey` on a `Results` collection of that object. The error in this case is:
>fatal error: use of unimplemented initializer 'init(realm:schema:)'

/c @jpsim @tgoyne