### PR TITLE
Lazily initialize Swift LinkingObjects instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ x.x.x Release notes (yyyy-MM-dd)
 
 * Return `RLMErrorSchemaMismatch` error rather than the more generic `RLMErrorFail`
   when a migration is required.
+* Improve the performance of allocating instances of `Object` subclasses
+  that have `LinkingObjects` properties.
 
 ### Bugfixes
 

--- a/Realm.xcodeproj/project.pbxproj
+++ b/Realm.xcodeproj/project.pbxproj
@@ -564,7 +564,7 @@
 		3FE556431B9A43E5002A1129 /* schema.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = schema.hpp; path = ObjectStore/schema.hpp; sourceTree = "<group>"; };
 		3FE79FF719BA6A5900780C9A /* RLMSwiftSupport.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RLMSwiftSupport.h; sourceTree = "<group>"; };
 		3FEC4A3D1BBB188B00F009C3 /* SwiftSchemaTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwiftSchemaTests.swift; sourceTree = "<group>"; };
-		5D1534B71CCFF545008976D7 /* LinkingObjects.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = LinkingObjects.swift; path = "RealmSwift-swift2.0/LinkingObjects.swift"; sourceTree = "<group>"; };
+		5D1534B71CCFF545008976D7 /* LinkingObjects.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = LinkingObjects.swift; path = "RealmSwift-swift2.0/LinkingObjects.swift"; sourceTree = SOURCE_ROOT; };
 		5D2E8F651C98DC0D00187B09 /* RLMProperty_Private.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = RLMProperty_Private.hpp; sourceTree = "<group>"; };
 		5D30B74A1B42039F00D90C5A /* RLMDefines.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RLMDefines.h; sourceTree = "<group>"; };
 		5D3E1A2C1C1FC6D5002913BA /* RLMPredicateUtil.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = RLMPredicateUtil.hpp; sourceTree = "<group>"; };
@@ -851,6 +851,7 @@
 			children = (
 				5D660FE31BE98D670021E04F /* Aliases.swift */,
 				29B7FDF51C0DA6560023224E /* Error.swift */,
+				5D1534B71CCFF545008976D7 /* LinkingObjects.swift */,
 				5D660FE41BE98D670021E04F /* List.swift */,
 				5D660FE51BE98D670021E04F /* Migration.swift */,
 				5D660FE61BE98D670021E04F /* Object.swift */,
