### PR TITLE
Deprecate old notification block APIs

### DIFF
--- a/Realm/RLMCollection.h
+++ b/Realm/RLMCollection.h
@@ -20,7 +20,7 @@
 
 RLM_ASSUME_NONNULL_BEGIN
 
-@class RLMRealm, RLMResults, RLMObject, RLMSortDescriptor, RLMNotificationToken;
+@class RLMRealm, RLMResults, RLMObject, RLMSortDescriptor, RLMNotificationToken, RLMCollectionChange;
 
 /**
  A homogenous collection of `RLMObject`s like `RLMArray` or `RLMResults`.
@@ -172,12 +172,65 @@ RLM_ASSUME_NONNULL_BEGIN
 #pragma mark - Notifications
 
 /**
- Register a block to be called each time the collection changes.
+ Register a block to be called each time the RLMCollection changes.
 
- @param block The block to be called each time the collection changes.
- @return A token which must be held for as long as you want notifications to be delivered.
+ The block will be asynchronously called with the initial collection, and then
+ called again after each write transaction which changes either any of the
+ objects in the collection, or which objects are in the collection.
+
+ The change parameter will be `nil` the first time the block is called with the
+ initial collection. For each call after that, it will contain information about
+ which rows in the collection were added, removed or modified. If a write transaction
+ did not modify any objects in this collection, the block is not called at all.
+ See the RLMCollectionChange documentation for information on how the changes
+ are reported and an example of updating a UITableView.
+
+ If an error occurs the block will be called with `nil` for the collection
+ parameter and a non-`nil` error. Currently the only errors that can occur are
+ when opening the RLMRealm on the background worker thread.
+
+ At the time when the block is called, the RLMCollection object will be fully
+ evaluated and up-to-date, and as long as you do not perform a write transaction
+ on the same thread or explicitly call `-[RLMRealm refresh]`, accessing it will
+ never perform blocking work.
+
+ Notifications are delivered via the standard run loop, and so can't be
+ delivered while the run loop is blocked by other activity. When
+ notifications can't be delivered instantly, multiple notifications may be
+ coalesced into a single notification. This can include the notification
+ with the initial collection. For example, the following code performs a write
+ transaction immediately after adding the notification block, so there is no
+ opportunity for the initial notification to be delivered first. As a
+ result, the initial notification will reflect the state of the Realm after
+ the write transaction.
+
+     id<RLMCollection> collection = [Dog allObjects];
+     NSLog(@"dogs.count: %zu", dogs.count); // => 0
+     self.token = [collection addNotificationBlock:^(id<RLMCollection> dogs,
+                                                  RLMCollectionChange *changes,
+                                                  NSError *error) {
+         // Only fired once for the example
+         NSLog(@"dogs.count: %zu", dogs.count); // => 1
+     }];
+     [realm transactionWithBlock:^{
+         Dog *dog = [[Dog alloc] init];
+         dog.name = @"Rex";
+         [realm addObject:dog];
+     }];
+     // end of run loop execution context
+
+ You must retain the returned token for as long as you want updates to continue
+ to be sent to the block. To stop receiving updates, call `-stop` on the token.
+
+ @warning This method cannot be called during a write transaction, or when the
+          containing realm is read-only.
+
+ @param block The block to be called with the evaluated collection.
+ @return A token which must be held for as long as you want collection notifications to be delivered.
  */
