### PR TITLE
Fix Results to not become invalidated when it depends on a deleted object (LinkView or Row)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,14 @@ x.x.x Release notes (yyyy-MM-dd)
 
 * All functionality deprecated in previous releases has been removed entirely.
 * Support for Xcode 6.x & Swift prior to 2.2 has been completely removed.
+* `RLMResults`/`Results` now become empty when a `RLMArray`/`List` or row they depend on is deleted,
+  rather than throwing an exception when accessed.
 
 ### Enhancements
 
-* None.
+* Added `invalidated` properties to `RLMResults`/`Results`, `RLMLinkingObjects`/`LinkingObjects`,
+  `RealmCollectionType` and `AnyRealmCollection`. These properties report whether the Realm
+  the object is associated with has been invalidated.
 
 ### Bugfixes
 

--- a/Realm/ObjectStore/results.cpp
+++ b/Realm/ObjectStore/results.cpp
@@ -91,10 +91,6 @@ void Results::validate_read() const
         m_realm->verify_thread();
     if (m_table && !m_table->is_attached())
         throw InvalidatedException();
-    if (m_mode == Mode::TableView && (!m_table_view.is_attached() || m_table_view.depends_on_deleted_object()))
-        throw InvalidatedException();
-    if (m_mode == Mode::LinkView && !m_link_view->is_attached())
-        throw InvalidatedException();
 }
 
 void Results::validate_write() const

--- a/Realm/ObjectStore/results.cpp
+++ b/Realm/ObjectStore/results.cpp
@@ -87,7 +87,6 @@ Results::~Results()
 
 bool Results::is_valid() const
 {
-    // We cannot use validate_read as it calls is_valid.
     if (m_realm)
         m_realm->verify_thread();
 
@@ -99,8 +98,7 @@ bool Results::is_valid() const
 
 void Results::validate_read() const
 {
-    if (m_realm)
-        m_realm->verify_thread();
+    // is_valid ensures that we're on the correct thread.
     if (!is_valid())
         throw InvalidatedException();
 }

--- a/Realm/ObjectStore/results.cpp
+++ b/Realm/ObjectStore/results.cpp
@@ -85,11 +85,23 @@ Results::~Results()
     }
 }
 
+bool Results::is_invalidated() const
+{
+    // We cannot use validate_read as it calls is_invalidated.
+    if (m_realm)
+        m_realm->verify_thread();
+
+    if (m_table && !m_table->is_attached())
+        return true;
+
+    return false;
+}
+
 void Results::validate_read() const
 {
     if (m_realm)
         m_realm->verify_thread();
-    if (m_table && !m_table->is_attached())
+    if (is_invalidated())
         throw InvalidatedException();
 }
 

--- a/Realm/ObjectStore/results.cpp
+++ b/Realm/ObjectStore/results.cpp
@@ -85,23 +85,23 @@ Results::~Results()
     }
 }
 
-bool Results::is_invalidated() const
+bool Results::is_valid() const
 {
-    // We cannot use validate_read as it calls is_invalidated.
+    // We cannot use validate_read as it calls is_valid.
     if (m_realm)
         m_realm->verify_thread();
 
     if (m_table && !m_table->is_attached())
-        return true;
+        return false;
 
-    return false;
+    return true;
 }
 
 void Results::validate_read() const
 {
     if (m_realm)
         m_realm->verify_thread();
-    if (is_invalidated())
+    if (!is_valid())
         throw InvalidatedException();
 }
 

--- a/Realm/ObjectStore/results.hpp
+++ b/Realm/ObjectStore/results.hpp
@@ -124,6 +124,9 @@ public:
     // Ideally this would not be public but it's needed for some KVO stuff
     Mode get_mode() const { return m_mode; }
 
+    // Has the Realm this Results is associated with been invalidated?
+    bool is_invalidated() const;
+
     // The Results object has been invalidated (due to the Realm being invalidated)
     // All non-noexcept functions can throw this
     struct InvalidatedException {};

