### PR TITLE
Adds support for async writes

### DIFF
--- a/Realm/ObjectStore/list.cpp
+++ b/Realm/ObjectStore/list.cpp
@@ -163,6 +163,11 @@ Results List::sort(SortOrder order)
     return Results(m_realm, get_query(), std::move(order));
 }
 
+LinkViewRef List::link_view()
+{
+    return m_link_view;
+}
+
 // These definitions rely on that LinkViews are interned by core
 bool List::operator==(List const& rgt) const noexcept
 {

--- a/Realm/ObjectStore/list.hpp
+++ b/Realm/ObjectStore/list.hpp
@@ -91,6 +91,8 @@ public:
 
     // The input Row object is not attached
     struct DetatchedAccessorException { };
+    
+    LinkViewRef link_view();
 
 private:
     std::shared_ptr<Realm> m_realm;

--- a/Realm/ObjectStore/shared_realm.cpp
+++ b/Realm/ObjectStore/shared_realm.cpp
@@ -178,6 +178,11 @@ Group *Realm::read_group()
     return m_group;
 }
 
+SharedGroup& Realm::shared_group()
+{
+    return *m_shared_group;
+}
+
 SharedRealm Realm::get_shared_realm(Config config)
 {
     return RealmCoordinator::get_coordinator(config.path)->get_realm(std::move(config));

--- a/Realm/ObjectStore/shared_realm.hpp
+++ b/Realm/ObjectStore/shared_realm.hpp
@@ -158,6 +158,8 @@ namespace realm {
 
         // FIXME private
         Group *read_group();
+        
+        SharedGroup& shared_group();
     };
 
     class RealmFileException : public std::runtime_error {

--- a/Realm/RLMArrayLinkView.mm
+++ b/Realm/RLMArrayLinkView.mm
@@ -400,6 +400,10 @@ static void RLMInsertObject(RLMArrayLinkView *ar, RLMObject *object, NSUInteger 
     return translateErrors([&] { return _backingList.get_query(); }).find_all();
 }
 
+- (realm::LinkViewRef)linkView {
+    return _backingList.link_view();
+}
+
 // The compiler complains about the method's argument type not matching due to
 // it not having the generic type attached, but it doesn't seem to be possible
 // to actually include the generic type

--- a/Realm/RLMArray_Private.hpp
+++ b/Realm/RLMArray_Private.hpp
@@ -72,6 +72,7 @@ class RLMObservationInfo;
 
 // deletes all objects in the RLMArray from their containing realms
 - (void)deleteObjectsFromRealm;
+- (realm::LinkViewRef)linkView;
 @end
 
 void RLMValidateArrayObservationKey(NSString *keyPath, RLMArray *array);
@@ -88,6 +89,7 @@ void RLMEnsureArrayObservationInfo(std::unique_ptr<RLMObservationInfo>& info, NS
                                    results:(realm::Results)results;
 
 - (void)deleteObjectsFromRealm;
+- (realm::Results)results;
 @end
 
 // An object which encapulates the shared logic for fast-enumerating RLMArray

--- a/Realm/RLMObject.mm
+++ b/Realm/RLMObject.mm
@@ -24,6 +24,11 @@
 #import "RLMRealm_Private.hpp"
 #import "RLMQueryUtil.hpp"
 
+#include <future>
+#include <realm/group_shared.hpp>
+#import <realm/link_view.hpp>
+#import <realm/row.hpp>
+
 // We declare things in RLMObject which are actually implemented in RLMObjectBase
 // for documentation's sake, which leads to -Wunimplemented-method warnings.
 // Other alternatives to this would be to disable -Wunimplemented-method for this

--- a/Realm/RLMObject.mm
+++ b/Realm/RLMObject.mm
@@ -24,11 +24,6 @@
 #import "RLMRealm_Private.hpp"
 #import "RLMQueryUtil.hpp"
 
-#include <future>
-#include <realm/group_shared.hpp>
-#import <realm/link_view.hpp>
-#import <realm/row.hpp>
-
 // We declare things in RLMObject which are actually implemented in RLMObjectBase
 // for documentation's sake, which leads to -Wunimplemented-method warnings.
 // Other alternatives to this would be to disable -Wunimplemented-method for this

--- a/Realm/RLMRealm.h
+++ b/Realm/RLMRealm.h
@@ -18,6 +18,8 @@
 
 #import <Foundation/Foundation.h>
 #import <Realm/RLMDefines.h>
+#import <Realm/RLMCollection.h>
+
 
 @class RLMRealmConfiguration, RLMObject, RLMSchema, RLMMigration, RLMNotificationToken;
 
@@ -500,6 +502,22 @@ typedef void (^RLMMigrationBlock)(RLMMigration *migration, uint64_t oldSchemaVer
  @see                 RLMMigration
  */
 + (NSError *)migrateRealm:(RLMRealmConfiguration *)configuration;
+
+#pragma mark - Async Writes
+
+typedef void (^RLMAsyncWriteBlock)(RLMRealm *realm);
+
+typedef void (^RLMAsyncWriteObjectBlock)(RLMRealm *realm, id object);
+
+typedef void (^RLMAsyncWriteCollectionBlock)(RLMRealm *realm, id<RLMCollection> collection);
+
+typedef void (^RLMCompletionBlock)(NSError *error);
+
+- (void)writeAsyncWithBlock:(RLMAsyncWriteBlock)block completion:(RLMCompletionBlock)completion;
+
+- (void)writeObjectAsync:(RLMObject *)object withBlock:(RLMAsyncWriteObjectBlock)block completion:(RLMCompletionBlock)completion;
+
+- (void)writeCollectionAsync:(id<RLMCollection>)collection withBlock:(RLMAsyncWriteCollectionBlock)block completion:(RLMCompletionBlock)completion;
 
 @end
 

--- a/Realm/RLMRealm.h
+++ b/Realm/RLMRealm.h
@@ -18,10 +18,10 @@
 
 #import <Foundation/Foundation.h>
 #import <Realm/RLMDefines.h>
-#import <Realm/RLMCollection.h>
-
 
 @class RLMRealmConfiguration, RLMObject, RLMSchema, RLMMigration, RLMNotificationToken;
+
+@protocol RLMCollection;
 
 RLM_ASSUME_NONNULL_BEGIN
 

--- a/Realm/RLMRealm.mm
+++ b/Realm/RLMRealm.mm
@@ -45,8 +45,7 @@
 #include <realm/disable_sync_to_disk.hpp>
 #include <realm/version.hpp>
 
-#include <future>
-#include <realm/group_shared.hpp>
+#import <realm/group_shared.hpp>
 #import <realm/link_view.hpp>
 #import <realm/row.hpp>
 #import <realm/results.hpp>

--- a/Realm/RLMRealm.mm
+++ b/Realm/RLMRealm.mm
@@ -34,6 +34,7 @@
 #import "RLMSchema_Private.hpp"
 #import "RLMUpdateChecker.hpp"
 #import "RLMUtil.hpp"
+#import "RLMResults_Private.h"
 
 #include "impl/realm_coordinator.hpp"
 #include "object_store.hpp"
@@ -43,6 +44,12 @@
 #include <realm/commit_log.hpp>
 #include <realm/disable_sync_to_disk.hpp>
 #include <realm/version.hpp>
+
+#include <future>
+#include <realm/group_shared.hpp>
+#import <realm/link_view.hpp>
+#import <realm/row.hpp>
+#import <realm/results.hpp>
 
 using namespace realm;
 using util::File;
@@ -778,6 +785,160 @@ static void CheckReadWrite(RLMRealm *realm, NSString *msg=@"Cannot write to a re
         [enumerator detach];
     }
     _collectionEnumerators = nil;
+}
+
+#pragma mark - Async Writes
+
+- (void)writeAsyncWithBlock:(RLMAsyncWriteBlock)block completion:(RLMCompletionBlock)completion {
+    RLMRealmConfiguration *config = self.configuration;
+    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0), ^{
+        NSError *error = nil;
+        RLMRealm *bgRealm = [RLMRealm realmWithConfiguration:config error:&error];
+        
+        if (error) {
+            dispatch_async(dispatch_get_main_queue(), ^{
+                completion(error);
+            });
+            return;
+        }
+        
+        [bgRealm transactionWithBlock:^{
+            block(bgRealm);
+        } error:&error];
+        
+        dispatch_async(dispatch_get_main_queue(), ^{
+            // Should refresh be called before completion?
+            completion(error);
+        });
+    });
+}
+
+- (void)writeObjectAsync:(RLMObject *)object withBlock:(RLMAsyncWriteObjectBlock)block completion:(RLMCompletionBlock)completion {
+    if (object.realm->_realm != self->_realm) {
+        @throw RLMException(@"Object is not persisted in this Realm");
+    }
+    
+    auto& sg = object.realm->_realm->shared_group();
+    __block std::unique_ptr<realm::SharedGroup::Handover<realm::Row> > handover_row = sg.export_for_handover(object->_row);
+    
+    RLMRealmConfiguration *config = object.realm.configuration;
+    Class accessorClass = object.objectSchema.accessorClass;
+    RLMObjectSchema *objectSchema = object.objectSchema;
+    
+    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0), ^{
+        NSError *error = nil;
+        RLMRealm *newRealm = [RLMRealm realmWithConfiguration:config error:&error];
+        
+        if (error) {
+            dispatch_async(dispatch_get_main_queue(), ^{
+                completion(error);
+            });
+            return;
+        }
+        
+        newRealm->_realm->read_group();
+        auto& new_sg = newRealm->_realm->shared_group();
+        std::unique_ptr<realm::Row> new_row( new_sg.import_from_handover(move(handover_row)) );
+        
+        RLMObject *handoverObject = [[accessorClass alloc] initWithRealm:newRealm
+                                                                  schema:objectSchema];
+        handoverObject->_row = *new_row;
+        
+        [newRealm transactionWithBlock:^{
+            block(newRealm, handoverObject);
+        } error:&error];
+        
+        dispatch_async(dispatch_get_main_queue(), ^{
+            // Should refresh be called before completion?
+            completion(error);
+        });
+    });
+}
+
+- (void)writeCollectionAsync:(id<RLMCollection>)collection withBlock:(RLMAsyncWriteCollectionBlock)block completion:(RLMCompletionBlock)completion
+{
+    if (collection.realm->_realm != self->_realm) {
+        @throw RLMException(@"Collection is not persisted in this Realm");
+    }
+    
+    auto& sg = collection.realm->_realm->shared_group();
+    RLMRealmConfiguration *config = collection.realm.configuration;
+    
+    if ([(NSObject *)collection isKindOfClass:[RLMArray class]]) {
+        RLMArrayLinkView *array = (RLMArrayLinkView *)collection;
+        LinkViewRef lv = array.linkView;
+        NSString *key = array->_key;
+        RLMObjectSchema *objectSchema = array.objectSchema;
+        
+        __block std::unique_ptr<SharedGroup::Handover<LinkView> > handover_link_view = sg.export_linkview_for_handover(lv);
+        
+        dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0), ^{
+            NSError *error = nil;
+            RLMRealm *newRealm = [RLMRealm realmWithConfiguration:config error:&error];
+            
+            if (error) {
+                dispatch_async(dispatch_get_main_queue(), ^{
+                    completion(error);
+                });
+                return;
+            }
+            
+            newRealm->_realm->read_group();
+            auto& new_sg = newRealm->_realm->shared_group();
+            LinkViewRef new_lv(new_sg.import_linkview_from_handover(move(handover_link_view)) );
+            
+            RLMArrayLinkView *handoverArray = [RLMArrayLinkView arrayWithObjectClassName:objectSchema.className
+                                                                                    view:new_lv
+                                                                                   realm:newRealm
+                                                                                     key:key
+                                                                            parentSchema:objectSchema];
+            
+            [newRealm transactionWithBlock:^{
+                block(newRealm, handoverArray);
+            } error:&error];
+            
+            dispatch_async(dispatch_get_main_queue(), ^{
+                // Should refresh be called before completion?
+                completion(error);
+            });
+        });
+    }
+    else {
+        RLMResults *results = (RLMResults *)collection;
+        realm::Results pvResults = results.results;
+        RLMObjectSchema *objectSchema = results.objectSchema;
+        
+        TableView tv = pvResults.get_tableview();
+        __block std::unique_ptr<SharedGroup::Handover<TableView>> handover_table_view = sg.export_for_handover(tv, ConstSourcePayload::Copy);
+        
+        dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0), ^{
+            NSError *error = nil;
+            RLMRealm *newRealm = [RLMRealm realmWithConfiguration:config error:&error];
+            
+            if (error) {
+                dispatch_async(dispatch_get_main_queue(), ^{
+                    completion(error);
+                });
+                return;
+            }
+            
+            newRealm->_realm->read_group();
+            auto& new_sg = newRealm->_realm->shared_group();
+            std::unique_ptr<TableView> new_tv(new_sg.import_from_handover(move(handover_table_view)) );
+            Query query = new_tv->get_query();
+            
+            RLMResults *handoverResults = [RLMResults resultsWithObjectSchema:objectSchema results:realm::Results(newRealm->_realm, std::move(query))];
+            
+            [newRealm transactionWithBlock:^{
+                block(newRealm, handoverResults);
+            } error:&error];
+            
+            dispatch_async(dispatch_get_main_queue(), ^{
+                // Should refresh be called before completion?
+                completion(error);
+            });
+        });
+    }
 }
 
 @end

