### PR TITLE
Fix a few async notifier issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,9 @@ x.x.x Release notes (yyyy-MM-dd)
 
 ### Bugfixes
 
-* None.
+* Fix a scenario that could lead to the assertion failure
+  "m_advancer_sg->get_version_of_current_transaction() ==
+  new_notifiers.front()->version()".
 
 0.99.0 Release notes (2016-04-22)
 =============================================================

--- a/Realm.xcodeproj/project.pbxproj
+++ b/Realm.xcodeproj/project.pbxproj
@@ -79,8 +79,8 @@
 		3F75566B1BE94CCC0058BC7E /* results.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3F7556691BE94CCC0058BC7E /* results.cpp */; };
 		3F75566C1BE94CCC0058BC7E /* results.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 3F75566A1BE94CCC0058BC7E /* results.hpp */; };
 		3F75566D1BE94CEA0058BC7E /* results.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3F7556691BE94CCC0058BC7E /* results.cpp */; };
-		3F7556751BE95A0C0058BC7E /* AsyncTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 3F7556731BE95A050058BC7E /* AsyncTests.m */; };
-		3F7556761BE95A0D0058BC7E /* AsyncTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 3F7556731BE95A050058BC7E /* AsyncTests.m */; };
+		3F7556751BE95A0C0058BC7E /* AsyncTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 3F7556731BE95A050058BC7E /* AsyncTests.mm */; };
+		3F7556761BE95A0D0058BC7E /* AsyncTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 3F7556731BE95A050058BC7E /* AsyncTests.mm */; };
 		3F7A3FAE1CC6EB7300301A17 /* collection_change_builder.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3F7A3FAC1CC6EB7300301A17 /* collection_change_builder.cpp */; };
 		3F7A3FAF1CC6EB7300301A17 /* collection_change_builder.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3F7A3FAC1CC6EB7300301A17 /* collection_change_builder.cpp */; };
 		3F7A3FB01CC6EB7300301A17 /* collection_change_builder.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 3F7A3FAD1CC6EB7300301A17 /* collection_change_builder.hpp */; };
@@ -524,7 +524,7 @@
 		3F6B89AE19EF40BA004E8EA8 /* librealm-ios.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = "librealm-ios.a"; path = "../core/librealm-ios.a"; sourceTree = "<group>"; };
 		3F7556691BE94CCC0058BC7E /* results.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = results.cpp; path = ObjectStore/results.cpp; sourceTree = "<group>"; };
 		3F75566A1BE94CCC0058BC7E /* results.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = results.hpp; path = ObjectStore/results.hpp; sourceTree = "<group>"; };
-		3F7556731BE95A050058BC7E /* AsyncTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AsyncTests.m; sourceTree = "<group>"; };
+		3F7556731BE95A050058BC7E /* AsyncTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = AsyncTests.mm; sourceTree = "<group>"; };
 		3F7A3FAC1CC6EB7300301A17 /* collection_change_builder.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = collection_change_builder.cpp; path = ObjectStore/impl/collection_change_builder.cpp; sourceTree = "<group>"; };
 		3F7A3FAD1CC6EB7300301A17 /* collection_change_builder.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = collection_change_builder.hpp; path = ObjectStore/impl/collection_change_builder.hpp; sourceTree = "<group>"; };
 		3F90260F1C625C5D006AE98E /* list.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = list.cpp; path = ObjectStore/list.cpp; sourceTree = "<group>"; };
@@ -922,7 +922,7 @@
 			isa = PBXGroup;
 			children = (
 				E81A1FB81955FE0100FDED82 /* ArrayPropertyTests.m */,
-				3F7556731BE95A050058BC7E /* AsyncTests.m */,
+				3F7556731BE95A050058BC7E /* AsyncTests.mm */,
 				E81A1FBA1955FE0100FDED82 /* DynamicTests.m */,
 				021A882F1AAFB5BE00EEAC84 /* EncryptionTests.mm */,
 				E81A1FBB1955FE0100FDED82 /* EnumeratorTests.m */,
