### PR TITLE
fix parse array of realm objects from json

### DIFF
--- a/Realm/RLMSchema.mm
+++ b/Realm/RLMSchema.mm
@@ -145,7 +145,11 @@ static void RLMRegisterClassLocalNames(Class *classes, NSUInteger count) {
 - (RLMObjectSchema *)objectForKeyedSubscript:(__unsafe_unretained id<NSCopying> const)className {
     RLMObjectSchema *schema = _objectSchemaByName[className];
     if (!schema) {
-        @throw RLMException(@"Object type '%@' not persisted in Realm", className);
+        RLMObject *object = [((RLMObject *)[NSClassFromString(className) alloc]) init];
+        schema = object.objectSchema;
+        if (!schema) {
+            @throw RLMException(@"Object type '%@' not persisted in Realm", className);
+        }
     }
     return schema;
 }


### PR DESCRIPTION
I have this classes: 
```objc
@interface UserContactModel : RLMObject

@property NSString *Contact;
@property UserContactType ContactType;
@property BOOL Confirmed;

@end

RLM_ARRAY_TYPE(UserContactModel)

@interface UserModel : RLMObject

@property NSNumber <RLMInt> *Id;
@property NSString *FirstName;
@property NSString *LastName;
@property NSString *Password;
@property NSString *FullName;
@property NSString *City;
@property NSString *State;
@property NSString *ProfessionalDegree;
@property NSString *Speciality;
@property NSString *ModifiedTime;
@property NSDate *RegisteredTime;
@property NSNumber <RLMInt> *AllowedDeviceKind;
@property UserType UserType;
@property RLMArray <UserContactModel *> <UserContactModel> *Contacts;

@end
```

when parse json have issue when can't find schema.
This should be fix it