### PR TITLE
Allow to create or update objects with RealmOptional as primary key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ x.x.x Release notes (yyyy-MM-dd)
 
 ### Bugfixes
 
-* None.
+* Swift: Fix an error thrown when trying to create or update `Object` instances via
+  `add(:_update:)` with a primary key property of type `RealmOptional`.
 
 1.0.0 Release notes (2016-05-25)
 =============================================================

--- a/Realm/RLMObjectStore.mm
+++ b/Realm/RLMObjectStore.mm
@@ -182,7 +182,7 @@ void RLMAddObjectToRealm(__unsafe_unretained RLMObjectBase *const object,
 
     // get or create row
     bool created;
-    auto primaryGetter = [=](__unsafe_unretained RLMProperty *const p) { return [object valueForKey:p.getterName]; };
+    auto primaryGetter = [=](__unsafe_unretained RLMProperty *const p) { return [object valueForKey:p.name]; };
     object->_row = (*schema.table)[RLMCreateOrGetRowForObject(schema, primaryGetter, createOrUpdate, created)];
 
     RLMCreationOptions creationOptions = RLMCreationOptionsPromoteStandalone;

--- a/RealmSwift-swift2.2/Tests/ObjectCreationTests.swift
+++ b/RealmSwift-swift2.2/Tests/ObjectCreationTests.swift
@@ -480,6 +480,24 @@ class ObjectCreationTests: TestCase {
         XCTAssertEqual(existingObject.intCol, 2)
     }
 
+    func testAddWithNumericOptionalPrimaryKeyProperty() {
+        let realm = try! Realm()
+        realm.beginWrite()
+
+        let object = SwiftPrimaryOptionalIntObject()
+        object.intCol.value = 1
+        realm.add(object, update: true)
+
+        let nilObject = SwiftPrimaryOptionalIntObject()
+        nilObject.intCol.value = nil
+        realm.add(nilObject, update: true)
+
+        try! realm.commitWrite()
+
+        XCTAssertNotNil(object.realm)
+        XCTAssertNotNil(nilObject.realm)
+    }
+
     // MARK: Private utilities
     private func verifySwiftObjectWithArrayLiteral(object: SwiftObject, array: [AnyObject], boolObjectValue: Bool,
                                                    boolObjectListValues: [Bool]) {


### PR DESCRIPTION
Fixes #3671.

/c @kishikawakatsumi @jpsim 