### PR TITLE
Prohibiting non-ignored lazy properties in models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ x.x.x Release notes (yyyy-MM-dd)
   transactions have been committed.
 * Fix a "Destruction of mutex in use" assertion failure after an error while
   opening a file.
+* Realm now throws an exception if an `Object` subclass is defined with a managed Swift `lazy` property.
+  Objects with ignored `lazy` properties should now work correctly.
 * Update the LLDB script to work with recent changes to the implementation of `RLMResults`.
 
 1.0.0 Release notes (2016-05-25)

--- a/Realm/Tests/Swift2.2/SwiftPropertyTypeTest.swift
+++ b/Realm/Tests/Swift2.2/SwiftPropertyTypeTest.swift
@@ -103,4 +103,20 @@ class SwiftPropertyTypeTest: RLMTestCase {
         XCTAssertEqual(obj.int32, v32)
         XCTAssertEqual(obj.int64, v64)
     }
+
+    func testLazyVarProperties() {
+        let realm = realmWithTestPath()
+        let succeeded : Void? = try? realm.transactionWithBlock() {
+            realm.addObject(SwiftLazyVarObject())
+        }
+        XCTAssertNotNil(succeeded, "Writing an NSObject-based object with an lazy property should work.")
+    }
+
+    func testIgnoredLazyVarProperties() {
+        let realm = realmWithTestPath()
+        let succeeded : Void? = try? realm.transactionWithBlock() {
+            realm.addObject(SwiftIgnoredLazyVarObject())
+        }
+        XCTAssertNotNil(succeeded, "Writing an object with an ignored lazy property should work.")
+    }
 }

--- a/Realm/Tests/Swift2.2/SwiftTestObjects.swift
+++ b/Realm/Tests/Swift2.2/SwiftTestObjects.swift
@@ -141,3 +141,12 @@ class SwiftLinkTargetObject: RLMObject {
         return ["backlinks": RLMPropertyDescriptor(withClass: SwiftLinkSourceObject.self, propertyName: "link")]
     }
 }
+
+class SwiftLazyVarObject : RLMObject {
+    dynamic lazy var lazyProperty : String = "hello world"
+}
+
+class SwiftIgnoredLazyVarObject : RLMObject {
+    dynamic lazy var ignoredVar : String = "hello world"
+    override class func ignoredProperties() -> [String] { return ["ignoredVar"] }
+}

--- a/RealmSwift-swift2.2/Tests/ObjectSchemaInitializationTests.swift
+++ b/RealmSwift-swift2.2/Tests/ObjectSchemaInitializationTests.swift
@@ -122,6 +122,8 @@ class ObjectSchemaInitializationTests: TestCase {
                      "Should throw when not ignoring a property of a type we can't persist")
         assertThrows(RLMObjectSchema(forObjectClass: SwiftObjectWithOptionalStringArray.self),
                      "Should throw when not ignoring a property of a type we can't persist")
+        assertThrows(RLMObjectSchema(forObjectClass: RealmObjectWithLazyVar.self),
+                     "Should throw when not ignoring a property marked as 'dynamic lazy var'")
 
         // Shouldn't throw when not ignoring a property of a type we can't persist if it's not dynamic
         _ = RLMObjectSchema(forObjectClass: SwiftObjectWithEnum.self)
@@ -147,6 +149,10 @@ class ObjectSchemaInitializationTests: TestCase {
         XCTAssertNil(schema["runtimeProperty"], "The object schema shouldn't contain ignored properties")
         XCTAssertNil(schema["runtimeDefaultProperty"], "The object schema shouldn't contain ignored properties")
         XCTAssertNil(schema["readOnlyProperty"], "The object schema shouldn't contain read-only properties")
+
+        assertSucceeds("Should not throw when ignoring a lazy property.") {
+            _ = RLMObjectSchema(forObjectClass: RealmObjectWithIgnoredLazyVar.self)
+        }
     }
 
     func testIndexedProperties() {
@@ -271,4 +277,13 @@ extension Set: RealmOptionalType { }
 
 class SwiftObjectWithNonRealmOptionalType: SwiftFakeObject {
     let set = RealmOptional<Set<Int>>()
+}
+
+class RealmObjectWithLazyVar: SwiftFakeObject {
+    dynamic lazy var someVar = ""
+}
+
+class RealmObjectWithIgnoredLazyVar: Object {
+    dynamic lazy var ignoredVar = ""
+    dynamic override class func ignoredProperties() -> [String] { return ["ignoredVar"] }
 }


### PR DESCRIPTION
@jpsim @bdash @tgoyne 

Fixing #3337 by prohibiting managed lazy properties in Realm model objects.

Changes:
- Non-ignored lazy properties in models will now cause an exception to be thrown when the schema is built
- Unit tests

NOTE: I'd like to write one more test - ensuring that a Realm Objective-C `RLMObject` subclass defined in Swift with a `lazy var` throws the exception properly. However, it doesn't seem to be possible to use `RLMSetTreatFakeObjectAsRLMObject()` properly from Swift. I'll look into this some more.