### PR TITLE
Factor out some duplicated error translation and improve the resulting messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ x.x.x Release notes (yyyy-MM-dd)
 
 ### Enhancements
 
-* None.
+* Improve the error messages when an I/O error occurs in `writeCopyToURL`.
 
 ### Bugfixes
 

--- a/Realm/ObjectStore/shared_realm.hpp
+++ b/Realm/ObjectStore/shared_realm.hpp
@@ -25,12 +25,14 @@
 #include <vector>
 
 namespace realm {
+    class BinaryData;
     class BindingContext;
     class Group;
     class Realm;
     class Replication;
     class Schema;
     class SharedGroup;
+    class StringData;
     typedef std::shared_ptr<Realm> SharedRealm;
     typedef std::weak_ptr<Realm> WeakRealm;
 
@@ -121,6 +123,7 @@ namespace realm {
 
         void invalidate();
         bool compact();
+        void write_copy(StringData path, BinaryData encryption_key);
 
         std::thread::id thread_id() const { return m_thread_id; }
         void verify_thread() const;

--- a/Realm/RLMUtil.mm
+++ b/Realm/RLMUtil.mm
@@ -228,24 +228,10 @@ NSError *RLMMakeError(RLMError code, const realm::util::File::AccessError& excep
 }
 
 NSError *RLMMakeError(RLMError code, const realm::RealmFileException& exception) {
-    // Errors for `open()` now include the path in the exception message, but
-    // RealmFileException's message already has the path, so remove the second
-    // copy as it makes errors much less readable.
-    NSString *underlying;
-    auto pathPos = exception.underlying().find(exception.path());
-    if (pathPos != std::string::npos) {
-        auto trimmed = exception.underlying();
-        trimmed.replace(pathPos, exception.path().size(), "");
-        underlying = @(trimmed.c_str());
-    }
-    else {
-        underlying = @(exception.underlying().c_str());
-    }
-
-    NSString *msg = underlying.length ? [NSString stringWithFormat:@"%s: %@", exception.what(), underlying] : @(exception.what());
+    NSString *underlying = @(exception.underlying().c_str());
     return [NSError errorWithDomain:RLMErrorDomain
                                code:code
-                           userInfo:@{NSLocalizedDescriptionKey: msg,
+                           userInfo:@{NSLocalizedDescriptionKey: @(exception.what()),
                                       NSFilePathErrorKey: @(exception.path().c_str()),
                                       @"Error Code": @(code),
                                       @"Underlying": underlying.length == 0 ? @"n/a" : underlying}];

--- a/Realm/Tests/UtilTests.mm
+++ b/Realm/Tests/UtilTests.mm
@@ -92,23 +92,13 @@ static BOOL RLMEqualExceptions(NSException *actual, NSException *expected) {
                                         "don't do that to your files",
                                         "lp0 on fire");
     RLMError dummyCode = RLMErrorFail;
-    NSDictionary *expectedUserInfo = @{NSLocalizedDescriptionKey: @"don't do that to your files: lp0 on fire",
+    NSDictionary *expectedUserInfo = @{NSLocalizedDescriptionKey: @"don't do that to your files",
                                        NSFilePathErrorKey: @"/some/path",
                                        @"Error Code": @(dummyCode),
                                        @"Underlying": @"lp0 on fire"};
 
     XCTAssertEqualObjects(RLMMakeError(dummyCode, exception),
                           [NSError errorWithDomain:RLMErrorDomain code:dummyCode userInfo:expectedUserInfo]);
-}
-
-- (void)testRealmFileExceptionStripsRedundantCopyOfPath {
-    realm::RealmFileException exception(realm::RealmFileException::Kind::NotFound,
-                                        "/some/path",
-                                        "Could not open /some/path",
-                                        "open(/some/path) failed: Unknown error");
-
-    XCTAssertEqualObjects(RLMMakeError(RLMErrorFileAccess, exception).localizedDescription,
-                          @"Could not open /some/path: open() failed: Unknown error");
 }
 
 - (void)testRLMMakeError {


### PR DESCRIPTION
`-writeCopyToURL` and `commitWriteTransaction` had their own incomplete copies of the file error translation that produced generally worse errors, so refactor things to reuse the same error translation as when opening Realms, add better tests for the error reporting, and improve some of the relevant error messages a bit (primarily in that the underlying error is now only tacked on in the generic AccessError case, and is done in a more appropriate place).