### PR TITLE
Adding unit test helper class

### DIFF
--- a/Realm.xcodeproj/project.pbxproj
+++ b/Realm.xcodeproj/project.pbxproj
@@ -132,6 +132,7 @@
 		1AFEF8431D52D2C900495005 /* Sync.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A7DE7021D38460B0029F0AE /* Sync.swift */; };
 		1A30CBB21D088521003989E6 /* RLMUnitTestHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = 1A30CBB01D088521003989E6 /* RLMUnitTestHelper.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		1A30CBB31D088521003989E6 /* RLMUnitTestHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 1A30CBB11D088521003989E6 /* RLMUnitTestHelper.m */; };
+		1AB605D51D495F4D007F53DE /* UnitTestHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AB605D41D495F4D007F53DE /* UnitTestHelper.swift */; };
 		2973CCF91C175AB400FEA0FA /* fileformat-pre-null.realm in Resources */ = {isa = PBXBuildFile; fileRef = 29B7FDF71C0DE76B0023224E /* fileformat-pre-null.realm */; };
 		297FBEFB1C19F696009D1118 /* RLMTestCaseUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 297FBEFA1C19F696009D1118 /* RLMTestCaseUtils.swift */; };
 		297FBEFF1C19F844009D1118 /* TestUtils.mm in Sources */ = {isa = PBXBuildFile; fileRef = 297FBEFE1C19F844009D1118 /* TestUtils.mm */; };
@@ -656,6 +657,7 @@
 		1AF7EA9A1D340E700001A9B5 /* RLMNetworkClient.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RLMNetworkClient.m; sourceTree = "<group>"; };
 		1A30CBB01D088521003989E6 /* RLMUnitTestHelper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RLMUnitTestHelper.h; sourceTree = "<group>"; };
 		1A30CBB11D088521003989E6 /* RLMUnitTestHelper.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RLMUnitTestHelper.m; sourceTree = "<group>"; };
+		1AB605D41D495F4D007F53DE /* UnitTestHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UnitTestHelper.swift; sourceTree = "<group>"; };
 		26F3CA681986CC86004623E1 /* SwiftPropertyTypeTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwiftPropertyTypeTest.swift; sourceTree = "<group>"; };
 		297FBEFA1C19F696009D1118 /* RLMTestCaseUtils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RLMTestCaseUtils.swift; sourceTree = "<group>"; };
 		297FBEFD1C19F844009D1118 /* TestUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TestUtils.h; path = Realm/Tests/TestUtils.h; sourceTree = SOURCE_ROOT; };
@@ -1206,6 +1208,7 @@
 				E8BF67FB1C24D07100E591CD /* SwiftVersion.swift */,
 				1A7DE7021D38460B0029F0AE /* Sync.swift */,
 				3F222C4D1E26F51300CA0713 /* ThreadSafeReference.swift */,
+				1AB605D41D495F4D007F53DE /* UnitTestHelper.swift */,
 				5D660FF01BE98D670021E04F /* Util.swift */,
 			);
 			path = RealmSwift;
@@ -2201,6 +2204,7 @@
 				5D1534B81CCFF545008976D7 /* LinkingObjects.swift in Sources */,
 				5D660FF21BE98D670021E04F /* List.swift in Sources */,
 				5D660FF31BE98D670021E04F /* Migration.swift in Sources */,
+				1AB605D51D495F4D007F53DE /* UnitTestHelper.swift in Sources */,
 				5D660FF41BE98D670021E04F /* Object.swift in Sources */,
 				5B77EACE1DCC5614006AB51D /* ObjectiveCSupport.swift in Sources */,
 				5D660FF51BE98D670021E04F /* ObjectSchema.swift in Sources */,

