### PR TITLE
Explicit error code for schema mismatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ x.x.x Release notes (yyyy-MM-dd)
 
 ### Enhancements
 
-* None.
+* Return `RLMErrorSchemaMismatch` error rather than the more generic `RLMErrorFail`
+  when a migration is required.
 
 ### Bugfixes
 

--- a/Realm/ObjectStore/shared_realm.cpp
+++ b/Realm/ObjectStore/shared_realm.cpp
@@ -136,7 +136,7 @@ void Realm::init(std::shared_ptr<RealmCoordinator> coordinator)
         if (target_schema) {
             if (m_config.read_only) {
                 if (m_config.schema_version == ObjectStore::NotVersioned) {
-                    throw UnitializedRealmException("Can't open an un-initialized Realm without a Schema");
+                    throw UninitializedRealmException("Can't open an un-initialized Realm without a Schema");
                 }
                 target_schema->validate();
                 ObjectStore::verify_schema(*m_config.schema, *target_schema, true);

--- a/Realm/ObjectStore/shared_realm.hpp
+++ b/Realm/ObjectStore/shared_realm.hpp
@@ -224,9 +224,9 @@ namespace realm {
         IncorrectThreadException() : std::runtime_error("Realm accessed from incorrect thread.") {}
     };
 
-    class UnitializedRealmException : public std::runtime_error {
+    class UninitializedRealmException : public std::runtime_error {
     public:
-        UnitializedRealmException(std::string message) : std::runtime_error(message) {}
+        UninitializedRealmException(std::string message) : std::runtime_error(message) {}
     };
 }
 

--- a/Realm/RLMConstants.h
+++ b/Realm/RLMConstants.h
@@ -85,6 +85,8 @@ typedef NS_ENUM(NSInteger, RLMError) {
     RLMErrorIncompatibleLockFile  = 8,
     /** Returned by RLMRealm if there is insufficient available address space. */
     RLMErrorAddressSpaceExhausted = 9,
+    /** Returned by RLMRealm if there is a schema version mismatch, so that a migration is required. */
+    RLMErrorSchemaMismatch = 10,
 };
 
 #pragma mark - Constants

--- a/Realm/RLMRealm.mm
+++ b/Realm/RLMRealm.mm
@@ -272,6 +272,9 @@ void RLMRealmTranslateException(NSError **error) {
     catch (AddressSpaceExhausted const &ex) {
         RLMSetErrorOrThrow(RLMMakeError(RLMErrorAddressSpaceExhausted, ex), error);
     }
+    catch (SchemaMismatchException const& ex) {
+        RLMSetErrorOrThrow(RLMMakeError(RLMErrorSchemaMismatch, ex), error);
+    }
     catch (std::system_error const& ex) {
         RLMSetErrorOrThrow(RLMMakeError(ex), error);
     }
@@ -360,17 +363,17 @@ void RLMRealmTranslateException(NSError **error) {
         try {
             realm->_realm = [self openSharedRealm:config error:error];
         }
-        catch (SchemaMismatchException const& exception) {
+        catch (SchemaMismatchException const& ex) {
             if (configuration.deleteRealmIfMigrationNeeded) {
                 BOOL success = [[NSFileManager defaultManager] removeItemAtURL:configuration.fileURL error:nil];
                 if (success) {
                     realm->_realm = [self openSharedRealm:config error:error];
                 } else {
-                    RLMSetErrorOrThrow(RLMMakeError(RLMException(exception)), error);
+                    RLMSetErrorOrThrow(RLMMakeError(RLMErrorSchemaMismatch, ex), error);
                     return nil;
                 }
             } else {
-                RLMSetErrorOrThrow(RLMMakeError(RLMException(exception)), error);
+                RLMSetErrorOrThrow(RLMMakeError(RLMErrorSchemaMismatch, ex), error);
                 return nil;
             }
         }
@@ -402,7 +405,7 @@ void RLMRealmTranslateException(NSError **error) {
                 }
 
                 RLMRealmSetSchemaAndAlign(realm, schema);
-            } catch (SchemaMismatchException const& exception) {
+            } catch (SchemaMismatchException const& ex) {
                 if (configuration.deleteRealmIfMigrationNeeded) {
                     BOOL success = [[NSFileManager defaultManager] removeItemAtURL:configuration.fileURL error:nil];
                     if (success) {
@@ -412,7 +415,7 @@ void RLMRealmTranslateException(NSError **error) {
                     }
                 }
 
-                RLMSetErrorOrThrow(RLMMakeError(RLMException(exception)), error);
+                RLMSetErrorOrThrow(RLMMakeError(RLMErrorSchemaMismatch, ex), error);
                 return nil;
             } catch (std::exception const& exception) {
                 RLMSetErrorOrThrow(RLMMakeError(RLMException(exception)), error);

--- a/Realm/Tests/MigrationTests.mm
+++ b/Realm/Tests/MigrationTests.mm
@@ -199,7 +199,7 @@ RLM_ARRAY_TYPE(MigrationObject);
         XCTFail(@"Migration block should not have been called");
     };
 
-    XCTAssertThrows([RLMRealm realmWithConfiguration:config error:nil]);
+    RLMAssertThrowsWithCodeMatching([RLMRealm realmWithConfiguration:config error:nil], RLMErrorSchemaMismatch);
 
     __block bool migrationCalled = false;
     config.schemaVersion = 1;

--- a/RealmSwift-swift2.0/Error.swift
+++ b/RealmSwift-swift2.0/Error.swift
@@ -64,6 +64,8 @@ public enum Error: ErrorType {
             return RLMError.FileFormatUpgradeRequired
         case .AddressSpaceExhausted:
             return RLMError.AddressSpaceExhausted
+        case .SchemaMismatch:
+            return RLMError.SchemaMismatch
         }
     }
 
@@ -95,6 +97,9 @@ public enum Error: ErrorType {
 
     /// Error thrown by Realm if there is insufficient available address space.
     case AddressSpaceExhausted
+
+    /** Error thrown by Realm if there is a schema version mismatch, so that a migration is required. */
+    case SchemaMismatch
 }
 
 // MARK: Equatable

--- a/RealmSwift-swift2.0/Tests/MigrationTests.swift
+++ b/RealmSwift-swift2.0/Tests/MigrationTests.swift
@@ -484,7 +484,7 @@ class MigrationTests: TestCase {
         }
 
         let migrationBlock: MigrationBlock = { _, _ in
-            XCTFail("Migration block should not have been called")
+            XCTFail("Migration block should not be called")
         }
         let config = Realm.Configuration(fileURL: defaultRealmURL(),
                                          migrationBlock: migrationBlock,

--- a/RealmSwift-swift2.0/Tests/MigrationTests.swift
+++ b/RealmSwift-swift2.0/Tests/MigrationTests.swift
@@ -444,22 +444,19 @@ class MigrationTests: TestCase {
 
         var config = Realm.Configuration(fileURL: defaultRealmURL(), objectTypes: [SwiftEmployeeObject.self])
         autoreleasepool {
-            do {
-                let _ = try Realm(configuration: config)
-                XCTFail("Migration error should be occurred")
-            } catch {}
+            assertFails(.Fail) {
+                try Realm(configuration: config)
+            }
         }
 
         config.migrationBlock = { _, _ in
-            XCTFail("Migration block should not have been called")
+            XCTFail("Migration block should not be called")
         }
         config.deleteRealmIfMigrationNeeded = true
 
         autoreleasepool {
-            do {
+            assertSucceeds {
                 let _ = try Realm(configuration: config)
-            } catch {
-                XCTFail("Migration error was occurred")
             }
         }
     }
@@ -481,10 +478,9 @@ class MigrationTests: TestCase {
         class_replaceMethod(metaClass, "sharedSchema", imp, "@@:")
 
         autoreleasepool {
-            do {
-                let _ = try Realm()
-                XCTFail("Migration error should be occurred")
-            } catch {}
+            assertFails(.Fail) {
+                try Realm()
+            }
         }
 
         let migrationBlock: MigrationBlock = { _, _ in
@@ -494,10 +490,8 @@ class MigrationTests: TestCase {
                                          migrationBlock: migrationBlock,
                                          deleteRealmIfMigrationNeeded: true)
 
-        do {
+        assertSucceeds {
             let _ = try Realm(configuration: config)
-        } catch {
-            XCTFail("Migration error was occurred")
         }
 
         class_replaceMethod(metaClass, "sharedSchema", originalImp, "@@:")

--- a/RealmSwift-swift2.0/Tests/MigrationTests.swift
+++ b/RealmSwift-swift2.0/Tests/MigrationTests.swift
@@ -435,7 +435,7 @@ class MigrationTests: TestCase {
         XCTAssertEqual(try! Realm().objects(SwiftBoolObject).count, 4)
     }
 
-    func testDeleteRealmIfMigrationNeededWithSetCustomSchema() {
+    func testFailOnSchemaMismatch() {
         let prop = RLMProperty(name: "name", type: RLMPropertyType.String, objectClassName: nil,
                                linkOriginPropertyName: nil, indexed: false, optional: false)
         autoreleasepool {
@@ -448,7 +448,16 @@ class MigrationTests: TestCase {
                 try Realm(configuration: config)
             }
         }
+    }
 
+    func testDeleteRealmIfMigrationNeededWithSetCustomSchema() {
+        let prop = RLMProperty(name: "name", type: RLMPropertyType.String, objectClassName: nil,
+                               linkOriginPropertyName: nil, indexed: false, optional: false)
+        autoreleasepool {
+            realmWithSingleClassProperties(defaultRealmURL(), className: "SwiftEmployeeObject", properties: [prop])
+        }
+
+        var config = Realm.Configuration(fileURL: defaultRealmURL(), objectTypes: [SwiftEmployeeObject.self])
         config.migrationBlock = { _, _ in
             XCTFail("Migration block should not be called")
         }

--- a/RealmSwift-swift2.0/Tests/MigrationTests.swift
+++ b/RealmSwift-swift2.0/Tests/MigrationTests.swift
@@ -444,7 +444,7 @@ class MigrationTests: TestCase {
 
         var config = Realm.Configuration(fileURL: defaultRealmURL(), objectTypes: [SwiftEmployeeObject.self])
         autoreleasepool {
-            assertFails(.Fail) {
+            assertFails(.SchemaMismatch) {
                 try Realm(configuration: config)
             }
         }
@@ -487,7 +487,7 @@ class MigrationTests: TestCase {
         class_replaceMethod(metaClass, "sharedSchema", imp, "@@:")
 
         autoreleasepool {
-            assertFails(.Fail) {
+            assertFails(.SchemaMismatch) {
                 try Realm()
             }
         }


### PR DESCRIPTION
This makes it easier to catch when a migration is required and provide a custom error handling, instead of relying on the built-in delete strategy.

This allows to workaround #3542. This fixes #3534.

/c @jpsim @austinzheng @kishikawakatsumi 