--- a/Realm/RLMResults.mm
+++ b/Realm/RLMResults.mm
@@ -528,6 +528,10 @@ static inline void RLMResultsValidateInWriteTransaction(__unsafe_unretained RLMR
     return translateErrors([&] { return _results.get_tableview(); });
 }
 
+- (realm::Results)results {
+    return _results;
+}
+
 // The compiler complains about the method's argument type not matching due to
 // it not having the generic type attached, but it doesn't seem to be possible
 // to actually include the generic type

--- a/Realm/Tests/ArrayPropertyTests.m
+++ b/Realm/Tests/ArrayPropertyTests.m
@@ -148,7 +148,6 @@
         [array addObject:child2];
     } completion:^(NSError * _Nonnull error) {
         XCTAssertNil(error);
-        [realm refresh];
         RLMResults *children = [StringObject allObjectsInRealm:realm];
         XCTAssertEqualObjects([children[0] stringCol], @"a", @"First child should be 'a'");
         XCTAssertEqualObjects([children[1] stringCol], @"b", @"Second child should be 'b'");

--- a/Realm/Tests/ArrayPropertyTests.m
+++ b/Realm/Tests/ArrayPropertyTests.m
@@ -127,6 +127,37 @@
     XCTAssertEqualObjects([children[1] stringCol], @"b", @"Second child should be 'b'");
 }
 