--- a/Realm.xcodeproj/project.pbxproj
+++ b/Realm.xcodeproj/project.pbxproj
@@ -130,6 +130,8 @@
 		1AFEF8411D52CD8D00495005 /* RLMRealmConfiguration+Sync.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1ABF256E1D52AB6200BAC441 /* RLMRealmConfiguration+Sync.mm */; };
 		1AFEF8421D52CD8F00495005 /* RLMRealmConfiguration+Sync.h in Headers */ = {isa = PBXBuildFile; fileRef = 1ABF256D1D52AB6200BAC441 /* RLMRealmConfiguration+Sync.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		1AFEF8431D52D2C900495005 /* Sync.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A7DE7021D38460B0029F0AE /* Sync.swift */; };
+		1A30CBB21D088521003989E6 /* RLMUnitTestHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = 1A30CBB01D088521003989E6 /* RLMUnitTestHelper.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1A30CBB31D088521003989E6 /* RLMUnitTestHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 1A30CBB11D088521003989E6 /* RLMUnitTestHelper.m */; };
 		2973CCF91C175AB400FEA0FA /* fileformat-pre-null.realm in Resources */ = {isa = PBXBuildFile; fileRef = 29B7FDF71C0DE76B0023224E /* fileformat-pre-null.realm */; };
 		297FBEFB1C19F696009D1118 /* RLMTestCaseUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 297FBEFA1C19F696009D1118 /* RLMTestCaseUtils.swift */; };
 		297FBEFF1C19F844009D1118 /* TestUtils.mm in Sources */ = {isa = PBXBuildFile; fileRef = 297FBEFE1C19F844009D1118 /* TestUtils.mm */; };
@@ -652,6 +654,8 @@
 		1AF7EA981D340D1F0001A9B5 /* RLMSyncManager_Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RLMSyncManager_Private.h; sourceTree = "<group>"; };
 		1AF7EA991D340E700001A9B5 /* RLMNetworkClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RLMNetworkClient.h; sourceTree = "<group>"; };
 		1AF7EA9A1D340E700001A9B5 /* RLMNetworkClient.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RLMNetworkClient.m; sourceTree = "<group>"; };
+		1A30CBB01D088521003989E6 /* RLMUnitTestHelper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RLMUnitTestHelper.h; sourceTree = "<group>"; };
+		1A30CBB11D088521003989E6 /* RLMUnitTestHelper.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RLMUnitTestHelper.m; sourceTree = "<group>"; };
 		26F3CA681986CC86004623E1 /* SwiftPropertyTypeTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwiftPropertyTypeTest.swift; sourceTree = "<group>"; };
 		297FBEFA1C19F696009D1118 /* RLMTestCaseUtils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RLMTestCaseUtils.swift; sourceTree = "<group>"; };
 		297FBEFD1C19F844009D1118 /* TestUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TestUtils.h; path = Realm/Tests/TestUtils.h; sourceTree = SOURCE_ROOT; };
@@ -1463,6 +1467,8 @@
 				3F20DA2119BE1EA6007DE308 /* RLMUpdateChecker.mm */,
 				E81A1F811955FC9300FDED82 /* RLMUtil.hpp */,
 				E81A1F821955FC9300FDED82 /* RLMUtil.mm */,
+				1A30CBB01D088521003989E6 /* RLMUnitTestHelper.h */,
+				1A30CBB11D088521003989E6 /* RLMUnitTestHelper.m */,
 			);
 			path = Realm;
 			sourceTree = "<group>";
