### PR TITLE
Add missing documentation

### DIFF
--- a/Realm/RLMCollection.h
+++ b/Realm/RLMCollection.h
@@ -300,9 +300,13 @@ RLM_ASSUME_NONNULL_BEGIN
 /// different object at that index will also be reported as a modification.
 @property (nonatomic, readonly) NSArray RLM_GENERIC(NSNumber *) *modifications;
 
-
+/// Returns index paths of the deletion indices in the given section.
 - (NSArray RLM_GENERIC(NSIndexPath *)*)deletionsInSection:(NSUInteger)section;
+
+/// Returns index paths of the insertion indices in the given section.
 - (NSArray RLM_GENERIC(NSIndexPath *)*)insertionsInSection:(NSUInteger)section;
+
+/// Returns index paths of the modification indices in the given section.
 - (NSArray RLM_GENERIC(NSIndexPath *)*)modificationsInSection:(NSUInteger)section;
 @end
 

--- a/Realm/RLMProperty.h
+++ b/Realm/RLMProperty.h
@@ -103,9 +103,18 @@ RLM_ASSUME_NONNULL_BEGIN
  */
 @interface RLMPropertyDescriptor : NSObject
 
+/**
+ Creates a property descriptor.
+
+ @param objectClass  The class of this property descriptor.
+ @param propertyName The name of this property descriptor.
+ */
 + (instancetype)descriptorWithClass:(Class)objectClass propertyName:(NSString *)propertyName;
 
+/// The class of the property.
 @property (nonatomic, readonly) Class objectClass;
+
+/// The name of the property.
 @property (nonatomic, readonly) NSString *propertyName;
 
 @end

--- a/RealmSwift-swift2.0/LinkingObjects.swift
+++ b/RealmSwift-swift2.0/LinkingObjects.swift
@@ -92,6 +92,14 @@ public final class LinkingObjects<T: Object>: LinkingObjectsBase {
 
     // MARK: Initializers
 
+    /**
+     Creates a LinkingObjects. This initializer should only be called when
+     declaring a property on a Realm model.
+
+     - parameter type:         The originating type linking to this object type.
+     - parameter propertyName: The property name of the incoming relationship
+                               this LinkingObjects should refer to.
+    */
     public init(fromType type: T.Type, property propertyName: String) {
         let className = (T.self as Object.Type).className()
         super.init(fromClassName: className, property: propertyName)

--- a/build.sh
+++ b/build.sh
@@ -711,8 +711,8 @@ case "$COMMAND" in
     "verify-docs")
         sh build.sh docs
         for lang in swift objc; do
-            undocumented="docs/${lang}_output/undocumented.txt"
-            if [ -s "$undocumented" ]; then
+            undocumented="docs/${lang}_output/undocumented.json"
+            if ! cat "$undocumented" | grep '"warnings":\[\]' > /dev/null 2>&1; then
               echo "Undocumented Realm $lang declarations:"
               cat "$undocumented"
               exit 1


### PR DESCRIPTION
Although we detect missing documentation on CI jobs, we failed to update this check when jazzy changed the undocumented file location, so we let a few undocumented APIs slip through. /cc @tgoyne @bdash @austinzheng 