### PR TITLE
Fix RLMLinkingObjects properties on RLMObject subclasses declared in Swift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ x.x.x Release notes (yyyy-MM-dd)
 
 ### Bugfixes
 
-* None.
+* `RLMLinkingObjects` properties declared in Swift subclasses of `RLMObject`
+  now work correctly.
 
 0.102.0 Release notes (2016-05-09)
 =============================================================

--- a/Realm/RLMObjectSchema.mm
+++ b/Realm/RLMObjectSchema.mm
@@ -196,6 +196,7 @@ using namespace realm;
         if (isSwiftClass) {
             prop = [[RLMProperty alloc] initSwiftPropertyWithName:propertyName
                                                           indexed:[indexed containsObject:propertyName]
+                                           linkPropertyDescriptor:linkingObjectsProperties[propertyName]
                                                          property:props[i]
                                                          instance:swiftObjectInstance];
         }

--- a/Realm/RLMProperty.mm
+++ b/Realm/RLMProperty.mm
@@ -321,6 +321,7 @@ static bool rawTypeIsComputedProperty(NSString *rawType) {
 
 - (instancetype)initSwiftPropertyWithName:(NSString *)name
                                   indexed:(BOOL)indexed
+                   linkPropertyDescriptor:(RLMPropertyDescriptor *)linkPropertyDescriptor
                                  property:(objc_property_t)property
                                  instance:(RLMObject *)obj {
     self = [super init];
@@ -330,6 +331,11 @@ static bool rawTypeIsComputedProperty(NSString *rawType) {
 
     _name = name;
     _indexed = indexed;
+
+    if (linkPropertyDescriptor) {
+        _objectClassName = [linkPropertyDescriptor.objectClass className];
+        _linkOriginPropertyName = linkPropertyDescriptor.propertyName;
+    }
 
     if ([self parseObjcProperty:property]) {
         return nil;
@@ -412,7 +418,7 @@ static bool rawTypeIsComputedProperty(NSString *rawType) {
     _indexed = indexed;
 
     if (linkPropertyDescriptor) {
-        _objectClassName = NSStringFromClass(linkPropertyDescriptor.objectClass);
+        _objectClassName = [linkPropertyDescriptor.objectClass className];
         _linkOriginPropertyName = linkPropertyDescriptor.propertyName;
     }
 

--- a/Realm/RLMProperty_Private.h
+++ b/Realm/RLMProperty_Private.h
@@ -36,6 +36,7 @@ BOOL RLMPropertyTypeIsComputed(RLMPropertyType propertyType);
 
 - (instancetype)initSwiftPropertyWithName:(NSString *)name
                                   indexed:(BOOL)indexed
+                   linkPropertyDescriptor:(RLMPropertyDescriptor *)linkPropertyDescriptor
                                  property:(objc_property_t)property
                                  instance:(RLMObjectBase *)objectInstance;
 

--- a/Realm/Tests/Swift2.0/SwiftLinkTests.swift
+++ b/Realm/Tests/Swift2.0/SwiftLinkTests.swift
@@ -98,6 +98,26 @@ class SwiftLinkTests: RLMTestCase {
         XCTAssertEqual(SwiftDogObject.allObjectsInRealm(realm).count, UInt(0), "Expecting 0 dogs")
     }
 
+    func testLinkingObjects() {
+        let realm = realmWithTestPath()
+
+        let target = SwiftLinkTargetObject()
+        target.id = 0
+
+        let source = SwiftLinkSourceObject()
+        source.id = 1234
+        source.link = target
+
+        XCTAssertEqual(0, target.backlinks!.count)
+
+        realm.beginWriteTransaction()
+        realm.addObject(source)
+        try! realm.commitWriteTransaction()
+
+        XCTAssertEqual(1, target.backlinks!.count)
+        XCTAssertEqual(1234, (target.backlinks!.firstObject() as! SwiftLinkSourceObject).id)
+    }
+
 //    FIXME - disabled until we fix commit log issue which break transacions when leaking realm objects
 //    func testCircularLinks() {
 //        let realm = realmWithTestPath()

--- a/Realm/Tests/Swift2.0/SwiftTestObjects.swift
+++ b/Realm/Tests/Swift2.0/SwiftTestObjects.swift
@@ -127,3 +127,17 @@ class SwiftPrimaryStringObject: RLMObject {
         return "stringCol"
     }
 }
+
+class SwiftLinkSourceObject: RLMObject {
+    dynamic var id = 0
+    dynamic var link: SwiftLinkTargetObject?
+}
+
+class SwiftLinkTargetObject: RLMObject {
+    dynamic var id = 0
+    dynamic var backlinks: RLMLinkingObjects?
+
+    override class func linkingObjectsProperties() -> [String : RLMPropertyDescriptor] {
+        return ["backlinks": RLMPropertyDescriptor(withClass: SwiftLinkSourceObject.self, propertyName: "link")]
+    }
+}


### PR DESCRIPTION
`RLMProperty` is initialized in a slightly different codepath for classes declared in Swift than Objective-C. The Swift codepath was missing the necessary logic to handle the linking objects property descriptor.

Fixes #3546.

/cc @jpsim @tgoyne 