@@ -1511,6 +1517,7 @@
 			files = (
 				3F73BC951E3A878500FE80B6 /* NSError+RLMSync.h in Headers */,
 				5D659EA51BE04556006515A0 /* Realm.h in Headers */,
+				1A30CBB21D088521003989E6 /* RLMUnitTestHelper.h in Headers */,
 				5D659EA71BE04556006515A0 /* RLMAccessor.h in Headers */,
 				5D659EA91BE04556006515A0 /* RLMArray.h in Headers */,
 				5D659EAA1BE04556006515A0 /* RLMArray_Private.h in Headers */,
@@ -2115,6 +2122,7 @@
 				3F7A3FAE1CC6EB7300301A17 /* collection_change_builder.cpp in Sources */,
 				3F9801AB1C8E4F6B000A8B07 /* collection_notifications.cpp in Sources */,
 				3F9801A41C8E4F55000A8B07 /* collection_notifier.cpp in Sources */,
+				1A30CBB31D088521003989E6 /* RLMUnitTestHelper.m in Sources */,
 				5D659E811BE04556006515A0 /* external_commit_helper.cpp in Sources */,
 				5DB591AA1D063DF8001D8F93 /* format.cpp in Sources */,
 				5D659E821BE04556006515A0 /* index_set.cpp in Sources */,

--- a/Realm/RLMUnitTestHelper.h
+++ b/Realm/RLMUnitTestHelper.h
@@ -1,0 +1,73 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2016 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+#import <Foundation/Foundation.h>
+
+@class RLMRealm, RLMSchema;
+
+/**
+ A helper class intended for use when writing unit tests involving Realms, especially those involving the use of GCD.
+
+ To use this class, create a property on your `XCTestCase` class of type `RLMUnitTestHelper`, and either instantiate the
+ test helper upon initialization or lazily when requested.
+
+ Your `XCTestCase` test case subclass must override the `-invokeTest` method. In that method, call the helper's
+ `invokeTestWithBlock:` method. Inside the block passed to `-invokeTestWithBlock:`, call `[super invokeTest]`. You can
+ also do additional work within the block if necessary.
+
+ The test helper overrides the default Realm configuration to use either a special file or special in-memory identifier.
+ Each test's Realms are completely isolated from the Realms of other tests. All internal state will automatically be
+ reset after each test.
+
+ Obtain this special Realm for test use simply by calling `[RLMRealm defaultRealm]`. You may also obtain Realms with
+ other configurations explicitly, as usual.
+
+ Instead of using GDC functions directly, use the `-dispatch:` and `dispatchAndWait:` methods instead.
+ */
+@interface RLMUnitTestHelper : NSObject
+
+/**
+ An on-disk test Realm for your unit test to use. The Realm is cleaned up and properly destroyed after each test suite.
+ */
+@property (nonatomic, readonly) RLMRealm *onDiskTestRealm;
+
+/**
+ An in-memory test Realm for your unit test to use. The Realm is properly destroyed after each test suite.
+ */
+@property (nonatomic, readonly) RLMRealm *inMemoryTestRealm;
+
+/**
+ Invokes the unit test.
+ 
+ This method should always be called within the `XCUnitTest`'s `-invokeTest` method. The block must contain a call to
+ `[super invokeTest]`.
+ */
+- (void)invokeTestWithBlock:(void (^)(void))invokeBlock;
+
+/**
+ Dispatches an asynchronous block on the test-specific dispatch queue. Prefer this method to using GCD directly.
+ */
+- (void)dispatch:(dispatch_block_t)block;
+
+/**
+ Dispatches a block on the test-specific dispatch queue, and wait for the block to complete executing before returning.
+ Prefer this method to using GCD directly.
+ */
+- (void)dispatchAndWait:(dispatch_block_t)block;
+
+@end

--- a/Realm/RLMUnitTestHelper.h
+++ b/Realm/RLMUnitTestHelper.h
@@ -37,9 +37,11 @@
  Obtain this special Realm for test use simply by calling `[RLMRealm defaultRealm]`. You may also obtain Realms with
  other configurations explicitly, as usual.
 
- Instead of using GDC functions directly, use the `-dispatch:` and `dispatchAndWait:` methods instead.
+ Instead of using GCD functions directly, use the `-dispatch:` and `dispatchAndWait:` methods instead.
  */
 @interface RLMUnitTestHelper : NSObject
+
+NS_ASSUME_NONNULL_BEGIN
 
 /**
  An on-disk test Realm for your unit test to use. The Realm is cleaned up and properly destroyed after each test suite.
@@ -69,5 +71,7 @@
  Prefer this method to using GCD directly.
  */
 - (void)dispatchAndWait:(dispatch_block_t)block;
+
+NS_ASSUME_NONNULL_END
 
 @end

--- a/Realm/RLMUnitTestHelper.m
+++ b/Realm/RLMUnitTestHelper.m
@@ -1,0 +1,128 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2016 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+#import "RLMUnitTestHelper.h"
+#import "RLMRealm_Private.h"
+#import "RLMRealmConfiguration_Private.h"
+
+@interface RLMUnitTestHelper ()
+
+@property (nonatomic) dispatch_queue_t queue;
+
+@property (nonatomic, readwrite) RLMRealm *onDiskTestRealm;
+@property (nonatomic, readwrite) RLMRealm *inMemoryTestRealm;
+
+@end
+
+@implementation RLMUnitTestHelper
+
+- (void)invokeTestWithBlock:(void (^)(void))invokeBlock {
+    if (!invokeBlock) {
+        NSAssert(NO, @"invokeTestWithBlock: cannot be called with a nil block");
+    }
+    @autoreleasepool {
+        invokeBlock();
+    }
+    @autoreleasepool {
+        if (self.queue) {
+            dispatch_sync(self.queue, ^{});
+            self.queue = nil;
+        }
+        [self _cleanup];
+    }
+}
+
+- (RLMRealm *)onDiskTestRealm {
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        NSFileManager *manager = [NSFileManager defaultManager];
+        NSError *error = nil;
+        NSURL *url = [manager URLForDirectory:NSCachesDirectory
+                                     inDomain:NSUserDomainMask appropriateForURL:nil create:YES error:&error];
+        if (error) {
+            @throw [NSException exceptionWithName:@"RLMTestHelperException"
+                                           reason:@"Couldn't create on-disk test Realm"
+                                         userInfo:@{@"error": error}];
+        }
+        NSString *thisName = [NSString stringWithFormat:@"RLMUnitTestHelper-%@", [[NSUUID UUID] UUIDString]];
+        RLMRealmConfiguration *config = [RLMRealmConfiguration defaultConfiguration];
+        config.fileURL = [url URLByAppendingPathComponent:thisName];
+
+        error = nil;
+        _onDiskTestRealm = [RLMRealm realmWithConfiguration:config error:&error];
+        if (error) {
+            @throw [NSException exceptionWithName:@"RLMTestHelperException"
+                                           reason:@"Couldn't create on-disk test Realm"
+                                         userInfo:@{@"error": error}];
+        }
+    });
+    return _onDiskTestRealm;
+}
+
+- (RLMRealm *)inMemoryTestRealm {
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        NSString *thisName = [NSString stringWithFormat:@"RLMUnitTestHelper-%@", [[NSUUID UUID] UUIDString]];
+        RLMRealmConfiguration *config = [RLMRealmConfiguration defaultConfiguration];
+        config.inMemoryIdentifier = thisName;
+
+        NSError *error = nil;
+        _inMemoryTestRealm = [RLMRealm realmWithConfiguration:config error:&error];
+        if (error) {
+            @throw [NSException exceptionWithName:@"RLMTestHelperException"
+                                           reason:@"Couldn't create in-memory test Realm"
+                                         userInfo:@{@"error": error}];
+        }
+    });
+    return _inMemoryTestRealm;
+}
+
+// MARK: Dispatch
+
+- (void)dispatch:(dispatch_block_t)block {
+    if (!self.queue) {
+        self.queue = dispatch_queue_create("test background queue", 0);
+    }
+    dispatch_async(self.queue, ^{
+        @autoreleasepool {
+            block();
+        }
+    });
+}
+
+- (void)dispatchAndWait:(dispatch_block_t)block {
+    [self dispatch:block];
+    dispatch_sync(self.queue, ^{});
+}
+
+
+// MARK: Private
+
+- (void)_cleanup {
+    [RLMRealm resetRealmState];
+    if (_onDiskTestRealm != nil) {
+        NSURL *fileURL = _onDiskTestRealm.configuration.fileURL;
+        NSFileManager *manager = [NSFileManager defaultManager];
+        [manager removeItemAtURL:fileURL error:nil];
+        [manager removeItemAtURL:[fileURL URLByAppendingPathExtension:@".lock"] error:nil];
+        // TODO: update this if we move the lock file into the .management dir
+        [manager removeItemAtURL:[fileURL URLByAppendingPathExtension:@".note"] error:nil];
+    }
+}
+
+@end

