### PR TITLE
Remove List::get_version_counter()

### DIFF
--- a/Realm/ObjectStore/list.cpp
+++ b/Realm/ObjectStore/list.cpp
@@ -201,8 +201,3 @@ NotificationToken List::add_notification_callback(CollectionChangeCallback cb)
     }
     return {m_notifier, m_notifier->add_callback(std::move(cb))};
 }
-
-uint_fast64_t List::get_version_counter() const noexcept
-{
-    return m_link_view->get_origin_table().get_version_counter();
-}

--- a/Realm/ObjectStore/list.hpp
+++ b/Realm/ObjectStore/list.hpp
@@ -72,9 +72,6 @@ public:
 
     NotificationToken add_notification_callback(CollectionChangeCallback cb);
 
-    // This should go away once we have real List notifications
-    uint_fast64_t get_version_counter() const noexcept;
-
     // These are implemented in object_accessor.hpp
     template <typename ValueType, typename ContextType>
     void add(ContextType ctx, ValueType value);


### PR DESCRIPTION
This was a temporary hack for list notifications which was made unnecessary by find-grained notifications.