### PR TITLE
Suppress the warning in console when use playground

### DIFF
--- a/Realm/RLMAnalytics.mm
+++ b/Realm/RLMAnalytics.mm
@@ -220,7 +220,7 @@ static NSDictionary *RLMAnalyticsPayload() {
 }
 
 void RLMSendAnalytics() {
-    if (getenv("REALM_DISABLE_ANALYTICS") || !RLMIsDebuggerAttached()) {
+    if (getenv("REALM_DISABLE_ANALYTICS") || !RLMIsDebuggerAttached() || RLMIsRunningInPlayground()) {
         return;
     }
 

--- a/Realm/RLMUpdateChecker.mm
+++ b/Realm/RLMUpdateChecker.mm
@@ -19,6 +19,7 @@
 #import "RLMUpdateChecker.hpp"
 
 #import "RLMRealm.h"
+#import "RLMUtil.hpp"
 
 #if TARGET_IPHONE_SIMULATOR && !defined(REALM_COCOA_VERSION)
 #import "RLMVersion.h"
@@ -26,7 +27,7 @@
 
 void RLMCheckForUpdates() {
 #if TARGET_IPHONE_SIMULATOR
-    if (getenv("REALM_DISABLE_UPDATE_CHECKER")) {
+    if (getenv("REALM_DISABLE_UPDATE_CHECKER") || RLMIsRunningInPlayground()) {
         return;
     }
 

--- a/Realm/RLMUtil.hpp
+++ b/Realm/RLMUtil.hpp
@@ -62,6 +62,7 @@ NSArray *RLMCollectionValueForKey(id<RLMFastEnumerable> collection, NSString *ke
 void RLMCollectionSetValueForKey(id<RLMFastEnumerable> collection, NSString *key, id value);
 
 BOOL RLMIsDebuggerAttached();
+BOOL RLMIsRunningInPlayground();
 
 // C version of isKindOfClass
 static inline BOOL RLMIsKindOfClass(Class class1, Class class2) {

--- a/Realm/RLMUtil.mm
+++ b/Realm/RLMUtil.mm
@@ -344,6 +344,10 @@ BOOL RLMIsDebuggerAttached()
     return (info.kp_proc.p_flag & P_TRACED) != 0;
 }
 
+BOOL RLMIsRunningInPlayground() {
+    return [[NSBundle mainBundle].bundleIdentifier hasPrefix:@"com.apple.dt.playground."];
+}
+
 id RLMMixedToObjc(realm::Mixed const& mixed) {
     switch (mixed.get_type()) {
         case realm::type_String:


### PR DESCRIPTION
Disable update checker and analytics if running in the playground.
Because network access is failed in the playground. It also logs some warnings in console.

```
Failed to obtain sandbox extension for path=/var/folders/wr/f0q3fd5976nd8fwpwk717btr0000gn/T/com.apple.dt.Xcode.pg/containers/com.apple.dt.playground.stub.iOS_Simulator.GettingStarted-A69D296F-ED9D-445A-AFCC-F5CE90FDEAB9/Library/Caches/com.apple.dt.playground.stub.iOS_Simulator.GettingStarted-A69D296F-ED9D-445A-AFCC-F5CE90FDEAB9. Errno:1
Failed to obtain sandbox extension for path=/var/folders/wr/f0q3fd5976nd8fwpwk717btr0000gn/T/com.apple.dt.Xcode.pg/containers/com.apple.dt.playground.stub.iOS_Simulator.GettingStarted-A69D296F-ED9D-445A-AFCC-F5CE90FDEAB9/Library/Caches/com.apple.dt.playground.stub.iOS_Simulator.GettingStarted-A69D296F-ED9D-445A-AFCC-F5CE90FDEAB9. Errno:1
```

Suppress the warnings since users will misunderstand that error occurred.

CC @jpsim @mrackwitz 