### PR TITLE
Set error if mmap address space is exhausted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,8 @@ x.x.x Release notes (yyyy-MM-dd)
 
 ### Enhancements
 
-* None.
+* Return a recoverable `RLMErrorAddressSpaceExhausted` error rather than crashing when failing to
+  mmap in Realm initialization or write commit.
 
 ### Bugfixes
 

--- a/Realm/RLMConstants.h
+++ b/Realm/RLMConstants.h
@@ -81,6 +81,8 @@ typedef NS_ENUM(NSInteger, RLMError) {
         process which cannot share with the current process due to an
         architecture mismatch. */
     RLMErrorIncompatibleLockFile  = 8,
+    /** Returned by RLMRealm if there is insufficient available address space. */
+    RLMErrorAddressSpaceExhausted = 9,
 };
 
 #pragma mark - Constants

--- a/Realm/RLMRealm.mm
+++ b/Realm/RLMRealm.mm
@@ -265,6 +265,9 @@ void RLMRealmTranslateException(NSError **error) {
                 break;
         }
     }
+    catch (AddressSpaceExhausted const &ex) {
+        RLMSetErrorOrThrow(RLMMakeError(RLMErrorAddressSpaceExhausted, ex), error);
+    }
     catch (std::system_error const& ex) {
         RLMSetErrorOrThrow(RLMMakeError(ex), error);
     }
@@ -484,6 +487,10 @@ void RLMRealmTranslateException(NSError **error) {
     }
     catch (File::AccessError const& ex) {
         RLMSetErrorOrThrow(RLMMakeError(RLMErrorFail, ex), outError);
+        return NO;
+    }
+    catch (AddressSpaceExhausted const &ex) {
+        RLMSetErrorOrThrow(RLMMakeError(RLMErrorAddressSpaceExhausted, ex), outError);
         return NO;
     }
     catch (std::exception const& ex) {

--- a/Realm/Tests/RealmTests.mm
+++ b/Realm/Tests/RealmTests.mm
@@ -177,6 +177,7 @@ extern "C" {
     RLMAssertThrowsWithCodeMatching([RLMRealm realmWithConfiguration:config error:nil], RLMErrorFileFormatUpgradeRequired);
 }
 
+#if TARGET_OS_IPHONE && (!TARGET_IPHONE_SIMULATOR || !TARGET_RT_64_BIT)
 - (void)testExceedingVirtualAddressSpace {
     RLMRealmConfiguration *config = [RLMRealmConfiguration defaultConfiguration];
 
@@ -227,6 +228,7 @@ extern "C" {
         XCTAssertNoThrow([RLMRealm realmWithConfiguration:config error:nil]);
     }
 }
+#endif
 
 #pragma mark - Adding and Removing Objects
 

--- a/RealmSwift-swift2.0/Error.swift
+++ b/RealmSwift-swift2.0/Error.swift
@@ -87,7 +87,7 @@ public enum Error: ErrorType {
     /// cannot share with the current process due to an architecture mismatch.
     case IncompatibleLockFile
 
-    /// Returned by RLMRealm if a file format upgrade is required to open the file,
+    /// Error thrown by Realm if a file format upgrade is required to open the file,
     /// but upgrades were explicilty disabled.
     case FileFormatUpgradeRequired
 }

--- a/RealmSwift-swift2.0/Error.swift
+++ b/RealmSwift-swift2.0/Error.swift
@@ -62,6 +62,8 @@ public enum Error: ErrorType {
             return RLMError.IncompatibleLockFile
         case .FileFormatUpgradeRequired:
             return RLMError.FileFormatUpgradeRequired
+        case .AddressSpaceExhausted:
+            return RLMError.AddressSpaceExhausted
         }
     }
 
@@ -90,6 +92,9 @@ public enum Error: ErrorType {
     /// Error thrown by Realm if a file format upgrade is required to open the file,
     /// but upgrades were explicilty disabled.
     case FileFormatUpgradeRequired
+
+    /// Error thrown by Realm if there is insufficient available address space.
+    case AddressSpaceExhausted
 }
 
 // MARK: Equatable


### PR DESCRIPTION
This is based on the assumption that the address space will be exhausted most commonly either on trying to map a Realm database which doesn't fit in the left address space or on committing a writing transaction when the memory is resized, while this could also happen on (auto-)refreshes.
Fixes #2269.

/c @jpsim @bdash @tgoyne 