### PR TITLE
Allow throws within write block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ x.x.x Release notes (yyyy-MM-dd)
 
 ### Enhancements
 
-* None.
+* Swift: A `write` block may now `throw`, reverting any changes already made in the transaction.
 
 ### Bugfixes
 

--- a/RealmSwift-swift2.2/Tests/RealmTests.swift
+++ b/RealmSwift-swift2.2/Tests/RealmTests.swift
@@ -25,6 +25,10 @@ import XCTest
 import Foundation
 
 class RealmTests: TestCase {
+    enum TestError: ErrorType {
+        case intentional
+    }
+
     func testFileURL() {
         XCTAssertEqual(try! Realm(fileURL: testRealmURL()).configuration.fileURL,
                        testRealmURL())
@@ -254,6 +258,20 @@ class RealmTests: TestCase {
             XCTAssertEqual(try! Realm().objects(SwiftStringObject.self).count, 0)
         }
         XCTAssertEqual(try! Realm().objects(SwiftStringObject.self).count, 0)
+    }
+
+    func testThrowsWrite() {
+        assertFails(TestError.intentional) {
+            try Realm().write {
+                throw TestError.intentional
+            }
+        }
+        assertFails(TestError.intentional) {
+            try Realm().write {
+                try! Realm().create(SwiftStringObject.self, value: ["1"])
+                throw TestError.intentional
+            }
+        }
     }
 
     func testInWriteTransaction() {


### PR DESCRIPTION
Currently, the user cannot call throwing functions within a `write` block unless they handle recovery _within_ the block. If the user wishes to propagate the error outside the block, this leads to very convoluted code.

```swift
var error: ErrorType?
try Realm().write {
  do {
    try createInterdimensionalPortal()
  } catch let ohNoes {
    error = ohNoes
  }
}
if let error = error { throw ohNoes }
```

Even worse, this will not cancel the write transaction, so any changes made before the `throw` will still be committed to the database. This pull request annotates the block parameter of `write` as `throws` so that it can optionally throw an exception, propagating that exception outside of the write block and canceling the transaction. Now, the above code can be properly written:
```swift
try Reaml().write {
  try createInterdimensionalPortal()
}
```