+- (void)testAsyncInsertMultiple {
+    RLMRealm *realm = [self realmWithTestPath];
+    NSString *path = realm.path;
+    
+    [realm beginWriteTransaction];
+    ArrayPropertyObject *obj = [ArrayPropertyObject createInRealm:realm withValue:@[@"arrayObject", @[], @[]]];
+    StringObject *child1 = [StringObject createInRealm:realm withValue:@[@"a"]];
+    [obj.array addObject:child1];
+    [realm commitWriteTransaction];
+    
+    XCTestExpectation *expectation =
+    [self expectationWithDescription:@""];
+    
+    [realm writeCollectionAsync:obj.array withBlock:^(RLMRealm * _Nonnull realm, RLMArray * _Nonnull array) {
+        XCTAssert([path isEqualToString:realm.path], @"Both Realms should have same path");
+        XCTAssertEqual(array.count, 1U, @"Should be 1 child object");
+        StringObject *child2 = [[StringObject alloc] init];
+        child2.stringCol = @"b";
+        [array addObject:child2];
+    } completion:^(NSError * _Nonnull error) {
+        XCTAssertNil(error);
+        [realm refresh];
+        RLMResults *children = [StringObject allObjectsInRealm:realm];
+        XCTAssertEqualObjects([children[0] stringCol], @"a", @"First child should be 'a'");
+        XCTAssertEqualObjects([children[1] stringCol], @"b", @"Second child should be 'b'");
+        [expectation fulfill];
+    }];
+    
+    [self waitForExpectationsWithTimeout:5.0 handler:nil];
+}
+
 -(void)testInsertAtIndex {
     RLMRealm *realm = [self realmWithTestPath];
 

--- a/Realm/Tests/ObjectTests.m
+++ b/Realm/Tests/ObjectTests.m
@@ -1521,7 +1521,6 @@ RLM_ARRAY_TYPE(PrimaryEmployeeObject);
         dog.age = 6;
     } completion:^(NSError * _Nonnull error) {
         XCTAssertNil(error);
-        [dog.realm refresh];
         XCTAssertEqual(dog.age, 6, @"Dog should be 6 years old");
         [expectation fulfill];
     }];

