### PR TITLE
deprecate duplicate realm configuration properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ x.x.x Release notes (yyyy-MM-dd)
 
 * Deprecate `-[RLMRealm removeNotification:]` in favor of
   `-[RLMNotificationToken stop]`.
+* `RLMRealm.path` and `RLMRealm.readOnly` have been deprecated in favor of their
+  counterparts on `RLMRealmConfiguration`.
 
 ### Enhancements
 

--- a/Realm.xcodeproj/project.pbxproj
+++ b/Realm.xcodeproj/project.pbxproj
@@ -340,6 +340,8 @@
 		E856D21D195615A900FB2FCF /* QueryTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E81A1FC11955FE0100FDED82 /* QueryTests.m */; };
 		E856D21E195615A900FB2FCF /* RealmTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = E81A1FC31955FE0100FDED82 /* RealmTests.mm */; };
 		E856D21F195615B100FB2FCF /* RLMTestCase.m in Sources */ = {isa = PBXBuildFile; fileRef = E81A1FC51955FE0100FDED82 /* RLMTestCase.m */; };
+		E86900E21CC04F5B0008A8B6 /* RLMRealmConfiguration_Private.hpp in Headers */ = {isa = PBXBuildFile; fileRef = E86900E11CC04F5B0008A8B6 /* RLMRealmConfiguration_Private.hpp */; };
+		E86900E31CC04F5B0008A8B6 /* RLMRealmConfiguration_Private.hpp in Headers */ = {isa = PBXBuildFile; fileRef = E86900E11CC04F5B0008A8B6 /* RLMRealmConfiguration_Private.hpp */; };
 		E8917598197A1B350068ACC6 /* UnicodeTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E8917597197A1B350068ACC6 /* UnicodeTests.m */; };
 		E8917599197A1B350068ACC6 /* UnicodeTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E8917597197A1B350068ACC6 /* UnicodeTests.m */; };
 		E8BF67FC1C24D07100E591CD /* SwiftVersion.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8BF67FB1C24D07100E591CD /* SwiftVersion.swift */; };
@@ -645,6 +647,7 @@
 		E83AF538196DDE58002275B2 /* SwiftDynamicTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwiftDynamicTests.swift; sourceTree = "<group>"; };
 		E844CC62196DE91F0005A5E7 /* SwiftMixedTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwiftMixedTests.swift; sourceTree = "<group>"; };
 		E856D1DF195614A400FB2FCF /* iOS static tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "iOS static tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		E86900E11CC04F5B0008A8B6 /* RLMRealmConfiguration_Private.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = RLMRealmConfiguration_Private.hpp; sourceTree = "<group>"; };
 		E8839B2C19E31FD90047B1A8 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = Realm/Tests/TestHost/Info.plist; sourceTree = SOURCE_ROOT; };
 		E8839B2D19E31FD90047B1A8 /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = main.m; path = Realm/Tests/TestHost/main.m; sourceTree = SOURCE_ROOT; };
 		E88C36FF19745E5500C9963D /* RLMSupport.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RLMSupport.swift; sourceTree = "<group>"; };
@@ -1011,6 +1014,7 @@
 				C0D2DD051B6BDEA1004E8919 /* RLMRealmConfiguration.h */,
 				C0D2DD061B6BDEA1004E8919 /* RLMRealmConfiguration.mm */,
 				C0D2DD0F1B6BE0DD004E8919 /* RLMRealmConfiguration_Private.h */,
+				E86900E11CC04F5B0008A8B6 /* RLMRealmConfiguration_Private.hpp */,
 				027A4D211AB100E000AA46F9 /* RLMRealmUtil.hpp */,
 				027A4D221AB100E000AA46F9 /* RLMRealmUtil.mm */,
 				02B8EF5819E601D80045A93D /* RLMResults.h */,
