### PR TITLE
Deprecate mixed properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ x.x.x Release notes (yyyy-MM-dd)
   `-[RLMNotificationToken stop]`.
 * `RLMRealm.path` and `RLMRealm.readOnly` have been deprecated in favor of their
   counterparts on `RLMRealmConfiguration`.
+* Deprecate properties of type `id`/`AnyObject`. This type was rarely used,
+  rarely useful and unsupported in every other Realm binding.
 
 ### Enhancements
 

--- a/Realm/RLMProperty.mm
+++ b/Realm/RLMProperty.mm
@@ -57,9 +57,17 @@ BOOL RLMPropertyTypeIsNumeric(RLMPropertyType propertyType) {
         _optional = optional;
         [self setObjcCodeFromType];
         [self updateAccessors];
+        [self logWarningIfMixed];
     }
 
     return self;
+}
+
+- (void)logWarningIfMixed {
+    if (_type == RLMPropertyTypeAny) {
+        NSLog(@"WARNING: Property '%@' is declared as type 'id', which is a deprecated type. "
+              "Support for 'id' properties will be removed in a future release.", _name);
+    }
 }
 
 -(void)updateAccessors {
@@ -317,6 +325,8 @@ BOOL RLMPropertyTypeIsNumeric(RLMPropertyType propertyType) {
             // Don't throw if the property is a List/RealmOptional property because those types only
             // get reported to ObjC with Swift 1.2 and not 2+.
             throwForPropertyName(self.name);
+        } else {
+            [self logWarningIfMixed];
         }
     } else if (_objcType == 'c') {
         // Check if it's a BOOL or Int8 by trying to set it to 2 and seeing if
@@ -352,6 +362,7 @@ BOOL RLMPropertyTypeIsNumeric(RLMPropertyType propertyType) {
         @throw RLMException(@"Can't persist property '%@' with incompatible type. "
                              "Add to ignoredPropertyNames: method to ignore.", self.name);
     }
+    [self logWarningIfMixed];
 
     // update getter/setter names
     [self updateAccessors];

--- a/Realm/RLMSchema.mm
+++ b/Realm/RLMSchema.mm
@@ -64,6 +64,15 @@ static RLMObjectSchema *RLMRegisterClass(Class cls) {
     RLMObjectSchema *schema = [RLMObjectSchema schemaForObjectClass:cls];
     s_sharedSchemaState = prevState;
 
+    // check whether mixed properties are used
+    for (RLMProperty *property in schema.properties) {
+        if (property.type == RLMPropertyTypeAny) {
+            NSLog(@"WARNING: Property '%@' of class '%@' is declared as type 'id'. "
+                   "Mixed properties are deprecated and support for them will be "
+                   "removed in a future release.", property.name, schema.className);
+        }
+    }
+
     // set standalone class on shared shema for standalone object creation
     schema.standaloneClass = RLMStandaloneAccessorClassForObjectClass(schema.objectClass, schema);
 

--- a/Realm/RLMSchema.mm
+++ b/Realm/RLMSchema.mm
@@ -64,15 +64,6 @@ static RLMObjectSchema *RLMRegisterClass(Class cls) {
     RLMObjectSchema *schema = [RLMObjectSchema schemaForObjectClass:cls];
     s_sharedSchemaState = prevState;
 
-    // check whether mixed properties are used
-    for (RLMProperty *property in schema.properties) {
-        if (property.type == RLMPropertyTypeAny) {
-            NSLog(@"WARNING: Property '%@' of class '%@' is declared as type 'id'. "
-                   "Mixed properties are deprecated and support for them will be "
-                   "removed in a future release.", property.name, schema.className);
-        }
-    }
-
     // set standalone class on shared shema for standalone object creation
     schema.standaloneClass = RLMStandaloneAccessorClassForObjectClass(schema.objectClass, schema);
 


### PR DESCRIPTION
Fixes #3347.

This warns only once on initialization of the shared runtime schema and points out which property cause the warning.
There is no warning yet for dynamic schemas, but as we consider them a more advanced feature, a deprecation warning there might not be necessary at all cost.

#### ToDo

* [x] Add changelog entry
* [x] Decide whether a warning is needed for dynamic schemas

/c @jpsim