### PR TITLE
Fixing many more tests

### DIFF
--- a/RealmSwift-swift3.0-dev/LinkingObjects.swift
+++ b/RealmSwift-swift3.0-dev/LinkingObjects.swift
@@ -405,6 +405,7 @@ extension LinkingObjects: RealmCollection {
     public var endIndex: Int { return count }
 
     public func index(after i: Int) -> Int { return i + 1 }
+    public func index(before i: Int) -> Int { return i - 1 }
 
     /// :nodoc:
     public func _addNotificationBlock(block: (RealmCollectionChange<AnyRealmCollection<T>>) -> Void) ->

--- a/RealmSwift-swift3.0-dev/List.swift
+++ b/RealmSwift-swift3.0-dev/List.swift
@@ -31,7 +31,7 @@ public class ListBase: RLMListBase {
         return descriptionWithMaxDepth(depth: RLMDescriptionMaxDepth)
     }
 
-    @objc private func descriptionWithMaxDepth(depth: UInt) -> String {
+    @objc(descriptionWithMaxDepth:) private func descriptionWithMaxDepth(depth: UInt) -> String {
         let type = "List<\(_rlmArray.objectClassName)>"
         return gsub(pattern: "RLMArray <0x[a-z0-9]+>", template: type, string: _rlmArray.description(withMaxDepth: depth)) ?? type
     }
@@ -505,6 +505,7 @@ extension List: RealmCollection, RangeReplaceableCollection {
     public var endIndex: Int { return count }
 
     public func index(after i: Int) -> Int { return i + 1 }
+    public func index(before i: Int) -> Int { return i - 1 }
 
     /// :nodoc:
     public func _addNotificationBlock(block: (RealmCollectionChange<AnyRealmCollection<T>>) -> Void) ->

--- a/RealmSwift-swift3.0-dev/List.swift
+++ b/RealmSwift-swift3.0-dev/List.swift
@@ -28,10 +28,10 @@ public class ListBase: RLMListBase {
     // generic class.
     /// Returns a human-readable description of the objects contained in the List.
     @objc public override var description: String {
-        return descriptionWithMaxDepth(depth: RLMDescriptionMaxDepth)
+        return descriptionWithMaxDepth(RLMDescriptionMaxDepth)
     }
 
-    @objc(descriptionWithMaxDepth:) private func descriptionWithMaxDepth(depth: UInt) -> String {
+    @objc private func descriptionWithMaxDepth(_ depth: UInt) -> String {
         let type = "List<\(_rlmArray.objectClassName)>"
         return gsub(pattern: "RLMArray <0x[a-z0-9]+>", template: type, string: _rlmArray.description(withMaxDepth: depth)) ?? type
     }

--- a/RealmSwift-swift3.0-dev/RealmCollectionType.swift
+++ b/RealmSwift-swift3.0-dev/RealmCollectionType.swift
@@ -117,7 +117,7 @@ public enum RealmCollectionChange<T> {
 A homogenous collection of `Object`s which can be retrieved, filtered, sorted,
 and operated upon.
 */
-public protocol RealmCollection: Collection, CustomStringConvertible {
+public protocol RealmCollection: RandomAccessCollection, CustomStringConvertible {
 
     /// Element type contained in this collection.
     associatedtype Element: Object
@@ -638,6 +638,7 @@ Element type, hiding the specifics of the underlying `RealmCollection`.
 public final class AnyRealmCollection<T: Object>: RealmCollection {
 
     public func index(after i: Int) -> Int { return i + 1 }
+    public func index(before i: Int) -> Int { return i - 1 }
 
     /// Element type contained in this collection.
     public typealias Element = T

--- a/RealmSwift-swift3.0-dev/Results.swift
+++ b/RealmSwift-swift3.0-dev/Results.swift
@@ -398,6 +398,7 @@ extension Results: RealmCollection {
     public var endIndex: Int { return count }
 
     public func index(after i: Int) -> Int { return i + 1 }
+    public func index(before i: Int) -> Int { return i - 1 }
 
     /// :nodoc:
     public func _addNotificationBlock(block: (RealmCollectionChange<AnyRealmCollection<T>>) -> Void) ->

--- a/RealmSwift-swift3.0-dev/Tests/ListTests.swift
+++ b/RealmSwift-swift3.0-dev/Tests/ListTests.swift
@@ -23,7 +23,7 @@ class ListTests: TestCase {
     var str1: SwiftStringObject?
     var str2: SwiftStringObject?
     var arrayObject: SwiftArrayPropertyObject!
-    var array: List<SwiftStringObject>!
+    var array: List<SwiftStringObject>?
 
     func createArray() -> SwiftArrayPropertyObject {
         fatalError("abstract")
@@ -76,6 +76,9 @@ class ListTests: TestCase {
     }
 
     func testInvalidated() {
+        guard let array = array else {
+            fatalError("Test precondition failure")
+        }
         XCTAssertFalse(array.invalidated)
 
         if let realm = arrayObject.realm {
@@ -85,7 +88,7 @@ class ListTests: TestCase {
     }
 
     func testFastEnumerationWithMutation() {
-        guard let str1 = str1, str2 = str2 else {
+        guard let array = array, str1 = str1, str2 = str2 else {
             fatalError("Test precondition failure")
         }
 
@@ -101,10 +104,9 @@ class ListTests: TestCase {
     }
 
     func testAppendObject() {
-        guard let str1 = str1, str2 = str2 else {
+        guard let array = array, str1 = str1, str2 = str2 else {
             fatalError("Test precondition failure")
         }
-
         for str in [str1, str2, str1] {
             array.append(str)
         }
@@ -114,67 +116,85 @@ class ListTests: TestCase {
         XCTAssertEqual(str1, array[2])
     }
 
-    /* disabled for Swift 3 conversion */
-//    func testAppendArray() {
-//        array.appendContentsOf([str1, str2, str1])
-//        XCTAssertEqual(Int(3), array.count)
-//        XCTAssertEqual(str1, array[0])
-//        XCTAssertEqual(str2, array[1])
-//        XCTAssertEqual(str1, array[2])
-//    }
-//
-//    func testAppendResults() {
-//        array.appendContentsOf(realmWithTestPath().objects(SwiftStringObject))
-//        XCTAssertEqual(Int(2), array.count)
-//        XCTAssertEqual(str1, array[0])
-//        XCTAssertEqual(str2, array[1])
-//    }
-//
-//    func testInsert() {
-//        XCTAssertEqual(Int(0), array.count)
-//
-//        array.insert(str1, at: 0)
-//        XCTAssertEqual(Int(1), array.count)
-//        XCTAssertEqual(str1, array[0])
-//
-//        array.insert(str2, at: 0)
-//        XCTAssertEqual(Int(2), array.count)
-//        XCTAssertEqual(str2, array[0])
-//        XCTAssertEqual(str1, array[1])
-//
-//        assertThrows(_ = self.array.insert(self.str2, at: 200))
-//        assertThrows(_ = self.array.insert(self.str2, at: -200))
-//    }
-//
-//    func testRemoveAtIndex() {
-//        array.appendContentsOf([str1, str2, str1])
-//
-//        array.remove(at: 1)
-//        XCTAssertEqual(str1, array[0])
-//        XCTAssertEqual(str1, array[1])
-//
-//        assertThrows(self.array.remove(at: 200))
-//        assertThrows(self.array.remove(at: -200))
-//    }
-//
-//    func testRemoveLast() {
-//        array.appendContentsOf([str1, str2])
-//
-//        array.removeLast()
-//        XCTAssertEqual(Int(1), array.count)
-//        XCTAssertEqual(str1, array[0])
-//
-//        array.removeLast()
-//        XCTAssertEqual(Int(0), array.count)
-//
-//        array.removeLast() // should be a no-op
-//        XCTAssertEqual(Int(0), array.count)
-//    }
-
-    func testRemoveAll() {
-        guard let str1 = str1, str2 = str2 else {
+    func testAppendArray() {
+        guard let array = array, str1 = str1, str2 = str2 else {
             fatalError("Test precondition failure")
         }
+        array.appendContentsOf([str1, str2, str1])
+        XCTAssertEqual(Int(3), array.count)
+        XCTAssertEqual(str1, array[0])
+        XCTAssertEqual(str2, array[1])
+        XCTAssertEqual(str1, array[2])
+    }
+
+    func testAppendResults() {
+        guard let array = array, str1 = str1, str2 = str2 else {
+            fatalError("Test precondition failure")
+        }
+        array.appendContentsOf(realmWithTestPath().objects(SwiftStringObject))
+        XCTAssertEqual(Int(2), array.count)
+        XCTAssertEqual(str1, array[0])
+        XCTAssertEqual(str2, array[1])
+    }
+
+    func testInsert() {
+        guard let array = array, str1 = str1, str2 = str2 else {
+            fatalError("Test precondition failure")
+        }
+
+        XCTAssertEqual(Int(0), array.count)
+
+        array.insert(str1, at: 0)
+        XCTAssertEqual(Int(1), array.count)
+        XCTAssertEqual(str1, array[0])
+
+        array.insert(str2, at: 0)
+        XCTAssertEqual(Int(2), array.count)
+        XCTAssertEqual(str2, array[0])
+        XCTAssertEqual(str1, array[1])
+
+        assertThrows(_ = array.insert(str2, at: 200))
+        assertThrows(_ = array.insert(str2, at: -200))
+    }
+
+    func testRemoveAtIndex() {
+        guard let array = array, str1 = str1, str2 = str2 else {
+            fatalError("Test precondition failure")
+        }
+
+        array.appendContentsOf([str1, str2, str1])
+
+        array.remove(at: 1)
+        XCTAssertEqual(str1, array[0])
+        XCTAssertEqual(str1, array[1])
+
+        assertThrows(array.remove(at: 200))
+        assertThrows(array.remove(at: -200))
+    }
+
+    func testRemoveLast() {
+        guard let array = array, str1 = str1, str2 = str2 else {
+            fatalError("Test precondition failure")
+        }
+
+        array.appendContentsOf([str1, str2])
+
+        array.removeLast()
+        XCTAssertEqual(Int(1), array.count)
+        XCTAssertEqual(str1, array[0])
+
+        array.removeLast()
+        XCTAssertEqual(Int(0), array.count)
+
+        array.removeLast() // should be a no-op
+        XCTAssertEqual(Int(0), array.count)
+    }
+
+    func testRemoveAll() {
+        guard let array = array, str1 = str1, str2 = str2 else {
+            fatalError("Test precondition failure")
+        }
+
         array.appendContentsOf([str1, str2])
 
         array.removeAll()
@@ -184,28 +204,32 @@ class ListTests: TestCase {
         XCTAssertEqual(Int(0), array.count)
     }
 
-    /* disabled for Swift 3 conversion */
-//    func testReplace() {
-//        array.appendContentsOf([str1, str1])
-//
-//        array.replace(index: 0, object: str2)
-//        XCTAssertEqual(Int(2), array.count)
-//        XCTAssertEqual(str2, array[0])
-//        XCTAssertEqual(str1, array[1])
-//
-//        array.replace(index: 1, object: str2)
-//        XCTAssertEqual(Int(2), array.count)
-//        XCTAssertEqual(str2, array[0])
-//        XCTAssertEqual(str2, array[1])
-//
-//        assertThrows(self.array.replace(index: 200, object: self.str2))
-//        assertThrows(self.array.replace(index: -200, object: self.str2))
-//    }
-
-    func testMove() {
-        guard let str1 = str1, str2 = str2 else {
+    func testReplace() {
+        guard let array = array, str1 = str1, str2 = str2 else {
             fatalError("Test precondition failure")
         }
+
+        array.appendContentsOf([str1, str1])
+
+        array.replace(index: 0, object: str2)
+        XCTAssertEqual(Int(2), array.count)
+        XCTAssertEqual(str2, array[0])
+        XCTAssertEqual(str1, array[1])
+
+        array.replace(index: 1, object: str2)
+        XCTAssertEqual(Int(2), array.count)
+        XCTAssertEqual(str2, array[0])
+        XCTAssertEqual(str2, array[1])
+
+        assertThrows(array.replace(index: 200, object: str2))
+        assertThrows(array.replace(index: -200, object: str2))
+    }
+
+    func testMove() {
+        guard let array = array, str1 = str1, str2 = str2 else {
+            fatalError("Test precondition failure")
+        }
+
         array.appendContentsOf([str1, str2])
 
         array.move(from: 1, to: 0)
@@ -223,59 +247,66 @@ class ListTests: TestCase {
         XCTAssertEqual(array[0].stringCol, "1")
         XCTAssertEqual(array[1].stringCol, "2")
 
-        assertThrows(self.array.move(from: 0, to: 2))
-        assertThrows(self.array.move(from: 2, to: 0))
+        assertThrows(array.move(from: 0, to: 2))
+        assertThrows(array.move(from: 2, to: 0))
     }
 
-    /* disabled for Swift 3 conversion */
-//    func testReplaceRange() {
-//        array.appendContentsOf([str1, str1])
-//
-//        array.replaceSubrange(0...0, with: [str2])
-//        XCTAssertEqual(Int(2), array.count)
-//        XCTAssertEqual(str2, array[0])
-//        XCTAssertEqual(str1, array[1])
-//
-//        array.replaceSubrange(1..<2, with: [str2])
-//        XCTAssertEqual(Int(2), array.count)
-//        XCTAssertEqual(str2, array[0])
-//        XCTAssertEqual(str2, array[1])
-//
-//        array.replaceSubrange(0..<0, with: [str2])
-//        XCTAssertEqual(Int(3), array.count)
-//        XCTAssertEqual(str2, array[0])
-//        XCTAssertEqual(str2, array[1])
-//        XCTAssertEqual(str2, array[2])
-//
-//        array.replaceSubrange(0..<3, with: [])
-//        XCTAssertEqual(Int(0), array.count)
-//
-//        assertThrows(self.array.replaceSubrange(200..<201, with: [self.str2]))
-//        assertThrows(self.array.replaceSubrange(-200...200, with: [self.str2]))
-//        assertThrows(self.array.replaceSubrange(0...200, with: [self.str2]))
-//    }
-//
-//    func testSwap() {
-//        array.appendContentsOf([str1, str2])
-//
-//        array.swap(index1: 0, 1)
-//        XCTAssertEqual(Int(2), array.count)
-//        XCTAssertEqual(str2, array[0])
-//        XCTAssertEqual(str1, array[1])
-//
-//        array.swap(index1: 1, 1)
-//        XCTAssertEqual(Int(2), array.count)
-//        XCTAssertEqual(str2, array[0])
-//        XCTAssertEqual(str1, array[1])
-//
-//        assertThrows(self.array.swap(index1: -1, 0))
-//        assertThrows(self.array.swap(index1: 0, -1))
-//        assertThrows(self.array.swap(index1: 1000, 0))
-//        assertThrows(self.array.swap(index1: 0, 1000))
-//    }
+    func testReplaceRange() {
+        guard let array = array, str1 = str1, str2 = str2 else {
+            fatalError("Test precondition failure")
+        }
+
+        array.appendContentsOf([str1, str1])
+
+        array.replaceSubrange(0..<1, with: [str2])
+        XCTAssertEqual(Int(2), array.count)
+        XCTAssertEqual(str2, array[0])
+        XCTAssertEqual(str1, array[1])
+
+        array.replaceSubrange(1..<2, with: [str2])
+        XCTAssertEqual(Int(2), array.count)
+        XCTAssertEqual(str2, array[0])
+        XCTAssertEqual(str2, array[1])
+
+        array.replaceSubrange(0..<0, with: [str2])
+        XCTAssertEqual(Int(3), array.count)
+        XCTAssertEqual(str2, array[0])
+        XCTAssertEqual(str2, array[1])
+        XCTAssertEqual(str2, array[2])
+
+        array.replaceSubrange(0..<3, with: [])
+        XCTAssertEqual(Int(0), array.count)
+
+        assertThrows(array.replaceSubrange(200..<201, with: [str2]))
+        assertThrows(array.replaceSubrange(-200..<200, with: [str2]))
+        assertThrows(array.replaceSubrange(0..<200, with: [str2]))
+    }
+
+    func testSwap() {
+        guard let array = array, str1 = str1, str2 = str2 else {
+            fatalError("Test precondition failure")
+        }
+
+        array.appendContentsOf([str1, str2])
+
+        array.swap(index1: 0, 1)
+        XCTAssertEqual(Int(2), array.count)
+        XCTAssertEqual(str2, array[0])
+        XCTAssertEqual(str1, array[1])
+
+        array.swap(index1: 1, 1)
+        XCTAssertEqual(Int(2), array.count)
+        XCTAssertEqual(str2, array[0])
+        XCTAssertEqual(str1, array[1])
+
+        assertThrows(array.swap(index1: -1, 0))
+        assertThrows(array.swap(index1: 0, -1))
+        assertThrows(array.swap(index1: 1000, 0))
+        assertThrows(array.swap(index1: 0, 1000))
+    }
 
     func testChangesArePersisted() {
-        guard let str1 = str1, str2 = str2 else {
+        guard let array = array, str1 = str1, str2 = str2 else {
             fatalError("Test precondition failure")
         }
         if let realm = array.realm {
@@ -287,6 +318,10 @@ class ListTests: TestCase {
     }
 
     func testPopulateEmptyArray() {
+        guard let array = array else {
+            fatalError("Test precondition failure")
+        }
+
         XCTAssertEqual(array.count, 0, "Should start with no array elements.")
 
         let obj = SwiftStringObject()

--- a/RealmSwift-swift3.0-dev/Tests/ObjectCreationTests.swift
+++ b/RealmSwift-swift3.0-dev/Tests/ObjectCreationTests.swift
@@ -463,8 +463,7 @@ class ObjectCreationTests: TestCase {
 
         XCTAssertNotNil(object.realm)
 
-        /* disabled for Swift 3 conversion */
-        // XCTAssertEqual(object.objectCol, existingObject)
+        XCTAssertEqual(object.objectCol, existingObject)
     }
 
     func testAddAndUpdateWithExisingNestedObjects() {

--- a/RealmSwift-swift3.0-dev/Tests/ObjectSchemaInitializationTests.swift
+++ b/RealmSwift-swift3.0-dev/Tests/ObjectSchemaInitializationTests.swift
@@ -181,16 +181,6 @@ class ObjectSchemaInitializationTests: TestCase {
         XCTAssertEqual(types, Set([.string, .string, .data, .date, .object, .int, .float, .double, .bool]))
     }
 
-    /* disabled for Swift 3 conversion */
-//    func testImplicitlyUnwrappedOptionalsAreParsedAsOptionals() {
-//        let schema = SwiftImplicitlyUnwrappedOptionalObject().objectSchema
-//        XCTAssertTrue(schema["optObjectCol"]!.optional)
-//        XCTAssertTrue(schema["optNSStringCol"]!.optional)
-//        XCTAssertTrue(schema["optStringCol"]!.optional)
-//        XCTAssertTrue(schema["optBinaryCol"]!.optional)
-//        XCTAssertTrue(schema["optDateCol"]!.optional)
-//    }
-
     func testNonRealmOptionalTypesDeclaredAsRealmOptional() {
         assertThrows(RLMObjectSchema(forObjectClass: SwiftObjectWithNonRealmOptionalType.self))
     }

--- a/RealmSwift-swift3.0-dev/Tests/ObjectTests.swift
+++ b/RealmSwift-swift3.0-dev/Tests/ObjectTests.swift
@@ -84,17 +84,16 @@ class ObjectTests: TestCase {
         XCTAssertTrue(object.isInvalidated)
     }
 
-    /* disabled for Swift 3 conversion */
-//    func testDescription() {
-//        let object = SwiftObject()
-//        // swiftlint:disable line_length
-//        XCTAssertEqual(object.description, "SwiftObject {\n\tboolCol = 0;\n\tintCol = 123;\n\tfloatCol = 1.23;\n\tdoubleCol = 12.3;\n\tstringCol = a;\n\tbinaryCol = <61 — 1 total bytes>;\n\tdateCol = 1970-01-01 00:00:01 +0000;\n\tobjectCol = SwiftBoolObject {\n\t\tboolCol = 0;\n\t};\n\tarrayCol = List<SwiftBoolObject> (\n\t\n\t);\n}")
-//
-//        let recursiveObject = SwiftRecursiveObject()
-//        recursiveObject.objects.append(recursiveObject)
-//        XCTAssertEqual(recursiveObject.description, "SwiftRecursiveObject {\n\tobjects = List<SwiftRecursiveObject> (\n\t\t[0] SwiftRecursiveObject {\n\t\t\tobjects = List<SwiftRecursiveObject> (\n\t\t\t\t[0] SwiftRecursiveObject {\n\t\t\t\t\tobjects = <Maximum depth exceeded>;\n\t\t\t\t}\n\t\t\t);\n\t\t}\n\t);\n}")
-//        // swiftlint:enable line_length
-//    }
+    func testDescription() {
+        let object = SwiftObject()
+        // swiftlint:disable line_length
+        XCTAssertEqual(object.description, "SwiftObject {\n\tboolCol = 0;\n\tintCol = 123;\n\tfloatCol = 1.23;\n\tdoubleCol = 12.3;\n\tstringCol = a;\n\tbinaryCol = <61 — 1 total bytes>;\n\tdateCol = 1970-01-01 00:00:01 +0000;\n\tobjectCol = SwiftBoolObject {\n\t\tboolCol = 0;\n\t};\n\tarrayCol = List<SwiftBoolObject> (\n\t\n\t);\n}")
+
+        let recursiveObject = SwiftRecursiveObject()
+        recursiveObject.objects.append(recursiveObject)
+        XCTAssertEqual(recursiveObject.description, "SwiftRecursiveObject {\n\tobjects = List<SwiftRecursiveObject> (\n\t\t[0] SwiftRecursiveObject {\n\t\t\tobjects = List<SwiftRecursiveObject> (\n\t\t\t\t[0] SwiftRecursiveObject {\n\t\t\t\t\tobjects = <Maximum depth exceeded>;\n\t\t\t\t}\n\t\t\t);\n\t\t}\n\t);\n}")
+        // swiftlint:enable line_length
+    }
 
     func testPrimaryKey() {
         XCTAssertNil(Object.primaryKey(), "primary key should default to nil")
@@ -192,16 +191,14 @@ class ObjectTests: TestCase {
 
         let boolObject = SwiftBoolObject(value: [true])
         setter(object, boolObject, "objectCol")
-        /* disabled for Swift 3 conversion */
-        // XCTAssertEqual(getter(object, "objectCol") as? SwiftBoolObject, boolObject)
+        XCTAssertEqual(getter(object, "objectCol") as? SwiftBoolObject, boolObject)
         XCTAssertEqual((getter(object, "objectCol") as! SwiftBoolObject).boolCol, true)
 
         let list = List<SwiftBoolObject>()
         list.append(boolObject)
         setter(object, list, "arrayCol")
         XCTAssertEqual((getter(object, "arrayCol") as! List<SwiftBoolObject>).count, 1)
-        /* disabled for Swift 3 conversion */
-        // XCTAssertEqual((getter(object, "arrayCol") as! List<SwiftBoolObject>).first!, boolObject)
+        XCTAssertEqual((getter(object, "arrayCol") as! List<SwiftBoolObject>).first!, boolObject)
 
         list.removeAll()
         setter(object, list, "arrayCol")
@@ -209,8 +206,7 @@ class ObjectTests: TestCase {
 
         setter(object, [boolObject], "arrayCol")
         XCTAssertEqual((getter(object, "arrayCol") as! List<SwiftBoolObject>).count, 1)
-        /* disabled for Swift 3 conversion */
-        // XCTAssertEqual((getter(object, "arrayCol") as! List<SwiftBoolObject>).first!, boolObject)
+        XCTAssertEqual((getter(object, "arrayCol") as! List<SwiftBoolObject>).first!, boolObject)
     }
 
     func dynamicSetAndTestAllTypes(_ setter: (DynamicObject, AnyObject?, String) -> (),
@@ -238,14 +234,12 @@ class ObjectTests: TestCase {
         XCTAssertEqual((getter(object, "dateCol") as! NSDate), NSDate(timeIntervalSince1970: 333))
 
         setter(object, boolObject, "objectCol")
-        /* disabled for Swift 3 conversion */
-        // XCTAssertEqual((getter(object, "objectCol") as! DynamicObject), boolObject)
+        XCTAssertEqual((getter(object, "objectCol") as! DynamicObject), boolObject)
         XCTAssertEqual(((getter(object, "objectCol") as! DynamicObject)["boolCol"] as! NSNumber), true as NSNumber)
 
         setter(object, [boolObject], "arrayCol")
         XCTAssertEqual((getter(object, "arrayCol") as! List<DynamicObject>).count, 1)
-        /* disabled for Swift 3 conversion */
-        // XCTAssertEqual((getter(object, "arrayCol") as! List<DynamicObject>).first!, boolObject)
+        XCTAssertEqual((getter(object, "arrayCol") as! List<DynamicObject>).first!, boolObject)
 
         let list = getter(object, "arrayCol") as! List<DynamicObject>
         list.removeAll()
@@ -254,8 +248,7 @@ class ObjectTests: TestCase {
 
         setter(object, [boolObject], "arrayCol")
         XCTAssertEqual((getter(object, "arrayCol") as! List<DynamicObject>).count, 1)
-        /* disabled for Swift 3 conversion */
-        // XCTAssertEqual((getter(object, "arrayCol") as! List<DynamicObject>).first!, boolObject)
+        XCTAssertEqual((getter(object, "arrayCol") as! List<DynamicObject>).first!, boolObject)
     }
 
     // Yields a read-write migration `SwiftObject` to the given block
@@ -334,9 +327,8 @@ class ObjectTests: TestCase {
         }
         let dynamicArray = arrayObject.dynamicList("array")
         XCTAssertEqual(dynamicArray.count, 2)
-        /* disabled for Swift 3 conversion */
-        // XCTAssertEqual(dynamicArray[0], str1)
-        // XCTAssertEqual(dynamicArray[1], str2)
+        XCTAssertEqual(dynamicArray[0], str1)
+        XCTAssertEqual(dynamicArray[1], str2)
         XCTAssertEqual(arrayObject.dynamicList("intArray").count, 0)
         assertThrows(arrayObject.dynamicList("noSuchList"))
     }

--- a/RealmSwift-swift3.0-dev/Tests/RealmCollectionTypeTests.swift
+++ b/RealmSwift-swift3.0-dev/Tests/RealmCollectionTypeTests.swift
@@ -50,16 +50,16 @@ class CTTStringList: Object {
 }
 
 class RealmCollectionTypeTests: TestCase {
-    var str1: CTTStringObjectWithLink!
-    var str2: CTTStringObjectWithLink!
-    var collection: AnyRealmCollection<CTTStringObjectWithLink>!
+    var str1: CTTStringObjectWithLink?
+    var str2: CTTStringObjectWithLink?
+    var collection: AnyRealmCollection<CTTStringObjectWithLink>?
 
     func getCollection() -> AnyRealmCollection<CTTStringObjectWithLink> {
-        fatalError("abstract")
+        fatalError("Abstract method. Try running tests using Control-U.")
     }
 
     func getAggregateableCollection() -> AnyRealmCollection<CTTAggregateObject> {
-        fatalError("abstract")
+        fatalError("Abstract method. Try running tests using Control-U.")
     }
 
     func makeAggregateableObjectsInWriteTransaction() -> [CTTAggregateObject] {
@@ -99,10 +99,13 @@ class RealmCollectionTypeTests: TestCase {
     override func setUp() {
         super.setUp()
 
-        str1 = CTTStringObjectWithLink()
+        let str1 = CTTStringObjectWithLink()
         str1.stringCol = "1"
-        str2 = CTTStringObjectWithLink()
+        self.str1 = str1
+
+        let str2 = CTTStringObjectWithLink()
         str2.stringCol = "2"
+        self.str2 = str2
 
         let realm = realmWithTestPath()
         try! realm.write {
@@ -130,15 +133,24 @@ class RealmCollectionTypeTests: TestCase {
     }
 
     func testRealm() {
+        guard let collection = collection else {
+            fatalError("Test precondition failed")
+        }
         XCTAssertEqual(collection.realm!.configuration.fileURL, realmWithTestPath().configuration.fileURL)
     }
 
     func testDescription() {
+        guard let collection = collection else {
+            fatalError("Test precondition failed")
+        }
         // swiftlint:disable:next line_length
         XCTAssertEqual(collection.description, "Results<CTTStringObjectWithLink> (\n\t[0] CTTStringObjectWithLink {\n\t\tstringCol = 1;\n\t\tlinkCol = (null);\n\t},\n\t[1] CTTStringObjectWithLink {\n\t\tstringCol = 2;\n\t\tlinkCol = (null);\n\t}\n)")
     }
 
     func testCount() {
+        guard let collection = collection else {
+            fatalError("Test precondition failed")
+        }
         XCTAssertEqual(2, collection.count)
         XCTAssertEqual(1, collection.filter("stringCol = '1'").count)
         XCTAssertEqual(1, collection.filter("stringCol = '2'").count)
@@ -146,6 +158,9 @@ class RealmCollectionTypeTests: TestCase {
     }
 
     func testIndexOfObject() {
+        guard let collection = collection, str1 = str1, str2 = str2 else {
+            fatalError("Test precondition failed")
+        }
         XCTAssertEqual(0, collection.index(of: str1)!)
         XCTAssertEqual(1, collection.index(of: str2)!)
 
@@ -155,6 +170,9 @@ class RealmCollectionTypeTests: TestCase {
     }
 
     func testIndexOfPredicate() {
+        guard let collection = collection else {
+            fatalError("Test precondition failed")
+        }
         let pred1 = NSPredicate(format: "stringCol = '1'")
         let pred2 = NSPredicate(format: "stringCol = '2'")
         let pred3 = NSPredicate(format: "stringCol = '3'")
@@ -165,6 +183,9 @@ class RealmCollectionTypeTests: TestCase {
     }
 
     func testIndexOfFormat() {
+        guard let collection = collection else {
+            fatalError("Test precondition failed")
+        }
         XCTAssertEqual(0, collection.index(of: "stringCol = '1'")!)
         XCTAssertEqual(0, collection.index(of: "stringCol = %@", "1")!)
         XCTAssertEqual(1, collection.index(of: "stringCol = %@", "2")!)
@@ -172,27 +193,38 @@ class RealmCollectionTypeTests: TestCase {
     }
 
     func testSubscript() {
+        guard let collection = collection else {
+            fatalError("Test precondition failed")
+        }
         XCTAssertEqual(str1, collection[0])
         XCTAssertEqual(str2, collection[1])
 
-        assertThrows(self.collection[200])
-        assertThrows(self.collection[-200])
+        assertThrows(collection[200])
+        assertThrows(collection[-200])
     }
 
     func testFirst() {
+        guard let collection = collection else {
+            fatalError("Test precondition failed")
+        }
         XCTAssertEqual(str1, collection.first!)
         XCTAssertEqual(str2, collection.filter("stringCol = '2'").first!)
         XCTAssertNil(collection.filter("stringCol = '3'").first)
     }
 
-    /* disabled for Swift 3 conversion */
-//    func testLast() {
-//        // XCTAssertEqual(str2, collection.last!)
-//        XCTAssertEqual(str2, collection.filter("stringCol = '2'").last!)
-//        XCTAssertNil(collection.filter("stringCol = '3'").last)
-//    }
+    func testLast() {
+        guard let collection = collection else {
+            fatalError("Test precondition failed")
+        }
+        XCTAssertEqual(str2, collection.last!)
+        XCTAssertEqual(str2, collection.filter("stringCol = '2'").last!)
+        XCTAssertNil(collection.filter("stringCol = '3'").last)
+    }
 
     func testValueForKey() {
+        guard let collection = collection else {
+            fatalError("Test precondition failed")
+        }
         let expected = collection.map { $0.stringCol }
         let actual = collection.value(forKey: "stringCol") as! [String]!
         XCTAssertEqual(expected, actual!)
@@ -201,6 +233,9 @@ class RealmCollectionTypeTests: TestCase {
     }
 
     func testSetValueForKey() {
+        guard let collection = collection else {
+            fatalError("Test precondition failed")
+        }
         try! realmWithTestPath().write {
             collection.setValue("hi there!", forKey: "stringCol")
         }
@@ -210,6 +245,9 @@ class RealmCollectionTypeTests: TestCase {
     }
 
     func testFilterFormat() {
+        guard let collection = collection else {
+            fatalError("Test precondition failed")
+        }
         XCTAssertEqual(1, collection.filter("stringCol = '1'").count)
         XCTAssertEqual(1, collection.filter("stringCol = %@", "1").count)
         XCTAssertEqual(1, collection.filter("stringCol = %@", "2").count)
@@ -240,6 +278,9 @@ class RealmCollectionTypeTests: TestCase {
     }
 
     func testFilterPredicate() {
+        guard let collection = collection else {
+            fatalError("Test precondition failed")
+        }
         let pred1 = NSPredicate(format: "stringCol = '1'")
         let pred2 = NSPredicate(format: "stringCol = '2'")
         let pred3 = NSPredicate(format: "stringCol = '3'")
@@ -250,6 +291,9 @@ class RealmCollectionTypeTests: TestCase {
     }
 
     func testSortWithProperty() {
+        guard let collection = collection else {
+            fatalError("Test precondition failed")
+        }
         var sorted = collection.sorted("stringCol", ascending: true)
         XCTAssertEqual("1", sorted[0].stringCol)
         XCTAssertEqual("2", sorted[1].stringCol)
@@ -258,7 +302,7 @@ class RealmCollectionTypeTests: TestCase {
         XCTAssertEqual("2", sorted[0].stringCol)
         XCTAssertEqual("1", sorted[1].stringCol)
 
-        assertThrows(self.collection.sorted("noSuchCol", ascending: true), named: "Invalid sort property")
+        assertThrows(collection.sorted("noSuchCol", ascending: true), named: "Invalid sort property")
     }
 
     func testSortWithDescriptor() {
@@ -318,6 +362,10 @@ class RealmCollectionTypeTests: TestCase {
     }
 
     func testFastEnumeration() {
+        guard let collection = collection else {
+            fatalError("Test precondition failed")
+        }
+
         var str = ""
         for obj in collection {
             str += obj.stringCol
@@ -327,6 +375,10 @@ class RealmCollectionTypeTests: TestCase {
     }
 
     func testFastEnumerationWithMutation() {
+        guard let collection = collection else {
+            fatalError("Test precondition failed")
+        }
+
         let realm = realmWithTestPath()
         try! realm.write {
             for obj in collection {
@@ -350,6 +402,10 @@ class RealmCollectionTypeTests: TestCase {
     }
 
     func testAddNotificationBlock() {
+        guard let collection = collection else {
+            fatalError("Test precondition failed")
+        }
+
         let theExpectation = expectation(withDescription: "")
         let token = collection.addNotificationBlock { (changes: RealmCollectionChange) in
             switch changes {
@@ -372,17 +428,25 @@ class RealmCollectionTypeTests: TestCase {
     }
 
     func testValueForKeyPath() {
-        XCTAssertEqual(["1", "2"], self.collection.value(forKeyPath: "@unionOfObjects.stringCol") as! NSArray?)
+        guard let collection = collection else {
+            fatalError("Test precondition failed")
+        }
 
-        let collection = getAggregateableCollection()
-        XCTAssertEqual(3, (collection.value(forKeyPath: "@count") as! NSNumber?)?.int64Value)
-        XCTAssertEqual(3, (collection.value(forKeyPath: "@max.intCol") as! NSNumber?)?.int64Value)
-        XCTAssertEqual(1, (collection.value(forKeyPath: "@min.intCol") as! NSNumber?)?.int64Value)
-        XCTAssertEqual(6, (collection.value(forKeyPath: "@sum.intCol") as! NSNumber?)?.int64Value)
-        XCTAssertEqual(2.0, (collection.value(forKeyPath: "@avg.intCol") as! NSNumber?)?.doubleValue)
+        XCTAssertEqual(["1", "2"], collection.value(forKeyPath: "@unionOfObjects.stringCol") as! NSArray?)
+
+        let theCollection = getAggregateableCollection()
+        XCTAssertEqual(3, (theCollection.value(forKeyPath: "@count") as! NSNumber?)?.int64Value)
+        XCTAssertEqual(3, (theCollection.value(forKeyPath: "@max.intCol") as! NSNumber?)?.int64Value)
+        XCTAssertEqual(1, (theCollection.value(forKeyPath: "@min.intCol") as! NSNumber?)?.int64Value)
+        XCTAssertEqual(6, (theCollection.value(forKeyPath: "@sum.intCol") as! NSNumber?)?.int64Value)
+        XCTAssertEqual(2.0, (theCollection.value(forKeyPath: "@avg.intCol") as! NSNumber?)?.doubleValue)
     }
 
     func testInvalidate() {
+        guard let collection = collection else {
+            fatalError("Test precondition failed")
+        }
+
         XCTAssertFalse(collection.invalidated)
         realmWithTestPath().invalidate()
         XCTAssertTrue(collection.realm == nil || collection.invalidated)
@@ -509,18 +573,11 @@ class ResultsWithCustomInitializerTest: TestCase {
         let expected = collection.map { $0.stringCol }
         let actual = collection.value(forKey: "stringCol") as! [String]!
         XCTAssertEqual(expected, actual!)
-
-        /* disabled for Swift 3 conversion */
-        // XCTAssertEqual(collection.map { $0 }, collection.value(forKey: "self") as! [CTTStringObjectWithLink])
+        XCTAssertEqual(collection.map { $0 }, collection.value(forKey: "self") as! [CTTStringObjectWithLink])
     }
 }
 
 class ResultsFromTableTests: ResultsTests {
-    /* disabled for Swift 3 conversion */
-    override func testFastEnumerationWithMutation() {}
-    override func testFirst() {}
-    override func testSubscript() {}
-    override func testValueForKey() {}
 
     override func collectionBaseInWriteTransaction() -> Results<CTTStringObjectWithLink> {
         return realmWithTestPath().objects(CTTStringObjectWithLink)
@@ -533,11 +590,6 @@ class ResultsFromTableTests: ResultsTests {
 }
 
 class ResultsFromTableViewTests: ResultsTests {
-    /* disabled for Swift 3 conversion */
-    override func testFastEnumerationWithMutation() {}
-    override func testFirst() {}
-    override func testSubscript() {}
-    override func testValueForKey() {}
 
     override func collectionBaseInWriteTransaction() -> Results<CTTStringObjectWithLink> {
         return realmWithTestPath().objects(CTTStringObjectWithLink).filter("stringCol != ''")
@@ -550,13 +602,11 @@ class ResultsFromTableViewTests: ResultsTests {
 }
 
 class ResultsFromLinkViewTests: ResultsTests {
-    /* disabled for Swift 3 conversion */
-    override func testFastEnumerationWithMutation() {}
-    override func testFirst() {}
-    override func testSubscript() {}
-    override func testValueForKey() {}
 
     override func collectionBaseInWriteTransaction() -> Results<CTTStringObjectWithLink> {
+        guard let str1 = str1, str2 = str2 else {
+            fatalError("Test precondition failed")
+        }
         let array = realmWithTestPath().create(CTTStringList.self, value: [[str1, str2]])
         return array.array.filter(NSPredicate(value: true))
     }
@@ -616,6 +666,9 @@ class ListRealmCollectionTypeTests: RealmCollectionTypeTests {
     }
 
     override func testDescription() {
+        guard let collection = collection else {
+            fatalError("Test precondition failed")
+        }
         // swiftlint:disable:next line_length
         XCTAssertEqual(collection.description, "List<CTTStringObjectWithLink> (\n\t[0] CTTStringObjectWithLink {\n\t\tstringCol = 1;\n\t\tlinkCol = (null);\n\t},\n\t[1] CTTStringObjectWithLink {\n\t\tstringCol = 2;\n\t\tlinkCol = (null);\n\t}\n)")
     }
@@ -646,6 +699,9 @@ class ListRealmCollectionTypeTests: RealmCollectionTypeTests {
 
 class ListStandaloneRealmCollectionTypeTests: ListRealmCollectionTypeTests {
     override func collectionBaseInWriteTransaction() -> List<CTTStringObjectWithLink> {
+        guard let str1 = str1, str2 = str2 else {
+            fatalError("Test precondition failed")
+        }
         return CTTStringList(value: [[str1, str2]]).array
     }
 
@@ -654,14 +710,23 @@ class ListStandaloneRealmCollectionTypeTests: ListRealmCollectionTypeTests {
     }
 
     override func testRealm() {
+        guard let collection = collection else {
+            fatalError("Test precondition failed")
+        }
         XCTAssertNil(collection.realm)
     }
 
     override func testCount() {
+        guard let collection = collection else {
+            fatalError("Test precondition failed")
+        }
         XCTAssertEqual(2, collection.count)
     }
 
     override func testIndexOfObject() {
+        guard let collection = collection, str1 = str1, str2 = str2 else {
+            fatalError("Test precondition failed")
+        }
         XCTAssertEqual(0, collection.index(of: str1)!)
         XCTAssertEqual(1, collection.index(of: str2)!)
     }
@@ -678,66 +743,98 @@ class ListStandaloneRealmCollectionTypeTests: ListRealmCollectionTypeTests {
     }
 
     override func testFirst() {
+        guard let collection = collection else {
+            fatalError("Test precondition failed")
+        }
         XCTAssertEqual(str1, collection.first!)
     }
 
-    /* disabled for Swift 3 conversion */
-//    override func testLast() {
-//        XCTAssertEqual(str2, collection.last!)
-//    }
+    override func testLast() {
+        guard let collection = collection else {
+            fatalError("Test precondition failed")
+        }
+        XCTAssertEqual(str2, collection.last!)
+    }
 
     // MARK: Things not implemented in standalone
 
     override func testSortWithProperty() {
-        assertThrows(self.collection.sorted("stringCol", ascending: true))
-        assertThrows(self.collection.sorted("noSuchCol", ascending: true))
+        guard let collection = collection else {
+            fatalError("Test precondition failed")
+        }
+        assertThrows(collection.sorted("stringCol", ascending: true))
+        assertThrows(collection.sorted("noSuchCol", ascending: true))
     }
 
     override func testFilterFormat() {
-        assertThrows(self.collection.filter("stringCol = '1'"))
-        assertThrows(self.collection.filter("noSuchCol = '1'"))
+        guard let collection = collection else {
+            fatalError("Test precondition failed")
+        }
+        assertThrows(collection.filter("stringCol = '1'"))
+        assertThrows(collection.filter("noSuchCol = '1'"))
     }
 
     override func testFilterPredicate() {
+        guard let collection = collection else {
+            fatalError("Test precondition failed")
+        }
         let pred1 = NSPredicate(format: "stringCol = '1'")
         let pred2 = NSPredicate(format: "noSuchCol = '2'")
 
-        assertThrows(self.collection.filter(pred1))
-        assertThrows(self.collection.filter(pred2))
+        assertThrows(collection.filter(pred1))
+        assertThrows(collection.filter(pred2))
     }
 
     override func testArrayAggregateWithSwiftObjectDoesntThrow() {
-        assertThrows(self.collection.filter("ANY stringListCol == %@", CTTStringObjectWithLink()))
+        guard let collection = collection else {
+            fatalError("Test precondition failed")
+        }
+        assertThrows(collection.filter("ANY stringListCol == %@", CTTStringObjectWithLink()))
     }
 
     override func testMin() {
-        assertThrows(self.collection.min("intCol") as Int!)
-        assertThrows(self.collection.min("floatCol") as Float!)
-        assertThrows(self.collection.min("doubleCol") as Double!)
-        assertThrows(self.collection.min("dateCol") as NSDate!)
+        guard let collection = collection else {
+            fatalError("Test precondition failed")
+        }
+        assertThrows(collection.min("intCol") as Int!)
+        assertThrows(collection.min("floatCol") as Float!)
+        assertThrows(collection.min("doubleCol") as Double!)
+        assertThrows(collection.min("dateCol") as NSDate!)
     }
 
     override func testMax() {
-        assertThrows(self.collection.max("intCol") as Int!)
-        assertThrows(self.collection.max("floatCol") as Float!)
-        assertThrows(self.collection.max("doubleCol") as Double!)
-        assertThrows(self.collection.max("dateCol") as NSDate!)
+        guard let collection = collection else {
+            fatalError("Test precondition failed")
+        }
+        assertThrows(collection.max("intCol") as Int!)
+        assertThrows(collection.max("floatCol") as Float!)
+        assertThrows(collection.max("doubleCol") as Double!)
+        assertThrows(collection.max("dateCol") as NSDate!)
     }
 
     override func testSum() {
-        assertThrows(self.collection.sum("intCol") as Int)
-        assertThrows(self.collection.sum("floatCol") as Float)
-        assertThrows(self.collection.sum("doubleCol") as Double)
+        guard let collection = collection else {
+            fatalError("Test precondition failed")
+        }
+        assertThrows(collection.sum("intCol") as Int)
+        assertThrows(collection.sum("floatCol") as Float)
+        assertThrows(collection.sum("doubleCol") as Double)
     }
 
     override func testAverage() {
-        assertThrows(self.collection.average("intCol") as Int!)
-        assertThrows(self.collection.average("floatCol") as Float!)
-        assertThrows(self.collection.average("doubleCol") as Double!)
+        guard let collection = collection else {
+            fatalError("Test precondition failed")
+        }
+        assertThrows(collection.average("intCol") as Int!)
+        assertThrows(collection.average("floatCol") as Float!)
+        assertThrows(collection.average("doubleCol") as Double!)
     }
 
     override func testAddNotificationBlock() {
-        assertThrows(self.collection.addNotificationBlock { (changes: RealmCollectionChange) in })
+        guard let collection = collection else {
+            fatalError("Test precondition failed")
+        }
+        assertThrows(collection.addNotificationBlock { (changes: RealmCollectionChange) in })
     }
 
     override func testAddNotificationBlockDirect() {

--- a/RealmSwift-swift3.0-dev/Tests/RealmTests.swift
+++ b/RealmSwift-swift3.0-dev/Tests/RealmTests.swift
@@ -391,35 +391,34 @@ class RealmTests: TestCase {
         }
     }
 
-    /* disabled for Swift 3 conversion */
-//    func testDeleteListOfObjects() {
-//        let realm = try! Realm()
-//        XCTAssertEqual(0, realm.objects(SwiftCompanyObject).count)
-//        try! realm.write {
-//            let obj = SwiftCompanyObject()
-//            obj.employees.append(SwiftEmployeeObject())
-//            realm.add(obj)
-//            XCTAssertEqual(1, realm.objects(SwiftEmployeeObject).count)
-//            realm.delete(obj.employees)
-//            XCTAssertEqual(0, obj.employees.count)
-//            XCTAssertEqual(0, realm.objects(SwiftEmployeeObject).count)
-//        }
-//        XCTAssertEqual(0, realm.objects(SwiftEmployeeObject).count)
-//    }
-//
-//    func testDeleteResults() {
-//        let realm = try! Realm(fileURL: testRealmURL())
-//        XCTAssertEqual(0, realm.objects(SwiftCompanyObject).count)
-//        try! realm.write {
-//            realm.add(SwiftIntObject(value: [1]))
-//            realm.add(SwiftIntObject(value: [1]))
-//            realm.add(SwiftIntObject(value: [2]))
-//            XCTAssertEqual(3, realm.objects(SwiftIntObject).count)
-//            realm.delete(realm.objects(SwiftIntObject).filter("intCol = 1"))
-//            XCTAssertEqual(1, realm.objects(SwiftIntObject).count)
-//        }
-//        XCTAssertEqual(1, realm.objects(SwiftIntObject).count)
-//    }
+    func testDeleteListOfObjects() {
+        let realm = try! Realm()
+        XCTAssertEqual(0, realm.objects(SwiftCompanyObject).count)
+        try! realm.write {
+            let obj = SwiftCompanyObject()
+            obj.employees.append(SwiftEmployeeObject())
+            realm.add(obj)
+            XCTAssertEqual(1, realm.objects(SwiftEmployeeObject).count)
+            realm.delete(obj.employees)
+            XCTAssertEqual(0, obj.employees.count)
+            XCTAssertEqual(0, realm.objects(SwiftEmployeeObject).count)
+        }
+        XCTAssertEqual(0, realm.objects(SwiftEmployeeObject).count)
+    }
+
+    func testDeleteResults() {
+        let realm = try! Realm(fileURL: testRealmURL())
+        XCTAssertEqual(0, realm.objects(SwiftCompanyObject).count)
+        try! realm.write {
+            realm.add(SwiftIntObject(value: [1]))
+            realm.add(SwiftIntObject(value: [1]))
+            realm.add(SwiftIntObject(value: [2]))
+            XCTAssertEqual(3, realm.objects(SwiftIntObject).count)
+            realm.delete(realm.objects(SwiftIntObject).filter("intCol = 1"))
+            XCTAssertEqual(1, realm.objects(SwiftIntObject).count)
+        }
+        XCTAssertEqual(1, realm.objects(SwiftIntObject).count)
+    }
 
     func testDeleteAll() {
         let realm = try! Realm()

--- a/RealmSwift-swift3.0-dev/Tests/SwiftTestObjects.swift
+++ b/RealmSwift-swift3.0-dev/Tests/SwiftTestObjects.swift
@@ -74,7 +74,6 @@ class SwiftOptionalObject: Object {
     let optDoubleCol = RealmOptional<Double>()
     let optBoolCol = RealmOptional<Bool>()
     dynamic var optObjectCol: SwiftBoolObject?
-    //    let arrayCol = List<SwiftBoolObject?>()
 }
 
 class SwiftImplicitlyUnwrappedOptionalObject: Object {
@@ -82,9 +81,6 @@ class SwiftImplicitlyUnwrappedOptionalObject: Object {
     dynamic var optStringCol: String!
     dynamic var optBinaryCol: NSData!
     dynamic var optDateCol: NSDate!
-    /* disabled for Swift 3 conversion */
-    //    dynamic var optObjectCol: SwiftBoolObject!
-    //    let arrayCol = List<SwiftBoolObject!>()
 }
 
 class SwiftOptionalDefaultValuesObject: Object {

--- a/RealmSwift-swift3.0-dev/Tests/SwiftUnicodeTests.swift
+++ b/RealmSwift-swift3.0-dev/Tests/SwiftUnicodeTests.swift
@@ -51,9 +51,7 @@ class SwiftUnicodeTests: TestCase {
         XCTAssertEqual(obj1.柱колоéнǢкƱаم👍, utf8TestString,
             "Storing and retrieving a string with UTF8 content should work")
 
-        // Test fails because of rdar://17735684
-        /* disabled for Swift 3 conversion */
-        // let obj2 = realm.objects(SwiftUTF8Object).filter("%K == %@", "柱колоéнǢкƱаم👍", utf8TestString).first!
-        // XCTAssertEqual(obj1, obj2, "Querying a realm searching for a string with UTF8 content should work")
+        let obj2 = realm.objects(SwiftUTF8Object).filter("%K == %@", "柱колоéнǢкƱаم👍", utf8TestString as AnyObject).first!
+        XCTAssertEqual(obj1, obj2, "Querying a realm searching for a string with UTF8 content should work")
     }
 }

--- a/RealmSwift-swift3.0-dev/Tests/SwiftUnicodeTests.swift
+++ b/RealmSwift-swift3.0-dev/Tests/SwiftUnicodeTests.swift
@@ -34,8 +34,7 @@ class SwiftUnicodeTests: TestCase {
         XCTAssertEqual(obj1.stringCol, utf8TestString)
 
         let obj2 = realm.objects(SwiftStringObject).filter("stringCol == %@", utf8TestString as AnyObject).first!
-        /* disabled for Swift 3 conversion */
-        // XCTAssertEqual(obj1, obj2)
+        XCTAssertEqual(obj1, obj2)
         XCTAssertEqual(obj2.stringCol, utf8TestString)
 
         XCTAssertEqual(Int(0), realm.objects(SwiftStringObject).filter("stringCol != %@", utf8TestString as AnyObject).count)


### PR DESCRIPTION
This accounts for most, but not all the tests.

@tgoyne @jpsim @bdash 

Changes:
- Realm collections are now RandomAccessCollections
- Gave list's "descriptionWithMaxDepth" a custom Objective-C selector, since it wasn't being found
- Reenabled many tests which were disabled because of the `isEqual` bug from the previous commit
- Some tests rewritten to use fewer IUOs