### PR TITLE
Remove the manual storage of observationInfo on RLMObject

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ x.x.x Release notes (yyyy-MM-dd)
   correctly defined in Swift Object subclasses, which don't qualify for auto-inheriting the required initializers.
 * `-[RLMResults indexOfObjectWithPredicate:]` now returns correct results
   for `RLMResults` instances that were created by filtering an `RLMArray`.
+* Adjust how RLMObjects are destroyed in order to support using an associated
+  object on an RLMObject to remove KVO observers from that RLMObject.
 
 0.98.6 Release notes (2016-03-25)
 =============================================================

--- a/Realm/RLMAccessor.mm
+++ b/Realm/RLMAccessor.mm
@@ -508,7 +508,7 @@ static IMP RLMAccessorGetter(RLMProperty *prop, RLMAccessorCode accessorCode) {
 
 template<typename Function>
 static void RLMWrapSetter(__unsafe_unretained RLMObjectBase *const obj, __unsafe_unretained NSString *const name, Function&& f) {
-    if (RLMObservationInfo *info = RLMGetObservationInfo(obj->_observationInfo.get(), obj->_row.get_index(), obj->_objectSchema)) {
+    if (RLMObservationInfo *info = RLMGetObservationInfo(obj->_observationInfo, obj->_row.get_index(), obj->_objectSchema)) {
         info->willChange(name);
         f();
         info->didChange(name);

--- a/Realm/RLMObjectBase.mm
+++ b/Realm/RLMObjectBase.mm
@@ -64,6 +64,13 @@ static bool RLMInitializedObjectSchema(RLMObjectBase *obj) {
     return self;
 }
 
+- (void)dealloc {
+    // This can't be a unique_ptr because associated objects are removed
+    // *after* c++ members are destroyed, and we need it to still be alive when
+    // that happens
+    delete _observationInfo;
+}
+
 static id RLMValidatedObjectForProperty(id obj, RLMProperty *prop, RLMSchema *schema) {
     if (RLMIsObjectValidForProperty(obj, prop)) {
         return obj;
@@ -286,7 +293,7 @@ static id RLMValidatedObjectForProperty(id obj, RLMProperty *prop, RLMSchema *sc
             options:(NSKeyValueObservingOptions)options
             context:(void *)context {
     if (!_observationInfo) {
-        _observationInfo = std::make_unique<RLMObservationInfo>(self);
+        _observationInfo = new RLMObservationInfo(self);
     }
     _observationInfo->recordObserver(_row, _objectSchema, keyPath);
 
@@ -298,16 +305,7 @@ static id RLMValidatedObjectForProperty(id obj, RLMProperty *prop, RLMSchema *sc
     _observationInfo->removeObserver();
 }
 
-- (void *)observationInfo {
-    return _observationInfo ? _observationInfo->kvoInfo : nullptr;
-}
-
-- (void)setObservationInfo:(void *)observationInfo {
-    _observationInfo->kvoInfo = observationInfo;
-}
-
-+ (BOOL)automaticallyNotifiesObserversForKey:(NSString *)key
-{
++ (BOOL)automaticallyNotifiesObserversForKey:(NSString *)key {
     const char *className = class_getName(self);
     const char accessorClassPrefix[] = "RLMAccessor_";
     if (!strncmp(className, accessorClassPrefix, sizeof(accessorClassPrefix) - 1)) {

--- a/Realm/RLMObject_Private.hpp
+++ b/Realm/RLMObject_Private.hpp
@@ -29,7 +29,7 @@ class RLMObservationInfo;
 @interface RLMObjectBase () {
     @public
     realm::Row _row;
-    std::unique_ptr<RLMObservationInfo> _observationInfo;
+    RLMObservationInfo *_observationInfo;
 }
 @end
 

--- a/Realm/RLMObservation.hpp
+++ b/Realm/RLMObservation.hpp
@@ -126,10 +126,6 @@ private:
     RLMObservationInfo(RLMObservationInfo&&) = delete;
     RLMObservationInfo& operator=(RLMObservationInfo const&) = delete;
     RLMObservationInfo& operator=(RLMObservationInfo&&) = delete;
-
-public:
-    // storage for the observationInfo property on RLMObjectBase
-    void *kvoInfo = nullptr;
 };
 
 // Get the the observation info chain for the given row


### PR DESCRIPTION
This was originally done for the sake of awful things that thankfully turned out to be unneeded and was left only as a free minor performance optimization, but in practice it doesn't help and it breaks removing observers via associated objects.

Fixes #3346,