### PR TITLE
Added Realm plugin compatibility for Xcode 7.3

### DIFF
--- a/plugin/RealmPlugin/RealmPlugin-Info.plist
+++ b/plugin/RealmPlugin/RealmPlugin-Info.plist
@@ -43,6 +43,7 @@
 		<string>7265231C-39B4-402C-89E1-16167C4CC990</string>
 		<string>9AFF134A-08DC-4096-8CEE-62A4BB123046</string>
 		<string>F41BD31E-2683-44B8-AE7F-5F09E919790E</string>
+		<string>ACA8656B-FEA8-4B6D-8E4A-93F4C95C362C</string>
 	</array>
 	<key>NSPrincipalClass</key>
 	<string>RLMPRealmPlugin</string>


### PR DESCRIPTION
This PR adds the necessary compatibility UUID to the Realm plugin project in order for it to be accepted by Xcode 7.3.