### PR TITLE
remove unnecessary swizzling

### DIFF
--- a/Realm/RLMSchema.mm
+++ b/Realm/RLMSchema.mm
@@ -107,7 +107,6 @@ static void RLMRegisterClassLocalNames(Class *classes, NSUInteger count) {
         }
 
         s_localNameToClass[className] = cls;
-        RLMReplaceClassNameMethod(cls, className);
     }
 }
 


### PR DESCRIPTION
#3235
`RLMReplaceClassNameMethod` does unnecessary swizzling. In `RLMObjectBase.mm` the method which is `+ (NSString *)className ` is the same as `className` in the code. 

On iOS 9.2, Swizzling slows down the performance, so I hope it would be changed.