### PR TITLE
Update to core 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,9 @@ x.x.x Release notes (yyyy-MM-dd)
 
 ### Bugfixes
 
-* None.
+* Fix a bug that sometimes resulted in a single object's NSData properties
+  changing from `nil` to a zero-length non-`nil` NSData when a different object
+  of the same type was deleted.
 
 0.103.0 Release notes (2016-05-18)
 =============================================================

--- a/Realm.xcodeproj/project.pbxproj
+++ b/Realm.xcodeproj/project.pbxproj
@@ -1270,7 +1270,7 @@
 			buildConfigurationList = 5D659ED61BE04556006515A0 /* Build configuration list for PBXNativeTarget "Realm" */;
 			buildPhases = (
 				5D659E7E1BE04556006515A0 /* Get Version Number */,
-				5D659E7F1BE04556006515A0 /* Download Core & Set Bitcode Symlink */,
+				5D659E7F1BE04556006515A0 /* Download Core */,
 				5D659E801BE04556006515A0 /* Sources */,
 				5D659E9F1BE04556006515A0 /* Headers */,
 				5D659ECE1BE04556006515A0 /* Resources */,
@@ -1331,7 +1331,7 @@
 			buildConfigurationList = 5DD755CC1BE056DE002800DA /* Build configuration list for PBXNativeTarget "Realm iOS static" */;
 			buildPhases = (
 				5DD7557C1BE056DE002800DA /* Get Version Number */,
-				5DD7557D1BE056DE002800DA /* Download Core & Set Bitcode Symlink */,
+				5DD7557D1BE056DE002800DA /* Download Core */,
 				5DD7557E1BE056DE002800DA /* Sources */,
 				5DD7559D1BE056DE002800DA /* Headers */,
 				5D6156F91BE083C600A4BD3F /* Generate RLMPlatform.h */,
@@ -1621,19 +1621,19 @@
 			shellPath = /bin/sh;
 			shellScript = "exec \"${SRCROOT}/scripts/generate-rlmversion.sh\"\n";
 		};
-		5D659E7F1BE04556006515A0 /* Download Core & Set Bitcode Symlink */ = {
+		5D659E7F1BE04556006515A0 /* Download Core */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Download Core & Set Bitcode Symlink";
+			name = "Download Core";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "sh build.sh download-core\nsh build.sh set-core-bitcode-symlink";
+			shellScript = "sh build.sh download-core";
 		};
 		5DD7557C1BE056DE002800DA /* Get Version Number */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -1651,19 +1651,19 @@
 			shellPath = /bin/sh;
 			shellScript = "exec \"${SRCROOT}/scripts/generate-rlmversion.sh\"\n";
 		};
-		5DD7557D1BE056DE002800DA /* Download Core & Set Bitcode Symlink */ = {
+		5DD7557D1BE056DE002800DA /* Download Core */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Download Core & Set Bitcode Symlink";
+			name = "Download Core";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "sh build.sh download-core\nsh build.sh set-core-bitcode-symlink";
+			shellScript = "sh build.sh download-core";
 		};
 		C04B4BDB1B55C47A00FAE58E /* Set Swift Version */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/Realm/Tests/AsyncTests.mm
+++ b/Realm/Tests/AsyncTests.mm
@@ -414,7 +414,7 @@
     XCTestExpectation *exp = [self expectationWithDescription:@""];
     auto token = [IntObject.allObjects addNotificationBlock:^(RLMResults *results, RLMCollectionChange *change, NSError *error) {
         XCTAssertNil(results);
-        RLMValidateRealmError(error, RLMErrorFail, @"Too many open files", nil);
+        RLMValidateRealmError(error, RLMErrorFileAccess, @"Too many open files", nil);
         called = true;
         [exp fulfill];
     }];
@@ -433,7 +433,7 @@
     XCTestExpectation *exp2 = [self expectationWithDescription:@""];
     auto token2 = [IntObject.allObjects addNotificationBlock:^(RLMResults *results, RLMCollectionChange *change, NSError *error) {
         XCTAssertNil(results);
-        RLMValidateRealmError(error, RLMErrorFail, @"Too many open files", nil);
+        RLMValidateRealmError(error, RLMErrorFileAccess, @"Too many open files", nil);
         [exp2 fulfill];
     }];
     [realm beginWriteTransaction];

