### PR TITLE
Fixes for Swift 3 DP 1

### DIFF
--- a/Realm/RLMCollection.mm
+++ b/Realm/RLMCollection.mm
@@ -311,7 +311,7 @@ RLMNotificationToken *RLMAddNotificationBlock(id objcCollection,
                 rethrow_exception(err);
             }
             catch (...) {
-                NSError *error;
+                NSError *error = nil;
                 RLMRealmTranslateException(&error);
                 block(nil, nil, error);
                 return;

--- a/Realm/RLMRealm.h
+++ b/Realm/RLMRealm.h
@@ -458,7 +458,7 @@ typedef void (^RLMMigrationBlock)(RLMMigration *migration, uint64_t oldSchemaVer
 
  @see                 RLMMigration
  */
-+ (NSError *)migrateRealm:(RLMRealmConfiguration *)configuration;
++ (nullable NSError *)migrateRealm:(RLMRealmConfiguration *)configuration;
 
 @end
 

--- a/Realm/RLMRealm.mm
+++ b/Realm/RLMRealm.mm
@@ -699,7 +699,7 @@ REALM_NOINLINE void RLMRealmTranslateException(NSError **error) {
     }
 
     @autoreleasepool {
-        NSError *error;
+        NSError *error = nil;
         [RLMRealm realmWithConfiguration:configuration error:&error];
         return error;
     }

--- a/RealmSwift-swift3.0-dev/Migration.swift
+++ b/RealmSwift-swift3.0-dev/Migration.swift
@@ -76,8 +76,11 @@ exactly when and how migrations are performed.
 - returns: `nil` if the migration was successful, or an `NSError` object that describes the problem
            that occurred otherwise.
 */
-public func migrateRealm(_ configuration: Realm.Configuration = Realm.Configuration.defaultConfiguration) -> NSError? {
-    return RLMRealm.migrateRealm(configuration.rlmConfiguration)
+@discardableResult
+public func migrateRealm(_ configuration: Realm.Configuration = Realm.Configuration.defaultConfiguration) throws {
+    if let error = RLMRealm.migrateRealm(configuration.rlmConfiguration) {
+        throw error
+    }
 }
 
 
@@ -127,6 +130,7 @@ public final class Migration {
 
     - returns: The created object.
     */
+    @discardableResult
     public func create(_ className: String, value: AnyObject = [:]) -> MigrationObject {
         return unsafeBitCast(rlmMigration.createObject(className, withValue: value), to: MigrationObject.self)
     }
@@ -150,6 +154,7 @@ public final class Migration {
 
     - returns: `true` if there was any data to delete.
     */
+    @discardableResult
     public func deleteData(_ objectClassName: String) -> Bool {
         return rlmMigration.deleteData(forClassName: objectClassName)
     }

--- a/RealmSwift-swift3.0-dev/Realm.swift
+++ b/RealmSwift-swift3.0-dev/Realm.swift
@@ -260,6 +260,7 @@ public final class Realm {
 
     - returns: The created object.
     */
+    @discardableResult
     public func create<T: Object>(_ type: T.Type, value: AnyObject = [:], update: Bool = false) -> T {
         let className = (type as Object.Type).className()
         if update && schema[className]?.primaryKeyProperty == nil {
@@ -296,6 +297,7 @@ public final class Realm {
 
     :nodoc:
     */
+    @discardableResult
     public func dynamicCreate(_ className: String, value: AnyObject = [:], update: Bool = false) -> DynamicObject {
         if update && schema[className]?.primaryKeyProperty == nil {
             throwRealmException("'\(className)' does not have a primary key and can not be updated")
@@ -526,6 +528,7 @@ public final class Realm {
     - returns: Whether the realm had any updates.
                Note that this may return true even if no data has actually changed.
     */
+    @discardableResult
     public func refresh() -> Bool {
         return rlmRealm.refresh()
     }

--- a/RealmSwift-swift3.0-dev/Tests/MigrationTests.swift
+++ b/RealmSwift-swift3.0-dev/Tests/MigrationTests.swift
@@ -23,6 +23,7 @@ import Realm.Private
 import Realm.Dynamic
 import Foundation
 
+@discardableResult
 private func realmWithSingleClassProperties(_ fileURL: NSURL, className: String, properties: [AnyObject]) -> RLMRealm {
     let schema = RLMSchema()
     let objectSchema = RLMObjectSchema(className: className, objectClass: MigrationObject.self, properties: properties)
@@ -72,7 +73,7 @@ class MigrationTests: TestCase {
                 _ = try! Realm(configuration: config)
             }
         } else {
-            migrateRealm(config)
+            try! migrateRealm(config)
         }
 
         XCTAssertEqual(didRun, shouldRun)
@@ -95,7 +96,7 @@ class MigrationTests: TestCase {
                                          migrationBlock: { _, _ in didRun = true })
         Realm.Configuration.defaultConfiguration = config
 
-        migrateRealm()
+        try! migrateRealm()
 
         XCTAssertEqual(didRun, true)
         XCTAssertEqual(1, try! schemaVersionAtURL(defaultRealmURL()))
@@ -138,7 +139,7 @@ class MigrationTests: TestCase {
     func testMigrationProperties() {
         let prop = RLMProperty(name: "stringCol", type: RLMPropertyType.int, objectClassName: nil,
                                linkOriginPropertyName: nil, indexed: false, optional: false)
-        autoreleasepool {
+        _ = autoreleasepool {
             realmWithSingleClassProperties(defaultRealmURL(), className: "SwiftStringObject", properties: [prop!])
         }
 
@@ -445,7 +446,7 @@ class MigrationTests: TestCase {
     func testFailOnSchemaMismatch() {
         let prop = RLMProperty(name: "name", type: RLMPropertyType.string, objectClassName: nil,
                                linkOriginPropertyName: nil, indexed: false, optional: false)
-        autoreleasepool {
+        _ = autoreleasepool {
             realmWithSingleClassProperties(defaultRealmURL(), className: "SwiftEmployeeObject", properties: [prop!])
         }
 
@@ -460,7 +461,7 @@ class MigrationTests: TestCase {
     func testDeleteRealmIfMigrationNeededWithSetCustomSchema() {
         let prop = RLMProperty(name: "name", type: RLMPropertyType.string, objectClassName: nil,
                                linkOriginPropertyName: nil, indexed: false, optional: false)
-        autoreleasepool {
+        _ = autoreleasepool {
             realmWithSingleClassProperties(defaultRealmURL(), className: "SwiftEmployeeObject", properties: [prop!])
         }
 

--- a/RealmSwift-swift3.0-dev/Tests/ObjectCreationTests.swift
+++ b/RealmSwift-swift3.0-dev/Tests/ObjectCreationTests.swift
@@ -550,22 +550,22 @@ class ObjectCreationTests: TestCase {
         let persistedObject = try! Realm().create(SwiftBoolObject.self, value: [true])
         try! Realm().commitWrite()
         switch type {
-            case .Bool:     return [true, NSNumber(value: 0 as Int), NSNumber(value: 1 as Int)]
-            case .Int:      return [NSNumber(value: 1 as Int)]
-            case .Float:    return [NSNumber(value: 1 as Int), NSNumber(value: 1.1 as Float), NSNumber(value: 11.1 as Double)]
-            case .Double:   return [NSNumber(value: 1 as Int), NSNumber(value: 1.1 as Float), NSNumber(value: 11.1 as Double)]
-            case .String:   return ["b"]
-            case .Data:     return ["b".data(using: NSUTF8StringEncoding, allowLossyConversion: false)! as NSData]
-            case .Date:     return [NSDate(timeIntervalSince1970: 2) as AnyObject]
-            case .Object:   return [[true], ["boolCol": true], SwiftBoolObject(value: [true]), persistedObject]
-            case .Array:    return [
+            case .bool:     return [true, NSNumber(value: 0 as Int), NSNumber(value: 1 as Int)]
+            case .int:      return [NSNumber(value: 1 as Int)]
+            case .float:    return [NSNumber(value: 1 as Int), NSNumber(value: 1.1 as Float), NSNumber(value: 11.1 as Double)]
+            case .double:   return [NSNumber(value: 1 as Int), NSNumber(value: 1.1 as Float), NSNumber(value: 11.1 as Double)]
+            case .string:   return ["b"]
+            case .data:     return ["b".data(using: NSUTF8StringEncoding, allowLossyConversion: false)! as NSData]
+            case .date:     return [NSDate(timeIntervalSince1970: 2) as AnyObject]
+            case .object:   return [[true], ["boolCol": true], SwiftBoolObject(value: [true]), persistedObject]
+            case .array:    return [
                 [[true], [false]],
                 [["boolCol": true], ["boolCol": false]],
                 [SwiftBoolObject(value: [true]), SwiftBoolObject(value: [false])],
                 [persistedObject, [false]]
             ]
-            case .Any: XCTFail("not supported")
-            case .LinkingObjects: XCTFail("not supported")
+            case .any: XCTFail("not supported")
+            case .linkingObjects: XCTFail("not supported")
         }
         return []
     }
@@ -576,18 +576,18 @@ class ObjectCreationTests: TestCase {
         let persistedObject = try! Realm().create(SwiftIntObject)
         try! Realm().commitWrite()
         switch type {
-            case .Bool:     return ["invalid", NSNumber(value: 2 as Int), NSNumber(value: 1.1 as Float), NSNumber(value: 11.1 as Double)]
-            case .Int:      return ["invalid", NSNumber(value: 1.1 as Float), NSNumber(value: 11.1 as Double)]
-            case .Float:    return ["invalid", true, false]
-            case .Double:   return ["invalid", true, false]
-            case .String:   return [0x197A71D, true, false]
-            case .Data:     return ["invalid"]
-            case .Date:     return ["invalid"]
-            case .Object:   return ["invalid", ["a"], ["boolCol": "a"], SwiftIntObject()]
-            case .Array:    return ["invalid", [["a"]], [["boolCol" : "a"]], [[SwiftIntObject()]], [[persistedObject]]]
+            case .bool:     return ["invalid", NSNumber(value: 2 as Int), NSNumber(value: 1.1 as Float), NSNumber(value: 11.1 as Double)]
+            case .int:      return ["invalid", NSNumber(value: 1.1 as Float), NSNumber(value: 11.1 as Double)]
+            case .float:    return ["invalid", true, false]
+            case .double:   return ["invalid", true, false]
+            case .string:   return [0x197A71D, true, false]
+            case .data:     return ["invalid"]
+            case .date:     return ["invalid"]
+            case .object:   return ["invalid", ["a"], ["boolCol": "a"], SwiftIntObject()]
+            case .array:    return ["invalid", [["a"]], [["boolCol" : "a"]], [[SwiftIntObject()]], [[persistedObject]]]
 
-            case .Any: XCTFail("not supported")
-            case .LinkingObjects: XCTFail("not supported")
+            case .any: XCTFail("not supported")
+            case .linkingObjects: XCTFail("not supported")
         }
         return []
     }

--- a/RealmSwift-swift3.0-dev/Tests/PerformanceTests.swift
+++ b/RealmSwift-swift3.0-dev/Tests/PerformanceTests.swift
@@ -288,7 +288,7 @@ class SwiftPerformanceTests: TestCase {
         }
         measure {
             for i in 0..<1000 {
-                realm.objects(SwiftStringObject).filter("stringCol = %@", i.description as AnyObject).first
+                _ = realm.objects(SwiftStringObject).filter("stringCol = %@", i.description as AnyObject).first
             }
         }
     }
@@ -302,7 +302,7 @@ class SwiftPerformanceTests: TestCase {
         }
         measure {
             for i in 0..<1000 {
-                realm.objects(SwiftIndexedPropertiesObject).filter("stringCol = %@", i.description as AnyObject).first
+                _ = realm.objects(SwiftIndexedPropertiesObject).filter("stringCol = %@", i.description as AnyObject).first
             }
         }
     }

--- a/RealmSwift-swift3.0-dev/Tests/RealmCollectionTypeTests.swift
+++ b/RealmSwift-swift3.0-dev/Tests/RealmCollectionTypeTests.swift
@@ -398,7 +398,7 @@ class RealmCollectionTypeTests: TestCase {
         let collection = getAggregateableCollection()
 
         // Should not throw a type error.
-        collection.filter("ANY stringListCol == %@", CTTStringObjectWithLink())
+        _ = collection.filter("ANY stringListCol == %@", CTTStringObjectWithLink())
     }
 
     func testAddNotificationBlock() {
@@ -584,7 +584,7 @@ class ResultsFromTableTests: ResultsTests {
     }
 
     override func getAggregateableCollection() -> AnyRealmCollection<CTTAggregateObject> {
-        makeAggregateableObjects()
+        _ = makeAggregateableObjects()
         return AnyRealmCollection(realmWithTestPath().objects(CTTAggregateObject))
     }
 }
@@ -596,7 +596,7 @@ class ResultsFromTableViewTests: ResultsTests {
     }
 
     override func getAggregateableCollection() -> AnyRealmCollection<CTTAggregateObject> {
-        makeAggregateableObjects()
+        _ = makeAggregateableObjects()
         return AnyRealmCollection(realmWithTestPath().objects(CTTAggregateObject).filter("trueCol == true"))
     }
 }

--- a/RealmSwift-swift3.0-dev/Tests/TestCase.swift
+++ b/RealmSwift-swift3.0-dev/Tests/TestCase.swift
@@ -31,6 +31,7 @@ class TestCase: XCTestCase {
     var exceptionThrown = false
     var testDir: String! = nil
 
+    @discardableResult
     func realmWithTestPath(configuration: Realm.Configuration = Realm.Configuration()) -> Realm {
         var configuration = configuration
         configuration.fileURL = testRealmURL()
@@ -130,7 +131,7 @@ class TestCase: XCTestCase {
                         fileName: StaticString = #file, lineNumber: UInt = #line,
                         block: @noescape () throws -> T) {
         do {
-            try block()
+            _ = try block()
             XCTFail("Expected to catch <\(expectedError)>, but no error was thrown.",
                 file: fileName, line: lineNumber)
         } catch expectedError {


### PR DESCRIPTION
@bdash @tgoyne @jpsim 

Changes:
- Fixed imported enum cases
- Annotated some APIs with @discardableResult
- Added "_ =" to tests that intentionally ignore return values to quiet warnings

NOTE: JP pointed out a few tests that are still commented out. A subsequent commit will restore them.