### PR TITLE
lint podspecs during build.sh verify-cocoapods

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -647,6 +647,7 @@ case "$COMMAND" in
         ;;
 
     "verify-cocoapods")
+        pod spec lint
         cd examples/installation
         sh build.sh test-ios-objc-cocoapods || exit 1
         sh build.sh test-ios-swift-cocoapods || exit 1


### PR DESCRIPTION
This will lint all podspecs (`Realm.podspec` & `RealmSwift.podspec`) /cc @bdash 