### PR TITLE
Ensure that the initial notification for Results is always .Initial

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ x.x.x Release notes (yyyy-MM-dd)
 * Fix a crash when reading the shared schema from an observed Swift object.
 * Fix crashes or incorrect results when passing an array of values to
   `createOrUpdate` after reordering the class's properties.
+* Ensure that the initial call of a Results notification block is always passed
+  .Initial even if there is a write transaction between when the notification
+  is added and when the first notification is delivered.
 
 1.0.1 Release notes (2016-06-12)
 =============================================================

--- a/Realm/RLMResults.mm
+++ b/Realm/RLMResults.mm
@@ -410,7 +410,7 @@ static inline void RLMResultsValidateInWriteTransaction(__unsafe_unretained RLMR
 #pragma clang diagnostic ignored "-Wmismatched-parameter-types"
 - (RLMNotificationToken *)addNotificationBlock:(void (^)(RLMResults *, RLMCollectionChange *, NSError *))block {
     [_realm verifyNotificationsAreSupported];
-    return RLMAddNotificationBlock(self, _results, block, false);
+    return RLMAddNotificationBlock(self, _results, block, true);
 }
 #pragma clang diagnostic pop
 

--- a/Realm/Tests/NotificationTests.m
+++ b/Realm/Tests/NotificationTests.m
@@ -196,7 +196,7 @@ static RLMCollectionChange *getChange(RLMTestCase<ChangesetTestCase> *self, void
         XCTAssertNotNil(results);
         XCTAssertNil(error);
         changes = c;
-        XCTAssertTrue(first || changes);
+        XCTAssertTrue(first == !changes);
         first = false;
         CFRunLoopStop(CFRunLoopGetCurrent());
     }];


### PR DESCRIPTION
There was logic which attempted to ensure this was the case, but it wasn't
tested, wasn't actually used, and didn't actually work.

Fixes #3501.