### PR TITLE
Date Parsing during JSON load

### DIFF
--- a/Realm/RLMObjectBase.mm
+++ b/Realm/RLMObjectBase.mm
@@ -92,7 +92,12 @@ static id RLMValidatedObjectForProperty(id obj, RLMProperty *prop, RLMSchema *sc
             [dateFormatter setDateFormat:@"yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"]; 
         }
         NSDate *date = [dateFormatter dateFromString:obj]; 
-        return date; 
+        if (date) {
+            return date; 
+        } else {
+            // if not convertible to prop throw
+            @throw RLMException(@"Invalid date value '%@' for property '%@' which should be either date or string in format [yyyy-MM-dd'T'HH:mm:ss.SSS'Z']", obj, prop.name);
+        }
     }
 
     // check for object or array of properties

--- a/Realm/RLMObjectBase.mm
+++ b/Realm/RLMObjectBase.mm
@@ -77,6 +77,24 @@ static id RLMValidatedObjectForProperty(id obj, RLMProperty *prop, RLMSchema *sc
         return obj;
     }
 
+    if (prop.type == RLMPropertyTypeDate) {
+        static NSDateFormatter* dateFormatter = nil; 
+        if (!dateFormatter) {
+            // map dates according to Javascript Date Time Format as per Javascript JSON convention aligning to ISO8601
+            // e.g. Only "2014-01-01T23:28:56.782Z"
+            //
+            // Apps using Realm can target: iOS 7 or later, OS X 10.9 or later & WatchKit.
+            //
+            // On iOS 7 and later NSDateFormatter is thread safe.
+            // On OS X 10.9 and later NSDateFormatter is thread safe so long as you are using the modern behavior in a 64-bit app.
+
+            dateFormatter = [[NSDateFormatter alloc] init]; 
+            [dateFormatter setDateFormat:@"yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"]; 
+        }
+        NSDate *date = [dateFormatter dateFromString:obj]; 
+        return date; 
+    }
+
     // check for object or array of properties
     if (prop.type == RLMPropertyTypeObject) {
         // for object create and try to initialize with obj

--- a/RealmSwift-swift2.2/Tests/ObjectCreationTests.swift
+++ b/RealmSwift-swift2.2/Tests/ObjectCreationTests.swift
@@ -162,8 +162,8 @@ class ObjectCreationTests: TestCase {
         let dateValue2 = [ "dateCol": theDate ]
         let dateValue3 = [ "dateCol": "1971-02-03" ]
 
-        XCTAssertEqual(SwiftObject(value:dateValue1).dateCol,theDate)
-        XCTAssertEqual(SwiftObject(value:dateValue2).dateCol,theDate)
+        XCTAssertEqual(SwiftObject(value:dateValue1).dateCol, theDate)
+        XCTAssertEqual(SwiftObject(value:dateValue2).dateCol, theDate)
         assertThrows(SwiftObject(value:dateValue3), "Date field should throw exception")
 
     }

--- a/RealmSwift-swift2.2/Tests/ObjectCreationTests.swift
+++ b/RealmSwift-swift2.2/Tests/ObjectCreationTests.swift
@@ -104,6 +104,7 @@ class ObjectCreationTests: TestCase {
     }
 
     func testInitWithArray() {
+
         // array with all values specified
         let baselineValues = [true, 1, 1.1, 11.1, "b", "b".dataUsingEncoding(NSUTF8StringEncoding)! as NSData,
             NSDate(timeIntervalSince1970: 2) as NSDate, ["boolCol": true], [[true], [false]]] as [AnyObject]
@@ -150,6 +151,23 @@ class ObjectCreationTests: TestCase {
         XCTAssertEqual(obj1.boolCol, obj2.boolCol,
             "object created via generic initializer should equal object created by calling initializer directly")
     }
+
+    func testInitWithStringDateDictionary() {
+
+        var formatter = NSDateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"
+        let theDate = NSDate(timeIntervalSince1970: 2) as NSDate
+
+        let dateValue1 = [ "dateCol": formatter.stringFromDate(theDate) ]
+        let dateValue2 = [ "dateCol": theDate ]
+        let dateValue3 = [ "dateCol": "1971-02-03" ]
+
+        XCTAssertEqual(SwiftObject(value:dateValue1).dateCol,theDate)
+        XCTAssertEqual(SwiftObject(value:dateValue2).dateCol,theDate)
+        assertThrows(SwiftObject(value:dateValue3), "Date field should throw exception")
+
+    }
+
 
     // MARK: Creation tests
 


### PR DESCRIPTION
Support loading of JSON using Realm.IO in the Javascript Date Time Format as per Javascript JSON convention aligning to ISO8601. e.g. Only "2014-01-01T23:28:56.782Z". At a minimum, this format should be supported as the acceptable standard.