### PR TITLE
run 'pod setup' before linting podspecs

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -648,6 +648,7 @@ case "$COMMAND" in
         ;;
 
     "verify-cocoapods")
+        pod setup
         pod spec lint Realm.podspec
         # allow warnings in the Swift podspec because there's no way to
         # prevent the typealias->associatedtype deprecation warning without


### PR DESCRIPTION
otherwise, linting RealmSwift.podspec may not find the current version of the Realm podspec. /cc @bdash @tgoyne