### PR TITLE
Fix BETWEEN queries that traverse List properties to ensure that a single related object satisfies the BETWEEN criteria

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,9 @@ x.x.x Release notes (yyyy-MM-dd)
 
 ### Bugfixes
 
-* None.
+* Fix `BETWEEN` queries that traverse `RLMArray`/`List` properties to ensure that
+  a single related object satisfies the `BETWEEN` criteria, rather than allowing
+  different objects in the array to satisfy the lower and upper bounds.
 
 0.101.0 Release notes (2016-05-04)
 =============================================================

--- a/Realm/RLMQueryUtil.mm
+++ b/Realm/RLMQueryUtil.mm
@@ -153,7 +153,7 @@ public:
     auto resolve(Query& query) const;
 
     template <typename T>
-    auto resolveWithSubquery(Query& query, Query subquery) const
+    auto resolve_with_subquery(Query& query, Query subquery) const
     {
         if (type() != RLMPropertyTypeLinkingObjects) {
             return table_for_query(query)->template column<T>(index(), std::move(subquery));
@@ -170,7 +170,7 @@ public:
     size_t index() const { return property().column; }
     RLMPropertyType type() const { return property().type; }
 
-    RLMObjectSchema *linkTargetObjectSchema() const
+    RLMObjectSchema *link_target_object_schema() const
     {
         switch (type()) {
             case RLMPropertyTypeObject:
@@ -550,7 +550,7 @@ void add_link_constraint_to_query(realm::Query & query,
 
     // NOTE: This precondition assumes that the argument `obj` will be always originating from the
     // queried table as verified before by `validate_property_value`
-    RLMPrecondition(column.linkTargetObjectSchema() == obj.objectSchema || !obj->_row.is_attached(),
+    RLMPrecondition(column.link_target_object_schema() == obj.objectSchema || !obj->_row.is_attached(),
                     @"Invalid value origin", @"Object must be from the Realm being queried");
 
     if (operatorType == NSEqualToPredicateOperatorType) {
@@ -1072,7 +1072,7 @@ void update_query_with_subquery_count_expression(RLMSchema *schema, RLMObjectSch
     Query subquery = collectionMemberObjectSchema.table->where();
     RLMUpdateQueryWithPredicate(&subquery, subqueryPredicate, schema, collectionMemberObjectSchema);
 
-    add_numeric_constraint_to_query(query, RLMPropertyTypeInt, operatorType, collectionColumn.resolveWithSubquery<LinkList>(query, std::move(subquery)).count(), value);
+    add_numeric_constraint_to_query(query, RLMPropertyTypeInt, operatorType, collectionColumn.resolve_with_subquery<LinkList>(query, std::move(subquery)).count(), value);
 }
 
 void update_query_with_function_subquery_expression(RLMSchema *schema, RLMObjectSchema *objectSchema, realm::Query& query,

--- a/Realm/Tests/QueryTests.m
+++ b/Realm/Tests/QueryTests.m
@@ -393,10 +393,14 @@
     stringObj.stringCol = @"string";
 
     [realm beginWriteTransaction];
-    [AllTypesObject createInRealm:realm withValue:@[@YES, @1, @1.0f, @1.0, @"a", [@"a" dataUsingEncoding:NSUTF8StringEncoding], date1, @YES, @((long)1), @1, stringObj]];
-    [AllTypesObject createInRealm:realm withValue:@[@YES, @2, @2.0f, @2.0, @"b", [@"b" dataUsingEncoding:NSUTF8StringEncoding], date2, @YES, @((long)2), @"mixed", stringObj]];
-    [AllTypesObject createInRealm:realm withValue:@[@NO, @3, @3.0f, @3.0, @"c", [@"c" dataUsingEncoding:NSUTF8StringEncoding], date3, @YES, @((long)3), @"mixed", stringObj]];
-    [AllTypesObject createInRealm:realm withValue:@[@NO, @33, @3.3f, @3.3, @"cc", [@"cc" dataUsingEncoding:NSUTF8StringEncoding], date33, @NO, @((long)3.3), @"mixed", stringObj]];
+    id a = [AllTypesObject createInRealm:realm withValue:@[@YES, @1, @1.0f, @1.0, @"a", [@"a" dataUsingEncoding:NSUTF8StringEncoding], date1, @YES, @((long)1), @1, stringObj]];
+    id b = [AllTypesObject createInRealm:realm withValue:@[@YES, @2, @2.0f, @2.0, @"b", [@"b" dataUsingEncoding:NSUTF8StringEncoding], date2, @YES, @((long)2), @"mixed", stringObj]];
+    id c = [AllTypesObject createInRealm:realm withValue:@[@NO, @3, @3.0f, @3.0, @"c", [@"c" dataUsingEncoding:NSUTF8StringEncoding], date3, @YES, @((long)3), @"mixed", stringObj]];
+    id d = [AllTypesObject createInRealm:realm withValue:@[@NO, @33, @3.3f, @3.3, @"cc", [@"cc" dataUsingEncoding:NSUTF8StringEncoding], date33, @NO, @((long)3.3), @"mixed", stringObj]];
+
+    [ArrayOfAllTypesObject createInRealm:realm withValue:@[ @[ a, c] ]];
+    [ArrayOfAllTypesObject createInRealm:realm withValue:@[ @[ b, d] ]];
+
     [realm commitWriteTransaction];
 
     RLMAssertCount(AllTypesObject, 2U, @"intCol BETWEEN %@", @[@2, @3]);
@@ -409,6 +413,10 @@
 
     RLMAssertCount(AllTypesObject.allObjects, 2U, @"intCol BETWEEN {2, 3}");
     RLMAssertCount(AllTypesObject.allObjects, 2U, @"doubleCol BETWEEN {3.0, 7.0}");
+
+    RLMAssertCount(ArrayOfAllTypesObject, 1U, @"ANY array.intCol BETWEEN %@", @[@3, @5]);
+    RLMAssertCount(ArrayOfAllTypesObject, 0U, @"ANY array.floatCol BETWEEN %@", @[@3.1, @3.2]);
+    RLMAssertCount(ArrayOfAllTypesObject, 0U, @"ANY array.doubleCol BETWEEN %@", @[@3.1, @3.2]);
 }
 
 - (void)testQueryWithDates


### PR DESCRIPTION
We previously allowed different objects in the array to satisfy the lower and upper bounds, which is not consistent with how Foundation evaluates predicates.

/cc @jpsim @tgoyne 