### PR TITLE
[Migration] Keep old value when nullable to required auto migration

### DIFF
--- a/Realm/Tests/MigrationTests.mm
+++ b/Realm/Tests/MigrationTests.mm
@@ -933,7 +933,7 @@ RLM_ARRAY_TYPE(MigrationObject);
     [self createTestRealmWithSchema:@[objectSchema] block:^(RLMRealm *realm) {
         [AllOptionalTypes createInRealm:realm withValue:@[ [NSNull null], [NSNull null], [NSNull null], [NSNull null],
                                                            [NSNull null], [NSNull null], [NSNull null]]];
-        [AllOptionalTypes createInRealm:realm withValue:@[@2, @2, @2, @0, @"str2",
+        [AllOptionalTypes createInRealm:realm withValue:@[@2, @2, @2, @1, @"str2",
                                                           [@"data2" dataUsingEncoding:NSUTF8StringEncoding],
                                                           [NSDate dateWithTimeIntervalSince1970:2]]];
     }];
@@ -965,13 +965,13 @@ RLM_ARRAY_TYPE(MigrationObject);
     XCTAssertEqualObjects([NSDate dateWithTimeIntervalSince1970:0], obj.date);
 
     obj = allObjects[1];
-    XCTAssertEqualObjects(@0, obj.intObj);
-    XCTAssertEqualObjects(@0, obj.floatObj);
-    XCTAssertEqualObjects(@0, obj.doubleObj);
-    XCTAssertEqualObjects(@0, obj.boolObj);
-    XCTAssertEqualObjects(@"", obj.string);
-    XCTAssertEqualObjects(NSData.data, obj.data);
-    XCTAssertEqualObjects([NSDate dateWithTimeIntervalSince1970:0], obj.date);
+    XCTAssertEqualObjects(@2, obj.intObj);
+    XCTAssertEqualObjects(@2, obj.floatObj);
+    XCTAssertEqualObjects(@2, obj.doubleObj);
+    XCTAssertEqualObjects(@1, obj.boolObj);
+    XCTAssertEqualObjects(@"str2", obj.string);
+    XCTAssertEqualObjects([@"data2" dataUsingEncoding:NSUTF8StringEncoding], obj.data);
+    XCTAssertEqualObjects([NSDate dateWithTimeIntervalSince1970:2], obj.date);
 }
 
 - (void)testMigrationAfterReorderingProperties {


### PR DESCRIPTION
If change the property attribute from nullable to required, automatic migration works. But the values will be cleared. This behavior is difficult to understand what happened.
So keep the value if just changing nullability.

If the old value is null, the new value will be an empty string, a zero, a zero-length data or a UNIX epoch date.

This user confused the current behavior https://github.com/realm/realm-cocoa/issues/3413.

CC @tgoyne @jpsim @bdash