### PR TITLE
Change the block parameter to a named tuple

### DIFF
--- a/RealmSwift-swift2.0/List.swift
+++ b/RealmSwift-swift2.0/List.swift
@@ -415,8 +415,8 @@ public final class List<T: Object>: ListBase {
     - returns: A token which must be held for as long as you want notifications to be delivered.
     */
     @warn_unused_result(message="You must hold on to the NotificationToken returned from addNotificationBlock")
-    public func addNotificationBlock(block: (List<T>) -> ()) -> NotificationToken {
-        return _rlmArray.addNotificationBlock { _, _ in block(self) }
+    public func addNotificationBlock(block: (list: List<T>) -> ()) -> NotificationToken {
+        return _rlmArray.addNotificationBlock { _, _ in block(list: self) }
     }
 }
 

--- a/RealmSwift-swift2.0/RealmCollectionType.swift
+++ b/RealmSwift-swift2.0/RealmCollectionType.swift
@@ -730,7 +730,8 @@ public final class AnyRealmCollection<T: Object>: RealmCollectionType {
     - returns: A token which must be held for as long as you want notifications to be delivered.
     */
     @warn_unused_result(message="You must hold on to the NotificationToken returned from addNotificationBlock")
-    public func addNotificationBlock(block: (AnyRealmCollection<Element>?, NSError?) -> ()) -> NotificationToken {
+    public func addNotificationBlock(block: (collection: AnyRealmCollection<Element>?,
+                                             error: NSError?) -> ()) -> NotificationToken {
         return base._addNotificationBlock(block)
     }
 

--- a/RealmSwift-swift2.0/Results.swift
+++ b/RealmSwift-swift2.0/Results.swift
@@ -352,12 +352,12 @@ public final class Results<T: Object>: ResultsBase {
      - returns: A token which must be held for as long as you want query results to be delivered.
      */
     @warn_unused_result(message="You must hold on to the NotificationToken returned from addNotificationBlock")
-    public func addNotificationBlock(block: (Results<T>?, NSError?) -> ()) -> NotificationToken {
+    public func addNotificationBlock(block: (results: Results<T>?, error: NSError?) -> ()) -> NotificationToken {
         return rlmResults.addNotificationBlock { results, error in
             if results != nil {
-                block(self, nil)
+                block(results: self, error: nil)
             } else {
-                block(nil, error)
+                block(results: nil, error: error)
             }
         }
     }


### PR DESCRIPTION
It allows complementing block parameter names by code completion.

### Before
<img width="657" alt="screen shot 2016-03-15 at 23 46 35" src="https://cloud.githubusercontent.com/assets/40610/13781921/591d950a-eb08-11e5-959b-e672a9107076.png">
<img width="644" alt="screen shot 2016-03-15 at 23 46 39" src="https://cloud.githubusercontent.com/assets/40610/13781922/5b765030-eb08-11e5-9098-42d92bf73aa0.png">

### After
<img width="745" alt="screen shot 2016-03-15 at 23 45 25" src="https://cloud.githubusercontent.com/assets/40610/13781928/6706b3ea-eb08-11e5-872f-07076f92fc84.png">
<img width="536" alt="screen shot 2016-03-15 at 23 45 39" src="https://cloud.githubusercontent.com/assets/40610/13781931/6a15b252-eb08-11e5-9de4-98dfb50c6117.png">


CC @jpsim @mrackwitz 

