### PR TITLE
Added New Linking Objects Syntax to Example Apps

### DIFF
--- a/examples/ios/objc/Backlink/AppDelegate.m
+++ b/examples/ios/objc/Backlink/AppDelegate.m
@@ -23,24 +23,24 @@
 @interface Dog : RLMObject
 @property NSString *name;
 @property NSInteger age;
-@property (readonly) NSArray *owners; // Realm doesn't persist this property because it is readonly
+@property (readonly) RLMLinkingObjects *owners;
 @end
-
-@implementation Dog
-// Define "owners" as the inverse relationship to Person.dogs
-- (NSArray *)owners {
-    return [self linkingObjectsOfClass:@"Person" forProperty:@"dogs"];
-}
-@end
-
 RLM_ARRAY_TYPE(Dog)
 
 @interface Person : RLMObject
 @property NSString      *name;
-@property RLMArray<Dog> *dogs;
+@property RLMArray<Dog *><Dog> *dogs;
 @end
 
 @implementation Person
+@end
+
+@implementation Dog
++ (NSDictionary *)linkingObjectsProperties
+{
+    // Define "owners" as the inverse relationship to Person.dogs
+    return @{ @"owners": [RLMPropertyDescriptor descriptorWithClass:Person.class propertyName:@"dogs"] };
+}
 @end
 
 @implementation AppDelegate

--- a/examples/ios/objc/Backlink/AppDelegate.m
+++ b/examples/ios/objc/Backlink/AppDelegate.m
@@ -23,7 +23,7 @@
 @interface Dog : RLMObject
 @property NSString *name;
 @property NSInteger age;
-@property (readonly) RLMLinkingObjects *owners;
+@property (readonly) RLMLinkingObjects *owners; // Realm doesn't persist this property because it is readonly
 @end
 RLM_ARRAY_TYPE(Dog)
 

--- a/examples/ios/swift-2.2/Backlink/AppDelegate.swift
+++ b/examples/ios/swift-2.2/Backlink/AppDelegate.swift
@@ -23,11 +23,8 @@ import RealmSwift
 class Dog: Object {
     dynamic var name = ""
     dynamic var age = 0
-    var owners: [Person] {
-        // Realm doesn't persist this property because it only has a getter defined
-        // Define "owners" as the inverse relationship to Person.dogs
-        return linkingObjects(Person.self, forProperty: "dogs")
-    }
+    // Define "owners" as the inverse relationship to Person.dogs
+    let owners = LinkingObjects(fromType: Person.self, property: "dogs")
 }
 
 class Person: Object {


### PR DESCRIPTION
A very minor PR that brings the 'Backlinks' sample app in line with the new linking objects properties feature syntax.

/cc @bdash @jpsim 