### PR TITLE
consistently use four spaces in doc comment code samples

### DIFF
--- a/RealmSwift-swift2.0/LinkingObjects.swift
+++ b/RealmSwift-swift2.0/LinkingObjects.swift
@@ -316,17 +316,17 @@ public final class LinkingObjects<T: Object>: LinkingObjectsBase {
      result, the initial notification will reflect the state of the Realm after
      the write transaction.
 
-     let dog = realm.objects(Dog).first!
-     let owners = dog.owners
-     print("owners.count: \(owners.count)") // => 0
-     let token = owners.addNotificationBlock { (owners, error) in
-         // Only fired once for the example
-         print("owners.count: \(owners.count)") // will only print "owners.count: 1"
-     }
-     try! realm.write {
-         realm.add(Person.self, value: ["name": "Mark", dogs: [dog]])
-     }
-     // end of runloop execution context
+         let dog = realm.objects(Dog).first!
+         let owners = dog.owners
+         print("owners.count: \(owners.count)") // => 0
+         let token = owners.addNotificationBlock { (owners, error) in
+             // Only fired once for the example
+             print("owners.count: \(owners.count)") // will only print "owners.count: 1"
+         }
+         try! realm.write {
+             realm.add(Person.self, value: ["name": "Mark", dogs: [dog]])
+         }
+         // end of runloop execution context
 
      You must retain the returned token for as long as you want updates to continue
      to be sent to the block. To stop receiving updates, call stop() on the token.
@@ -378,26 +378,26 @@ public final class LinkingObjects<T: Object>: LinkingObjectsBase {
      result, the initial notification will reflect the state of the Realm after
      the write transaction.
 
-     let dog = realm.objects(Dog).first!
-     let owners = dog.owners
-     print("owners.count: \(owners.count)") // => 0
-     let token = owners.addNotificationBlock { (changes: RealmCollectionChange) in
-         switch changes {
-             case .Initial(let owners):
-                 // Will print "owners.count: 1"
-                 print("owners.count: \(owners.count)")
-                 break
-             case .Update:
-                 // Will not be hit in this example
-                 break
-             case .Error:
-                 break
+         let dog = realm.objects(Dog).first!
+         let owners = dog.owners
+         print("owners.count: \(owners.count)") // => 0
+         let token = owners.addNotificationBlock { (changes: RealmCollectionChange) in
+             switch changes {
+                 case .Initial(let owners):
+                     // Will print "owners.count: 1"
+                     print("owners.count: \(owners.count)")
+                     break
+                 case .Update:
+                     // Will not be hit in this example
+                     break
+                 case .Error:
+                     break
+             }
          }
-     }
-     try! realm.write {
-         realm.add(Person.self, value: ["name": "Mark", dogs: [dog]])
-     }
-     // end of runloop execution context
+         try! realm.write {
+             realm.add(Person.self, value: ["name": "Mark", dogs: [dog]])
+         }
+         // end of runloop execution context
 
      You must retain the returned token for as long as you want updates to continue
      to be sent to the block. To stop receiving updates, call stop() on the token.

--- a/RealmSwift-swift2.0/RealmCollectionType.swift
+++ b/RealmSwift-swift2.0/RealmCollectionType.swift
@@ -50,29 +50,29 @@ public final class RLMGenerator<T: Object>: GeneratorType {
  after converting to index paths in the appropriate section. For example, for a
  simple one-section table view, you can do the following:
 
-        self.notificationToken = results.addNotificationBlock { changes
-            switch changes {
-            case .Initial:
-                // Results are now populated and can be accessed without blocking the UI
-                self.tableView.reloadData()
-                break
-            case .Update(_, let deletions, let insertions, let modifications):
-                // Query results have changed, so apply them to the TableView
-                self.tableView.beginUpdates()
-                self.tableView.insertRowsAtIndexPaths(insertions.map { NSIndexPath(forRow: $0, inSection: 0) },
-                    withRowAnimation: .Automatic)
-                self.tableView.deleteRowsAtIndexPaths(deletions.map { NSIndexPath(forRow: $0, inSection: 0) },
-                    withRowAnimation: .Automatic)
-                self.tableView.reloadRowsAtIndexPaths(modifications.map { NSIndexPath(forRow: $0, inSection: 0) },
-                    withRowAnimation: .Automatic)
-                self.tableView.endUpdates()
-                break
-            case .Error(let err):
-                // An error occurred while opening the Realm file on the background worker thread
-                fatalError("\(err)")
-                break
-            }
+    self.notificationToken = results.addNotificationBlock { changes
+        switch changes {
+        case .Initial:
+            // Results are now populated and can be accessed without blocking the UI
+            self.tableView.reloadData()
+            break
+        case .Update(_, let deletions, let insertions, let modifications):
+            // Query results have changed, so apply them to the TableView
+            self.tableView.beginUpdates()
+            self.tableView.insertRowsAtIndexPaths(insertions.map { NSIndexPath(forRow: $0, inSection: 0) },
+                withRowAnimation: .Automatic)
+            self.tableView.deleteRowsAtIndexPaths(deletions.map { NSIndexPath(forRow: $0, inSection: 0) },
+                withRowAnimation: .Automatic)
+            self.tableView.reloadRowsAtIndexPaths(modifications.map { NSIndexPath(forRow: $0, inSection: 0) },
+                withRowAnimation: .Automatic)
+            self.tableView.endUpdates()
+            break
+        case .Error(let err):
+            // An error occurred while opening the Realm file on the background worker thread
+            fatalError("\(err)")
+            break
         }
+    }
  */
 public enum RealmCollectionChange<T> {
     /// The initial run of the query has completed (if applicable), and the


### PR DESCRIPTION
otherwise docs render like this:

![image](https://cloud.githubusercontent.com/assets/474794/14942122/ced090d4-0fb3-11e6-9182-3ecfd0c6e24b.png)
