### PR TITLE
Fix a debug assertion failure when deleting objects in row order

### DIFF
--- a/Realm/ObjectStore/impl/collection_change_builder.cpp
+++ b/Realm/ObjectStore/impl/collection_change_builder.cpp
@@ -249,8 +249,13 @@ void CollectionChangeBuilder::move_over(size_t row_ndx, size_t last_row, bool tr
     REALM_ASSERT(row_ndx <= last_row);
     REALM_ASSERT(insertions.empty() || prev(insertions.end())->second - 1 <= last_row);
     REALM_ASSERT(modifications.empty() || prev(modifications.end())->second - 1 <= last_row);
-    if (track_moves && row_ndx == last_row) {
-        erase(row_ndx);
+
+    if (row_ndx == last_row) {
+        auto shifted_from = insertions.erase_or_unshift(row_ndx);
+        if (shifted_from != IndexSet::npos)
+            deletions.add_shifted(shifted_from);
+        modifications.remove(row_ndx);
+        m_move_mapping.erase(row_ndx);
         return;
     }
 

--- a/Realm/Tests/NotificationTests.m
+++ b/Realm/Tests/NotificationTests.m
@@ -291,6 +291,10 @@ static void ExpectChange(id self, NSArray *deletions, NSArray *insertions, NSArr
         [realm deleteObjects:[IntObject objectsInRealm:realm where:@"intCol > 4"]];
         [realm deleteObjects:[IntObject objectsInRealm:realm where:@"intCol < 1"]];
     });
+
+    ExpectChange(self, @[@0, @1, @2, @3], @[], @[], ^(RLMRealm *realm) {
+        [realm deleteObjects:[[IntObject allObjectsInRealm:realm] valueForKey:@"self"]];
+    });
 }
 
 - (void)testDeleteNewlyInsertedRowMatchingQuery {


### PR DESCRIPTION
Dispatching to erase() from CollectionChangeBuilder::move_over() doesn't actually work as erase() doesn't update m_move_mapping (since m_move_mapping only makes sense for unordered deletions). I'm not sure if this would ever actually cause any functional problems in non-debug builds, but I hit it while trying to reproduce other issues.