### PR TITLE
Fix empty strings and null on the right side of BEGINSWITH, ENDSWITH and CONTAINS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@ x.x.x Release notes (yyyy-MM-dd)
 
 ### API breaking changes
 
-* None.
+* Fix empty strings and null on the right side of `BEGINSWITH`, `ENDSWITH` and `CONTAINS`
+  operators in predicates to match Foundation's semantics of never matching any strings.
 
 ### Enhancements
 

--- a/Realm/RLMQueryUtil.mm
+++ b/Realm/RLMQueryUtil.mm
@@ -402,10 +402,8 @@ void add_bool_constraint_to_query(realm::Query &query, NSPredicateOperatorType o
 }
 
 
-struct SkipCheckForEmptyAndNullStrings {};
-
 template <typename T>
-void add_substring_constraint_to_query(SkipCheckForEmptyAndNullStrings, Query& query, NSPredicateOperatorType operatorType, bool caseSensitive, Columns<String> column, T value)
+void add_substring_constraint_without_empty_string_checks_to_query(Query& query, NSPredicateOperatorType operatorType, bool caseSensitive, Columns<String> column, T value)
 {
     switch (operatorType) {
         case NSBeginsWithPredicateOperatorType:
@@ -431,7 +429,7 @@ void add_substring_constraint_to_query(Query& query, NSPredicateOperatorType ope
         return;
     }
 
-    add_substring_constraint_to_query(SkipCheckForEmptyAndNullStrings{}, query, operatorType, caseSensitive, std::move(column), value);
+    add_substring_constraint_without_empty_string_checks_to_query(query, operatorType, caseSensitive, std::move(column), value);
 }
 
 void add_substring_constraint_to_query(Query& query, NSPredicateOperatorType operatorType, bool caseSensitive, Columns<String> column1, Columns<String> column2)
@@ -441,7 +439,7 @@ void add_substring_constraint_to_query(Query& query, NSPredicateOperatorType ope
     // and producing multiple values per row as such expressions will have been rejected.
     query.group();
     query.and_query(column2 != null() && column2 != "");
-    add_substring_constraint_to_query(SkipCheckForEmptyAndNullStrings{}, query, operatorType, caseSensitive, std::move(column1), std::move(column2));
+    add_substring_constraint_without_empty_string_checks_to_query(query, operatorType, caseSensitive, std::move(column1), std::move(column2));
     query.end_group();
 }
 

--- a/Realm/RLMQueryUtil.mm
+++ b/Realm/RLMQueryUtil.mm
@@ -401,17 +401,12 @@ void add_bool_constraint_to_query(realm::Query &query, NSPredicateOperatorType o
     }
 }
 
