### PR TITLE
Fix typo in `operatorName()` BETWEENS => BETWEEN

### DIFF
--- a/Realm/RLMQueryUtil.mm
+++ b/Realm/RLMQueryUtil.mm
@@ -130,7 +130,7 @@ NSString *operatorName(NSPredicateOperatorType operatorType)
         case NSContainsPredicateOperatorType:
             return @"CONTAINS";
         case NSBetweenPredicateOperatorType:
-            return @"BETWEENS";
+            return @"BETWEEN";
         case NSCustomSelectorPredicateOperatorType:
             return @"custom selector";
     }


### PR DESCRIPTION
This doesn't affect any behaviors. It is used only exception messages.

CC @TimOliver @mrackwitz 