@@ -1110,6 +1114,7 @@
 				5D659EBD1BE04556006515A0 /* RLMProperty_Private.h in Headers */,
 				5D659EBE1BE04556006515A0 /* RLMQueryUtil.hpp in Headers */,
 				5D659EBF1BE04556006515A0 /* RLMRealm.h in Headers */,
+				E86900E21CC04F5B0008A8B6 /* RLMRealmConfiguration_Private.hpp in Headers */,
 				5D659EC01BE04556006515A0 /* RLMRealm_Dynamic.h in Headers */,
 				5D659EC11BE04556006515A0 /* RLMRealm_Private.h in Headers */,
 				5D659EC21BE04556006515A0 /* RLMRealmConfiguration.h in Headers */,
@@ -1161,6 +1166,7 @@
 				5DD755B21BE056DE002800DA /* RLMObjectBase_Dynamic.h in Headers */,
 				5DD755B31BE056DE002800DA /* RLMObjectSchema.h in Headers */,
 				5DD755B41BE056DE002800DA /* RLMObjectSchema_Private.h in Headers */,
+				E86900E31CC04F5B0008A8B6 /* RLMRealmConfiguration_Private.hpp in Headers */,
 				5DD755B51BE056DE002800DA /* RLMObjectSchema_Private.hpp in Headers */,
 				5DD755B61BE056DE002800DA /* RLMObjectStore.h in Headers */,
 				5DD755B71BE056DE002800DA /* RLMObservation.hpp in Headers */,
