### PR TITLE
Fix reading of optional scalar types via the dynamic API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ x.x.x Release notes (yyyy-MM-dd)
 * Fix an assertion failure which could occur when opening a Realm after opening
   that Realm failed previously in some specific ways in the same run of the
   application.
+* Reading optional integers, floats, and doubles during a migration block now
+  correctly returns `nil` rather than 0 when the stored value is `nil`.
 
 0.103.1 Release notes (2016-05-19)
 =============================================================

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ x.x.x Release notes (yyyy-MM-dd)
 * Fix an assertion failure which could occur when opening a Realm after opening
   that Realm failed previously in some specific ways in the same run of the
   application.
-* Reading optional integers, floats, and doubles during a migration block now
+* Reading optional integers, floats, and doubles from within a migration block now
   correctly returns `nil` rather than 0 when the stored value is `nil`.
 
 0.103.1 Release notes (2016-05-19)

--- a/Realm/RLMProperty.mm
+++ b/Realm/RLMProperty.mm
@@ -112,6 +112,7 @@ static bool rawTypeIsComputedProperty(NSString *rawType) {
 -(void)setObjcCodeFromType {
     if (_optional) {
         _objcType = '@';
+        return;
     }
     switch (_type) {
         case RLMPropertyTypeInt:

--- a/Realm/Tests/DynamicTests.m
+++ b/Realm/Tests/DynamicTests.m
@@ -225,4 +225,28 @@
     XCTAssertEqualObjects(array[1][@"stringCol"], stringObject[@"stringCol"]);
 }
 
+- (void)testReadingNulls {
+    @autoreleasepool {
+        // open realm in autoreleasepool to create tables and then dispose
+        [RLMRealm realmWithURL:RLMTestRealmURL()];
+    }
+
+    RLMRealm *dyrealm = [self realmWithTestPathAndSchema:nil];
+    [dyrealm beginWriteTransaction];
+    [dyrealm createObject:AllOptionalTypes.className withValue:@[ [NSNull null], [NSNull null], [NSNull null], [NSNull null], [NSNull null], [NSNull null], [NSNull null] ]];
+    [dyrealm commitWriteTransaction];
+
+    RLMResults *results = [dyrealm allObjects:AllOptionalTypes.className];
+    XCTAssertEqual(1U, results.count);
+    RLMObject *object = results.firstObject;
+
+    XCTAssertNil(object[@"intObj"]);
+    XCTAssertNil(object[@"floatObj"]);
+    XCTAssertNil(object[@"doubleObj"]);
+    XCTAssertNil(object[@"boolObj"]);
+    XCTAssertNil(object[@"string"]);
+    XCTAssertNil(object[@"data"]);
+    XCTAssertNil(object[@"date"]);
+}
+
 @end

--- a/RealmSwift-swift2.2/Tests/MigrationTests.swift
+++ b/RealmSwift-swift2.2/Tests/MigrationTests.swift
@@ -512,4 +512,38 @@ class MigrationTests: TestCase {
 
         class_replaceMethod(metaClass, #selector(RLMObjectBase.sharedSchema), originalImp, "@@:")
     }
+
+    func testReadNullsDuringMigration() {
+        autoreleasepool {
+            try! Realm().write {
+                try! Realm().add(SwiftOptionalObject())
+            }
+        }
+
+        var migrated = false
+        migrateAndTestDefaultRealm() { migration, oldSchemaVersion in
+            migrated = true
+
+            var enumerated = false
+            migration.enumerate("SwiftOptionalObject") { oldObj, newObj in
+                XCTAssertNil(oldObj!["optNSStringCol"])
+                XCTAssertNil(oldObj!["optStringCol"])
+                XCTAssertNil(oldObj!["optBinaryCol"])
+                XCTAssertNil(oldObj!["optDateCol"])
+                XCTAssertNil(oldObj!["optIntCol"])
+                XCTAssertNil(oldObj!["optInt8Col"])
+                XCTAssertNil(oldObj!["optInt16Col"])
+                XCTAssertNil(oldObj!["optInt32Col"])
+                XCTAssertNil(oldObj!["optInt64Col"])
+                XCTAssertNil(oldObj!["optFloatCol"])
+                XCTAssertNil(oldObj!["optDoubleCol"])
+                XCTAssertNil(oldObj!["optBoolCol"])
+                XCTAssertNil(oldObj!["optObjectCol"])
+
+                enumerated = true
+            }
+            XCTAssertTrue(enumerated)
+        }
+        XCTAssertTrue(migrated)
+    }
 }


### PR DESCRIPTION
Optional properties of scalar types were getting the wrong Objective-C type code, leading to the dynamic accessors taking the non-optional code path. This resulted in `nil` values being returned as 0.

Fixes #3641.

/cc @tgoyne @jpsim @austinzheng 