-template <typename T>
-void add_string_constraint_to_query(realm::Query &query,
-                                    NSPredicateOperatorType operatorType,
-                                    NSComparisonPredicateOptions predicateOptions,
-                                    Columns<String> &&column,
-                                    T value) {
-    bool caseSensitive = !(predicateOptions & NSCaseInsensitivePredicateOption);
-    bool diacriticInsensitive = (predicateOptions & NSDiacriticInsensitivePredicateOption);
-    RLMPrecondition(!diacriticInsensitive, @"Invalid predicate option",
-                    @"NSDiacriticInsensitivePredicateOption not supported for string type");
 
+struct SkipCheckForEmptyAndNullStrings {};
+
+template <typename T>
+void add_substring_constraint_to_query(SkipCheckForEmptyAndNullStrings, Query& query, NSPredicateOperatorType operatorType, bool caseSensitive, Columns<String> column, T value)
+{
     switch (operatorType) {
         case NSBeginsWithPredicateOperatorType:
             query.and_query(column.begins_with(value, caseSensitive));
@@ -422,12 +417,59 @@ void add_string_constraint_to_query(realm::Query &query,
         case NSContainsPredicateOperatorType:
             query.and_query(column.contains(value, caseSensitive));
             break;
+        default:
+            // It is our caller's responsibility to ensure this is not reached.
+            REALM_ASSERT(false);
+    }
+}
+
+void add_substring_constraint_to_query(Query& query, NSPredicateOperatorType operatorType, bool caseSensitive, Columns<String> column, StringData value)
+{
+    if (!value.size()) {
+        // Foundation always returns false for substring operations with a RHS of null or "".
+        query.and_query(std::unique_ptr<Expression>(new FalseExpression));
+        return;
+    }
+
+    add_substring_constraint_to_query(SkipCheckForEmptyAndNullStrings{}, query, operatorType, caseSensitive, std::move(column), value);
+}
+
+void add_substring_constraint_to_query(Query& query, NSPredicateOperatorType operatorType, bool caseSensitive, Columns<String> column1, Columns<String> column2)
+{
+    // Foundation always returns false for substring operations with a RHS of null or "".
+    // We don't need to concern ourselves with the possiblity of column2 traversing a link list
+    // and producing multiple values per row as such expressions will have been rejected.
+    query.group();
+    query.and_query(column2 != null() && column2 != "");
+    add_substring_constraint_to_query(SkipCheckForEmptyAndNullStrings{}, query, operatorType, caseSensitive, std::move(column1), std::move(column2));
+    query.end_group();
+}
+
+template <typename T>
+void add_string_constraint_to_query(realm::Query &query,
+                                    NSPredicateOperatorType operatorType,
+                                    NSComparisonPredicateOptions predicateOptions,
+                                    Columns<String> column,
+                                    T&& value) {
+    bool caseSensitive = !(predicateOptions & NSCaseInsensitivePredicateOption);
+    bool diacriticInsensitive = (predicateOptions & NSDiacriticInsensitivePredicateOption);
+    RLMPrecondition(!diacriticInsensitive, @"Invalid predicate option",
+                    @"NSDiacriticInsensitivePredicateOption not supported for string type");
+
+    switch (operatorType) {
         case NSEqualToPredicateOperatorType:
             query.and_query(column.equal(value, caseSensitive));
             break;
         case NSNotEqualToPredicateOperatorType:
             query.and_query(column.not_equal(value, caseSensitive));
             break;
+
+        case NSBeginsWithPredicateOperatorType:
+        case NSEndsWithPredicateOperatorType:
+        case NSContainsPredicateOperatorType:
+            add_substring_constraint_to_query(query, operatorType, caseSensitive, std::move(column), std::forward<T>(value));
+            break;
+
         default:
             @throw RLMPredicateException(@"Invalid operator type",
                                          @"Operator '%@' not supported for string type", operatorName(operatorType));

--- a/Realm/Tests/QueryTests.m
+++ b/Realm/Tests/QueryTests.m
@@ -856,14 +856,18 @@
     RLMAssertCount(StringObject, 0U, @"stringCol ENDSWITH 'bbc'");
     RLMAssertCount(StringObject, 0U, @"stringCol ENDSWITH 'a'");
     RLMAssertCount(StringObject, 0U, @"stringCol ENDSWITH 'C'");
+    RLMAssertCount(StringObject, 0U, @"stringCol ENDSWITH ''");
     RLMAssertCount(StringObject, 1U, @"stringCol ENDSWITH[c] 'c'");
     RLMAssertCount(StringObject, 1U, @"stringCol ENDSWITH[c] 'C'");
+    RLMAssertCount(StringObject, 0U, @"stringCol ENDSWITH[c] ''");
 
     RLMAssertCount(AllTypesObject, 1U, @"objectCol.stringCol ENDSWITH 'c'");
     RLMAssertCount(AllTypesObject, 0U, @"objectCol.stringCol ENDSWITH 'a'");
     RLMAssertCount(AllTypesObject, 0U, @"objectCol.stringCol ENDSWITH 'C'");
+    RLMAssertCount(AllTypesObject, 0U, @"objectCol.stringCol ENDSWITH ''");
     RLMAssertCount(AllTypesObject, 1U, @"objectCol.stringCol ENDSWITH[c] 'c'");
     RLMAssertCount(AllTypesObject, 1U, @"objectCol.stringCol ENDSWITH[c] 'C'");
+    RLMAssertCount(AllTypesObject, 0U, @"objectCol.stringCol ENDSWITH[c] ''");
 }
 
 - (void)testStringContains
@@ -888,16 +892,20 @@
     RLMAssertCount(StringObject, 0U, @"stringCol CONTAINS 'd'");
     RLMAssertCount(StringObject, 0U, @"stringCol CONTAINS 'aabc'");
     RLMAssertCount(StringObject, 0U, @"stringCol CONTAINS 'bbc'");
+    RLMAssertCount(StringObject, 0U, @"stringCol CONTAINS ''");
 
     RLMAssertCount(StringObject, 0U, @"stringCol CONTAINS 'C'");
     RLMAssertCount(StringObject, 1U, @"stringCol CONTAINS[c] 'c'");
     RLMAssertCount(StringObject, 1U, @"stringCol CONTAINS[c] 'C'");
+    RLMAssertCount(StringObject, 0U, @"stringCol CONTAINS[c] ''");
 
     RLMAssertCount(AllTypesObject, 0U, @"objectCol.stringCol CONTAINS 'd'");
     RLMAssertCount(AllTypesObject, 1U, @"objectCol.stringCol CONTAINS 'c'");
     RLMAssertCount(AllTypesObject, 0U, @"objectCol.stringCol CONTAINS 'C'");
+    RLMAssertCount(AllTypesObject, 0U, @"objectCol.stringCol CONTAINS ''");
     RLMAssertCount(AllTypesObject, 1U, @"objectCol.stringCol CONTAINS[c] 'c'");
     RLMAssertCount(AllTypesObject, 1U, @"objectCol.stringCol CONTAINS[c] 'C'");
+    RLMAssertCount(AllTypesObject, 0U, @"objectCol.stringCol CONTAINS[c] ''");
 }
 
 - (void)testStringEquality
@@ -2125,15 +2133,15 @@
         XCTAssertEqual(2U, nilStrings.count);
         XCTAssertEqual(2U, nonNilStrings.count);
 
-        XCTAssertEqualObjects([nonNilStrings valueForKey:@"stringCol"], [[stringObjectClass objectsInRealm:realm where:@"stringCol CONTAINS ''"] valueForKey:@"stringCol"]);
-        XCTAssertEqualObjects([nonNilStrings valueForKey:@"stringCol"], [[stringObjectClass objectsInRealm:realm where:@"stringCol BEGINSWITH ''"] valueForKey:@"stringCol"]);
-        XCTAssertEqualObjects([nonNilStrings valueForKey:@"stringCol"], [[stringObjectClass objectsInRealm:realm where:@"stringCol ENDSWITH ''"] valueForKey:@"stringCol"]);
-        XCTAssertEqualObjects([nonNilStrings valueForKey:@"stringCol"], [[stringObjectClass objectsInRealm:realm where:@"stringCol CONTAINS[c] ''"] valueForKey:@"stringCol"]);
-        XCTAssertEqualObjects([nonNilStrings valueForKey:@"stringCol"], [[stringObjectClass objectsInRealm:realm where:@"stringCol BEGINSWITH[c] ''"] valueForKey:@"stringCol"]);
-        XCTAssertEqualObjects([nonNilStrings valueForKey:@"stringCol"], [[stringObjectClass objectsInRealm:realm where:@"stringCol ENDSWITH[c] ''"] valueForKey:@"stringCol"]);
+        XCTAssertEqualObjects(@[], [[stringObjectClass objectsInRealm:realm where:@"stringCol CONTAINS ''"] valueForKey:@"stringCol"]);
+        XCTAssertEqualObjects(@[], [[stringObjectClass objectsInRealm:realm where:@"stringCol BEGINSWITH ''"] valueForKey:@"stringCol"]);
+        XCTAssertEqualObjects(@[], [[stringObjectClass objectsInRealm:realm where:@"stringCol ENDSWITH ''"] valueForKey:@"stringCol"]);
+        XCTAssertEqualObjects(@[], [[stringObjectClass objectsInRealm:realm where:@"stringCol CONTAINS[c] ''"] valueForKey:@"stringCol"]);
+        XCTAssertEqualObjects(@[], [[stringObjectClass objectsInRealm:realm where:@"stringCol BEGINSWITH[c] ''"] valueForKey:@"stringCol"]);
+        XCTAssertEqualObjects(@[], [[stringObjectClass objectsInRealm:realm where:@"stringCol ENDSWITH[c] ''"] valueForKey:@"stringCol"]);
 
         XCTAssertEqualObjects(@[], ([[stringObjectClass objectsInRealm:realm where:@"stringCol CONTAINS %@", @"\0"] valueForKey:@"self"]));
-        XCTAssertEqualObjects([[stringObjectClass allObjectsInRealm:realm] valueForKey:@"stringCol"], ([[StringObject objectsInRealm:realm where:@"stringCol CONTAINS NULL"] valueForKey:@"stringCol"]));
+        XCTAssertEqualObjects(@[], ([[StringObject objectsInRealm:realm where:@"stringCol CONTAINS NULL"] valueForKey:@"stringCol"]));
     };
     testWithStringClass([StringObject class]);
     testWithStringClass([IndexedStringObject class]);
@@ -2304,9 +2312,9 @@ struct NullTestData {
             RLMAssertOperator(>=, 1U, 0U, 0U);
         }
         if (d.substringOperations) {
-            RLMAssertOperator(BEGINSWITH, 1U, 0U, 1U);
-            RLMAssertOperator(ENDSWITH, 1U, 0U, 1U);
-            RLMAssertOperator(CONTAINS, 1U, 0U, 1U);
+            RLMAssertOperator(BEGINSWITH, 0U, 0U, 0U);
+            RLMAssertOperator(ENDSWITH, 0U, 0U, 0U);
+            RLMAssertOperator(CONTAINS, 0U, 0U, 0U);
         }
     }
 
