### PR TITLE
Speed up creating RealmSwift.Realm instances

### DIFF
--- a/Realm/RLMRealmConfiguration.mm
+++ b/Realm/RLMRealmConfiguration.mm
@@ -41,15 +41,15 @@ static NSString *const c_RLMRealmConfigurationProperties[] = {
 static NSString *const c_defaultRealmFileName = @"default.realm";
 RLMRealmConfiguration *s_defaultConfiguration;
 
-NSString *RLMRealmPathForFileAndBundleIdentifier(NSString *fileName, NSString *bundleIdentifier) {
+static NSString *defaultDirectoryForBundleIdentifier(NSString *bundleIdentifier) {
 #if TARGET_OS_TV
     (void)bundleIdentifier;
     // tvOS prohibits writing to the Documents directory, so we use the Library/Caches directory instead.
-    NSString *path = NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES)[0];
+    return NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES)[0];
 #elif TARGET_OS_IPHONE
     (void)bundleIdentifier;
     // On iOS the Documents directory isn't user-visible, so put files there
-    NSString *path = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES)[0];
+    return NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES)[0];
 #else
     // On OS X it is, so put files in Application Support. If we aren't running
     // in a sandbox, put it in a subdirectory based on the bundle identifier
@@ -71,12 +71,18 @@ NSString *RLMRealmPathForFileAndBundleIdentifier(NSString *fileName, NSString *b
                                                    attributes:nil
                                                         error:nil];
     }
+    return path;
 #endif
-    return [path stringByAppendingPathComponent:fileName];
+}
+
+NSString *RLMRealmPathForFileAndBundleIdentifier(NSString *fileName, NSString *bundleIdentifier) {
+    return [defaultDirectoryForBundleIdentifier(bundleIdentifier)
+            stringByAppendingPathComponent:fileName];
 }
 
 NSString *RLMRealmPathForFile(NSString *fileName) {
-    return RLMRealmPathForFileAndBundleIdentifier(fileName, nil);
+    static NSString *directory = defaultDirectoryForBundleIdentifier(nil);
+    return [directory stringByAppendingPathComponent:fileName];
 }
 
 @implementation RLMRealmConfiguration {

--- a/RealmSwift-swift2.0/Realm.swift
+++ b/RealmSwift-swift2.0/Realm.swift
@@ -66,14 +66,24 @@ public final class Realm {
     // MARK: Initializers
 
     /**
-    Obtains a Realm instance with the given configuration. Defaults to the default Realm configuration,
-    which can be changed by setting `Realm.Configuration.defaultConfiguration`.
+    Obtains a Realm instance with the default Realm configuration, which can be
+    changed by setting `Realm.Configuration.defaultConfiguration`.
+
+    - throws: An NSError if the Realm could not be initialized.
+    */
+    public convenience init() throws {
+        let rlmRealm = try RLMRealm(configuration: RLMRealmConfiguration.defaultConfiguration())
+        self.init(rlmRealm)
+    }
+
+    /**
+    Obtains a Realm instance with the given configuration.
 
     - parameter configuration: The configuration to use when creating the Realm instance.
 
     - throws: An NSError if the Realm could not be initialized.
     */
-    public convenience init(configuration: Configuration = Configuration.defaultConfiguration) throws {
+    public convenience init(configuration: Configuration) throws {
         let rlmRealm = try RLMRealm(configuration: configuration.rlmConfiguration)
         self.init(rlmRealm)
     }

--- a/RealmSwift-swift2.0/Tests/PerformanceTests.swift
+++ b/RealmSwift-swift2.0/Tests/PerformanceTests.swift
@@ -351,13 +351,13 @@ class SwiftPerformanceTests: TestCase {
     func testRealmCreationCached() {
         var realm: Realm!
         dispatchSyncNewThread {
-            realm = self.realmWithTestPath()
+            realm = try! Realm()
         }
 
         measureBlock {
             for _ in 0..<250 {
                 autoreleasepool {
-                    _ = self.realmWithTestPath()
+                    _ = try! Realm()
                 }
             }
         }
@@ -368,7 +368,7 @@ class SwiftPerformanceTests: TestCase {
         measureBlock {
             for _ in 0..<50 {
                 autoreleasepool {
-                    _ = self.realmWithTestPath()
+                    _ = try! Realm()
                 }
             }
         }


### PR DESCRIPTION
Nothing particularly exciting, but while checking why the relevant perf test was failing I noticed it was spending a lot of time on unnecessary things. This makes both `Realm()` and `self.testRealmPath()` (in our tests) take about a third less time, and switches the testRealmCreationCached test over to testing what is hopefully a more realistic scenario.