### PR TITLE
Adding better error domain support for system errors

### DIFF
--- a/Realm/ObjectStore/impl/realm_coordinator.cpp
+++ b/Realm/ObjectStore/impl/realm_coordinator.cpp
@@ -69,7 +69,7 @@ std::shared_ptr<Realm> RealmCoordinator::get_realm(Realm::Config config)
                 m_notifier = std::make_unique<ExternalCommitHelper>(*this);
             }
             catch (std::system_error const& ex) {
-                throw RealmFileException(RealmFileException::Kind::AccessError, config.path, ex.code().message());
+                throw RealmFileException(RealmFileException::Kind::AccessError, config.path, ex.code().message(), "");
             }
         }
     }

--- a/Realm/ObjectStore/shared_realm.cpp
+++ b/Realm/ObjectStore/shared_realm.cpp
@@ -88,29 +88,35 @@ void Realm::open_with_config(const Config& config,
     catch (util::File::PermissionDenied const& ex) {
         throw RealmFileException(RealmFileException::Kind::PermissionDenied, ex.get_path(),
                                  "Unable to open a realm at path '" + ex.get_path() +
-                                 "'. Please use a path where your app has " + (config.read_only ? "read" : "read-write") + " permissions.");
+                                 "'. Please use a path where your app has " + (config.read_only ? "read" : "read-write") + " permissions.",
+                                 ex.what());
     }
     catch (util::File::Exists const& ex) {
         throw RealmFileException(RealmFileException::Kind::Exists, ex.get_path(),
-                                 "File at path '" + ex.get_path() + "' already exists.");
+                                 "File at path '" + ex.get_path() + "' already exists.",
+                                 ex.what());
     }
     catch (util::File::NotFound const& ex) {
         throw RealmFileException(RealmFileException::Kind::NotFound, ex.get_path(),
-                                 "File at path '" + ex.get_path() + "' does not exist.");
+                                 "File at path '" + ex.get_path() + "' does not exist.",
+                                 ex.what());
     }
     catch (util::File::AccessError const& ex) {
         throw RealmFileException(RealmFileException::Kind::AccessError, ex.get_path(),
-                                 "Unable to open a realm at path '" + ex.get_path() + "'");
+                                 "Unable to open a realm at path '" + ex.get_path() + "'",
+                                 ex.what());
     }
     catch (IncompatibleLockFile const& ex) {
         throw RealmFileException(RealmFileException::Kind::IncompatibleLockFile, config.path,
                                  "Realm file is currently open in another process "
-                                 "which cannot share access with this process. All processes sharing a single file must be the same architecture.");
+                                 "which cannot share access with this process. All processes sharing a single file must be the same architecture.",
+                                 ex.what());
     }
     catch (FileFormatUpgradeRequired const& ex) {
         throw RealmFileException(RealmFileException::Kind::FormatUpgradeRequired, config.path,
                                  "The Realm file format must be allowed to be upgraded "
-                                 "in order to proceed.");
+                                 "in order to proceed.",
+                                 ex.what());
     }
 }
 

--- a/Realm/ObjectStore/shared_realm.hpp
+++ b/Realm/ObjectStore/shared_realm.hpp
@@ -199,14 +199,16 @@ namespace realm {
             /** Thrown if the file needs to be upgraded to a new format, but upgrades have been explicitly disabled. */
             FormatUpgradeRequired,
         };
-        RealmFileException(Kind kind, std::string path, std::string message) :
-            std::runtime_error(std::move(message)), m_kind(kind), m_path(std::move(path)) {}
+        RealmFileException(Kind kind, std::string path, std::string message, std::string underlying) :
+            std::runtime_error(std::move(message)), m_kind(kind), m_path(std::move(path)), m_underlying(std::move(underlying)) {}
         Kind kind() const { return m_kind; }
         const std::string& path() const { return m_path; }
+        const std::string& underlying() const { return m_underlying; }
 
     private:
         Kind m_kind;
         std::string m_path;
