### PR TITLE
fix assertion failure in clean_up_dead_notifiers

### DIFF
--- a/Realm/ObjectStore/impl/realm_coordinator.cpp
+++ b/Realm/ObjectStore/impl/realm_coordinator.cpp
@@ -299,8 +299,8 @@ void RealmCoordinator::clean_up_dead_notifiers()
         }
     }
     if (swap_remove(m_new_notifiers)) {
-        REALM_ASSERT_3(m_advancer_sg->get_transact_stage(), ==, SharedGroup::transact_Reading);
         if (m_new_notifiers.empty() && m_advancer_sg) {
+            REALM_ASSERT_3(m_advancer_sg->get_transact_stage(), ==, SharedGroup::transact_Reading);
             m_advancer_sg->end_read();
         }
     }


### PR DESCRIPTION
we shouldn't be reading `m_advancer_sg->get_transact_stage()` without first checking if `m_advancer_sg` is set /cc @tgoyne 

I think this should fix https://secure.helpscout.net/conversation/199189388/4080 (internal link)