@@ -2332,9 +2340,9 @@ struct NullTestData {
             RLMAssertOperator(>=, 0U, 0U, 1U);
         }
         if (d.substringOperations) {
-            RLMAssertOperator(BEGINSWITH, 0U, 0U, 1U);
-            RLMAssertOperator(ENDSWITH, 0U, 0U, 1U);
-            RLMAssertOperator(CONTAINS, 0U, 0U, 1U);
+            RLMAssertOperator(BEGINSWITH, 0U, 0U, 0U);
+            RLMAssertOperator(ENDSWITH, 0U, 0U, 0U);
+            RLMAssertOperator(CONTAINS, 0U, 0U, 0U);
         }
     }
 }

--- a/Realm/Tests/QueryTests.m
+++ b/Realm/Tests/QueryTests.m
@@ -822,14 +822,18 @@
     RLMAssertCount(StringObject, 0U, @"stringCol BEGINSWITH 'abd'");
     RLMAssertCount(StringObject, 0U, @"stringCol BEGINSWITH 'c'");
     RLMAssertCount(StringObject, 0U, @"stringCol BEGINSWITH 'A'");
+    RLMAssertCount(StringObject, 0U, @"stringCol BEGINSWITH ''");
     RLMAssertCount(StringObject, 1U, @"stringCol BEGINSWITH[c] 'a'");
     RLMAssertCount(StringObject, 1U, @"stringCol BEGINSWITH[c] 'A'");