--- a/Realm/Tests/RealmTests.mm
+++ b/Realm/Tests/RealmTests.mm
@@ -99,7 +99,7 @@ extern "C" {
     [NSFileManager.defaultManager setAttributes:@{NSFileImmutable: @YES} ofItemAtPath:RLMTestRealmURL().path error:nil];
 
     // Should not be able to open read-write
-    RLMAssertThrowsWithCodeMatching([self realmWithTestPath], RLMErrorFail);
+    RLMAssertThrowsWithCodeMatching([self realmWithTestPath], RLMErrorFileAccess);
 
     RLMRealm *realm;
     XCTAssertNoThrow(realm = [self readOnlyRealmWithURL:RLMTestRealmURL() error:nil]);

--- a/Realm/Tests/UtilTests.mm
+++ b/Realm/Tests/UtilTests.mm
@@ -88,17 +88,27 @@ static BOOL RLMEqualExceptions(NSException *actual, NSException *expected) {
 
 - (void)testRealmFileException {
     realm::RealmFileException exception(realm::RealmFileException::Kind::NotFound,
-                                 "/some/path",
-                                 "don't do that to your files",
-                                 "lp0 on fire");
+                                        "/some/path",
+                                        "don't do that to your files",
+                                        "lp0 on fire");
     RLMError dummyCode = RLMErrorFail;
-    NSDictionary *expectedUserInfo = @{NSLocalizedDescriptionKey: @"don't do that to your files",
+    NSDictionary *expectedUserInfo = @{NSLocalizedDescriptionKey: @"don't do that to your files: lp0 on fire",
                                        NSFilePathErrorKey: @"/some/path",
                                        @"Error Code": @(dummyCode),
                                        @"Underlying": @"lp0 on fire"};
 
     XCTAssertEqualObjects(RLMMakeError(dummyCode, exception),
                           [NSError errorWithDomain:RLMErrorDomain code:dummyCode userInfo:expectedUserInfo]);
+}
+
+- (void)testRealmFileExceptionStripsRedundantCopyOfPath {
+    realm::RealmFileException exception(realm::RealmFileException::Kind::NotFound,
+                                        "/some/path",
+                                        "Could not open /some/path",
+                                        "open(/some/path) failed: Unknown error");
+
+    XCTAssertEqualObjects(RLMMakeError(RLMErrorFileAccess, exception).localizedDescription,
+                          @"Could not open /some/path: open() failed: Unknown error");
 }
 
 - (void)testRLMMakeError {

--- a/RealmSwift-swift2.2/Tests/RealmTests.swift
+++ b/RealmSwift-swift2.2/Tests/RealmTests.swift
@@ -64,7 +64,7 @@ class RealmTests: TestCase {
         try! fileManager.setAttributes([ NSFileImmutable: NSNumber(bool: true) ], ofItemAtPath: testRealmURL().path!)
 
         // Should not be able to open read-write
-        assertFails(Error.Fail) {
+        assertFails(Error.FileAccess) {
             try Realm(fileURL: testRealmURL())
         }
 

--- a/build.sh
+++ b/build.sh
@@ -14,7 +14,7 @@ set -o pipefail
 set -e
 
 # You can override the version of the core library
-: ${REALM_CORE_VERSION:=0.100.4} # set to "current" to always use the current build
+: ${REALM_CORE_VERSION:=1.0.0} # set to "current" to always use the current build
 
 # You can override the xcmode used
 : ${XCMODE:=xcodebuild} # must be one of: xcodebuild (default), xcpretty, xctool
@@ -38,7 +38,6 @@ Usage: sh $0 command [argument]
 command:
   clean:                clean up/remove all generated files
   download-core:        downloads core library (binary version)
-  set-core-bitcode-symlink: set core symlink to bitcode version
   build:                builds all iOS  and OS X frameworks
   ios-static:           builds fat iOS static framework
   ios-dynamic:          builds iOS dynamic frameworks
@@ -368,15 +367,6 @@ case "$COMMAND" in
             echo "The core library seems to be up to date."
         fi
         exit 0
-        ;;
-
-    "set-core-bitcode-symlink")
-        cd core
-        rm -f librealm-ios.a librealm-ios-dbg.a
-        # FIXME: Stop bundling core with & without bitcode
-        echo "Using core with bitcode"
-        ln -s librealm-ios-bitcode.a librealm-ios.a
-        ln -s librealm-ios-bitcode-dbg.a librealm-ios-dbg.a
         ;;
 
     ######################################
@@ -889,11 +879,6 @@ case "$COMMAND" in
     "cocoapods-setup")
         if [ ! -d core ]; then
           sh build.sh download-core
-        fi
-
-        if [[ "$2" != "swift" ]]; then
-          echo 'Installing for Xcode 7+.'
-          mv core/librealm-ios-bitcode.a core/librealm-ios.a
         fi
 
         # CocoaPods won't automatically preserve files referenced via symlinks


### PR DESCRIPTION
Removes the bitcode/non-bitcode core logic and adjusts some of the exception translation to deal with that core is now throwing different exceptions for many errors.

Fixes #3601.