@@ -1858,7 +1858,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				E856D214195615A900FB2FCF /* ArrayPropertyTests.m in Sources */,
-				3F7556761BE95A0D0058BC7E /* AsyncTests.m in Sources */,
+				3F7556761BE95A0D0058BC7E /* AsyncTests.mm in Sources */,
 				E856D216195615A900FB2FCF /* DynamicTests.m in Sources */,
 				021A88331AAFB5C900EEAC84 /* EncryptionTests.mm in Sources */,
 				E856D217195615A900FB2FCF /* EnumeratorTests.m in Sources */,
@@ -1903,7 +1903,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				E81A1FD51955FE0100FDED82 /* ArrayPropertyTests.m in Sources */,
-				3F7556751BE95A0C0058BC7E /* AsyncTests.m in Sources */,
+				3F7556751BE95A0C0058BC7E /* AsyncTests.mm in Sources */,
 				02E334C31A5F41C7009F8810 /* DynamicTests.m in Sources */,
 				021A88321AAFB5C800EEAC84 /* EncryptionTests.mm in Sources */,
 				E81A1FDB1955FE0100FDED82 /* EnumeratorTests.m in Sources */,

--- a/Realm/ObjectStore/impl/collection_notifier.cpp
+++ b/Realm/ObjectStore/impl/collection_notifier.cpp
@@ -180,10 +180,13 @@ void CollectionNotifier::prepare_handover()
     do_prepare_handover(*m_sg);
 }
 