+    RLMAssertCount(StringObject, 0U, @"stringCol BEGINSWITH[c] ''");
 
     RLMAssertCount(AllTypesObject, 1U, @"objectCol.stringCol BEGINSWITH 'a'");
     RLMAssertCount(AllTypesObject, 0U, @"objectCol.stringCol BEGINSWITH 'c'");
     RLMAssertCount(AllTypesObject, 0U, @"objectCol.stringCol BEGINSWITH 'A'");
+    RLMAssertCount(AllTypesObject, 0U, @"objectCol.stringCol BEGINSWITH ''");
     RLMAssertCount(AllTypesObject, 1U, @"objectCol.stringCol BEGINSWITH[c] 'a'");
     RLMAssertCount(AllTypesObject, 1U, @"objectCol.stringCol BEGINSWITH[c] 'A'");
+    RLMAssertCount(AllTypesObject, 0U, @"objectCol.stringCol BEGINSWITH[c] ''");
 }
 
 - (void)testStringEndsWith

--- a/Realm/Tests/QueryTests.m
+++ b/Realm/Tests/QueryTests.m
@@ -1972,6 +1972,106 @@
     XCTAssertEqualObjects(asArray(r13), (@[ hannah, elijah, mark, jason, diane, carol, mackenzie ]));
 }
 
