### PR TITLE
Optimize accessor class creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ x.x.x Release notes (yyyy-MM-dd)
   write does not actually change existing values.
 * Improve performance of deleting all objects in an RLMResults.
 * Reduce the number of files opened per thread-specific Realm on macOS.
+* Improve startup performance with large numbers of `RLMObject`/`Object`
+  subclasses.
 
 ### Bugfixes
 

--- a/Realm/RLMAccessor.h
+++ b/Realm/RLMAccessor.h
@@ -37,9 +37,6 @@ NS_ASSUME_NONNULL_BEGIN
 Class RLMManagedAccessorClassForObjectClass(Class objectClass, RLMObjectSchema *schema, const char *name);
 Class RLMUnmanagedAccessorClassForObjectClass(Class objectClass, RLMObjectSchema *schema);
 
-// Check if a given class is a generated accessor class
-bool RLMIsGeneratedClass(Class cls);
-
 //
 // Dynamic getters/setters
 //

--- a/Realm/RLMAccessor.h
+++ b/Realm/RLMAccessor.h
@@ -34,7 +34,7 @@ NS_ASSUME_NONNULL_BEGIN
 //
 
 // get accessor classes for an object class - generates classes if not cached
-Class RLMAccessorClassForObjectClass(Class objectClass, RLMObjectSchema *schema, NSString *prefix);
+Class RLMManagedAccessorClassForObjectClass(Class objectClass, RLMObjectSchema *schema, const char *name);
 Class RLMUnmanagedAccessorClassForObjectClass(Class objectClass, RLMObjectSchema *schema);
 
 // Check if a given class is a generated accessor class

--- a/Realm/RLMAccessor.mm
+++ b/Realm/RLMAccessor.mm
@@ -297,83 +297,83 @@ static inline void RLMSetValue(__unsafe_unretained RLMObjectBase *const obj, NSU
 }
 
 // dynamic getter with column closure
