### PR TITLE
Passing method directly to `XCTAssertNotNil`, it doesn't seem working properly

### DIFF
--- a/RealmSwift-swift2.0/Tests/RealmTests.swift
+++ b/RealmSwift-swift2.0/Tests/RealmTests.swift
@@ -502,8 +502,9 @@ class RealmTests: TestCase {
             realm.create(SwiftPrimaryStringObject.self, value: ["b", 2])
         }
 
-        XCTAssertNotNil(realm.objectForPrimaryKey(SwiftPrimaryStringObject.self, key: "a"))
-        XCTAssertNotNil(realm.objectForPrimaryKey(SwiftPrimaryStringObject.self, key: "z"))
+        // When this is directly inside the XCTAssertNotNil, it doesn't work
+        let object = realm.objectForPrimaryKey(SwiftPrimaryStringObject.self, key: "a")
+        XCTAssertNotNil(object)
 
         // When this is directly inside the XCTAssertNil, it fails for some reason
         let missingObject = realm.objectForPrimaryKey(SwiftPrimaryStringObject.self, key: "z")

--- a/RealmSwift-swift2.0/Tests/RealmTests.swift
+++ b/RealmSwift-swift2.0/Tests/RealmTests.swift
@@ -503,6 +503,7 @@ class RealmTests: TestCase {
         }
 
         XCTAssertNotNil(realm.objectForPrimaryKey(SwiftPrimaryStringObject.self, key: "a"))
+        XCTAssertNotNil(realm.objectForPrimaryKey(SwiftPrimaryStringObject.self, key: "z"))
 
         // When this is directly inside the XCTAssertNil, it fails for some reason
         let missingObject = realm.objectForPrimaryKey(SwiftPrimaryStringObject.self, key: "z")


### PR DESCRIPTION
[This assertion (`XCTAssertNotNil(realm.objectForPrimaryKey(SwiftPrimaryStringObject.self, key: "z"))`)](https://github.com/realm/realm-cocoa/pull/3600/commits/255a143a6ff67bea44cd2ada4e99a33a1aeb0a8b#diff-1758d54637561148c515c83f473e8becR506) should fail but it succeeded (see https://travis-ci.org/realm/realm-cocoa/jobs/130850198).

This PR pass a local value to `XCTAssertNotNil` instead method directly.

Before:
```swift
XCTAssertNotNil(realm.objectForPrimaryKey(SwiftPrimaryStringObject.self, key: "a"))
```

After:
```swift
let object = realm.objectForPrimaryKey(SwiftPrimaryStringObject.self, key: "a")
XCTAssertNotNil(object)
```

CC: @jpsim @tgoyne @bdash 