+        std::string m_underlying;
     };
 
     class MismatchedConfigException : public std::runtime_error {

--- a/Realm/RLMConstants.h
+++ b/Realm/RLMConstants.h
@@ -124,6 +124,9 @@ extern const uint64_t RLMNotVersioned;
 /** Error domain used in Realm. */
 extern NSString * const RLMErrorDomain;
 
+/** Error domain used for non-specific system errors. */
+extern NSString * const RLMUnknownSystemErrorDomain;
+
 /** Key for name of Realm exceptions. */
 extern NSString * const RLMExceptionName;
 

--- a/Realm/RLMConstants.m
+++ b/Realm/RLMConstants.m
@@ -23,6 +23,8 @@ NSString * const RLMRealmDidChangeNotification = @"RLMRealmDidChangeNotification
 
 NSString * const RLMErrorDomain = @"io.realm";
 
+NSString * const RLMUnknownSystemErrorDomain = @"io.realm.unknown";
+
 NSString * const RLMExceptionName = @"RLMException";
 
 NSString * const RLMRealmVersionKey = @"RLMRealmVersion";

--- a/Realm/RLMUtil.mm
+++ b/Realm/RLMUtil.mm
@@ -244,10 +244,15 @@ NSError *RLMMakeError(RLMError code, const realm::RealmFileException& exception)
 }
 
 NSError *RLMMakeError(std::system_error const& exception) {
-    return [NSError errorWithDomain:RLMErrorDomain
+    BOOL isGenericCategoryError = (exception.code().category() == std::generic_category());
+    NSString *category = [NSString stringWithUTF8String:exception.code().category().name()];
+    NSString *errorDomain = isGenericCategoryError ? NSPOSIXErrorDomain : RLMUnknownSystemErrorDomain;
+
+    return [NSError errorWithDomain:errorDomain
                                code:exception.code().value()
                            userInfo:@{NSLocalizedDescriptionKey: @(exception.what()),
-                                      @"Error Code": @(exception.code().value())}];
+                                      @"Error Code": @(exception.code().value()),
+                                      @"Category": category}];
 }
 
 NSError *RLMMakeError(NSException *exception) {

--- a/Realm/RLMUtil.mm
+++ b/Realm/RLMUtil.mm
@@ -236,16 +236,18 @@ NSError *RLMMakeError(RLMError code, const realm::util::File::AccessError& excep
 }
 
 NSError *RLMMakeError(RLMError code, const realm::RealmFileException& exception) {
+    NSString *underlying = @(exception.underlying().c_str());
     return [NSError errorWithDomain:RLMErrorDomain
                                code:code
                            userInfo:@{NSLocalizedDescriptionKey: @(exception.what()),
                                       NSFilePathErrorKey: @(exception.path().c_str()),
-                                      @"Error Code": @(code)}];
+                                      @"Error Code": @(code),
+                                      @"Underlying": underlying.length == 0 ? @"n/a" : underlying}];
 }
 
 NSError *RLMMakeError(std::system_error const& exception) {
     BOOL isGenericCategoryError = (exception.code().category() == std::generic_category());
-    NSString *category = [NSString stringWithUTF8String:exception.code().category().name()];
+    NSString *category = @(exception.code().category().name());
     NSString *errorDomain = isGenericCategoryError ? NSPOSIXErrorDomain : RLMUnknownSystemErrorDomain;
 
     return [NSError errorWithDomain:errorDomain

--- a/Realm/Tests/AsyncTests.mm
+++ b/Realm/Tests/AsyncTests.mm
@@ -414,11 +414,7 @@
     XCTestExpectation *exp = [self expectationWithDescription:@""];
     auto token = [IntObject.allObjects addNotificationBlock:^(RLMResults *results, RLMCollectionChange *change, NSError *error) {
         XCTAssertNil(results);
-        XCTAssertNotNil(error);
-        // Validate error
-        XCTAssertEqualObjects(error.domain, RLMErrorDomain);
-        XCTAssertEqual(error.code, RLMErrorFail);
-        XCTAssert([error.localizedDescription rangeOfString:@"Too many open files"].location != NSNotFound);
+        RLMValidateRealmError(error, RLMErrorFail, @"Too many open files", nil);
         called = true;
         [exp fulfill];
     }];
@@ -437,10 +433,7 @@
     XCTestExpectation *exp2 = [self expectationWithDescription:@""];
     auto token2 = [IntObject.allObjects addNotificationBlock:^(RLMResults *results, RLMCollectionChange *change, NSError *error) {
         XCTAssertNil(results);
-        XCTAssertNotNil(error);
-        // Validate error
-        XCTAssertEqualObjects(error.domain, RLMErrorDomain);
-        XCTAssertEqual(error.code, RLMErrorFail);
+        RLMValidateRealmError(error, RLMErrorFail, @"Too many open files", nil);
         [exp2 fulfill];
     }];
     [realm beginWriteTransaction];

--- a/Realm/Tests/AsyncTests.mm
+++ b/Realm/Tests/AsyncTests.mm
@@ -415,6 +415,8 @@
     auto token = [IntObject.allObjects addNotificationBlock:^(RLMResults *results, RLMCollectionChange *change, NSError *error) {
         XCTAssertNil(results);
         XCTAssertNotNil(error);
+        // Validate error
+        XCTAssertEqualObjects(error.domain, RLMErrorDomain);
         XCTAssertEqual(error.code, RLMErrorFail);
         XCTAssert([error.localizedDescription rangeOfString:@"Too many open files"].location != NSNotFound);
         called = true;
@@ -436,6 +438,9 @@
     auto token2 = [IntObject.allObjects addNotificationBlock:^(RLMResults *results, RLMCollectionChange *change, NSError *error) {
         XCTAssertNil(results);
         XCTAssertNotNil(error);
+        // Validate error
+        XCTAssertEqualObjects(error.domain, RLMErrorDomain);
+        XCTAssertEqual(error.code, RLMErrorFail);
         [exp2 fulfill];
     }];
     [realm beginWriteTransaction];

--- a/Realm/Tests/EncryptionTests.mm
+++ b/Realm/Tests/EncryptionTests.mm
@@ -75,7 +75,10 @@
     }
 
     @autoreleasepool {
-        XCTAssertThrows([RLMRealm defaultRealm]);
+        RLMAssertThrowsWithError([RLMRealm defaultRealm],
+                                 @"Unable to open a realm at path",
+                                 RLMErrorFileAccess,
+                                 @"Not a Realm file");
     }
 }
 
@@ -87,7 +90,10 @@
 
     @autoreleasepool {
         NSData *key = RLMGenerateKey();
-        XCTAssertThrows([self realmWithKey:key]);
+        RLMAssertThrowsWithError([self realmWithKey:key],
+                                 @"Unable to open a realm at path",
+                                 RLMErrorFileAccess,
+                                 @"Realm file decryption failed");
     }
 }
 
@@ -98,13 +104,16 @@
 
     @autoreleasepool {
         NSData *key = RLMGenerateKey();
-        XCTAssertThrows([self realmWithKey:key]);
+        RLMAssertThrowsWithError([self realmWithKey:key],
+                                 @"Unable to open a realm at path",
+                                 RLMErrorFileAccess,
+                                 @"Realm file decryption failed");
     }
 }
 
 - (void)testOpenWithNewKeyWhileAlreadyOpenThrows {
     [self realmWithKey:RLMGenerateKey()];
-    XCTAssertThrows([self realmWithKey:RLMGenerateKey()]);
+    RLMAssertThrows([self realmWithKey:RLMGenerateKey()], @"already opened with different encryption key");
 }
 
 #pragma mark - writeCopyToURL:

--- a/Realm/Tests/MigrationTests.mm
+++ b/Realm/Tests/MigrationTests.mm
@@ -290,12 +290,7 @@ RLM_ARRAY_TYPE(MigrationObject);
     XCTAssertThrows([RLMRealm schemaVersionAtURL:RLMDefaultRealmURL() encryptionKey:nil error:nil]);
     NSError *error;
     XCTAssertEqual(RLMNotVersioned, [RLMRealm schemaVersionAtURL:RLMDefaultRealmURL() encryptionKey:nil error:&error]);
-    XCTAssertNotNil(error);
-    // Validate error
-    XCTAssertEqualObjects(error.domain, RLMErrorDomain);
-    XCTAssertEqual(error.code, RLMErrorFail);
-    XCTAssert([error.localizedDescription rangeOfString:
-               @"Cannot open an uninitialized realm in read-only mode"].location != NSNotFound);
+    RLMValidateRealmError(error, RLMErrorFail, @"Cannot open an uninitialized realm in read-only mode", nil);
 
     RLMRealmConfiguration *config = [RLMRealmConfiguration defaultConfiguration];
     @autoreleasepool { [RLMRealm realmWithConfiguration:config error:nil]; }

--- a/Realm/Tests/MigrationTests.mm
+++ b/Realm/Tests/MigrationTests.mm
@@ -291,6 +291,11 @@ RLM_ARRAY_TYPE(MigrationObject);
     NSError *error;
     XCTAssertEqual(RLMNotVersioned, [RLMRealm schemaVersionAtURL:RLMDefaultRealmURL() encryptionKey:nil error:&error]);
     XCTAssertNotNil(error);