-bool CollectionNotifier::deliver(SharedGroup& sg, std::exception_ptr err)
+bool CollectionNotifier::deliver(Realm& realm, SharedGroup& sg, std::exception_ptr err)
 {
-    if (!is_for_current_thread()) {
-        return false;
+    {
+        std::lock_guard<std::mutex> lock(m_realm_mutex);
+        if (m_realm.get() != &realm) {
+            return false;
+        }
     }
 
     if (err) {

--- a/Realm/ObjectStore/impl/collection_notifier.hpp
+++ b/Realm/ObjectStore/impl/collection_notifier.hpp
@@ -27,7 +27,6 @@
 #include <exception>
 #include <functional>
 #include <mutex>
-#include <thread>
 #include <unordered_map>
 
 namespace realm {
@@ -109,7 +108,7 @@ public:
 
     virtual void run() = 0;
     void prepare_handover();
-    bool deliver(SharedGroup&, std::exception_ptr);
+    bool deliver(Realm&, SharedGroup&, std::exception_ptr);
 
 protected:
     bool have_callbacks() const noexcept { return m_have_callbacks; }
@@ -123,9 +122,6 @@ private:
     virtual void do_prepare_handover(SharedGroup&) = 0;
     virtual bool do_deliver(SharedGroup&) { return true; }
     virtual bool do_add_required_change_info(TransactionChangeInfo&) = 0;
-
-    const std::thread::id m_thread_id = std::this_thread::get_id();
-    bool is_for_current_thread() const { return m_thread_id == std::this_thread::get_id(); }
 
     mutable std::mutex m_realm_mutex;
     std::shared_ptr<Realm> m_realm;

--- a/Realm/ObjectStore/impl/realm_coordinator.cpp
+++ b/Realm/ObjectStore/impl/realm_coordinator.cpp
@@ -243,13 +243,17 @@ void RealmCoordinator::pin_version(uint_fast64_t version, uint_fast32_t index)
     }
     else if (m_new_notifiers.empty()) {
         // If this is the first notifier then we don't already have a read transaction
+        REALM_ASSERT_3(m_advancer_sg->get_transact_stage(), ==, SharedGroup::transact_Ready);
         m_advancer_sg->begin_read(versionid);
     }
-    else if (versionid < m_advancer_sg->get_version_of_current_transaction()) {
-        // Ensure we're holding a readlock on the oldest version we have a
-        // handover object for, as handover objects don't
-        m_advancer_sg->end_read();
-        m_advancer_sg->begin_read(versionid);
+    else {
+        REALM_ASSERT_3(m_advancer_sg->get_transact_stage(), ==, SharedGroup::transact_Reading);
+        if (versionid < m_advancer_sg->get_version_of_current_transaction()) {
+            // Ensure we're holding a readlock on the oldest version we have a
+            // handover object for, as handover objects don't
+            m_advancer_sg->end_read();
+            m_advancer_sg->begin_read(versionid);
+        }
     }
 }
 
@@ -290,10 +294,12 @@ void RealmCoordinator::clean_up_dead_notifiers()
         // are no notifiers left, but don't close them entirely as opening shared
         // groups is expensive
         if (m_notifiers.empty() && m_notifier_sg) {
+            REALM_ASSERT_3(m_notifier_sg->get_transact_stage(), ==, SharedGroup::transact_Reading);
             m_notifier_sg->end_read();
         }
     }
     if (swap_remove(m_new_notifiers)) {
+        REALM_ASSERT_3(m_advancer_sg->get_transact_stage(), ==, SharedGroup::transact_Reading);
         if (m_new_notifiers.empty() && m_advancer_sg) {
             m_advancer_sg->end_read();
         }
@@ -432,7 +438,14 @@ void RealmCoordinator::run_async_notifiers()
     IncrementalChangeInfo new_notifier_change_info(*m_advancer_sg, new_notifiers);
 
     if (!new_notifiers.empty()) {
-        REALM_ASSERT(m_advancer_sg->get_version_of_current_transaction() == new_notifiers.front()->version());
+        REALM_ASSERT_3(m_advancer_sg->get_transact_stage(), ==, SharedGroup::transact_Reading);
+        REALM_ASSERT_3(m_advancer_sg->get_version_of_current_transaction().version,
+                       <=, new_notifiers.front()->version().version);
+
+        // The advancer SG can be at an older version than the oldest new notifier
+        // if a notifier was added and then removed before it ever got the chance
+        // to run, as we don't move the pin forward when removing dead notifiers
+        transaction::advance(*m_advancer_sg, nullptr, new_notifiers.front()->version());
 
         // Advance each of the new notifiers to the latest version, attaching them
         // to the SG at their handover version. This requires a unique
@@ -454,6 +467,7 @@ void RealmCoordinator::run_async_notifiers()
         version = m_advancer_sg->get_version_of_current_transaction();
         m_advancer_sg->end_read();
     }
+    REALM_ASSERT_3(m_advancer_sg->get_transact_stage(), ==, SharedGroup::transact_Ready);
 
     // Make a copy of the notifiers vector and then release the lock to avoid
     // blocking other threads trying to register or unregister notifiers while we run them

--- a/Realm/ObjectStore/impl/realm_coordinator.cpp
+++ b/Realm/ObjectStore/impl/realm_coordinator.cpp
@@ -575,7 +575,7 @@ void RealmCoordinator::advance_to_ready(Realm& realm)
 
         // Query version now matches the SG version, so we can deliver them
         for (auto& notifier : m_notifiers) {
-            if (notifier->deliver(sg, m_async_error)) {
+            if (notifier->deliver(realm, sg, m_async_error)) {
                 notifiers.push_back(notifier);
             }
         }
@@ -594,7 +594,7 @@ void RealmCoordinator::process_available_async(Realm& realm)
     {
         std::lock_guard<std::mutex> lock(m_notifier_mutex);
         for (auto& notifier : m_notifiers) {
-            if (notifier->deliver(sg, m_async_error)) {
+            if (notifier->deliver(realm, sg, m_async_error)) {
                 notifiers.push_back(notifier);
             }
         }


### PR DESCRIPTION
This may or may not fix any actual issues hit by users. The newly added test hits the "m_advancer_sg->get_version_of_current_transaction() == new_notifiers.front()->version()" assertion failure, but does so in a way that is very unlikely to be the same as how users are hitting it (at the minimum, to hit it via the public API would require active runloops on multiple threads).

The problem fixed in the second commit is almost certainly not relevant to any actual users.

@bdash @jpsim