### PR TITLE
Have -[RLMResults indexOfObjectWithPredicate:] respect the sort order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ x.x.x Release notes (yyyy-MM-dd)
   for `RLMResults` instances that were created by filtering an `RLMArray`.
 * Adjust how RLMObjects are destroyed in order to support using an associated
   object on an RLMObject to remove KVO observers from that RLMObject.
+* `-[RLMResults indexOfObjectWithPredicate:]` now returns the index of the first matching object for a
+  sorted `RLMResults`, matching its documented behavior.
 
 0.98.6 Release notes (2016-03-25)
 =============================================================

--- a/Realm/RLMResults.mm
+++ b/Realm/RLMResults.mm
@@ -287,10 +287,18 @@ static inline void RLMResultsValidateInWriteTransaction(__unsafe_unretained RLMR
     Query query = translateErrors([&] { return _results.get_query(); });
     RLMUpdateQueryWithPredicate(&query, predicate, _realm.schema, _objectSchema);
 
-    // FIXME: We're only looking for a single object so we'd like to be able to use `Query::find`
-    // for this, but as of core v0.97.1 it gives incorrect results if the query is restricted
-    // to a link view (<https://github.com/realm/realm-core/issues/1565>).
-    auto table_view = query.find_all(0, -1, 1);
+    TableView table_view;
+    if (const auto& sort = _results.get_sort()) {
+        // A sort order is specified so we need to return the first match given that ordering.
+        table_view = query.find_all();
+        table_view.sort(sort.columnIndices, sort.ascending);
+    } else {
+        // No sort order is specified so we only need to find a single match.
+        // FIXME: We're only looking for a single object so we'd like to be able to use `Query::find`
+        // for this, but as of core v0.97.1 it gives incorrect results if the query is restricted
+        // to a link view (<https://github.com/realm/realm-core/issues/1565>).
+        table_view = query.find_all(0, -1, 1);
+    }
     if (!table_view.size()) {
         return NSNotFound;
     }

--- a/Realm/Tests/ResultsTests.m
+++ b/Realm/Tests/ResultsTests.m
@@ -479,6 +479,7 @@
     [EmployeeObject createInRealm:realm withValue:@{@"name": @"Joe",  @"age": @40, @"hired": @YES}];
     [EmployeeObject createInRealm:realm withValue:@{@"name": @"John", @"age": @30, @"hired": @NO}];
     [EmployeeObject createInRealm:realm withValue:@{@"name": @"Jill", @"age": @25, @"hired": @YES}];
+    [EmployeeObject createInRealm:realm withValue:@{@"name": @"Phil", @"age": @38, @"hired": @NO}];
     [realm commitWriteTransaction];
 
     RLMResults *results = [EmployeeObject objectsWhere:@"hired = YES"];
@@ -491,6 +492,14 @@
     XCTAssertEqual(1U, ([results indexOfObjectWhere:@"age = %d", 30]));
     XCTAssertEqual(2U, ([results indexOfObjectWhere:@"age = %d", 25]));
     XCTAssertEqual((NSUInteger)NSNotFound, ([results indexOfObjectWhere:@"age = %d", 35]));
+
+    results = [[EmployeeObject allObjects] sortedResultsUsingProperty:@"age" ascending:YES];
+    NSUInteger youngestHired = [results indexOfObjectWhere:@"hired = YES"];
+    XCTAssertEqual(0U, youngestHired);
+    XCTAssertEqualObjects(@"Jill", [results[youngestHired] name]);
+    NSUInteger youngestNotHired = [results indexOfObjectWhere:@"hired = NO"];
+    XCTAssertEqual(1U, youngestNotHired);
+    XCTAssertEqualObjects(@"John", [results[youngestNotHired] name]);
 }
 
 - (void)testSubqueryLifetime


### PR DESCRIPTION
If the `RLMResults` has been sorted then the returned index should be the first object that is matched by the predicate, not an arbitrary object.

Fixes #3410.

/cc @jpsim @tgoyne 

The performance here could be improved if `TableView` supported partial sorting or selecting the nth element based on the sort criteria. Those doesn't really fit with `TableView`'s current design for sorting though.