### PR TITLE
Set TMPDIR value correctly if it's nil.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -20,7 +20,7 @@ set -e
 : ${XCMODE:=xcodebuild} # must be one of: xcodebuild (default), xcpretty, xctool
 
 # Provide a fallback value for TMPDIR, relevant for Xcode Bots
-: ${TMPDIR:=getconf DARWIN_USER_TEMP_DIR}
+: ${TMPDIR:=$(getconf DARWIN_USER_TEMP_DIR)}
 
 PATH=/usr/libexec:$PATH
 


### PR DESCRIPTION
`build.sh` set `TMPDIR`  to string `"getconf DARWIN_USER_TEMP_DIR"` if TMPDIR is empty.
This causes instlation failure. (when TMPDIR is empty)

`getconf DARWIN_USER_TEMP_DIR` should be enclosed by `$()`.