### PR TITLE
Deprecate string-based path APIs in favor of NSURL-based ones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,31 +9,31 @@ x.x.x Release notes (yyyy-MM-dd)
   `-[RLMResults addNotificationBlock:]` now takes another parameter.
 * The following Objective-C APIs have been deprecated in favor of newer or preferred versions:
 
-| Deprecated API                                         | New API                                                   |
-|:-------------------------------------------------------|:----------------------------------------------------------|
-| `-[RLMRealm removeNotification:]`                      | `-[RLMNotificationToken stop]`                            |
-| `RLMRealmConfiguration.path`                           | `RLMRealmConfiguration.fileURL`                           |
-| `RLMRealm.path`                                        | `RLMRealmConfiguration.fileURL`                           |
-| `RLMRealm.readOnly`                                    | `RLMRealmConfiguration.readOnly`                          |
-| `+[RLMRealm realmWithPath:]`                           | `+[RLMRealm realmWithFileURL:]`                           |
-| `+[RLMRealm writeCopyToPath:error:]`                   | `+[RLMRealm writeCopyToFileURL:encryptionKey:error:]`     |
-| `+[RLMRealm writeCopyToPath:encryptionKey:error:]`     | `+[RLMRealm writeCopyToFileURL:encryptionKey:error:]`     |
-| `+[RLMRealm schemaVersionAtPath:error:]`               | `+[RLMRealm schemaVersionAtFileURL:encryptionKey:error:]` |
-| `+[RLMRealm writeCopyToPath:error:]`                   | `+[RLMRealm writeCopyToFileURL:error:]`                   |
-| `+[RLMRealm writeCopyToPath:encryptionKey:error:]`     | `+[RLMRealm writeCopyToFileURL:encryptionKey:error:]`     |
-| `+[RLMRealm schemaVersionAtPath:error:]`               | `+[RLMRealm schemaVersionAtFileURL:error:]`               |
-| `+[RLMRealm schemaVersionAtPath:encryptionKey:error:]` | `+[RLMRealm schemaVersionAtFileURL:encryptionKey:error:]` |
+| Deprecated API                                         | New API                                               |
+|:-------------------------------------------------------|:------------------------------------------------------|
+| `-[RLMRealm removeNotification:]`                      | `-[RLMNotificationToken stop]`                        |
+| `RLMRealmConfiguration.path`                           | `RLMRealmConfiguration.fileURL`                       |
+| `RLMRealm.path`                                        | `RLMRealmConfiguration.fileURL`                       |
+| `RLMRealm.readOnly`                                    | `RLMRealmConfiguration.readOnly`                      |
+| `+[RLMRealm realmWithPath:]`                           | `+[RLMRealm realmWithURL:]`                       |
+| `+[RLMRealm writeCopyToPath:error:]`                   | `+[RLMRealm writeCopyToURL:encryptionKey:error:]`     |
+| `+[RLMRealm writeCopyToPath:encryptionKey:error:]`     | `+[RLMRealm writeCopyToURL:encryptionKey:error:]`     |
+| `+[RLMRealm schemaVersionAtPath:error:]`               | `+[RLMRealm schemaVersionAtURL:encryptionKey:error:]` |
+| `+[RLMRealm writeCopyToPath:error:]`                   | `+[RLMRealm writeCopyToURL:error:]`                   |
+| `+[RLMRealm writeCopyToPath:encryptionKey:error:]`     | `+[RLMRealm writeCopyToURL:encryptionKey:error:]`     |
+| `+[RLMRealm schemaVersionAtPath:error:]`               | `+[RLMRealm schemaVersionAtURL:error:]`               |
+| `+[RLMRealm schemaVersionAtPath:encryptionKey:error:]` | `+[RLMRealm schemaVersionAtURL:encryptionKey:error:]` |
 
 * The following Swift APIs have been deprecated in favor of newer or preferred versions:
 
-| Deprecated API                                | New API                                      |
-|:----------------------------------------------|:---------------------------------------------|
-| `Realm.removeNotification(_:)`                | `NotificationToken.stop()`                   |
-| `Realm.Configuration.path`                    | `Realm.Configuration.fileURL`                |
-| `Realm.path`                                  | `Realm.Configuration.fileURL`                |
-| `Realm.readOnly`                              | `Realm.Configuration.readOnly`               |
-| `Realm.writeCopyToPath(_:encryptionKey:)`     | `Realm.writeCopyToFileURL(_:encryptionKey:)` |
-| `schemaVersionAtPath(_:encryptionKey:error:)` | `schemaVersionAtFileURL(_:encryptionKey:)`   |
+| Deprecated API                                | New API                                  |
+|:----------------------------------------------|:-----------------------------------------|
+| `Realm.removeNotification(_:)`                | `NotificationToken.stop()`               |
+| `Realm.Configuration.path`                    | `Realm.Configuration.fileURL`            |
+| `Realm.path`                                  | `Realm.Configuration.fileURL`            |
+| `Realm.readOnly`                              | `Realm.Configuration.readOnly`           |
+| `Realm.writeCopyToPath(_:encryptionKey:)`     | `Realm.writeCopyToURL(_:encryptionKey:)` |
+| `schemaVersionAtPath(_:encryptionKey:error:)` | `schemaVersionAtURL(_:encryptionKey:)`   |
 
 ### Enhancements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,9 @@ x.x.x Release notes (yyyy-MM-dd)
 | Deprecated API                                         | New API                                                   |
 |:-------------------------------------------------------|:----------------------------------------------------------|
 | `-[RLMRealm removeNotification:]`                      | `-[RLMNotificationToken stop]`                            |
-| `RLMRealmConfiguration.path`                           | `RLMConfiguration.fileURL`                                |
-| `RLMRealm.path`                                        | `RLMConfiguration.fileURL`                                |
-| `RLMRealm.readOnly`                                    | `RLMConfiguration.readOnly`                               |
+| `RLMRealmConfiguration.path`                           | `RLMRealmConfiguration.fileURL`                           |
+| `RLMRealm.path`                                        | `RLMRealmConfiguration.fileURL`                           |
+| `RLMRealm.readOnly`                                    | `RLMRealmConfiguration.readOnly`                          |
 | `+[RLMRealm realmWithPath:]`                           | `+[RLMRealm realmWithFileURL:]`                           |
 | `+[RLMRealm writeCopyToPath:error:]`                   | `+[RLMRealm writeCopyToFileURL:encryptionKey:error:]`     |
 | `+[RLMRealm writeCopyToPath:encryptionKey:error:]`     | `+[RLMRealm writeCopyToFileURL:encryptionKey:error:]`     |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,57 @@ x.x.x Release notes (yyyy-MM-dd)
   rarely useful and unsupported in every other Realm binding.
 * The block for `-[RLMArray addNotificationBlock:]` and
   `-[RLMResults addNotificationBlock:]` now takes another parameter.
+* The following Objective-C APIs have been deprecated in favor of newer or preferred versions:
+
+| Deprecated API                              | New API                                   |
+|:--------------------------------------------|:------------------------------------------|
+| `-[RLMRealm removeNotification:]`           | `-[RLMNotificationToken stop]`            |
+| `+[RLMObject primaryKey]`                   | `+[RLMObject objectID]`                   |
+| `+[RLMObject objectForPrimaryKey:]`         | `+[RLMObject objectForObjectID:]`         |
+| `+[RLMObject objectInRealm:forPrimaryKey:]` | `+[RLMObject objectInRealm:forObjectID:]` |
+| `-[RLMObjectSchema primaryKeyProperty]`     | `-[RLMObjectSchema objectIDProperty]`     |
+| `RLMRealm.path`                             | `RLMConfiguration.path`                   |
+| `RLMRealm.readOnly`                         | `RLMConfiguration.readOnly`               |
+
+* The following Swift APIs have been deprecated in favor of newer or preferred versions:
+
+| Deprecated API                      | New API                          |
+|:------------------------------------|:---------------------------------|
+| `Realm.removeNotification(_:)`      | `NotificationToken.stop()`       |
+| `Object.primaryKey()`               | `Object.objectID()`              |
+| `Realm.objectForPrimaryKey(_:key:)` | `Realm.objectForObjectID(_:id:)` |
+| `ObjectSchema.primaryKeyProperty`   | `ObjectSchema.objectIDProperty`  |
+| `Realm.path`                        | `Realm.Configuration.fileURL`    |
+| `Realm.readOnly`                    | `Realm.Configuration.readOnly`   |
+| Deprecated API                                         | New API                                                   |
+|:-------------------------------------------------------|:----------------------------------------------------------|
+| `-[RLMRealm removeNotification:]`                      | `-[RLMNotificationToken stop]`                            |
+| `+[RLMObject primaryKey]`                              | `+[RLMObject objectID]`                                   |
+| `+[RLMObject objectForPrimaryKey:]`                    | `+[RLMObject objectWithID:]`                              |
+| `+[RLMObject objectInRealm:forPrimaryKey:]`            | `+[RLMObject objectInRealm:withID:]`                      |
+| `-[RLMObjectSchema primaryKeyProperty]`                | `-[RLMObjectSchema objectIDProperty]`                     |
+| `RLMRealmConfiguration.path`                           | `RLMConfiguration.fileURL`                                |
+| `RLMRealm.path`                                        | `RLMConfiguration.fileURL`                                |
+| `RLMRealm.readOnly`                                    | `RLMConfiguration.readOnly`                               |
+| `+[RLMRealm realmWithPath:]`                           | `+[RLMRealm realmWithFileURL:]`                           |
+| `+[RLMRealm writeCopyToPath:error:]`                   | `+[RLMRealm writeCopyToFileURL:encryptionKey:error:]`     |
+| `+[RLMRealm writeCopyToPath:encryptionKey:error:]`     | `+[RLMRealm writeCopyToFileURL:encryptionKey:error:]`     |
+| `+[RLMRealm schemaVersionAtPath:error:]`               | `+[RLMRealm schemaVersionAtFileURL:encryptionKey:error:]` |
+| `+[RLMRealm schemaVersionAtPath:encryptionKey:error:]` | `+[RLMRealm schemaVersionAtFileURL:encryptionKey:error:]` |
+
+* The following Swift APIs have been deprecated in favor of newer or preferred versions:
+
+| Deprecated API                                | New API                                      |
+|:----------------------------------------------|:---------------------------------------------|
+| `Realm.removeNotification(_:)`                | `NotificationToken.stop()`                   |
+| `Object.primaryKey()`                         | `Object.objectID()`                          |
+| `Realm.objectForPrimaryKey(_:key:)`           | `Realm.objectWithID(_:id:)`                  |
+| `ObjectSchema.primaryKeyProperty`             | `ObjectSchema.objectIDProperty`              |
+| `Realm.Configuration.path`                    | `Realm.Configuration.fileURL`                |
+| `Realm.path`                                  | `Realm.Configuration.fileURL`                |
+| `Realm.readOnly`                              | `Realm.Configuration.readOnly`               |
+| `Realm.writeCopyToPath(_:encryptionKey:)`     | `Realm.writeCopyToFileURL(_:encryptionKey:)` |
+| `schemaVersionAtPath(_:encryptionKey:error:)` | `schemaVersionAtFileURL(_:encryptionKey:)`   |
 
 ### Enhancements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,13 +15,10 @@ x.x.x Release notes (yyyy-MM-dd)
 | `RLMRealmConfiguration.path`                           | `RLMRealmConfiguration.fileURL`                       |
 | `RLMRealm.path`                                        | `RLMRealmConfiguration.fileURL`                       |
 | `RLMRealm.readOnly`                                    | `RLMRealmConfiguration.readOnly`                      |
-| `+[RLMRealm realmWithPath:]`                           | `+[RLMRealm realmWithURL:]`                       |
+| `+[RLMRealm realmWithPath:]`                           | `+[RLMRealm realmWithURL:]`                           |
 | `+[RLMRealm writeCopyToPath:error:]`                   | `+[RLMRealm writeCopyToURL:encryptionKey:error:]`     |
 | `+[RLMRealm writeCopyToPath:encryptionKey:error:]`     | `+[RLMRealm writeCopyToURL:encryptionKey:error:]`     |
 | `+[RLMRealm schemaVersionAtPath:error:]`               | `+[RLMRealm schemaVersionAtURL:encryptionKey:error:]` |
-| `+[RLMRealm writeCopyToPath:error:]`                   | `+[RLMRealm writeCopyToURL:error:]`                   |
-| `+[RLMRealm writeCopyToPath:encryptionKey:error:]`     | `+[RLMRealm writeCopyToURL:encryptionKey:error:]`     |
-| `+[RLMRealm schemaVersionAtPath:error:]`               | `+[RLMRealm schemaVersionAtURL:error:]`               |
 | `+[RLMRealm schemaVersionAtPath:encryptionKey:error:]` | `+[RLMRealm schemaVersionAtURL:encryptionKey:error:]` |
 
 * The following Swift APIs have been deprecated in favor of newer or preferred versions:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,43 +3,15 @@ x.x.x Release notes (yyyy-MM-dd)
 
 ### API breaking changes
 
-* Deprecate `-[RLMRealm removeNotification:]` in favor of
-  `-[RLMNotificationToken stop]`.
-* `RLMRealm.path` and `RLMRealm.readOnly` have been deprecated in favor of their
-  counterparts on `RLMRealmConfiguration`.
 * Deprecate properties of type `id`/`AnyObject`. This type was rarely used,
   rarely useful and unsupported in every other Realm binding.
 * The block for `-[RLMArray addNotificationBlock:]` and
   `-[RLMResults addNotificationBlock:]` now takes another parameter.
 * The following Objective-C APIs have been deprecated in favor of newer or preferred versions:
 
-| Deprecated API                              | New API                                   |
-|:--------------------------------------------|:------------------------------------------|
-| `-[RLMRealm removeNotification:]`           | `-[RLMNotificationToken stop]`            |
-| `+[RLMObject primaryKey]`                   | `+[RLMObject objectID]`                   |
-| `+[RLMObject objectForPrimaryKey:]`         | `+[RLMObject objectForObjectID:]`         |
-| `+[RLMObject objectInRealm:forPrimaryKey:]` | `+[RLMObject objectInRealm:forObjectID:]` |
-| `-[RLMObjectSchema primaryKeyProperty]`     | `-[RLMObjectSchema objectIDProperty]`     |
-| `RLMRealm.path`                             | `RLMConfiguration.path`                   |
-| `RLMRealm.readOnly`                         | `RLMConfiguration.readOnly`               |
-
-* The following Swift APIs have been deprecated in favor of newer or preferred versions:
-
-| Deprecated API                      | New API                          |
-|:------------------------------------|:---------------------------------|
-| `Realm.removeNotification(_:)`      | `NotificationToken.stop()`       |
-| `Object.primaryKey()`               | `Object.objectID()`              |
-| `Realm.objectForPrimaryKey(_:key:)` | `Realm.objectForObjectID(_:id:)` |
-| `ObjectSchema.primaryKeyProperty`   | `ObjectSchema.objectIDProperty`  |
-| `Realm.path`                        | `Realm.Configuration.fileURL`    |
-| `Realm.readOnly`                    | `Realm.Configuration.readOnly`   |
 | Deprecated API                                         | New API                                                   |
 |:-------------------------------------------------------|:----------------------------------------------------------|
 | `-[RLMRealm removeNotification:]`                      | `-[RLMNotificationToken stop]`                            |
-| `+[RLMObject primaryKey]`                              | `+[RLMObject objectID]`                                   |
-| `+[RLMObject objectForPrimaryKey:]`                    | `+[RLMObject objectWithID:]`                              |
-| `+[RLMObject objectInRealm:forPrimaryKey:]`            | `+[RLMObject objectInRealm:withID:]`                      |
-| `-[RLMObjectSchema primaryKeyProperty]`                | `-[RLMObjectSchema objectIDProperty]`                     |
 | `RLMRealmConfiguration.path`                           | `RLMConfiguration.fileURL`                                |
 | `RLMRealm.path`                                        | `RLMConfiguration.fileURL`                                |
 | `RLMRealm.readOnly`                                    | `RLMConfiguration.readOnly`                               |
@@ -47,6 +19,9 @@ x.x.x Release notes (yyyy-MM-dd)
 | `+[RLMRealm writeCopyToPath:error:]`                   | `+[RLMRealm writeCopyToFileURL:encryptionKey:error:]`     |
 | `+[RLMRealm writeCopyToPath:encryptionKey:error:]`     | `+[RLMRealm writeCopyToFileURL:encryptionKey:error:]`     |
 | `+[RLMRealm schemaVersionAtPath:error:]`               | `+[RLMRealm schemaVersionAtFileURL:encryptionKey:error:]` |
+| `+[RLMRealm writeCopyToPath:error:]`                   | `+[RLMRealm writeCopyToFileURL:error:]`                   |
+| `+[RLMRealm writeCopyToPath:encryptionKey:error:]`     | `+[RLMRealm writeCopyToFileURL:encryptionKey:error:]`     |
+| `+[RLMRealm schemaVersionAtPath:error:]`               | `+[RLMRealm schemaVersionAtFileURL:error:]`               |
 | `+[RLMRealm schemaVersionAtPath:encryptionKey:error:]` | `+[RLMRealm schemaVersionAtFileURL:encryptionKey:error:]` |
 
 * The following Swift APIs have been deprecated in favor of newer or preferred versions:
@@ -54,9 +29,6 @@ x.x.x Release notes (yyyy-MM-dd)
 | Deprecated API                                | New API                                      |
 |:----------------------------------------------|:---------------------------------------------|
 | `Realm.removeNotification(_:)`                | `NotificationToken.stop()`                   |
-| `Object.primaryKey()`                         | `Object.objectID()`                          |
-| `Realm.objectForPrimaryKey(_:key:)`           | `Realm.objectWithID(_:id:)`                  |
-| `ObjectSchema.primaryKeyProperty`             | `ObjectSchema.objectIDProperty`              |
 | `Realm.Configuration.path`                    | `Realm.Configuration.fileURL`                |
 | `Realm.path`                                  | `Realm.Configuration.fileURL`                |
 | `Realm.readOnly`                              | `Realm.Configuration.readOnly`               |