+- (void)testCountOnCollection {
+    RLMRealm *realm = [RLMRealm defaultRealm];
+    [realm beginWriteTransaction];
+
+    IntegerArrayPropertyObject *arr = [IntegerArrayPropertyObject createInRealm:realm withValue:@[ @1, @[]]];
+    [arr.array addObject:[IntObject createInRealm:realm withValue:@[ @456 ]]];
+
+    arr = [IntegerArrayPropertyObject createInRealm:realm withValue:@[ @2, @[]]];
+    [arr.array addObject:[IntObject createInRealm:realm withValue:@[ @1 ]]];
+    [arr.array addObject:[IntObject createInRealm:realm withValue:@[ @2 ]]];
+    [arr.array addObject:[IntObject createInRealm:realm withValue:@[ @3 ]]];
+
+    arr = [IntegerArrayPropertyObject createInRealm:realm withValue:@[ @0, @[]]];
+
+    [realm commitWriteTransaction];
+
+    RLMAssertCount(IntegerArrayPropertyObject, 2U, @"array.@count > 0");
+    RLMAssertCount(IntegerArrayPropertyObject, 1U, @"array.@count == 3");
+    RLMAssertCount(IntegerArrayPropertyObject, 1U, @"array.@count < 1");
+    RLMAssertCount(IntegerArrayPropertyObject, 2U, @"0 < array.@count");
+    RLMAssertCount(IntegerArrayPropertyObject, 1U, @"3 == array.@count");
+    RLMAssertCount(IntegerArrayPropertyObject, 1U, @"1 >  array.@count");
+
+    RLMAssertCount(IntegerArrayPropertyObject, 2U, @"array.@count == number");
+    RLMAssertCount(IntegerArrayPropertyObject, 1U, @"array.@count > number");
+    RLMAssertCount(IntegerArrayPropertyObject, 1U, @"number < array.@count");
+
+    // We do not yet handle collection operations on both sides of the comparison.
+    RLMAssertThrowsWithReasonMatching(([IntegerArrayPropertyObject objectsWhere:@"array.@count == array.@count"]),
+                                      @"aggregate operations cannot be compared with other aggregate operations");
+
+    RLMAssertThrowsWithReasonMatching(([IntegerArrayPropertyObject objectsWhere:@"array.@count.foo.bar != 0"]),
+                                      @"single level key");
+    RLMAssertThrowsWithReasonMatching(([IntegerArrayPropertyObject objectsWhere:@"array.@count.intCol > 0"]),
+                                      @"@count does not have any properties");
+    RLMAssertThrowsWithReasonMatching(([IntegerArrayPropertyObject objectsWhere:@"array.@count != 'Hello'"]),
+                                      @"@count can only be compared with a numeric value");
+}
+
+- (void)testAggregateCollectionOperators {
+    RLMRealm *realm = [RLMRealm defaultRealm];
+    [realm beginWriteTransaction];
+
+    IntegerArrayPropertyObject *arr = [IntegerArrayPropertyObject createInRealm:realm withValue:@[ @1111, @[] ]];
+    [arr.array addObject:[IntObject createInRealm:realm withValue:@[ @1234 ]]];
+    [arr.array addObject:[IntObject createInRealm:realm withValue:@[ @2 ]]];
+    [arr.array addObject:[IntObject createInRealm:realm withValue:@[ @-12345 ]]];
+
+    arr = [IntegerArrayPropertyObject createInRealm:realm withValue:@[ @2222, @[] ]];
+    [arr.array addObject:[IntObject createInRealm:realm withValue:@[ @100 ]]];
+
+    arr = [IntegerArrayPropertyObject createInRealm:realm withValue:@[ @3333, @[] ]];
+
+    [realm commitWriteTransaction];
+
+    RLMAssertCount(IntegerArrayPropertyObject, 1U, @"array.@min.intCol == -12345");
+    RLMAssertCount(IntegerArrayPropertyObject, 1U, @"array.@min.intCol == 100");
+    RLMAssertCount(IntegerArrayPropertyObject, 2U, @"array.@min.intCol < 1000");
+    RLMAssertCount(IntegerArrayPropertyObject, 1U, @"array.@min.intCol > -1000");
+
+    RLMAssertCount(IntegerArrayPropertyObject, 1U, @"array.@max.intCol == 1234");
+    RLMAssertCount(IntegerArrayPropertyObject, 1U, @"array.@max.intCol == 100");
+    RLMAssertCount(IntegerArrayPropertyObject, 2U, @"array.@max.intCol > -1000");
+    RLMAssertCount(IntegerArrayPropertyObject, 1U, @"array.@max.intCol > 1000");
+
+    RLMAssertCount(IntegerArrayPropertyObject, 1U, @"array.@sum.intCol == 100");
+    RLMAssertCount(IntegerArrayPropertyObject, 1U, @"array.@sum.intCol == -11109");
+    RLMAssertCount(IntegerArrayPropertyObject, 1U, @"array.@sum.intCol == 0");
+    RLMAssertCount(IntegerArrayPropertyObject, 2U, @"array.@sum.intCol > -50");
+    RLMAssertCount(IntegerArrayPropertyObject, 2U, @"array.@sum.intCol < 50");
+
+    RLMAssertCount(IntegerArrayPropertyObject, 1U, @"array.@avg.intCol == 100");
+    RLMAssertCount(IntegerArrayPropertyObject, 1U, @"array.@avg.intCol == -3703.0");
+    RLMAssertCount(IntegerArrayPropertyObject, 0U, @"array.@avg.intCol == 0");
+    RLMAssertCount(IntegerArrayPropertyObject, 1U, @"array.@avg.intCol < -50");
+    RLMAssertCount(IntegerArrayPropertyObject, 1U, @"array.@avg.intCol > 50");
+
+    RLMAssertCount(IntegerArrayPropertyObject, 2U, @"array.@min.intCol < number");
+    RLMAssertCount(IntegerArrayPropertyObject, 2U, @"number > array.@min.intCol");
+
+    RLMAssertCount(IntegerArrayPropertyObject, 1U, @"array.@max.intCol < number");
+    RLMAssertCount(IntegerArrayPropertyObject, 1U, @"number > array.@max.intCol");
+
+    RLMAssertCount(IntegerArrayPropertyObject, 2U, @"array.@avg.intCol < number");
+    RLMAssertCount(IntegerArrayPropertyObject, 2U, @"number > array.@avg.intCol");
+
+    // We do not yet handle collection operations on both sides of the comparison.
+    RLMAssertThrowsWithReasonMatching(([IntegerArrayPropertyObject objectsWhere:@"array.@min.intCol == array.@min.intCol"]), @"aggregate operations cannot be compared with other aggregate operations");
+
+    RLMAssertThrowsWithReasonMatching(([IntegerArrayPropertyObject objectsWhere:@"array.@min.intCol.foo.bar == 1.23"]), @"single level key");
+    RLMAssertThrowsWithReasonMatching(([IntegerArrayPropertyObject objectsWhere:@"array.@max.intCol.foo.bar == 1.23"]), @"single level key");
+    RLMAssertThrowsWithReasonMatching(([IntegerArrayPropertyObject objectsWhere:@"array.@sum.intCol.foo.bar == 1.23"]), @"single level key");
+    RLMAssertThrowsWithReasonMatching(([IntegerArrayPropertyObject objectsWhere:@"array.@avg.intCol.foo.bar == 1.23"]), @"single level key");
+
+    // Average is omitted from this test as its result is always a double.
+    RLMAssertThrowsWithReasonMatching(([IntegerArrayPropertyObject objectsWhere:@"array.@min.intCol == 1.23"]), @"@min.*type int cannot be compared");
+    RLMAssertThrowsWithReasonMatching(([IntegerArrayPropertyObject objectsWhere:@"array.@max.intCol == 1.23"]), @"@max.*type int cannot be compared");
+    RLMAssertThrowsWithReasonMatching(([IntegerArrayPropertyObject objectsWhere:@"array.@sum.intCol == 1.23"]), @"@sum.*type int cannot be compared");
+}
+
 @end
 
 @interface NullQueryTests : QueryTests
