### PR TITLE
Fix an assertion failure in IndexSet::do_add() following a table clear

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ x.x.x Release notes (yyyy-MM-dd)
 
 * `RLMLinkingObjects` properties declared in Swift subclasses of `RLMObject`
   now work correctly.
+* Fix an assertion failure when deleting all objects of a type, inserting more
+  objects, and then deleting some of the newly inserted objects within a single
+  write transaction when there is an active notification block for a different
+  object type which links to the objects being deleted.
 
 0.102.0 Release notes (2016-05-09)
 =============================================================

--- a/Realm/ObjectStore/impl/collection_change_builder.cpp
+++ b/Realm/ObjectStore/impl/collection_change_builder.cpp
@@ -251,11 +251,13 @@ void CollectionChangeBuilder::move_over(size_t row_ndx, size_t last_row, bool tr
     REALM_ASSERT(modifications.empty() || prev(modifications.end())->second - 1 <= last_row);
 
     if (row_ndx == last_row) {
-        auto shifted_from = insertions.erase_or_unshift(row_ndx);
-        if (shifted_from != IndexSet::npos)
-            deletions.add_shifted(shifted_from);
+        if (track_moves) {
+            auto shifted_from = insertions.erase_or_unshift(row_ndx);
+            if (shifted_from != IndexSet::npos)
+                deletions.add_shifted(shifted_from);
+            m_move_mapping.erase(row_ndx);
+        }
         modifications.remove(row_ndx);
-        m_move_mapping.erase(row_ndx);
         return;
     }
 


### PR DESCRIPTION
We don't track insertions and deletions for tables that are merely linked to by tables actually being observed (for performance reasons, since we don't need that information), but the check for that was missing in one place. This would be merely a slowdown rather than a crash, but deletions.add_shifted() can overflow size_t if the passed-in index represents a newly inserted row and the check for that didn't work due to not tracking insertions for the table.

The only remotely realistic way to actually have size_t overflow is to have previously cleared the table (the table clear instruction does not include the old size of the table, so it just marks {0, SIZE_T_MAX} as deleted).

Fixes #3537.