### PR TITLE
Fix an assertion failure in IndexSet::do_add()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ x.x.x Release notes (yyyy-MM-dd)
 
 ### Bugfixes
 
-* None.
+* Fix an assertion failure of "!more_before || index >= std::prev(it)->second)"
+  in `IndexSet::do_add()`.
 
 0.100.0 Release notes (2016-04-29)
 =============================================================

--- a/Realm/ObjectStore/index_set.cpp
+++ b/Realm/ObjectStore/index_set.cpp
@@ -151,7 +151,7 @@ ChunkedRangeVector::iterator ChunkedRangeVector::erase(iterator pos)
     if (chunk.data.size() == 0) {
         pos.m_outer = m_data.erase(pos.m_outer);
         pos.m_end = m_data.end();
-        pos.m_inner = pos.m_outer == m_data.end() ? nullptr : &pos.m_outer->data.back();
+        pos.m_inner = pos.m_outer == m_data.end() ? nullptr : &pos.m_outer->data.front();
         verify();
         return pos;
     }


### PR DESCRIPTION
ChunkedVector::erase() was returning the wrong iterator when a chunk was removed entirely, resulting in the next operation using that iterator to fail.

The [objectstore version of this commit](https://github.com/realm/realm-object-store/commit/f277639cb8386d60e79284b551a5c32df60f06ba) has a basic test case that hits this, but no obj-c test because hitting it via the obj-c api would be tremendously awkward as that codepath is used only in the changeset merging logic.