### PR TITLE
Fixing sequence iterators

### DIFF
--- a/Realm/Swift/RLMSupport.swift
+++ b/Realm/Swift/RLMSupport.swift
@@ -29,7 +29,7 @@ extension RLMObject {
     }
 }
 
-public final class RLMGenerator: GeneratorType {
+public final class RLMIterator: IteratorProtocol {
     private let generatorBase: NSFastGenerator
 
     internal init(collection: RLMCollection) {
@@ -41,10 +41,10 @@ public final class RLMGenerator: GeneratorType {
     }
 }
 
-extension RLMArray: SequenceType {
+extension RLMArray: Sequence {
     // Support Sequence-style enumeration
-    public func generate() -> RLMGenerator {
-        return RLMGenerator(collection: self)
+    public func makeIterator() -> RLMIterator {
+        return RLMIterator(collection: self)
     }
 
     // Swift query convenience functions
@@ -57,10 +57,10 @@ extension RLMArray: SequenceType {
     }
 }
 
-extension RLMResults: SequenceType {
+extension RLMResults: Sequence {
     // Support Sequence-style enumeration
-    public func generate() -> RLMGenerator {
-        return RLMGenerator(collection: self)
+    public func makeIterator() -> RLMIterator {
+        return RLMIterator(collection: self)
     }
 
     // Swift query convenience functions

--- a/RealmSwift-swift3.0-dev/LinkingObjects.swift
+++ b/RealmSwift-swift3.0-dev/LinkingObjects.swift
@@ -388,9 +388,9 @@ public final class LinkingObjects<T: Object>: LinkingObjectsBase {
 extension LinkingObjects: RealmCollection {
     // MARK: Sequence Support
 
-    /// Returns a `GeneratorOf<T>` that yields successive elements in the results.
-    public func generate() -> RLMGenerator<T> {
-        return RLMGenerator(collection: rlmResults)
+    /// Returns an `RLMIterator` that yields successive elements in the results.
+    public func makeIterator() -> RLMIterator<T> {
+        return RLMIterator(collection: rlmResults)
     }
 
     // MARK: Collection Support

--- a/RealmSwift-swift3.0-dev/List.swift
+++ b/RealmSwift-swift3.0-dev/List.swift
@@ -472,9 +472,9 @@ public final class List<T: Object>: ListBase {
 extension List: RealmCollection, RangeReplaceableCollection {
     // MARK: Sequence Support
 
-    /// Returns a `GeneratorOf<T>` that yields successive elements in the List.
-    public func generate() -> RLMGenerator<T> {
-        return RLMGenerator(collection: _rlmArray)
+    /// Returns a `RLMIterator` that yields successive elements in the `List`.
+    public func makeIterator() -> RLMIterator<T> {
+        return RLMIterator(collection: _rlmArray)
     }
 
     // MARK: RangeReplaceableCollection Support

--- a/RealmSwift-swift3.0-dev/Results.swift
+++ b/RealmSwift-swift3.0-dev/Results.swift
@@ -381,9 +381,9 @@ public final class Results<T: Object>: NSObject, NSFastEnumeration {
 extension Results: RealmCollection {
     // MARK: Sequence Support
 
-    /// Returns a `GeneratorOf<T>` that yields successive elements in the results.
-    public func generate() -> RLMGenerator<T> {
-        return RLMGenerator(collection: rlmResults)
+    /// Returns a `RLMIterator` that yields successive elements in the results.
+    public func makeIterator() -> RLMIterator<T> {
+        return RLMIterator(collection: rlmResults)
     }
 
     // MARK: Collection Support

--- a/RealmSwift-swift3.0-dev/Tests/ListTests.swift
+++ b/RealmSwift-swift3.0-dev/Tests/ListTests.swift
@@ -80,19 +80,19 @@ class ListTests: TestCase {
         }
     }
 
+    func testFastEnumerationWithMutation() {
+        array.appendContentsOf([str1, str2, str1, str2, str1, str2, str1, str2, str1,
+            str2, str1, str2, str1, str2, str1, str2, str1, str2, str1, str2])
+        var str = ""
+        for obj in array {
+            str += obj.stringCol
+            array.appendContentsOf([str1])
+        }
+
+        XCTAssertEqual(str, "12121212121212121212")
+    }
+
     /* disabled for Swift 3 conversion */
-//    func testFastEnumerationWithMutation() {
-//        array.appendContentsOf([str1, str2, str1, str2, str1, str2, str1, str2, str1,
-//            str2, str1, str2, str1, str2, str1, str2, str1, str2, str1, str2])
-//        var str = ""
-//        for obj in array {
-//            str += obj.stringCol
-//            array.appendContentsOf([str1])
-//        }
-//
-//        XCTAssertEqual(str, "12121212121212121212")
-//    }
-//
 //    func testAppendObject() {
 //        for str in [str1, str2, str1] {
 //            array.append(str!)

--- a/RealmSwift-swift3.0-dev/Tests/ObjectAccessorTests.swift
+++ b/RealmSwift-swift3.0-dev/Tests/ObjectAccessorTests.swift
@@ -202,8 +202,8 @@ class ObjectAccessorTests: TestCase {
         let lastObject = objects.last
         XCTAssertEqual(2, lastObject!.arrayCol.count)
 
-//        let generator = objects.generate()
-//        let next = generator.next()!
+//        let iterator = objects.makeIterator()
+//        let next = iterator.next()!
 //        XCTAssertEqual(next.arrayCol.count, 2)
 
         for obj in objects {


### PR DESCRIPTION
@jpsim 

Changes:
- Updated sequence, collection, and iterator protocols and types for Swift 3
- Restored use of NSFastEnumerationIterator
- Reenabled a test