### PR TITLE
remove podspec target checks

### DIFF
--- a/Realm.podspec
+++ b/Realm.podspec
@@ -68,15 +68,11 @@ Pod::Spec.new do |s|
   s.osx.deployment_target   = '10.9'
   s.osx.vendored_library    = 'core/librealm-macosx.a'
 
-  if s.respond_to?(:watchos)
-    s.watchos.deployment_target = '2.0'
-    s.watchos.vendored_library  = 'core/librealm-watchos.a'
-  end
+  s.watchos.deployment_target = '2.0'
+  s.watchos.vendored_library  = 'core/librealm-watchos.a'
 
-  if s.respond_to?(:tvos)
-    s.tvos.deployment_target = '9.0'
-    s.tvos.vendored_library  = 'core/librealm-tvos.a'
-  end
+  s.tvos.deployment_target = '9.0'
+  s.tvos.vendored_library  = 'core/librealm-tvos.a'
 
   s.subspec 'Headers' do |s|
     s.source_files          = public_header_files

--- a/RealmSwift.podspec
+++ b/RealmSwift.podspec
@@ -26,6 +26,6 @@ Pod::Spec.new do |s|
 
   s.ios.deployment_target     = '8.0'
   s.osx.deployment_target     = '10.9'
-  s.watchos.deployment_target = '2.0' if s.respond_to?(:watchos)
-  s.tvos.deployment_target    = '9.0' if s.respond_to?(:tvos)
+  s.watchos.deployment_target = '2.0'
+  s.tvos.deployment_target    = '9.0'
 end


### PR DESCRIPTION
since CocoaPods 0.39.0 is the minimum CocoaPods version required, these are guaranteed to be present.

watchos was added in 0.38.0 and tvos was added in 0.39.0

/cc @mrackwitz 