-static IMP RLMAccessorGetter(RLMProperty *prop, RLMAccessorCode accessorCode) {
+static id RLMAccessorGetter(RLMProperty *prop, RLMAccessorCode accessorCode) {
     NSUInteger index = prop.index;
     switch (accessorCode) {
         case RLMAccessorCodeByte:
-            return imp_implementationWithBlock(^(__unsafe_unretained RLMObjectBase *const obj) {
+            return ^(__unsafe_unretained RLMObjectBase *const obj) {
                 return (char)get<int64_t>(obj, index);
-            });
+            };
         case RLMAccessorCodeShort:
-            return imp_implementationWithBlock(^(__unsafe_unretained RLMObjectBase *const obj) {
+            return ^(__unsafe_unretained RLMObjectBase *const obj) {
                 return (short)get<int64_t>(obj, index);
-            });
+            };
         case RLMAccessorCodeInt:
-            return imp_implementationWithBlock(^(__unsafe_unretained RLMObjectBase *const obj) {
+            return ^(__unsafe_unretained RLMObjectBase *const obj) {
                 return (int)get<int64_t>(obj, index);
-            });
+            };
         case RLMAccessorCodeLongLong:
-            return imp_implementationWithBlock(^(__unsafe_unretained RLMObjectBase *const obj) {
+            return ^(__unsafe_unretained RLMObjectBase *const obj) {
                 return get<int64_t>(obj, index);
-            });
+            };
         case RLMAccessorCodeLong:
-            return imp_implementationWithBlock(^(__unsafe_unretained RLMObjectBase *const obj) {
+            return ^(__unsafe_unretained RLMObjectBase *const obj) {
                 return (long)get<int64_t>(obj, index);
-            });
+            };
         case RLMAccessorCodeFloat:
-            return imp_implementationWithBlock(^(__unsafe_unretained RLMObjectBase *const obj) {
+            return ^(__unsafe_unretained RLMObjectBase *const obj) {
                 return get<float>(obj, index);
-            });
+            };
         case RLMAccessorCodeDouble:
-            return imp_implementationWithBlock(^(__unsafe_unretained RLMObjectBase *const obj) {
+            return ^(__unsafe_unretained RLMObjectBase *const obj) {
                 return get<double>(obj, index);
-            });
+            };
         case RLMAccessorCodeBool:
-            return imp_implementationWithBlock(^(__unsafe_unretained RLMObjectBase *const obj) {
+            return ^(__unsafe_unretained RLMObjectBase *const obj) {
                 return get<bool>(obj, index);
-            });
+            };
         case RLMAccessorCodeString:
-            return imp_implementationWithBlock(^(__unsafe_unretained RLMObjectBase *const obj) {
+            return ^(__unsafe_unretained RLMObjectBase *const obj) {
                 return RLMGetString(obj, index);
-            });
+            };
         case RLMAccessorCodeDate:
-            return imp_implementationWithBlock(^(__unsafe_unretained RLMObjectBase *const obj) {
+            return ^(__unsafe_unretained RLMObjectBase *const obj) {
                 return RLMGetDate(obj, index);
-            });
+            };
         case RLMAccessorCodeData:
-            return imp_implementationWithBlock(^(__unsafe_unretained RLMObjectBase *const obj) {
+            return ^(__unsafe_unretained RLMObjectBase *const obj) {
                 return RLMGetData(obj, index);
-            });
+            };
         case RLMAccessorCodeLink:
-            return imp_implementationWithBlock(^id(__unsafe_unretained RLMObjectBase *const obj) {
+            return ^id(__unsafe_unretained RLMObjectBase *const obj) {
                 return RLMGetLink(obj, index);
-            });
+            };
         case RLMAccessorCodeArray:
-            return imp_implementationWithBlock(^(__unsafe_unretained RLMObjectBase *const obj) {
+            return ^(__unsafe_unretained RLMObjectBase *const obj) {
                 return RLMGetArray(obj, index);
-            });
+            };
         case RLMAccessorCodeAny:
             @throw RLMException(@"Cannot create accessor class for schema with Mixed properties");
         case RLMAccessorCodeIntObject:
-            return imp_implementationWithBlock(^(__unsafe_unretained RLMObjectBase *const obj) {
+            return ^(__unsafe_unretained RLMObjectBase *const obj) {
                 return getBoxed<int64_t>(obj, index);
-            });
+            };
         case RLMAccessorCodeFloatObject:
-            return imp_implementationWithBlock(^(__unsafe_unretained RLMObjectBase *const obj) {
+            return ^(__unsafe_unretained RLMObjectBase *const obj) {
                 return getBoxed<float>(obj, index);
-            });
+            };
         case RLMAccessorCodeDoubleObject:
-            return imp_implementationWithBlock(^(__unsafe_unretained RLMObjectBase *const obj) {
+            return ^(__unsafe_unretained RLMObjectBase *const obj) {
                 return getBoxed<double>(obj, index);
-            });
+            };
         case RLMAccessorCodeBoolObject:
-            return imp_implementationWithBlock(^(__unsafe_unretained RLMObjectBase *const obj) {
+            return ^(__unsafe_unretained RLMObjectBase *const obj) {
                 return getBoxed<bool>(obj, index);
-            });
+            };
         case RLMAccessorCodeLinkingObjects:
-            return imp_implementationWithBlock(^(__unsafe_unretained RLMObjectBase *const obj) {
+            return ^(__unsafe_unretained RLMObjectBase *const obj) {
                 return RLMGetLinkingObjects(obj, prop);
-            });
+            };
     }
 }
 
@@ -390,23 +390,23 @@ static void RLMWrapSetter(__unsafe_unretained RLMObjectBase *const obj, __unsafe
 }
 
 template<typename ArgType, typename StorageType=ArgType>
-static IMP RLMMakeSetter(RLMProperty *prop) {
+static id RLMMakeSetter(RLMProperty *prop) {
     NSUInteger index = prop.index;
     NSString *name = prop.name;
     if (prop.isPrimary) {
-        return imp_implementationWithBlock(^(__unused RLMObjectBase *obj, __unused ArgType val) {
+        return ^(__unused RLMObjectBase *obj, __unused ArgType val) {
             @throw RLMException(@"Primary key can't be changed after an object is inserted.");
-        });
+        };
     }
-    return imp_implementationWithBlock(^(__unsafe_unretained RLMObjectBase *const obj, ArgType val) {
+    return ^(__unsafe_unretained RLMObjectBase *const obj, ArgType val) {
         RLMWrapSetter(obj, name, [&] {
             RLMSetValue(obj, obj->_info->objectSchema->persisted_properties[index].table_column, static_cast<StorageType>(val), false);
         });
-    });
+    };
 }
 
 // dynamic setter with column closure
-static IMP RLMAccessorSetter(RLMProperty *prop, RLMAccessorCode accessorCode) {
+static id RLMAccessorSetter(RLMProperty *prop, RLMAccessorCode accessorCode) {
     switch (accessorCode) {
         case RLMAccessorCodeByte:         return RLMMakeSetter<char, long long>(prop);
         case RLMAccessorCodeShort:        return RLMMakeSetter<short, long long>(prop);
@@ -449,39 +449,39 @@ static void RLMSuperSet(RLMObjectBase *obj, NSString *propName, id val) {
 }
 
 // getter/setter for unmanaged object
-static IMP RLMAccessorUnmanagedGetter(RLMProperty *prop, RLMAccessorCode accessorCode) {
+static id RLMAccessorUnmanagedGetter(RLMProperty *prop, RLMAccessorCode accessorCode) {
     // only override getters for RLMArray and linking objects properties
     if (accessorCode == RLMAccessorCodeArray) {
         NSString *objectClassName = prop.objectClassName;
         NSString *propName = prop.name;
 
-        return imp_implementationWithBlock(^(RLMObjectBase *obj) {
+        return ^(RLMObjectBase *obj) {
             id val = RLMSuperGet(obj, propName);
             if (!val) {
                 val = [[RLMArray alloc] initWithObjectClassName:objectClassName];
                 RLMSuperSet(obj, propName, val);
             }
             return val;
-        });
+        };
     }
     else if (accessorCode == RLMAccessorCodeLinkingObjects) {
-        return imp_implementationWithBlock(^(RLMObjectBase *){
+        return ^(RLMObjectBase *){
             return [RLMResults emptyDetachedResults];
-        });
+        };
     }
     return nil;
 }
-static IMP RLMAccessorUnmanagedSetter(RLMProperty *prop, RLMAccessorCode accessorCode) {
+static id RLMAccessorUnmanagedSetter(RLMProperty *prop, RLMAccessorCode accessorCode) {
     // only override getters for RLMArray and linking objects properties
     if (accessorCode == RLMAccessorCodeArray) {
         NSString *propName = prop.name;
         NSString *objectClassName = prop.objectClassName;
-        return imp_implementationWithBlock(^(RLMObjectBase *obj, id<NSFastEnumeration> ar) {
+        return ^(RLMObjectBase *obj, id<NSFastEnumeration> ar) {
             // make copy when setting (as is the case for all other variants)
             RLMArray *unmanagedAr = [[RLMArray alloc] initWithObjectClassName:objectClassName];
             [unmanagedAr addObjects:ar];
             RLMSuperSet(obj, propName, unmanagedAr);
-        });
+        };
     }
     return nil;
 }
@@ -617,8 +617,8 @@ bool RLMIsGeneratedClass(Class cls) {
 static Class RLMCreateAccessorClass(Class objectClass,
                                     RLMObjectSchema *schema,
                                     const char *accessorClassName,
-                                    IMP (*getterGetter)(RLMProperty *, RLMAccessorCode),
-                                    IMP (*setterGetter)(RLMProperty *, RLMAccessorCode)) {
+                                    id (*getterGetter)(RLMProperty *, RLMAccessorCode),
+                                    id (*setterGetter)(RLMProperty *, RLMAccessorCode)) {
     REALM_ASSERT_DEBUG(RLMIsObjectOrSubclass(objectClass));
 
     // create and register proxy class which derives from object class
@@ -633,19 +633,22 @@ static Class RLMCreateAccessorClass(Class objectClass,
     for (RLMProperty *prop in schema.properties) {
         RLMAccessorCode accessorCode = accessorCodeForType(prop.objcType, prop.type);
         if (prop.getterSel && getterGetter) {
-            if (IMP getterImp = getterGetter(prop, accessorCode)) {
+            if (id getter = getterGetter(prop, accessorCode)) {
+                IMP getterImp = imp_implementationWithBlock(getter);
                 class_addMethod(accClass, prop.getterSel, getterImp, getterTypeStringForObjcCode(prop.objcType));
             }
         }
         if (prop.setterSel && setterGetter) {
-            if (IMP setterImp = setterGetter(prop, accessorCode)) {
+            if (id setter = setterGetter(prop, accessorCode)) {
+                IMP setterImp = imp_implementationWithBlock(setter);
                 class_addMethod(accClass, prop.setterSel, setterImp, setterTypeStringForObjcCode(prop.objcType));
             }
         }
     }
     for (RLMProperty *prop in schema.computedProperties) {
         if (prop.getterSel && getterGetter) {
-            if (IMP getterImp = getterGetter(prop, accessorCodeForType(prop.objcType, prop.type))) {
+            if (id getter = getterGetter(prop, accessorCodeForType(prop.objcType, prop.type))) {
+                IMP getterImp = imp_implementationWithBlock(getter);
                 class_addMethod(accClass, prop.getterSel, getterImp, getterTypeStringForObjcCode(prop.objcType));
             }
         }

--- a/Realm/RLMAccessor.mm
+++ b/Realm/RLMAccessor.mm
@@ -592,26 +592,14 @@ void RLMReplaceSharedSchemaMethod(Class accessorClass, RLMObjectSchema *schema) 
             cls = parent;
             parent = class_getSuperclass(cls);
         }
-        if (RLMIsGeneratedClass(cls)) {
+        const char *prefix = "RLM:";
+        if (strncmp(prefix, class_getName(cls), strlen(prefix)) == 0) {
             return schema;
         }
 
         return [RLMSchema sharedSchemaForClass:cls];
     });
     class_addMethod(metaClass, @selector(sharedSchema), imp, "@@:");
-}
-
-static NSMutableSet *s_generatedClasses = [NSMutableSet new];
-static void RLMMarkClassAsGenerated(Class cls) {
-    @synchronized (s_generatedClasses) {
-        [s_generatedClasses addObject:cls];
-    }
-}
-
-bool RLMIsGeneratedClass(Class cls) {
-    @synchronized (s_generatedClasses) {
-        return [s_generatedClasses containsObject:cls];
-    }
 }
 
 static Class RLMCreateAccessorClass(Class objectClass,
@@ -654,7 +642,6 @@ static Class RLMCreateAccessorClass(Class objectClass,
         }
     }
 
-    RLMMarkClassAsGenerated(accClass);
     objc_registerClassPair(accClass);
 
     return accClass;
@@ -665,7 +652,7 @@ Class RLMManagedAccessorClassForObjectClass(Class objectClass, RLMObjectSchema *
 }
 
 Class RLMUnmanagedAccessorClassForObjectClass(Class objectClass, RLMObjectSchema *schema) {
-    return RLMCreateAccessorClass(objectClass, schema, [@"RLMUnmanaged_" stringByAppendingString:schema.className].UTF8String,
+    return RLMCreateAccessorClass(objectClass, schema, [@"RLM:Unmanaged " stringByAppendingString:schema.className].UTF8String,
                                   RLMAccessorUnmanagedGetter, RLMAccessorUnmanagedSetter);
 }
 

--- a/Realm/RLMObjectBase.mm
+++ b/Realm/RLMObjectBase.mm
@@ -333,7 +333,7 @@ id RLMCreateManagedAccessor(Class cls, __unsafe_unretained RLMRealm *realm, RLMC
     const char *className = class_getName(self);
     const char accessorClassPrefix[] = "RLM:Managed";
     if (!strncmp(className, accessorClassPrefix, sizeof(accessorClassPrefix) - 1)) {
-        if (self.sharedSchema[key]) {
+        if ([class_getSuperclass(self.class) sharedSchema][key]) {
             return NO;
         }
     }

--- a/Realm/RLMObjectBase.mm
+++ b/Realm/RLMObjectBase.mm
@@ -331,7 +331,7 @@ id RLMCreateManagedAccessor(Class cls, __unsafe_unretained RLMRealm *realm, RLMC
 
 + (BOOL)automaticallyNotifiesObserversForKey:(NSString *)key {
     const char *className = class_getName(self);
-    const char accessorClassPrefix[] = "RLMAccessor_";
+    const char accessorClassPrefix[] = "RLM:Managed";
     if (!strncmp(className, accessorClassPrefix, sizeof(accessorClassPrefix) - 1)) {
         if (self.sharedSchema[key]) {
             return NO;

--- a/Realm/RLMObjectStore.mm
+++ b/Realm/RLMObjectStore.mm
@@ -41,14 +41,21 @@
 using namespace realm;
 
 void RLMRealmCreateAccessors(RLMSchema *schema) {
+    const size_t bufferSize = sizeof("RLMAccessor__") // includes null terminator
+                            + std::numeric_limits<unsigned long long>::digits10
+                            + realm::Group::max_table_name_length;
+
+    char className[bufferSize] = "RLMAccessor_";
+    char *const start = className + strlen(className);
+
     for (RLMObjectSchema *objectSchema in schema.objectSchema) {
         if (objectSchema.accessorClass != objectSchema.objectClass) {
             continue;
         }
 
         static unsigned long long count = 0;
-        NSString *prefix = [NSString stringWithFormat:@"RLMAccessor_%llu_", count++];
-        objectSchema.accessorClass = RLMAccessorClassForObjectClass(objectSchema.objectClass, objectSchema, prefix);
+        sprintf(start, "%llu_%s", count++, objectSchema.className.UTF8String);
+        objectSchema.accessorClass = RLMManagedAccessorClassForObjectClass(objectSchema.objectClass, objectSchema, className);
     }
 }
 

--- a/Realm/RLMObjectStore.mm
+++ b/Realm/RLMObjectStore.mm
@@ -205,7 +205,7 @@ static NSUInteger createRowForObjectWithPrimaryKey(RLMClassInfo const& info, id 
                     row.set_null(primaryColumnIndex); // FIXME: Use `set_null_unique` once Core supports it
                 }
                 break;
-                
+
             default:
                 REALM_UNREACHABLE();
         }
@@ -269,7 +269,7 @@ static NSUInteger createOrGetRowForObject(RLMClassInfo const& info, F valueForPr
 }
 
 void RLMAddObjectToRealm(__unsafe_unretained RLMObjectBase *const object,
-                         __unsafe_unretained RLMRealm *const realm, 
+                         __unsafe_unretained RLMRealm *const realm,
                          bool createOrUpdate) {
     RLMVerifyInWriteTransaction(realm);
 

--- a/Realm/RLMObjectStore.mm
+++ b/Realm/RLMObjectStore.mm
@@ -41,11 +41,11 @@
 using namespace realm;
 
 void RLMRealmCreateAccessors(RLMSchema *schema) {
-    const size_t bufferSize = sizeof("RLMAccessor__") // includes null terminator
+    const size_t bufferSize = sizeof("RLM:Managed  ") // includes null terminator
                             + std::numeric_limits<unsigned long long>::digits10
                             + realm::Group::max_table_name_length;
 
-    char className[bufferSize] = "RLMAccessor_";
+    char className[bufferSize] = "RLM:Managed ";
     char *const start = className + strlen(className);
 
     for (RLMObjectSchema *objectSchema in schema.objectSchema) {
@@ -54,7 +54,7 @@ void RLMRealmCreateAccessors(RLMSchema *schema) {
         }
 
         static unsigned long long count = 0;
-        sprintf(start, "%llu_%s", count++, objectSchema.className.UTF8String);
+        sprintf(start, "%llu %s", count++, objectSchema.className.UTF8String);
         objectSchema.accessorClass = RLMManagedAccessorClassForObjectClass(objectSchema.objectClass, objectSchema, className);
     }
 }

--- a/Realm/RLMProperty_Private.h
+++ b/Realm/RLMProperty_Private.h
@@ -69,8 +69,6 @@ FOUNDATION_EXTERN void RLMValidateSwiftPropertyName(NSString *name);
 
 // private properties
 @property (nonatomic, assign) NSUInteger index;
-@property (nonatomic, assign) char objcType;
-@property (nonatomic, copy) NSString *objcRawType;
 @property (nonatomic, assign) BOOL isPrimary;
 @property (nonatomic, assign) Ivar swiftIvar;
 

--- a/Realm/RLMSchema.mm
+++ b/Realm/RLMSchema.mm
@@ -87,12 +87,15 @@ static RLMObjectSchema *RLMRegisterClass(Class cls) {
 static void RLMRegisterClassLocalNames(Class *classes, NSUInteger count) {
     for (NSUInteger i = 0; i < count; i++) {
         Class cls = classes[i];
-
-        if (!RLMIsObjectSubclass(cls) || RLMIsGeneratedClass(cls)) {
+        if (!RLMIsObjectSubclass(cls)) {
             continue;
         }
 
         NSString *className = NSStringFromClass(cls);
+        if ([className hasPrefix:@"RLM:"]) {
+            continue;
+        }
+
         if ([RLMSwiftSupport isSwiftClassName:className]) {
             className = [RLMSwiftSupport demangleClassName:className];
         }

--- a/Realm/Tests/MigrationTests.mm
+++ b/Realm/Tests/MigrationTests.mm
@@ -479,24 +479,12 @@ RLM_ARRAY_TYPE(MigrationObject);
     RLMObjectSchema *from = [RLMObjectSchema schemaForObjectClass:MigrationObject.class];
 
     RLMObjectSchema *to = [RLMObjectSchema schemaForObjectClass:MigrationObject.class];
+    to.objectClass = RLMObject.class;
     RLMProperty *prop = to.properties[0];
     RLMProperty *strProp = to.properties[1];
     prop.type = strProp.type;
-    prop.objcRawType = strProp.objcRawType;
-    prop.objcType = strProp.objcType;
 
     [self assertMigrationRequiredForChangeFrom:@[from] to:@[to]];
-}
-
-- (void)testChangingIntSizeDoesNotRequireMigration {
-    RLMObjectSchema *from = [RLMObjectSchema schemaForObjectClass:MigrationObject.class];
-
-    RLMObjectSchema *to = [RLMObjectSchema schemaForObjectClass:MigrationObject.class];
-    RLMProperty *prop = to.properties[0];
-    prop.objcRawType = @"q"; // 'long long' rather than 'int'
-    prop.objcType = 'q';
-
-    [self assertNoMigrationRequiredForChangeFrom:@[from] to:@[to]];
 }
 
 - (void)testDeleteRealmIfMigrationNeededWithSetCustomSchema {
@@ -535,9 +523,9 @@ RLM_ARRAY_TYPE(MigrationObject);
         }
 
         // Change string to int, requiring a migration
+        objectSchema.objectClass = RLMObject.class;
         RLMProperty *stringCol = objectSchema.properties[1];
         stringCol.type = RLMPropertyTypeInt;
-        stringCol.objcType = 'i';
         stringCol.optional = NO;
         objectSchema.properties = @[stringCol];
 
@@ -814,9 +802,9 @@ RLM_ARRAY_TYPE(MigrationObject);
 - (void)testChangePropertyType {
     // make string an int
     RLMObjectSchema *objectSchema = [RLMObjectSchema schemaForObjectClass:MigrationObject.class];
+    objectSchema.objectClass = RLMObject.class;
     RLMProperty *stringCol = objectSchema.properties[1];
     stringCol.type = RLMPropertyTypeInt;
-    stringCol.objcType = 'i';
     stringCol.optional = NO;
 
     // create realm with old schema and populate
@@ -829,7 +817,7 @@ RLM_ARRAY_TYPE(MigrationObject);
     RLMRealm *realm = [self migrateTestRealmWithBlock:^(RLMMigration *migration, uint64_t oldSchemaVersion) {
         XCTAssertEqual(oldSchemaVersion, 0U, @"Initial schema version should be 0");
         [migration enumerateObjects:MigrationObject.className
-                                       block:^(RLMObject *oldObject, RLMObject *newObject) {
+                              block:^(RLMObject *oldObject, RLMObject *newObject) {
             XCTAssertEqualObjects(newObject[@"intCol"], oldObject[@"intCol"]);
             NSNumber *intObj = oldObject[@"stringCol"];
             XCTAssert([intObj isKindOfClass:NSNumber.class], @"Old stringCol should be int");
@@ -1050,6 +1038,7 @@ RLM_ARRAY_TYPE(MigrationObject);
                                                           [NSDate dateWithTimeIntervalSince1970:2]]];
     }];
 
+    objectSchema.objectClass = RLMObject.class;
     [objectSchema.properties setValue:@NO forKey:@"optional"];
 
     RLMRealm *realm;
@@ -1068,22 +1057,22 @@ RLM_ARRAY_TYPE(MigrationObject);
     XCTAssertEqual(2U, allObjects.count);
 
     AllOptionalTypes *obj = allObjects[0];
-    XCTAssertEqualObjects(@0, obj.intObj);
-    XCTAssertEqualObjects(@0, obj.floatObj);
-    XCTAssertEqualObjects(@0, obj.doubleObj);
-    XCTAssertEqualObjects(@0, obj.boolObj);
-    XCTAssertEqualObjects(@"", obj.string);
-    XCTAssertEqualObjects(NSData.data, obj.data);
-    XCTAssertEqualObjects([NSDate dateWithTimeIntervalSince1970:0], obj.date);
+    XCTAssertEqualObjects(@0, obj[@"intObj"]);
+    XCTAssertEqualObjects(@0, obj[@"floatObj"]);
+    XCTAssertEqualObjects(@0, obj[@"doubleObj"]);
+    XCTAssertEqualObjects(@0, obj[@"boolObj"]);
+    XCTAssertEqualObjects(@"", obj[@"string"]);
+    XCTAssertEqualObjects(NSData.data, obj[@"data"]);
+    XCTAssertEqualObjects([NSDate dateWithTimeIntervalSince1970:0], obj[@"date"]);
 
     obj = allObjects[1];
-    XCTAssertEqualObjects(@0, obj.intObj);
-    XCTAssertEqualObjects(@0, obj.floatObj);
-    XCTAssertEqualObjects(@0, obj.doubleObj);
-    XCTAssertEqualObjects(@0, obj.boolObj);
-    XCTAssertEqualObjects(@"", obj.string);
-    XCTAssertEqualObjects(NSData.data, obj.data);
-    XCTAssertEqualObjects([NSDate dateWithTimeIntervalSince1970:0], obj.date);
+    XCTAssertEqualObjects(@0, obj[@"intObj"]);
+    XCTAssertEqualObjects(@0, obj[@"floatObj"]);
+    XCTAssertEqualObjects(@0, obj[@"doubleObj"]);
+    XCTAssertEqualObjects(@0, obj[@"boolObj"]);
+    XCTAssertEqualObjects(@"", obj[@"string"]);
+    XCTAssertEqualObjects(NSData.data, obj[@"data"]);
+    XCTAssertEqualObjects([NSDate dateWithTimeIntervalSince1970:0], obj[@"date"]);
 }
 
 - (void)testMigrationAfterReorderingProperties {

--- a/Realm/Tests/ObjectTests.m
+++ b/Realm/Tests/ObjectTests.m
@@ -43,7 +43,7 @@
 {
     NSString *binaryString = @"binary";
     NSData *binaryData = [binaryString dataUsingEncoding:NSUTF8StringEncoding];
-    
+
     return @{@"intCol" : @12,
              @"floatCol" : @88.9f,
              @"doubleCol" : @1002.892,
@@ -321,32 +321,32 @@ RLM_ARRAY_TYPE(PrimaryEmployeeObject);
 - (void)testObjectInit
 {
     RLMRealm *realm = [RLMRealm defaultRealm];
-    
+
     [realm beginWriteTransaction];
-    
+
     // Init object before adding to realm
     EmployeeObject *soInit = [[EmployeeObject alloc] init];
     soInit.name = @"Peter";
     soInit.age = 30;
     soInit.hired = YES;
     [realm addObject:soInit];
-    
+
     // Create object while adding to realm using NSArray
     EmployeeObject *soUsingArray = [EmployeeObject createInRealm:realm withValue:@[@"John", @40, @NO]];
-    
+
     // Create object while adding to realm using NSDictionary
     EmployeeObject *soUsingDictionary = [EmployeeObject createInRealm:realm withValue:@{@"name": @"Susi", @"age": @25, @"hired": @YES}];
-    
+
     [realm commitWriteTransaction];
-    
+
     XCTAssertEqualObjects(soInit.name, @"Peter", @"Name should be Peter");
     XCTAssertEqual(soInit.age, 30, @"Age should be 30");
     XCTAssertEqual(soInit.hired, YES, @"Hired should YES");
-    
+
     XCTAssertEqualObjects(soUsingArray.name, @"John", @"Name should be John");
     XCTAssertEqual(soUsingArray.age, 40, @"Age should be 40");
     XCTAssertEqual(soUsingArray.hired, NO, @"Hired should NO");
-    
+
     XCTAssertEqualObjects(soUsingDictionary.name, @"Susi", @"Name should be Susi");
     XCTAssertEqual(soUsingDictionary.age, 25, @"Age should be 25");
     XCTAssertEqual(soUsingDictionary.hired, YES, @"Hired should YES");
@@ -375,24 +375,24 @@ RLM_ARRAY_TYPE(PrimaryEmployeeObject);
 -(void)testObjectInitWithObjectTypeArray
 {
     EmployeeObject *obj1 = [[EmployeeObject alloc] initWithValue:@[@"Peter", @30, @YES]];
-    
+
     XCTAssertEqualObjects(obj1.name, @"Peter", @"Names should be equal");
     XCTAssertEqual(obj1.age, 30, @"Age should be equal");
     XCTAssertEqual(obj1.hired, YES, @"Hired should be equal");
-    
+
     // Add to realm
     RLMRealm *realm = [RLMRealm defaultRealm];
     [realm beginWriteTransaction];
     [realm addObject:obj1];
     [realm commitWriteTransaction];
-    
+
     RLMResults *all = [EmployeeObject allObjects];
     EmployeeObject *fromRealm = all.firstObject;
-    
+
     XCTAssertEqualObjects(fromRealm.name, @"Peter", @"Names should be equal");
     XCTAssertEqual(fromRealm.age, 30, @"Age should be equal");
     XCTAssertEqual(fromRealm.hired, YES, @"Hired should be equal");
-    
+
     XCTAssertThrows(([[EmployeeObject alloc] initWithValue:@[@"Peter", @30]]), @"To few arguments");
     XCTAssertThrows(([[EmployeeObject alloc] initWithValue:@[@YES, @"Peter", @30]]), @"Wrong arguments");
     XCTAssertThrows(([[EmployeeObject alloc] initWithValue:@[]]), @"empty arguments");
@@ -401,24 +401,24 @@ RLM_ARRAY_TYPE(PrimaryEmployeeObject);
 -(void)testObjectInitWithObjectTypeDictionary
 {
     EmployeeObject *obj1 = [[EmployeeObject alloc] initWithValue:@{@"name": @"Susi", @"age": @25, @"hired": @YES}];
-    
+
     XCTAssertEqualObjects(obj1.name, @"Susi", @"Names should be equal");
     XCTAssertEqual(obj1.age, 25, @"Age should be equal");
     XCTAssertEqual(obj1.hired, YES, @"Hired should be equal");
-    
+
     // Add to realm
     RLMRealm *realm = [RLMRealm defaultRealm];
     [realm beginWriteTransaction];
     [realm addObject:obj1];
     [realm commitWriteTransaction];
-    
+
     RLMResults *all = [EmployeeObject allObjects];
     EmployeeObject *fromRealm = all.firstObject;
-    
+
     XCTAssertEqualObjects(fromRealm.name, @"Susi", @"Names should be equal");
     XCTAssertEqual(fromRealm.age, 25, @"Age should be equal");
     XCTAssertEqual(fromRealm.hired, YES, @"Hired should be equal");
-    
+
     XCTAssertNoThrow([[EmployeeObject alloc] initWithValue:@{}], @"Initialization with missing values should not throw");
     XCTAssertNoThrow([[DefaultObject alloc] initWithValue:@{@"intCol": @1}],
                      "Overriding some default values at initialization should not throw");
@@ -541,14 +541,14 @@ RLM_ARRAY_TYPE(PrimaryEmployeeObject);
     EmployeeObject *obj0 = [EmployeeObject createInRealm:realm withValue:@{@"name" : @"Test1", @"age" : @24, @"hired": @NO}];
     EmployeeObject *obj1 = [EmployeeObject createInRealm:realm withValue:@{@"name" : @"Test2", @"age" : @25, @"hired": @YES}];
     [realm commitWriteTransaction];
-    
+
     XCTAssertEqualObjects(obj0[@"name"], @"Test1",  @"Name should be Test1");
     XCTAssertEqualObjects(obj1[@"name"], @"Test2", @"Name should be Test1");
-    
+
     [realm beginWriteTransaction];
     obj0[@"name"] = @"newName";
     [realm commitWriteTransaction];
-    
+
     XCTAssertEqualObjects(obj0[@"name"], @"newName",  @"Name should be newName");
 
     [realm beginWriteTransaction];
@@ -587,7 +587,7 @@ RLM_ARRAY_TYPE(PrimaryEmployeeObject);
 {
     RLMRealm *realm = [RLMRealm defaultRealm];
     [realm beginWriteTransaction];
-    
+
     const char bin[4] = { 0, 1, 2, 3 };
     NSData *bin1 = [[NSData alloc] initWithBytes:bin length:sizeof bin / 2];
     NSData *bin2 = [[NSData alloc] initWithBytes:bin length:sizeof bin];
@@ -595,7 +595,7 @@ RLM_ARRAY_TYPE(PrimaryEmployeeObject);
     NSDate *timeZero = [NSDate dateWithTimeIntervalSince1970:0];
 
     AllTypesObject *c = [[AllTypesObject alloc] init];
-    
+
     c.boolCol   = NO;
     c.intCol  = 54;
     c.floatCol = 0.7f;
@@ -607,13 +607,13 @@ RLM_ARRAY_TYPE(PrimaryEmployeeObject);
     c.longCol = 99;
     c.objectCol = [[StringObject alloc] init];
     c.objectCol.stringCol = @"c";
-    
+
     [realm addObject:c];
 
     [AllTypesObject createInRealm:realm withValue:@[@YES, @506, @7.7f, @8.8, @"banach", bin2,
                                                      timeNow, @YES, @(-20), NSNull.null]];
     [realm commitWriteTransaction];
-    
+
     AllTypesObject *row1 = [AllTypesObject allObjects][0];
     AllTypesObject *row2 = [AllTypesObject allObjects][1];
 
@@ -1094,6 +1094,28 @@ static void testDatesInRange(NSTimeInterval from, NSTimeInterval to, void (^chec
     assertNonNullProperties(no);
 }
 
+- (void)testRequiredNumberProperties {
+    RLMRealm *realm = [RLMRealm defaultRealm];
+    [realm beginWriteTransaction];
+    RequiredNumberObject *obj = [RequiredNumberObject createInRealm:realm withValue:@[@0, @0, @0, @0]];
+
+    XCTAssertThrows(obj.intObj = nil);
+    XCTAssertThrows(obj.floatObj = nil);
+    XCTAssertThrows(obj.doubleObj = nil);
+    XCTAssertThrows(obj.boolObj = nil);
+
+    obj.intObj = @1;
+    XCTAssertEqualObjects(obj.intObj, @1);
+    obj.floatObj = @2.2f;
+    XCTAssertEqualObjects(obj.floatObj, @2.2f);
+    obj.doubleObj = @3.3;
+    XCTAssertEqualObjects(obj.doubleObj, @3.3);
+    obj.boolObj = @YES;
+    XCTAssertEqualObjects(obj.boolObj, @YES);
+
+    [realm cancelWriteTransaction];
+}
+
 - (void)testSettingNonOptionalPropertiesToNil {
     RequiredPropertiesObject *ro = [[RequiredPropertiesObject alloc] init];
 
@@ -1114,18 +1136,22 @@ static void testDatesInRange(NSTimeInterval from, NSTimeInterval to, void (^chec
     [realm cancelWriteTransaction];
 }
 
+static void addProperty(Class cls, const char *name, const char *type, size_t size, size_t align, id getter) {
+    objc_property_attribute_t objectColAttrs[] = {
+        {"T", type},
+    };
+    class_addIvar(cls, name, size, align, type);
+    class_addProperty(cls, name, objectColAttrs, sizeof(objectColAttrs) / sizeof(objc_property_attribute_t));
+
+    char encoding[4] = " @:";
+    encoding[0] = *type;
+    class_addMethod(cls, sel_registerName(name), imp_implementationWithBlock(getter), encoding);
+}
+
 - (void)testObjectSubclassAddedAtRuntime {
     Class objectClass = objc_allocateClassPair(RLMObject.class, "RuntimeGeneratedObject", 0);
-    objc_property_attribute_t objectColAttrs[] = {
-        { "T", "@\"RuntimeGeneratedObject\"" },
-    };
-    class_addIvar(objectClass, "objectCol", sizeof(id), alignof(id), "@\"RuntimeGeneratedObject\"");
-    class_addProperty(objectClass, "objectCol", objectColAttrs, sizeof(objectColAttrs) / sizeof(objc_property_attribute_t));
-    objc_property_attribute_t intColAttrs[] = {
-        { "T", "i" },
-    };
-    class_addIvar(objectClass, "intCol", sizeof(int), alignof(int), "i");
-    class_addProperty(objectClass, "intCol", intColAttrs, sizeof(intColAttrs) / sizeof(objc_property_attribute_t));
+    addProperty(objectClass, "objectCol", "@\"RuntimeGeneratedObject\"", sizeof(id), alignof(id), ^(__unused id obj) { return nil; });
+    addProperty(objectClass, "intCol", "i", sizeof(int), alignof(int), ^int(__unused id obj) { return 0; });
     objc_registerClassPair(objectClass);
     XCTAssertEqualObjects([objectClass className], @"RuntimeGeneratedObject");
 
@@ -1155,7 +1181,7 @@ static void testDatesInRange(NSTimeInterval from, NSTimeInterval to, void (^chec
 - (void)testNoDefaultAdd
 {
     RLMRealm *realm = [RLMRealm defaultRealm];
-    
+
     [realm beginWriteTransaction];
 
     // Test #1
@@ -1166,7 +1192,7 @@ static void testDatesInRange(NSTimeInterval from, NSTimeInterval to, void (^chec
     dateObject = [[DateObject alloc] init];
     dateObject.dateCol = [NSDate date];
     XCTAssertNoThrow(([realm addObject:dateObject]), @"Having values in all NSObject properties should not throw exception when being added to realm");
-    
+
     // Test #3
     IntObject *intObj = [[IntObject alloc] init];
     XCTAssertNoThrow(([realm addObject:intObj]), @"Having no NSObject properties should not throw exception when being added to realm");
@@ -1295,7 +1321,7 @@ static void testDatesInRange(NSTimeInterval from, NSTimeInterval to, void (^chec
 - (void)testIgnoredUnsupportedProperty
 {
     RLMRealm *realm = [RLMRealm defaultRealm];
-    
+
     [realm beginWriteTransaction];
     XCTAssertNoThrow([IgnoredURLObject new], @"Creating a new object with an (ignored) unsupported \
                                                property type should not throw");
@@ -1305,22 +1331,22 @@ static void testDatesInRange(NSTimeInterval from, NSTimeInterval to, void (^chec
 {
     NSURL *url = [NSURL URLWithString:@"http://realm.io"];
     RLMRealm *realm = [RLMRealm defaultRealm];
-    
+
     [realm beginWriteTransaction];
-    
+
     IgnoredURLObject *obj = [IgnoredURLObject new];
     obj.name = @"Realm";
     obj.url = url;
     [realm addObject:obj];
     XCTAssertEqual(obj.url, url, @"ignored properties should still be assignable and gettable inside a write block");
-    
+
     [realm commitWriteTransaction];
-    
+
     XCTAssertEqual(obj.url, url, @"ignored properties should still be assignable and gettable outside a write block");
-    
+
     IgnoredURLObject *obj2 = [[IgnoredURLObject objectsWithPredicate:nil] firstObject];
     XCTAssertNotNil(obj2, @"object with ignored property should still be stored and accessible through the realm");
-    
+
     XCTAssertEqualObjects(obj2.name, obj.name, @"managed property should be the same");
     XCTAssertNil(obj2.url, @"ignored property should be nil when getting from realm");
 }
@@ -1342,7 +1368,7 @@ static void testDatesInRange(NSTimeInterval from, NSTimeInterval to, void (^chec
 - (void)testCreateInRealmValidationForDictionary
 {
     RLMRealm *realm = [RLMRealm defaultRealm];
-    
+
     const char bin[4] = { 0, 1, 2, 3 };
     NSData *bin1 = [[NSData alloc] initWithBytes:bin length:sizeof bin / 2];
     NSDate *timeNow = [NSDate dateWithTimeIntervalSince1970:1000000];
@@ -1356,65 +1382,65 @@ static void testDatesInRange(NSTimeInterval from, NSTimeInterval to, void (^chec
                                                @"cBoolCol"  : @NO,
                                                @"longCol"   : @(99),
                                                @"objectCol" : NSNull.null};
-    
+
     [realm beginWriteTransaction];
-    
+
     // Test NSDictonary
     XCTAssertNoThrow(([AllTypesObject createInRealm:realm withValue:dictValidAllTypes]),
                      @"Creating object with valid value types should not throw exception");
-    
+
     for (NSString *keyToInvalidate in dictValidAllTypes.allKeys) {
         NSMutableDictionary *invalidInput = [dictValidAllTypes mutableCopy];
         id obj = @"invalid";
         if ([keyToInvalidate isEqualToString:@"stringCol"]) {
             obj = @1;
         }
-        
+
         invalidInput[keyToInvalidate] = obj;
-        
+
         XCTAssertThrows(([AllTypesObject createInRealm:realm withValue:invalidInput]),
                         @"Creating object with invalid value types should throw exception");
     }
-    
-    
+
+
     [realm commitWriteTransaction];
 }
 
 - (void)testCreateInRealmValidationForArray
 {
     RLMRealm *realm = [RLMRealm defaultRealm];
-    
+
     // add test/link object to realm
     [realm beginWriteTransaction];
     StringObject *to = [StringObject createInRealm:realm withValue:@[@"c"]];
     [realm commitWriteTransaction];
-    
+
     const char bin[4] = { 0, 1, 2, 3 };
     NSData *bin1 = [[NSData alloc] initWithBytes:bin length:sizeof bin / 2];
     NSDate *timeNow = [NSDate dateWithTimeIntervalSince1970:1000000];
     NSArray *const arrayValidAllTypes = @[@NO, @54, @0.7f, @0.8, @"foo", bin1, timeNow, @NO, @(99), to];
-    
+
     [realm beginWriteTransaction];
-    
+
     // Test NSArray
     XCTAssertNoThrow(([AllTypesObject createInRealm:realm withValue:arrayValidAllTypes]),
                      @"Creating object with valid value types should not throw exception");
-    
+
     const NSInteger stringColIndex = 4;
     for (NSUInteger i = 0; i < arrayValidAllTypes.count; i++) {
         NSMutableArray *invalidInput = [arrayValidAllTypes mutableCopy];
-        
+
         id obj = @"invalid";
         if (i == stringColIndex) {
             obj = @1;
         }
-        
+
         invalidInput[i] = obj;
-        
+
         XCTAssertThrows(([AllTypesObject createInRealm:realm withValue:invalidInput]),
                         @"Creating object with invalid value types should throw exception");
     }
-    
+
     [realm commitWriteTransaction];
 }
 
@@ -1577,9 +1603,9 @@ static void testDatesInRange(NSTimeInterval from, NSTimeInterval to, void (^chec
 - (void)testCreateInRealmWithMissingValue
 {
     RLMRealm *realm = [RLMRealm defaultRealm];
-    
+
     [realm beginWriteTransaction];
-    
+
     // This exception only gets thrown when there is no default vaule and it is for an NSObject property
     XCTAssertThrows(([AggregateObject createInRealm:realm withValue:@{@"boolCol" : @YES}]), @"Missing values in NSDictionary should throw default value exception");
     EmployeeObject *eo = nil;
@@ -1587,43 +1613,43 @@ static void testDatesInRange(NSTimeInterval from, NSTimeInterval to, void (^chec
     XCTAssertNil(eo.name);
     eo = [EmployeeObject createInRealm:realm withValue:@{@"name":NSNull.null, @"age":@20, @"hired": @YES}];
     XCTAssertNil(eo.name);
-    
+
     // This exception gets thrown when count of array does not match with object schema
     XCTAssertThrows(([EmployeeObject createInRealm:realm withValue:@[@27, @YES]]), @"Missing values in NSDictionary should throw default value exception");
-    
+
     [realm commitWriteTransaction];
 }
 
 - (void)testObjectDescription
 {
     RLMRealm *realm = [RLMRealm defaultRealm];
-    
+
     [realm beginWriteTransaction];
-    
+
     // Init object before adding to realm
     EmployeeObject *soInit = [[EmployeeObject alloc] init];
     soInit.name = @"Peter";
     soInit.age = 30;
     soInit.hired = YES;
     [realm addObject:soInit];
-    
+
     // description asserts block
     void (^descriptionAsserts)(NSString *) = ^(NSString *description) {
         XCTAssertTrue([description rangeOfString:@"name"].location != NSNotFound, @"column names should be displayed when calling \"description\" on RLMObject subclasses");
         XCTAssertTrue([description rangeOfString:@"Peter"].location != NSNotFound, @"column values should be displayed when calling \"description\" on RLMObject subclasses");
-        
+
         XCTAssertTrue([description rangeOfString:@"age"].location != NSNotFound, @"column names should be displayed when calling \"description\" on RLMObject subclasses");
         XCTAssertTrue([description rangeOfString:[@30 description]].location != NSNotFound, @"column values should be displayed when calling \"description\" on RLMObject subclasses");
-        
+
         XCTAssertTrue([description rangeOfString:@"hired"].location != NSNotFound, @"column names should be displayed when calling \"description\" on RLMObject subclasses");
         XCTAssertTrue([description rangeOfString:[@YES description]].location != NSNotFound, @"column values should be displayed when calling \"description\" on RLMObject subclasses");
     };
-    
+
     // Test description in write block
     descriptionAsserts(soInit.description);
-    
+
     [realm commitWriteTransaction];
-    
+
     // Test description in read block
     NSString *objDescription = [[[EmployeeObject objectsWithPredicate:nil] firstObject] description];
     descriptionAsserts(objDescription);
@@ -1700,7 +1726,7 @@ static void testDatesInRange(NSTimeInterval from, NSTimeInterval to, void (^chec
 
     RLMProperty *optionalBoolProperty = schema[IndexedObject.className][@"optionalBoolCol"];
     XCTAssertTrue(optionalBoolProperty.indexed, @"indexed property should have an index");
-    
+
     RLMProperty *floatProperty = schema[IndexedObject.className][@"floatCol"];
     XCTAssertFalse(floatProperty.indexed, @"non-indexed property shouldn't have an index");
 

--- a/Realm/Tests/RLMTestObjects.h
+++ b/Realm/Tests/RLMTestObjects.h
@@ -304,6 +304,13 @@ RLM_ARRAY_TYPE(CircleObject);
 @interface NumberDefaultsObject : NumberObject
 @end
 
+@interface RequiredNumberObject : RLMObject
+@property NSNumber<RLMInt> *intObj;
+@property NSNumber<RLMFloat> *floatObj;
+@property NSNumber<RLMDouble> *doubleObj;
+@property NSNumber<RLMBool> *boolObj;
+@end
+
 #pragma mark CustomInitializerObject
 
 @interface CustomInitializerObject : RLMObject

--- a/Realm/Tests/RLMTestObjects.m
+++ b/Realm/Tests/RLMTestObjects.m
@@ -209,6 +209,12 @@
 }
 @end
 
+@implementation RequiredNumberObject
++ (NSArray *)requiredProperties {
+    return @[@"intObj", @"floatObj", @"doubleObj", @"boolObj"];
+}
+@end
+
 #pragma mark CustomInitializerObject
 
 @implementation CustomInitializerObject

--- a/Realm/Tests/SchemaTests.mm
+++ b/Realm/Tests/SchemaTests.mm
@@ -311,6 +311,7 @@ RLM_ARRAY_TYPE(NotARealClass)
     // Test each permutation of loading orders and verify that all properties
     // are initialized correctly
     std::sort(testClasses, std::end(testClasses), pred);
+    unsigned long iteration = 0;
     do @autoreleasepool {
         // Clean up any existing overridden things
         for (Class cls : testClasses) {
@@ -330,9 +331,11 @@ RLM_ARRAY_TYPE(NotARealClass)
         schema.objectSchema = objectSchemas;
 
         for (RLMObjectSchema *objectSchema in objectSchemas) {
-            objectSchema.accessorClass = RLMAccessorClassForObjectClass(objectSchema.objectClass, objectSchema, @"RLMAccessor_");
+            NSString *name = [NSString stringWithFormat:@"RLMTestAccessor_%lu_%@", iteration, objectSchema.className];
+            objectSchema.accessorClass = RLMManagedAccessorClassForObjectClass(objectSchema.objectClass, objectSchema, name.UTF8String);
             objectSchema.unmanagedClass = RLMUnmanagedAccessorClassForObjectClass(objectSchema.objectClass, objectSchema);
         }
+        ++iteration;
 
         for (Class cls : testClasses) {
             NSString *className = NSStringFromClass(cls);


### PR DESCRIPTION
In total this cuts the time to create the accessor classes in half. In absolute terms it's not an exciting speedup (it was only ~10 ms for our test schema before on an iPad Air running 9.1), but supporting schema changes while the app is running involves creating a lot more accessor classes, which lead to it starting to be an issue.