@@ -2119,106 +2219,6 @@
     }
 
     [realm cancelWriteTransaction];
-}
-
-- (void)testCountOnCollection {
-    RLMRealm *realm = [RLMRealm defaultRealm];
-    [realm beginWriteTransaction];
-
-    IntegerArrayPropertyObject *arr = [IntegerArrayPropertyObject createInRealm:realm withValue:@[ @1, @[]]];
-    [arr.array addObject:[IntObject createInRealm:realm withValue:@[ @456 ]]];
-
-    arr = [IntegerArrayPropertyObject createInRealm:realm withValue:@[ @2, @[]]];
-    [arr.array addObject:[IntObject createInRealm:realm withValue:@[ @1 ]]];
-    [arr.array addObject:[IntObject createInRealm:realm withValue:@[ @2 ]]];
-    [arr.array addObject:[IntObject createInRealm:realm withValue:@[ @3 ]]];
-
-    arr = [IntegerArrayPropertyObject createInRealm:realm withValue:@[ @0, @[]]];
-
-    [realm commitWriteTransaction];
-
-    RLMAssertCount(IntegerArrayPropertyObject, 2U, @"array.@count > 0");
-    RLMAssertCount(IntegerArrayPropertyObject, 1U, @"array.@count == 3");
-    RLMAssertCount(IntegerArrayPropertyObject, 1U, @"array.@count < 1");
-    RLMAssertCount(IntegerArrayPropertyObject, 2U, @"0 < array.@count");
-    RLMAssertCount(IntegerArrayPropertyObject, 1U, @"3 == array.@count");
-    RLMAssertCount(IntegerArrayPropertyObject, 1U, @"1 >  array.@count");
-
-    RLMAssertCount(IntegerArrayPropertyObject, 2U, @"array.@count == number");
-    RLMAssertCount(IntegerArrayPropertyObject, 1U, @"array.@count > number");
-    RLMAssertCount(IntegerArrayPropertyObject, 1U, @"number < array.@count");
-
-    // We do not yet handle collection operations on both sides of the comparison.
-    RLMAssertThrowsWithReasonMatching(([IntegerArrayPropertyObject objectsWhere:@"array.@count == array.@count"]),
-                                      @"aggregate operations cannot be compared with other aggregate operations");
-
-    RLMAssertThrowsWithReasonMatching(([IntegerArrayPropertyObject objectsWhere:@"array.@count.foo.bar != 0"]),
-                                      @"single level key");
-    RLMAssertThrowsWithReasonMatching(([IntegerArrayPropertyObject objectsWhere:@"array.@count.intCol > 0"]),
-                                      @"@count does not have any properties");
-    RLMAssertThrowsWithReasonMatching(([IntegerArrayPropertyObject objectsWhere:@"array.@count != 'Hello'"]),
-                                      @"@count can only be compared with a numeric value");
-}
-
-- (void)testAggregateCollectionOperators {
-    RLMRealm *realm = [RLMRealm defaultRealm];
-    [realm beginWriteTransaction];
-
-    IntegerArrayPropertyObject *arr = [IntegerArrayPropertyObject createInRealm:realm withValue:@[ @1111, @[] ]];
-    [arr.array addObject:[IntObject createInRealm:realm withValue:@[ @1234 ]]];
-    [arr.array addObject:[IntObject createInRealm:realm withValue:@[ @2 ]]];
-    [arr.array addObject:[IntObject createInRealm:realm withValue:@[ @-12345 ]]];
-
-    arr = [IntegerArrayPropertyObject createInRealm:realm withValue:@[ @2222, @[] ]];
-    [arr.array addObject:[IntObject createInRealm:realm withValue:@[ @100 ]]];
-
-    arr = [IntegerArrayPropertyObject createInRealm:realm withValue:@[ @3333, @[] ]];
-
-    [realm commitWriteTransaction];
-
-    RLMAssertCount(IntegerArrayPropertyObject, 1U, @"array.@min.intCol == -12345");
-    RLMAssertCount(IntegerArrayPropertyObject, 1U, @"array.@min.intCol == 100");
-    RLMAssertCount(IntegerArrayPropertyObject, 2U, @"array.@min.intCol < 1000");
-    RLMAssertCount(IntegerArrayPropertyObject, 1U, @"array.@min.intCol > -1000");
-
-    RLMAssertCount(IntegerArrayPropertyObject, 1U, @"array.@max.intCol == 1234");
-    RLMAssertCount(IntegerArrayPropertyObject, 1U, @"array.@max.intCol == 100");
-    RLMAssertCount(IntegerArrayPropertyObject, 2U, @"array.@max.intCol > -1000");
-    RLMAssertCount(IntegerArrayPropertyObject, 1U, @"array.@max.intCol > 1000");
-
-    RLMAssertCount(IntegerArrayPropertyObject, 1U, @"array.@sum.intCol == 100");
-    RLMAssertCount(IntegerArrayPropertyObject, 1U, @"array.@sum.intCol == -11109");
-    RLMAssertCount(IntegerArrayPropertyObject, 1U, @"array.@sum.intCol == 0");
-    RLMAssertCount(IntegerArrayPropertyObject, 2U, @"array.@sum.intCol > -50");
-    RLMAssertCount(IntegerArrayPropertyObject, 2U, @"array.@sum.intCol < 50");
-
-    RLMAssertCount(IntegerArrayPropertyObject, 1U, @"array.@avg.intCol == 100");
-    RLMAssertCount(IntegerArrayPropertyObject, 1U, @"array.@avg.intCol == -3703.0");
-    RLMAssertCount(IntegerArrayPropertyObject, 0U, @"array.@avg.intCol == 0");
-    RLMAssertCount(IntegerArrayPropertyObject, 1U, @"array.@avg.intCol < -50");
-    RLMAssertCount(IntegerArrayPropertyObject, 1U, @"array.@avg.intCol > 50");
-
-    RLMAssertCount(IntegerArrayPropertyObject, 2U, @"array.@min.intCol < number");
-    RLMAssertCount(IntegerArrayPropertyObject, 2U, @"number > array.@min.intCol");
-
-    RLMAssertCount(IntegerArrayPropertyObject, 1U, @"array.@max.intCol < number");
-    RLMAssertCount(IntegerArrayPropertyObject, 1U, @"number > array.@max.intCol");
-
-    RLMAssertCount(IntegerArrayPropertyObject, 2U, @"array.@avg.intCol < number");
-    RLMAssertCount(IntegerArrayPropertyObject, 2U, @"number > array.@avg.intCol");
-
-    // We do not yet handle collection operations on both sides of the comparison.
-    RLMAssertThrowsWithReasonMatching(([IntegerArrayPropertyObject objectsWhere:@"array.@min.intCol == array.@min.intCol"]), @"aggregate operations cannot be compared with other aggregate operations");
-
-    RLMAssertThrowsWithReasonMatching(([IntegerArrayPropertyObject objectsWhere:@"array.@min.intCol.foo.bar == 1.23"]), @"single level key");
-    RLMAssertThrowsWithReasonMatching(([IntegerArrayPropertyObject objectsWhere:@"array.@max.intCol.foo.bar == 1.23"]), @"single level key");
-    RLMAssertThrowsWithReasonMatching(([IntegerArrayPropertyObject objectsWhere:@"array.@sum.intCol.foo.bar == 1.23"]), @"single level key");
-    RLMAssertThrowsWithReasonMatching(([IntegerArrayPropertyObject objectsWhere:@"array.@avg.intCol.foo.bar == 1.23"]), @"single level key");
-
-    // Average is omitted from this test as its result is always a double.
-    RLMAssertThrowsWithReasonMatching(([IntegerArrayPropertyObject objectsWhere:@"array.@min.intCol == 1.23"]), @"@min.*type int cannot be compared");
-    RLMAssertThrowsWithReasonMatching(([IntegerArrayPropertyObject objectsWhere:@"array.@max.intCol == 1.23"]), @"@max.*type int cannot be compared");
-    RLMAssertThrowsWithReasonMatching(([IntegerArrayPropertyObject objectsWhere:@"array.@sum.intCol == 1.23"]), @"@sum.*type int cannot be compared");
 }
 
 struct NullTestData {


### PR DESCRIPTION
Foundation never matches an empty or null string with `BEGINSWITH`, `ENDSWITH` and `CONTAINS`. Core's query engine treats them as always matching since they're logically a match at any character position within the string. To emulate Foundation's semantics we generate additional criteria on the core query.

/cc @kishikawakatsumi @tgoyne @jpsim @austinzheng 
