### PR TITLE
Add supported data types to doc comments for indexedProperties

### DIFF
--- a/Realm/RLMObject.h
+++ b/Realm/RLMObject.h
@@ -233,7 +233,7 @@ RLM_ASSUME_NONNULL_BEGIN
 
 /**
  Return an array of property names for properties which should be indexed. Only supported
- for string and int properties.
+ for strings, integers, booleans and NSDate properties.
  @return    NSArray of property names.
  */
 + (NSArray RLM_GENERIC(NSString *) *)indexedProperties;

--- a/RealmSwift-swift2.0/Object.swift
+++ b/RealmSwift-swift2.0/Object.swift
@@ -160,7 +160,7 @@ public class Object: RLMObjectBase {
 
     /**
     Return an array of property names for properties which should be indexed. Only supported
-    for string and int properties.
+    for strings, integers, booleans and NSDate properties.
 
     - returns: `Array` of property names to index.
     */


### PR DESCRIPTION
Indexing BOOL/Bool and NSDate properties have been supported from v0.97.1.

Closes https://github.com/realm/realm-cocoa/issues/3339

CC @jpsim @mrackwitz