-- (RLMNotificationToken *)addNotificationBlock:(void (^)(id<RLMCollection> collection))block RLM_WARN_UNUSED_RESULT;
+- (RLMNotificationToken *)addNotificationBlock:(void (^)(id<RLMCollection> __nullable collection,
+                                                         RLMCollectionChange *__nullable change,
+                                                         NSError *__nullable error))block RLM_WARN_UNUSED_RESULT;
 
 @end
 /**

--- a/RealmSwift-swift2.0/List.swift
+++ b/RealmSwift-swift2.0/List.swift
@@ -431,7 +431,7 @@ public final class List<T: Object>: ListBase {
 
         let person = realm.objects(Person).first!
         print("dogs.count: \(person.dogs.count)") // => 0
-        let token = person.dogs.addNotificationBlock { (changes: RealmCollectionChange) in
+        let token = person.dogs.addNotificationBlock { changes in
             switch changes {
                 case .Initial(let dogs):
                     // Will print "dogs.count: 1"
@@ -465,7 +465,7 @@ public final class List<T: Object>: ListBase {
     @warn_unused_result(message="You must hold on to the NotificationToken returned from addNotificationBlock")
     public func addNotificationBlock(block: (RealmCollectionChange<List>) -> ()) -> NotificationToken {
         return _rlmArray.addNotificationBlock { list, change, error in
-            block(RealmCollectionChange<List>.fromObjc(self, change: change, error: error))
+            block(RealmCollectionChange.fromObjc(self, change: change, error: error))
         }
     }
 }
@@ -506,8 +506,11 @@ extension List: RealmCollectionType, RangeReplaceableCollectionType {
     public var endIndex: Int { return count }
 
     /// :nodoc:
-    public func _addNotificationBlock(block: (AnyRealmCollection<T>?, NSError?) -> ()) -> NotificationToken {
+    public func _addNotificationBlock(block: (RealmCollectionChange<AnyRealmCollection<T>>) -> Void) ->
+        NotificationToken {
         let anyCollection = AnyRealmCollection(self)
-        return _rlmArray.addNotificationBlock { _, _, _ in block(anyCollection, nil) }
+        return _rlmArray.addNotificationBlock { _, change, error in
+            block(RealmCollectionChange.fromObjc(anyCollection, change: change, error: error))
+        }
     }
 }

--- a/RealmSwift-swift2.0/List.swift
+++ b/RealmSwift-swift2.0/List.swift
@@ -409,6 +409,58 @@ public final class List<T: Object>: ListBase {
     called again after each write transaction which changes the list or any of
     the items in the list.
 
+    The block is called on the same thread as it was added on, and can only
+    be added on threads which are currently within a run loop. Unless you are
+    specifically creating and running a run loop on a background thread, this
+    will normally only be the main thread.
+
+    Notifications are delivered via the standard run loop, and so can't be
+    delivered while the run loop is blocked by other activity. When
+    notifications can't be delivered instantly, multiple notifications may be
+    coalesced into a single notification. This can include the notification
+    with the initial list. For example, the following code performs a write
+    transaction immediately after adding the notification block, so there is no
+    opportunity for the initial notification to be delivered first. As a
+    result, the initial notification will reflect the state of the Realm after
+    the write transaction.
+
+        let person = realm.objects(Person).first!
+        print("dogs.count: \(person.dogs.count)") // => 0
+        let token = person.dogs.addNotificationBlock { (dogs: List) in
+            // Only fired once for the example
+            print("dogs.count: \(dogs.count)") // will only print "dogs.count: 1"
+        }
+        try! realm.write {
+            let dog = Dog()
+            dog.name = "Rex"
+            person.dogs.append(dog)
+        }
+        // end of run loop execution context
+
+    You must retain the returned token for as long as you want updates to continue
+    to be sent to the block. To stop receiving updates, call stop() on the token.
+
+     - warning: This method cannot be called during a write transaction, or when
+                the source realm is read-only.
+     - warning: This method can only be called on Lists which are stored on an
+                Object which has been added to or retrieved from a Realm.
+
+    - parameter block: The block to be called each time the list changes.
+    - returns: A token which must be held for as long as you want notifications to be delivered.
+    */
+    @available(*, deprecated=1, message="Use addNotificationBlock with changes")
+    @warn_unused_result(message="You must hold on to the NotificationToken returned from addNotificationBlock")
+    public func addNotificationBlock(block: (list: List<T>) -> ()) -> NotificationToken {
+        return _rlmArray.addNotificationBlock { _, _, _ in block(list: self) }
+    }
+
+    /**
+    Register a block to be called each time the List changes.
+
+    The block will be asynchronously called with the initial list, and then
+    called again after each write transaction which changes the list or any of
+    the items in the list.
+
     This version of this method reports which of the objects in the List were
     added, removed, or modified in each write transaction as indices within the
     List. See the RealmCollectionChange documentation for more information on
@@ -431,7 +483,7 @@ public final class List<T: Object>: ListBase {
 
         let person = realm.objects(Person).first!
         print("dogs.count: \(person.dogs.count)") // => 0
-        let token = person.dogs.addNotificationBlock { changes in
+        let token = person.dogs.addNotificationBlock { (changes: RealmCollectionChange) in
             switch changes {
                 case .Initial(let dogs):
                     // Will print "dogs.count: 1"

--- a/RealmSwift-swift2.0/List.swift
+++ b/RealmSwift-swift2.0/List.swift
@@ -409,57 +409,6 @@ public final class List<T: Object>: ListBase {
     called again after each write transaction which changes the list or any of
     the items in the list.
 
-    The block is called on the same thread as it was added on, and can only
-    be added on threads which are currently within a run loop. Unless you are
-    specifically creating and running a run loop on a background thread, this
-    will normally only be the main thread.
-
-    Notifications are delivered via the standard run loop, and so can't be
-    delivered while the run loop is blocked by other activity. When
-    notifications can't be delivered instantly, multiple notifications may be
-    coalesced into a single notification. This can include the notification
-    with the initial list. For example, the following code performs a write
-    transaction immediately after adding the notification block, so there is no
-    opportunity for the initial notification to be delivered first. As a
-    result, the initial notification will reflect the state of the Realm after
-    the write transaction.
-
-        let person = realm.objects(Person).first!
-        print("dogs.count: \(person.dogs.count)") // => 0
-        let token = person.dogs.addNotificationBlock { (dogs: List) in
-            // Only fired once for the example
-            print("dogs.count: \(dogs.count)") // will only print "dogs.count: 1"
-        }
-        try! realm.write {
-            let dog = Dog()
-            dog.name = "Rex"
-            person.dogs.append(dog)
-        }
-        // end of run loop execution context
-
-    You must retain the returned token for as long as you want updates to continue
-    to be sent to the block. To stop receiving updates, call stop() on the token.
-
-     - warning: This method cannot be called during a write transaction, or when
-                the source realm is read-only.
-     - warning: This method can only be called on Lists which are stored on an
-                Object which has been added to or retrieved from a Realm.
-
-    - parameter block: The block to be called each time the list changes.
-    - returns: A token which must be held for as long as you want notifications to be delivered.
-    */
-    @warn_unused_result(message="You must hold on to the NotificationToken returned from addNotificationBlock")
-    public func addNotificationBlock(block: (list: List<T>) -> ()) -> NotificationToken {
-        return _rlmArray.addNotificationBlock { _, _, _ in block(list: self) }
-    }
-
-    /**
-    Register a block to be called each time the List changes.
-
-    The block will be asynchronously called with the initial list, and then
-    called again after each write transaction which changes the list or any of
-    the items in the list.
-
     This version of this method reports which of the objects in the List were
     added, removed, or modified in each write transaction as indices within the
     List. See the RealmCollectionChange documentation for more information on

--- a/RealmSwift-swift2.0/RealmCollectionType.swift
+++ b/RealmSwift-swift2.0/RealmCollectionType.swift
@@ -790,6 +790,48 @@ public final class AnyRealmCollection<T: Object>: RealmCollectionType {
     // MARK: Notifications
 
     /**
+    Register a block to be called each time the collection changes.
+
+    The block will be asynchronously called with the initial collection, and
+    then called again after each write transaction which changes the collection
+    or any of the items in the collection.
+
+    The block is called on the same thread as it was added on, and can only
+    be added on threads which are currently within a run loop. Unless you are
+    specifically creating and running a run loop on a background thread, this
+    normally will only be the main thread.
+
+    Notifications can't be delivered as long as the runloop is blocked by
+    other activity. When notifications can't be delivered instantly, multiple
+    notifications may be coalesced. That can include the notification about the
+    initial collection.
+
+    You must retain the returned token for as long as you want updates to continue
+    to be sent to the block. To stop receiving updates, call stop() on the token.
+
+    - parameter block: The block to be called each time the collection changes.
+    - returns: A token which must be held for as long as you want notifications to be delivered.
+    */
+    @available(*, deprecated=1, message="Use addNotificationBlock with changes")
+    @warn_unused_result(message="You must hold on to the NotificationToken returned from addNotificationBlock")
+    public func addNotificationBlock(block: (collection: AnyRealmCollection<Element>?,
+                                             error: NSError?) -> ()) -> NotificationToken {
+        return base._addNotificationBlock { changes in
+            switch changes {
+            case .Initial(let collection):
+                block(collection: collection, error: nil)
+                break
+            case .Update(let collection, _, _, _):
+                block(collection: collection, error: nil)
+                break
+            case .Error(let error):
+                block(collection: nil, error: error)
+                break
+            }
+        }
+    }
+
+    /**
      Register a block to be called each time the collection changes.
 
      The block will be asynchronously called with the initial results, and then
@@ -813,7 +855,7 @@ public final class AnyRealmCollection<T: Object>: RealmCollectionType {
 
          let results = realm.objects(Dog)
          print("dogs.count: \(dogs?.count)") // => 0
-         let token = dogs.addNotificationBlock { changes in
+         let token = dogs.addNotificationBlock { (changes: RealmCollectionChange) in
              switch changes {
                  case .Initial(let dogs):
                      // Will print "dogs.count: 1"
@@ -844,8 +886,6 @@ public final class AnyRealmCollection<T: Object>: RealmCollectionType {
      */
     public func addNotificationBlock(block: (RealmCollectionChange<AnyRealmCollection>) -> ())
         -> NotificationToken { return base._addNotificationBlock(block) }
