### PR TITLE
The key parameter of `objectForPrimaryKey(_:, key:)`/`dynamicObjectForPrimaryKey()` should be optional.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@ x.x.x Release notes (yyyy-MM-dd)
 
 ### API breaking changes
 
-* None.
+* The `key` parameter of `objectForPrimaryKey(_:, key:)` is 
+  now marked as optional.
 
 ### Enhancements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,7 @@ x.x.x Release notes (yyyy-MM-dd)
 
 ### API breaking changes
 
-* The `key` parameter of `objectForPrimaryKey(_:, key:)` is 
-  now marked as optional.
+* None.
 
 ### Enhancements
 
@@ -15,6 +14,8 @@ x.x.x Release notes (yyyy-MM-dd)
 * Swift: Fix an error thrown when trying to create or update `Object` instances via
   `add(:_update:)` with a primary key property of type `RealmOptional`.
 * Xcode playground in Swift release zip now runs successfully.
+* The `key` parameter of `Realm.objectForPrimaryKey(_:key:)`/ `Realm.dynamicObjectForPrimaryKey(_:key:)`
+ is now marked as optional.
 
 1.0.0 Release notes (2016-05-25)
 =============================================================

--- a/RealmSwift-swift2.2/Realm.swift
+++ b/RealmSwift-swift2.2/Realm.swift
@@ -432,7 +432,7 @@ public final class Realm {
 
      :nodoc:
      */
-    public func dynamicObjectForPrimaryKey(className: String, key: AnyObject) -> DynamicObject? {
+    public func dynamicObjectForPrimaryKey(className: String, key: AnyObject?) -> DynamicObject? {
         return unsafeBitCast(RLMGetObject(rlmRealm, className, key), Optional<DynamicObject>.self)
     }
 

--- a/RealmSwift-swift2.2/Realm.swift
+++ b/RealmSwift-swift2.2/Realm.swift
@@ -406,7 +406,7 @@ public final class Realm {
 
      - returns: An object of type `type`, or `nil` if no instance with the given primary key exists.
      */
-    public func objectForPrimaryKey<T: Object>(type: T.Type, key: AnyObject) -> T? {
+    public func objectForPrimaryKey<T: Object>(type: T.Type, key: AnyObject?) -> T? {
         return unsafeBitCast(RLMGetObject(rlmRealm, (type as Object.Type).className(), key), Optional<T>.self)
     }
 

--- a/RealmSwift-swift2.2/Tests/RealmTests.swift
+++ b/RealmSwift-swift2.2/Tests/RealmTests.swift
@@ -548,8 +548,11 @@ class RealmTests: TestCase {
             let object1 = realm.objectForPrimaryKey(SwiftPrimaryOptionalStringObject.self, key: NSNull())
             XCTAssertNotNil(object1)
 
-            let object2 = realm.objectForPrimaryKey(SwiftPrimaryOptionalStringObject.self, key: "b")
-            XCTAssertNotNil(object2)
+            let object2 = realm.objectForPrimaryKey(SwiftPrimaryOptionalStringObject.self, key: nil)
+            XCTAssertEqual(object1, object2)
+
+            let object3 = realm.objectForPrimaryKey(SwiftPrimaryOptionalStringObject.self, key: "b")
+            XCTAssertNotNil(object3)
 
             let missingObject = realm.objectForPrimaryKey(SwiftPrimaryOptionalStringObject.self, key: "z")
             XCTAssertNil(missingObject)
@@ -567,8 +570,11 @@ class RealmTests: TestCase {
             let object1 = realm.objectForPrimaryKey(objectType, key: NSNull())
             XCTAssertNotNil(object1)
 
-            let object2 = realm.objectForPrimaryKey(objectType, key: 2)
-            XCTAssertNotNil(object2)
+            let object2 = realm.objectForPrimaryKey(objectType, key: nil)
+            XCTAssertEqual(object1, object2)
+
+            let object3 = realm.objectForPrimaryKey(objectType, key: 2)
+            XCTAssertNotNil(object3)
 
             let missingObject = realm.objectForPrimaryKey(objectType, key: 0)
             XCTAssertNil(missingObject)


### PR DESCRIPTION
Otherwise, we must pass the `NSNull()` to retrieve a value for null primary key.
In Objective-C, that parameter is specified as `nullable`.

```objc
+[RLMObject objectForPrimaryKey:(nullable id)primaryKey]
```

CC @jpsim @mrackwitz @tgoyne @bdash @austinzheng