### PR TITLE
Fix a use-after-free when removing KVO observers via an associated object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ x.x.x Release notes (yyyy-MM-dd)
 
 ### Bugfixes
 
-* None.
+* Fix a use-after-free when an associated object's dealloc method is used to
+  remove observers from an RLMObject.
 
 0.98.8 Release notes (2016-04-15)
 =============================================================

--- a/Realm/RLMObjectBase.mm
+++ b/Realm/RLMObjectBase.mm
@@ -66,9 +66,10 @@ static bool RLMInitializedObjectSchema(RLMObjectBase *obj) {
 
 - (void)dealloc {
     // This can't be a unique_ptr because associated objects are removed
-    // *after* c++ members are destroyed, and we need it to still be alive when
-    // that happens
+    // *after* c++ members are destroyed and dealloc is called, and we need it
+    // to be in a validish state when that happens
     delete _observationInfo;
+    _observationInfo = nullptr;
 }
 
 static id RLMValidatedObjectForProperty(id obj, RLMProperty *prop, RLMSchema *schema) {
@@ -302,7 +303,8 @@ static id RLMValidatedObjectForProperty(id obj, RLMProperty *prop, RLMSchema *sc
 
 - (void)removeObserver:(NSObject *)observer forKeyPath:(NSString *)keyPath {
     [super removeObserver:observer forKeyPath:keyPath];
-    _observationInfo->removeObserver();
+    if (_observationInfo)
+        _observationInfo->removeObserver();
 }
 
 + (BOOL)automaticallyNotifiesObserversForKey:(NSString *)key {


### PR DESCRIPTION
Associated objects are actually removed *after* dealloc is called, so supporting this means supporting calling removeObserver:forKeyPath: on an RLMObject after dealloc.