-
-    // MARK: Notifications
 
     /// :nodoc:
     public func _addNotificationBlock(block: (RealmCollectionChange<AnyRealmCollection>) -> ())

--- a/RealmSwift-swift2.0/Results.swift
+++ b/RealmSwift-swift2.0/Results.swift
@@ -328,6 +328,64 @@ public final class Results<T: Object>: ResultsBase {
      called again after each write transaction which changes either any of the
      objects in the results, or which objects are in the results.
 
+     If an error occurs the block will be called with `nil` for the results
+     parameter and a non-`nil` error. Currently the only errors that can occur are
+     when opening the Realm on the background worker thread fails.
+
+     At the time when the block is called, the Results object will be fully
+     evaluated and up-to-date, and as long as you do not perform a write transaction
+     on the same thread or explicitly call realm.refresh(), accessing it will never
+     perform blocking work.
+
+     Notifications are delivered via the standard run loop, and so can't be
+     delivered while the run loop is blocked by other activity. When
+     notifications can't be delivered instantly, multiple notifications may be
+     coalesced into a single notification. This can include the notification
+     with the initial results. For example, the following code performs a write
+     transaction immediately after adding the notification block, so there is no
+     opportunity for the initial notification to be delivered first. As a
+     result, the initial notification will reflect the state of the Realm after
+     the write transaction.
+
+         let results = realm.objects(Dog)
+         print("dogs.count: \(results?.count)") // => 0
+         let token = results.addNotificationBlock { (dogs, error) in
+             // Only fired once for the example
+             print("dogs.count: \(dogs?.count)") // will only print "dogs.count: 1"
+         }
+         try! realm.write {
+             realm.add(Dog.self, value: ["name": "Rex", "age": 7])
+         }
+         // end of runloop execution context
+
+     You must retain the returned token for as long as you want updates to continue
+     to be sent to the block. To stop receiving updates, call stop() on the token.
+
+     - warning: This method cannot be called during a write transaction, or when
+                the source realm is read-only.
+
+     - parameter block: The block to be called with the evaluated results.
+     - returns: A token which must be held for as long as you want query results to be delivered.
+     */
+    @available(*, deprecated=1, message="Use addNotificationBlock with changes")
+    @warn_unused_result(message="You must hold on to the NotificationToken returned from addNotificationBlock")
+    public func addNotificationBlock(block: (results: Results<T>?, error: NSError?) -> ()) -> NotificationToken {
+        return rlmResults.addNotificationBlock { results, changes, error in
+            if results != nil {
+                block(results: self, error: nil)
+            } else {
+                block(results: nil, error: error)
+            }
+        }
+    }
+
+    /**
+     Register a block to be called each time the Results changes.
+
+     The block will be asynchronously called with the initial results, and then
+     called again after each write transaction which changes either any of the
+     objects in the results, or which objects are in the results.
+
      This version of this method reports which of the objects in the results were
      added, removed, or modified in each write transaction as indices within the
      results. See the RealmCollectionChange documentation for more information on
@@ -351,7 +409,7 @@ public final class Results<T: Object>: ResultsBase {
 
          let dogs = realm.objects(Dog)
          print("dogs.count: \(dogs?.count)") // => 0
-         let token = dogs.addNotificationBlock { changes in
+         let token = dogs.addNotificationBlock { (changes: RealmCollectionChange) in
              switch changes {
                  case .Initial(let dogs):
                      // Will print "dogs.count: 1"

--- a/RealmSwift-swift2.0/Results.swift
+++ b/RealmSwift-swift2.0/Results.swift
@@ -351,7 +351,7 @@ public final class Results<T: Object>: ResultsBase {
 
          let dogs = realm.objects(Dog)
          print("dogs.count: \(dogs?.count)") // => 0
-         let token = dogs.addNotificationBlock { (changes: RealmCollectionChange) in
+         let token = dogs.addNotificationBlock { changes in
              switch changes {
                  case .Initial(let dogs):
                      // Will print "dogs.count: 1"
@@ -383,7 +383,7 @@ public final class Results<T: Object>: ResultsBase {
     @warn_unused_result(message="You must hold on to the NotificationToken returned from addNotificationBlock")
     public func addNotificationBlock(block: (RealmCollectionChange<Results> -> Void)) -> NotificationToken {
         return rlmResults.addNotificationBlock { results, change, error in
-            block(RealmCollectionChange<Results>.fromObjc(self, change: change, error: error))
+            block(RealmCollectionChange.fromObjc(self, change: change, error: error))
         }
     }
 }
@@ -408,14 +408,11 @@ extension Results: RealmCollectionType {
     public var endIndex: Int { return count }
 
     /// :nodoc:
-    public func _addNotificationBlock(block: (AnyRealmCollection<T>?, NSError?) -> ()) -> NotificationToken {
+    public func _addNotificationBlock(block: (RealmCollectionChange<AnyRealmCollection<T>>) -> Void) ->
+        NotificationToken {
         let anyCollection = AnyRealmCollection(self)
-        return rlmResults.addNotificationBlock { results, change, error in
-            if results != nil {
-                block(anyCollection, nil)
-            } else {
-                block(nil, error)
-            }
+        return rlmResults.addNotificationBlock { _, change, error in
+            block(RealmCollectionChange.fromObjc(anyCollection, change: change, error: error))
         }
     }
 }

--- a/RealmSwift-swift2.0/Results.swift
+++ b/RealmSwift-swift2.0/Results.swift
@@ -328,63 +328,6 @@ public final class Results<T: Object>: ResultsBase {
      called again after each write transaction which changes either any of the
      objects in the results, or which objects are in the results.
 
-     If an error occurs the block will be called with `nil` for the results
-     parameter and a non-`nil` error. Currently the only errors that can occur are
-     when opening the Realm on the background worker thread fails.
-
-     At the time when the block is called, the Results object will be fully
-     evaluated and up-to-date, and as long as you do not perform a write transaction
-     on the same thread or explicitly call realm.refresh(), accessing it will never
-     perform blocking work.
-
-     Notifications are delivered via the standard run loop, and so can't be
-     delivered while the run loop is blocked by other activity. When
-     notifications can't be delivered instantly, multiple notifications may be
-     coalesced into a single notification. This can include the notification
-     with the initial results. For example, the following code performs a write
-     transaction immediately after adding the notification block, so there is no
-     opportunity for the initial notification to be delivered first. As a
-     result, the initial notification will reflect the state of the Realm after
-     the write transaction.
-
-         let results = realm.objects(Dog)
-         print("dogs.count: \(results?.count)") // => 0
-         let token = results.addNotificationBlock { (dogs, error) in
-             // Only fired once for the example
-             print("dogs.count: \(dogs?.count)") // will only print "dogs.count: 1"
-         }
-         try! realm.write {
-             realm.add(Dog.self, value: ["name": "Rex", "age": 7])
-         }
-         // end of runloop execution context
-
-     You must retain the returned token for as long as you want updates to continue
-     to be sent to the block. To stop receiving updates, call stop() on the token.
-
-     - warning: This method cannot be called during a write transaction, or when
-                the source realm is read-only.
-
-     - parameter block: The block to be called with the evaluated results.
-     - returns: A token which must be held for as long as you want query results to be delivered.
-     */
-    @warn_unused_result(message="You must hold on to the NotificationToken returned from addNotificationBlock")
-    public func addNotificationBlock(block: (results: Results<T>?, error: NSError?) -> ()) -> NotificationToken {
-        return rlmResults.addNotificationBlock { results, changes, error in
-            if results != nil {
-                block(results: self, error: nil)
-            } else {
-                block(results: nil, error: error)
-            }
-        }
-    }
-
-    /**
-     Register a block to be called each time the Results changes.
-
-     The block will be asynchronously called with the initial results, and then
-     called again after each write transaction which changes either any of the
-     objects in the results, or which objects are in the results.
-
      This version of this method reports which of the objects in the results were
      added, removed, or modified in each write transaction as indices within the
      results. See the RealmCollectionChange documentation for more information on

--- a/RealmSwift-swift2.0/Tests/RealmCollectionTypeTests.swift
+++ b/RealmSwift-swift2.0/Tests/RealmCollectionTypeTests.swift
@@ -312,7 +312,7 @@ class RealmCollectionTypeTests: TestCase {
         try! realm.commitWrite()
 
         let expectation = expectationWithDescription("")
-        let token = collection.addNotificationBlock { changes in
+        let token = collection.addNotificationBlock { (changes: RealmCollectionChange) in
             switch changes {
             case .Initial(let collection):
                 XCTAssertEqual(collection.count, 2)
@@ -385,7 +385,7 @@ class ResultsTests: RealmCollectionTypeTests {
 
         var expectation = expectationWithDescription("")
         var calls = 0
-        let token = collection.addNotificationBlock { changes in
+        let token = collection.addNotificationBlock { (changes: RealmCollectionChange) in
             switch changes {
             case .Initial(let results):
                 XCTAssertEqual(results.count, calls + 2)
@@ -549,7 +549,7 @@ class ListRealmCollectionTypeTests: RealmCollectionTypeTests {
         try! realm.commitWrite()
 
         let expectation = expectationWithDescription("")
-        let token = collection.addNotificationBlock { changes in
+        let token = collection.addNotificationBlock { (changes: RealmCollectionChange) in
             switch changes {
             case .Initial(let list):
                 XCTAssertEqual(list.count, 2)
@@ -664,7 +664,7 @@ class ListStandaloneRealmCollectionTypeTests: ListRealmCollectionTypeTests {
     override func testAddNotificationBlock() {
         let realm = realmWithTestPath()
         try! realm.commitWrite()
-        assertThrows(self.collection.addNotificationBlock { _ in })
+        assertThrows(self.collection.addNotificationBlock { (changes: RealmCollectionChange) in })
         realm.beginWrite()
     }
 
@@ -673,7 +673,7 @@ class ListStandaloneRealmCollectionTypeTests: ListRealmCollectionTypeTests {
         let realm = realmWithTestPath()
         try! realm.commitWrite()
 
-        assertThrows(collection.addNotificationBlock { _ in })
+        assertThrows(collection.addNotificationBlock { (changes: RealmCollectionChange) in })
         realm.beginWrite()
     }
 }

--- a/RealmSwift-swift2.0/Tests/RealmCollectionTypeTests.swift
+++ b/RealmSwift-swift2.0/Tests/RealmCollectionTypeTests.swift
@@ -312,10 +312,19 @@ class RealmCollectionTypeTests: TestCase {
         try! realm.commitWrite()
 
         let expectation = expectationWithDescription("")
-        let token = collection.addNotificationBlock { c, error in
-            XCTAssertNil(error)
-            XCTAssertNotNil(c)
-            XCTAssertEqual(c!.count, 2)
+        let token = collection.addNotificationBlock { changes in
+            switch changes {
+            case .Initial(let collection):
+                XCTAssertEqual(collection.count, 2)
+                break
+            case .Update:
+                XCTFail("Shouldn't happen")
+                break
+            case .Error:
+                XCTFail("Shouldn't happen")
+                break
+            }
+
             expectation.fulfill()
         }
         waitForExpectationsWithTimeout(1, handler: nil)
@@ -655,7 +664,7 @@ class ListStandaloneRealmCollectionTypeTests: ListRealmCollectionTypeTests {
     override func testAddNotificationBlock() {
         let realm = realmWithTestPath()
         try! realm.commitWrite()
-        assertThrows(self.collection.addNotificationBlock { _, _ in })
+        assertThrows(self.collection.addNotificationBlock { _ in })
         realm.beginWrite()
     }
 

--- a/examples/ios/swift-2.2/TableView/TableViewController.swift
+++ b/examples/ios/swift-2.2/TableView/TableViewController.swift
@@ -46,7 +46,7 @@ class TableViewController: UITableViewController {
         setupUI()
 
         // Set results notification block
-        self.notificationToken = results.addNotificationBlock { (changes: RealmCollectionChange) in
+        self.notificationToken = results.addNotificationBlock { changes in
             switch changes {
             case .Initial:
                 // Results are now populated and can be accessed without blocking the UI

--- a/examples/ios/swift-2.2/TableView/TableViewController.swift
+++ b/examples/ios/swift-2.2/TableView/TableViewController.swift
@@ -46,7 +46,7 @@ class TableViewController: UITableViewController {
         setupUI()
 
         // Set results notification block
-        self.notificationToken = results.addNotificationBlock { changes in
+        self.notificationToken = results.addNotificationBlock { (changes: RealmCollectionChange) in
             switch changes {
             case .Initial:
                 // Results are now populated and can be accessed without blocking the UI


### PR DESCRIPTION
As best I can tell, this was just missed in #3359 /cc @tgoyne 

I think this is compatible with #3419 but not 100% sure just yet. /cc @bdash