### PR TITLE
Fix -[RLMResults indexOfObjectWithPredicate:] for RLMResults instances that were created by filtering an RLMArray

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ x.x.x Release notes (yyyy-MM-dd)
 
 * Mark further initializers in Objective-C as NS_DESIGNATED_INITIALIZER to prevent that these aren't
   correctly defined in Swift Object subclasses, which don't qualify for auto-inheriting the required initializers.
+* `-[RLMResults indexOfObjectWithPredicate:]` now returns correct results
+  for `RLMResults` instances that were created by filtering an `RLMArray`.
 
 0.98.6 Release notes (2016-03-25)
 =============================================================

--- a/Realm/RLMResults.mm
+++ b/Realm/RLMResults.mm
@@ -290,7 +290,7 @@ static inline void RLMResultsValidateInWriteTransaction(__unsafe_unretained RLMR
     // FIXME: We're only looking for a single object so we'd like to be able to use `Query::find`
     // for this, but as of core v0.97.1 it gives incorrect results if the query is restricted
     // to a link view (<https://github.com/realm/realm-core/issues/1565>).
-    auto table_view = query.find_all();
+    auto table_view = query.find_all(0, -1, 1);
     if (!table_view.size()) {
         return NSNotFound;
     }

--- a/Realm/RLMResults.mm
+++ b/Realm/RLMResults.mm
@@ -286,11 +286,15 @@ static inline void RLMResultsValidateInWriteTransaction(__unsafe_unretained RLMR
 
     Query query = translateErrors([&] { return _results.get_query(); });
     RLMUpdateQueryWithPredicate(&query, predicate, _realm.schema, _objectSchema);
-    size_t index = query.find();
-    if (index == realm::not_found) {
+
+    // FIXME: We're only looking for a single object so we'd like to be able to use `Query::find`
+    // for this, but as of core v0.97.1 it gives incorrect results if the query is restricted
+    // to a link view (<https://github.com/realm/realm-core/issues/1565>).
+    auto table_view = query.find_all();
+    if (!table_view.size()) {
         return NSNotFound;
     }
-    return _results.index_of(index);
+    return _results.index_of(table_view.get_source_ndx(0));
 }
 
 - (id)objectAtIndex:(NSUInteger)index {

--- a/Realm/Tests/ArrayPropertyTests.m
+++ b/Realm/Tests/ArrayPropertyTests.m
@@ -475,11 +475,12 @@
     EmployeeObject *po1 = [EmployeeObject createInRealm:realm withValue:@{@"name": @"Joe",  @"age": @40, @"hired": @YES}];
     [EmployeeObject createInRealm:realm withValue:@{@"name": @"John", @"age": @30, @"hired": @NO}];
     EmployeeObject *po3 = [EmployeeObject createInRealm:realm withValue:@{@"name": @"Jill", @"age": @25, @"hired": @YES}];
+    EmployeeObject *po4 = [EmployeeObject createInRealm:realm withValue:@{@"name": @"Bill", @"age": @55, @"hired": @YES}];
 
     // create company
     CompanyObject *company = [[CompanyObject alloc] init];
     company.name = @"name";
-    [company.employees addObjects:@[po3, po1]];
+    [company.employees addObjects:@[po3, po1, po4]];
 
     // test standalone
     XCTAssertEqual(0U, [company.employees indexOfObjectWhere:@"name = 'Jill'"]);
@@ -494,6 +495,12 @@
     XCTAssertEqual(0U, [company.employees indexOfObjectWhere:@"name = 'Jill'"]);
     XCTAssertEqual(1U, [company.employees indexOfObjectWhere:@"name = 'Joe'"]);
     XCTAssertEqual((NSUInteger)NSNotFound, [company.employees indexOfObjectWhere:@"name = 'John'"]);
+
+    RLMResults *results = [company.employees objectsWhere:@"age > 30"];
+    XCTAssertEqual(0U, [results indexOfObjectWhere:@"name = 'Joe'"]);
+    XCTAssertEqual(1U, [results indexOfObjectWhere:@"name = 'Bill'"]);
+    XCTAssertEqual((NSUInteger)NSNotFound, [results indexOfObjectWhere:@"name = 'John'"]);
+    XCTAssertEqual((NSUInteger)NSNotFound, [results indexOfObjectWhere:@"name = 'Jill'"]);
 }
 
 - (void)testFastEnumeration


### PR DESCRIPTION
Fixes #3319.

/cc @tgoyne 

This is working around a core issue (realm/realm-core#1565). It gives correct results for calls to `indexOfObjectWithPredicate:` at the expense of making them do more work (potentially a lot more), even in cases that aren't affected by the bug. I'm not sure if that's a good tradeoff for us to ship, but it may prove useful to anyone that is affected by #3319.