@@ -980,7 +981,6 @@
 		E8D89B8E1955FC6D00CF2B9A = {
 			isa = PBXGroup;
 			children = (
-				5D1534B71CCFF545008976D7 /* LinkingObjects.swift */,
 				5D660FB71BE98B770021E04F /* Configuration */,
 				E81A1FB41955FCE000FDED82 /* LICENSE */,
 				E8D89B991955FC6D00CF2B9A /* Products */,

--- a/Realm.xcodeproj/project.pbxproj
+++ b/Realm.xcodeproj/project.pbxproj
@@ -564,7 +564,7 @@
 		3FE556431B9A43E5002A1129 /* schema.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = schema.hpp; path = ObjectStore/schema.hpp; sourceTree = "<group>"; };
 		3FE79FF719BA6A5900780C9A /* RLMSwiftSupport.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RLMSwiftSupport.h; sourceTree = "<group>"; };
 		3FEC4A3D1BBB188B00F009C3 /* SwiftSchemaTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwiftSchemaTests.swift; sourceTree = "<group>"; };
-		5D1534B71CCFF545008976D7 /* LinkingObjects.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = LinkingObjects.swift; path = "RealmSwift-swift2.0/LinkingObjects.swift"; sourceTree = SOURCE_ROOT; };
+		5D1534B71CCFF545008976D7 /* LinkingObjects.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LinkingObjects.swift; sourceTree = "<group>"; };
 		5D2E8F651C98DC0D00187B09 /* RLMProperty_Private.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = RLMProperty_Private.hpp; sourceTree = "<group>"; };
 		5D30B74A1B42039F00D90C5A /* RLMDefines.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RLMDefines.h; sourceTree = "<group>"; };
 		5D3E1A2C1C1FC6D5002913BA /* RLMPredicateUtil.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = RLMPredicateUtil.hpp; sourceTree = "<group>"; };

--- a/Realm/RLMObject.mm
+++ b/Realm/RLMObject.mm
@@ -219,3 +219,31 @@
 }
 
 @end
+
+@implementation RLMWeakObjectHandle {
+    realm::Row _row;
+    RLMRealm *_realm;
+    RLMObjectSchema *_objectSchema;
+    Class _objectClass;
+}
+
+- (instancetype)initWithObject:(RLMObjectBase *)object {
+    if (!(self = [super init])) {
+        return nil;
+    }
+
+    _row = object->_row;
+    _realm = object->_realm;
+    _objectSchema = object->_objectSchema;
+    _objectClass = object.class;
+
+    return self;
+}
+
+- (RLMObjectBase *)object {
+    RLMObjectBase *object = [[_objectClass alloc] initWithRealm:_realm schema:_objectSchema];
+    object->_row = _row;
+    return object;
+}
+
+@end

--- a/Realm/RLMObject.mm
+++ b/Realm/RLMObject.mm
@@ -242,7 +242,7 @@
 
 - (RLMObjectBase *)object {
     RLMObjectBase *object = [[_objectClass alloc] initWithRealm:_realm schema:_objectSchema];
-    object->_row = _row;
+    object->_row = std::move(_row);
     return object;
 }
 

--- a/Realm/RLMObjectBase.mm
+++ b/Realm/RLMObjectBase.mm
@@ -483,7 +483,7 @@ Class RLMObjectUtilClass(BOOL isSwift) {
 + (void)initializeOptionalProperty:(__unused RLMObjectBase *)object property:(__unused RLMProperty *)property {
 }
 
-+ (void)initializeLinkingObjectsProperty:(__unused RLMObjectBase *)object property:(__unused RLMProperty *)property results:(__unused RLMResults *)results {
++ (void)initializeLinkingObjectsProperty:(__unused RLMObjectBase *)object property:(__unused RLMProperty *)property {
 }
 
 + (NSDictionary *)getOptionalProperties:(__unused id)obj {

--- a/Realm/RLMObjectStore.mm
+++ b/Realm/RLMObjectStore.mm
@@ -106,8 +106,7 @@ void RLMInitializeSwiftAccessorGenerics(__unsafe_unretained RLMObjectBase *const
             [RLMObjectUtilClass(YES) initializeListProperty:object property:prop array:array];
         }
         else if (prop.type == RLMPropertyTypeLinkingObjects) {
-            RLMResults *results = RLMDynamicGet(object, prop);
-            [RLMObjectUtilClass(YES) initializeLinkingObjectsProperty:object property:prop results:results];
+            [RLMObjectUtilClass(YES) initializeLinkingObjectsProperty:object property:prop];
         }
         else {
             [RLMObjectUtilClass(YES) initializeOptionalProperty:object property:prop];

--- a/Realm/RLMObject_Private.h
+++ b/Realm/RLMObject_Private.h
@@ -58,6 +58,14 @@
 
 @end
 
+// A reference to an object's row that doesn't keep the object accessor alive.
+// Used by some Swift property types, such as LinkingObjects, to avoid retain cycles
+// with their containing object.
+@interface RLMWeakObjectHandle : NSObject
+- (instancetype)initWithObject:(RLMObjectBase *)object;
+@property (nonatomic, readonly) RLMObjectBase *object;
+@end
+
 //
 // Getters and setters for RLMObjectBase ivars for realm and objectSchema
 //
@@ -96,7 +104,7 @@ FOUNDATION_EXTERN const NSUInteger RLMDescriptionMaxDepth;
 
 + (void)initializeListProperty:(RLMObjectBase *)object property:(RLMProperty *)property array:(RLMArray *)array;
 + (void)initializeOptionalProperty:(RLMObjectBase *)object property:(RLMProperty *)property;
-+ (void)initializeLinkingObjectsProperty:(RLMObjectBase *)object property:(RLMProperty *)property results:(RLMResults *)results;
++ (void)initializeLinkingObjectsProperty:(RLMObjectBase *)object property:(RLMProperty *)property;
 
 + (NSDictionary RLM_GENERIC(NSString *, NSNumber *) *)getOptionalProperties:(id)obj;
 + (NSArray RLM_GENERIC(NSString *) *)requiredPropertiesForClass:(Class)cls;

--- a/Realm/RLMObject_Private.h
+++ b/Realm/RLMObject_Private.h
@@ -62,8 +62,12 @@
 // Used by some Swift property types, such as LinkingObjects, to avoid retain cycles
 // with their containing object.
 @interface RLMWeakObjectHandle : NSObject
+
 - (instancetype)initWithObject:(RLMObjectBase *)object;
+
+// Consumes the row, so can only usefully be called once.
 @property (nonatomic, readonly) RLMObjectBase *object;
+
 @end
 
 //

--- a/RealmSwift-swift2.0/LinkingObjects.swift
+++ b/RealmSwift-swift2.0/LinkingObjects.swift
@@ -37,7 +37,7 @@ public class LinkingObjectsBase: NSObject, NSFastEnumeration {
 
     internal var rlmResults: RLMResults {
         if cachedRLMResults == nil {
-            if let object = self.object, let property = self.property {
+            if let object = self.object, property = self.property {
                 cachedRLMResults = RLMDynamicGet(object.object, property)! as? RLMResults
                 self.object = nil
                 self.property = nil

--- a/RealmSwift-swift2.0/LinkingObjects.swift
+++ b/RealmSwift-swift2.0/LinkingObjects.swift
@@ -22,12 +22,33 @@ import Realm
 /// :nodoc:
 /// Internal class. Do not use directly. Used for reflection and initialization
 public class LinkingObjectsBase: NSObject, NSFastEnumeration {
-    internal var rlmResults: RLMResults
     internal let objectClassName: String
     internal let propertyName: String
 
-    init(results: RLMResults, fromClassName objectClassName: String, property propertyName: String) {
-        self.rlmResults = results
+    private var cachedRLMResults: RLMResults?
+    private var object: RLMWeakObjectHandle?
+    private var property: RLMProperty?
+
+    internal func attachTo(object object: RLMObjectBase, property: RLMProperty) {
+        self.object = RLMWeakObjectHandle(object: object)
+        self.property = property
+        self.cachedRLMResults = nil
+    }
+
+    internal var rlmResults: RLMResults {
+        if cachedRLMResults == nil {
+            if let object = self.object, let property = self.property {
+                cachedRLMResults = RLMDynamicGet(object.object, property)! as? RLMResults
+                self.object = nil
+                self.property = nil
+            } else {
+                cachedRLMResults = RLMResults.emptyDetachedResults()
+            }
+        }
+        return cachedRLMResults!
+    }
+
+    init(fromClassName objectClassName: String, property propertyName: String) {
         self.objectClassName = objectClassName
         self.propertyName = propertyName
     }
@@ -73,7 +94,7 @@ public final class LinkingObjects<T: Object>: LinkingObjectsBase {
 
     public init(fromType type: T.Type, property propertyName: String) {
         let className = (T.self as Object.Type).className()
-        super.init(results: RLMResults.emptyDetachedResults(), fromClassName: className, property: propertyName)
+        super.init(fromClassName: className, property: propertyName)
     }
 
     /// Returns a human-readable description of the objects contained in these linking objects.

--- a/RealmSwift-swift2.0/Object.swift
+++ b/RealmSwift-swift2.0/Object.swift
@@ -431,9 +431,8 @@ public class ObjectUtil: NSObject {
         }
     }
 
-    @objc private class func initializeLinkingObjectsProperty(object: RLMObjectBase, property: RLMProperty,
-                                                              results: RLMResults) {
+    @objc private class func initializeLinkingObjectsProperty(object: RLMObjectBase, property: RLMProperty) {
         guard let linkingObjects = (object as! Object).linkingObjectsForProperty(property) else { return }
-        linkingObjects.rlmResults = results
+        linkingObjects.attachTo(object: object, property: property)
     }
 }


### PR DESCRIPTION
`LinkingObjects` instances were being initialized eagerly by `RLMInitializeSwiftAccessorGenerics`, which was resulting in a backlinks `TableView` being created for every Swift instance of a type that contained a `LinkingObjects` property. Lazily initializing these properties means that the work of building the backlinks view is deferred until the property is first accessed. This significantly reduces the cost of allocating a Swift object that has a `LinkingObjects` property.

/cc @tgoyne @jpsim @austinzheng 

This was visible in an Instruments trace a user provided via email.