### PR TITLE
Fix the initial ref count for WeakRealmNotifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ x.x.x Release notes (yyyy-MM-dd)
 
 * Fix a use-after-free when an associated object's dealloc method is used to
   remove observers from an RLMObject.
+* Fix a small memory leak each time a Realm file is opened.
 
 0.98.8 Release notes (2016-04-15)
 =============================================================

--- a/Realm/ObjectStore/impl/apple/weak_realm_notifier.cpp
+++ b/Realm/ObjectStore/impl/apple/weak_realm_notifier.cpp
@@ -34,7 +34,7 @@ WeakRealmNotifier::WeakRealmNotifier(const std::shared_ptr<Realm>& realm, bool c
     };
 
     CFRunLoopSourceContext ctx{};
-    ctx.info = new RefCountedWeakPointer{realm, {1}};
+    ctx.info = new RefCountedWeakPointer{realm, {0}};
     ctx.perform = [](void* info) {
         if (auto realm = static_cast<RefCountedWeakPointer*>(info)->realm.lock()) {
             realm->notify();


### PR DESCRIPTION
Adding the run loop source to the run loop retains it, so the initial refcount should be 0, not 1.

Fixes #3270.