@@ -2121,6 +2127,7 @@
 				5D0A40871C62ACCC00BBB612 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 		5D659ED61BE04556006515A0 /* Build configuration list for PBXNativeTarget "Realm" */ = {
 			isa = XCConfigurationList;

--- a/Realm/RLMRealm.h
+++ b/Realm/RLMRealm.h
@@ -90,7 +90,7 @@ RLM_ASSUME_NONNULL_BEGIN
 /**
  Path to the file where this Realm is persisted.
  */
-@property (nonatomic, readonly) NSString *path;
+@property (nonatomic, readonly) NSString *path DEPRECATED_MSG_ATTRIBUTE("use configuration.path");
 
 /**
  Indicates if this Realm was opened in read-only mode.

--- a/Realm/RLMRealm.h
+++ b/Realm/RLMRealm.h
@@ -95,7 +95,7 @@ RLM_ASSUME_NONNULL_BEGIN
 /**
  Indicates if this Realm was opened in read-only mode.
  */
-@property (nonatomic, readonly, getter = isReadOnly) BOOL readOnly;
+@property (nonatomic, readonly, getter = isReadOnly) BOOL readOnly DEPRECATED_MSG_ATTRIBUTE("use configuration.readOnly");
 
 /**
  The RLMSchema used by this RLMRealm.

--- a/Realm/RLMRealm.mm
+++ b/Realm/RLMRealm.mm
@@ -413,7 +413,7 @@ void RLMRealmTranslateException(NSError **error) {
 
 - (void)verifyNotificationsAreSupported {
     [self verifyThread];
-    if (self.configuration.readOnly) {
+    if (_realm->config().read_only) {
         @throw RLMException(@"Read-only Realms do not change and do not have change notifications");
     }
     if (!_realm->can_deliver_notifications()) {
@@ -450,7 +450,7 @@ void RLMRealmTranslateException(NSError **error) {
 }
 
 - (void)sendNotifications:(NSString *)notification {
-    NSAssert(!self.configuration.readOnly, @"Read-only realms do not have notifications");
+    NSAssert(!_realm->config().read_only, @"Read-only realms do not have notifications");
 
     // call this realms notification blocks
     for (RLMRealmNotificationToken *token in [_notificationHandlers allObjects]) {

--- a/Realm/RLMRealm.mm
+++ b/Realm/RLMRealm.mm
@@ -411,15 +411,11 @@ void RLMRealmTranslateException(NSError **error) {
     [RLMRealmConfiguration resetRealmConfigurationState];
 }
 
-static void CheckReadWrite(RLMRealm *realm, NSString *msg=@"Cannot write to a read-only Realm") {
-    if (realm.readOnly) {
-        @throw RLMException(@"%@", msg);
-    }
-}
-
 - (void)verifyNotificationsAreSupported {
     [self verifyThread];
-    CheckReadWrite(self, @"Read-only Realms do not change and do not have change notifications");
+    if (self.configuration.readOnly) {
+        @throw RLMException(@"Read-only Realms do not change and do not have change notifications");
+    }
     if (!_realm->can_deliver_notifications()) {
         @throw RLMException(@"Can only add notification blocks from within runloops.");
     }
@@ -454,7 +450,7 @@ static void CheckReadWrite(RLMRealm *realm, NSString *msg=@"Cannot write to a re
 }
 
 - (void)sendNotifications:(NSString *)notification {
-    NSAssert(!self.readOnly, @"Read-only realms do not have notifications");
+    NSAssert(!self.configuration.readOnly, @"Read-only realms do not have notifications");
 
     // call this realms notification blocks
     for (RLMRealmNotificationToken *token in [_notificationHandlers allObjects]) {

--- a/Realm/RLMRealm.mm
+++ b/Realm/RLMRealm.mm
@@ -20,7 +20,7 @@
 
 #import "RLMAnalytics.hpp"
 #import "RLMArray_Private.hpp"
-#import "RLMRealmConfiguration_Private.h"
+#import "RLMRealmConfiguration_Private.hpp"
 #import "RLMMigration_Private.h"
 #import "RLMObjectSchema_Private.hpp"
 #import "RLMProperty_Private.h"
@@ -46,10 +46,6 @@
 
 using namespace realm;
 using util::File;
-
-@interface RLMRealmConfiguration ()
-- (realm::Realm::Config&)config;
-@end
 
 @interface RLMRealm ()
 - (void)sendNotifications:(NSString *)notification;

--- a/Realm/RLMRealmConfiguration_Private.hpp
+++ b/Realm/RLMRealmConfiguration_Private.hpp
@@ -1,0 +1,24 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2014 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+#import "RLMRealmConfiguration_Private.h"
+#include "shared_realm.hpp"
+
+@interface RLMRealmConfiguration ()
+- (realm::Realm::Config&)config;
+@end

--- a/Realm/RLMRealmConfiguration_Private.hpp
+++ b/Realm/RLMRealmConfiguration_Private.hpp
@@ -17,7 +17,7 @@
 ////////////////////////////////////////////////////////////////////////////
 
 #import "RLMRealmConfiguration_Private.h"
-#include "shared_realm.hpp"
+#import "shared_realm.hpp"
 
 @interface RLMRealmConfiguration ()
 - (realm::Realm::Config&)config;

--- a/Realm/Tests/AsyncTests.m
+++ b/Realm/Tests/AsyncTests.m
@@ -400,7 +400,7 @@
 
     // Force an error when opening the helper SharedGroups by deleting the file
     // after opening the Realm
-    [NSFileManager.defaultManager removeItemAtPath:realm.path error:nil];
+    [NSFileManager.defaultManager removeItemAtPath:realm.configuration.path error:nil];
 
     __block bool called = false;
     XCTestExpectation *exp = [self expectationWithDescription:@""];

--- a/Realm/Tests/PerformanceTests.m
+++ b/Realm/Tests/PerformanceTests.m
@@ -369,7 +369,7 @@ static RLMRealm *s_smallRealm, *s_mediumRealm, *s_largeRealm;
             }
         }
     }];
-    [realm path];
+    [realm.configuration path];
 }
 
 - (void)testRealmCreationUncached {

--- a/Realm/Tests/RealmConfigurationTests.mm
+++ b/Realm/Tests/RealmConfigurationTests.mm
@@ -118,17 +118,19 @@
 
 - (void)testDefaultRealmUsesDefaultConfiguration {
     RLMRealmConfiguration *config = [RLMRealmConfiguration defaultConfiguration];
-    @autoreleasepool { XCTAssertEqualObjects(RLMRealm.defaultRealm.path, config.path); }
+    @autoreleasepool { XCTAssertEqualObjects(RLMRealm.defaultRealm.configuration.path, config.path); }
 
     config.path = RLMTestRealmPath();
-    @autoreleasepool { XCTAssertNotEqualObjects(RLMRealm.defaultRealm.path, config.path); }
+    @autoreleasepool { XCTAssertNotEqualObjects(RLMRealm.defaultRealm.configuration.path, config.path); }
     RLMRealmConfiguration.defaultConfiguration = config;
-    @autoreleasepool { XCTAssertEqualObjects(RLMRealm.defaultRealm.path, config.path); }
+    @autoreleasepool { XCTAssertEqualObjects(RLMRealm.defaultRealm.configuration.path, config.path); }
 
     config.inMemoryIdentifier = @"default";
     RLMRealmConfiguration.defaultConfiguration = config;
     @autoreleasepool {
         RLMRealm *realm = RLMRealm.defaultRealm;
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         XCTAssertTrue([realm.path hasSuffix:@"/default"]);
         XCTAssertTrue([realm.path hasPrefix:NSTemporaryDirectory()]);
     }
@@ -139,6 +141,7 @@
         RLMRealm *realm = RLMRealm.defaultRealm;
         XCTAssertEqual(1U, [RLMRealm schemaVersionAtPath:realm.path error:nil]);
     }
+#pragma clang diagnostic pop
 
     config.path = RLMDefaultRealmPath();
     RLMRealmConfiguration.defaultConfiguration = config;

--- a/Realm/Tests/RealmConfigurationTests.mm
+++ b/Realm/Tests/RealmConfigurationTests.mm
@@ -127,21 +127,25 @@
 
     config.inMemoryIdentifier = @"default";
     RLMRealmConfiguration.defaultConfiguration = config;
+    __block NSString *realmPath = nil;
     @autoreleasepool {
-        RLMRealm *realm = RLMRealm.defaultRealm;
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
-        XCTAssertTrue([realm.path hasSuffix:@"/default"]);
-        XCTAssertTrue([realm.path hasPrefix:NSTemporaryDirectory()]);
+        // using deprecated realm.path property here to validate the underlying
+        // shared group location because configuration.path is nil for in-memory
+        // realms.
+        realmPath = RLMRealm.defaultRealm.path;
+#pragma clang diagnostic pop
+        XCTAssertTrue([realmPath hasSuffix:@"/default"]);
+        XCTAssertTrue([realmPath hasPrefix:NSTemporaryDirectory()]);
     }
 
     config.schemaVersion = 1;
     RLMRealmConfiguration.defaultConfiguration = config;
     @autoreleasepool {
-        RLMRealm *realm = RLMRealm.defaultRealm;
-        XCTAssertEqual(1U, [RLMRealm schemaVersionAtPath:realm.path error:nil]);
+        __unused RLMRealm *realm = RLMRealm.defaultRealm;
+        XCTAssertEqual(1U, [RLMRealm schemaVersionAtPath:realmPath error:nil]);
     }
-#pragma clang diagnostic pop
 
     config.path = RLMDefaultRealmPath();
     RLMRealmConfiguration.defaultConfiguration = config;

--- a/Realm/Tests/RealmConfigurationTests.mm
+++ b/Realm/Tests/RealmConfigurationTests.mm
@@ -126,9 +126,9 @@
 
     config.inMemoryIdentifier = @"default";
     RLMRealmConfiguration.defaultConfiguration = config;
-    __block NSString *realmPath = nil;
     @autoreleasepool {
-        realmPath = @(config.config.path.c_str());
+        RLMRealm *realm = RLMRealm.defaultRealm;
+        NSString *realmPath = @(realm.configuration.config.path.c_str());
         XCTAssertTrue([realmPath hasSuffix:@"/default"]);
         XCTAssertTrue([realmPath hasPrefix:NSTemporaryDirectory()]);
     }
@@ -136,7 +136,8 @@
     config.schemaVersion = 1;
     RLMRealmConfiguration.defaultConfiguration = config;
     @autoreleasepool {
-        __unused RLMRealm *realm = RLMRealm.defaultRealm;
+        RLMRealm *realm = RLMRealm.defaultRealm;
+        NSString *realmPath = @(realm.configuration.config.path.c_str());
         XCTAssertEqual(1U, [RLMRealm schemaVersionAtPath:realmPath error:nil]);
     }
 

--- a/Realm/Tests/RealmConfigurationTests.mm
+++ b/Realm/Tests/RealmConfigurationTests.mm
@@ -18,12 +18,11 @@
 
 #import "RLMTestCase.h"
 
-#import "RLMRealmConfiguration_Private.h"
+#import "RLMRealmConfiguration_Private.hpp"
 #import "RLMTestObjects.h"
 #import "RLMUtil.hpp"
 
 @interface RealmConfigurationTests : RLMTestCase
-
 @end
 
 @implementation RealmConfigurationTests
@@ -129,13 +128,7 @@
     RLMRealmConfiguration.defaultConfiguration = config;
     __block NSString *realmPath = nil;
     @autoreleasepool {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-        // using deprecated realm.path property here to validate the underlying
-        // shared group location because configuration.path is nil for in-memory
-        // realms.
-        realmPath = RLMRealm.defaultRealm.path;
-#pragma clang diagnostic pop
+        realmPath = @(config.config.path.c_str());
         XCTAssertTrue([realmPath hasSuffix:@"/default"]);
         XCTAssertTrue([realmPath hasPrefix:NSTemporaryDirectory()]);
     }

--- a/Realm/Tests/RealmTests.mm
+++ b/Realm/Tests/RealmTests.mm
@@ -69,8 +69,11 @@ extern "C" {
     config.inMemoryIdentifier = @"identifier";
     RLMRealm *inMemoryRealm = [RLMRealm realmWithConfiguration:config error:nil];
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     // make sure we can't open disk-realm at same path
     config.path = inMemoryRealm.path;
+#pragma clang diagnostic pop
     NSError *error; // passing in a reference to assert that this error can't be catched!
     RLMAssertThrowsWithReasonMatching([RLMRealm realmWithConfiguration:config error:&error], @"Realm at path '.*' already opened with different inMemory settings");
 }
@@ -1090,7 +1093,7 @@ extern "C" {
     // runloop) is actually destroyed
     std::thread([&] { realm = [RLMRealm defaultRealm]; }).join();
 
-    [realm path]; // ensure ARC releases the object after the thread has finished
+    [realm.configuration path]; // ensure ARC releases the object after the thread has finished
 }
 
 - (void)testBackgroundRealmIsNotified {
@@ -1396,7 +1399,7 @@ extern "C" {
     RLMRealm *realm = [self realmWithTestPath];
 
     RLMRealmConfiguration *configuration = [RLMRealmConfiguration defaultConfiguration];
-    configuration.path = realm.path;
+    configuration.path = realm.configuration.path;
     XCTAssertThrows([RLMRealm migrateRealm:configuration]);
 }
 
@@ -1424,7 +1427,7 @@ extern "C" {
         NSDictionary *attributes = [[NSFileManager defaultManager] attributesOfItemAtPath:path error:nil];
         return [(NSNumber *)attributes[NSFileSize] unsignedLongLongValue];
     };
-    unsigned long long fileSizeBefore = fileSize(realm.path);
+    unsigned long long fileSizeBefore = fileSize(realm.configuration.path);
     StringObject *object = [StringObject allObjectsInRealm:realm].firstObject;
 
     XCTAssertTrue([realm compact]);
@@ -1434,7 +1437,7 @@ extern "C" {
     XCTAssertEqualObjects(@"A", [[StringObject allObjectsInRealm:realm].firstObject stringCol]);
     XCTAssertEqualObjects(@"B", [[StringObject allObjectsInRealm:realm].lastObject stringCol]);
 
-    unsigned long long fileSizeAfter = fileSize(realm.path);
+    unsigned long long fileSizeAfter = fileSize(realm.configuration.path);
     XCTAssertGreaterThan(fileSizeBefore, fileSizeAfter);
 }
 

--- a/Realm/Tests/RealmTests.mm
+++ b/Realm/Tests/RealmTests.mm
@@ -18,7 +18,7 @@
 
 #import "RLMTestCase.h"
 
-#import "RLMRealmConfiguration_Private.h"
+#import "RLMRealmConfiguration_Private.hpp"
 #import "RLMObjectSchema_Private.hpp"
 #import "RLMRealm_Dynamic.h"
 
@@ -69,14 +69,8 @@ extern "C" {
     config.inMemoryIdentifier = @"identifier";
     RLMRealm *inMemoryRealm = [RLMRealm realmWithConfiguration:config error:nil];
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     // make sure we can't open disk-realm at same path
-    // using deprecated realm.path property here to validate the underlying
-    // shared group location because configuration.path is nil for in-memory
-    // realms.
-    config.path = inMemoryRealm.path;
-#pragma clang diagnostic pop
+    config.path = @(inMemoryRealm.configuration.config.path.c_str());;
     NSError *error; // passing in a reference to assert that this error can't be catched!
     RLMAssertThrowsWithReasonMatching([RLMRealm realmWithConfiguration:config error:&error], @"Realm at path '.*' already opened with different inMemory settings");
 }

--- a/Realm/Tests/RealmTests.mm
+++ b/Realm/Tests/RealmTests.mm
@@ -72,6 +72,9 @@ extern "C" {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
     // make sure we can't open disk-realm at same path
+    // using deprecated realm.path property here to validate the underlying
+    // shared group location because configuration.path is nil for in-memory
+    // realms.
     config.path = inMemoryRealm.path;
 #pragma clang diagnostic pop
     NSError *error; // passing in a reference to assert that this error can't be catched!

--- a/RealmSwift-swift2.0/Realm.swift
+++ b/RealmSwift-swift2.0/Realm.swift
@@ -47,10 +47,12 @@ public final class Realm {
     // MARK: Properties
 
     /// Path to the file where this Realm is persisted.
-    public var path: String { return rlmRealm.path }
+    @available(*, deprecated=1, message="Use configuration.path")
+    public var path: String { return configuration.path! }
 
     /// Indicates if this Realm was opened in read-only mode.
-    public var readOnly: Bool { return rlmRealm.readOnly }
+    @available(*, deprecated=1, message="Use configuration.readOnly")
+    public var readOnly: Bool { return configuration.readOnly }
 
     /// The Schema used by this realm.
     public var schema: Schema { return Schema(rlmRealm.schema) }

--- a/RealmSwift-swift2.0/Tests/PerformanceTests.swift
+++ b/RealmSwift-swift2.0/Tests/PerformanceTests.swift
@@ -361,7 +361,7 @@ class SwiftPerformanceTests: TestCase {
                 }
             }
         }
-        _ = realm.path
+        _ = realm
     }
 
     func testRealmCreationUncached() {

--- a/RealmSwift-swift2.0/Tests/PerformanceTests.swift
+++ b/RealmSwift-swift2.0/Tests/PerformanceTests.swift
@@ -361,7 +361,7 @@ class SwiftPerformanceTests: TestCase {
                 }
             }
         }
-        _ = realm
+        _ = realm.configuration
     }
 
     func testRealmCreationUncached() {

--- a/RealmSwift-swift2.0/Tests/RealmCollectionTypeTests.swift
+++ b/RealmSwift-swift2.0/Tests/RealmCollectionTypeTests.swift
@@ -97,7 +97,7 @@ class RealmCollectionTypeTests: TestCase {
     }
 
     func testRealm() {
-        XCTAssertEqual(collection.realm!.path, realmWithTestPath().path)
+        XCTAssertEqual(collection.realm!.configuration.path, realmWithTestPath().configuration.path)
     }
 
     func testDescription() {

--- a/RealmSwift-swift2.0/Tests/RealmConfigurationTests.swift
+++ b/RealmSwift-swift2.0/Tests/RealmConfigurationTests.swift
@@ -24,7 +24,7 @@ class RealmConfigurationTests: TestCase {
     func testDefaultConfiguration() {
         let defaultConfiguration = Realm.Configuration.defaultConfiguration
 
-        XCTAssertEqual(defaultConfiguration.path, try! Realm().path)
+        XCTAssertEqual(defaultConfiguration.path, try! Realm().configuration.path)
         XCTAssertNil(defaultConfiguration.inMemoryIdentifier)
         XCTAssertNil(defaultConfiguration.encryptionKey)
         XCTAssertFalse(defaultConfiguration.readOnly)

--- a/RealmSwift-swift2.0/Tests/RealmTests.swift
+++ b/RealmSwift-swift2.0/Tests/RealmTests.swift
@@ -26,19 +26,19 @@ import Foundation
 
 class RealmTests: TestCase {
     func testPath() {
-        XCTAssertEqual(try! Realm(path: testRealmPath()).path, testRealmPath())
+        XCTAssertEqual(try! Realm(path: testRealmPath()).configuration.path, testRealmPath())
     }
 
     func testReadOnly() {
         autoreleasepool {
-            XCTAssertEqual(try! Realm().readOnly, false)
+            XCTAssertEqual(try! Realm().configuration.readOnly, false)
 
             try! Realm().write {
                 try! Realm().create(SwiftIntObject.self, value: [100])
             }
         }
         let readOnlyRealm = try! Realm(configuration: Realm.Configuration(path: defaultRealmPath(), readOnly: true))
-        XCTAssertEqual(true, readOnlyRealm.readOnly)
+        XCTAssertEqual(true, readOnlyRealm.configuration.readOnly)
         XCTAssertEqual(1, readOnlyRealm.objects(SwiftIntObject).count)
 
         assertThrows(try! Realm(), "Realm has different readOnly settings")
@@ -135,7 +135,7 @@ class RealmTests: TestCase {
     }
 
     func testInit() {
-        XCTAssertEqual(try! Realm(path: testRealmPath()).path, testRealmPath())
+        XCTAssertEqual(try! Realm(path: testRealmPath()).configuration.path, testRealmPath())
         assertThrows(try! Realm(path: ""))
     }
 
@@ -531,7 +531,7 @@ class RealmTests: TestCase {
         let realm = try! Realm()
         var notificationCalled = false
         let token = realm.addNotificationBlock { _, realm in
-            XCTAssertEqual(realm.path, self.defaultRealmPath())
+            XCTAssertEqual(realm.configuration.path, self.defaultRealmPath())
             notificationCalled = true
         }
         XCTAssertFalse(notificationCalled)
@@ -544,7 +544,7 @@ class RealmTests: TestCase {
         let realm = try! Realm()
         var notificationCalled = false
         let token = realm.addNotificationBlock { (notification, realm) -> Void in
-            XCTAssertEqual(realm.path, self.defaultRealmPath())
+            XCTAssertEqual(realm.configuration.path, self.defaultRealmPath())
             notificationCalled = true
         }
         token.stop()


### PR DESCRIPTION
Closes #3396. /cc @tgoyne @bdash 

I also think it would make sense to move `RLMRealm.schema` to `RLMRealmConfiguration.schema` (renaming `customSchema` to `schema` in the process), but that's a bit more involved so I want to make sure we agree it's a good idea before I go down that path.

To do:

- [x] Determine if we should move `RLMRealm.schema` to `RLMRealmConfiguration.schema`
- [x] Reflect these deprecations in Realm Swift