+    // Validate error
+    XCTAssertEqualObjects(error.domain, RLMErrorDomain);
+    XCTAssertEqual(error.code, RLMErrorFail);
+    XCTAssert([error.localizedDescription rangeOfString:
+               @"Cannot open an uninitialized realm in read-only mode"].location != NSNotFound);
 
     RLMRealmConfiguration *config = [RLMRealmConfiguration defaultConfiguration];
     @autoreleasepool { [RLMRealm realmWithConfiguration:config error:nil]; }

--- a/Realm/Tests/RLMAssertions.h
+++ b/Realm/Tests/RLMAssertions.h
@@ -63,30 +63,30 @@
     XCTAssertEqual([exception.userInfo[NSUnderlyingErrorKey] code], expectedCode, __VA_ARGS__); \
 })
 
-#define RLMValidateRealmError(__error, __errnum, __description, __underlying)                        \
+#define RLMValidateRealmError(macro_error, macro_errnum, macro_description, macro_underlying)        \
 ({                                                                                                   \
-    NSString *__dsc = __description;                                                                 \
-    NSString *__usl = __underlying;                                                                  \
-    NSError *__castErr = (NSError *)__error;                                                         \
-    XCTAssertNotNil(__castErr);                                                                      \
-    XCTAssertEqual(__castErr.domain, RLMErrorDomain);                                                \
-    XCTAssertEqual(__castErr.code, __errnum);                                                        \
-    if (__dsc.length) {                                                                              \
-        NSString *__dscActual = __castErr.userInfo[NSLocalizedDescriptionKey];                       \
-        XCTAssertNotNil(__dscActual);                                                                \
-        XCTAssert([__dscActual rangeOfString:__dsc].location != NSNotFound);                         \  
+    NSString *macro_dsc = macro_description;                                                         \
+    NSString *macro_usl = macro_underlying;                                                          \
+    NSError *macro_castErr = (NSError *)macro_error;                                                 \
+    XCTAssertNotNil(macro_castErr);                                                                  \
+    XCTAssertEqual(macro_castErr.domain, RLMErrorDomain);                                            \
+    XCTAssertEqual(macro_castErr.code, macro_errnum);                                                \
+    if (macro_dsc.length) {                                                                          \
+        NSString *macro_dscActual = macro_castErr.userInfo[NSLocalizedDescriptionKey];               \
+        XCTAssertNotNil(macro_dscActual);                                                            \
+        XCTAssert([macro_dscActual rangeOfString:macro_dsc].location != NSNotFound);                 \
     }                                                                                                \
-    if (__usl.length) {                                                                              \
-        NSString *__uslActual = __castErr.userInfo[@"Underlying"];                                   \
-        XCTAssertNotNil(__uslActual);                                                                \
-        XCTAssert([__uslActual rangeOfString:__usl].location != NSNotFound);                         \
+    if (macro_usl.length) {                                                                          \
+        NSString *macro_uslActual = macro_castErr.userInfo[@"Underlying"];                           \
+        XCTAssertNotNil(macro_uslActual);                                                            \
+        XCTAssert([macro_uslActual rangeOfString:macro_usl].location != NSNotFound);                 \
     }                                                                                                \
 })
 
 /// Check that an exception is thrown, and validate additional details about its underlying error.
-#define RLMAssertThrowsWithError(__expr, __except_string, __errnum, __underlying_string)               \
-({                                                                                                     \
-    NSException *__exception = RLMAssertThrowsWithReasonMatching(__expr, __except_string);             \
-    NSError *__excErr = (NSError *)(__exception.userInfo[NSUnderlyingErrorKey]);                       \
-    RLMValidateRealmError(__excErr, __errnum, nil, __underlying_string);                               \
+#define RLMAssertThrowsWithError(macro_expr, macro_except_string, macro_errnum, macro_underlying_string) \
+({                                                                                                       \
+    NSException *macro_exception = RLMAssertThrowsWithReasonMatching(macro_expr, macro_except_string);   \
+    NSError *macro_excErr = (NSError *)(macro_exception.userInfo[NSUnderlyingErrorKey]);                 \
+    RLMValidateRealmError(macro_excErr, macro_errnum, nil, macro_underlying_string);                     \
 })

--- a/Realm/Tests/RLMAssertions.h
+++ b/Realm/Tests/RLMAssertions.h
@@ -54,10 +54,39 @@
     if (exception) { \
         RLMAssertMatches(exception.reason, regex, __VA_ARGS__); \
     } \
+    exception; \
 })
 
 #define RLMAssertThrowsWithCodeMatching(expression, expectedCode, ...) \
 ({ \
     NSException *exception = RLMAssertThrows(expression, __VA_ARGS__); \
     XCTAssertEqual([exception.userInfo[NSUnderlyingErrorKey] code], expectedCode, __VA_ARGS__); \
+})
+
+#define RLMValidateRealmError(__error, __errnum, __description, __underlying)                        \
+({                                                                                                   \
+    NSString *__dsc = __description;                                                                 \
+    NSString *__usl = __underlying;                                                                  \
+    NSError *__castErr = (NSError *)__error;                                                         \
+    XCTAssertNotNil(__castErr);                                                                      \
+    XCTAssertEqual(__castErr.domain, RLMErrorDomain);                                                \
+    XCTAssertEqual(__castErr.code, __errnum);                                                        \
+    if (__dsc.length) {                                                                              \
+        NSString *__dscActual = __castErr.userInfo[NSLocalizedDescriptionKey];                       \
+        XCTAssertNotNil(__dscActual);                                                                \
+        XCTAssert([__dscActual rangeOfString:__dsc].location != NSNotFound);                         \  
+    }                                                                                                \
+    if (__usl.length) {                                                                              \
+        NSString *__uslActual = __castErr.userInfo[@"Underlying"];                                   \
+        XCTAssertNotNil(__uslActual);                                                                \
+        XCTAssert([__uslActual rangeOfString:__usl].location != NSNotFound);                         \
+    }                                                                                                \
+})
+
+/// Check that an exception is thrown, and validate additional details about its underlying error.
+#define RLMAssertThrowsWithError(__expr, __except_string, __errnum, __underlying_string)               \
+({                                                                                                     \
+    NSException *__exception = RLMAssertThrowsWithReasonMatching(__expr, __except_string);             \
+    NSError *__excErr = (NSError *)(__exception.userInfo[NSUnderlyingErrorKey]);                       \
+    RLMValidateRealmError(__excErr, __errnum, nil, __underlying_string);                               \
 })

--- a/Realm/Tests/RealmTests.mm
+++ b/Realm/Tests/RealmTests.mm
@@ -1449,7 +1449,8 @@ extern "C" {
 }
 
 - (void)testRealmFileAccessNilPath {
-    XCTAssertThrows([RLMRealm realmWithURL:self.nonLiteralNil], @"nil path");
+    RLMAssertThrowsWithReasonMatching([RLMRealm realmWithURL:self.nonLiteralNil],
+                                      @"Realm path must not be empty", @"nil path");
 }
 
 - (void)testRealmFileAccessNoExistingFile

--- a/Realm/Tests/UtilTests.mm
+++ b/Realm/Tests/UtilTests.mm
@@ -22,6 +22,8 @@
 #import "RLMUtil.hpp"
 #import "RLMVersion.h"
 
+#import "shared_realm.hpp"
+
 @interface UtilTests : RLMTestCase
 
 @end
@@ -84,11 +86,8 @@ static BOOL RLMEqualExceptions(NSException *actual, NSException *expected) {
                           [NSError errorWithDomain:RLMUnknownSystemErrorDomain code:code userInfo:expectedUserInfo]);
 }
 
-using namespace realm;
-#import "shared_realm.hpp"
-
 - (void)testRealmFileException {
-    RealmFileException exception(RealmFileException::Kind::NotFound,
+    realm::RealmFileException exception(realm::RealmFileException::Kind::NotFound,
                                  "/some/path",
                                  "don't do that to your files",
                                  "lp0 on fire");

--- a/Realm/Tests/UtilTests.mm
+++ b/Realm/Tests/UtilTests.mm
@@ -56,7 +56,7 @@ static BOOL RLMEqualExceptions(NSException *actual, NSException *expected) {
                                      [NSException exceptionWithName:RLMExceptionName reason:@"Reason" userInfo:expectedUserInfo]));
 }
 
-- (void)testRLMExceptionWithPOSIXSystemException {
+- (void)testSystemExceptionWithPOSIXSystemException {
     int code = ENOENT;
     NSString *description = @"No such file or directory";
 
@@ -70,7 +70,7 @@ static BOOL RLMEqualExceptions(NSException *actual, NSException *expected) {
                           [NSError errorWithDomain:NSPOSIXErrorDomain code:code userInfo:expectedUserInfo]);
 }
 
-- (void)testRLMExceptionWithNonPOSIXSystemException {
+- (void)testSystemExceptionWithNonPOSIXSystemException {
     int code = 999;
     NSString *description = @"unspecified system_category error";
 
@@ -82,6 +82,24 @@ static BOOL RLMEqualExceptions(NSException *actual, NSException *expected) {
                                        };
     XCTAssertEqualObjects(RLMMakeError(exception),
                           [NSError errorWithDomain:RLMUnknownSystemErrorDomain code:code userInfo:expectedUserInfo]);
+}
+
+using namespace realm;
+#import "shared_realm.hpp"
+
+- (void)testRealmFileException {
+    RealmFileException exception(RealmFileException::Kind::NotFound,
+                                 "/some/path",
+                                 "don't do that to your files",
+                                 "lp0 on fire");
+    RLMError dummyCode = RLMErrorFail;
+    NSDictionary *expectedUserInfo = @{NSLocalizedDescriptionKey: @"don't do that to your files",
+                                       NSFilePathErrorKey: @"/some/path",
+                                       @"Error Code": @(dummyCode),
+                                       @"Underlying": @"lp0 on fire"};
+
+    XCTAssertEqualObjects(RLMMakeError(dummyCode, exception),
+                          [NSError errorWithDomain:RLMErrorDomain code:dummyCode userInfo:expectedUserInfo]);
 }
 
 - (void)testRLMMakeError {


### PR DESCRIPTION
A first shot at addressing #3069 and #3438. `NSError` objects created from system exceptions should be slightly more descriptive now. @bdash @tgoyne

Changes:
- Realm NSError now populated with the NSPOSIXErrorDomain when appropriate
- NSError user info now contains system error category
- Added RLMUnknownSystemErrorDomain for non-POSIX errors