### PR TITLE
explicitly use 'Type.self' notation when passing types to Realm Swift APIs

### DIFF
--- a/RealmSwift-swift2.2/LinkingObjects.swift
+++ b/RealmSwift-swift2.2/LinkingObjects.swift
@@ -343,7 +343,7 @@ public final class LinkingObjects<T: Object>: LinkingObjectsBase {
      the write transaction.
 
      ```swift
-     let dog = realm.objects(Dog).first!
+     let dog = realm.objects(Dog.self).first!
      let owners = dog.owners
      print("owners.count: \(owners.count)") // => 0
      let token = owners.addNotificationBlock { changes in

--- a/RealmSwift-swift2.2/List.swift
+++ b/RealmSwift-swift2.2/List.swift
@@ -423,7 +423,7 @@ public final class List<T: Object>: ListBase {
      after the write transaction, and will not include change information.
 
      ```swift
-     let person = realm.objects(Person).first!
+     let person = realm.objects(Person.self).first!
      print("dogs.count: \(person.dogs.count)") // => 0
      let token = person.dogs.addNotificationBlock { changes in
          switch changes {

--- a/RealmSwift-swift2.2/RealmCollectionType.swift
+++ b/RealmSwift-swift2.2/RealmCollectionType.swift
@@ -321,7 +321,7 @@ public protocol RealmCollectionType: CollectionType, CustomStringConvertible {
      the write transaction.
 
      ```swift
-     let results = realm.objects(Dog)
+     let results = realm.objects(Dog.self)
      print("dogs.count: \(dogs?.count)") // => 0
      let token = dogs.addNotificationBlock { changes in
          switch changes {
@@ -878,7 +878,7 @@ public final class AnyRealmCollection<T: Object>: RealmCollectionType {
      the write transaction.
 
      ```swift
-     let results = realm.objects(Dog)
+     let results = realm.objects(Dog.self)
      print("dogs.count: \(dogs?.count)") // => 0
      let token = dogs.addNotificationBlock { changes in
          switch changes {

--- a/RealmSwift-swift2.2/Results.swift
+++ b/RealmSwift-swift2.2/Results.swift
@@ -352,7 +352,7 @@ public final class Results<T: Object>: ResultsBase {
      result, the initial notification will reflect the state of the Realm after
      the write transaction.
 
-         let dogs = realm.objects(Dog)
+         let dogs = realm.objects(Dog.self)
          print("dogs.count: \(dogs?.count)") // => 0
          let token = dogs.addNotificationBlock { (changes: RealmCollectionChange) in
              switch changes {

--- a/RealmSwift-swift2.2/Tests/ListTests.swift
+++ b/RealmSwift-swift2.2/Tests/ListTests.swift
@@ -111,7 +111,7 @@ class ListTests: TestCase {
     }
 
     func testAppendResults() {
-        array.appendContentsOf(realmWithTestPath().objects(SwiftStringObject))
+        array.appendContentsOf(realmWithTestPath().objects(SwiftStringObject.self))
         XCTAssertEqual(Int(2), array.count)
         XCTAssertEqual(str1, array[0])
         XCTAssertEqual(str2, array[1])
@@ -257,7 +257,7 @@ class ListTests: TestCase {
         if let realm = array.realm {
             array.appendContentsOf([str1, str2])
 
-            let otherArray = realm.objects(SwiftArrayPropertyObject).first!.array
+            let otherArray = realm.objects(SwiftArrayPropertyObject.self).first!.array
             XCTAssertEqual(Int(2), otherArray.count)
         }
     }
@@ -364,7 +364,7 @@ class ListRetrievedTests: ListTests {
         realm.beginWrite()
         realm.create(SwiftArrayPropertyObject.self, value: ["name", [], []])
         try! realm.commitWrite()
-        let array = realm.objects(SwiftArrayPropertyObject).first!
+        let array = realm.objects(SwiftArrayPropertyObject.self).first!
 
         XCTAssertNotNil(array.realm)
         return array
@@ -375,7 +375,7 @@ class ListRetrievedTests: ListTests {
         realm.beginWrite()
         realm.create(SwiftListOfSwiftObject)
         try! realm.commitWrite()
-        let array = realm.objects(SwiftListOfSwiftObject).first!
+        let array = realm.objects(SwiftListOfSwiftObject.self).first!
 
         XCTAssertNotNil(array.realm)
         return array

--- a/RealmSwift-swift2.2/Tests/MigrationTests.swift
+++ b/RealmSwift-swift2.2/Tests/MigrationTests.swift
@@ -266,7 +266,7 @@ class MigrationTests: TestCase {
             self.assertThrows(migration.create("NoSuchObject", value: []))
         }
 
-        let objects = try! Realm().objects(SwiftStringObject)
+        let objects = try! Realm().objects(SwiftStringObject.self)
         XCTAssertEqual(objects.count, 3)
         XCTAssertEqual(objects[0].stringCol, "string")
         XCTAssertEqual(objects[1].stringCol, "string")
@@ -292,7 +292,7 @@ class MigrationTests: TestCase {
             })
         }
 
-        XCTAssertEqual(try! Realm().objects(SwiftStringObject).count, 1)
+        XCTAssertEqual(try! Realm().objects(SwiftStringObject.self).count, 1)
     }
 
     func testDeleteData() {
@@ -426,7 +426,7 @@ class MigrationTests: TestCase {
         try! Realm().refresh()
 
         // check edited values
-        let object = try! Realm().objects(SwiftObject).first!
+        let object = try! Realm().objects(SwiftObject.self).first!
         XCTAssertEqual(object.boolCol, false)
         XCTAssertEqual(object.intCol, 1)
         XCTAssertEqual(object.floatCol, 1.0 as Float)
@@ -439,7 +439,7 @@ class MigrationTests: TestCase {
         XCTAssertEqual(object.arrayCol[1].boolCol, true)
 
         // make sure we added new bool objects as object property and in the list
-        XCTAssertEqual(try! Realm().objects(SwiftBoolObject).count, 4)
+        XCTAssertEqual(try! Realm().objects(SwiftBoolObject.self).count, 4)
     }
 
     func testFailOnSchemaMismatch() {

--- a/RealmSwift-swift2.2/Tests/ObjectAccessorTests.swift
+++ b/RealmSwift-swift2.2/Tests/ObjectAccessorTests.swift
@@ -137,7 +137,7 @@ class ObjectAccessorTests: TestCase {
             testObject()
         }
 
-        let obj = realm.objects(SwiftAllIntSizesObject).first!
+        let obj = realm.objects(SwiftAllIntSizesObject.self).first!
         XCTAssertEqual(obj.int8, v8)
         XCTAssertEqual(obj.int16, v16)
         XCTAssertEqual(obj.int32, v32)
@@ -158,7 +158,7 @@ class ObjectAccessorTests: TestCase {
         realm.create(SwiftLongObject.self, value: [NSNumber(longLong: negativeLongNumber)])
         try! realm.commitWrite()
 
-        let objects = realm.objects(SwiftLongObject)
+        let objects = realm.objects(SwiftLongObject.self)
         XCTAssertEqual(objects.count, Int(3), "3 rows expected")
         XCTAssertEqual(objects[0].longCol, longNumber, "2 ^ 34 expected")
         XCTAssertEqual(objects[1].longCol, intNumber, "2 ^ 31 - 1 expected")
@@ -194,7 +194,7 @@ class ObjectAccessorTests: TestCase {
             realm.add(object2)
         }
 
-        let objects = realm.objects(SwiftObject)
+        let objects = realm.objects(SwiftObject.self)
 
         let firstObject = objects.first
         XCTAssertEqual(2, firstObject!.arrayCol.count)
@@ -215,7 +215,7 @@ class ObjectAccessorTests: TestCase {
         let realm = try! Realm()
         try! realm.write {
             let obj = realm.create(SwiftOptionalObject)
-            let copy = realm.objects(SwiftOptionalObject).first!
+            let copy = realm.objects(SwiftOptionalObject.self).first!
             realm.delete(obj)
 
             self.assertThrows(copy.optIntCol.value = 1)

--- a/RealmSwift-swift2.2/Tests/ObjectCreationTests.swift
+++ b/RealmSwift-swift2.2/Tests/ObjectCreationTests.swift
@@ -158,7 +158,7 @@ class ObjectCreationTests: TestCase {
         assertThrows(realm.create(SwiftObject), "Must be in write transaction")
 
         var object: SwiftObject!
-        let objects = realm.objects(SwiftObject)
+        let objects = realm.objects(SwiftObject.self)
         XCTAssertEqual(0, objects.count)
         try! realm.write {
             // test create with all defaults
@@ -305,7 +305,7 @@ class ObjectCreationTests: TestCase {
 
         verifySwiftObjectWithDictionaryLiteral(objectWithKVCObject, dictionary: valueDict, boolObjectValue: false,
             boolObjectListValues: [])
-        XCTAssertEqual(try! Realm().objects(SwiftObject).count, 2, "Object should have been copied")
+        XCTAssertEqual(try! Realm().objects(SwiftObject.self).count, 2, "Object should have been copied")
     }
 
     func testCreateWithNestedObjects() {
@@ -316,7 +316,7 @@ class ObjectCreationTests: TestCase {
             [standalone]])
         try! Realm().commitWrite()
 
-        let stringObjects = try! Realm().objects(SwiftPrimaryStringObject)
+        let stringObjects = try! Realm().objects(SwiftPrimaryStringObject.self)
         XCTAssertEqual(stringObjects.count, 2)
         let persistedObject = stringObjects.first!
 
@@ -339,7 +339,7 @@ class ObjectCreationTests: TestCase {
             [["primary", 12]]], update: true)
         try! Realm().commitWrite()
 
-        let stringObjects = try! Realm().objects(SwiftPrimaryStringObject)
+        let stringObjects = try! Realm().objects(SwiftPrimaryStringObject.self)
         XCTAssertEqual(stringObjects.count, 1)
         let persistedObject = object.object!
 
@@ -422,8 +422,8 @@ class ObjectCreationTests: TestCase {
         try! Realm().commitWrite()
 
         XCTAssertNotEqual(otherRealmObject, object) // the object from the other realm should be copied into this realm
-        XCTAssertEqual(try! Realm().objects(SwiftLinkToPrimaryStringObject).count, 1)
-        XCTAssertEqual(try! Realm().objects(SwiftPrimaryStringObject).count, 4)
+        XCTAssertEqual(try! Realm().objects(SwiftLinkToPrimaryStringObject.self).count, 1)
+        XCTAssertEqual(try! Realm().objects(SwiftPrimaryStringObject.self).count, 4)
     }
 
     func testCreateWithNSNullLinks() {

--- a/RealmSwift-swift2.2/Tests/PerformanceTests.swift
+++ b/RealmSwift-swift2.2/Tests/PerformanceTests.swift
@@ -149,7 +149,7 @@ class SwiftPerformanceTests: TestCase {
         let realm = copyRealmToTestPath(largeRealm)
         measureBlock {
             for _ in 0..<50 {
-                let results = realm.objects(SwiftStringObject).filter("stringCol = 'a'")
+                let results = realm.objects(SwiftStringObject.self).filter("stringCol = 'a'")
                 _ = results.count
             }
         }
@@ -159,7 +159,7 @@ class SwiftPerformanceTests: TestCase {
         let realm = copyRealmToTestPath(mediumRealm)
         measureBlock {
             for _ in 0..<50 {
-                let results = realm.objects(SwiftStringObject).filter("stringCol = 'a'")
+                let results = realm.objects(SwiftStringObject.self).filter("stringCol = 'a'")
                 _ = results.first
                 _ = results.count
             }
@@ -169,7 +169,7 @@ class SwiftPerformanceTests: TestCase {
     func testEnumerateAndAccessQuery() {
         let realm = copyRealmToTestPath(largeRealm)
         measureBlock {
-            for stringObject in realm.objects(SwiftStringObject).filter("stringCol = 'a'") {
+            for stringObject in realm.objects(SwiftStringObject.self).filter("stringCol = 'a'") {
                 _ = stringObject.stringCol
             }
         }
@@ -178,7 +178,7 @@ class SwiftPerformanceTests: TestCase {
     func testEnumerateAndAccessAll() {
         let realm = copyRealmToTestPath(largeRealm)
         measureBlock {
-            for stringObject in realm.objects(SwiftStringObject) {
+            for stringObject in realm.objects(SwiftStringObject.self) {
                 _ = stringObject.stringCol
             }
         }
@@ -187,7 +187,7 @@ class SwiftPerformanceTests: TestCase {
     func testEnumerateAndAccessAllSlow() {
         let realm = copyRealmToTestPath(largeRealm)
         measureBlock {
-            let results = realm.objects(SwiftStringObject)
+            let results = realm.objects(SwiftStringObject.self)
             for i in 0..<results.count {
                 _ = results[i].stringCol
             }
@@ -198,7 +198,7 @@ class SwiftPerformanceTests: TestCase {
         let realm = copyRealmToTestPath(largeRealm)
         realm.beginWrite()
         let arrayPropertyObject = realm.create(SwiftArrayPropertyObject.self,
-            value: ["name", realm.objects(SwiftStringObject).map { $0 }, []])
+            value: ["name", realm.objects(SwiftStringObject.self).map { $0 }, []])
         try! realm.commitWrite()
 
         measureBlock {
@@ -212,7 +212,7 @@ class SwiftPerformanceTests: TestCase {
         let realm = copyRealmToTestPath(largeRealm)
         realm.beginWrite()
         let arrayPropertyObject = realm.create(SwiftArrayPropertyObject.self,
-            value: ["name", realm.objects(SwiftStringObject).map { $0 }, []])
+            value: ["name", realm.objects(SwiftStringObject.self).map { $0 }, []])
         try! realm.commitWrite()
 
         measureBlock {
@@ -227,7 +227,7 @@ class SwiftPerformanceTests: TestCase {
         let realm = copyRealmToTestPath(largeRealm)
         measureBlock {
             try! realm.write {
-                for stringObject in realm.objects(SwiftStringObject) {
+                for stringObject in realm.objects(SwiftStringObject.self) {
                     stringObject.stringCol = "c"
                 }
             }
@@ -238,7 +238,7 @@ class SwiftPerformanceTests: TestCase {
         let realm = copyRealmToTestPath(largeRealm)
         measureBlock {
             try! realm.write {
-                for stringObject in realm.objects(SwiftStringObject).filter("stringCol != 'b'") {
+                for stringObject in realm.objects(SwiftStringObject.self).filter("stringCol != 'b'") {
                     stringObject.stringCol = "c"
                 }
             }
@@ -250,7 +250,7 @@ class SwiftPerformanceTests: TestCase {
             let realm = self.copyRealmToTestPath(largeRealm)
             self.startMeasuring()
             try! realm.write {
-                realm.delete(realm.objects(SwiftStringObject))
+                realm.delete(realm.objects(SwiftStringObject.self))
             }
             self.stopMeasuring()
         }
@@ -261,7 +261,7 @@ class SwiftPerformanceTests: TestCase {
             let realm = self.copyRealmToTestPath(mediumRealm)
             self.startMeasuring()
             try! realm.write {
-                realm.delete(realm.objects(SwiftStringObject).filter("stringCol = 'a' OR stringCol = 'b'"))
+                realm.delete(realm.objects(SwiftStringObject.self).filter("stringCol = 'a' OR stringCol = 'b'"))
             }
             self.stopMeasuring()
         }
@@ -270,7 +270,7 @@ class SwiftPerformanceTests: TestCase {
     func testManualDeletion() {
         inMeasureBlock {
             let realm = self.copyRealmToTestPath(mediumRealm)
-            let objects = realm.objects(SwiftStringObject).map { $0 }
+            let objects = realm.objects(SwiftStringObject.self).map { $0 }
             self.startMeasuring()
             try! realm.write {
                 realm.delete(objects)
@@ -288,7 +288,7 @@ class SwiftPerformanceTests: TestCase {
         }
         measureBlock {
             for i in 0..<1000 {
-                realm.objects(SwiftStringObject).filter("stringCol = %@", i.description).first
+                realm.objects(SwiftStringObject.self).filter("stringCol = %@", i.description).first
             }
         }
     }
@@ -302,7 +302,7 @@ class SwiftPerformanceTests: TestCase {
         }
         measureBlock {
             for i in 0..<1000 {
-                realm.objects(SwiftIndexedPropertiesObject).filter("stringCol = %@", i.description).first
+                realm.objects(SwiftIndexedPropertiesObject.self).filter("stringCol = %@", i.description).first
             }
         }
     }
@@ -319,7 +319,7 @@ class SwiftPerformanceTests: TestCase {
         }
         try! realm.commitWrite()
         measureBlock {
-            _ = realm.objects(SwiftIntObject).filter("intCol IN %@", ids).first
+            _ = realm.objects(SwiftIntObject.self).filter("intCol IN %@", ids).first
         }
     }
 
@@ -332,7 +332,7 @@ class SwiftPerformanceTests: TestCase {
             }
         }
         measureBlock {
-            _ = realm.objects(SwiftIntObject).sorted("intCol", ascending: true).last
+            _ = realm.objects(SwiftIntObject.self).sorted("intCol", ascending: true).last
         }
     }
 
@@ -407,7 +407,7 @@ class SwiftPerformanceTests: TestCase {
             dispatch_async(queue) {
                 autoreleasepool {
                     let realm = inMemoryRealm("test")
-                    let object = realm.objects(SwiftIntObject).first!
+                    let object = realm.objects(SwiftIntObject.self).first!
                     var token: NotificationToken! = nil
                     CFRunLoopPerformBlock(CFRunLoopGetCurrent(), kCFRunLoopDefaultMode) {
                         token = realm.addNotificationBlock { _, _ in
@@ -446,7 +446,7 @@ class SwiftPerformanceTests: TestCase {
             dispatch_async(queue) {
                 autoreleasepool {
                     let realm = inMemoryRealm("test")
-                    let object = realm.objects(SwiftIntObject).first!
+                    let object = realm.objects(SwiftIntObject.self).first!
                     var token: NotificationToken! = nil
                     CFRunLoopPerformBlock(CFRunLoopGetCurrent(), kCFRunLoopDefaultMode) {
                         token = realm.addNotificationBlock { _, _ in

--- a/RealmSwift-swift2.2/Tests/RealmCollectionTypeTests.swift
+++ b/RealmSwift-swift2.2/Tests/RealmCollectionTypeTests.swift
@@ -224,7 +224,7 @@ class RealmCollectionTypeTests: TestCase {
         try! realm.write {
             realm.add(outerArray)
         }
-        XCTAssertEqual(1, outerArray.array.filter("ANY array IN %@", realm.objects(SwiftObject)).count)
+        XCTAssertEqual(1, outerArray.array.filter("ANY array IN %@", realm.objects(SwiftObject.self)).count)
     }
 
     func testFilterResults() {
@@ -235,7 +235,7 @@ class RealmCollectionTypeTests: TestCase {
             realm.add(array)
         }
         XCTAssertEqual(1,
-            realm.objects(SwiftListOfSwiftObject).filter("ANY array IN %@", realm.objects(SwiftObject)).count)
+            realm.objects(SwiftListOfSwiftObject.self).filter("ANY array IN %@", realm.objects(SwiftObject.self)).count)
     }
 
     func testFilterPredicate() {
@@ -504,7 +504,7 @@ class ResultsWithCustomInitializerTest: TestCase {
             realm.add(SwiftCustomInitializerObject(stringVal: "A"))
         }
 
-        let collection = realm.objects(SwiftCustomInitializerObject)
+        let collection = realm.objects(SwiftCustomInitializerObject.self)
         let expected = collection.map { $0.stringCol }
         let actual = collection.valueForKey("stringCol") as! [String]!
         XCTAssertEqual(expected, actual)
@@ -515,23 +515,23 @@ class ResultsWithCustomInitializerTest: TestCase {
 
 class ResultsFromTableTests: ResultsTests {
     override func collectionBaseInWriteTransaction() -> Results<CTTStringObjectWithLink> {
-        return realmWithTestPath().objects(CTTStringObjectWithLink)
+        return realmWithTestPath().objects(CTTStringObjectWithLink.self)
     }
 
     override func getAggregateableCollection() -> AnyRealmCollection<CTTAggregateObject> {
         makeAggregateableObjects()
-        return AnyRealmCollection(realmWithTestPath().objects(CTTAggregateObject))
+        return AnyRealmCollection(realmWithTestPath().objects(CTTAggregateObject.self))
     }
 }
 
 class ResultsFromTableViewTests: ResultsTests {
     override func collectionBaseInWriteTransaction() -> Results<CTTStringObjectWithLink> {
-        return realmWithTestPath().objects(CTTStringObjectWithLink).filter("stringCol != ''")
+        return realmWithTestPath().objects(CTTStringObjectWithLink.self).filter("stringCol != ''")
     }
 
     override func getAggregateableCollection() -> AnyRealmCollection<CTTAggregateObject> {
         makeAggregateableObjects()
-        return AnyRealmCollection(realmWithTestPath().objects(CTTAggregateObject).filter("trueCol == true"))
+        return AnyRealmCollection(realmWithTestPath().objects(CTTAggregateObject.self).filter("trueCol == true"))
     }
 }
 
@@ -554,7 +554,7 @@ class ResultsFromLinkViewTests: ResultsTests {
     override func addObjectToResults() {
         let realm = realmWithTestPath()
         try! realm.write {
-            let array = realm.objects(CTTStringList).last!
+            let array = realm.objects(CTTStringList.self).last!
             array.array.append(realm.create(CTTStringObjectWithLink.self, value: ["a"]))
         }
     }
@@ -761,7 +761,7 @@ class ListNewlyCreatedRealmCollectionTypeTests: ListRealmCollectionTypeTests {
 class ListRetrievedRealmCollectionTypeTests: ListRealmCollectionTypeTests {
     override func collectionBaseInWriteTransaction() -> List<CTTStringObjectWithLink> {
         realmWithTestPath().create(CTTStringList.self, value: [[str1, str2]])
-        let array = realmWithTestPath().objects(CTTStringList).first!
+        let array = realmWithTestPath().objects(CTTStringList.self).first!
         return array.array
     }
 
@@ -779,7 +779,7 @@ class ListRetrievedRealmCollectionTypeTests: ListRealmCollectionTypeTests {
 class LinkingObjectsCollectionTypeTests: RealmCollectionTypeTests {
     func collectionBaseInWriteTransaction() -> LinkingObjects<CTTStringObjectWithLink> {
         let target = realmWithTestPath().create(CTTLinkTarget.self, value: [0])
-        for object in realmWithTestPath().objects(CTTStringObjectWithLink) {
+        for object in realmWithTestPath().objects(CTTStringObjectWithLink.self) {
             object.linkCol = target
         }
         return target.stringObjects

--- a/RealmSwift-swift2.2/Tests/RealmTests.swift
+++ b/RealmSwift-swift2.2/Tests/RealmTests.swift
@@ -41,7 +41,7 @@ class RealmTests: TestCase {
         let config = Realm.Configuration(fileURL: defaultRealmURL(), readOnly: true)
         let readOnlyRealm = try! Realm(configuration: config)
         XCTAssertEqual(true, readOnlyRealm.configuration.readOnly)
-        XCTAssertEqual(1, readOnlyRealm.objects(SwiftIntObject).count)
+        XCTAssertEqual(1, readOnlyRealm.objects(SwiftIntObject.self).count)
 
         assertThrows(try! Realm(), "Realm has different readOnly settings")
     }
@@ -71,7 +71,7 @@ class RealmTests: TestCase {
         assertSucceeds {
             let realm = try Realm(configuration:
                 Realm.Configuration(fileURL: testRealmURL(), readOnly: true))
-            XCTAssertEqual(1, realm.objects(SwiftStringObject).count)
+            XCTAssertEqual(1, realm.objects(SwiftStringObject.self).count)
         }
 
         try! fileManager.setAttributes([ NSFileImmutable: NSNumber(bool: false) ], ofItemAtPath: testRealmURL().path!)
@@ -169,18 +169,18 @@ class RealmTests: TestCase {
             }
         }
         let realm = inMemoryRealm("identifier")
-        XCTAssertEqual(realm.objects(SwiftIntObject).count, 0)
+        XCTAssertEqual(realm.objects(SwiftIntObject.self).count, 0)
 
         try! realm.write {
             realm.create(SwiftIntObject.self, value: [1])
-            XCTAssertEqual(realm.objects(SwiftIntObject).count, 1)
+            XCTAssertEqual(realm.objects(SwiftIntObject.self).count, 1)
 
             inMemoryRealm("identifier").create(SwiftIntObject.self, value: [1])
-            XCTAssertEqual(realm.objects(SwiftIntObject).count, 2)
+            XCTAssertEqual(realm.objects(SwiftIntObject.self).count, 2)
         }
 
         let realm2 = inMemoryRealm("identifier2")
-        XCTAssertEqual(realm2.objects(SwiftIntObject).count, 0)
+        XCTAssertEqual(realm2.objects(SwiftIntObject.self).count, 0)
     }
 
     func testInitCustomClassList() {
@@ -196,9 +196,9 @@ class RealmTests: TestCase {
             self.assertThrows(try! Realm().beginWrite())
             self.assertThrows(try! Realm().write { })
             try! Realm().create(SwiftStringObject.self, value: ["1"])
-            XCTAssertEqual(try! Realm().objects(SwiftStringObject).count, 1)
+            XCTAssertEqual(try! Realm().objects(SwiftStringObject.self).count, 1)
         }
-        XCTAssertEqual(try! Realm().objects(SwiftStringObject).count, 1)
+        XCTAssertEqual(try! Realm().objects(SwiftStringObject.self).count, 1)
     }
 
     func testDynamicWrite() {
@@ -206,9 +206,9 @@ class RealmTests: TestCase {
             self.assertThrows(try! Realm().beginWrite())
             self.assertThrows(try! Realm().write { })
             try! Realm().dynamicCreate("SwiftStringObject", value: ["1"])
-            XCTAssertEqual(try! Realm().objects(SwiftStringObject).count, 1)
+            XCTAssertEqual(try! Realm().objects(SwiftStringObject.self).count, 1)
         }
-        XCTAssertEqual(try! Realm().objects(SwiftStringObject).count, 1)
+        XCTAssertEqual(try! Realm().objects(SwiftStringObject.self).count, 1)
     }
 
     func testDynamicWriteSubscripting() {
@@ -228,14 +228,14 @@ class RealmTests: TestCase {
         try! Realm().cancelWrite()
         try! Realm().beginWrite()
         try! Realm().create(SwiftStringObject.self, value: ["1"])
-        XCTAssertEqual(try! Realm().objects(SwiftStringObject).count, 1)
+        XCTAssertEqual(try! Realm().objects(SwiftStringObject.self).count, 1)
     }
 
     func testCommitWrite() {
         try! Realm().beginWrite()
         try! Realm().create(SwiftStringObject.self, value: ["1"])
         try! Realm().commitWrite()
-        XCTAssertEqual(try! Realm().objects(SwiftStringObject).count, 1)
+        XCTAssertEqual(try! Realm().objects(SwiftStringObject.self).count, 1)
         try! Realm().beginWrite()
     }
 
@@ -244,16 +244,16 @@ class RealmTests: TestCase {
         try! Realm().beginWrite()
         try! Realm().create(SwiftStringObject.self, value: ["1"])
         try! Realm().cancelWrite()
-        XCTAssertEqual(try! Realm().objects(SwiftStringObject).count, 0)
+        XCTAssertEqual(try! Realm().objects(SwiftStringObject.self).count, 0)
 
         try! Realm().write {
             self.assertThrows(self.realmWithTestPath().cancelWrite())
             let object = try! Realm().create(SwiftStringObject)
             try! Realm().cancelWrite()
             XCTAssertTrue(object.invalidated)
-            XCTAssertEqual(try! Realm().objects(SwiftStringObject).count, 0)
+            XCTAssertEqual(try! Realm().objects(SwiftStringObject.self).count, 0)
         }
-        XCTAssertEqual(try! Realm().objects(SwiftStringObject).count, 0)
+        XCTAssertEqual(try! Realm().objects(SwiftStringObject.self).count, 0)
     }
 
     func testInWriteTransaction() {
@@ -276,16 +276,16 @@ class RealmTests: TestCase {
     func testAddSingleObject() {
         let realm = try! Realm()
         assertThrows(_ = realm.add(SwiftObject()))
-        XCTAssertEqual(0, realm.objects(SwiftObject).count)
+        XCTAssertEqual(0, realm.objects(SwiftObject.self).count)
         var defaultRealmObject: SwiftObject!
         try! realm.write {
             defaultRealmObject = SwiftObject()
             realm.add(defaultRealmObject)
-            XCTAssertEqual(1, realm.objects(SwiftObject).count)
+            XCTAssertEqual(1, realm.objects(SwiftObject.self).count)
             realm.add(defaultRealmObject)
-            XCTAssertEqual(1, realm.objects(SwiftObject).count)
+            XCTAssertEqual(1, realm.objects(SwiftObject.self).count)
         }
-        XCTAssertEqual(1, realm.objects(SwiftObject).count)
+        XCTAssertEqual(1, realm.objects(SwiftObject.self).count)
 
         let testRealm = realmWithTestPath()
         try! testRealm.write {
@@ -295,16 +295,16 @@ class RealmTests: TestCase {
 
     func testAddWithUpdateSingleObject() {
         let realm = try! Realm()
-        XCTAssertEqual(0, realm.objects(SwiftPrimaryStringObject).count)
+        XCTAssertEqual(0, realm.objects(SwiftPrimaryStringObject.self).count)
         var defaultRealmObject: SwiftPrimaryStringObject!
         try! realm.write {
             defaultRealmObject = SwiftPrimaryStringObject()
             realm.add(defaultRealmObject, update: true)
-            XCTAssertEqual(1, realm.objects(SwiftPrimaryStringObject).count)
+            XCTAssertEqual(1, realm.objects(SwiftPrimaryStringObject.self).count)
             realm.add(SwiftPrimaryStringObject(), update: true)
-            XCTAssertEqual(1, realm.objects(SwiftPrimaryStringObject).count)
+            XCTAssertEqual(1, realm.objects(SwiftPrimaryStringObject.self).count)
         }
-        XCTAssertEqual(1, realm.objects(SwiftPrimaryStringObject).count)
+        XCTAssertEqual(1, realm.objects(SwiftPrimaryStringObject.self).count)
 
         let testRealm = realmWithTestPath()
         try! testRealm.write {
@@ -315,33 +315,33 @@ class RealmTests: TestCase {
     func testAddMultipleObjects() {
         let realm = try! Realm()
         assertThrows(_ = realm.add([SwiftObject(), SwiftObject()]))
-        XCTAssertEqual(0, realm.objects(SwiftObject).count)
+        XCTAssertEqual(0, realm.objects(SwiftObject.self).count)
         try! realm.write {
             let objs = [SwiftObject(), SwiftObject()]
             realm.add(objs)
-            XCTAssertEqual(2, realm.objects(SwiftObject).count)
+            XCTAssertEqual(2, realm.objects(SwiftObject.self).count)
         }
-        XCTAssertEqual(2, realm.objects(SwiftObject).count)
+        XCTAssertEqual(2, realm.objects(SwiftObject.self).count)
 
         let testRealm = realmWithTestPath()
         try! testRealm.write {
-            self.assertThrows(_ = testRealm.add(realm.objects(SwiftObject)))
+            self.assertThrows(_ = testRealm.add(realm.objects(SwiftObject.self)))
         }
     }
 
     func testAddWithUpdateMultipleObjects() {
         let realm = try! Realm()
-        XCTAssertEqual(0, realm.objects(SwiftPrimaryStringObject).count)
+        XCTAssertEqual(0, realm.objects(SwiftPrimaryStringObject.self).count)
         try! realm.write {
             let objs = [SwiftPrimaryStringObject(), SwiftPrimaryStringObject()]
             realm.add(objs, update: true)
-            XCTAssertEqual(1, realm.objects(SwiftPrimaryStringObject).count)
+            XCTAssertEqual(1, realm.objects(SwiftPrimaryStringObject.self).count)
         }
-        XCTAssertEqual(1, realm.objects(SwiftPrimaryStringObject).count)
+        XCTAssertEqual(1, realm.objects(SwiftPrimaryStringObject.self).count)
 
         let testRealm = realmWithTestPath()
         try! testRealm.write {
-            self.assertThrows(_ = testRealm.add(realm.objects(SwiftPrimaryStringObject), update: true))
+            self.assertThrows(_ = testRealm.add(realm.objects(SwiftPrimaryStringObject.self), update: true))
         }
     }
 
@@ -349,20 +349,20 @@ class RealmTests: TestCase {
 
     func testDeleteSingleObject() {
         let realm = try! Realm()
-        XCTAssertEqual(0, realm.objects(SwiftObject).count)
+        XCTAssertEqual(0, realm.objects(SwiftObject.self).count)
         assertThrows(_ = realm.delete(SwiftObject()))
         var defaultRealmObject: SwiftObject!
         try! realm.write {
             defaultRealmObject = SwiftObject()
             self.assertThrows(_ = realm.delete(defaultRealmObject))
-            XCTAssertEqual(0, realm.objects(SwiftObject).count)
+            XCTAssertEqual(0, realm.objects(SwiftObject.self).count)
             realm.add(defaultRealmObject)
-            XCTAssertEqual(1, realm.objects(SwiftObject).count)
+            XCTAssertEqual(1, realm.objects(SwiftObject.self).count)
             realm.delete(defaultRealmObject)
-            XCTAssertEqual(0, realm.objects(SwiftObject).count)
+            XCTAssertEqual(0, realm.objects(SwiftObject.self).count)
         }
         assertThrows(_ = realm.delete(defaultRealmObject))
-        XCTAssertEqual(0, realm.objects(SwiftObject).count)
+        XCTAssertEqual(0, realm.objects(SwiftObject.self).count)
 
         let testRealm = realmWithTestPath()
         assertThrows(_ = testRealm.delete(defaultRealmObject))
@@ -373,16 +373,16 @@ class RealmTests: TestCase {
 
     func testDeleteSequenceOfObjects() {
         let realm = try! Realm()
-        XCTAssertEqual(0, realm.objects(SwiftObject).count)
+        XCTAssertEqual(0, realm.objects(SwiftObject.self).count)
         var objs: [SwiftObject]!
         try! realm.write {
             objs = [SwiftObject(), SwiftObject()]
             realm.add(objs)
-            XCTAssertEqual(2, realm.objects(SwiftObject).count)
+            XCTAssertEqual(2, realm.objects(SwiftObject.self).count)
             realm.delete(objs)
-            XCTAssertEqual(0, realm.objects(SwiftObject).count)
+            XCTAssertEqual(0, realm.objects(SwiftObject.self).count)
         }
-        XCTAssertEqual(0, realm.objects(SwiftObject).count)
+        XCTAssertEqual(0, realm.objects(SwiftObject.self).count)
 
         let testRealm = realmWithTestPath()
         assertThrows(_ = testRealm.delete(objs))
@@ -393,42 +393,42 @@ class RealmTests: TestCase {
 
     func testDeleteListOfObjects() {
         let realm = try! Realm()
-        XCTAssertEqual(0, realm.objects(SwiftCompanyObject).count)
+        XCTAssertEqual(0, realm.objects(SwiftCompanyObject.self).count)
         try! realm.write {
             let obj = SwiftCompanyObject()
             obj.employees.append(SwiftEmployeeObject())
             realm.add(obj)
-            XCTAssertEqual(1, realm.objects(SwiftEmployeeObject).count)
+            XCTAssertEqual(1, realm.objects(SwiftEmployeeObject.self).count)
             realm.delete(obj.employees)
             XCTAssertEqual(0, obj.employees.count)
-            XCTAssertEqual(0, realm.objects(SwiftEmployeeObject).count)
+            XCTAssertEqual(0, realm.objects(SwiftEmployeeObject.self).count)
         }
-        XCTAssertEqual(0, realm.objects(SwiftEmployeeObject).count)
+        XCTAssertEqual(0, realm.objects(SwiftEmployeeObject.self).count)
     }
 
     func testDeleteResults() {
         let realm = try! Realm(fileURL: testRealmURL())
-        XCTAssertEqual(0, realm.objects(SwiftCompanyObject).count)
+        XCTAssertEqual(0, realm.objects(SwiftCompanyObject.self).count)
         try! realm.write {
             realm.add(SwiftIntObject(value: [1]))
             realm.add(SwiftIntObject(value: [1]))
             realm.add(SwiftIntObject(value: [2]))
-            XCTAssertEqual(3, realm.objects(SwiftIntObject).count)
-            realm.delete(realm.objects(SwiftIntObject).filter("intCol = 1"))
-            XCTAssertEqual(1, realm.objects(SwiftIntObject).count)
+            XCTAssertEqual(3, realm.objects(SwiftIntObject.self).count)
+            realm.delete(realm.objects(SwiftIntObject.self).filter("intCol = 1"))
+            XCTAssertEqual(1, realm.objects(SwiftIntObject.self).count)
         }
-        XCTAssertEqual(1, realm.objects(SwiftIntObject).count)
+        XCTAssertEqual(1, realm.objects(SwiftIntObject.self).count)
     }
 
     func testDeleteAll() {
         let realm = try! Realm()
         try! realm.write {
             realm.add(SwiftObject())
-            XCTAssertEqual(1, realm.objects(SwiftObject).count)
+            XCTAssertEqual(1, realm.objects(SwiftObject.self).count)
             realm.deleteAll()
-            XCTAssertEqual(0, realm.objects(SwiftObject).count)
+            XCTAssertEqual(0, realm.objects(SwiftObject.self).count)
         }
-        XCTAssertEqual(0, realm.objects(SwiftObject).count)
+        XCTAssertEqual(0, realm.objects(SwiftObject.self).count)
     }
 
     func testObjects() {
@@ -438,9 +438,9 @@ class RealmTests: TestCase {
             try! Realm().create(SwiftIntObject.self, value: [300])
         }
 
-        XCTAssertEqual(0, try! Realm().objects(SwiftStringObject).count)
-        XCTAssertEqual(3, try! Realm().objects(SwiftIntObject).count)
-        assertThrows(try! Realm().objects(Object))
+        XCTAssertEqual(0, try! Realm().objects(SwiftStringObject.self).count)
+        XCTAssertEqual(3, try! Realm().objects(SwiftIntObject.self).count)
+        assertThrows(try! Realm().objects(Object.self))
     }
 
     func testDynamicObjects() {
@@ -723,7 +723,7 @@ class RealmTests: TestCase {
         token.stop()
 
         // get object
-        let results = realm.objects(SwiftStringObject)
+        let results = realm.objects(SwiftStringObject.self)
         XCTAssertEqual(results.count, Int(1), "There should be 1 object of type StringObject")
         XCTAssertEqual(results[0].stringCol, "string", "Value of first column should be 'string'")
     }
@@ -740,7 +740,7 @@ class RealmTests: TestCase {
             notificationFired.fulfill()
         }
 
-        let results = realm.objects(SwiftStringObject)
+        let results = realm.objects(SwiftStringObject.self)
         XCTAssertEqual(results.count, Int(0), "There should be 1 object of type StringObject")
 
         dispatchSyncNewThread {
@@ -775,7 +775,7 @@ class RealmTests: TestCase {
             realm.add(SwiftObject())
             return
         }
-        XCTAssertEqual(realm.objects(SwiftObject).count, 2)
+        XCTAssertEqual(realm.objects(SwiftObject.self).count, 2)
         XCTAssertEqual(object.invalidated, true)
     }
 
@@ -793,7 +793,7 @@ class RealmTests: TestCase {
         }
         autoreleasepool {
             let copy = try! Realm(fileURL: fileURL)
-            XCTAssertEqual(1, copy.objects(SwiftObject).count)
+            XCTAssertEqual(1, copy.objects(SwiftObject.self).count)
         }
         try! NSFileManager.defaultManager().removeItemAtURL(fileURL)
     }

--- a/RealmSwift-swift2.2/Tests/SwiftLinkTests.swift
+++ b/RealmSwift-swift2.2/Tests/SwiftLinkTests.swift
@@ -31,8 +31,8 @@ class SwiftLinkTests: TestCase {
 
         try! realm.write { realm.add(owner) }
 
-        let owners = realm.objects(SwiftOwnerObject)
-        let dogs = realm.objects(SwiftDogObject)
+        let owners = realm.objects(SwiftOwnerObject.self)
+        let dogs = realm.objects(SwiftDogObject.self)
         XCTAssertEqual(owners.count, Int(1), "Expecting 1 owner")
         XCTAssertEqual(dogs.count, Int(1), "Expecting 1 dog")
         XCTAssertEqual(owners[0].name, "Tim", "Tim is named Tim")
@@ -51,16 +51,16 @@ class SwiftLinkTests: TestCase {
 
         try! realm.write { realm.add(owner) }
 
-        XCTAssertEqual(realm.objects(SwiftOwnerObject).count, Int(1), "Expecting 1 owner")
-        XCTAssertEqual(realm.objects(SwiftDogObject).count, Int(1), "Expecting 1 dog")
+        XCTAssertEqual(realm.objects(SwiftOwnerObject.self).count, Int(1), "Expecting 1 owner")
+        XCTAssertEqual(realm.objects(SwiftDogObject.self).count, Int(1), "Expecting 1 dog")
 
         realm.beginWrite()
         let fiel = realm.create(SwiftOwnerObject.self, value: ["Fiel", NSNull()])
         fiel.dog = owner.dog
         try! realm.commitWrite()
 
-        XCTAssertEqual(realm.objects(SwiftOwnerObject).count, Int(2), "Expecting 2 owners")
-        XCTAssertEqual(realm.objects(SwiftDogObject).count, Int(1), "Expecting 1 dog")
+        XCTAssertEqual(realm.objects(SwiftOwnerObject.self).count, Int(2), "Expecting 2 owners")
+        XCTAssertEqual(realm.objects(SwiftDogObject.self).count, Int(1), "Expecting 1 dog")
     }
 
     func testLinkRemoval() {
@@ -73,18 +73,18 @@ class SwiftLinkTests: TestCase {
 
         try! realm.write { realm.add(owner) }
 
-        XCTAssertEqual(realm.objects(SwiftOwnerObject).count, Int(1), "Expecting 1 owner")
-        XCTAssertEqual(realm.objects(SwiftDogObject).count, Int(1), "Expecting 1 dog")
+        XCTAssertEqual(realm.objects(SwiftOwnerObject.self).count, Int(1), "Expecting 1 owner")
+        XCTAssertEqual(realm.objects(SwiftDogObject.self).count, Int(1), "Expecting 1 dog")
 
         try! realm.write { realm.delete(owner.dog!) }
 
         XCTAssertNil(owner.dog, "Dog should be nullified when deleted")
 
         // refresh owner and check
-        let owner2 = realm.objects(SwiftOwnerObject).first!
+        let owner2 = realm.objects(SwiftOwnerObject.self).first!
         XCTAssertNotNil(owner2, "Should have 1 owner")
         XCTAssertNil(owner2.dog, "Dog should be nullified when deleted")
-        XCTAssertEqual(realm.objects(SwiftDogObject).count, Int(0), "Expecting 0 dogs")
+        XCTAssertEqual(realm.objects(SwiftDogObject.self).count, Int(0), "Expecting 0 dogs")
     }
 
     func testLinkingObjects() {

--- a/RealmSwift-swift2.2/Tests/SwiftUnicodeTests.swift
+++ b/RealmSwift-swift2.2/Tests/SwiftUnicodeTests.swift
@@ -30,14 +30,14 @@ class SwiftUnicodeTests: TestCase {
             return
         }
 
-        let obj1 = realm.objects(SwiftStringObject).first!
+        let obj1 = realm.objects(SwiftStringObject.self).first!
         XCTAssertEqual(obj1.stringCol, utf8TestString)
 
-        let obj2 = realm.objects(SwiftStringObject).filter("stringCol == %@", utf8TestString).first!
+        let obj2 = realm.objects(SwiftStringObject.self).filter("stringCol == %@", utf8TestString).first!
         XCTAssertEqual(obj1, obj2)
         XCTAssertEqual(obj2.stringCol, utf8TestString)
 
-        XCTAssertEqual(Int(0), realm.objects(SwiftStringObject).filter("stringCol != %@", utf8TestString).count)
+        XCTAssertEqual(Int(0), realm.objects(SwiftStringObject.self).filter("stringCol != %@", utf8TestString).count)
     }
 
     func testUTF8PropertyWithUTF8StringContents() {
@@ -47,12 +47,12 @@ class SwiftUnicodeTests: TestCase {
             return
         }
 
-        let obj1 = realm.objects(SwiftUTF8Object).first!
+        let obj1 = realm.objects(SwiftUTF8Object.self).first!
         XCTAssertEqual(obj1.柱колоéнǢкƱаم👍, utf8TestString,
             "Storing and retrieving a string with UTF8 content should work")
 
         // Test fails because of rdar://17735684
-        let obj2 = realm.objects(SwiftUTF8Object).filter("%K == %@", "柱колоéнǢкƱаم👍", utf8TestString).first!
+        let obj2 = realm.objects(SwiftUTF8Object.self).filter("%K == %@", "柱колоéнǢкƱаم👍", utf8TestString).first!
         XCTAssertEqual(obj1, obj2, "Querying a realm searching for a string with UTF8 content should work")
     }
 }

--- a/examples/ios/swift-2.2/Backlink/AppDelegate.swift
+++ b/examples/ios/swift-2.2/Backlink/AppDelegate.swift
@@ -53,7 +53,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         }
 
         // Log all dogs and their owners using the "owners" inverse relationship
-        let allDogs = realm.objects(Dog)
+        let allDogs = realm.objects(Dog.self)
         for dog in allDogs {
             let ownerNames = dog.owners.map { $0.name }
             print("\(dog.name) has \(ownerNames.count) owners (\(ownerNames))")

--- a/examples/ios/swift-2.2/Encryption/ViewController.swift
+++ b/examples/ios/swift-2.2/Encryption/ViewController.swift
@@ -75,7 +75,7 @@ class ViewController: UIViewController {
         autoreleasepool {
             let configuration = Realm.Configuration(encryptionKey: getKey())
             let realm = try! Realm(configuration: configuration)
-            if let stringProp = realm.objects(EncryptionObject).first?.stringProp {
+            if let stringProp = realm.objects(EncryptionObject.self).first?.stringProp {
                 log("Saved object: \(stringProp)")
             }
         }

--- a/examples/ios/swift-2.2/GettingStarted.playground/Contents.swift
+++ b/examples/ios/swift-2.2/GettingStarted.playground/Contents.swift
@@ -63,7 +63,7 @@ try! realm.write {
 
 let favorites = ["Jennifer"]
 
-let favoritePeopleWithSpousesAndCars = realm.objects(Person)
+let favoritePeopleWithSpousesAndCars = realm.objects(Person.self)
     .filter("cars.@count > 1 && spouse != nil && name IN %@", favorites)
     .sorted("age")
 
@@ -91,5 +91,5 @@ try! realm.write {
     realm.deleteAll()
 }
 
-realm.objects(Person).count
+realm.objects(Person.self).count
 //: Thanks! To learn more about Realm go to https://realm.io

--- a/examples/ios/swift-2.2/GroupedTableView/TableViewController.swift
+++ b/examples/ios/swift-2.2/GroupedTableView/TableViewController.swift
@@ -54,7 +54,7 @@ class TableViewController: UITableViewController {
             self.tableView.reloadData()
         }
         for section in sectionTitles {
-            let unsortedObjects = realm.objects(DemoObject).filter("sectionTitle == '\(section)'")
+            let unsortedObjects = realm.objects(DemoObject.self).filter("sectionTitle == '\(section)'")
             let sortedObjects = unsortedObjects.sorted("date", ascending: true)
             objectsBySection.append(sortedObjects)
         }

--- a/examples/ios/swift-2.2/Migration/AppDelegate.swift
+++ b/examples/ios/swift-2.2/Migration/AppDelegate.swift
@@ -103,7 +103,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         // print out all migrated objects in the default realm
         // migration is performed implicitly on Realm access
-        print("Migrated objects in the default Realm: \(try! Realm().objects(Person))")
+        print("Migrated objects in the default Realm: \(try! Realm().objects(Person.self))")
 
         //
         // Migrate a realms at a custom paths
@@ -127,9 +127,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
             // print out all migrated objects in the migrated realms
             let realmv1 = try! Realm(configuration: realmv1Configuration)
-            print("Migrated objects in the Realm migrated from v1: \(realmv1.objects(Person))")
+            print("Migrated objects in the Realm migrated from v1: \(realmv1.objects(Person.self))")
             let realmv2 = try! Realm(configuration: realmv2Configuration)
-            print("Migrated objects in the Realm migrated from v2: \(realmv2.objects(Person))")
+            print("Migrated objects in the Realm migrated from v2: \(realmv2.objects(Person.self))")
         }
 
         return true

--- a/examples/ios/swift-2.2/ReactKit/TableViewController.swift
+++ b/examples/ios/swift-2.2/ReactKit/TableViewController.swift
@@ -65,7 +65,7 @@ class TableViewController: UITableViewController {
         // would be supplied as the data source by whatever is displaying this
         // table view
         let realm = try! Realm()
-        let obj = realm.objects(GroupParent).first
+        let obj = realm.objects(GroupParent.self).first
         if obj != nil {
             return obj!
         }
@@ -204,7 +204,7 @@ class TableViewController: UITableViewController {
     func modifyInBackground(block: (List<Group>) -> Void) {
         dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0)) {
             let realm = try! Realm()
-            let parent = realm.objects(GroupParent).first!
+            let parent = realm.objects(GroupParent.self).first!
             try! realm.write {
                 block(parent.groups)
             }

--- a/examples/ios/swift-2.2/Simple/AppDelegate.swift
+++ b/examples/ios/swift-2.2/Simple/AppDelegate.swift
@@ -60,7 +60,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         try! realm.commitWrite()
 
         // Query
-        let results = realm.objects(Dog).filter(NSPredicate(format:"name contains 'x'"))
+        let results = realm.objects(Dog.self).filter(NSPredicate(format:"name contains 'x'"))
 
         // Queries are chainable!
         let results2 = results.filter("age > 8")
@@ -79,7 +79,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Multi-threading
         dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0)) {
             let otherRealm = try! Realm()
-            let otherResults = otherRealm.objects(Dog).filter(NSPredicate(format:"name contains 'Rex'"))
+            let otherResults = otherRealm.objects(Dog.self).filter(NSPredicate(format:"name contains 'Rex'"))
             print("Number of dogs \(otherResults.count)")
         }
 

--- a/examples/ios/swift-2.2/TableView/TableViewController.swift
+++ b/examples/ios/swift-2.2/TableView/TableViewController.swift
@@ -37,7 +37,7 @@ class Cell: UITableViewCell {
 class TableViewController: UITableViewController {
 
     let realm = try! Realm()
-    let results = try! Realm().objects(DemoObject).sorted("date")
+    let results = try! Realm().objects(DemoObject.self).sorted("date")
     var notificationToken: NotificationToken?
 
     override func viewDidLoad() {

--- a/examples/tvos/swift/DownloadCache/RepositoriesViewController.swift
+++ b/examples/tvos/swift/DownloadCache/RepositoriesViewController.swift
@@ -100,7 +100,7 @@ class RepositoriesViewController: UICollectionViewController, UITextFieldDelegat
 
     func reloadData() {
         let realm = try! Realm()
-        results = realm.objects(Repository)
+        results = realm.objects(Repository.self)
         if let text = searchField.text where !text.isEmpty {
             results = results?.filter("name contains[c] %@", text)
         }

--- a/examples/tvos/swift/PreloadedData/PlacesViewController.swift
+++ b/examples/tvos/swift/PreloadedData/PlacesViewController.swift
@@ -55,7 +55,7 @@ class PlacesViewController: UITableViewController, UITextFieldDelegate {
 
     func reloadData() {
         let realm = try! Realm()
-        results = realm.objects(Place)
+        results = realm.objects(Place.self)
         if let text = searchField.text where !text.isEmpty {
             results = results?.filter("postalCode beginswith %@", text)
         }


### PR DESCRIPTION
/cc @austinzheng 

fixes #3711