--- a/Realm/Realm.h
+++ b/Realm/Realm.h
@@ -39,3 +39,4 @@
 #import <Realm/RLMSyncUser.h>
 #import <Realm/RLMSyncUtil.h>
 #import <Realm/NSError+RLMSync.h>
+#import <Realm/RLMUnitTestHelper.h>

--- a/RealmSwift/Aliases.swift
+++ b/RealmSwift/Aliases.swift
@@ -55,3 +55,5 @@ public typealias PropertyType = RLMPropertyType
  - see: `addNotificationBlock(_:)`
  */
 public typealias NotificationToken = RLMNotificationToken
+
+public typealias UnitTestHelper = RLMUnitTestHelper

--- a/RealmSwift/Aliases.swift
+++ b/RealmSwift/Aliases.swift
@@ -55,5 +55,3 @@ public typealias PropertyType = RLMPropertyType
  - see: `addNotificationBlock(_:)`
  */
 public typealias NotificationToken = RLMNotificationToken
-
-public typealias UnitTestHelper = RLMUnitTestHelper

--- a/RealmSwift/Tests/ObjectTests.swift
+++ b/RealmSwift/Tests/ObjectTests.swift
@@ -58,7 +58,7 @@ class ObjectTests: TestCase {
         XCTAssertNotNil(persisted.realm)
         XCTAssertEqual(realm, persisted.realm!)
 
-        dispatchSyncNewThread {
+        testHelper.dispatchAndWait {
             autoreleasepool {
                 XCTAssertNotEqual(try! Realm(), persisted.realm!)
             }

--- a/RealmSwift/Tests/PerformanceTests.swift
+++ b/RealmSwift/Tests/PerformanceTests.swift
@@ -55,6 +55,11 @@ class SwiftPerformanceTests: TestCase {
         }
     }
 
+    override func setUp() {
+        super.setUp()
+        testHelper.shouldResetState = false
+    }
+
     override class func tearDown() {
         smallRealm = nil
         mediumRealm = nil
@@ -338,7 +343,7 @@ class SwiftPerformanceTests: TestCase {
 
     func testRealmCreationCached() {
         var realm: Realm!
-        dispatchSyncNewThread {
+        testHelper.dispatchAndWait {
             realm = try! Realm()
         }
 

--- a/RealmSwift/UnitTestHelper.swift
+++ b/RealmSwift/UnitTestHelper.swift
@@ -1,0 +1,128 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2016 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+import Foundation
+import Realm
+
+/**
+ A helper class intended for use when writing unit tests involving Realms, especially those involving the use of GCD.
+
+ To use this class, create a property on your `XCTestCase` class of type `UnitTestHelper`, and either instantiate the
+ test helper upon initialization or lazily when requested.
+
+ Your `XCTestCase` test case subclass must override the `invokeTest()` method. In that method, call the helper's
+ `invokeTest(with:)` method. Inside the block passed to `invokeTest(with:)`, call `super.invokeTest()`. You can also do
+ additional work within the block if necessary.
+
+ Instead of using GCD functions directly, use the `dispatch()` and `dispatchAndWait()` methods instead.
+ */
+public class UnitTestHelper {
+
+    private let queue = DispatchQueue(label: "UnitTestHelper_dispatch_queue")
+
+    public var shouldResetState : Bool = true
+
+    public init() { }
+
+    /**
+     An on-disk test Realm for your unit test to use. The Realm is cleaned up and properly destroyed after each test
+     suite.
+     */
+    public var onDiskTestRealm : Realm {
+        get {
+            didCreateOnDiskTestRealm = true
+            return _onDiskTestRealm
+        }
+    }
+
+    private var didCreateOnDiskTestRealm = false
+
+    private(set) lazy var _onDiskTestRealm : Realm = {
+        let fileManager = FileManager.default
+        let url = try! fileManager.urlForDirectory(.cachesDirectory,
+                                                  in: .userDomainMask,
+                                                  appropriateFor: nil,
+                                                  create: true)
+        let thisName = "RLMUnitTestHelper-\(UUID().uuidString)"
+
+        var config = Realm.Configuration.defaultConfiguration
+        config.fileURL = try! url.appendingPathComponent(thisName)
+
+        return try! Realm(configuration: config)
+    }()
+
+    /**
+     An in-memory test Realm for your unit test to use. The Realm is properly destroyed after each test suite, unless
+     the 'do not clean .
+     */
+    public private(set) lazy var inMemoryTestRealm : Realm = {
+        let thisName = "RLMUnitTestHelper-\(UUID().uuidString)"
+
+        var config = Realm.Configuration.defaultConfiguration
+        config.inMemoryIdentifier = thisName
+
+        return try! Realm(configuration: config)
+    }()
+
+    /**
+     Invoke the unit test.
+
+     This method should always be called within the `XCUnitTest`'s `invokeTest()` method. The block must contain a call
+     to `super.invokeTest()`.
+     */
+    public func invokeTest(with block: () -> Void) {
+        autoreleasepool { block() }
+        autoreleasepool {
+            queue.sync { }
+            cleanup()
+        }
+    }
+
+    /**
+     Dispatches an asynchronous block on the test-specific dispatch queue. Prefer this method to using GCD directly.
+     */
+    public func dispatch(_ block: () -> Void) {
+        queue.async {
+            autoreleasepool { block() }
+        }
+    }
+
+    /**
+     Dispatches a block on the test-specific dispatch queue, and wait for the block to complete executing before
+     returning.
+     
+     Prefer this method to using GCD directly.
+     */
+    public func dispatchAndWait(_ block: () -> Void) {
+        dispatch(block)
+        queue.sync { }
+    }
+
+    private func cleanup() {
+        guard shouldResetState else { return }
+        RLMRealm.resetRealmState()
+        if didCreateOnDiskTestRealm {
+            let manager = FileManager.default
+            let fileURL = _onDiskTestRealm.configuration.fileURL!
+            try! manager.removeItem(at: fileURL)
+            try! manager.removeItem(at: fileURL.appendingPathExtension("lock"))
+            // TODO: update this if we move the note file into the .management dir
+            try! manager.removeItem(at: fileURL.appendingPathExtension("note"))
+        }
+    }
+}


### PR DESCRIPTION
@tgoyne @bdash @jpsim

Here is a helper class that I'm hoping can help our users write more robust unit tests involving Realms. It's basically a helper class based off our `RLMTestCase` base test case, but with no XCTest dependencies.

The idea is that a user would create an instance of this class belonging to every test case class they make which uses Realms. They'd have to override `invokeTest` on their test class to call the helper's `invokeTest` method. They'd use this class's methods to perform async and sync work, but write their tests as usual otherwise.

This isn't so much of a review as it is asking what you think of the basic concept. How is the API? Could it use more helper methods? Is it too cumbersome? Let me know your thoughts.

(If this is something we want to pursue further I'll add documentation and a Swift wrapper.)
