### PR TITLE
Extract primaryKey class method into PrimaryKeyObject protocol

### DIFF
--- a/Realm/RLMObjectBase.mm
+++ b/Realm/RLMObjectBase.mm
@@ -461,6 +461,10 @@ Class RLMObjectUtilClass(BOOL isSwift) {
     return [cls indexedProperties];
 }
 
++ (NSString *)primaryKeyPropertyForClass:(Class)cls {
+    return [cls primaryKey];
+}
+
 + (NSArray *)getGenericListPropertyNames:(__unused id)obj {
     return nil;
 }

--- a/Realm/RLMObjectSchema.mm
+++ b/Realm/RLMObjectSchema.mm
@@ -122,22 +122,21 @@ using namespace realm;
         }
     }
 
-    if ([objectClass respondsToSelector:@selector(primaryKey)]) {
-        if (NSString *primaryKey = [objectClass primaryKey]) {
-            for (RLMProperty *prop in schema.properties) {
-                if ([primaryKey isEqualToString:prop.name]) {
-                    prop.indexed = YES;
-                    schema.primaryKeyProperty = prop;
-                    break;
-                }
+    Class objectUtil = [objectClass objectUtilClass:isSwift];
+    if (NSString *primaryKey = [objectUtil primaryKeyPropertyForClass:objectClass]) {
+        for (RLMProperty *prop in schema.properties) {
+            if ([primaryKey isEqualToString:prop.name]) {
+                prop.indexed = YES;
+                schema.primaryKeyProperty = prop;
+                break;
             }
+        }
 
-            if (!schema.primaryKeyProperty) {
-                @throw RLMException(@"Primary key property '%@' does not exist on object '%@'", primaryKey, className);
-            }
-            if (schema.primaryKeyProperty.type != RLMPropertyTypeInt && schema.primaryKeyProperty.type != RLMPropertyTypeString) {
-                @throw RLMException(@"Only 'string' and 'int' properties can be designated the primary key");
-            }
+        if (!schema.primaryKeyProperty) {
+            @throw RLMException(@"Primary key property '%@' does not exist on object '%@'", primaryKey, className);
+        }
+        if (schema.primaryKeyProperty.type != RLMPropertyTypeInt && schema.primaryKeyProperty.type != RLMPropertyTypeString) {
+            @throw RLMException(@"Only 'string' and 'int' properties can be designated the primary key");
         }
     }
 

--- a/Realm/RLMObjectSchema.mm
+++ b/Realm/RLMObjectSchema.mm
@@ -122,20 +122,22 @@ using namespace realm;
         }
     }
 
-    if (NSString *primaryKey = [objectClass primaryKey]) {
-        for (RLMProperty *prop in schema.properties) {
-            if ([primaryKey isEqualToString:prop.name]) {
-                prop.indexed = YES;
-                schema.primaryKeyProperty = prop;
-                break;
+    if ([objectClass respondsToSelector:@selector(primaryKey)]) {
+        if (NSString *primaryKey = [objectClass primaryKey]) {
+            for (RLMProperty *prop in schema.properties) {
+                if ([primaryKey isEqualToString:prop.name]) {
+                    prop.indexed = YES;
+                    schema.primaryKeyProperty = prop;
+                    break;
+                }
             }
-        }
 
-        if (!schema.primaryKeyProperty) {
-            @throw RLMException(@"Primary key property '%@' does not exist on object '%@'", primaryKey, className);
-        }
-        if (schema.primaryKeyProperty.type != RLMPropertyTypeInt && schema.primaryKeyProperty.type != RLMPropertyTypeString) {
-            @throw RLMException(@"Only 'string' and 'int' properties can be designated the primary key");
+            if (!schema.primaryKeyProperty) {
+                @throw RLMException(@"Primary key property '%@' does not exist on object '%@'", primaryKey, className);
+            }
+            if (schema.primaryKeyProperty.type != RLMPropertyTypeInt && schema.primaryKeyProperty.type != RLMPropertyTypeString) {
+                @throw RLMException(@"Only 'string' and 'int' properties can be designated the primary key");
+            }
         }
     }
 

--- a/Realm/RLMObject_Private.h
+++ b/Realm/RLMObject_Private.h
@@ -89,6 +89,7 @@ FOUNDATION_EXTERN const NSUInteger RLMDescriptionMaxDepth;
 
 + (NSArray RLM_GENERIC(NSString *) *)ignoredPropertiesForClass:(Class)cls;
 + (NSArray RLM_GENERIC(NSString *) *)indexedPropertiesForClass:(Class)cls;
++ (NSString *)primaryKeyPropertyForClass:(Class)cls;
 
 + (NSArray RLM_GENERIC(NSString *) *)getGenericListPropertyNames:(id)obj;
 + (void)initializeListProperty:(RLMObjectBase *)object property:(RLMProperty *)property array:(RLMArray *)array;

--- a/RealmSwift-swift2.0/Object.swift
+++ b/RealmSwift-swift2.0/Object.swift
@@ -141,16 +141,6 @@ public class Object: RLMObjectBase {
     // MARK: Object Customization
 
     /**
-    Override to designate a property as the primary key for an `Object` subclass. Only properties of
-    type String and Int can be designated as the primary key. Primary key
-    properties enforce uniqueness for each value whenever the property is set which incurs some overhead.
-    Indexes are created automatically for primary key properties.
-
-    - returns: Name of the property designated as the primary key, or `nil` if the model has no primary key.
-    */
-    public class func primaryKey() -> String? { return nil }
-
-    /**
     Override to return an array of property names to ignore. These properties will not be persisted
     and are treated as transient.
 
@@ -273,6 +263,18 @@ public class Object: RLMObjectBase {
     }
 }
 
+/// Implement this protocol to designate a property as the primary key of an `Object` subclass.
+public protocol PrimaryKeyObject : class {
+    /**
+     Override to designate a property as the primary key for an `Object` subclass. Only properties of
+     type String and Int can be designated as the primary key. Primary key
+     properties enforce uniqueness for each value whenever the property is set which incurs some overhead.
+     Indexes are created automatically for primary key properties.
+
+     - returns: Name of the property designated as the primary key.
+     */
+    static func primaryKey() -> String
+}
 
 
 /// Object interface which allows untyped getters and setters for Objects.

--- a/RealmSwift-swift2.0/Object.swift
+++ b/RealmSwift-swift2.0/Object.swift
@@ -342,6 +342,21 @@ public class ObjectUtil: NSObject {
         return nil
     }
 
+    @objc private class func primaryKeyPropertyForClass(type: AnyClass) -> String? {
+        if let type = type as? PrimaryKeyObject.Type {
+            return type.primaryKey()
+        }
+        // Note: This shoud prevent that a schema definition error is mystified by the requirement
+        // of a schema version bump, if previously a property was designated as primary key by
+        // overriding the inherited method but the later introduced protocol `PrimaryKeyObject` was
+        // not adopted yet.
+        if type.respondsToSelector("primaryKey") {
+            throwRealmException("WARNING: '\(type)' declares a static method 'primaryKey' but"
+                + "doesn't implement the protocol 'PrimaryKeyObject'.")
+        }
+        return nil
+    }
+
     // Get the names of all properties in the object which are of type List<>.
     @objc private class func getGenericListPropertyNames(object: AnyObject) -> NSArray {
         return Mirror(reflecting: object).children.filter { (prop: Mirror.Child) in

--- a/RealmSwift-swift2.0/Tests/KVOTests.swift
+++ b/RealmSwift-swift2.0/Tests/KVOTests.swift
@@ -25,7 +25,7 @@ func nextPrimaryKey() -> Int {
     return pkCounter
 }
 
-class KVOObject: Object {
+class KVOObject: Object, PrimaryKeyObject {
     // swiftlint:disable:next variable_name
     dynamic var pk = nextPrimaryKey() // primary key for equality
     dynamic var ignored: Int = 0
@@ -50,7 +50,7 @@ class KVOObject: Object {
     dynamic var optBinaryCol: NSData?
     dynamic var optDateCol: NSDate?
 
-    override class func primaryKey() -> String { return "pk" }
+    class func primaryKey() -> String { return "pk" }
     override class func ignoredProperties() -> [String] { return ["ignored"] }
 }
 

--- a/RealmSwift-swift2.0/Tests/ObjectSchemaInitializationTests.swift
+++ b/RealmSwift-swift2.0/Tests/ObjectSchemaInitializationTests.swift
@@ -130,6 +130,8 @@ class ObjectSchemaInitializationTests: TestCase {
 
         assertThrows(RLMObjectSchema(forObjectClass: SwiftObjectWithDatePrimaryKey.self),
             "Should throw when setting a non int/string primary key")
+        assertThrows(RLMObjectSchema(forObjectClass: SwiftObjectWithPrimaryKeyMethodButWithoutProtocol.self),
+            "Should throw when declaring primaryKey method but not implementing PrimaryKeyObject protocol")
         assertThrows(RLMObjectSchema(forObjectClass: SwiftObjectWithNSURL.self),
             "Should throw when not ignoring a property of a type we can't persist")
         assertThrows(RLMObjectSchema(forObjectClass: SwiftObjectWithNonOptionalLinkProperty.self),
@@ -235,6 +237,14 @@ class SwiftObjectWithDatePrimaryKey: SwiftFakeObject, PrimaryKeyObject {
 
     class func primaryKey() -> String {
         return "date"
+    }
+}
+
+class SwiftObjectWithPrimaryKeyMethodButWithoutProtocol: SwiftFakeObject {
+    dynamic var stringCol = ""
+
+    dynamic class func primaryKey() -> String {
+        return "stringCol"
     }
 }
 

--- a/RealmSwift-swift2.0/Tests/ObjectSchemaInitializationTests.swift
+++ b/RealmSwift-swift2.0/Tests/ObjectSchemaInitializationTests.swift
@@ -197,7 +197,6 @@ class ObjectSchemaInitializationTests: TestCase {
 
 class SwiftFakeObject: NSObject {
     dynamic class func objectUtilClass(isSwift: Bool) -> AnyClass { return ObjectUtil.self }
-    dynamic class func primaryKey() -> String? { return nil }
     dynamic class func ignoredProperties() -> [String] { return [] }
     dynamic class func indexedProperties() -> [String] { return [] }
 }
@@ -231,10 +230,10 @@ class SwiftObjectWithStruct: SwiftFakeObject {
     var swiftStruct = SortDescriptor(property: "prop")
 }
 
-class SwiftObjectWithDatePrimaryKey: SwiftFakeObject {
+class SwiftObjectWithDatePrimaryKey: SwiftFakeObject, PrimaryKeyObject {
     dynamic var date = NSDate()
 
-    dynamic override class func primaryKey() -> String? {
+    class func primaryKey() -> String {
         return "date"
     }
 }

--- a/RealmSwift-swift2.0/Tests/ObjectTests.swift
+++ b/RealmSwift-swift2.0/Tests/ObjectTests.swift
@@ -96,10 +96,8 @@ class ObjectTests: TestCase {
     }
 
     func testPrimaryKey() {
-        XCTAssertNil(Object.primaryKey(), "primary key should default to nil")
-        XCTAssertNil(SwiftStringObject.primaryKey())
         XCTAssertNil(SwiftStringObject().objectSchema.primaryKeyProperty)
-        XCTAssertEqual(SwiftPrimaryStringObject.primaryKey()!, "stringCol")
+        XCTAssertEqual(SwiftPrimaryStringObject.primaryKey(), "stringCol")
         XCTAssertEqual(SwiftPrimaryStringObject().objectSchema.primaryKeyProperty!.name, "stringCol")
     }
 

--- a/RealmSwift-swift2.0/Tests/SwiftTestObjects.swift
+++ b/RealmSwift-swift2.0/Tests/SwiftTestObjects.swift
@@ -194,13 +194,13 @@ class SwiftArrayPropertySubclassObject: SwiftArrayPropertyObject {
     let boolArray = List<SwiftBoolObject>()
 }
 
-class SwiftLinkToPrimaryStringObject: Object {
+class SwiftLinkToPrimaryStringObject: Object, PrimaryKeyObject {
     // swiftlint:disable:next variable_name
     dynamic var pk = ""
     dynamic var object: SwiftPrimaryStringObject?
     let objects = List<SwiftPrimaryStringObject>()
 
-    override class func primaryKey() -> String? {
+    class func primaryKey() -> String {
         return "pk"
     }
 }
@@ -226,11 +226,11 @@ class SwiftRecursiveObject: Object {
     let objects = List<SwiftRecursiveObject>()
 }
 
-class SwiftPrimaryStringObject: Object {
+class SwiftPrimaryStringObject: Object, PrimaryKeyObject {
     dynamic var stringCol = ""
     dynamic var intCol = 0
 
-    override class func primaryKey() -> String? {
+    class func primaryKey() -> String {
         return "stringCol"
     }
 }


### PR DESCRIPTION
:warning: This would be a breaking change.

By moving the class method `Object.primaryKey` into a protocol `PrimaryKeyObject`, we can restrict the methods which allow upserts only to those `Object` subclasses which define a primary key.