--- a/Realm/Tests/RealmTests.mm
+++ b/Realm/Tests/RealmTests.mm
@@ -577,6 +577,21 @@ extern "C" {
     [realm cancelWriteTransaction];
 }
 
+- (void)testAsyncAddObjects {
+    RLMRealm *realm = [self realmWithTestPath];
+    
+    [realm writeAsyncWithBlock:^(RLMRealm * _Nonnull realm) {
+        [StringObject createInRealm:realm withValue:@[@"a"]];
+        [StringObject createInRealm:realm withValue:@[@"b"]];
+        [StringObject createInRealm:realm withValue:@[@"c"]];
+        XCTAssertEqual([StringObject objectsInRealm:realm withPredicate:nil].count, 3U, @"Expecting 3 objects");
+    } completion:^(NSError * _Nonnull error) {
+        XCTAssertNil(error);
+        RLMResults *objects = [StringObject allObjectsInRealm:realm];
+        XCTAssertEqual(objects.count, 3U, @"Expecting 3 objects");
+    }];
+}
+
 #pragma mark - Transactions
 
 - (void)testRealmTransactionBlock {

--- a/Realm/Tests/ResultsTests.m
+++ b/Realm/Tests/ResultsTests.m
@@ -577,7 +577,6 @@
         [EmployeeObject createInRealm:realm withValue:@{@"name": @"B", @"age": @30, @"hired": @NO}];
     } completion:^(NSError * _Nonnull error) {
         XCTAssertNil(error);
-        [realm refresh];
         XCTAssertEqual(employees.count, 3U, @"Should be 3 employees");
         [expectation fulfill];
     }];
