### PR TITLE
Remove property with type 'id' from the RubyMotion sample

### DIFF
--- a/examples/ios/rubymotion/Simple/app/app_delegate.rb
+++ b/examples/ios/rubymotion/Simple/app/app_delegate.rb
@@ -15,14 +15,6 @@ class AppDelegate
     obj.cBoolProp = true
     obj.longProp = 123456
 
-    # Property types of "id" supports any other type
-    obj.mixedProp = true
-    obj.mixedProp = 123
-    obj.mixedProp = 123.45
-    obj.mixedProp = "abcd"
-    obj.mixedProp = "abcd".dataUsingEncoding(NSUTF8StringEncoding)
-    obj.mixedProp = NSDate.date
-
     # Object properties are supported
     stringObj = StringObject.new
     stringObj.stringProp = "xyz"

--- a/examples/ios/rubymotion/Simple/models/RubyMotionRealmObject.h
+++ b/examples/ios/rubymotion/Simple/models/RubyMotionRealmObject.h
@@ -19,7 +19,6 @@ RLM_ARRAY_TYPE(StringObject);
 @property NSDate       *dateProp;
 @property bool          cBoolProp;
 @property long          longProp;
-@property id            mixedProp;
 @property StringObject *objectProp;
 
 // FIXME: Support array properties in RubyMotion


### PR DESCRIPTION
I have investigated a little and have not seen an alternative to an 'id' property. If someone let's me know an alternative I will be happy to modify the PR with the fix :)