--- a/Realm/ObjectStore/results.hpp
+++ b/Realm/ObjectStore/results.hpp
@@ -124,8 +124,8 @@ public:
     // Ideally this would not be public but it's needed for some KVO stuff
     Mode get_mode() const { return m_mode; }
 
-    // Has the Realm this Results is associated with been invalidated?
-    bool is_invalidated() const;
+    // Is this Results associated with a Realm that has not been invalidated?
+    bool is_valid() const;
 
     // The Results object has been invalidated (due to the Realm being invalidated)
     // All non-noexcept functions can throw this

--- a/Realm/RLMResults.h
+++ b/Realm/RLMResults.h
@@ -67,6 +67,13 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nonatomic, readonly) RLMRealm *realm;
 
+/**
+ Indicates if the results can no longer be accessed.
+
+ The results can no longer be accessed if `invalidate` is called on the containing `realm`.
+ */
+@property (nonatomic, readonly, getter = isInvalidated) BOOL invalidated;
+
 #pragma mark - Accessing Objects from an RLMResults
 
 /**

--- a/Realm/RLMResults.mm
+++ b/Realm/RLMResults.mm
@@ -127,7 +127,7 @@ static inline void RLMResultsValidateInWriteTransaction(__unsafe_unretained RLMR
 }
 
 - (BOOL)isInvalidated {
-    return translateErrors([&] { return _results.is_invalidated(); });
+    return translateErrors([&] { return !_results.is_valid(); });
 }
 
 - (NSUInteger)count {

--- a/Realm/RLMResults.mm
+++ b/Realm/RLMResults.mm
@@ -126,6 +126,10 @@ static inline void RLMResultsValidateInWriteTransaction(__unsafe_unretained RLMR
     ar->_realm->_realm->verify_in_write();
 }
 
+- (BOOL)isInvalidated {
+    return translateErrors([&] { return _results.is_invalidated(); });
+}
+
 - (NSUInteger)count {
     return translateErrors([&] { return _results.size(); });
 }

--- a/Realm/Tests/LinkingObjectsTests.mm
+++ b/Realm/Tests/LinkingObjectsTests.mm
@@ -50,7 +50,7 @@
     [realm beginWriteTransaction];
     [realm deleteObject:hannah];
     [realm commitWriteTransaction];
-    RLMAssertThrowsWithReasonMatching(asArray(hannahsParents), @"has been invalidated");
+    XCTAssertEqualObjects(asArray(hannahsParents), (@[ ]));
 }
 
 - (void)testFilteredLinkingObjects {

--- a/Realm/Tests/ResultsTests.m
+++ b/Realm/Tests/ResultsTests.m
@@ -857,13 +857,11 @@ static vm_size_t get_resident_size() {
 
 - (void)testAllMethodsCheckForInvalidation {
     RLMRealm *realm = [RLMRealm defaultRealm];
-    __block IntegerArrayPropertyObject *object;
     [realm transactionWithBlock:^{
-        IntObject* intObject = [IntObject createInDefaultRealmWithValue:@[@0]];
-        object = [IntegerArrayPropertyObject createInDefaultRealmWithValue:@[ @0, @[ intObject ] ]];
+        [IntObject createInDefaultRealmWithValue:@[@0]];
     }];
 
-    RLMResults *results = [object.array sortedResultsUsingProperty:@"intCol" ascending:YES];
+    RLMResults *results = [IntObject allObjects];
     XCTAssertFalse(results.isInvalidated);
     XCTAssertNoThrow([results objectAtIndex:0]);
     XCTAssertNoThrow([results firstObject]);

--- a/Realm/Tests/ResultsTests.m
+++ b/Realm/Tests/ResultsTests.m
@@ -862,6 +862,7 @@ static vm_size_t get_resident_size() {
     }];
 
     RLMResults *results = [object.array sortedResultsUsingProperty:@"intCol" ascending:YES];
+    XCTAssertFalse(results.isInvalidated);
     XCTAssertNoThrow([results objectAtIndex:0]);
     XCTAssertNoThrow([results firstObject]);
     XCTAssertNoThrow([results lastObject]);
@@ -882,6 +883,7 @@ static vm_size_t get_resident_size() {
 
     [realm invalidate];
 
+    XCTAssertTrue(results.isInvalidated);
     XCTAssertThrows([results objectAtIndex:0]);
     XCTAssertThrows([results firstObject]);
     XCTAssertThrows([results lastObject]);
@@ -918,6 +920,9 @@ static vm_size_t get_resident_size() {
         [realm deleteObject:object];
     }];
 
+    XCTAssertFalse(results.isInvalidated);
+    XCTAssertFalse(unevaluatedResults.isInvalidated);
+
     XCTAssertEqual(0u, results.count);
     XCTAssertEqual(0u, unevaluatedResults.count);
 
@@ -941,6 +946,9 @@ static vm_size_t get_resident_size() {
     [realm transactionWithBlock:^{
         [realm deleteObject:dog];
     }];
+
+    XCTAssertFalse(results.isInvalidated);
+    XCTAssertFalse(unevaluatedResults.isInvalidated);
 
     XCTAssertEqual(0u, results.count);
     XCTAssertEqual(0u, unevaluatedResults.count);

--- a/Realm/Tests/ResultsTests.m
+++ b/Realm/Tests/ResultsTests.m
@@ -816,6 +816,7 @@ static vm_size_t get_resident_size() {
     }];
 
     RLMResults *results = [IntObject allObjects];
+    XCTAssertNoThrow([results isInvalidated]);
     XCTAssertNoThrow([results objectAtIndex:0]);
     XCTAssertNoThrow([results firstObject]);
     XCTAssertNoThrow([results lastObject]);
@@ -834,6 +835,7 @@ static vm_size_t get_resident_size() {
     XCTAssertNoThrow([results valueForKey:@"intCol"]);
 
     [self dispatchAsyncAndWait:^{
+        XCTAssertThrows([results isInvalidated]);
         XCTAssertThrows([results objectAtIndex:0]);
         XCTAssertThrows([results firstObject]);
         XCTAssertThrows([results lastObject]);

--- a/RealmSwift-swift2.2/LinkingObjects.swift
+++ b/RealmSwift-swift2.2/LinkingObjects.swift
@@ -87,6 +87,11 @@ public final class LinkingObjects<T: Object>: LinkingObjectsBase {
     /// Returns the Realm these linking objects are associated with.
     public var realm: Realm? { return rlmResults.attached ? Realm(rlmResults.realm) : nil }
 
+    /// Indicates if the linking objects can no longer be accessed.
+    ///
+    /// Linking objects can no longer be accessed if `invalidate` is called on the containing `Realm`.
+    public var invalidated: Bool { return rlmResults.invalidated }
+
     /// Returns the number of objects in these linking objects.
     public var count: Int { return Int(rlmResults.count) }
 

--- a/RealmSwift-swift2.2/RealmCollectionType.swift
+++ b/RealmSwift-swift2.2/RealmCollectionType.swift
@@ -130,6 +130,11 @@ public protocol RealmCollectionType: CollectionType, CustomStringConvertible {
     /// standalone).
     var realm: Realm? { get }
 
+    /// Indicates if the collection can no longer be accessed.
+    ///
+    /// The collection can no longer be accessed if `invalidate` is called on the containing `Realm`.
+    var invalidated: Bool { get }
+
     /// Returns the number of objects in this collection.
     var count: Int { get }
 
@@ -360,6 +365,7 @@ private class _AnyRealmCollectionBase<T: Object> {
     typealias Wrapper = AnyRealmCollection<Element>
     typealias Element = T
     var realm: Realm? { fatalError() }
+    var invalidated: Bool { fatalError() }
     var count: Int { fatalError() }
     var description: String { fatalError() }
     func indexOf(object: Element) -> Int? { fatalError() }
@@ -398,6 +404,11 @@ private final class _AnyRealmCollection<C: RealmCollectionType>: _AnyRealmCollec
     /// collection's owning object does not belong to a realm (the collection is
     /// standalone).
     override var realm: Realm? { return base.realm }
+
+    /// Indicates if the collection can no longer be accessed.
+    ///
+    /// The collection can no longer be accessed if `invalidate` is called on the containing `Realm`.
+    override var invalidated: Bool { return base.invalidated }
 
     /// Returns the number of objects in this collection.
     override var count: Int { return base.count }
@@ -641,6 +652,11 @@ public final class AnyRealmCollection<T: Object>: RealmCollectionType {
     /// collection's owning object does not belong to a realm (the collection is
     /// standalone).
     public var realm: Realm? { return base.realm }
+
+    /// Indicates if the collection can no longer be accessed.
+    ///
+    /// The collection can no longer be accessed if `invalidate` is called on the containing `Realm`.
+    public var invalidated: Bool { return base.invalidated }
 
     /// Returns the number of objects in this collection.
     public var count: Int { return base.count }

--- a/RealmSwift-swift2.2/Results.swift
+++ b/RealmSwift-swift2.2/Results.swift
@@ -109,6 +109,11 @@ public final class Results<T: Object>: ResultsBase {
     /// cannot exist independently from a `Realm`.
     public var realm: Realm? { return Realm(rlmResults.realm) }
 
+    /// Indicates if the results can no longer be accessed.
+    ///
+    /// Results can no longer be accessed if `invalidate` is called on the containing `Realm`.
+    public var invalidated: Bool { return rlmResults.invalidated }
+
     /// Returns the number of objects in these results.
     public var count: Int { return Int(rlmResults.count) }
 

--- a/RealmSwift-swift2.2/Tests/RealmCollectionTypeTests.swift
+++ b/RealmSwift-swift2.2/Tests/RealmCollectionTypeTests.swift
@@ -380,6 +380,12 @@ class RealmCollectionTypeTests: TestCase {
         XCTAssertEqual(6, collection.valueForKeyPath("@sum.intCol")?.longValue)
         XCTAssertEqual(2.0, collection.valueForKeyPath("@avg.intCol")?.doubleValue)
     }
+
+    func testInvalidate() {
+        XCTAssertFalse(collection.invalidated)
+        realmWithTestPath().invalidate()
+        XCTAssertTrue(collection.realm == nil || collection.invalidated)
+    }
 }
 
 // MARK: Results

--- a/RealmSwift-swift2.2/Tests/RealmCollectionTypeTests.swift
+++ b/RealmSwift-swift2.2/Tests/RealmCollectionTypeTests.swift
@@ -62,7 +62,7 @@ class RealmCollectionTypeTests: TestCase {
         fatalError("abstract")
     }
 
-    func makeAggregateableObjects() -> [CTTAggregateObject] {
+    func makeAggregateableObjectsInWriteTransaction() -> [CTTAggregateObject] {
         let obj1 = CTTAggregateObject()
         obj1.intCol = 1
         obj1.floatCol = 1.1
@@ -88,6 +88,14 @@ class RealmCollectionTypeTests: TestCase {
         return [obj1, obj2, obj3]
     }
 
+    func makeAggregateableObjects() -> [CTTAggregateObject] {
+        var result: [CTTAggregateObject]?
+        try! realmWithTestPath().write {
+            result = makeAggregateableObjectsInWriteTransaction()
+        }
+        return result!
+    }
+
     override func setUp() {
         super.setUp()
 
@@ -97,16 +105,15 @@ class RealmCollectionTypeTests: TestCase {
         str2.stringCol = "2"
 
         let realm = realmWithTestPath()
-        realm.beginWrite()
-        realm.add(str1)
-        realm.add(str2)
+        try! realm.write {
+            realm.add(str1)
+            realm.add(str2)
+        }
 
         collection = AnyRealmCollection(getCollection())
     }
 
     override func tearDown() {
-        realmWithTestPath().cancelWrite()
-
         str1 = nil
         str2 = nil
         collection = nil
@@ -193,7 +200,9 @@ class RealmCollectionTypeTests: TestCase {
     }
 
     func testSetValueForKey() {
-        collection.setValue("hi there!", forKey: "stringCol")
+        try! realmWithTestPath().write {
+            collection.setValue("hi there!", forKey: "stringCol")
+        }
         let expected = (0..<collection.count).map { _ in "hi there!" }
         let actual = collection.map { $0.stringCol }
         XCTAssertEqual(expected, actual)
@@ -212,7 +221,9 @@ class RealmCollectionTypeTests: TestCase {
         let innerArray = SwiftListOfSwiftObject()
         innerArray.array.append(SwiftObject())
         outerArray.array.append(innerArray)
-        realm.add(outerArray)
+        try! realm.write {
+            realm.add(outerArray)
+        }
         XCTAssertEqual(1, outerArray.array.filter("ANY array IN %@", realm.objects(SwiftObject)).count)
     }
 
@@ -220,7 +231,9 @@ class RealmCollectionTypeTests: TestCase {
         let array = SwiftListOfSwiftObject()
         let realm = realmWithTestPath()
         array.array.append(SwiftObject())
-        realm.add(array)
+        try! realm.write {
+            realm.add(array)
+        }
         XCTAssertEqual(1,
             realm.objects(SwiftListOfSwiftObject).filter("ANY array IN %@", realm.objects(SwiftObject)).count)
     }
@@ -314,8 +327,10 @@ class RealmCollectionTypeTests: TestCase {
 
     func testFastEnumerationWithMutation() {
         let realm = realmWithTestPath()
-        for obj in collection {
-            realm.delete(obj)
+        try! realm.write {
+            for obj in collection {
+                realm.delete(obj)
+            }
         }
         XCTAssertEqual(0, collection.count)
     }
@@ -334,9 +349,6 @@ class RealmCollectionTypeTests: TestCase {
     }
 
     func testAddNotificationBlock() {
-        let realm = realmWithTestPath()
-        try! realm.commitWrite()
-
         let expectation = expectationWithDescription("")
         let token = collection.addNotificationBlock { (changes: RealmCollectionChange) in
             switch changes {
@@ -356,7 +368,6 @@ class RealmCollectionTypeTests: TestCase {
         waitForExpectationsWithTimeout(1, handler: nil)
 
         token.stop()
-        realm.beginWrite()
     }
 
     func testValueForKeyPath() {
@@ -382,8 +393,16 @@ class ResultsTests: RealmCollectionTypeTests {
         return super.defaultTestSuite()
     }
 
-    func collectionBase() -> Results<CTTStringObjectWithLink> {
+    func collectionBaseInWriteTransaction() -> Results<CTTStringObjectWithLink> {
         fatalError("abstract")
+    }
+
+    final func collectionBase() -> Results<CTTStringObjectWithLink> {
+        var result: Results<CTTStringObjectWithLink>?
+        try! realmWithTestPath().write {
+            result = collectionBaseInWriteTransaction()
+        }
+        return result!
     }
 
     override func getCollection() -> AnyRealmCollection<CTTStringObjectWithLink> {
@@ -391,9 +410,11 @@ class ResultsTests: RealmCollectionTypeTests {
     }
 
     override func testAssignListProperty() {
-        let array = CTTStringList()
-        realmWithTestPath().add(array)
-        array["array"] = collectionBase()
+        try! realmWithTestPath().write {
+            let array = CTTStringList()
+            realmWithTestPath().add(array)
+            array["array"] = collectionBaseInWriteTransaction()
+        }
     }
 
     func addObjectToResults() {
@@ -405,9 +426,6 @@ class ResultsTests: RealmCollectionTypeTests {
 
     func testNotificationBlockUpdating() {
         let collection = collectionBase()
-
-        let realm = realmWithTestPath()
-        try! realm.commitWrite()
 
         var expectation = expectationWithDescription("")
         var calls = 0
@@ -435,14 +453,10 @@ class ResultsTests: RealmCollectionTypeTests {
         waitForExpectationsWithTimeout(1, handler: nil)
 
         token.stop()
-        realm.beginWrite()
     }
 
     func testNotificationBlockChangeIndices() {
         let collection = collectionBase()
-
-        let realm = realmWithTestPath()
-        try! realm.commitWrite()
 
         var expectation = expectationWithDescription("")
         var calls = 0
@@ -474,7 +488,6 @@ class ResultsTests: RealmCollectionTypeTests {
         waitForExpectationsWithTimeout(1, handler: nil)
 
         token.stop()
-        realm.beginWrite()
     }
 }
 
@@ -495,7 +508,7 @@ class ResultsWithCustomInitializerTest: TestCase {
 }
 
 class ResultsFromTableTests: ResultsTests {
-    override func collectionBase() -> Results<CTTStringObjectWithLink> {
+    override func collectionBaseInWriteTransaction() -> Results<CTTStringObjectWithLink> {
         return realmWithTestPath().objects(CTTStringObjectWithLink)
     }
 
@@ -506,7 +519,7 @@ class ResultsFromTableTests: ResultsTests {
 }
 
 class ResultsFromTableViewTests: ResultsTests {
-    override func collectionBase() -> Results<CTTStringObjectWithLink> {
+    override func collectionBaseInWriteTransaction() -> Results<CTTStringObjectWithLink> {
         return realmWithTestPath().objects(CTTStringObjectWithLink).filter("stringCol != ''")
     }
 
@@ -517,16 +530,19 @@ class ResultsFromTableViewTests: ResultsTests {
 }
 
 class ResultsFromLinkViewTests: ResultsTests {
-    override func collectionBase() -> Results<CTTStringObjectWithLink> {
+    override func collectionBaseInWriteTransaction() -> Results<CTTStringObjectWithLink> {
         let array = realmWithTestPath().create(CTTStringList.self, value: [[str1, str2]])
         return array.array.filter(NSPredicate(value: true))
     }
 
     override func getAggregateableCollection() -> AnyRealmCollection<CTTAggregateObject> {
-        let list = CTTAggregateObjectList()
-        realmWithTestPath().add(list)
-        list.list.appendContentsOf(makeAggregateableObjects())
-        return AnyRealmCollection(list.list.filter(NSPredicate(value: true)))
+        var list: CTTAggregateObjectList?
+        try! realmWithTestPath().write {
+            list = CTTAggregateObjectList()
+            realmWithTestPath().add(list!)
+            list!.list.appendContentsOf(makeAggregateableObjectsInWriteTransaction())
+        }
+        return AnyRealmCollection(list!.list.filter(NSPredicate(value: true)))
     }
 
     override func addObjectToResults() {
@@ -549,8 +565,16 @@ class ListRealmCollectionTypeTests: RealmCollectionTypeTests {
         return super.defaultTestSuite()
     }
 
-    func collectionBase() -> List<CTTStringObjectWithLink> {
+    func collectionBaseInWriteTransaction() -> List<CTTStringObjectWithLink> {
         fatalError("abstract")
+    }
+
+    final func collectionBase() -> List<CTTStringObjectWithLink> {
+        var collection: List<CTTStringObjectWithLink>?
+        try! realmWithTestPath().write {
+            collection = collectionBaseInWriteTransaction()
+        }
+        return collection!
     }
 
     override func getCollection() -> AnyRealmCollection<CTTStringObjectWithLink> {
@@ -558,9 +582,11 @@ class ListRealmCollectionTypeTests: RealmCollectionTypeTests {
     }
 
     override func testAssignListProperty() {
-        let array = CTTStringList()
-        realmWithTestPath().add(array)
-        array["array"] = collectionBase()
+        try! realmWithTestPath().write {
+            let array = CTTStringList()
+            realmWithTestPath().add(array)
+            array["array"] = collectionBaseInWriteTransaction()
+        }
     }
 
     override func testDescription() {
@@ -570,9 +596,6 @@ class ListRealmCollectionTypeTests: RealmCollectionTypeTests {
 
     func testAddNotificationBlockDirect() {
         let collection = collectionBase()
-
-        let realm = realmWithTestPath()
-        try! realm.commitWrite()
 
         let expectation = expectationWithDescription("")
         let token = collection.addNotificationBlock { (changes: RealmCollectionChange) in
@@ -592,12 +615,11 @@ class ListRealmCollectionTypeTests: RealmCollectionTypeTests {
         waitForExpectationsWithTimeout(1, handler: nil)
 
         token.stop()
-        realm.beginWrite()
     }
 }
 
 class ListStandaloneRealmCollectionTypeTests: ListRealmCollectionTypeTests {
-    override func collectionBase() -> List<CTTStringObjectWithLink> {
+    override func collectionBaseInWriteTransaction() -> List<CTTStringObjectWithLink> {
         return CTTStringList(value: [[str1, str2]]).array
     }
 
@@ -688,64 +710,66 @@ class ListStandaloneRealmCollectionTypeTests: ListRealmCollectionTypeTests {
     }
 
     override func testAddNotificationBlock() {
-        let realm = realmWithTestPath()
-        try! realm.commitWrite()
         assertThrows(self.collection.addNotificationBlock { (changes: RealmCollectionChange) in })
-        realm.beginWrite()
     }
 
     override func testAddNotificationBlockDirect() {
         let collection = collectionBase()
-        let realm = realmWithTestPath()
-        try! realm.commitWrite()
-
         assertThrows(collection.addNotificationBlock { (changes: RealmCollectionChange) in })
-        realm.beginWrite()
     }
 }
 
 class ListNewlyAddedRealmCollectionTypeTests: ListRealmCollectionTypeTests {
-    override func collectionBase() -> List<CTTStringObjectWithLink> {
+    override func collectionBaseInWriteTransaction() -> List<CTTStringObjectWithLink> {
         let array = CTTStringList(value: [[str1, str2]])
         realmWithTestPath().add(array)
         return array.array
     }
 
     override func getAggregateableCollection() -> AnyRealmCollection<CTTAggregateObject> {
-        let list = CTTAggregateObjectList(value: [makeAggregateableObjects()])
-        realmWithTestPath().add(list)
-        return AnyRealmCollection(list.list)
+        var list: CTTAggregateObjectList?
+        try! realmWithTestPath().write {
+            list = CTTAggregateObjectList(value: [makeAggregateableObjectsInWriteTransaction()])
+            realmWithTestPath().add(list!)
+        }
+        return AnyRealmCollection(list!.list)
     }
 }
 
 class ListNewlyCreatedRealmCollectionTypeTests: ListRealmCollectionTypeTests {
-    override func collectionBase() -> List<CTTStringObjectWithLink> {
+    override func collectionBaseInWriteTransaction() -> List<CTTStringObjectWithLink> {
         let array = realmWithTestPath().create(CTTStringList.self, value: [[str1, str2]])
         return array.array
     }
 
     override func getAggregateableCollection() -> AnyRealmCollection<CTTAggregateObject> {
-        let list = realmWithTestPath().create(CTTAggregateObjectList.self, value: [makeAggregateableObjects()])
-        return AnyRealmCollection(list.list)
+        var list: CTTAggregateObjectList?
+        try! realmWithTestPath().write {
+            list = realmWithTestPath().create(CTTAggregateObjectList.self, value: [makeAggregateableObjectsInWriteTransaction()])
+        }
+        return AnyRealmCollection(list!.list)
     }
 }
 
 class ListRetrievedRealmCollectionTypeTests: ListRealmCollectionTypeTests {
-    override func collectionBase() -> List<CTTStringObjectWithLink> {
+    override func collectionBaseInWriteTransaction() -> List<CTTStringObjectWithLink> {
         realmWithTestPath().create(CTTStringList.self, value: [[str1, str2]])
         let array = realmWithTestPath().objects(CTTStringList).first!
         return array.array
     }
 
     override func getAggregateableCollection() -> AnyRealmCollection<CTTAggregateObject> {
-        realmWithTestPath().create(CTTAggregateObjectList.self, value: [makeAggregateableObjects()])
-        let list = realmWithTestPath().objects(CTTAggregateObjectList.self).first!
-        return AnyRealmCollection(list.list)
+        var list: CTTAggregateObjectList?
+        try! realmWithTestPath().write {
+            realmWithTestPath().create(CTTAggregateObjectList.self, value: [makeAggregateableObjectsInWriteTransaction()])
+            list = realmWithTestPath().objects(CTTAggregateObjectList.self).first
+        }
+        return AnyRealmCollection(list!.list)
     }
 }
 
 class LinkingObjectsCollectionTypeTests: RealmCollectionTypeTests {
-    func collectionBase() -> LinkingObjects<CTTStringObjectWithLink> {
+    func collectionBaseInWriteTransaction() -> LinkingObjects<CTTStringObjectWithLink> {
         let target = realmWithTestPath().create(CTTLinkTarget.self, value: [0])
         for object in realmWithTestPath().objects(CTTStringObjectWithLink) {
             object.linkCol = target
@@ -753,17 +777,28 @@ class LinkingObjectsCollectionTypeTests: RealmCollectionTypeTests {
         return target.stringObjects
     }
 
+    final func collectionBase() -> LinkingObjects<CTTStringObjectWithLink> {
+        var result: LinkingObjects<CTTStringObjectWithLink>?
+        try! realmWithTestPath().write {
+            result = collectionBaseInWriteTransaction()
+        }
+        return result!
+    }
+
     override func getCollection() -> AnyRealmCollection<CTTStringObjectWithLink> {
         return AnyRealmCollection(collectionBase())
     }
 
     override func getAggregateableCollection() -> AnyRealmCollection<CTTAggregateObject> {
-        let objects = makeAggregateableObjects()
-        let target = realmWithTestPath().create(CTTLinkTarget.self, value: [0])
-        for object in objects {
-            object.linkCol = target
+        var target: CTTLinkTarget?
+        try! realmWithTestPath().write {
+            let objects = makeAggregateableObjectsInWriteTransaction()
+            target = realmWithTestPath().create(CTTLinkTarget.self, value: [0])
+            for object in objects {
+                object.linkCol = target
+            }
         }
-        return AnyRealmCollection(target.aggregateObjects)
+        return AnyRealmCollection(target!.aggregateObjects)
     }
 
     override func testDescription() {
@@ -773,7 +808,9 @@ class LinkingObjectsCollectionTypeTests: RealmCollectionTypeTests {
 
     override func testAssignListProperty() {
         let array = CTTStringList()
-        realmWithTestPath().add(array)
-        array["array"] = collectionBase()
+        try! realmWithTestPath().write {
+            realmWithTestPath().add(array)
+            array["array"] = collectionBaseInWriteTransaction()
+        }
     }
 }

--- a/RealmSwift-swift2.2/Tests/RealmCollectionTypeTests.swift
+++ b/RealmSwift-swift2.2/Tests/RealmCollectionTypeTests.swift
@@ -751,7 +751,8 @@ class ListNewlyCreatedRealmCollectionTypeTests: ListRealmCollectionTypeTests {
     override func getAggregateableCollection() -> AnyRealmCollection<CTTAggregateObject> {
         var list: CTTAggregateObjectList?
         try! realmWithTestPath().write {
-            list = realmWithTestPath().create(CTTAggregateObjectList.self, value: [makeAggregateableObjectsInWriteTransaction()])
+            list = realmWithTestPath().create(CTTAggregateObjectList.self,
+                value: [makeAggregateableObjectsInWriteTransaction()])
         }
         return AnyRealmCollection(list!.list)
     }
@@ -767,7 +768,8 @@ class ListRetrievedRealmCollectionTypeTests: ListRealmCollectionTypeTests {
     override func getAggregateableCollection() -> AnyRealmCollection<CTTAggregateObject> {
         var list: CTTAggregateObjectList?
         try! realmWithTestPath().write {
-            realmWithTestPath().create(CTTAggregateObjectList.self, value: [makeAggregateableObjectsInWriteTransaction()])
+            realmWithTestPath().create(CTTAggregateObjectList.self,
+                value: [makeAggregateableObjectsInWriteTransaction()])
             list = realmWithTestPath().objects(CTTAggregateObjectList.self).first
         }
         return AnyRealmCollection(list!.list)


### PR DESCRIPTION
`Results` is now only invalidated when `invalidate` is called on the `Realm` that it is associated with.

Also exposes an `invalidated` property to `Results` and `LinkingObjects` to allow determining whether a given object is invalidated.

Fixes #3579.

/cc @jpsim @tgoyne @austinzheng 