@@ -605,7 +604,6 @@
         [EmployeeObject createInRealm:realm withValue:@{@"name": @"B", @"age": @30, @"hired": @NO}];
     } completion:^(NSError * _Nonnull error) {
         XCTAssertNil(error);
-        [realm refresh];
         XCTAssertEqual(30, [(EmployeeObject *)sortedAge[1] age]);
         XCTAssertEqual(sortedAge.count, 3U, @"Should be 3 employees");
         [expectation fulfill];
@@ -635,7 +633,6 @@
         [EmployeeObject createInRealm:realm withValue:@{@"name": @"B", @"age": @30, @"hired": @YES}];
     } completion:^(NSError * _Nonnull error) {
         XCTAssertNil(error);
-        [realm refresh];
         XCTAssertEqual(30, [(EmployeeObject *)sortedAge[1] age]);
         XCTAssertEqual(sortedAge.count, 3U, @"Should be 3 employees");
         [expectation fulfill];


### PR DESCRIPTION
1. Block with a thread local RLMRealm instance
2. Block with a thread local RLMObject instance (handed over from calling thread)
3. Block with a thread local RLMArray/RLMResults (handed over from the calling thread)

Tests for each. I am more dubious of the implementation for RLMResults, since the difference between all the various backing objects.

Fixes #3136