### PR TITLE
Remove `addNotificationBlock(_:)` from `RealmCollectionType`.

### DIFF
--- a/RealmSwift-swift2.0/RealmCollectionType.swift
+++ b/RealmSwift-swift2.0/RealmCollectionType.swift
@@ -299,61 +299,6 @@ public protocol RealmCollectionType: CollectionType, CustomStringConvertible {
 
     /// :nodoc:
     func _addNotificationBlock(block: (AnyRealmCollection<Element>?, NSError?) -> ()) -> NotificationToken
-
-    /**
-     Register a block to be called each time the collection changes.
-
-     The block will be asynchronously called with the initial results, and then
-     called again after each write transaction which changes either any of the
-     objects in the collection, or which objects are in the collection.
-
-     At the time when the block is called, the collection object will be fully
-     evaluated and up-to-date, and as long as you do not perform a write
-     transaction on the same thread or explicitly call realm.refresh(),
-     accessing it will never perform blocking work.
-
-     Notifications are delivered via the standard run loop, and so can't be
-     delivered while the run loop is blocked by other activity. When
-     notifications can't be delivered instantly, multiple notifications may be
-     coalesced into a single notification. This can include the notification
-     with the initial collection. For example, the following code performs a write
-     transaction immediately after adding the notification block, so there is no
-     opportunity for the initial notification to be delivered first. As a
-     result, the initial notification will reflect the state of the Realm after
-     the write transaction.
-
-         let results = realm.objects(Dog)
-         print("dogs.count: \(dogs?.count)") // => 0
-         let token = dogs.addNotificationBlock { (changes: RealmCollectionChange) in
-             switch changes {
-                 case .Initial(let dogs):
-                     // Will print "dogs.count: 1"
-                     print("dogs.count: \(dogs.count)")
-                     break
-                 case .Update:
-                     // Will not be hit in this example
-                     break
-                 case .Error:
-                     break
-             }
-         }
-         try! realm.write {
-             let dog = Dog()
-             dog.name = "Rex"
-             person.dogs.append(dog)
-         }
-         // end of run loop execution context
-
-     You must retain the returned token for as long as you want updates to continue
-     to be sent to the block. To stop receiving updates, call stop() on the token.
-
-     - warning: This method cannot be called during a write transaction, or when
-                the source realm is read-only.
-
-     - parameter block: The block to be called with the evaluated collection and change information.
-     - returns: A token which must be held for as long as you want updates to be delivered.
-     */
-    func addNotificationBlock(block: (RealmCollectionChange<Self>) -> ()) -> NotificationToken
 }
 
 private class _AnyRealmCollectionBase<T: Object> {
@@ -619,27 +564,6 @@ private final class _AnyRealmCollection<C: RealmCollectionType>: _AnyRealmCollec
     /// :nodoc:
     override func _addNotificationBlock(block: (Wrapper?, NSError?) -> ()) -> NotificationToken {
         return base._addNotificationBlock(block)
-    }
-
-    /// :nodoc:
-    override func addNotificationBlock(wrapper: Wrapper, block: (RealmCollectionChange<Wrapper>) -> ())
-            -> NotificationToken {
-        return base.addNotificationBlock { (change: RealmCollectionChange<C>) in
-            switch change {
-            case .Initial:
-                block(.Initial(wrapper))
-                break
-            case .Update(_, let deletions, let insertions, let modifications):
-                block(.Update(wrapper,
-                    deletions: deletions,
-                    insertions: insertions,
-                    modifications: modifications))
-                break
-            case .Error(let err):
-                block(.Error(err))
-                break
-            }
-        }
     }
 }
 


### PR DESCRIPTION
Cherry-picked from #3419.

> It no longer compiles now that `Results` is not final. It was added as part of the fine-grained notifications work and has not yet shipped in a release, so it's ok to remove. We can look into bringing it back in the future if we can find a way to do so.

/cc @bdash