--- a/Realm/RLMRealm.h
+++ b/Realm/RLMRealm.h
@@ -510,7 +510,19 @@ typedef void (^RLMMigrationBlock)(RLMMigration *migration, uint64_t oldSchemaVer
 
  @return            The version of the Realm at `realmPath` or RLMNotVersioned if the version cannot be read.
  */
-+ (uint64_t)schemaVersionAtPath:(NSString *)realmPath error:(NSError **)error;
++ (uint64_t)schemaVersionAtPath:(NSString *)realmPath error:(NSError **)error DEPRECATED_MSG_ATTRIBUTE("use +[RLMRealm schemaVersionAtFileURL:error:]");
+
+/**
+ Get the schema version for a Realm at a given local URL.
+
+ @param fileURL Local URL to a Realm file.
+ @param error   If an error occurs, upon return contains an `NSError` object
+                that describes the problem. If you are not interested in
+                possible errors, pass in `NULL`.
+
+ @return        The version of the Realm at `realmPath` or RLMNotVersioned if the version cannot be read.
+ */
++ (uint64_t)schemaVersionAtFileURL:(NSURL *)fileURL error:(NSError **)error;
 
 /**
  Get the schema version for an encrypted Realm at a given path.
@@ -521,9 +533,22 @@ typedef void (^RLMMigrationBlock)(RLMMigration *migration, uint64_t oldSchemaVer
                     that describes the problem. If you are not interested in
                     possible errors, pass in `NULL`.
 
- @return            The version of the Realm at `realmPath` or RLMNotVersioned if the version cannot be read.
+ @return            The version of the Realm at `fileURL` or RLMNotVersioned if the version cannot be read.
  */
-+ (uint64_t)schemaVersionAtPath:(NSString *)realmPath encryptionKey:(nullable NSData *)key error:(NSError **)error;
++ (uint64_t)schemaVersionAtPath:(NSString *)realmPath encryptionKey:(nullable NSData *)key error:(NSError **)error DEPRECATED_MSG_ATTRIBUTE("use +[RLMRealm schemaVersionAtFileURL:encryptionKey:error:]");
+
+/**
+ Get the schema version for an encrypted Realm at a given local URL.
+
+ @param fileURL Local URL to a Realm file
+ @param key     64-byte encryption key.
+ @param error   If an error occurs, upon return contains an `NSError` object
+                that describes the problem. If you are not interested in
+                possible errors, pass in `NULL`.
+
+ @return        The version of the Realm at `fileURL` or RLMNotVersioned if the version cannot be read.
+ */
++ (uint64_t)schemaVersionAtFileURL:(NSURL *)fileURL encryptionKey:(nullable NSData *)key error:(NSError **)error;
 
 /**
  Performs the given Realm configuration's migration block on a Realm at the given path.

--- a/Realm/RLMRealm.h
+++ b/Realm/RLMRealm.h
@@ -27,7 +27,7 @@ RLM_ASSUME_NONNULL_BEGIN
  An RLMRealm instance (also referred to as "a realm") represents a Realm
  database.
 
- Realms can either be stored on disk (see +[RLMRealm realmWithPath:]) or in
+ Realms can either be stored on disk (see +[RLMRealm realmWithFileURL:]) or in
  memory (see RLMRealmConfiguration).
 
  RLMRealm instances are cached internally, and constructing equivalent RLMRealm
@@ -85,7 +85,16 @@ RLM_ASSUME_NONNULL_BEGIN
 
  @return An `RLMRealm` instance.
  */
-+ (instancetype)realmWithPath:(NSString *)path;
++ (instancetype)realmWithPath:(NSString *)path DEPRECATED_MSG_ATTRIBUTE("use +[RLMRealm realmWithFileURL:]");
+
+/**
+ Obtains an `RLMRealm` instance persisted at a specific file URL.
+
+ @param fileURL Local URL to the file you want the data saved in.
+
+ @return An `RLMRealm` instance.
+ */
++ (instancetype)realmWithFileURL:(NSURL *)fileURL;
 
 /**
  Path to the file where this Realm is persisted.

--- a/Realm/RLMRealm.h
+++ b/Realm/RLMRealm.h
@@ -326,7 +326,21 @@ typedef void (^RLMNotificationBlock)(NSString *notification, RLMRealm *realm);
  @param error On input, a pointer to an error object. If an error occurs, this pointer is set to an actual error object containing the error information. You may specify nil for this parameter if you do not want the error information.
  @return YES if the realm was copied successfully. Returns NO if an error occurred.
 */
-- (BOOL)writeCopyToPath:(NSString *)path error:(NSError **)error;
+- (BOOL)writeCopyToPath:(NSString *)path error:(NSError **)error DEPRECATED_MSG_ATTRIBUTE("use +[RLMRealm writeCopyToFileURL:error:]");
+
+/**
+ Write a compacted copy of the RLMRealm to the given local URL.
+
+ The destination file cannot already exist.
+
+ Note that if this is called from within a write transaction it writes the
+ *current* data, and not data when the last write transaction was committed.
+
+ @param fileURL Local URL to save the Realm to.
+ @param error On input, a pointer to an error object. If an error occurs, this pointer is set to an actual error object containing the error information. You may specify nil for this parameter if you do not want the error information.
+ @return YES if the realm was copied successfully. Returns NO if an error occurred.
+*/
+- (BOOL)writeCopyToFileURL:(NSURL *)fileURL error:(NSError **)error;
 
 /**
  Write an encrypted and compacted copy of the RLMRealm to the given path.
@@ -341,7 +355,22 @@ typedef void (^RLMNotificationBlock)(NSString *notification, RLMRealm *realm);
  @param error On input, a pointer to an error object. If an error occurs, this pointer is set to an actual error object containing the error information. You may specify nil for this parameter if you do not want the error information.
  @return YES if the realm was copied successfully. Returns NO if an error occurred.
 */
-- (BOOL)writeCopyToPath:(NSString *)path encryptionKey:(NSData *)key error:(NSError **)error;
+- (BOOL)writeCopyToPath:(NSString *)path encryptionKey:(NSData *)key error:(NSError **)error DEPRECATED_MSG_ATTRIBUTE("use +[RLMRealm writeCopyToFileURL:encryptionKey:error:]");
+
+/**
+ Write an encrypted and compacted copy of the RLMRealm to the given local URL.
+
+ The destination file cannot already exist.
+
+ Note that if this is called from within a write transaction it writes the
+ *current* data, and not data when the last write transaction was committed.
+
+ @param fileURL Local URL to save the Realm to.
+ @param key     64-byte encryption key to encrypt the new file with
+ @param error   On input, a pointer to an error object. If an error occurs, this pointer is set to an actual error object containing the error information. You may specify nil for this parameter if you do not want the error information.
+ @return YES    if the realm was copied successfully. Returns NO if an error occurred.
+*/
+- (BOOL)writeCopyToFileURL:(NSURL *)fileURL encryptionKey:(NSData *)key error:(NSError **)error;
 
 /**
  Invalidate all RLMObjects and RLMResults read from this Realm.

--- a/Realm/RLMRealm.h
+++ b/Realm/RLMRealm.h
@@ -90,7 +90,7 @@ RLM_ASSUME_NONNULL_BEGIN
 /**
  Path to the file where this Realm is persisted.
  */
-@property (nonatomic, readonly) NSString *path DEPRECATED_MSG_ATTRIBUTE("use configuration.path");
+@property (nonatomic, readonly) NSString *path DEPRECATED_MSG_ATTRIBUTE("use configuration.fileURL");
 
 /**
  Indicates if this Realm was opened in read-only mode.

--- a/Realm/RLMRealm.h
+++ b/Realm/RLMRealm.h
@@ -27,7 +27,7 @@ RLM_ASSUME_NONNULL_BEGIN
  An RLMRealm instance (also referred to as "a realm") represents a Realm
  database.
 
- Realms can either be stored on disk (see +[RLMRealm realmWithFileURL:]) or in
+ Realms can either be stored on disk (see +[RLMRealm realmWithURL:]) or in
  memory (see RLMRealmConfiguration).
 
  RLMRealm instances are cached internally, and constructing equivalent RLMRealm
@@ -85,7 +85,7 @@ RLM_ASSUME_NONNULL_BEGIN
 
  @return An `RLMRealm` instance.
  */
-+ (instancetype)realmWithPath:(NSString *)path DEPRECATED_MSG_ATTRIBUTE("use +[RLMRealm realmWithFileURL:]");
++ (instancetype)realmWithPath:(NSString *)path DEPRECATED_MSG_ATTRIBUTE("use +[RLMRealm realmWithURL:]");
 
 /**
  Obtains an `RLMRealm` instance persisted at a specific file URL.
@@ -94,7 +94,7 @@ RLM_ASSUME_NONNULL_BEGIN
 
  @return An `RLMRealm` instance.
  */
-+ (instancetype)realmWithFileURL:(NSURL *)fileURL;
++ (instancetype)realmWithURL:(NSURL *)fileURL;
 
 /**
  Path to the file where this Realm is persisted.
@@ -326,7 +326,7 @@ typedef void (^RLMNotificationBlock)(NSString *notification, RLMRealm *realm);
  @param error On input, a pointer to an error object. If an error occurs, this pointer is set to an actual error object containing the error information. You may specify nil for this parameter if you do not want the error information.
  @return YES if the realm was copied successfully. Returns NO if an error occurred.
 */
-- (BOOL)writeCopyToPath:(NSString *)path error:(NSError **)error DEPRECATED_MSG_ATTRIBUTE("use +[RLMRealm writeCopyToFileURL:encryptionKey:error:]");
+- (BOOL)writeCopyToPath:(NSString *)path error:(NSError **)error DEPRECATED_MSG_ATTRIBUTE("use +[RLMRealm writeCopyToURL:encryptionKey:error:]");
 
 /**
  Write an encrypted and compacted copy of the RLMRealm to the given path.
@@ -341,7 +341,7 @@ typedef void (^RLMNotificationBlock)(NSString *notification, RLMRealm *realm);
  @param error On input, a pointer to an error object. If an error occurs, this pointer is set to an actual error object containing the error information. You may specify nil for this parameter if you do not want the error information.
  @return YES if the realm was copied successfully. Returns NO if an error occurred.
 */
-- (BOOL)writeCopyToPath:(NSString *)path encryptionKey:(NSData *)key error:(NSError **)error DEPRECATED_MSG_ATTRIBUTE("use +[RLMRealm writeCopyToFileURL:encryptionKey:error:]");
+- (BOOL)writeCopyToPath:(NSString *)path encryptionKey:(NSData *)key error:(NSError **)error DEPRECATED_MSG_ATTRIBUTE("use +[RLMRealm writeCopyToURL:encryptionKey:error:]");
 
 /**
  Write an encrypted and compacted copy of the RLMRealm to the given local URL.
@@ -360,7 +360,7 @@ typedef void (^RLMNotificationBlock)(NSString *notification, RLMRealm *realm);
 
  @return YES if the realm was copied successfully. Returns NO if an error occurred.
 */
-- (BOOL)writeCopyToFileURL:(NSURL *)fileURL encryptionKey:(nullable NSData *)key error:(NSError **)error;
+- (BOOL)writeCopyToURL:(NSURL *)fileURL encryptionKey:(nullable NSData *)key error:(NSError **)error;
 
 /**
  Invalidate all RLMObjects and RLMResults read from this Realm.
@@ -500,7 +500,7 @@ typedef void (^RLMMigrationBlock)(RLMMigration *migration, uint64_t oldSchemaVer
 
  @return            The version of the Realm at `realmPath` or RLMNotVersioned if the version cannot be read.
  */
-+ (uint64_t)schemaVersionAtPath:(NSString *)realmPath error:(NSError **)error DEPRECATED_MSG_ATTRIBUTE("use +[RLMRealm schemaVersionAtFileURL:encryptionKey:error:]");
++ (uint64_t)schemaVersionAtPath:(NSString *)realmPath error:(NSError **)error DEPRECATED_MSG_ATTRIBUTE("use +[RLMRealm schemaVersionAtURL:encryptionKey:error:]");
 
 /**
  Get the schema version for an encrypted Realm at a given path.
@@ -513,7 +513,7 @@ typedef void (^RLMMigrationBlock)(RLMMigration *migration, uint64_t oldSchemaVer
 
  @return            The version of the Realm at `fileURL` or RLMNotVersioned if the version cannot be read.
  */
-+ (uint64_t)schemaVersionAtPath:(NSString *)realmPath encryptionKey:(nullable NSData *)key error:(NSError **)error DEPRECATED_MSG_ATTRIBUTE("use +[RLMRealm schemaVersionAtFileURL:encryptionKey:error:]");
++ (uint64_t)schemaVersionAtPath:(NSString *)realmPath encryptionKey:(nullable NSData *)key error:(NSError **)error DEPRECATED_MSG_ATTRIBUTE("use +[RLMRealm schemaVersionAtURL:encryptionKey:error:]");
 
 /**
  Get the schema version for an encrypted Realm at a given local URL.
@@ -526,7 +526,7 @@ typedef void (^RLMMigrationBlock)(RLMMigration *migration, uint64_t oldSchemaVer
 
  @return The version of the Realm at `fileURL` or RLMNotVersioned if the version cannot be read.
  */
-+ (uint64_t)schemaVersionAtFileURL:(NSURL *)fileURL encryptionKey:(nullable NSData *)key error:(NSError **)error;
++ (uint64_t)schemaVersionAtURL:(NSURL *)fileURL encryptionKey:(nullable NSData *)key error:(NSError **)error;
 
 /**
  Performs the given Realm configuration's migration block on a Realm at the given path.

--- a/Realm/RLMRealm.h
+++ b/Realm/RLMRealm.h
@@ -326,21 +326,7 @@ typedef void (^RLMNotificationBlock)(NSString *notification, RLMRealm *realm);
  @param error On input, a pointer to an error object. If an error occurs, this pointer is set to an actual error object containing the error information. You may specify nil for this parameter if you do not want the error information.
  @return YES if the realm was copied successfully. Returns NO if an error occurred.
 */
-- (BOOL)writeCopyToPath:(NSString *)path error:(NSError **)error DEPRECATED_MSG_ATTRIBUTE("use +[RLMRealm writeCopyToFileURL:error:]");
-
-/**
- Write a compacted copy of the RLMRealm to the given local URL.
-
- The destination file cannot already exist.
-
- Note that if this is called from within a write transaction it writes the
- *current* data, and not data when the last write transaction was committed.
-
- @param fileURL Local URL to save the Realm to.
- @param error On input, a pointer to an error object. If an error occurs, this pointer is set to an actual error object containing the error information. You may specify nil for this parameter if you do not want the error information.
- @return YES if the realm was copied successfully. Returns NO if an error occurred.
-*/
-- (BOOL)writeCopyToFileURL:(NSURL *)fileURL error:(NSError **)error;
+- (BOOL)writeCopyToPath:(NSString *)path error:(NSError **)error DEPRECATED_MSG_ATTRIBUTE("use +[RLMRealm writeCopyToFileURL:encryptionKey:error:]");
 
 /**
  Write an encrypted and compacted copy of the RLMRealm to the given path.
@@ -370,7 +356,7 @@ typedef void (^RLMNotificationBlock)(NSString *notification, RLMRealm *realm);
  @param error   On input, a pointer to an error object. If an error occurs, this pointer is set to an actual error object containing the error information. You may specify nil for this parameter if you do not want the error information.
  @return YES    if the realm was copied successfully. Returns NO if an error occurred.
 */
-- (BOOL)writeCopyToFileURL:(NSURL *)fileURL encryptionKey:(NSData *)key error:(NSError **)error;
+- (BOOL)writeCopyToFileURL:(NSURL *)fileURL encryptionKey:(nullable NSData *)key error:(NSError **)error;
 
 /**
  Invalidate all RLMObjects and RLMResults read from this Realm.
@@ -510,19 +496,7 @@ typedef void (^RLMMigrationBlock)(RLMMigration *migration, uint64_t oldSchemaVer
 
  @return            The version of the Realm at `realmPath` or RLMNotVersioned if the version cannot be read.
  */
-+ (uint64_t)schemaVersionAtPath:(NSString *)realmPath error:(NSError **)error DEPRECATED_MSG_ATTRIBUTE("use +[RLMRealm schemaVersionAtFileURL:error:]");
-
-/**
- Get the schema version for a Realm at a given local URL.
-
- @param fileURL Local URL to a Realm file.
- @param error   If an error occurs, upon return contains an `NSError` object
-                that describes the problem. If you are not interested in
-                possible errors, pass in `NULL`.
-
- @return        The version of the Realm at `realmPath` or RLMNotVersioned if the version cannot be read.
- */
-+ (uint64_t)schemaVersionAtFileURL:(NSURL *)fileURL error:(NSError **)error;
++ (uint64_t)schemaVersionAtPath:(NSString *)realmPath error:(NSError **)error DEPRECATED_MSG_ATTRIBUTE("use +[RLMRealm schemaVersionAtFileURL:encryptionKey:error:]");
 
 /**
  Get the schema version for an encrypted Realm at a given path.

--- a/Realm/RLMRealm.h
+++ b/Realm/RLMRealm.h
@@ -344,7 +344,8 @@ typedef void (^RLMNotificationBlock)(NSString *notification, RLMRealm *realm);
 - (BOOL)writeCopyToPath:(NSString *)path encryptionKey:(NSData *)key error:(NSError **)error DEPRECATED_MSG_ATTRIBUTE("use +[RLMRealm writeCopyToURL:encryptionKey:error:]");
 
 /**
- Write an encrypted and compacted copy of the RLMRealm to the given local URL.
+ Write a compacted and optionally encrypted copy of the RLMRealm to the given
+ local URL.
 
  The destination file cannot already exist.
 
@@ -352,11 +353,11 @@ typedef void (^RLMNotificationBlock)(NSString *notification, RLMRealm *realm);
  *current* data, and not data when the last write transaction was committed.
 
  @param fileURL Local URL to save the Realm to.
- @param key   Optional 64-byte encryption key to encrypt the new file with.
- @param error On input, a pointer to an error object. If an error occurs, this
-              pointer is set to an actual error object containing the error
-              information. You may specify nil for this parameter if you do not
-              want the error information.
+ @param key     Optional 64-byte encryption key to encrypt the new file with.
+ @param error   On input, a pointer to an error object. If an error occurs,
+                this pointer is set to an actual error object containing the
+                error information. You may specify nil for this parameter if you
+                do not want the error information.
 
  @return YES if the realm was copied successfully. Returns NO if an error occurred.
 */
@@ -516,10 +517,10 @@ typedef void (^RLMMigrationBlock)(RLMMigration *migration, uint64_t oldSchemaVer
 + (uint64_t)schemaVersionAtPath:(NSString *)realmPath encryptionKey:(nullable NSData *)key error:(NSError **)error DEPRECATED_MSG_ATTRIBUTE("use +[RLMRealm schemaVersionAtURL:encryptionKey:error:]");
 
 /**
- Get the schema version for an encrypted Realm at a given local URL.
+ Get the schema version for a Realm at a given local URL.
 
- @param fileURL Local URL to a Realm file
- @param key     Optional 64-byte encryption key.
+ @param fileURL Local URL to a Realm file.
+ @param key     64-byte key used to encrypt the file, or nil if it is unencrypted.
  @param error   If an error occurs, upon return contains an `NSError` object
                 that describes the problem. If you are not interested in
                 possible errors, pass in `NULL`.

--- a/Realm/RLMRealm.h
+++ b/Realm/RLMRealm.h
@@ -352,9 +352,13 @@ typedef void (^RLMNotificationBlock)(NSString *notification, RLMRealm *realm);
  *current* data, and not data when the last write transaction was committed.
 
  @param fileURL Local URL to save the Realm to.
- @param key     64-byte encryption key to encrypt the new file with
- @param error   On input, a pointer to an error object. If an error occurs, this pointer is set to an actual error object containing the error information. You may specify nil for this parameter if you do not want the error information.
- @return YES    if the realm was copied successfully. Returns NO if an error occurred.
+ @param key   Optional 64-byte encryption key to encrypt the new file with.
+ @param error On input, a pointer to an error object. If an error occurs, this
+              pointer is set to an actual error object containing the error
+              information. You may specify nil for this parameter if you do not
+              want the error information.
+
+ @return YES if the realm was copied successfully. Returns NO if an error occurred.
 */
 - (BOOL)writeCopyToFileURL:(NSURL *)fileURL encryptionKey:(nullable NSData *)key error:(NSError **)error;
 
@@ -515,12 +519,12 @@ typedef void (^RLMMigrationBlock)(RLMMigration *migration, uint64_t oldSchemaVer
  Get the schema version for an encrypted Realm at a given local URL.
 
  @param fileURL Local URL to a Realm file
- @param key     64-byte encryption key.
+ @param key     Optional 64-byte encryption key.
  @param error   If an error occurs, upon return contains an `NSError` object
                 that describes the problem. If you are not interested in
                 possible errors, pass in `NULL`.
 
- @return        The version of the Realm at `fileURL` or RLMNotVersioned if the version cannot be read.
+ @return The version of the Realm at `fileURL` or RLMNotVersioned if the version cannot be read.
  */
 + (uint64_t)schemaVersionAtFileURL:(NSURL *)fileURL encryptionKey:(nullable NSData *)key error:(NSError **)error;
 

--- a/Realm/RLMRealm.mm
+++ b/Realm/RLMRealm.mm
@@ -162,12 +162,16 @@ NSData *RLMRealmValidatedEncryptionKey(NSData *key) {
 }
 
 + (instancetype)realmWithPath:(NSString *)path {
+    return [RLMRealm realmWithFileURL:[NSURL fileURLWithPath:path]];
+}
+
++ (instancetype)realmWithFileURL:(NSURL *)fileURL {
     RLMRealmConfiguration *configuration = [RLMRealmConfiguration defaultConfiguration];
-    configuration.fileURL = [NSURL fileURLWithPath:path];
+    configuration.fileURL = fileURL;
     return [RLMRealm realmWithConfiguration:configuration error:nil];
 }
 
-+ (instancetype)realmWithPath:(NSString *)path
++ (instancetype)realmWithFileURL:(NSURL *)fileURL
                           key:(NSData *)key
                      readOnly:(BOOL)readonly
                      inMemory:(BOOL)inMemory
@@ -177,10 +181,10 @@ NSData *RLMRealmValidatedEncryptionKey(NSData *key) {
 {
     RLMRealmConfiguration *configuration = [[RLMRealmConfiguration alloc] init];
     if (inMemory) {
-        configuration.inMemoryIdentifier = path.lastPathComponent;
+        configuration.inMemoryIdentifier = fileURL.lastPathComponent;
     }
     else {
-        configuration.fileURL = [NSURL fileURLWithPath:path];
+        configuration.fileURL = fileURL;
     }
     configuration.encryptionKey = key;
     configuration.readOnly = readonly;

--- a/Realm/RLMRealm.mm
+++ b/Realm/RLMRealm.mm
@@ -172,12 +172,12 @@ NSData *RLMRealmValidatedEncryptionKey(NSData *key) {
 }
 
 + (instancetype)realmWithURL:(NSURL *)fileURL
-                          key:(NSData *)key
-                     readOnly:(BOOL)readonly
-                     inMemory:(BOOL)inMemory
-                      dynamic:(BOOL)dynamic
-                       schema:(RLMSchema *)customSchema
-                        error:(NSError **)outError
+                         key:(NSData *)key
+                    readOnly:(BOOL)readonly
+                    inMemory:(BOOL)inMemory
+                     dynamic:(BOOL)dynamic
+                      schema:(RLMSchema *)customSchema
+                       error:(NSError **)outError
 {
     RLMRealmConfiguration *configuration = [[RLMRealmConfiguration alloc] init];
     if (inMemory) {

--- a/Realm/RLMRealm.mm
+++ b/Realm/RLMRealm.mm
@@ -162,16 +162,16 @@ NSData *RLMRealmValidatedEncryptionKey(NSData *key) {
 }
 
 + (instancetype)realmWithPath:(NSString *)path {
-    return [RLMRealm realmWithFileURL:[NSURL fileURLWithPath:path]];
+    return [RLMRealm realmWithURL:[NSURL fileURLWithPath:path]];
 }
 
-+ (instancetype)realmWithFileURL:(NSURL *)fileURL {
++ (instancetype)realmWithURL:(NSURL *)fileURL {
     RLMRealmConfiguration *configuration = [RLMRealmConfiguration defaultConfiguration];
     configuration.fileURL = fileURL;
     return [RLMRealm realmWithConfiguration:configuration error:nil];
 }
 
-+ (instancetype)realmWithFileURL:(NSURL *)fileURL
++ (instancetype)realmWithURL:(NSURL *)fileURL
                           key:(NSData *)key
                      readOnly:(BOOL)readonly
                      inMemory:(BOOL)inMemory
@@ -682,14 +682,14 @@ void RLMRealmTranslateException(NSError **error) {
 }
 
 + (uint64_t)schemaVersionAtPath:(NSString *)realmPath error:(NSError **)error {
-    return [RLMRealm schemaVersionAtFileURL:[NSURL fileURLWithPath:realmPath] encryptionKey:nil error:error];
+    return [RLMRealm schemaVersionAtURL:[NSURL fileURLWithPath:realmPath] encryptionKey:nil error:error];
 }
 
 + (uint64_t)schemaVersionAtPath:(NSString *)realmPath encryptionKey:(NSData *)key error:(NSError **)error {
-    return [self schemaVersionAtFileURL:[NSURL fileURLWithPath:realmPath] encryptionKey:key error:error];
+    return [self schemaVersionAtURL:[NSURL fileURLWithPath:realmPath] encryptionKey:key error:error];
 }
 
-+ (uint64_t)schemaVersionAtFileURL:(NSURL *)fileURL encryptionKey:(NSData *)key error:(NSError **)error {
++ (uint64_t)schemaVersionAtURL:(NSURL *)fileURL encryptionKey:(NSData *)key error:(NSError **)error {
     try {
         RLMRealmConfiguration *config = [[RLMRealmConfiguration alloc] init];
         config.fileURL = fileURL;
@@ -724,14 +724,14 @@ void RLMRealmTranslateException(NSError **error) {
 }
 
 - (BOOL)writeCopyToPath:(NSString *)path error:(NSError **)error {
-    return [self writeCopyToFileURL:[NSURL fileURLWithPath:path] encryptionKey:nil error:error];
+    return [self writeCopyToURL:[NSURL fileURLWithPath:path] encryptionKey:nil error:error];
 }
 
 - (BOOL)writeCopyToPath:(NSString *)path encryptionKey:(NSData *)key error:(NSError **)error {
-    return [self writeCopyToFileURL:[NSURL fileURLWithPath:path] encryptionKey:key error:error];
+    return [self writeCopyToURL:[NSURL fileURLWithPath:path] encryptionKey:key error:error];
 }
 
-- (BOOL)writeCopyToFileURL:(NSURL *)fileURL encryptionKey:(NSData *)key error:(NSError **)error {
+- (BOOL)writeCopyToURL:(NSURL *)fileURL encryptionKey:(NSData *)key error:(NSError **)error {
     key = RLMRealmValidatedEncryptionKey(key);
     NSString *path = fileURL.path;
 

--- a/Realm/RLMRealm.mm
+++ b/Realm/RLMRealm.mm
@@ -163,7 +163,7 @@ NSData *RLMRealmValidatedEncryptionKey(NSData *key) {
 
 + (instancetype)realmWithPath:(NSString *)path {
     RLMRealmConfiguration *configuration = [RLMRealmConfiguration defaultConfiguration];
-    configuration.path = path;
+    configuration.fileURL = [NSURL fileURLWithPath:path];
     return [RLMRealm realmWithConfiguration:configuration error:nil];
 }
 
@@ -180,7 +180,7 @@ NSData *RLMRealmValidatedEncryptionKey(NSData *key) {
         configuration.inMemoryIdentifier = path.lastPathComponent;
     }
     else {
-        configuration.path = path;
+        configuration.fileURL = [NSURL fileURLWithPath:path];
     }
     configuration.encryptionKey = key;
     configuration.readOnly = readonly;
@@ -684,7 +684,7 @@ void RLMRealmTranslateException(NSError **error) {
 + (uint64_t)schemaVersionAtPath:(NSString *)realmPath encryptionKey:(NSData *)key error:(NSError **)outError {
     try {
         RLMRealmConfiguration *config = [[RLMRealmConfiguration alloc] init];
-        config.path = realmPath;
+        config.fileURL = [NSURL fileURLWithPath:realmPath];
         config.encryptionKey = RLMRealmValidatedEncryptionKey(key);
 
         uint64_t version = Realm::get_schema_version(config.config);

--- a/Realm/RLMRealm.mm
+++ b/Realm/RLMRealm.mm
@@ -759,12 +759,20 @@ void RLMRealmTranslateException(NSError **error) {
     return [self writeCopyToPath:path key:nil error:error];
 }
 
+- (BOOL)writeCopyToFileURL:(NSURL *)fileURL error:(NSError **)error {
+    return [self writeCopyToPath:fileURL.path key:nil error:error];
+}
+
 - (BOOL)writeCopyToPath:(NSString *)path encryptionKey:(NSData *)key error:(NSError **)error {
+    return [self writeCopyToFileURL:[NSURL fileURLWithPath:path] encryptionKey:key error:error];
+}
+
+- (BOOL)writeCopyToFileURL:(NSURL *)fileURL encryptionKey:(NSData *)key error:(NSError **)error {
     if (!key) {
         @throw RLMException(@"Encryption key must not be nil");
     }
 
-    return [self writeCopyToPath:path key:key error:error];
+    return [self writeCopyToPath:fileURL.path key:key error:error];
 }
 
 - (void)registerEnumerator:(RLMFastEnumerator *)enumerator {

--- a/Realm/RLMRealm.mm
+++ b/Realm/RLMRealm.mm
@@ -685,20 +685,28 @@ void RLMRealmTranslateException(NSError **error) {
     return [RLMRealm schemaVersionAtPath:realmPath encryptionKey:nil error:error];
 }
 
-+ (uint64_t)schemaVersionAtPath:(NSString *)realmPath encryptionKey:(NSData *)key error:(NSError **)outError {
++ (uint64_t)schemaVersionAtFileURL:(NSURL *)fileURL error:(NSError * _Nullable __autoreleasing *)error {
+    return [RLMRealm schemaVersionAtFileURL:fileURL encryptionKey:nil error:error];
+}
+
++ (uint64_t)schemaVersionAtPath:(NSString *)realmPath encryptionKey:(NSData *)key error:(NSError **)error {
+    return [self schemaVersionAtFileURL:[NSURL fileURLWithPath:realmPath] encryptionKey:key error:error];
+}
+
++ (uint64_t)schemaVersionAtFileURL:(NSURL *)fileURL encryptionKey:(NSData *)key error:(NSError **)error {
     try {
         RLMRealmConfiguration *config = [[RLMRealmConfiguration alloc] init];
-        config.fileURL = [NSURL fileURLWithPath:realmPath];
+        config.fileURL = fileURL;
         config.encryptionKey = RLMRealmValidatedEncryptionKey(key);
 
         uint64_t version = Realm::get_schema_version(config.config);
         if (version == realm::ObjectStore::NotVersioned) {
-            RLMSetErrorOrThrow([NSError errorWithDomain:RLMErrorDomain code:RLMErrorFail userInfo:@{NSLocalizedDescriptionKey:@"Cannot open an uninitialized realm in read-only mode"}], outError);
+            RLMSetErrorOrThrow([NSError errorWithDomain:RLMErrorDomain code:RLMErrorFail userInfo:@{NSLocalizedDescriptionKey:@"Cannot open an uninitialized realm in read-only mode"}], error);
         }
         return version;
     }
     catch (std::exception &exp) {
-        RLMSetErrorOrThrow(RLMMakeError(RLMErrorFail, exp), outError);
+        RLMSetErrorOrThrow(RLMMakeError(RLMErrorFail, exp), error);
         return RLMNotVersioned;
     }
 }

--- a/Realm/RLMRealm.mm
+++ b/Realm/RLMRealm.mm
@@ -682,11 +682,7 @@ void RLMRealmTranslateException(NSError **error) {
 }
 
 + (uint64_t)schemaVersionAtPath:(NSString *)realmPath error:(NSError **)error {
-    return [RLMRealm schemaVersionAtPath:realmPath encryptionKey:nil error:error];
-}
-
-+ (uint64_t)schemaVersionAtFileURL:(NSURL *)fileURL error:(NSError * _Nullable __autoreleasing *)error {
-    return [RLMRealm schemaVersionAtFileURL:fileURL encryptionKey:nil error:error];
+    return [RLMRealm schemaVersionAtFileURL:[NSURL fileURLWithPath:realmPath] encryptionKey:nil error:error];
 }
 
 + (uint64_t)schemaVersionAtPath:(NSString *)realmPath encryptionKey:(NSData *)key error:(NSError **)error {
@@ -727,8 +723,17 @@ void RLMRealmTranslateException(NSError **error) {
     return (RLMObject *)RLMCreateObjectInRealmWithValue(self, className, value, false);
 }
 
-- (BOOL)writeCopyToPath:(NSString *)path key:(NSData *)key error:(NSError **)error {
+- (BOOL)writeCopyToPath:(NSString *)path error:(NSError **)error {
+    return [self writeCopyToFileURL:[NSURL fileURLWithPath:path] encryptionKey:nil error:error];
+}
+
+- (BOOL)writeCopyToPath:(NSString *)path encryptionKey:(NSData *)key error:(NSError **)error {
+    return [self writeCopyToFileURL:[NSURL fileURLWithPath:path] encryptionKey:key error:error];
+}
+
+- (BOOL)writeCopyToFileURL:(NSURL *)fileURL encryptionKey:(NSData *)key error:(NSError **)error {
     key = RLMRealmValidatedEncryptionKey(key);
+    NSString *path = fileURL.path;
 
     try {
         self.group->write(path.UTF8String, static_cast<const char *>(key.bytes));
@@ -761,26 +766,6 @@ void RLMRealmTranslateException(NSError **error) {
     }
 
     return NO;
-}
-
-- (BOOL)writeCopyToPath:(NSString *)path error:(NSError **)error {
-    return [self writeCopyToPath:path key:nil error:error];
-}
-
-- (BOOL)writeCopyToFileURL:(NSURL *)fileURL error:(NSError **)error {
-    return [self writeCopyToPath:fileURL.path key:nil error:error];
-}
-
-- (BOOL)writeCopyToPath:(NSString *)path encryptionKey:(NSData *)key error:(NSError **)error {
-    return [self writeCopyToFileURL:[NSURL fileURLWithPath:path] encryptionKey:key error:error];
-}
-
-- (BOOL)writeCopyToFileURL:(NSURL *)fileURL encryptionKey:(NSData *)key error:(NSError **)error {
-    if (!key) {
-        @throw RLMException(@"Encryption key must not be nil");
-    }
-
-    return [self writeCopyToPath:fileURL.path key:key error:error];
 }
 
 - (void)registerEnumerator:(RLMFastEnumerator *)enumerator {

--- a/Realm/RLMRealmConfiguration.h
+++ b/Realm/RLMRealmConfiguration.h
@@ -53,8 +53,11 @@ RLM_ASSUME_NONNULL_BEGIN
 
 #pragma mark - Properties
 
+/// The local URL to the realm file. Mutually exclusive with `inMemoryIdentifier`.
+@property (nonatomic, copy, nullable) NSURL *fileURL;
+
 /// The path to the realm file. Mutually exclusive with `inMemoryIdentifier`.
-@property (nonatomic, copy, nullable) NSString *path;
+@property (nonatomic, copy, nullable) NSString *path DEPRECATED_MSG_ATTRIBUTE("use fileURL");
 
 /// A string used to identify a particular in-memory Realm. Mutually exclusive with `path`.
 @property (nonatomic, copy, nullable) NSString *inMemoryIdentifier;

--- a/Realm/RLMRealmConfiguration.mm
+++ b/Realm/RLMRealmConfiguration.mm
@@ -27,7 +27,7 @@
 #import "shared_realm.hpp"
 
 static NSString *const c_RLMRealmConfigurationProperties[] = {
-    @"path",
+    @"fileURL",
     @"inMemoryIdentifier",
     @"encryptionKey",
     @"readOnly",
@@ -117,8 +117,8 @@ NSString *RLMRealmPathForFile(NSString *fileName) {
 - (instancetype)init {
     self = [super init];
     if (self) {
-        static NSString *defaultRealmPath = RLMRealmPathForFile(c_defaultRealmFileName);
-        self.path = defaultRealmPath;
+        static NSURL *defaultRealmURL = [NSURL fileURLWithPath:RLMRealmPathForFile(c_defaultRealmFileName)];
+        self.fileURL = defaultRealmURL;
         self.schemaVersion = 0;
     }
 
@@ -145,10 +145,6 @@ NSString *RLMRealmPathForFile(NSString *fileName) {
     return [string stringByAppendingString:@"}"];
 }
 
-- (NSString *)path {
-    return _config.in_memory ? nil :@(_config.path.c_str());
-}
-
 static void RLMNSStringToStdString(std::string &out, NSString *in) {
     out.resize([in maximumLengthOfBytesUsingEncoding:NSUTF8StringEncoding]);
     if (out.empty()) {
@@ -164,13 +160,26 @@ static void RLMNSStringToStdString(std::string &out, NSString *in) {
     out.resize(size);
 }
 
-- (void)setPath:(NSString *)path {
+- (NSURL *)fileURL {
+    return _config.in_memory ? nil : [NSURL fileURLWithPath:@(_config.path.c_str())];
+}
+
+- (void)setFileURL:(NSURL *)fileURL {
+    NSString *path = fileURL.path;
     if (path.length == 0) {
         @throw RLMException(@"Realm path must not be empty");
     }
 
     RLMNSStringToStdString(_config.path, path);
     _config.in_memory = false;
+}
+
+- (NSString *)path {
+    return self.fileURL.path;
+}
+
+- (void)setPath:(NSString *)path {
+    self.fileURL = [NSURL fileURLWithPath:path];
 }
 
 - (NSString *)inMemoryIdentifier {

--- a/Realm/RLMRealm_Private.h
+++ b/Realm/RLMRealm_Private.h
@@ -41,14 +41,14 @@ void RLMRealmTranslateException(NSError **error);
  This method is useful only in specialized circumstances, for example, when opening Realm files
  retrieved externally that contain a different schema than defined in your application.
  If you are simply building an app on Realm you should consider using:
- [defaultRealm]([RLMRealm defaultRealm]) or [realmWithPath:]([RLMRealm realmWithPath:])
+ [defaultRealm]([RLMRealm defaultRealm]) or [realmWithFileURL:]([RLMRealm realmWithFileURL:])
  
  Obtains an `RLMRealm` instance with persistence to a specific file path with
  options.
  
  @warning This method is useful only in specialized circumstances.
  
- @param path         Path to the file you want the data saved in.
+ @param fileURL      Local URL to the file you want the data saved in.
  @param key          64-byte key to use to encrypt the data.
  @param readonly     `BOOL` indicating if this Realm is read-only (must use for read-only files)
  @param inMemory     `BOOL` indicating if this Realm is in-memory
@@ -61,11 +61,11 @@ void RLMRealmTranslateException(NSError **error);
  @return An `RLMRealm` instance.
  
  @see RLMRealm defaultRealm
- @see RLMRealm realmWithPath:
- @see RLMRealm realmWithPath:readOnly:error:
- @see RLMRealm realmWithPath:encryptionKey:readOnly:error:
+ @see RLMRealm realmWithFileURL:
+ @see RLMRealm realmWithFileURL:readOnly:error:
+ @see RLMRealm realmWithFileURL:encryptionKey:readOnly:error:
  */
-+ (instancetype)realmWithPath:(NSString *)path
++ (instancetype)realmWithFileURL:(NSURL *)fileURL
                           key:(NSData *)key
                      readOnly:(BOOL)readonly
                      inMemory:(BOOL)inMemory

--- a/Realm/RLMRealm_Private.h
+++ b/Realm/RLMRealm_Private.h
@@ -66,12 +66,12 @@ void RLMRealmTranslateException(NSError **error);
  @see RLMRealm realmWithURL:encryptionKey:readOnly:error:
  */
 + (instancetype)realmWithURL:(NSURL *)fileURL
-                          key:(NSData *)key
-                     readOnly:(BOOL)readonly
-                     inMemory:(BOOL)inMemory
-                      dynamic:(BOOL)dynamic
-                       schema:(RLMSchema *)customSchema
-                        error:(NSError **)outError;
+                         key:(NSData *)key
+                    readOnly:(BOOL)readonly
+                    inMemory:(BOOL)inMemory
+                     dynamic:(BOOL)dynamic
+                      schema:(RLMSchema *)customSchema
+                       error:(NSError **)outError;
 
 - (void)registerEnumerator:(RLMFastEnumerator *)enumerator;
 - (void)unregisterEnumerator:(RLMFastEnumerator *)enumerator;

--- a/Realm/RLMRealm_Private.h
+++ b/Realm/RLMRealm_Private.h
@@ -41,7 +41,7 @@ void RLMRealmTranslateException(NSError **error);
  This method is useful only in specialized circumstances, for example, when opening Realm files
  retrieved externally that contain a different schema than defined in your application.
  If you are simply building an app on Realm you should consider using:
- [defaultRealm]([RLMRealm defaultRealm]) or [realmWithFileURL:]([RLMRealm realmWithFileURL:])
+ [defaultRealm]([RLMRealm defaultRealm]) or [realmWithURL:]([RLMRealm realmWithURL:])
  
  Obtains an `RLMRealm` instance with persistence to a specific file path with
  options.
@@ -61,11 +61,11 @@ void RLMRealmTranslateException(NSError **error);
  @return An `RLMRealm` instance.
  
  @see RLMRealm defaultRealm
- @see RLMRealm realmWithFileURL:
- @see RLMRealm realmWithFileURL:readOnly:error:
- @see RLMRealm realmWithFileURL:encryptionKey:readOnly:error:
+ @see RLMRealm realmWithURL:
+ @see RLMRealm realmWithURL:readOnly:error:
+ @see RLMRealm realmWithURL:encryptionKey:readOnly:error:
  */
-+ (instancetype)realmWithFileURL:(NSURL *)fileURL
++ (instancetype)realmWithURL:(NSURL *)fileURL
                           key:(NSData *)key
                      readOnly:(BOOL)readonly
                      inMemory:(BOOL)inMemory

--- a/Realm/Tests/AsyncTests.m
+++ b/Realm/Tests/AsyncTests.m
@@ -399,7 +399,7 @@
 
     // Force an error when opening the helper SharedGroups by deleting the file
     // after opening the Realm
-    [NSFileManager.defaultManager removeItemAtPath:realm.configuration.path error:nil];
+    [NSFileManager.defaultManager removeItemAtURL:realm.configuration.fileURL error:nil];
 
     __block bool called = false;
     XCTestExpectation *exp = [self expectationWithDescription:@""];

--- a/Realm/Tests/DynamicTests.m
+++ b/Realm/Tests/DynamicTests.m
@@ -86,7 +86,7 @@
     XCTAssertNotNil(expectedSchema);
 
     NSError *error = nil;
-    RLMSchema *dynamicSchema = [[RLMRealm realmWithPath:RLMTestRealmPath() key:nil readOnly:NO inMemory:NO dynamic:YES schema:nil error:&error] schema];
+    RLMSchema *dynamicSchema = [[RLMRealm realmWithFileURL:[NSURL fileURLWithPath:RLMTestRealmPath()] key:nil readOnly:NO inMemory:NO dynamic:YES schema:nil error:&error] schema];
     XCTAssertNil(error);
     XCTAssertEqual(dynamicSchema.objectSchema.count, expectedSchema.objectSchema.count);
     for (RLMObjectSchema *expectedObjectSchema in expectedSchema.objectSchema) {

--- a/Realm/Tests/DynamicTests.m
+++ b/Realm/Tests/DynamicTests.m
@@ -33,7 +33,7 @@
 - (void)testDynamicRealmExists {
     @autoreleasepool {
         // open realm in autoreleasepool to create tables and then dispose
-        RLMRealm *realm = [RLMRealm realmWithPath:RLMTestRealmPath()];
+        RLMRealm *realm = [RLMRealm realmWithFileURL:[NSURL fileURLWithPath:RLMTestRealmPath()]];
         [realm beginWriteTransaction];
         [DynamicObject createInRealm:realm withValue:@[@"column1", @1]];
         [DynamicObject createInRealm:realm withValue:@[@"column2", @2]];
@@ -117,7 +117,7 @@
 - (void)testDynamicProperties {
     @autoreleasepool {
         // open realm in autoreleasepool to create tables and then dispose
-        RLMRealm *realm = [RLMRealm realmWithPath:RLMTestRealmPath()];
+        RLMRealm *realm = [RLMRealm realmWithFileURL:[NSURL fileURLWithPath:RLMTestRealmPath()]];
         [realm beginWriteTransaction];
         [DynamicObject createInRealm:realm withValue:@[@"column1", @1]];
         [DynamicObject createInRealm:realm withValue:@[@"column2", @2]];
@@ -144,7 +144,7 @@
     id obj2 = @[@NO, @2, @2.2f, @2.22, @"string2", [NSData dataWithBytes:"b" length:1], now, @NO, @22, now, obj];
     @autoreleasepool {
         // open realm in autoreleasepool to create tables and then dispose
-        RLMRealm *realm = [RLMRealm realmWithPath:RLMTestRealmPath()];
+        RLMRealm *realm = [RLMRealm realmWithFileURL:[NSURL fileURLWithPath:RLMTestRealmPath()]];
         [realm beginWriteTransaction];
         [AllTypesObject createInRealm:realm withValue:obj1];
         [AllTypesObject createInRealm:realm withValue:obj2];
@@ -176,7 +176,7 @@
 - (void)testDynamicAdd {
     @autoreleasepool {
         // open realm in autoreleasepool to create tables and then dispose
-        [RLMRealm realmWithPath:RLMTestRealmPath()];
+        [RLMRealm realmWithFileURL:[NSURL fileURLWithPath:RLMTestRealmPath()]];
     }
 
     RLMRealm *dyrealm = [self realmWithTestPathAndSchema:nil];
@@ -193,7 +193,7 @@
 - (void)testDynamicArray {
     @autoreleasepool {
         // open realm in autoreleasepool to create tables and then dispose
-        [RLMRealm realmWithPath:RLMTestRealmPath()];
+        [RLMRealm realmWithFileURL:[NSURL fileURLWithPath:RLMTestRealmPath()]];
     }
 
     RLMRealm *dyrealm = [self realmWithTestPathAndSchema:nil];

--- a/Realm/Tests/DynamicTests.m
+++ b/Realm/Tests/DynamicTests.m
@@ -33,7 +33,7 @@
 - (void)testDynamicRealmExists {
     @autoreleasepool {
         // open realm in autoreleasepool to create tables and then dispose
-        RLMRealm *realm = [RLMRealm realmWithFileURL:[NSURL fileURLWithPath:RLMTestRealmPath()]];
+        RLMRealm *realm = [RLMRealm realmWithURL:[NSURL fileURLWithPath:RLMTestRealmPath()]];
         [realm beginWriteTransaction];
         [DynamicObject createInRealm:realm withValue:@[@"column1", @1]];
         [DynamicObject createInRealm:realm withValue:@[@"column2", @2]];
@@ -86,7 +86,7 @@
     XCTAssertNotNil(expectedSchema);
 
     NSError *error = nil;
-    RLMSchema *dynamicSchema = [[RLMRealm realmWithFileURL:[NSURL fileURLWithPath:RLMTestRealmPath()] key:nil readOnly:NO inMemory:NO dynamic:YES schema:nil error:&error] schema];
+    RLMSchema *dynamicSchema = [[RLMRealm realmWithURL:[NSURL fileURLWithPath:RLMTestRealmPath()] key:nil readOnly:NO inMemory:NO dynamic:YES schema:nil error:&error] schema];
     XCTAssertNil(error);
     XCTAssertEqual(dynamicSchema.objectSchema.count, expectedSchema.objectSchema.count);
     for (RLMObjectSchema *expectedObjectSchema in expectedSchema.objectSchema) {
@@ -117,7 +117,7 @@
 - (void)testDynamicProperties {
     @autoreleasepool {
         // open realm in autoreleasepool to create tables and then dispose
-        RLMRealm *realm = [RLMRealm realmWithFileURL:[NSURL fileURLWithPath:RLMTestRealmPath()]];
+        RLMRealm *realm = [RLMRealm realmWithURL:[NSURL fileURLWithPath:RLMTestRealmPath()]];
         [realm beginWriteTransaction];
         [DynamicObject createInRealm:realm withValue:@[@"column1", @1]];
         [DynamicObject createInRealm:realm withValue:@[@"column2", @2]];
@@ -144,7 +144,7 @@
     id obj2 = @[@NO, @2, @2.2f, @2.22, @"string2", [NSData dataWithBytes:"b" length:1], now, @NO, @22, now, obj];
     @autoreleasepool {
         // open realm in autoreleasepool to create tables and then dispose
-        RLMRealm *realm = [RLMRealm realmWithFileURL:[NSURL fileURLWithPath:RLMTestRealmPath()]];
+        RLMRealm *realm = [RLMRealm realmWithURL:[NSURL fileURLWithPath:RLMTestRealmPath()]];
         [realm beginWriteTransaction];
         [AllTypesObject createInRealm:realm withValue:obj1];
         [AllTypesObject createInRealm:realm withValue:obj2];
@@ -176,7 +176,7 @@
 - (void)testDynamicAdd {
     @autoreleasepool {
         // open realm in autoreleasepool to create tables and then dispose
-        [RLMRealm realmWithFileURL:[NSURL fileURLWithPath:RLMTestRealmPath()]];
+        [RLMRealm realmWithURL:[NSURL fileURLWithPath:RLMTestRealmPath()]];
     }
 
     RLMRealm *dyrealm = [self realmWithTestPathAndSchema:nil];
@@ -193,7 +193,7 @@
 - (void)testDynamicArray {
     @autoreleasepool {
         // open realm in autoreleasepool to create tables and then dispose
-        [RLMRealm realmWithFileURL:[NSURL fileURLWithPath:RLMTestRealmPath()]];
+        [RLMRealm realmWithURL:[NSURL fileURLWithPath:RLMTestRealmPath()]];
     }
 
     RLMRealm *dyrealm = [self realmWithTestPathAndSchema:nil];

--- a/Realm/Tests/DynamicTests.m
+++ b/Realm/Tests/DynamicTests.m
@@ -33,7 +33,7 @@
 - (void)testDynamicRealmExists {
     @autoreleasepool {
         // open realm in autoreleasepool to create tables and then dispose
-        RLMRealm *realm = [RLMRealm realmWithURL:[NSURL fileURLWithPath:RLMTestRealmPath()]];
+        RLMRealm *realm = [RLMRealm realmWithURL:RLMTestRealmURL()];
         [realm beginWriteTransaction];
         [DynamicObject createInRealm:realm withValue:@[@"column1", @1]];
         [DynamicObject createInRealm:realm withValue:@[@"column2", @2]];
@@ -86,7 +86,7 @@
     XCTAssertNotNil(expectedSchema);
 
     NSError *error = nil;
-    RLMSchema *dynamicSchema = [[RLMRealm realmWithURL:[NSURL fileURLWithPath:RLMTestRealmPath()] key:nil readOnly:NO inMemory:NO dynamic:YES schema:nil error:&error] schema];
+    RLMSchema *dynamicSchema = [[RLMRealm realmWithURL:RLMTestRealmURL() key:nil readOnly:NO inMemory:NO dynamic:YES schema:nil error:&error] schema];
     XCTAssertNil(error);
     XCTAssertEqual(dynamicSchema.objectSchema.count, expectedSchema.objectSchema.count);
     for (RLMObjectSchema *expectedObjectSchema in expectedSchema.objectSchema) {
@@ -117,7 +117,7 @@
 - (void)testDynamicProperties {
     @autoreleasepool {
         // open realm in autoreleasepool to create tables and then dispose
-        RLMRealm *realm = [RLMRealm realmWithURL:[NSURL fileURLWithPath:RLMTestRealmPath()]];
+        RLMRealm *realm = [RLMRealm realmWithURL:RLMTestRealmURL()];
         [realm beginWriteTransaction];
         [DynamicObject createInRealm:realm withValue:@[@"column1", @1]];
         [DynamicObject createInRealm:realm withValue:@[@"column2", @2]];
@@ -144,7 +144,7 @@
     id obj2 = @[@NO, @2, @2.2f, @2.22, @"string2", [NSData dataWithBytes:"b" length:1], now, @NO, @22, now, obj];
     @autoreleasepool {
         // open realm in autoreleasepool to create tables and then dispose
-        RLMRealm *realm = [RLMRealm realmWithURL:[NSURL fileURLWithPath:RLMTestRealmPath()]];
+        RLMRealm *realm = [RLMRealm realmWithURL:RLMTestRealmURL()];
         [realm beginWriteTransaction];
         [AllTypesObject createInRealm:realm withValue:obj1];
         [AllTypesObject createInRealm:realm withValue:obj2];
@@ -176,7 +176,7 @@
 - (void)testDynamicAdd {
     @autoreleasepool {
         // open realm in autoreleasepool to create tables and then dispose
-        [RLMRealm realmWithURL:[NSURL fileURLWithPath:RLMTestRealmPath()]];
+        [RLMRealm realmWithURL:RLMTestRealmURL()];
     }
 
     RLMRealm *dyrealm = [self realmWithTestPathAndSchema:nil];
@@ -193,7 +193,7 @@
 - (void)testDynamicArray {
     @autoreleasepool {
         // open realm in autoreleasepool to create tables and then dispose
-        [RLMRealm realmWithURL:[NSURL fileURLWithPath:RLMTestRealmPath()]];
+        [RLMRealm realmWithURL:RLMTestRealmURL()];
     }
 
     RLMRealm *dyrealm = [self realmWithTestPathAndSchema:nil];

--- a/Realm/Tests/EncryptionTests.mm
+++ b/Realm/Tests/EncryptionTests.mm
@@ -157,8 +157,8 @@
 
     // Create the Realm file on disk
     @autoreleasepool {
-        [RLMRealm realmWithPath:RLMDefaultRealmPath() key:key readOnly:NO
-                       inMemory:NO dynamic:YES schema: schema error:nil];
+        [RLMRealm realmWithFileURL:[NSURL fileURLWithPath:RLMDefaultRealmPath()] key:key readOnly:NO
+                          inMemory:NO dynamic:YES schema: schema error:nil];
     }
 
     RLMRealmConfiguration *config = [RLMRealmConfiguration defaultConfiguration];

--- a/Realm/Tests/EncryptionTests.mm
+++ b/Realm/Tests/EncryptionTests.mm
@@ -42,13 +42,13 @@
 #pragma mark - Key validation
 
 - (void)testBadEncryptionKeys {
-    XCTAssertThrows([RLMRealm.defaultRealm writeCopyToPath:RLMTestRealmPath() encryptionKey:self.nonLiteralNil error:nil]);
-    XCTAssertThrows([RLMRealm.defaultRealm writeCopyToPath:RLMTestRealmPath() encryptionKey:NSData.data error:nil]);
+    XCTAssertThrows([RLMRealm.defaultRealm writeCopyToFileURL:[NSURL fileURLWithPath:RLMTestRealmPath()] encryptionKey:self.nonLiteralNil error:nil]);
+    XCTAssertThrows([RLMRealm.defaultRealm writeCopyToFileURL:[NSURL fileURLWithPath:RLMTestRealmPath()] encryptionKey:NSData.data error:nil]);
 }
 
 - (void)testValidEncryptionKeys {
     NSData *key = [[NSMutableData alloc] initWithLength:64];
-    XCTAssertNoThrow([RLMRealm.defaultRealm writeCopyToPath:RLMTestRealmPath() encryptionKey:key error:nil]);
+    XCTAssertNoThrow([RLMRealm.defaultRealm writeCopyToFileURL:[NSURL fileURLWithPath:RLMTestRealmPath()] encryptionKey:key error:nil]);
 }
 
 #pragma mark - realmWithPath:
@@ -116,7 +116,7 @@
         [realm transactionWithBlock:^{
             [IntObject createInRealm:realm withValue:@[@1]];
         }];
-        [realm writeCopyToPath:RLMTestRealmPath() error:nil];
+        [realm writeCopyToFileURL:[NSURL fileURLWithPath:RLMTestRealmPath()] error:nil];
     }
 
     @autoreleasepool {
@@ -134,7 +134,7 @@
         [realm transactionWithBlock:^{
             [IntObject createInRealm:realm withValue:@[@1]];
         }];
-        [realm writeCopyToPath:RLMTestRealmPath() encryptionKey:key2 error:nil];
+        [realm writeCopyToFileURL:[NSURL fileURLWithPath:RLMTestRealmPath()] encryptionKey:key2 error:nil];
     }
 
     @autoreleasepool {

--- a/Realm/Tests/EncryptionTests.mm
+++ b/Realm/Tests/EncryptionTests.mm
@@ -30,7 +30,7 @@
 
 - (RLMRealmConfiguration *)configurationWithKey:(NSData *)key {
     RLMRealmConfiguration *configuration = [[RLMRealmConfiguration alloc] init];
-    configuration.path = RLMDefaultRealmPath();
+    configuration.fileURL = [NSURL fileURLWithPath:RLMDefaultRealmPath()];
     configuration.encryptionKey = key;
     return configuration;
 }
@@ -139,7 +139,7 @@
 
     @autoreleasepool {
         RLMRealmConfiguration *config = [self configurationWithKey:key2];
-        config.path = RLMTestRealmPath();
+        config.fileURL = [NSURL fileURLWithPath:RLMTestRealmPath()];
         RLMRealm *realm = [RLMRealm realmWithConfiguration:config error:nil];
         XCTAssertEqual(1U, [IntObject allObjectsInRealm:realm].count);
     }

--- a/Realm/Tests/EncryptionTests.mm
+++ b/Realm/Tests/EncryptionTests.mm
@@ -30,7 +30,7 @@
 
 - (RLMRealmConfiguration *)configurationWithKey:(NSData *)key {
     RLMRealmConfiguration *configuration = [[RLMRealmConfiguration alloc] init];
-    configuration.fileURL = [NSURL fileURLWithPath:RLMDefaultRealmPath()];
+    configuration.fileURL = RLMDefaultRealmURL();
     configuration.encryptionKey = key;
     return configuration;
 }
@@ -42,13 +42,13 @@
 #pragma mark - Key validation
 
 - (void)testBadEncryptionKeys {
-    XCTAssertThrows([RLMRealm.defaultRealm writeCopyToURL:[NSURL fileURLWithPath:RLMTestRealmPath()] encryptionKey:NSData.data error:nil]);
+    XCTAssertThrows([RLMRealm.defaultRealm writeCopyToURL:RLMTestRealmURL() encryptionKey:NSData.data error:nil]);
 }
 
 - (void)testValidEncryptionKeys {
-    XCTAssertNoThrow([RLMRealm.defaultRealm writeCopyToURL:[NSURL fileURLWithPath:RLMTestRealmPath()] encryptionKey:self.nonLiteralNil error:nil]);
+    XCTAssertNoThrow([RLMRealm.defaultRealm writeCopyToURL:RLMTestRealmURL() encryptionKey:self.nonLiteralNil error:nil]);
     NSData *key = [[NSMutableData alloc] initWithLength:64];
-    XCTAssertNoThrow([RLMRealm.defaultRealm writeCopyToURL:[NSURL fileURLWithPath:RLMTestRealmPath()] encryptionKey:key error:nil]);
+    XCTAssertNoThrow([RLMRealm.defaultRealm writeCopyToURL:RLMTestRealmURL() encryptionKey:key error:nil]);
 }
 
 #pragma mark - realmWithPath:
@@ -116,7 +116,7 @@
         [realm transactionWithBlock:^{
             [IntObject createInRealm:realm withValue:@[@1]];
         }];
-        [realm writeCopyToURL:[NSURL fileURLWithPath:RLMTestRealmPath()] encryptionKey:nil error:nil];
+        [realm writeCopyToURL:RLMTestRealmURL() encryptionKey:nil error:nil];
     }
 
     @autoreleasepool {
@@ -134,12 +134,12 @@
         [realm transactionWithBlock:^{
             [IntObject createInRealm:realm withValue:@[@1]];
         }];
-        [realm writeCopyToURL:[NSURL fileURLWithPath:RLMTestRealmPath()] encryptionKey:key2 error:nil];
+        [realm writeCopyToURL:RLMTestRealmURL() encryptionKey:key2 error:nil];
     }
 
     @autoreleasepool {
         RLMRealmConfiguration *config = [self configurationWithKey:key2];
-        config.fileURL = [NSURL fileURLWithPath:RLMTestRealmPath()];
+        config.fileURL = RLMTestRealmURL();
         RLMRealm *realm = [RLMRealm realmWithConfiguration:config error:nil];
         XCTAssertEqual(1U, [IntObject allObjectsInRealm:realm].count);
     }
@@ -157,7 +157,7 @@
 
     // Create the Realm file on disk
     @autoreleasepool {
-        [RLMRealm realmWithURL:[NSURL fileURLWithPath:RLMDefaultRealmPath()] key:key readOnly:NO
+        [RLMRealm realmWithURL:RLMDefaultRealmURL() key:key readOnly:NO
                           inMemory:NO dynamic:YES schema: schema error:nil];
     }
 

--- a/Realm/Tests/EncryptionTests.mm
+++ b/Realm/Tests/EncryptionTests.mm
@@ -42,11 +42,11 @@
 #pragma mark - Key validation
 
 - (void)testBadEncryptionKeys {
-    XCTAssertThrows([RLMRealm.defaultRealm writeCopyToFileURL:[NSURL fileURLWithPath:RLMTestRealmPath()] encryptionKey:self.nonLiteralNil error:nil]);
     XCTAssertThrows([RLMRealm.defaultRealm writeCopyToFileURL:[NSURL fileURLWithPath:RLMTestRealmPath()] encryptionKey:NSData.data error:nil]);
 }
 
 - (void)testValidEncryptionKeys {
+    XCTAssertNoThrow([RLMRealm.defaultRealm writeCopyToFileURL:[NSURL fileURLWithPath:RLMTestRealmPath()] encryptionKey:self.nonLiteralNil error:nil]);
     NSData *key = [[NSMutableData alloc] initWithLength:64];
     XCTAssertNoThrow([RLMRealm.defaultRealm writeCopyToFileURL:[NSURL fileURLWithPath:RLMTestRealmPath()] encryptionKey:key error:nil]);
 }
@@ -116,7 +116,7 @@
         [realm transactionWithBlock:^{
             [IntObject createInRealm:realm withValue:@[@1]];
         }];
-        [realm writeCopyToFileURL:[NSURL fileURLWithPath:RLMTestRealmPath()] error:nil];
+        [realm writeCopyToFileURL:[NSURL fileURLWithPath:RLMTestRealmPath()] encryptionKey:nil error:nil];
     }
 
     @autoreleasepool {

--- a/Realm/Tests/EncryptionTests.mm
+++ b/Realm/Tests/EncryptionTests.mm
@@ -42,13 +42,13 @@
 #pragma mark - Key validation
 
 - (void)testBadEncryptionKeys {
-    XCTAssertThrows([RLMRealm.defaultRealm writeCopyToFileURL:[NSURL fileURLWithPath:RLMTestRealmPath()] encryptionKey:NSData.data error:nil]);
+    XCTAssertThrows([RLMRealm.defaultRealm writeCopyToURL:[NSURL fileURLWithPath:RLMTestRealmPath()] encryptionKey:NSData.data error:nil]);
 }
 
 - (void)testValidEncryptionKeys {
-    XCTAssertNoThrow([RLMRealm.defaultRealm writeCopyToFileURL:[NSURL fileURLWithPath:RLMTestRealmPath()] encryptionKey:self.nonLiteralNil error:nil]);
+    XCTAssertNoThrow([RLMRealm.defaultRealm writeCopyToURL:[NSURL fileURLWithPath:RLMTestRealmPath()] encryptionKey:self.nonLiteralNil error:nil]);
     NSData *key = [[NSMutableData alloc] initWithLength:64];
-    XCTAssertNoThrow([RLMRealm.defaultRealm writeCopyToFileURL:[NSURL fileURLWithPath:RLMTestRealmPath()] encryptionKey:key error:nil]);
+    XCTAssertNoThrow([RLMRealm.defaultRealm writeCopyToURL:[NSURL fileURLWithPath:RLMTestRealmPath()] encryptionKey:key error:nil]);
 }
 
 #pragma mark - realmWithPath:
@@ -116,7 +116,7 @@
         [realm transactionWithBlock:^{
             [IntObject createInRealm:realm withValue:@[@1]];
         }];
-        [realm writeCopyToFileURL:[NSURL fileURLWithPath:RLMTestRealmPath()] encryptionKey:nil error:nil];
+        [realm writeCopyToURL:[NSURL fileURLWithPath:RLMTestRealmPath()] encryptionKey:nil error:nil];
     }
 
     @autoreleasepool {
@@ -134,7 +134,7 @@
         [realm transactionWithBlock:^{
             [IntObject createInRealm:realm withValue:@[@1]];
         }];
-        [realm writeCopyToFileURL:[NSURL fileURLWithPath:RLMTestRealmPath()] encryptionKey:key2 error:nil];
+        [realm writeCopyToURL:[NSURL fileURLWithPath:RLMTestRealmPath()] encryptionKey:key2 error:nil];
     }
 
     @autoreleasepool {
@@ -157,7 +157,7 @@
 
     // Create the Realm file on disk
     @autoreleasepool {
-        [RLMRealm realmWithFileURL:[NSURL fileURLWithPath:RLMDefaultRealmPath()] key:key readOnly:NO
+        [RLMRealm realmWithURL:[NSURL fileURLWithPath:RLMDefaultRealmPath()] key:key readOnly:NO
                           inMemory:NO dynamic:YES schema: schema error:nil];
     }
 

--- a/Realm/Tests/MigrationTests.mm
+++ b/Realm/Tests/MigrationTests.mm
@@ -115,7 +115,7 @@ RLM_ARRAY_TYPE(MigrationObject);
 
 - (RLMRealmConfiguration *)config {
     RLMRealmConfiguration *config = [RLMRealmConfiguration new];
-    config.path = RLMTestRealmPath();
+    config.fileURL = [NSURL fileURLWithPath:RLMTestRealmPath()];
     return config;
 }
 
@@ -130,7 +130,7 @@ RLM_ARRAY_TYPE(MigrationObject);
 - (void)createTestRealmWithSchema:(NSArray *)objectSchema block:(void (^)(RLMRealm *realm))block {
     @autoreleasepool {
         RLMRealmConfiguration *config = [RLMRealmConfiguration new];
-        config.path = RLMTestRealmPath();
+        config.fileURL = [NSURL fileURLWithPath:RLMTestRealmPath()];
         config.customSchema = [self schemaWithObjects:objectSchema];
 
         RLMRealm *realm = [RLMRealm realmWithConfiguration:config error:nil];
@@ -143,7 +143,7 @@ RLM_ARRAY_TYPE(MigrationObject);
 - (RLMRealm *)migrateTestRealmWithBlock:(RLMMigrationBlock)block NS_RETURNS_RETAINED {
     @autoreleasepool {
         RLMRealmConfiguration *config = [RLMRealmConfiguration new];
-        config.path = RLMTestRealmPath();
+        config.fileURL = [NSURL fileURLWithPath:RLMTestRealmPath()];
         config.schemaVersion = 1;
         config.migrationBlock = block;
         XCTAssertNil([RLMRealm migrateRealm:config]);
@@ -157,7 +157,7 @@ RLM_ARRAY_TYPE(MigrationObject);
 - (void)failToMigrateTestRealmWithBlock:(RLMMigrationBlock)block {
     @autoreleasepool {
         RLMRealmConfiguration *config = [RLMRealmConfiguration new];
-        config.path = RLMTestRealmPath();
+        config.fileURL = [NSURL fileURLWithPath:RLMTestRealmPath()];
         config.schemaVersion = 1;
         config.migrationBlock = block;
         XCTAssertNotNil([RLMRealm migrateRealm:config]);
@@ -210,7 +210,7 @@ RLM_ARRAY_TYPE(MigrationObject);
 
     RLMRealmConfiguration *config = [RLMRealmConfiguration defaultConfiguration];
     @autoreleasepool { [RLMRealm realmWithConfiguration:config error:nil]; }
-    XCTAssertEqual(0U, [RLMRealm schemaVersionAtPath:config.path encryptionKey:nil error:nil]);
+    XCTAssertEqual(0U, [RLMRealm schemaVersionAtPath:config.fileURL.path encryptionKey:nil error:nil]);
 
     config.schemaVersion = 1;
     config.migrationBlock = ^(__unused RLMMigration *migration, uint64_t oldSchemaVersion) {
@@ -218,14 +218,14 @@ RLM_ARRAY_TYPE(MigrationObject);
     };
 
     @autoreleasepool { [RLMRealm realmWithConfiguration:config error:nil]; }
-    XCTAssertEqual(1U, [RLMRealm schemaVersionAtPath:config.path encryptionKey:nil error:nil]);
+    XCTAssertEqual(1U, [RLMRealm schemaVersionAtPath:config.fileURL.path encryptionKey:nil error:nil]);
 }
 
 - (void)testSchemaVersionCannotGoDown {
     RLMRealmConfiguration *config = [RLMRealmConfiguration defaultConfiguration];
     config.schemaVersion = 10;
     @autoreleasepool { [RLMRealm realmWithConfiguration:config error:nil]; }
-    XCTAssertEqual(10U, [RLMRealm schemaVersionAtPath:config.path encryptionKey:nil error:nil]);
+    XCTAssertEqual(10U, [RLMRealm schemaVersionAtPath:config.fileURL.path encryptionKey:nil error:nil]);
 
     config.schemaVersion = 5;
     RLMAssertThrowsWithReasonMatching([RLMRealm realmWithConfiguration:config error:nil],
@@ -236,16 +236,16 @@ RLM_ARRAY_TYPE(MigrationObject);
     RLMRealmConfiguration *config = [RLMRealmConfiguration defaultConfiguration];
     config.schemaVersion = 10;
     @autoreleasepool { [RLMRealm realmWithConfiguration:config error:nil]; }
-    XCTAssertEqual(10U, [RLMRealm schemaVersionAtPath:config.path encryptionKey:nil error:nil]);
+    XCTAssertEqual(10U, [RLMRealm schemaVersionAtPath:config.fileURL.path encryptionKey:nil error:nil]);
 
     RLMRealmConfiguration *config2 = [RLMRealmConfiguration defaultConfiguration];
     config2.schemaVersion = 5;
-    config2.path = RLMTestRealmPath();
+    config2.fileURL = [NSURL fileURLWithPath:RLMTestRealmPath()];
     @autoreleasepool { [RLMRealm realmWithConfiguration:config2 error:nil]; }
-    XCTAssertEqual(5U, [RLMRealm schemaVersionAtPath:config2.path encryptionKey:nil error:nil]);
+    XCTAssertEqual(5U, [RLMRealm schemaVersionAtPath:config2.fileURL.path encryptionKey:nil error:nil]);
 
     // Should not have been changed
-    XCTAssertEqual(10U, [RLMRealm schemaVersionAtPath:config.path encryptionKey:nil error:nil]);
+    XCTAssertEqual(10U, [RLMRealm schemaVersionAtPath:config.fileURL.path encryptionKey:nil error:nil]);
 }
 
 #pragma mark - Migration Requirements
@@ -943,7 +943,7 @@ RLM_ARRAY_TYPE(MigrationObject);
     RLMRealm *realm;
     @autoreleasepool {
         RLMRealmConfiguration *config = [RLMRealmConfiguration new];
-        config.path = RLMTestRealmPath();
+        config.fileURL = [NSURL fileURLWithPath:RLMTestRealmPath()];
         config.customSchema = [self schemaWithObjects:@[ objectSchema ]];
         config.schemaVersion = 1;
         XCTAssertNil([RLMRealm migrateRealm:config]);
@@ -987,7 +987,7 @@ RLM_ARRAY_TYPE(MigrationObject);
 
     objectSchema = [RLMObjectSchema schemaForObjectClass:RequiredPropertiesObject.class];
     RLMRealmConfiguration *config = [RLMRealmConfiguration new];
-    config.path = RLMTestRealmPath();
+    config.fileURL = [NSURL fileURLWithPath:RLMTestRealmPath()];
     config.customSchema = [self schemaWithObjects:@[objectSchema]];
     config.schemaVersion = 1;
     config.migrationBlock = ^(RLMMigration *migration, uint64_t) {

--- a/Realm/Tests/MigrationTests.mm
+++ b/Realm/Tests/MigrationTests.mm
@@ -203,14 +203,14 @@ RLM_ARRAY_TYPE(MigrationObject);
 #pragma mark - Schema versions
 
 - (void)testGetSchemaVersion {
-    XCTAssertThrows([RLMRealm schemaVersionAtPath:RLMDefaultRealmPath() encryptionKey:nil error:nil]);
+    XCTAssertThrows([RLMRealm schemaVersionAtFileURL:[NSURL fileURLWithPath:RLMDefaultRealmPath()] encryptionKey:nil error:nil]);
     NSError *error;
-    XCTAssertEqual(RLMNotVersioned, [RLMRealm schemaVersionAtPath:RLMDefaultRealmPath() encryptionKey:nil error:&error]);
+    XCTAssertEqual(RLMNotVersioned, [RLMRealm schemaVersionAtFileURL:[NSURL fileURLWithPath:RLMDefaultRealmPath()] encryptionKey:nil error:&error]);
     XCTAssertNotNil(error);
 
     RLMRealmConfiguration *config = [RLMRealmConfiguration defaultConfiguration];
     @autoreleasepool { [RLMRealm realmWithConfiguration:config error:nil]; }
-    XCTAssertEqual(0U, [RLMRealm schemaVersionAtPath:config.fileURL.path encryptionKey:nil error:nil]);
+    XCTAssertEqual(0U, [RLMRealm schemaVersionAtFileURL:config.fileURL encryptionKey:nil error:nil]);
 
     config.schemaVersion = 1;
     config.migrationBlock = ^(__unused RLMMigration *migration, uint64_t oldSchemaVersion) {
@@ -218,14 +218,14 @@ RLM_ARRAY_TYPE(MigrationObject);
     };
 
     @autoreleasepool { [RLMRealm realmWithConfiguration:config error:nil]; }
-    XCTAssertEqual(1U, [RLMRealm schemaVersionAtPath:config.fileURL.path encryptionKey:nil error:nil]);
+    XCTAssertEqual(1U, [RLMRealm schemaVersionAtFileURL:config.fileURL encryptionKey:nil error:nil]);
 }
 
 - (void)testSchemaVersionCannotGoDown {
     RLMRealmConfiguration *config = [RLMRealmConfiguration defaultConfiguration];
     config.schemaVersion = 10;
     @autoreleasepool { [RLMRealm realmWithConfiguration:config error:nil]; }
-    XCTAssertEqual(10U, [RLMRealm schemaVersionAtPath:config.fileURL.path encryptionKey:nil error:nil]);
+    XCTAssertEqual(10U, [RLMRealm schemaVersionAtFileURL:config.fileURL encryptionKey:nil error:nil]);
 
     config.schemaVersion = 5;
     RLMAssertThrowsWithReasonMatching([RLMRealm realmWithConfiguration:config error:nil],
@@ -236,16 +236,16 @@ RLM_ARRAY_TYPE(MigrationObject);
     RLMRealmConfiguration *config = [RLMRealmConfiguration defaultConfiguration];
     config.schemaVersion = 10;
     @autoreleasepool { [RLMRealm realmWithConfiguration:config error:nil]; }
-    XCTAssertEqual(10U, [RLMRealm schemaVersionAtPath:config.fileURL.path encryptionKey:nil error:nil]);
+    XCTAssertEqual(10U, [RLMRealm schemaVersionAtFileURL:config.fileURL encryptionKey:nil error:nil]);
 
     RLMRealmConfiguration *config2 = [RLMRealmConfiguration defaultConfiguration];
     config2.schemaVersion = 5;
     config2.fileURL = [NSURL fileURLWithPath:RLMTestRealmPath()];
     @autoreleasepool { [RLMRealm realmWithConfiguration:config2 error:nil]; }
-    XCTAssertEqual(5U, [RLMRealm schemaVersionAtPath:config2.fileURL.path encryptionKey:nil error:nil]);
+    XCTAssertEqual(5U, [RLMRealm schemaVersionAtFileURL:config2.fileURL encryptionKey:nil error:nil]);
 
     // Should not have been changed
-    XCTAssertEqual(10U, [RLMRealm schemaVersionAtPath:config.fileURL.path encryptionKey:nil error:nil]);
+    XCTAssertEqual(10U, [RLMRealm schemaVersionAtFileURL:config.fileURL encryptionKey:nil error:nil]);
 }
 
 #pragma mark - Migration Requirements

--- a/Realm/Tests/MigrationTests.mm
+++ b/Realm/Tests/MigrationTests.mm
@@ -115,7 +115,7 @@ RLM_ARRAY_TYPE(MigrationObject);
 
 - (RLMRealmConfiguration *)config {
     RLMRealmConfiguration *config = [RLMRealmConfiguration new];
-    config.fileURL = [NSURL fileURLWithPath:RLMTestRealmPath()];
+    config.fileURL = RLMTestRealmURL();
     return config;
 }
 
@@ -130,7 +130,7 @@ RLM_ARRAY_TYPE(MigrationObject);
 - (void)createTestRealmWithSchema:(NSArray *)objectSchema block:(void (^)(RLMRealm *realm))block {
     @autoreleasepool {
         RLMRealmConfiguration *config = [RLMRealmConfiguration new];
-        config.fileURL = [NSURL fileURLWithPath:RLMTestRealmPath()];
+        config.fileURL = RLMTestRealmURL();
         config.customSchema = [self schemaWithObjects:objectSchema];
 
         RLMRealm *realm = [RLMRealm realmWithConfiguration:config error:nil];
@@ -143,7 +143,7 @@ RLM_ARRAY_TYPE(MigrationObject);
 - (RLMRealm *)migrateTestRealmWithBlock:(RLMMigrationBlock)block NS_RETURNS_RETAINED {
     @autoreleasepool {
         RLMRealmConfiguration *config = [RLMRealmConfiguration new];
-        config.fileURL = [NSURL fileURLWithPath:RLMTestRealmPath()];
+        config.fileURL = RLMTestRealmURL();
         config.schemaVersion = 1;
         config.migrationBlock = block;
         XCTAssertNil([RLMRealm migrateRealm:config]);
@@ -157,7 +157,7 @@ RLM_ARRAY_TYPE(MigrationObject);
 - (void)failToMigrateTestRealmWithBlock:(RLMMigrationBlock)block {
     @autoreleasepool {
         RLMRealmConfiguration *config = [RLMRealmConfiguration new];
-        config.fileURL = [NSURL fileURLWithPath:RLMTestRealmPath()];
+        config.fileURL = RLMTestRealmURL();
         config.schemaVersion = 1;
         config.migrationBlock = block;
         XCTAssertNotNil([RLMRealm migrateRealm:config]);
@@ -203,9 +203,9 @@ RLM_ARRAY_TYPE(MigrationObject);
 #pragma mark - Schema versions
 
 - (void)testGetSchemaVersion {
-    XCTAssertThrows([RLMRealm schemaVersionAtURL:[NSURL fileURLWithPath:RLMDefaultRealmPath()] encryptionKey:nil error:nil]);
+    XCTAssertThrows([RLMRealm schemaVersionAtURL:RLMDefaultRealmURL() encryptionKey:nil error:nil]);
     NSError *error;
-    XCTAssertEqual(RLMNotVersioned, [RLMRealm schemaVersionAtURL:[NSURL fileURLWithPath:RLMDefaultRealmPath()] encryptionKey:nil error:&error]);
+    XCTAssertEqual(RLMNotVersioned, [RLMRealm schemaVersionAtURL:RLMDefaultRealmURL() encryptionKey:nil error:&error]);
     XCTAssertNotNil(error);
 
     RLMRealmConfiguration *config = [RLMRealmConfiguration defaultConfiguration];
@@ -240,7 +240,7 @@ RLM_ARRAY_TYPE(MigrationObject);
 
     RLMRealmConfiguration *config2 = [RLMRealmConfiguration defaultConfiguration];
     config2.schemaVersion = 5;
-    config2.fileURL = [NSURL fileURLWithPath:RLMTestRealmPath()];
+    config2.fileURL = RLMTestRealmURL();
     @autoreleasepool { [RLMRealm realmWithConfiguration:config2 error:nil]; }
     XCTAssertEqual(5U, [RLMRealm schemaVersionAtURL:config2.fileURL encryptionKey:nil error:nil]);
 
@@ -487,7 +487,7 @@ RLM_ARRAY_TYPE(MigrationObject);
 
     Class intObjectAccessorClass;
     @autoreleasepool {
-        RLMRealm *realm = [self readOnlyRealmWithPath:RLMTestRealmPath() error:nil];
+        RLMRealm *realm = [self readOnlyRealmWithURL:RLMTestRealmURL() error:nil];
 
         intObjectAccessorClass = realm.schema[IntObject.className].accessorClass;
 
@@ -943,7 +943,7 @@ RLM_ARRAY_TYPE(MigrationObject);
     RLMRealm *realm;
     @autoreleasepool {
         RLMRealmConfiguration *config = [RLMRealmConfiguration new];
-        config.fileURL = [NSURL fileURLWithPath:RLMTestRealmPath()];
+        config.fileURL = RLMTestRealmURL();
         config.customSchema = [self schemaWithObjects:@[ objectSchema ]];
         config.schemaVersion = 1;
         XCTAssertNil([RLMRealm migrateRealm:config]);
@@ -987,7 +987,7 @@ RLM_ARRAY_TYPE(MigrationObject);
 
     objectSchema = [RLMObjectSchema schemaForObjectClass:RequiredPropertiesObject.class];
     RLMRealmConfiguration *config = [RLMRealmConfiguration new];
-    config.fileURL = [NSURL fileURLWithPath:RLMTestRealmPath()];
+    config.fileURL = RLMTestRealmURL();
     config.customSchema = [self schemaWithObjects:@[objectSchema]];
     config.schemaVersion = 1;
     config.migrationBlock = ^(RLMMigration *migration, uint64_t) {

--- a/Realm/Tests/MigrationTests.mm
+++ b/Realm/Tests/MigrationTests.mm
@@ -203,14 +203,14 @@ RLM_ARRAY_TYPE(MigrationObject);
 #pragma mark - Schema versions
 
 - (void)testGetSchemaVersion {
-    XCTAssertThrows([RLMRealm schemaVersionAtFileURL:[NSURL fileURLWithPath:RLMDefaultRealmPath()] encryptionKey:nil error:nil]);
+    XCTAssertThrows([RLMRealm schemaVersionAtURL:[NSURL fileURLWithPath:RLMDefaultRealmPath()] encryptionKey:nil error:nil]);
     NSError *error;
-    XCTAssertEqual(RLMNotVersioned, [RLMRealm schemaVersionAtFileURL:[NSURL fileURLWithPath:RLMDefaultRealmPath()] encryptionKey:nil error:&error]);
+    XCTAssertEqual(RLMNotVersioned, [RLMRealm schemaVersionAtURL:[NSURL fileURLWithPath:RLMDefaultRealmPath()] encryptionKey:nil error:&error]);
     XCTAssertNotNil(error);
 
     RLMRealmConfiguration *config = [RLMRealmConfiguration defaultConfiguration];
     @autoreleasepool { [RLMRealm realmWithConfiguration:config error:nil]; }
-    XCTAssertEqual(0U, [RLMRealm schemaVersionAtFileURL:config.fileURL encryptionKey:nil error:nil]);
+    XCTAssertEqual(0U, [RLMRealm schemaVersionAtURL:config.fileURL encryptionKey:nil error:nil]);
 
     config.schemaVersion = 1;
     config.migrationBlock = ^(__unused RLMMigration *migration, uint64_t oldSchemaVersion) {
@@ -218,14 +218,14 @@ RLM_ARRAY_TYPE(MigrationObject);
     };
 
     @autoreleasepool { [RLMRealm realmWithConfiguration:config error:nil]; }
-    XCTAssertEqual(1U, [RLMRealm schemaVersionAtFileURL:config.fileURL encryptionKey:nil error:nil]);
+    XCTAssertEqual(1U, [RLMRealm schemaVersionAtURL:config.fileURL encryptionKey:nil error:nil]);
 }
 
 - (void)testSchemaVersionCannotGoDown {
     RLMRealmConfiguration *config = [RLMRealmConfiguration defaultConfiguration];
     config.schemaVersion = 10;
     @autoreleasepool { [RLMRealm realmWithConfiguration:config error:nil]; }
-    XCTAssertEqual(10U, [RLMRealm schemaVersionAtFileURL:config.fileURL encryptionKey:nil error:nil]);
+    XCTAssertEqual(10U, [RLMRealm schemaVersionAtURL:config.fileURL encryptionKey:nil error:nil]);
 
     config.schemaVersion = 5;
     RLMAssertThrowsWithReasonMatching([RLMRealm realmWithConfiguration:config error:nil],
@@ -236,16 +236,16 @@ RLM_ARRAY_TYPE(MigrationObject);
     RLMRealmConfiguration *config = [RLMRealmConfiguration defaultConfiguration];
     config.schemaVersion = 10;
     @autoreleasepool { [RLMRealm realmWithConfiguration:config error:nil]; }
-    XCTAssertEqual(10U, [RLMRealm schemaVersionAtFileURL:config.fileURL encryptionKey:nil error:nil]);
+    XCTAssertEqual(10U, [RLMRealm schemaVersionAtURL:config.fileURL encryptionKey:nil error:nil]);
 
     RLMRealmConfiguration *config2 = [RLMRealmConfiguration defaultConfiguration];
     config2.schemaVersion = 5;
     config2.fileURL = [NSURL fileURLWithPath:RLMTestRealmPath()];
     @autoreleasepool { [RLMRealm realmWithConfiguration:config2 error:nil]; }
-    XCTAssertEqual(5U, [RLMRealm schemaVersionAtFileURL:config2.fileURL encryptionKey:nil error:nil]);
+    XCTAssertEqual(5U, [RLMRealm schemaVersionAtURL:config2.fileURL encryptionKey:nil error:nil]);
 
     // Should not have been changed
-    XCTAssertEqual(10U, [RLMRealm schemaVersionAtFileURL:config.fileURL encryptionKey:nil error:nil]);
+    XCTAssertEqual(10U, [RLMRealm schemaVersionAtURL:config.fileURL encryptionKey:nil error:nil]);
 }
 
 #pragma mark - Migration Requirements

--- a/Realm/Tests/PerformanceTests.m
+++ b/Realm/Tests/PerformanceTests.m
@@ -132,7 +132,7 @@ static RLMRealm *s_smallRealm, *s_mediumRealm, *s_largeRealm;
     config.inMemoryIdentifier = @(factor).stringValue;
     RLMRealm *realm = [RLMRealm realmWithConfiguration:config error:nil];
     [NSFileManager.defaultManager removeItemAtPath:RLMTestRealmPath() error:nil];
-    [realm writeCopyToPath:RLMTestRealmPath() error:nil];
+    [realm writeCopyToFileURL:[NSURL fileURLWithPath:RLMTestRealmPath()] error:nil];
     return [self realmWithTestPath];
 }
 

--- a/Realm/Tests/PerformanceTests.m
+++ b/Realm/Tests/PerformanceTests.m
@@ -132,7 +132,7 @@ static RLMRealm *s_smallRealm, *s_mediumRealm, *s_largeRealm;
     config.inMemoryIdentifier = @(factor).stringValue;
     RLMRealm *realm = [RLMRealm realmWithConfiguration:config error:nil];
     [NSFileManager.defaultManager removeItemAtPath:RLMTestRealmPath() error:nil];
-    [realm writeCopyToFileURL:[NSURL fileURLWithPath:RLMTestRealmPath()] error:nil];
+    [realm writeCopyToFileURL:[NSURL fileURLWithPath:RLMTestRealmPath()] encryptionKey:nil error:nil];
     return [self realmWithTestPath];
 }
 

--- a/Realm/Tests/PerformanceTests.m
+++ b/Realm/Tests/PerformanceTests.m
@@ -132,7 +132,7 @@ static RLMRealm *s_smallRealm, *s_mediumRealm, *s_largeRealm;
     config.inMemoryIdentifier = @(factor).stringValue;
     RLMRealm *realm = [RLMRealm realmWithConfiguration:config error:nil];
     [NSFileManager.defaultManager removeItemAtPath:RLMTestRealmPath() error:nil];
-    [realm writeCopyToFileURL:[NSURL fileURLWithPath:RLMTestRealmPath()] encryptionKey:nil error:nil];
+    [realm writeCopyToURL:[NSURL fileURLWithPath:RLMTestRealmPath()] encryptionKey:nil error:nil];
     return [self realmWithTestPath];
 }
 

--- a/Realm/Tests/PerformanceTests.m
+++ b/Realm/Tests/PerformanceTests.m
@@ -131,8 +131,8 @@ static RLMRealm *s_smallRealm, *s_mediumRealm, *s_largeRealm;
     RLMRealmConfiguration *config = [RLMRealmConfiguration new];
     config.inMemoryIdentifier = @(factor).stringValue;
     RLMRealm *realm = [RLMRealm realmWithConfiguration:config error:nil];
-    [NSFileManager.defaultManager removeItemAtPath:RLMTestRealmPath() error:nil];
-    [realm writeCopyToURL:[NSURL fileURLWithPath:RLMTestRealmPath()] encryptionKey:nil error:nil];
+    [NSFileManager.defaultManager removeItemAtPath:RLMTestRealmURL() error:nil];
+    [realm writeCopyToURL:RLMTestRealmURL() encryptionKey:nil error:nil];
     return [self realmWithTestPath];
 }
 

--- a/Realm/Tests/RLMMultiProcessTestCase.m
+++ b/Realm/Tests/RLMMultiProcessTestCase.m
@@ -66,7 +66,7 @@
         // RLMRealmConfiguration isn't aware of this, but our test's RLMDefaultRealmPath helper does.
         // Use it to reset the default configuration's path so it matches the parent.
         RLMRealmConfiguration *configuration = [RLMRealmConfiguration defaultConfiguration];
-        configuration.path = RLMDefaultRealmPath();
+        configuration.fileURL = [NSURL fileURLWithPath:RLMDefaultRealmPath()];
         [RLMRealmConfiguration setDefaultConfiguration:configuration];
     }
 

--- a/Realm/Tests/RLMMultiProcessTestCase.m
+++ b/Realm/Tests/RLMMultiProcessTestCase.m
@@ -63,10 +63,10 @@
 
     if (!self.isParent) {
         // For multi-process tests, the child's concept of a default path needs to match the parent.
-        // RLMRealmConfiguration isn't aware of this, but our test's RLMDefaultRealmPath helper does.
+        // RLMRealmConfiguration isn't aware of this, but our test's RLMDefaultRealmURL helper does.
         // Use it to reset the default configuration's path so it matches the parent.
         RLMRealmConfiguration *configuration = [RLMRealmConfiguration defaultConfiguration];
-        configuration.fileURL = [NSURL fileURLWithPath:RLMDefaultRealmPath()];
+        configuration.fileURL = RLMDefaultRealmURL();
         [RLMRealmConfiguration setDefaultConfiguration:configuration];
     }
 

--- a/Realm/Tests/RLMTestCase.h
+++ b/Realm/Tests/RLMTestCase.h
@@ -23,8 +23,8 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-NSString *RLMTestRealmPath(void);
-NSString *RLMDefaultRealmPath(void);
+NSURL *RLMTestRealmURL(void);
+NSURL *RLMDefaultRealmURL(void);
 NSString *RLMRealmPathForFile(NSString *);
 NSData *RLMGenerateKey(void);
 #ifdef __cplusplus
@@ -37,10 +37,10 @@ NSData *RLMGenerateKey(void);
 - (RLMRealm *)realmWithTestPathAndSchema:(RLMSchema *)schema;
 
 - (RLMRealm *)inMemoryRealmWithIdentifier:(NSString *)identifier;
-- (RLMRealm *)readOnlyRealmWithPath:(NSString *)path error:(NSError **)error;
+- (RLMRealm *)readOnlyRealmWithURL:(NSURL *)fileURL error:(NSError **)error;
 
 - (void)deleteFiles;
-- (void)deleteRealmFileAtPath:(NSString *)realmPath;
+- (void)deleteRealmFileAtURL:(NSURL *)fileURL;
 
 - (void)waitForNotification:(NSString *)expectedNote realm:(RLMRealm *)realm block:(dispatch_block_t)block;
 

--- a/Realm/Tests/RLMTestCase.m
+++ b/Realm/Tests/RLMTestCase.m
@@ -147,11 +147,11 @@ static BOOL encryptTests() {
 
 - (RLMRealm *)realmWithTestPath
 {
-    return [RLMRealm realmWithPath:RLMTestRealmPath()];
+    return [RLMRealm realmWithFileURL:[NSURL fileURLWithPath:RLMTestRealmPath()]];
 }
 
 - (RLMRealm *)realmWithTestPathAndSchema:(RLMSchema *)schema {
-    return [RLMRealm realmWithPath:RLMTestRealmPath() key:nil readOnly:NO inMemory:NO dynamic:YES schema:schema error:nil];
+    return [RLMRealm realmWithFileURL:[NSURL fileURLWithPath:RLMTestRealmPath()] key:nil readOnly:NO inMemory:NO dynamic:YES schema:schema error:nil];
 }
 
 - (RLMRealm *)inMemoryRealmWithIdentifier:(NSString *)identifier {

--- a/Realm/Tests/RLMTestCase.m
+++ b/Realm/Tests/RLMTestCase.m
@@ -162,7 +162,7 @@ static BOOL encryptTests() {
 
 - (RLMRealm *)readOnlyRealmWithPath:(NSString *)path error:(NSError **)error {
     RLMRealmConfiguration *configuration = [RLMRealmConfiguration defaultConfiguration];
-    configuration.path = path;
+    configuration.fileURL = [NSURL fileURLWithPath:path];
     configuration.readOnly = true;
     return [RLMRealm realmWithConfiguration:configuration error:error];
 }

--- a/Realm/Tests/RLMTestCase.m
+++ b/Realm/Tests/RLMTestCase.m
@@ -35,17 +35,17 @@ static NSString *parentProcessBundleIdentifier()
     return identifier;
 }
 
-NSString *RLMDefaultRealmPath() {
-    return RLMRealmPathForFileAndBundleIdentifier(@"default.realm", parentProcessBundleIdentifier());
+NSURL *RLMDefaultRealmURL() {
+    return [NSURL fileURLWithPath:RLMRealmPathForFileAndBundleIdentifier(@"default.realm", parentProcessBundleIdentifier())];
 }
 
-NSString *RLMTestRealmPath() {
-    return RLMRealmPathForFileAndBundleIdentifier(@"test.realm", parentProcessBundleIdentifier());
+NSURL *RLMTestRealmURL() {
+    return [NSURL fileURLWithPath:RLMRealmPathForFileAndBundleIdentifier(@"test.realm", parentProcessBundleIdentifier())];
 }
 
-static void deleteOrThrow(NSString *path) {
+static void deleteOrThrow(NSURL *fileURL) {
     NSError *error;
-    if (![[NSFileManager defaultManager] removeItemAtPath:path error:&error]) {
+    if (![[NSFileManager defaultManager] removeItemAtURL:fileURL error:&error]) {
         if (error.code != NSFileNoSuchFileError) {
             @throw [NSException exceptionWithName:@"RLMTestException"
                                            reason:[@"Unable to delete realm: " stringByAppendingString:error.description]
@@ -92,8 +92,8 @@ static BOOL encryptTests() {
 
     // Ensure the documents directory exists as it sometimes doesn't after
     // resetting the simulator
-    [NSFileManager.defaultManager createDirectoryAtPath:RLMDefaultRealmPath().stringByDeletingLastPathComponent
-                            withIntermediateDirectories:YES attributes:nil error:nil];
+    [NSFileManager.defaultManager createDirectoryAtURL:RLMDefaultRealmURL().URLByDeletingLastPathComponent
+                           withIntermediateDirectories:YES attributes:nil error:nil];
 }
 
 // This ensures the shared schema is initialized outside of of a test case,
@@ -109,19 +109,19 @@ static BOOL encryptTests() {
     [self resetRealmState];
 
     // Delete Realm files
-    [self deleteRealmFileAtPath:RLMDefaultRealmPath()];
-    [self deleteRealmFileAtPath:RLMTestRealmPath()];
+    [self deleteRealmFileAtURL:RLMDefaultRealmURL()];
+    [self deleteRealmFileAtURL:RLMTestRealmURL()];
 }
 
 - (void)resetRealmState {
     [RLMRealm resetRealmState];
 }
 
-- (void)deleteRealmFileAtPath:(NSString *)path
+- (void)deleteRealmFileAtURL:(NSURL *)fileURL
 {
-    deleteOrThrow(path);
-    deleteOrThrow([path stringByAppendingString:@".lock"]);
-    deleteOrThrow([path stringByAppendingString:@".note"]);
+    deleteOrThrow(fileURL);
+    deleteOrThrow([fileURL URLByAppendingPathExtension:@"lock"]);
+    deleteOrThrow([fileURL URLByAppendingPathExtension:@"note"]);
 }
 
 - (void)invokeTest {
@@ -147,11 +147,11 @@ static BOOL encryptTests() {
 
 - (RLMRealm *)realmWithTestPath
 {
-    return [RLMRealm realmWithURL:[NSURL fileURLWithPath:RLMTestRealmPath()]];
+    return [RLMRealm realmWithURL:RLMTestRealmURL()];
 }
 
 - (RLMRealm *)realmWithTestPathAndSchema:(RLMSchema *)schema {
-    return [RLMRealm realmWithURL:[NSURL fileURLWithPath:RLMTestRealmPath()] key:nil readOnly:NO inMemory:NO dynamic:YES schema:schema error:nil];
+    return [RLMRealm realmWithURL:RLMTestRealmURL() key:nil readOnly:NO inMemory:NO dynamic:YES schema:schema error:nil];
 }
 
 - (RLMRealm *)inMemoryRealmWithIdentifier:(NSString *)identifier {
@@ -160,9 +160,9 @@ static BOOL encryptTests() {
     return [RLMRealm realmWithConfiguration:configuration error:nil];
 }
 
-- (RLMRealm *)readOnlyRealmWithPath:(NSString *)path error:(NSError **)error {
+- (RLMRealm *)readOnlyRealmWithURL:(NSURL *)fileURL error:(NSError **)error {
     RLMRealmConfiguration *configuration = [RLMRealmConfiguration defaultConfiguration];
-    configuration.fileURL = [NSURL fileURLWithPath:path];
+    configuration.fileURL = fileURL;
     configuration.readOnly = true;
     return [RLMRealm realmWithConfiguration:configuration error:error];
 }

--- a/Realm/Tests/RLMTestCase.m
+++ b/Realm/Tests/RLMTestCase.m
@@ -147,11 +147,11 @@ static BOOL encryptTests() {
 
 - (RLMRealm *)realmWithTestPath
 {
-    return [RLMRealm realmWithFileURL:[NSURL fileURLWithPath:RLMTestRealmPath()]];
+    return [RLMRealm realmWithURL:[NSURL fileURLWithPath:RLMTestRealmPath()]];
 }
 
 - (RLMRealm *)realmWithTestPathAndSchema:(RLMSchema *)schema {
-    return [RLMRealm realmWithFileURL:[NSURL fileURLWithPath:RLMTestRealmPath()] key:nil readOnly:NO inMemory:NO dynamic:YES schema:schema error:nil];
+    return [RLMRealm realmWithURL:[NSURL fileURLWithPath:RLMTestRealmPath()] key:nil readOnly:NO inMemory:NO dynamic:YES schema:schema error:nil];
 }
 
 - (RLMRealm *)inMemoryRealmWithIdentifier:(NSString *)identifier {

--- a/Realm/Tests/RealmConfigurationTests.mm
+++ b/Realm/Tests/RealmConfigurationTests.mm
@@ -137,7 +137,7 @@
     @autoreleasepool {
         RLMRealm *realm = RLMRealm.defaultRealm;
         NSString *realmPath = @(realm.configuration.config.path.c_str());
-        XCTAssertEqual(1U, [RLMRealm schemaVersionAtPath:realmPath error:nil]);
+        XCTAssertEqual(1U, [RLMRealm schemaVersionAtFileURL:[NSURL fileURLWithPath:realmPath] error:nil]);
     }
 
     config.fileURL = [NSURL fileURLWithPath:RLMDefaultRealmPath()];

--- a/Realm/Tests/RealmConfigurationTests.mm
+++ b/Realm/Tests/RealmConfigurationTests.mm
@@ -36,9 +36,9 @@
     XCTAssertNil(configuration.path);
     XCTAssertEqualObjects(configuration.inMemoryIdentifier, @"identifier");
 
-    configuration.path = @"path";
+    configuration.path = @"/dev/null";
     XCTAssertNil(configuration.inMemoryIdentifier);
-    XCTAssertEqualObjects(configuration.path, @"path");
+    XCTAssertEqualObjects(configuration.path, @"/dev/null");
 }
 
 - (void)testPathValidation {
@@ -98,9 +98,9 @@
 
 - (void)testSetDefaultConfiguration {
     RLMRealmConfiguration *configuration = [[RLMRealmConfiguration alloc] init];
-    configuration.path = @"path";
+    configuration.path = @"/dev/null";
     [RLMRealmConfiguration setDefaultConfiguration:configuration];
-    XCTAssertEqualObjects(RLMRealmConfiguration.defaultConfiguration.path, @"path");
+    XCTAssertEqualObjects(RLMRealmConfiguration.defaultConfiguration.path, @"/dev/null");
 }
 
 - (void)testDefaultConfiugrationUsesValueSemantics {

--- a/Realm/Tests/RealmConfigurationTests.mm
+++ b/Realm/Tests/RealmConfigurationTests.mm
@@ -137,7 +137,7 @@
     @autoreleasepool {
         RLMRealm *realm = RLMRealm.defaultRealm;
         NSString *realmPath = @(realm.configuration.config.path.c_str());
-        XCTAssertEqual(1U, [RLMRealm schemaVersionAtFileURL:[NSURL fileURLWithPath:realmPath] error:nil]);
+        XCTAssertEqual(1U, [RLMRealm schemaVersionAtFileURL:[NSURL fileURLWithPath:realmPath] encryptionKey:nil error:nil]);
     }
 
     config.fileURL = [NSURL fileURLWithPath:RLMDefaultRealmPath()];

--- a/Realm/Tests/RealmConfigurationTests.mm
+++ b/Realm/Tests/RealmConfigurationTests.mm
@@ -137,7 +137,7 @@
     @autoreleasepool {
         RLMRealm *realm = RLMRealm.defaultRealm;
         NSString *realmPath = @(realm.configuration.config.path.c_str());
-        XCTAssertEqual(1U, [RLMRealm schemaVersionAtFileURL:[NSURL fileURLWithPath:realmPath] encryptionKey:nil error:nil]);
+        XCTAssertEqual(1U, [RLMRealm schemaVersionAtURL:[NSURL fileURLWithPath:realmPath] encryptionKey:nil error:nil]);
     }
 
     config.fileURL = [NSURL fileURLWithPath:RLMDefaultRealmPath()];

--- a/Realm/Tests/RealmConfigurationTests.mm
+++ b/Realm/Tests/RealmConfigurationTests.mm
@@ -79,11 +79,11 @@
     XCTAssertNoThrow(configuration.objectClasses = (@[CompanyObject.class, EmployeeObject.class]));
 }
 
-#pragma mark - Default Confiugration
+#pragma mark - Default Configuration
 
 - (void)testDefaultConfiguration {
     RLMRealmConfiguration *defaultConfiguration = [RLMRealmConfiguration defaultConfiguration];
-    XCTAssertEqualObjects(defaultConfiguration.fileURL.path, RLMDefaultRealmPath());
+    XCTAssertEqualObjects(defaultConfiguration.fileURL, RLMDefaultRealmURL());
     XCTAssertNil(defaultConfiguration.inMemoryIdentifier);
     XCTAssertNil(defaultConfiguration.encryptionKey);
     XCTAssertFalse(defaultConfiguration.readOnly);
@@ -118,7 +118,7 @@
     RLMRealmConfiguration *config = [RLMRealmConfiguration defaultConfiguration];
     @autoreleasepool { XCTAssertEqualObjects(RLMRealm.defaultRealm.configuration.fileURL, config.fileURL); }
 
-    config.fileURL = [NSURL fileURLWithPath:RLMTestRealmPath()];
+    config.fileURL = RLMTestRealmURL();
     @autoreleasepool { XCTAssertNotEqualObjects(RLMRealm.defaultRealm.configuration.fileURL, config.fileURL); }
     RLMRealmConfiguration.defaultConfiguration = config;
     @autoreleasepool { XCTAssertEqualObjects(RLMRealm.defaultRealm.configuration.fileURL, config.fileURL); }
@@ -140,7 +140,7 @@
         XCTAssertEqual(1U, [RLMRealm schemaVersionAtURL:[NSURL fileURLWithPath:realmPath] encryptionKey:nil error:nil]);
     }
 
-    config.fileURL = [NSURL fileURLWithPath:RLMDefaultRealmPath()];
+    config.fileURL = RLMDefaultRealmURL();
     RLMRealmConfiguration.defaultConfiguration = config;
 
     config.encryptionKey = RLMGenerateKey();
@@ -150,7 +150,7 @@
         XCTAssertThrows([RLMRealm defaultRealm]);
     }
 
-    [self deleteRealmFileAtPath:config.fileURL.path];
+    [self deleteRealmFileAtURL:config.fileURL];
     // Create and then re-open with same key
     @autoreleasepool { XCTAssertNoThrow([RLMRealm defaultRealm]); }
     @autoreleasepool { XCTAssertNoThrow([RLMRealm defaultRealm]); }
@@ -162,7 +162,7 @@
 
     // Verify that the default realm's migration block is used implicitly
     // when needed
-    [self deleteRealmFileAtPath:config.fileURL.path];
+    [self deleteRealmFileAtURL:config.fileURL];
     @autoreleasepool { XCTAssertNoThrow([RLMRealm defaultRealm]); }
 
     config.schemaVersion = 2;

--- a/Realm/Tests/RealmTests.mm
+++ b/Realm/Tests/RealmTests.mm
@@ -82,7 +82,7 @@ extern "C" {
     RLMRealmConfiguration *newDefaultConfiguration = [originalDefaultConfiguration copy];
     newDefaultConfiguration.objectClasses = @[];
     [RLMRealmConfiguration setDefaultConfiguration:newDefaultConfiguration];
-    XCTAssertEqual([[[[RLMRealm realmWithFileURL:[NSURL fileURLWithPath:RLMTestRealmPath()]] configuration] objectClasses] count], 0U);
+    XCTAssertEqual([[[[RLMRealm realmWithURL:[NSURL fileURLWithPath:RLMTestRealmPath()]] configuration] objectClasses] count], 0U);
     [RLMRealmConfiguration setDefaultConfiguration:originalDefaultConfiguration];
 }
 
@@ -1308,7 +1308,7 @@ extern "C" {
     }];
 
     NSError *writeError;
-    XCTAssertTrue([realm writeCopyToFileURL:[NSURL fileURLWithPath:RLMTestRealmPath()] encryptionKey:nil error:&writeError]);
+    XCTAssertTrue([realm writeCopyToURL:[NSURL fileURLWithPath:RLMTestRealmPath()] encryptionKey:nil error:&writeError]);
     XCTAssertNil(writeError);
     RLMRealm *copy = [self realmWithTestPath];
     XCTAssertEqual(1U, [IntObject allObjectsInRealm:copy].count);
@@ -1322,7 +1322,7 @@ extern "C" {
     }];
 
     NSError *writeError;
-    XCTAssertFalse([realm writeCopyToFileURL:[NSURL fileURLWithPath:RLMTestRealmPath()] encryptionKey:nil error:&writeError]);
+    XCTAssertFalse([realm writeCopyToURL:[NSURL fileURLWithPath:RLMTestRealmPath()] encryptionKey:nil error:&writeError]);
     XCTAssertEqual(writeError.code, RLMErrorFileExists);
 }
 
@@ -1334,7 +1334,7 @@ extern "C" {
     }];
 
     NSError *writeError;
-    XCTAssertFalse([realm writeCopyToFileURL:[NSURL fileURLWithPath:@"/tmp/RLMTestDirMayNotExist/foo"] encryptionKey:nil error:&writeError]);
+    XCTAssertFalse([realm writeCopyToURL:[NSURL fileURLWithPath:@"/tmp/RLMTestDirMayNotExist/foo"] encryptionKey:nil error:&writeError]);
     XCTAssertEqual(writeError.code, RLMErrorFileNotFound);
 }
 
@@ -1345,7 +1345,7 @@ extern "C" {
         [IntObject createInRealm:realm withValue:@[@0]];
 
         NSError *writeError;
-        XCTAssertTrue([realm writeCopyToFileURL:[NSURL fileURLWithPath:RLMTestRealmPath()] encryptionKey:nil error:&writeError]);
+        XCTAssertTrue([realm writeCopyToURL:[NSURL fileURLWithPath:RLMTestRealmPath()] encryptionKey:nil error:&writeError]);
         XCTAssertNil(writeError);
         RLMRealm *copy = [self realmWithTestPath];
         XCTAssertEqual(1U, [IntObject allObjectsInRealm:copy].count);
@@ -1382,7 +1382,7 @@ extern "C" {
 
 - (void)testRealmFileAccess
 {
-    XCTAssertThrows([RLMRealm realmWithFileURL:self.nonLiteralNil], @"nil path");
+    XCTAssertThrows([RLMRealm realmWithURL:self.nonLiteralNil], @"nil path");
 
     NSString *content = @"Some content";
     NSData *fileContents = [content dataUsingEncoding:NSUTF8StringEncoding];
@@ -1505,7 +1505,7 @@ extern "C" {
 {
     NSMutableArray *realms = [NSMutableArray array];
     for (NSString *realmPath in self.pathsFor100Realms) {
-        [realms addObject:[RLMRealm realmWithFileURL:[NSURL fileURLWithPath:realmPath]]];
+        [realms addObject:[RLMRealm realmWithURL:[NSURL fileURLWithPath:realmPath]]];
     }
 
     XCTestExpectation *expectation = [self expectationWithDescription:@"Block dispatched to concurrent queue should be executed"];

--- a/Realm/Tests/RealmTests.mm
+++ b/Realm/Tests/RealmTests.mm
@@ -82,7 +82,7 @@ extern "C" {
     RLMRealmConfiguration *newDefaultConfiguration = [originalDefaultConfiguration copy];
     newDefaultConfiguration.objectClasses = @[];
     [RLMRealmConfiguration setDefaultConfiguration:newDefaultConfiguration];
-    XCTAssertEqual([[[[RLMRealm realmWithPath:RLMTestRealmPath()] configuration] objectClasses] count], 0U);
+    XCTAssertEqual([[[[RLMRealm realmWithFileURL:[NSURL fileURLWithPath:RLMTestRealmPath()]] configuration] objectClasses] count], 0U);
     [RLMRealmConfiguration setDefaultConfiguration:originalDefaultConfiguration];
 }
 
@@ -1383,8 +1383,7 @@ extern "C" {
 
 - (void)testRealmFileAccess
 {
-    XCTAssertThrows([RLMRealm realmWithPath:self.nonLiteralNil], @"nil path");
-    XCTAssertThrows([RLMRealm realmWithPath:@""], @"empty path");
+    XCTAssertThrows([RLMRealm realmWithFileURL:self.nonLiteralNil], @"nil path");
 
     NSString *content = @"Some content";
     NSData *fileContents = [content dataUsingEncoding:NSUTF8StringEncoding];
@@ -1507,7 +1506,7 @@ extern "C" {
 {
     NSMutableArray *realms = [NSMutableArray array];
     for (NSString *realmPath in self.pathsFor100Realms) {
-        [realms addObject:[RLMRealm realmWithPath:realmPath]];
+        [realms addObject:[RLMRealm realmWithFileURL:[NSURL fileURLWithPath:realmPath]]];
     }
 
     XCTestExpectation *expectation = [self expectationWithDescription:@"Block dispatched to concurrent queue should be executed"];

--- a/Realm/Tests/RealmTests.mm
+++ b/Realm/Tests/RealmTests.mm
@@ -1308,7 +1308,7 @@ extern "C" {
     }];
 
     NSError *writeError;
-    XCTAssertTrue([realm writeCopyToFileURL:[NSURL fileURLWithPath:RLMTestRealmPath()] error:&writeError]);
+    XCTAssertTrue([realm writeCopyToFileURL:[NSURL fileURLWithPath:RLMTestRealmPath()] encryptionKey:nil error:&writeError]);
     XCTAssertNil(writeError);
     RLMRealm *copy = [self realmWithTestPath];
     XCTAssertEqual(1U, [IntObject allObjectsInRealm:copy].count);
@@ -1322,7 +1322,7 @@ extern "C" {
     }];
 
     NSError *writeError;
-    XCTAssertFalse([realm writeCopyToFileURL:[NSURL fileURLWithPath:RLMTestRealmPath()] error:&writeError]);
+    XCTAssertFalse([realm writeCopyToFileURL:[NSURL fileURLWithPath:RLMTestRealmPath()] encryptionKey:nil error:&writeError]);
     XCTAssertEqual(writeError.code, RLMErrorFileExists);
 }
 
@@ -1334,7 +1334,7 @@ extern "C" {
     }];
 
     NSError *writeError;
-    XCTAssertFalse([realm writeCopyToFileURL:[NSURL fileURLWithPath:@"/tmp/RLMTestDirMayNotExist/foo"] error:&writeError]);
+    XCTAssertFalse([realm writeCopyToFileURL:[NSURL fileURLWithPath:@"/tmp/RLMTestDirMayNotExist/foo"] encryptionKey:nil error:&writeError]);
     XCTAssertEqual(writeError.code, RLMErrorFileNotFound);
 }
 
@@ -1345,7 +1345,7 @@ extern "C" {
         [IntObject createInRealm:realm withValue:@[@0]];
 
         NSError *writeError;
-        XCTAssertTrue([realm writeCopyToFileURL:[NSURL fileURLWithPath:RLMTestRealmPath()] error:&writeError]);
+        XCTAssertTrue([realm writeCopyToFileURL:[NSURL fileURLWithPath:RLMTestRealmPath()] encryptionKey:nil error:&writeError]);
         XCTAssertNil(writeError);
         RLMRealm *copy = [self realmWithTestPath];
         XCTAssertEqual(1U, [IntObject allObjectsInRealm:copy].count);

--- a/Realm/Tests/RealmTests.mm
+++ b/Realm/Tests/RealmTests.mm
@@ -1308,7 +1308,7 @@ extern "C" {
     }];
 
     NSError *writeError;
-    XCTAssertTrue([realm writeCopyToPath:RLMTestRealmPath() error:&writeError]);
+    XCTAssertTrue([realm writeCopyToFileURL:[NSURL fileURLWithPath:RLMTestRealmPath()] error:&writeError]);
     XCTAssertNil(writeError);
     RLMRealm *copy = [self realmWithTestPath];
     XCTAssertEqual(1U, [IntObject allObjectsInRealm:copy].count);
@@ -1322,7 +1322,7 @@ extern "C" {
     }];
 
     NSError *writeError;
-    XCTAssertFalse([realm writeCopyToPath:RLMTestRealmPath() error:&writeError]);
+    XCTAssertFalse([realm writeCopyToFileURL:[NSURL fileURLWithPath:RLMTestRealmPath()] error:&writeError]);
     XCTAssertEqual(writeError.code, RLMErrorFileExists);
 }
 
@@ -1333,9 +1333,8 @@ extern "C" {
         [IntObject createInRealm:realm withValue:@[@0]];
     }];
 
-
     NSError *writeError;
-    XCTAssertFalse([realm writeCopyToPath:@"/tmp/RLMTestDirMayNotExist/foo" error:&writeError]);
+    XCTAssertFalse([realm writeCopyToFileURL:[NSURL fileURLWithPath:@"/tmp/RLMTestDirMayNotExist/foo"] error:&writeError]);
     XCTAssertEqual(writeError.code, RLMErrorFileNotFound);
 }
 
@@ -1346,7 +1345,7 @@ extern "C" {
         [IntObject createInRealm:realm withValue:@[@0]];
 
         NSError *writeError;
-        XCTAssertTrue([realm writeCopyToPath:RLMTestRealmPath() error:&writeError]);
+        XCTAssertTrue([realm writeCopyToFileURL:[NSURL fileURLWithPath:RLMTestRealmPath()] error:&writeError]);
         XCTAssertNil(writeError);
         RLMRealm *copy = [self realmWithTestPath];
         XCTAssertEqual(1U, [IntObject allObjectsInRealm:copy].count);

--- a/Realm/Tests/Swift1.2/SwiftDynamicTests.swift
+++ b/Realm/Tests/Swift1.2/SwiftDynamicTests.swift
@@ -28,7 +28,7 @@ class SwiftDynamicTests: RLMTestCase {
     func testDynamicRealmExists() {
         autoreleasepool {
             // open realm in autoreleasepool to create tables and then dispose
-            let realm = RLMRealm(path: RLMTestRealmPath())
+            let realm = RLMRealm(fileURL: NSURL(fileURLWithPath: RLMTestRealmPath())!)
             realm.beginWriteTransaction()
             SwiftDynamicObject.createInRealm(realm, withValue: ["column1", 1])
             SwiftDynamicObject.createInRealm(realm, withValue: ["column2", 2])
@@ -54,7 +54,7 @@ class SwiftDynamicTests: RLMTestCase {
     func testDynamicProperties() {
         autoreleasepool {
             // open realm in autoreleasepool to create tables and then dispose
-            let realm = RLMRealm(path: RLMTestRealmPath())
+            let realm = RLMRealm(fileURL: NSURL(fileURLWithPath: RLMTestRealmPath())!)
             realm.beginWriteTransaction()
             SwiftDynamicObject.createInRealm(realm, withValue: ["column1", 1])
             SwiftDynamicObject.createInRealm(realm, withValue: ["column2", 2])
@@ -74,7 +74,7 @@ class SwiftDynamicTests: RLMTestCase {
     func testDynamicRealmExists_objc() {
         autoreleasepool {
             // open realm in autoreleasepool to create tables and then dispose
-            let realm = RLMRealm(path: RLMTestRealmPath())
+            let realm = RLMRealm(fileURL: NSURL(fileURLWithPath: RLMTestRealmPath())!)
             realm.beginWriteTransaction()
             DynamicObject.createInRealm(realm, withValue: ["column1", 1])
             DynamicObject.createInRealm(realm, withValue: ["column2", 2])
@@ -100,7 +100,7 @@ class SwiftDynamicTests: RLMTestCase {
     func testDynamicProperties_objc() {
         autoreleasepool {
             // open realm in autoreleasepool to create tables and then dispose
-            let realm = RLMRealm(path: RLMTestRealmPath())
+            let realm = RLMRealm(fileURL: NSURL(fileURLWithPath: RLMTestRealmPath())!)
             realm.beginWriteTransaction()
             DynamicObject.createInRealm(realm, withValue: ["column1", 1])
             DynamicObject.createInRealm(realm, withValue: ["column2", 2])

--- a/Realm/Tests/Swift1.2/SwiftDynamicTests.swift
+++ b/Realm/Tests/Swift1.2/SwiftDynamicTests.swift
@@ -28,7 +28,7 @@ class SwiftDynamicTests: RLMTestCase {
     func testDynamicRealmExists() {
         autoreleasepool {
             // open realm in autoreleasepool to create tables and then dispose
-            let realm = RLMRealm(fileURL: NSURL(fileURLWithPath: RLMTestRealmPath())!)
+            let realm = RLMRealm(URL: NSURL(fileURLWithPath: RLMTestRealmPath())!)
             realm.beginWriteTransaction()
             SwiftDynamicObject.createInRealm(realm, withValue: ["column1", 1])
             SwiftDynamicObject.createInRealm(realm, withValue: ["column2", 2])
@@ -54,7 +54,7 @@ class SwiftDynamicTests: RLMTestCase {
     func testDynamicProperties() {
         autoreleasepool {
             // open realm in autoreleasepool to create tables and then dispose
-            let realm = RLMRealm(fileURL: NSURL(fileURLWithPath: RLMTestRealmPath())!)
+            let realm = RLMRealm(URL: NSURL(fileURLWithPath: RLMTestRealmPath())!)
             realm.beginWriteTransaction()
             SwiftDynamicObject.createInRealm(realm, withValue: ["column1", 1])
             SwiftDynamicObject.createInRealm(realm, withValue: ["column2", 2])
@@ -74,7 +74,7 @@ class SwiftDynamicTests: RLMTestCase {
     func testDynamicRealmExists_objc() {
         autoreleasepool {
             // open realm in autoreleasepool to create tables and then dispose
-            let realm = RLMRealm(fileURL: NSURL(fileURLWithPath: RLMTestRealmPath())!)
+            let realm = RLMRealm(URL: NSURL(fileURLWithPath: RLMTestRealmPath())!)
             realm.beginWriteTransaction()
             DynamicObject.createInRealm(realm, withValue: ["column1", 1])
             DynamicObject.createInRealm(realm, withValue: ["column2", 2])
@@ -100,7 +100,7 @@ class SwiftDynamicTests: RLMTestCase {
     func testDynamicProperties_objc() {
         autoreleasepool {
             // open realm in autoreleasepool to create tables and then dispose
-            let realm = RLMRealm(fileURL: NSURL(fileURLWithPath: RLMTestRealmPath())!)
+            let realm = RLMRealm(URL: NSURL(fileURLWithPath: RLMTestRealmPath())!)
             realm.beginWriteTransaction()
             DynamicObject.createInRealm(realm, withValue: ["column1", 1])
             DynamicObject.createInRealm(realm, withValue: ["column2", 2])

--- a/Realm/Tests/Swift1.2/SwiftDynamicTests.swift
+++ b/Realm/Tests/Swift1.2/SwiftDynamicTests.swift
@@ -28,7 +28,7 @@ class SwiftDynamicTests: RLMTestCase {
     func testDynamicRealmExists() {
         autoreleasepool {
             // open realm in autoreleasepool to create tables and then dispose
-            let realm = RLMRealm(URL: NSURL(fileURLWithPath: RLMTestRealmPath())!)
+            let realm = RLMRealm(URL: RLMTestRealmURL())
             realm.beginWriteTransaction()
             SwiftDynamicObject.createInRealm(realm, withValue: ["column1", 1])
             SwiftDynamicObject.createInRealm(realm, withValue: ["column2", 2])
@@ -54,7 +54,7 @@ class SwiftDynamicTests: RLMTestCase {
     func testDynamicProperties() {
         autoreleasepool {
             // open realm in autoreleasepool to create tables and then dispose
-            let realm = RLMRealm(URL: NSURL(fileURLWithPath: RLMTestRealmPath())!)
+            let realm = RLMRealm(URL: RLMTestRealmURL())
             realm.beginWriteTransaction()
             SwiftDynamicObject.createInRealm(realm, withValue: ["column1", 1])
             SwiftDynamicObject.createInRealm(realm, withValue: ["column2", 2])
@@ -74,7 +74,7 @@ class SwiftDynamicTests: RLMTestCase {
     func testDynamicRealmExists_objc() {
         autoreleasepool {
             // open realm in autoreleasepool to create tables and then dispose
-            let realm = RLMRealm(URL: NSURL(fileURLWithPath: RLMTestRealmPath())!)
+            let realm = RLMRealm(URL: RLMTestRealmURL())
             realm.beginWriteTransaction()
             DynamicObject.createInRealm(realm, withValue: ["column1", 1])
             DynamicObject.createInRealm(realm, withValue: ["column2", 2])
@@ -100,7 +100,7 @@ class SwiftDynamicTests: RLMTestCase {
     func testDynamicProperties_objc() {
         autoreleasepool {
             // open realm in autoreleasepool to create tables and then dispose
-            let realm = RLMRealm(URL: NSURL(fileURLWithPath: RLMTestRealmPath())!)
+            let realm = RLMRealm(URL: RLMTestRealmURL())
             realm.beginWriteTransaction()
             DynamicObject.createInRealm(realm, withValue: ["column1", 1])
             DynamicObject.createInRealm(realm, withValue: ["column2", 2])

--- a/Realm/Tests/Swift2.0/SwiftDynamicTests.swift
+++ b/Realm/Tests/Swift2.0/SwiftDynamicTests.swift
@@ -28,7 +28,7 @@ class SwiftDynamicTests: RLMTestCase {
     func testDynamicRealmExists() {
         autoreleasepool {
             // open realm in autoreleasepool to create tables and then dispose
-            let realm = RLMRealm(path: RLMTestRealmPath())
+            let realm = RLMRealm(fileURL: NSURL(fileURLWithPath: RLMTestRealmPath()))
             realm.beginWriteTransaction()
             SwiftDynamicObject.createInRealm(realm, withValue: ["column1", 1])
             SwiftDynamicObject.createInRealm(realm, withValue: ["column2", 2])
@@ -54,7 +54,7 @@ class SwiftDynamicTests: RLMTestCase {
     func testDynamicProperties() {
         autoreleasepool {
             // open realm in autoreleasepool to create tables and then dispose
-            let realm = RLMRealm(path: RLMTestRealmPath())
+            let realm = RLMRealm(fileURL: NSURL(fileURLWithPath: RLMTestRealmPath()))
             realm.beginWriteTransaction()
             SwiftDynamicObject.createInRealm(realm, withValue: ["column1", 1])
             SwiftDynamicObject.createInRealm(realm, withValue: ["column2", 2])
@@ -74,7 +74,7 @@ class SwiftDynamicTests: RLMTestCase {
     func testDynamicRealmExists_objc() {
         autoreleasepool {
             // open realm in autoreleasepool to create tables and then dispose
-            let realm = RLMRealm(path: RLMTestRealmPath())
+            let realm = RLMRealm(fileURL: NSURL(fileURLWithPath: RLMTestRealmPath()))
             realm.beginWriteTransaction()
             DynamicObject.createInRealm(realm, withValue: ["column1", 1])
             DynamicObject.createInRealm(realm, withValue: ["column2", 2])
@@ -100,7 +100,7 @@ class SwiftDynamicTests: RLMTestCase {
     func testDynamicProperties_objc() {
         autoreleasepool {
             // open realm in autoreleasepool to create tables and then dispose
-            let realm = RLMRealm(path: RLMTestRealmPath())
+            let realm = RLMRealm(fileURL: NSURL(fileURLWithPath: RLMTestRealmPath()))
             realm.beginWriteTransaction()
             DynamicObject.createInRealm(realm, withValue: ["column1", 1])
             DynamicObject.createInRealm(realm, withValue: ["column2", 2])

--- a/Realm/Tests/Swift2.0/SwiftDynamicTests.swift
+++ b/Realm/Tests/Swift2.0/SwiftDynamicTests.swift
@@ -28,7 +28,7 @@ class SwiftDynamicTests: RLMTestCase {
     func testDynamicRealmExists() {
         autoreleasepool {
             // open realm in autoreleasepool to create tables and then dispose
-            let realm = RLMRealm(URL: NSURL(fileURLWithPath: RLMTestRealmPath()))
+            let realm = RLMRealm(URL: RLMTestRealmURL())
             realm.beginWriteTransaction()
             SwiftDynamicObject.createInRealm(realm, withValue: ["column1", 1])
             SwiftDynamicObject.createInRealm(realm, withValue: ["column2", 2])
@@ -54,7 +54,7 @@ class SwiftDynamicTests: RLMTestCase {
     func testDynamicProperties() {
         autoreleasepool {
             // open realm in autoreleasepool to create tables and then dispose
-            let realm = RLMRealm(URL: NSURL(fileURLWithPath: RLMTestRealmPath()))
+            let realm = RLMRealm(URL: RLMTestRealmURL())
             realm.beginWriteTransaction()
             SwiftDynamicObject.createInRealm(realm, withValue: ["column1", 1])
             SwiftDynamicObject.createInRealm(realm, withValue: ["column2", 2])
@@ -74,7 +74,7 @@ class SwiftDynamicTests: RLMTestCase {
     func testDynamicRealmExists_objc() {
         autoreleasepool {
             // open realm in autoreleasepool to create tables and then dispose
-            let realm = RLMRealm(URL: NSURL(fileURLWithPath: RLMTestRealmPath()))
+            let realm = RLMRealm(URL: RLMTestRealmURL())
             realm.beginWriteTransaction()
             DynamicObject.createInRealm(realm, withValue: ["column1", 1])
             DynamicObject.createInRealm(realm, withValue: ["column2", 2])
@@ -100,7 +100,7 @@ class SwiftDynamicTests: RLMTestCase {
     func testDynamicProperties_objc() {
         autoreleasepool {
             // open realm in autoreleasepool to create tables and then dispose
-            let realm = RLMRealm(URL: NSURL(fileURLWithPath: RLMTestRealmPath()))
+            let realm = RLMRealm(URL: RLMTestRealmURL())
             realm.beginWriteTransaction()
             DynamicObject.createInRealm(realm, withValue: ["column1", 1])
             DynamicObject.createInRealm(realm, withValue: ["column2", 2])

--- a/Realm/Tests/Swift2.0/SwiftDynamicTests.swift
+++ b/Realm/Tests/Swift2.0/SwiftDynamicTests.swift
@@ -28,7 +28,7 @@ class SwiftDynamicTests: RLMTestCase {
     func testDynamicRealmExists() {
         autoreleasepool {
             // open realm in autoreleasepool to create tables and then dispose
-            let realm = RLMRealm(fileURL: NSURL(fileURLWithPath: RLMTestRealmPath()))
+            let realm = RLMRealm(URL: NSURL(fileURLWithPath: RLMTestRealmPath()))
             realm.beginWriteTransaction()
             SwiftDynamicObject.createInRealm(realm, withValue: ["column1", 1])
             SwiftDynamicObject.createInRealm(realm, withValue: ["column2", 2])
@@ -54,7 +54,7 @@ class SwiftDynamicTests: RLMTestCase {
     func testDynamicProperties() {
         autoreleasepool {
             // open realm in autoreleasepool to create tables and then dispose
-            let realm = RLMRealm(fileURL: NSURL(fileURLWithPath: RLMTestRealmPath()))
+            let realm = RLMRealm(URL: NSURL(fileURLWithPath: RLMTestRealmPath()))
             realm.beginWriteTransaction()
             SwiftDynamicObject.createInRealm(realm, withValue: ["column1", 1])
             SwiftDynamicObject.createInRealm(realm, withValue: ["column2", 2])
@@ -74,7 +74,7 @@ class SwiftDynamicTests: RLMTestCase {
     func testDynamicRealmExists_objc() {
         autoreleasepool {
             // open realm in autoreleasepool to create tables and then dispose
-            let realm = RLMRealm(fileURL: NSURL(fileURLWithPath: RLMTestRealmPath()))
+            let realm = RLMRealm(URL: NSURL(fileURLWithPath: RLMTestRealmPath()))
             realm.beginWriteTransaction()
             DynamicObject.createInRealm(realm, withValue: ["column1", 1])
             DynamicObject.createInRealm(realm, withValue: ["column2", 2])
@@ -100,7 +100,7 @@ class SwiftDynamicTests: RLMTestCase {
     func testDynamicProperties_objc() {
         autoreleasepool {
             // open realm in autoreleasepool to create tables and then dispose
-            let realm = RLMRealm(fileURL: NSURL(fileURLWithPath: RLMTestRealmPath()))
+            let realm = RLMRealm(URL: NSURL(fileURLWithPath: RLMTestRealmPath()))
             realm.beginWriteTransaction()
             DynamicObject.createInRealm(realm, withValue: ["column1", 1])
             DynamicObject.createInRealm(realm, withValue: ["column2", 2])

--- a/RealmSwift-swift2.0/Migration.swift
+++ b/RealmSwift-swift2.0/Migration.swift
@@ -52,11 +52,31 @@ Get the schema version for a Realm at a given path.
 
 - returns: The version of the Realm at `realmPath` or `nil` if the version cannot be read.
 */
+@available(*, deprecated=1, message="Use schemaVersionAtFileURL(_:encryptionKey:)")
 public func schemaVersionAtPath(realmPath: String, encryptionKey: NSData? = nil,
                                 error: NSErrorPointer = nil) -> UInt64? {
     let version = RLMRealm.schemaVersionAtPath(realmPath, encryptionKey: encryptionKey, error: error)
     if version == RLMNotVersioned {
         return nil
+    }
+    return version
+}
+
+/**
+Get the schema version for a Realm at a given local URL.
+
+- parameter fileURL:       Local URL to a Realm file.
+- parameter encryptionKey: Optional 64-byte encryption key for encrypted Realms.
+
+- throws: An NSError that describes the problem.
+
+- returns: The version of the Realm at `fileURL`.
+*/
+public func schemaVersionAtFileURL(fileURL: NSURL, encryptionKey: NSData? = nil) throws -> UInt64 {
+    var error: NSError? = nil
+    let version = RLMRealm.schemaVersionAtFileURL(fileURL, encryptionKey: encryptionKey, error: &error)
+    if let error = error {
+        throw error
     }
     return version
 }

--- a/RealmSwift-swift2.0/Migration.swift
+++ b/RealmSwift-swift2.0/Migration.swift
@@ -52,7 +52,7 @@ Get the schema version for a Realm at a given path.
 
 - returns: The version of the Realm at `realmPath` or `nil` if the version cannot be read.
 */
-@available(*, deprecated=1, message="Use schemaVersionAtFileURL(_:encryptionKey:)")
+@available(*, deprecated=1, message="Use schemaVersionAtURL(_:encryptionKey:)")
 public func schemaVersionAtPath(realmPath: String, encryptionKey: NSData? = nil,
                                 error: NSErrorPointer = nil) -> UInt64? {
     let version = RLMRealm.schemaVersionAtPath(realmPath, encryptionKey: encryptionKey, error: error)
@@ -72,9 +72,9 @@ Get the schema version for a Realm at a given local URL.
 
 - returns: The version of the Realm at `fileURL`.
 */
-public func schemaVersionAtFileURL(fileURL: NSURL, encryptionKey: NSData? = nil) throws -> UInt64 {
+public func schemaVersionAtURL(fileURL: NSURL, encryptionKey: NSData? = nil) throws -> UInt64 {
     var error: NSError? = nil
-    let version = RLMRealm.schemaVersionAtFileURL(fileURL, encryptionKey: encryptionKey, error: &error)
+    let version = RLMRealm.schemaVersionAtURL(fileURL, encryptionKey: encryptionKey, error: &error)
     if let error = error {
         throw error
     }

--- a/RealmSwift-swift2.0/Realm.swift
+++ b/RealmSwift-swift2.0/Realm.swift
@@ -47,7 +47,7 @@ public final class Realm {
     // MARK: Properties
 
     /// Path to the file where this Realm is persisted.
-    @available(*, deprecated=1, message="Use configuration.path")
+    @available(*, deprecated=1, message="Use configuration.fileURL")
     public var path: String { return configuration.path! }
 
     /// Indicates if this Realm was opened in read-only mode.
@@ -87,7 +87,7 @@ public final class Realm {
     */
     public convenience init(path: String) throws {
         var configuration = Configuration.defaultConfiguration
-        configuration.path = path
+        configuration.fileURL = NSURL(fileURLWithPath: path)
         try self.init(configuration: configuration)
     }
 

--- a/RealmSwift-swift2.0/Realm.swift
+++ b/RealmSwift-swift2.0/Realm.swift
@@ -85,9 +85,23 @@ public final class Realm {
 
     - throws: An NSError if the Realm could not be initialized.
     */
+    @available(*, deprecated=1, message="Use Realm(fileURL:)")
     public convenience init(path: String) throws {
         var configuration = Configuration.defaultConfiguration
         configuration.fileURL = NSURL(fileURLWithPath: path)
+        try self.init(configuration: configuration)
+    }
+
+    /**
+    Obtains a Realm instance persisted at the specified file URL.
+
+    - parameter fileURL: Local URL to the realm file.
+
+    - throws: An NSError if the Realm could not be initialized.
+    */
+    public convenience init(fileURL: NSURL) throws {
+        var configuration = Configuration.defaultConfiguration
+        configuration.fileURL = fileURL
         try self.init(configuration: configuration)
     }
 

--- a/RealmSwift-swift2.0/Realm.swift
+++ b/RealmSwift-swift2.0/Realm.swift
@@ -610,11 +610,7 @@ public final class Realm {
     - throws: An NSError if the copy could not be written.
     */
     public func writeCopyToFileURL(fileURL: NSURL, encryptionKey: NSData? = nil) throws {
-        if let encryptionKey = encryptionKey {
-            try rlmRealm.writeCopyToFileURL(fileURL, encryptionKey: encryptionKey)
-        } else {
-            try rlmRealm.writeCopyToFileURL(fileURL)
-        }
+        try rlmRealm.writeCopyToFileURL(fileURL, encryptionKey: encryptionKey)
     }
 
     // MARK: Internal

--- a/RealmSwift-swift2.0/Realm.swift
+++ b/RealmSwift-swift2.0/Realm.swift
@@ -593,7 +593,7 @@ public final class Realm {
     */
     @available(*, deprecated=1, message="Use Realm.writeCopyToURL(_:encryptionKey:)")
     public func writeCopyToPath(path: String, encryptionKey: NSData? = nil) throws {
-        try writeCopyToFileURL(NSURL(fileURLWithPath: path))
+        try writeCopyToURL(NSURL(fileURLWithPath: path))
     }
 
     /**
@@ -609,8 +609,8 @@ public final class Realm {
 
     - throws: An NSError if the copy could not be written.
     */
-    public func writeCopyToFileURL(fileURL: NSURL, encryptionKey: NSData? = nil) throws {
-        try rlmRealm.writeCopyToFileURL(fileURL, encryptionKey: encryptionKey)
+    public func writeCopyToURL(fileURL: NSURL, encryptionKey: NSData? = nil) throws {
+        try rlmRealm.writeCopyToURL(fileURL, encryptionKey: encryptionKey)
     }
 
     // MARK: Internal

--- a/RealmSwift-swift2.0/Realm.swift
+++ b/RealmSwift-swift2.0/Realm.swift
@@ -591,11 +591,29 @@ public final class Realm {
 
     - throws: An NSError if the copy could not be written.
     */
+    @available(*, deprecated=1, message="Use Realm.writeCopyToURL(_:encryptionKey:)")
     public func writeCopyToPath(path: String, encryptionKey: NSData? = nil) throws {
+        try writeCopyToFileURL(NSURL(fileURLWithPath: path))
+    }
+
+    /**
+    Write an encrypted and compacted copy of the Realm to the given local URL.
+
+    The destination file cannot already exist.
+
+    Note that if this is called from within a write transaction it writes the
+    *current* data, and not data when the last write transaction was committed.
+
+    - parameter fileURL:       Local URL to save the Realm to.
+    - parameter encryptionKey: Optional 64-byte encryption key to encrypt the new file with.
+
+    - throws: An NSError if the copy could not be written.
+    */
+    public func writeCopyToFileURL(fileURL: NSURL, encryptionKey: NSData? = nil) throws {
         if let encryptionKey = encryptionKey {
-            try rlmRealm.writeCopyToPath(path, encryptionKey: encryptionKey)
+            try rlmRealm.writeCopyToFileURL(fileURL, encryptionKey: encryptionKey)
         } else {
-            try rlmRealm.writeCopyToPath(path)
+            try rlmRealm.writeCopyToFileURL(fileURL)
         }
     }
 

--- a/RealmSwift-swift2.0/Tests/MigrationTests.swift
+++ b/RealmSwift-swift2.0/Tests/MigrationTests.swift
@@ -24,7 +24,7 @@ import Realm.Dynamic
 import Foundation
 
 private func realmWithCustomSchema(path: String, schema: RLMSchema) -> RLMRealm {
-    return try! RLMRealm(path: path, key: nil, readOnly: false, inMemory: false, dynamic: true, schema: schema)
+    return try! RLMRealm(fileURL: NSURL(fileURLWithPath: path), key: nil, readOnly: false, inMemory: false, dynamic: true, schema: schema)
 }
 
 private func realmWithSingleClass(path: String, objectSchema: RLMObjectSchema) -> RLMRealm {
@@ -39,7 +39,7 @@ private func realmWithSingleClassProperties(path: String, className: String, pro
 }
 
 private func dynamicRealm(path: String) -> RLMRealm {
-    return try! RLMRealm(path: path, key: nil, readOnly: false, inMemory: false, dynamic: true, schema: nil)
+    return try! RLMRealm(fileURL: NSURL(fileURLWithPath: path), key: nil, readOnly: false, inMemory: false, dynamic: true, schema: nil)
 }
 
 class MigrationTests: TestCase {

--- a/RealmSwift-swift2.0/Tests/MigrationTests.swift
+++ b/RealmSwift-swift2.0/Tests/MigrationTests.swift
@@ -59,7 +59,7 @@ class MigrationTests: TestCase {
     private func migrateAndTestRealm(realmPath: String, shouldRun: Bool = true, schemaVersion: UInt64 = 1,
                                      autoMigration: Bool = false, block: MigrationBlock? = nil) {
         var didRun = false
-        let config = Realm.Configuration(path: realmPath, schemaVersion: schemaVersion,
+        let config = Realm.Configuration(fileURL: NSURL(fileURLWithPath: realmPath), schemaVersion: schemaVersion,
             migrationBlock: { migration, oldSchemaVersion in
                 if let block = block {
                     block(migration: migration, oldSchemaVersion: oldSchemaVersion)
@@ -81,7 +81,7 @@ class MigrationTests: TestCase {
 
     private func migrateAndTestDefaultRealm(schemaVersion: UInt64 = 1, block: MigrationBlock) {
         migrateAndTestRealm(defaultRealmPath(), schemaVersion: schemaVersion, block: block)
-        Realm.Configuration.defaultConfiguration = Realm.Configuration(path: defaultRealmPath(),
+        Realm.Configuration.defaultConfiguration = Realm.Configuration(fileURL: NSURL(fileURLWithPath: defaultRealmPath()),
             schemaVersion: schemaVersion)
     }
 
@@ -91,7 +91,7 @@ class MigrationTests: TestCase {
         createAndTestRealmAtPath(defaultRealmPath())
 
         var didRun = false
-        let config = Realm.Configuration(path: defaultRealmPath(), schemaVersion: 1, migrationBlock: { _, _ in
+        let config = Realm.Configuration(fileURL: NSURL(fileURLWithPath: defaultRealmPath()), schemaVersion: 1, migrationBlock: { _, _ in
             didRun = true
         })
         Realm.Configuration.defaultConfiguration = config

--- a/RealmSwift-swift2.0/Tests/MigrationTests.swift
+++ b/RealmSwift-swift2.0/Tests/MigrationTests.swift
@@ -49,7 +49,7 @@ class MigrationTests: TestCase {
     // create realm at path and test version is 0
     private func createAndTestRealmAtPath(realmPath: String) {
         autoreleasepool {
-            _ = try! Realm(path: realmPath)
+            _ = try! Realm(fileURL: NSURL(fileURLWithPath: realmPath))
             return
         }
         XCTAssertEqual(UInt64(0), schemaVersionAtPath(realmPath)!, "Initial version should be 0")

--- a/RealmSwift-swift2.0/Tests/MigrationTests.swift
+++ b/RealmSwift-swift2.0/Tests/MigrationTests.swift
@@ -24,7 +24,8 @@ import Realm.Dynamic
 import Foundation
 
 private func realmWithCustomSchema(path: String, schema: RLMSchema) -> RLMRealm {
-    return try! RLMRealm(fileURL: NSURL(fileURLWithPath: path), key: nil, readOnly: false, inMemory: false, dynamic: true, schema: schema)
+    return try! RLMRealm(fileURL: NSURL(fileURLWithPath: path), key: nil, readOnly: false, inMemory: false,
+                         dynamic: true, schema: schema)
 }
 
 private func realmWithSingleClass(path: String, objectSchema: RLMObjectSchema) -> RLMRealm {
@@ -39,7 +40,8 @@ private func realmWithSingleClassProperties(path: String, className: String, pro
 }
 
 private func dynamicRealm(path: String) -> RLMRealm {
-    return try! RLMRealm(fileURL: NSURL(fileURLWithPath: path), key: nil, readOnly: false, inMemory: false, dynamic: true, schema: nil)
+    return try! RLMRealm(fileURL: NSURL(fileURLWithPath: path), key: nil, readOnly: false, inMemory: false,
+                         dynamic: true, schema: nil)
 }
 
 class MigrationTests: TestCase {
@@ -82,8 +84,9 @@ class MigrationTests: TestCase {
 
     private func migrateAndTestDefaultRealm(schemaVersion: UInt64 = 1, block: MigrationBlock) {
         migrateAndTestRealm(defaultRealmPath(), schemaVersion: schemaVersion, block: block)
-        Realm.Configuration.defaultConfiguration = Realm.Configuration(fileURL: NSURL(fileURLWithPath: defaultRealmPath()),
-            schemaVersion: schemaVersion)
+        let config = Realm.Configuration(fileURL: NSURL(fileURLWithPath: defaultRealmPath()),
+                                         schemaVersion: schemaVersion)
+        Realm.Configuration.defaultConfiguration = config
     }
 
     // MARK Test cases
@@ -92,9 +95,8 @@ class MigrationTests: TestCase {
         createAndTestRealmAtPath(defaultRealmPath())
 
         var didRun = false
-        let config = Realm.Configuration(fileURL: NSURL(fileURLWithPath: defaultRealmPath()), schemaVersion: 1, migrationBlock: { _, _ in
-            didRun = true
-        })
+        let config = Realm.Configuration(fileURL: NSURL(fileURLWithPath: defaultRealmPath()), schemaVersion: 1,
+                                         migrationBlock: { _, _ in didRun = true })
         Realm.Configuration.defaultConfiguration = config
 
         migrateRealm()
@@ -117,7 +119,8 @@ class MigrationTests: TestCase {
         }
 
         _ = try! Realm()
-        XCTAssertEqual(0, try! schemaVersionAtFileURL(NSURL(fileURLWithPath: defaultRealmPath())), "Initial version should be 0")
+        XCTAssertEqual(0, try! schemaVersionAtFileURL(NSURL(fileURLWithPath: defaultRealmPath())),
+                       "Initial version should be 0")
         assertFails(.Fail) {
             try schemaVersionAtFileURL(NSURL(fileURLWithPath: "/dev/null"))
         }

--- a/RealmSwift-swift2.0/Tests/MigrationTests.swift
+++ b/RealmSwift-swift2.0/Tests/MigrationTests.swift
@@ -24,7 +24,7 @@ import Realm.Dynamic
 import Foundation
 
 private func realmWithCustomSchema(path: String, schema: RLMSchema) -> RLMRealm {
-    return try! RLMRealm(fileURL: NSURL(fileURLWithPath: path), key: nil, readOnly: false, inMemory: false,
+    return try! RLMRealm(URL: NSURL(fileURLWithPath: path), key: nil, readOnly: false, inMemory: false,
                          dynamic: true, schema: schema)
 }
 
@@ -40,7 +40,7 @@ private func realmWithSingleClassProperties(path: String, className: String, pro
 }
 
 private func dynamicRealm(path: String) -> RLMRealm {
-    return try! RLMRealm(fileURL: NSURL(fileURLWithPath: path), key: nil, readOnly: false, inMemory: false,
+    return try! RLMRealm(URL: NSURL(fileURLWithPath: path), key: nil, readOnly: false, inMemory: false,
                          dynamic: true, schema: nil)
 }
 
@@ -55,7 +55,7 @@ class MigrationTests: TestCase {
             _ = try! Realm(fileURL: fileURL)
             return
         }
-        XCTAssertEqual(0, try! schemaVersionAtFileURL(fileURL), "Initial version should be 0")
+        XCTAssertEqual(0, try! schemaVersionAtURL(fileURL), "Initial version should be 0")
     }
 
     // migrate realm at path and ensure migration
@@ -102,27 +102,27 @@ class MigrationTests: TestCase {
         migrateRealm()
 
         XCTAssertEqual(didRun, true)
-        XCTAssertEqual(1, try! schemaVersionAtFileURL(NSURL(fileURLWithPath: defaultRealmPath())))
+        XCTAssertEqual(1, try! schemaVersionAtURL(NSURL(fileURLWithPath: defaultRealmPath())))
     }
 
     func testSetSchemaVersion() {
         createAndTestRealmAtPath(testRealmPath())
         migrateAndTestRealm(testRealmPath())
 
-        XCTAssertEqual(1, try! schemaVersionAtFileURL(NSURL(fileURLWithPath: testRealmPath())))
+        XCTAssertEqual(1, try! schemaVersionAtURL(NSURL(fileURLWithPath: testRealmPath())))
     }
 
-    func testSchemaVersionAtFileURL() {
+    func testSchemaVersionAtURL() {
         assertFails(.Fail) {
             // Version should throw before Realm creation
-            try schemaVersionAtFileURL(NSURL(fileURLWithPath: defaultRealmPath()))
+            try schemaVersionAtURL(NSURL(fileURLWithPath: defaultRealmPath()))
         }
 
         _ = try! Realm()
-        XCTAssertEqual(0, try! schemaVersionAtFileURL(NSURL(fileURLWithPath: defaultRealmPath())),
+        XCTAssertEqual(0, try! schemaVersionAtURL(NSURL(fileURLWithPath: defaultRealmPath())),
                        "Initial version should be 0")
         assertFails(.Fail) {
-            try schemaVersionAtFileURL(NSURL(fileURLWithPath: "/dev/null"))
+            try schemaVersionAtURL(NSURL(fileURLWithPath: "/dev/null"))
         }
     }
 

--- a/RealmSwift-swift2.0/Tests/PerformanceTests.swift
+++ b/RealmSwift-swift2.0/Tests/PerformanceTests.swift
@@ -97,7 +97,7 @@ class SwiftPerformanceTests: TestCase {
             fatalError("Unexpected error: \(error)")
         }
 
-        try! realm.writeCopyToPath(testRealmPath())
+        try! realm.writeCopyToFileURL(NSURL(fileURLWithPath: testRealmPath()))
         return realmWithTestPath()
     }
 

--- a/RealmSwift-swift2.0/Tests/PerformanceTests.swift
+++ b/RealmSwift-swift2.0/Tests/PerformanceTests.swift
@@ -97,7 +97,7 @@ class SwiftPerformanceTests: TestCase {
             fatalError("Unexpected error: \(error)")
         }
 
-        try! realm.writeCopyToFileURL(NSURL(fileURLWithPath: testRealmPath()))
+        try! realm.writeCopyToURL(NSURL(fileURLWithPath: testRealmPath()))
         return realmWithTestPath()
     }
 

--- a/RealmSwift-swift2.0/Tests/PerformanceTests.swift
+++ b/RealmSwift-swift2.0/Tests/PerformanceTests.swift
@@ -90,14 +90,14 @@ class SwiftPerformanceTests: TestCase {
 
     private func copyRealmToTestPath(realm: Realm) -> Realm {
         do {
-            try NSFileManager.defaultManager().removeItemAtPath(testRealmPath())
+            try NSFileManager.defaultManager().removeItemAtURL(testRealmURL())
         } catch let error as NSError {
             XCTAssertTrue(error.domain == NSCocoaErrorDomain && error.code == 4)
         } catch {
             fatalError("Unexpected error: \(error)")
         }
 
-        try! realm.writeCopyToURL(NSURL(fileURLWithPath: testRealmPath()))
+        try! realm.writeCopyToURL(testRealmURL())
         return realmWithTestPath()
     }
 

--- a/RealmSwift-swift2.0/Tests/RealmCollectionTypeTests.swift
+++ b/RealmSwift-swift2.0/Tests/RealmCollectionTypeTests.swift
@@ -97,7 +97,7 @@ class RealmCollectionTypeTests: TestCase {
     }
 
     func testRealm() {
-        XCTAssertEqual(collection.realm!.configuration.path, realmWithTestPath().configuration.path)
+        XCTAssertEqual(collection.realm!.configuration.fileURL!.path, realmWithTestPath().configuration.fileURL?.path)
     }
 
     func testDescription() {

--- a/RealmSwift-swift2.0/Tests/RealmCollectionTypeTests.swift
+++ b/RealmSwift-swift2.0/Tests/RealmCollectionTypeTests.swift
@@ -97,7 +97,7 @@ class RealmCollectionTypeTests: TestCase {
     }
 
     func testRealm() {
-        XCTAssertEqual(collection.realm!.configuration.fileURL!.path, realmWithTestPath().configuration.fileURL?.path)
+        XCTAssertEqual(collection.realm!.configuration.fileURL, realmWithTestPath().configuration.fileURL)
     }
 
     func testDescription() {

--- a/RealmSwift-swift2.0/Tests/RealmConfigurationTests.swift
+++ b/RealmSwift-swift2.0/Tests/RealmConfigurationTests.swift
@@ -24,7 +24,7 @@ class RealmConfigurationTests: TestCase {
     func testDefaultConfiguration() {
         let defaultConfiguration = Realm.Configuration.defaultConfiguration
 
-        XCTAssertEqual(defaultConfiguration.path, try! Realm().configuration.path)
+        XCTAssertEqual(defaultConfiguration.fileURL, try! Realm().configuration.fileURL)
         XCTAssertNil(defaultConfiguration.inMemoryIdentifier)
         XCTAssertNil(defaultConfiguration.encryptionKey)
         XCTAssertFalse(defaultConfiguration.readOnly)
@@ -33,10 +33,10 @@ class RealmConfigurationTests: TestCase {
     }
 
     func testSetDefaultConfiguration() {
-        let path = Realm.Configuration.defaultConfiguration.path!
-        let configuration = Realm.Configuration(path: "path")
+        let fileURL = Realm.Configuration.defaultConfiguration.fileURL
+        let configuration = Realm.Configuration(fileURL: NSURL(fileURLWithPath: "/dev/null"))
         Realm.Configuration.defaultConfiguration = configuration
-        XCTAssertEqual(Realm.Configuration.defaultConfiguration.path, "/private/tmp/path")
-        Realm.Configuration.defaultConfiguration.path = path
+        XCTAssertEqual(Realm.Configuration.defaultConfiguration.fileURL, NSURL(fileURLWithPath: "/dev/null"))
+        Realm.Configuration.defaultConfiguration.fileURL = fileURL
     }
 }

--- a/RealmSwift-swift2.0/Tests/RealmConfigurationTests.swift
+++ b/RealmSwift-swift2.0/Tests/RealmConfigurationTests.swift
@@ -36,7 +36,7 @@ class RealmConfigurationTests: TestCase {
         let path = Realm.Configuration.defaultConfiguration.path!
         let configuration = Realm.Configuration(path: "path")
         Realm.Configuration.defaultConfiguration = configuration
-        XCTAssertEqual(Realm.Configuration.defaultConfiguration.path, "path")
+        XCTAssertEqual(Realm.Configuration.defaultConfiguration.path, "/private/tmp/path")
         Realm.Configuration.defaultConfiguration.path = path
     }
 }

--- a/RealmSwift-swift2.0/Tests/RealmTests.swift
+++ b/RealmSwift-swift2.0/Tests/RealmTests.swift
@@ -26,7 +26,7 @@ import Foundation
 
 class RealmTests: TestCase {
     func testFileURL() {
-        XCTAssertEqual(try! Realm(path: testRealmPath()).configuration.fileURL, NSURL(fileURLWithPath: testRealmPath()))
+        XCTAssertEqual(try! Realm(fileURL: NSURL(fileURLWithPath: testRealmPath())).configuration.fileURL, NSURL(fileURLWithPath: testRealmPath()))
     }
 
     func testReadOnly() {
@@ -52,7 +52,7 @@ class RealmTests: TestCase {
 
     func testReadOnlyFile() {
         autoreleasepool {
-            let realm = try! Realm(path: testRealmPath())
+            let realm = try! Realm(fileURL: NSURL(fileURLWithPath: testRealmPath()))
             try! realm.write {
                 realm.create(SwiftStringObject.self, value: ["a"])
             }
@@ -63,7 +63,7 @@ class RealmTests: TestCase {
 
         // Should not be able to open read-write
         assertFails(Error.Fail) {
-            try Realm(path: testRealmPath())
+            try Realm(fileURL: NSURL(fileURLWithPath: testRealmPath()))
         }
 
         assertSucceeds {
@@ -82,7 +82,7 @@ class RealmTests: TestCase {
 
     func testFilePermissionDenied() {
         autoreleasepool {
-            let _ = try! Realm(path: testRealmPath())
+            let _ = try! Realm(fileURL: NSURL(fileURLWithPath: testRealmPath()))
         }
 
         // Make Realm at test path temporarily unreadable
@@ -91,7 +91,7 @@ class RealmTests: TestCase {
         try! fileManager.setAttributes([ NSFilePosixPermissions: NSNumber(int: 0000) ], ofItemAtPath: testRealmPath())
 
         assertFails(Error.FilePermissionDenied) {
-            try Realm(path: testRealmPath())
+            try Realm(fileURL: NSURL(fileURLWithPath: testRealmPath()))
         }
 
         try! fileManager.setAttributes([ NSFilePosixPermissions: permissions ], ofItemAtPath: testRealmPath())
@@ -135,8 +135,7 @@ class RealmTests: TestCase {
     }
 
     func testInit() {
-        XCTAssertEqual(try! Realm(path: testRealmPath()).configuration.fileURL, NSURL(fileURLWithPath: testRealmPath()))
-        // FIXME: assertThrows(try! Realm(path: ""))
+        XCTAssertEqual(try! Realm(fileURL: NSURL(fileURLWithPath: testRealmPath())).configuration.fileURL, NSURL(fileURLWithPath: testRealmPath()))
     }
 
     func testInitFailable() {
@@ -401,7 +400,7 @@ class RealmTests: TestCase {
     }
 
     func testDeleteResults() {
-        let realm = try! Realm(path: testRealmPath())
+        let realm = try! Realm(fileURL: NSURL(fileURLWithPath: testRealmPath()))
         XCTAssertEqual(0, realm.objects(SwiftCompanyObject).count)
         try! realm.write {
             realm.add(SwiftIntObject(value: [1]))
@@ -647,7 +646,7 @@ class RealmTests: TestCase {
             XCTFail("writeCopyToPath failed")
         }
         autoreleasepool {
-            let copy = try! Realm(path: path)
+            let copy = try! Realm(fileURL: NSURL(fileURLWithPath: path))
             XCTAssertEqual(1, copy.objects(SwiftObject).count)
         }
         try! NSFileManager.defaultManager().removeItemAtPath(path)

--- a/RealmSwift-swift2.0/Tests/RealmTests.swift
+++ b/RealmSwift-swift2.0/Tests/RealmTests.swift
@@ -25,8 +25,8 @@ import XCTest
 import Foundation
 
 class RealmTests: TestCase {
-    func testPath() {
-        XCTAssertEqual(try! Realm(path: testRealmPath()).configuration.path, testRealmPath())
+    func testFileURL() {
+        XCTAssertEqual(try! Realm(path: testRealmPath()).configuration.fileURL, NSURL(fileURLWithPath: testRealmPath()))
     }
 
     func testReadOnly() {
@@ -37,7 +37,7 @@ class RealmTests: TestCase {
                 try! Realm().create(SwiftIntObject.self, value: [100])
             }
         }
-        let readOnlyRealm = try! Realm(configuration: Realm.Configuration(path: defaultRealmPath(), readOnly: true))
+        let readOnlyRealm = try! Realm(configuration: Realm.Configuration(fileURL: NSURL(fileURLWithPath: defaultRealmPath()),readOnly: true))
         XCTAssertEqual(true, readOnlyRealm.configuration.readOnly)
         XCTAssertEqual(1, readOnlyRealm.objects(SwiftIntObject).count)
 
@@ -46,7 +46,7 @@ class RealmTests: TestCase {
 
     func testOpeningInvalidPathThrows() {
         assertFails(Error.FileAccess) {
-            try Realm(configuration: Realm.Configuration(path: "/dev/null/foo"))
+            try Realm(configuration: Realm.Configuration(fileURL: NSURL(fileURLWithPath: "/dev/null/foo")))
         }
     }
 
@@ -67,7 +67,7 @@ class RealmTests: TestCase {
         }
 
         assertSucceeds {
-            let realm = try Realm(configuration: Realm.Configuration(path: self.testRealmPath(), readOnly: true))
+            let realm = try Realm(configuration: Realm.Configuration(fileURL: NSURL(fileURLWithPath: testRealmPath()), readOnly: true))
             XCTAssertEqual(1, realm.objects(SwiftStringObject).count)
         }
 
@@ -76,7 +76,7 @@ class RealmTests: TestCase {
 
     func testReadOnlyRealmMustExist() {
         assertFails(Error.FileNotFound) {
-            try Realm(configuration: Realm.Configuration(path: defaultRealmPath(), readOnly: true))
+            try Realm(configuration: Realm.Configuration(fileURL: NSURL(fileURLWithPath: defaultRealmPath()), readOnly: true))
         }
     }
 
@@ -135,7 +135,7 @@ class RealmTests: TestCase {
     }
 
     func testInit() {
-        XCTAssertEqual(try! Realm(path: testRealmPath()).configuration.path, testRealmPath())
+        XCTAssertEqual(try! Realm(path: testRealmPath()).configuration.fileURL, NSURL(fileURLWithPath: testRealmPath()))
         // FIXME: assertThrows(try! Realm(path: ""))
     }
 
@@ -178,7 +178,7 @@ class RealmTests: TestCase {
     }
 
     func testInitCustomClassList() {
-        let configuration = Realm.Configuration(path: Realm.Configuration.defaultConfiguration.path,
+        let configuration = Realm.Configuration(fileURL: Realm.Configuration.defaultConfiguration.fileURL,
             objectTypes: [SwiftStringObject.self])
         XCTAssert(configuration.objectTypes! is [SwiftStringObject.Type])
         let realm = try! Realm(configuration: configuration)
@@ -531,7 +531,7 @@ class RealmTests: TestCase {
         let realm = try! Realm()
         var notificationCalled = false
         let token = realm.addNotificationBlock { _, realm in
-            XCTAssertEqual(realm.configuration.path, self.defaultRealmPath())
+            XCTAssertEqual(realm.configuration.fileURL, NSURL(fileURLWithPath: self.defaultRealmPath()))
             notificationCalled = true
         }
         XCTAssertFalse(notificationCalled)
@@ -544,7 +544,7 @@ class RealmTests: TestCase {
         let realm = try! Realm()
         var notificationCalled = false
         let token = realm.addNotificationBlock { (notification, realm) -> Void in
-            XCTAssertEqual(realm.configuration.path, self.defaultRealmPath())
+            XCTAssertEqual(realm.configuration.fileURL, NSURL(fileURLWithPath: self.defaultRealmPath()))
             notificationCalled = true
         }
         token.stop()

--- a/RealmSwift-swift2.0/Tests/RealmTests.swift
+++ b/RealmSwift-swift2.0/Tests/RealmTests.swift
@@ -641,9 +641,9 @@ class RealmTests: TestCase {
         let path = ((defaultRealmPath() as NSString).stringByDeletingLastPathComponent as NSString )
             .stringByAppendingPathComponent("copy.realm")
         do {
-            try realm.writeCopyToPath(path)
+            try realm.writeCopyToFileURL(NSURL(fileURLWithPath: path))
         } catch {
-            XCTFail("writeCopyToPath failed")
+            XCTFail("writeCopyToFileURL failed")
         }
         autoreleasepool {
             let copy = try! Realm(fileURL: NSURL(fileURLWithPath: path))

--- a/RealmSwift-swift2.0/Tests/RealmTests.swift
+++ b/RealmSwift-swift2.0/Tests/RealmTests.swift
@@ -136,7 +136,7 @@ class RealmTests: TestCase {
 
     func testInit() {
         XCTAssertEqual(try! Realm(path: testRealmPath()).configuration.path, testRealmPath())
-        assertThrows(try! Realm(path: ""))
+        // FIXME: assertThrows(try! Realm(path: ""))
     }
 
     func testInitFailable() {

--- a/RealmSwift-swift2.0/Tests/RealmTests.swift
+++ b/RealmSwift-swift2.0/Tests/RealmTests.swift
@@ -646,9 +646,9 @@ class RealmTests: TestCase {
         let path = ((defaultRealmPath() as NSString).stringByDeletingLastPathComponent as NSString )
             .stringByAppendingPathComponent("copy.realm")
         do {
-            try realm.writeCopyToFileURL(NSURL(fileURLWithPath: path))
+            try realm.writeCopyToURL(NSURL(fileURLWithPath: path))
         } catch {
-            XCTFail("writeCopyToFileURL failed")
+            XCTFail("writeCopyToURL failed")
         }
         autoreleasepool {
             let copy = try! Realm(fileURL: NSURL(fileURLWithPath: path))

--- a/RealmSwift-swift2.0/Tests/RealmTests.swift
+++ b/RealmSwift-swift2.0/Tests/RealmTests.swift
@@ -91,8 +91,10 @@ class RealmTests: TestCase {
 
         // Make Realm at test path temporarily unreadable
         let fileManager = NSFileManager.defaultManager()
-        let permissions = try! fileManager.attributesOfItemAtPath(testRealmURL().path!)[NSFilePosixPermissions] as! NSNumber
-        try! fileManager.setAttributes([ NSFilePosixPermissions: NSNumber(int: 0000) ], ofItemAtPath: testRealmURL().path!)
+        let permissions = try! fileManager
+            .attributesOfItemAtPath(testRealmURL().path!)[NSFilePosixPermissions] as! NSNumber
+        try! fileManager.setAttributes([ NSFilePosixPermissions: NSNumber(int: 0000) ],
+                                       ofItemAtPath: testRealmURL().path!)
 
         assertFails(Error.FilePermissionDenied) {
             try Realm(fileURL: testRealmURL())

--- a/RealmSwift-swift2.0/Tests/RealmTests.swift
+++ b/RealmSwift-swift2.0/Tests/RealmTests.swift
@@ -26,7 +26,8 @@ import Foundation
 
 class RealmTests: TestCase {
     func testFileURL() {
-        XCTAssertEqual(try! Realm(fileURL: NSURL(fileURLWithPath: testRealmPath())).configuration.fileURL, NSURL(fileURLWithPath: testRealmPath()))
+        XCTAssertEqual(try! Realm(fileURL: NSURL(fileURLWithPath: testRealmPath())).configuration.fileURL,
+                       NSURL(fileURLWithPath: testRealmPath()))
     }
 
     func testReadOnly() {
@@ -37,7 +38,8 @@ class RealmTests: TestCase {
                 try! Realm().create(SwiftIntObject.self, value: [100])
             }
         }
-        let readOnlyRealm = try! Realm(configuration: Realm.Configuration(fileURL: NSURL(fileURLWithPath: defaultRealmPath()),readOnly: true))
+        let config = Realm.Configuration(fileURL: NSURL(fileURLWithPath: defaultRealmPath()), readOnly: true)
+        let readOnlyRealm = try! Realm(configuration: config)
         XCTAssertEqual(true, readOnlyRealm.configuration.readOnly)
         XCTAssertEqual(1, readOnlyRealm.objects(SwiftIntObject).count)
 
@@ -67,7 +69,8 @@ class RealmTests: TestCase {
         }
 
         assertSucceeds {
-            let realm = try Realm(configuration: Realm.Configuration(fileURL: NSURL(fileURLWithPath: testRealmPath()), readOnly: true))
+            let realm = try Realm(configuration:
+                Realm.Configuration(fileURL: NSURL(fileURLWithPath: testRealmPath()), readOnly: true))
             XCTAssertEqual(1, realm.objects(SwiftStringObject).count)
         }
 
@@ -76,7 +79,8 @@ class RealmTests: TestCase {
 
     func testReadOnlyRealmMustExist() {
         assertFails(Error.FileNotFound) {
-            try Realm(configuration: Realm.Configuration(fileURL: NSURL(fileURLWithPath: defaultRealmPath()), readOnly: true))
+            try Realm(configuration:
+                Realm.Configuration(fileURL: NSURL(fileURLWithPath: defaultRealmPath()), readOnly: true))
         }
     }
 
@@ -135,7 +139,8 @@ class RealmTests: TestCase {
     }
 
     func testInit() {
-        XCTAssertEqual(try! Realm(fileURL: NSURL(fileURLWithPath: testRealmPath())).configuration.fileURL, NSURL(fileURLWithPath: testRealmPath()))
+        XCTAssertEqual(try! Realm(fileURL: NSURL(fileURLWithPath: testRealmPath())).configuration.fileURL,
+                       NSURL(fileURLWithPath: testRealmPath()))
     }
 
     func testInitFailable() {

--- a/RealmSwift-swift2.0/Tests/TestCase.swift
+++ b/RealmSwift-swift2.0/Tests/TestCase.swift
@@ -39,7 +39,7 @@ class TestCase: XCTestCase {
 
     func realmWithTestPath(configuration: Realm.Configuration = Realm.Configuration()) -> Realm {
         var configuration = configuration
-        configuration.path = testRealmPath()
+        configuration.fileURL = NSURL(fileURLWithPath: testRealmPath())
         return try! Realm(configuration: configuration)
     }
 
@@ -75,7 +75,7 @@ class TestCase: XCTestCase {
         try! NSFileManager.defaultManager().createDirectoryAtPath(testDir, withIntermediateDirectories: true,
             attributes: nil)
 
-        Realm.Configuration.defaultConfiguration = Realm.Configuration(path: defaultRealmPath())
+        Realm.Configuration.defaultConfiguration = Realm.Configuration(fileURL: NSURL(fileURLWithPath: defaultRealmPath()))
 
         exceptionThrown = false
         autoreleasepool { super.invokeTest() }

--- a/RealmSwift-swift2.0/Tests/TestCase.swift
+++ b/RealmSwift-swift2.0/Tests/TestCase.swift
@@ -39,7 +39,7 @@ class TestCase: XCTestCase {
 
     func realmWithTestPath(configuration: Realm.Configuration = Realm.Configuration()) -> Realm {
         var configuration = configuration
-        configuration.fileURL = NSURL(fileURLWithPath: testRealmPath())
+        configuration.fileURL = testRealmURL()
         return try! Realm(configuration: configuration)
     }
 
@@ -75,15 +75,15 @@ class TestCase: XCTestCase {
         try! NSFileManager.defaultManager().createDirectoryAtPath(testDir, withIntermediateDirectories: true,
             attributes: nil)
 
-        let config = Realm.Configuration(fileURL: NSURL(fileURLWithPath: defaultRealmPath()))
+        let config = Realm.Configuration(fileURL: defaultRealmURL())
         Realm.Configuration.defaultConfiguration = config
 
         exceptionThrown = false
         autoreleasepool { super.invokeTest() }
 
         if !exceptionThrown {
-            XCTAssertFalse(RLMHasCachedRealmForPath(defaultRealmPath()))
-            XCTAssertFalse(RLMHasCachedRealmForPath(testRealmPath()))
+            XCTAssertFalse(RLMHasCachedRealmForPath(defaultRealmURL().path!))
+            XCTAssertFalse(RLMHasCachedRealmForPath(testRealmURL().path!))
         }
 
         resetRealmState()
@@ -155,21 +155,21 @@ class TestCase: XCTestCase {
     private func realmFilePrefix() -> String {
         let remove = NSCharacterSet(charactersInString: "-[]")
 #if REALM_XCODE_VERSION_0730
-        return self.name!.stringByTrimmingCharactersInSet(remove)
+        return name!.stringByTrimmingCharactersInSet(remove)
 #else
-        return self.name.stringByTrimmingCharactersInSet(remove)
+        return name.stringByTrimmingCharactersInSet(remove)
 #endif
     }
 
-    internal func testRealmPath() -> String {
-        return realmPathForFile("test.realm")
+    internal func testRealmURL() -> NSURL {
+        return realmURLForFile("test.realm")
     }
 
-    internal func defaultRealmPath() -> String {
-        return realmPathForFile("default.realm")
+    internal func defaultRealmURL() -> NSURL {
+        return realmURLForFile("default.realm")
     }
 
-    private func realmPathForFile(fileName: String) -> String {
-        return (testDir as NSString).stringByAppendingPathComponent(fileName)
+    private func realmURLForFile(fileName: String) -> NSURL {
+        return NSURL(fileURLWithPath: testDir).URLByAppendingPathComponent(fileName)
     }
 }

--- a/RealmSwift-swift2.0/Tests/TestCase.swift
+++ b/RealmSwift-swift2.0/Tests/TestCase.swift
@@ -75,7 +75,8 @@ class TestCase: XCTestCase {
         try! NSFileManager.defaultManager().createDirectoryAtPath(testDir, withIntermediateDirectories: true,
             attributes: nil)
 
-        Realm.Configuration.defaultConfiguration = Realm.Configuration(fileURL: NSURL(fileURLWithPath: defaultRealmPath()))
+        let config = Realm.Configuration(fileURL: NSURL(fileURLWithPath: defaultRealmPath()))
+        Realm.Configuration.defaultConfiguration = config
 
         exceptionThrown = false
         autoreleasepool { super.invokeTest() }

--- a/examples/ios/objc/Backlink/AppDelegate.m
+++ b/examples/ios/objc/Backlink/AppDelegate.m
@@ -51,7 +51,7 @@ RLM_ARRAY_TYPE(Dog)
     self.window.rootViewController = [[UIViewController alloc] init];
     [self.window makeKeyAndVisible];
 
-    [[NSFileManager defaultManager] removeItemAtPath:[RLMRealmConfiguration defaultConfiguration].path error:nil];
+    [[NSFileManager defaultManager] removeItemAtURL:[RLMRealmConfiguration defaultConfiguration].fileURL error:nil];
 
     RLMRealm *realm = [RLMRealm defaultRealm];
     [realm transactionWithBlock:^{

--- a/examples/ios/objc/Extension/AppDelegate.m
+++ b/examples/ios/objc/Extension/AppDelegate.m
@@ -31,7 +31,7 @@
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
     RLMRealmConfiguration *configuration = [RLMRealmConfiguration defaultConfiguration];
-    configuration.path = [[[NSFileManager defaultManager] containerURLForSecurityApplicationGroupIdentifier:@"group.io.realm.examples.extension"] URLByAppendingPathComponent:@"extension.realm"].path;
+    configuration.fileURL = [[[NSFileManager defaultManager] containerURLForSecurityApplicationGroupIdentifier:@"group.io.realm.examples.extension"] URLByAppendingPathComponent:@"extension.realm"];
     [RLMRealmConfiguration setDefaultConfiguration:configuration];
     self.window = [[UIWindow alloc] initWithFrame:[[UIScreen mainScreen] bounds]];
     self.window.rootViewController = [[TickViewController alloc] init];

--- a/examples/ios/objc/Migration/AppDelegate.m
+++ b/examples/ios/objc/Migration/AppDelegate.m
@@ -29,12 +29,11 @@
     [self.window makeKeyAndVisible];
 
     // copy over old data files for migration
-    NSString *defaultRealmPath = [RLMRealmConfiguration defaultConfiguration].path;
-    NSString *defaultRealmParentPath = [defaultRealmPath stringByDeletingLastPathComponent];
-    NSString *v0Path = [[[NSBundle mainBundle] resourcePath] stringByAppendingPathComponent:@"default-v0.realm"];
-    [[NSFileManager defaultManager] removeItemAtPath:defaultRealmPath error:nil];
-    [[NSFileManager defaultManager] copyItemAtPath:v0Path toPath:defaultRealmPath error:nil];
-
+    NSURL *defaultRealmURL = [RLMRealmConfiguration defaultConfiguration].fileURL;
+    NSURL *defaultRealmParentURL = [defaultRealmURL URLByDeletingLastPathComponent];
+    NSURL *v0URL = [[NSBundle mainBundle] URLForResource:@"default-v0" withExtension:@"realm"];
+    [[NSFileManager defaultManager] removeItemAtURL:defaultRealmURL error:nil];
+    [[NSFileManager defaultManager] copyItemAtURL:v0URL toURL:defaultRealmURL error:nil];
 
     // trying to open an outdated realm file without first registering a new schema version and migration block
     // with throw
@@ -95,21 +94,21 @@
     //
     // Migrate other Realm versions
     //
-    NSString *v1Path = [[[NSBundle mainBundle] resourcePath] stringByAppendingPathComponent:@"default-v1.realm"];
-    NSString *v2Path = [[[NSBundle mainBundle] resourcePath] stringByAppendingPathComponent:@"default-v2.realm"];
-    NSString *realmv1Path = [defaultRealmParentPath stringByAppendingPathComponent:@"default-v1.realm"];
-    NSString *realmv2Path = [defaultRealmParentPath stringByAppendingPathComponent:@"default-v2.realm"];
-    [[NSFileManager defaultManager] removeItemAtPath:realmv1Path error:nil];
-    [[NSFileManager defaultManager] copyItemAtPath:v1Path toPath:realmv1Path error:nil];
-    [[NSFileManager defaultManager] removeItemAtPath:realmv2Path error:nil];
-    [[NSFileManager defaultManager] copyItemAtPath:v2Path toPath:realmv2Path error:nil];
+    NSURL *v1URL = [[NSBundle mainBundle] URLForResource:@"default-v1" withExtension:@"realm"];
+    NSURL *v2URL = [[NSBundle mainBundle] URLForResource:@"default-v2" withExtension:@"realm"];
+    NSURL *realmv1URL = [defaultRealmParentURL URLByAppendingPathComponent:@"default-v1.realm"];
+    NSURL *realmv2URL = [defaultRealmParentURL URLByAppendingPathComponent:@"default-v2.realm"];
+    [[NSFileManager defaultManager] removeItemAtURL:realmv1URL error:nil];
+    [[NSFileManager defaultManager] copyItemAtURL:v1URL toURL:realmv1URL error:nil];
+    [[NSFileManager defaultManager] removeItemAtURL:realmv2URL error:nil];
+    [[NSFileManager defaultManager] copyItemAtURL:v2URL toURL:realmv2URL error:nil];
 
     // set schemave versions and migration blocks form Realms at each path
     RLMRealmConfiguration *realmv1Configuration = [configuration copy];
-    realmv1Configuration.path = realmv1Path;
+    realmv1Configuration.fileURL = realmv1URL;
 
     RLMRealmConfiguration *realmv2Configuration = [configuration copy];
-    realmv2Configuration.path = realmv2Path;
+    realmv2Configuration.fileURL = realmv2URL;
 
     // manully migration v1Path, v2Path is migrated implicitly on access
     [RLMRealm migrateRealm:realmv1Configuration];

--- a/examples/ios/objc/REST/AppDelegate.m
+++ b/examples/ios/objc/REST/AppDelegate.m
@@ -37,7 +37,7 @@ NSString *clientSecret = @"YOUR CLIENT SECRET";
     [self.window makeKeyAndVisible];
 
     // Ensure we start with an empty database
-    [[NSFileManager defaultManager] removeItemAtPath:[RLMRealmConfiguration defaultConfiguration].path error:nil];
+    [[NSFileManager defaultManager] removeItemAtURL:[RLMRealmConfiguration defaultConfiguration].fileURL error:nil];
 
     // Query Foursquare API
     NSDictionary *foursquareVenues = [self getFoursquareVenues];

--- a/examples/ios/objc/Simple/AppDelegate.m
+++ b/examples/ios/objc/Simple/AppDelegate.m
@@ -47,7 +47,7 @@ RLM_ARRAY_TYPE(Dog)
     self.window.rootViewController = [[UIViewController alloc] init];
     [self.window makeKeyAndVisible];
 
-    [[NSFileManager defaultManager] removeItemAtPath:[RLMRealmConfiguration defaultConfiguration].path error:nil];
+    [[NSFileManager defaultManager] removeItemAtURL:[RLMRealmConfiguration defaultConfiguration].fileURL error:nil];
 
     // Create a standalone object
     Dog *mydog = [[Dog alloc] init];

--- a/examples/ios/objc/TodayExtension/TodayViewController.m
+++ b/examples/ios/objc/TodayExtension/TodayViewController.m
@@ -35,7 +35,7 @@
     [super viewDidLoad];
     self.preferredContentSize = CGSizeMake(0, 200.0);
     RLMRealmConfiguration *configuration = [RLMRealmConfiguration defaultConfiguration];
-    configuration.path = [[[NSFileManager defaultManager] containerURLForSecurityApplicationGroupIdentifier:@"group.io.realm.examples.extension"] URLByAppendingPathComponent:@"extension.realm"].path;
+    configuration.fileURL = [[[NSFileManager defaultManager] containerURLForSecurityApplicationGroupIdentifier:@"group.io.realm.examples.extension"] URLByAppendingPathComponent:@"extension.realm"];
     [RLMRealmConfiguration setDefaultConfiguration:configuration];
     self.tick = [Tick allObjects].firstObject;
     if (!self.tick) {

--- a/examples/ios/objc/extension WatchKit Extension/InterfaceController.m
+++ b/examples/ios/objc/extension WatchKit Extension/InterfaceController.m
@@ -39,7 +39,7 @@
     NSLog(@"%@ awakeWithContext", self);
 
     RLMRealmConfiguration *configuration = [RLMRealmConfiguration defaultConfiguration];
-    configuration.path = [[[NSFileManager defaultManager] containerURLForSecurityApplicationGroupIdentifier:@"group.io.realm.examples.extension"] URLByAppendingPathComponent:@"extension.realm"].path;
+    configuration.fileURL = [[[NSFileManager defaultManager] containerURLForSecurityApplicationGroupIdentifier:@"group.io.realm.examples.extension"] URLByAppendingPathComponent:@"extension.realm"];
     [RLMRealmConfiguration setDefaultConfiguration:configuration];
     self.tick = [Tick allObjects].firstObject;
     if (!self.tick) {

--- a/examples/ios/swift-2.2/Backlink/AppDelegate.swift
+++ b/examples/ios/swift-2.2/Backlink/AppDelegate.swift
@@ -46,7 +46,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         window?.makeKeyAndVisible()
 
         do {
-            try NSFileManager.defaultManager().removeItemAtPath(Realm.Configuration.defaultConfiguration.path!)
+            try NSFileManager.defaultManager().removeItemAtURL(Realm.Configuration.defaultConfiguration.fileURL!)
         } catch {}
 
         let realm = try! Realm()

--- a/examples/ios/swift-2.2/Encryption/ViewController.swift
+++ b/examples/ios/swift-2.2/Encryption/ViewController.swift
@@ -65,7 +65,7 @@ class ViewController: UIViewController {
         // Opening wihout supplying a key at all fails
         autoreleasepool {
             do {
-                _ = try Realm(path: Realm.Configuration.defaultConfiguration.path!)
+                _ = try Realm()
             } catch {
                 log("Open with no key: \(error)")
             }

--- a/examples/ios/swift-2.2/Migration/AppDelegate.swift
+++ b/examples/ios/swift-2.2/Migration/AppDelegate.swift
@@ -47,9 +47,8 @@ class Person: Object {
     let pets = List<Pet>() // Add pets field
 }
 
-func bundlePath(path: String) -> String? {
-    let resourcePath = NSBundle.mainBundle().resourcePath as NSString?
-    return resourcePath?.stringByAppendingPathComponent(path)
+func bundleURL(name: String) -> NSURL? {
+    return NSBundle.mainBundle().URLForResource(name, withExtension: "realm")
 }
 
 @UIApplicationMain
@@ -63,13 +62,13 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         window?.makeKeyAndVisible()
 
         // copy over old data files for migration
-        let defaultPath = Realm.Configuration.defaultConfiguration.path!
-        let defaultParentPath = (defaultPath as NSString).stringByDeletingLastPathComponent
+        let defaultURL = Realm.Configuration.defaultConfiguration.fileURL!
+        let defaultParentURL = defaultURL.URLByDeletingLastPathComponent
 
-        if let v0Path = bundlePath("default-v0.realm") {
+        if let v0URL = bundleURL("default-v0") {
             do {
-                try NSFileManager.defaultManager().removeItemAtPath(defaultPath)
-                try NSFileManager.defaultManager().copyItemAtPath(v0Path, toPath: defaultPath)
+                try NSFileManager.defaultManager().removeItemAtURL(defaultURL)
+                try NSFileManager.defaultManager().copyItemAtURL(v0URL, toURL: defaultURL)
             } catch {}
         }
 
@@ -109,18 +108,18 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         //
         // Migrate a realms at a custom paths
         //
-        if let v1Path = bundlePath("default-v1.realm"), v2Path = bundlePath("default-v2.realm") {
-            let realmv1Path = (defaultParentPath as NSString).stringByAppendingPathComponent("default-v1.realm")
-            let realmv2Path = (defaultParentPath as NSString).stringByAppendingPathComponent("default-v2.realm")
+        if let v1URL = bundleURL("default-v1"), v2URL = bundleURL("default-v2") {
+            let realmv1URL = defaultParentURL!.URLByAppendingPathComponent("default-v1.realm")
+            let realmv2URL = defaultParentURL!.URLByAppendingPathComponent("default-v2.realm")
 
-            let realmv1Configuration = Realm.Configuration(path: realmv1Path, schemaVersion: 3, migrationBlock: migrationBlock)
-            let realmv2Configuration = Realm.Configuration(path: realmv2Path, schemaVersion: 3, migrationBlock: migrationBlock)
+            let realmv1Configuration = Realm.Configuration(fileURL: realmv1URL, schemaVersion: 2, migrationBlock: migrationBlock)
+            let realmv2Configuration = Realm.Configuration(fileURL: realmv2URL, schemaVersion: 3, migrationBlock: migrationBlock)
 
             do {
-                try NSFileManager.defaultManager().removeItemAtPath(realmv1Path)
-                try NSFileManager.defaultManager().copyItemAtPath(v1Path, toPath: realmv1Path)
-                try NSFileManager.defaultManager().removeItemAtPath(realmv2Path)
-                try NSFileManager.defaultManager().copyItemAtPath(v2Path, toPath: realmv2Path)
+                try NSFileManager.defaultManager().removeItemAtURL(realmv1URL)
+                try NSFileManager.defaultManager().copyItemAtURL(v1URL, toURL: realmv1URL)
+                try NSFileManager.defaultManager().removeItemAtURL(realmv2URL)
+                try NSFileManager.defaultManager().copyItemAtURL(v2URL, toURL: realmv2URL)
             } catch {}
 
             // migrate realms at realmv1Path manually, realmv2Path is migrated automatically on access

--- a/examples/ios/swift-2.2/Simple/AppDelegate.swift
+++ b/examples/ios/swift-2.2/Simple/AppDelegate.swift
@@ -40,7 +40,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         window?.makeKeyAndVisible()
 
         do {
-            try NSFileManager.defaultManager().removeItemAtPath(Realm.Configuration.defaultConfiguration.path!)
+            try NSFileManager.defaultManager().removeItemAtURL(Realm.Configuration.defaultConfiguration.fileURL!)
         } catch {}
 
         // Create a standalone object

--- a/examples/osx/objc/JSONImport/main.m
+++ b/examples/osx/objc/JSONImport/main.m
@@ -40,7 +40,7 @@ int main(int argc, const char * argv[])
         dateFormatter.dateFormat = @"MMMM dd, yyyy";
         dateFormatter.timeZone = [NSTimeZone timeZoneForSecondsFromGMT:0];
 
-        [[NSFileManager defaultManager] removeItemAtPath:[RLMRealmConfiguration defaultConfiguration].path
+        [[NSFileManager defaultManager] removeItemAtURL:[RLMRealmConfiguration defaultConfiguration].fileURL
                                                    error:nil];
 
         RLMRealm *realm = [RLMRealm defaultRealm];

--- a/examples/tvos/objc/PreloadedData/PlacesViewController.m
+++ b/examples/tvos/objc/PreloadedData/PlacesViewController.m
@@ -33,11 +33,7 @@
 
     RLMRealmConfiguration *config = [RLMRealmConfiguration defaultConfiguration];
     config.readOnly = YES;
-
-    NSBundle *mainBundle = [NSBundle mainBundle];
-    NSString *seedFilePath = [mainBundle pathForResource:@"Places" ofType:@"realm"];
-    config.path = seedFilePath;
-
+    config.fileURL = [[NSBundle mainBundle] URLForResource:@"Places" withExtension:@"realm"];
     [RLMRealmConfiguration setDefaultConfiguration:config];
 
     [self reloadData];

--- a/examples/tvos/swift/PreloadedData/PlacesViewController.swift
+++ b/examples/tvos/swift/PreloadedData/PlacesViewController.swift
@@ -27,12 +27,8 @@ class PlacesViewController: UITableViewController, UITextFieldDelegate {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-
-        let mainBundle = NSBundle.mainBundle()
-        let seedFilePath = mainBundle.pathForResource("Places", ofType: "realm")
-
-        let config = Realm.Configuration(readOnly: true, path: seedFilePath)
-
+        let seedFileURL = NSBundle.mainBundle().URLForResource("Places", withExtension: "realm")
+        let config = Realm.Configuration(fileURL: seedFileURL, readOnly: true)
         Realm.Configuration.defaultConfiguration = config
 
         reloadData()


### PR DESCRIPTION
Closes #2593.

~~Depends on #3455. Diff with that PR: https://github.com/realm/realm-cocoa/compare/jp/api/rename-primary-key-to-object-id...jp/api/url-paths~~ (UPDATE: no longer the case)

I'm torn as to whether or not this is something we should be doing. On the one hand, it's aligned with recent Foundation API changes. On the other, we gain (almost) nothing internally by representing paths as URLs, since it's all string based under the hood.

I still wanted to do this work to fully assess if it's the right move, as we're going through other deprecations.

Thoughts @tgoyne @bdash @mrackwitz?