### PR TITLE
Use a separate index for column -> property lookups rather than sorting the properties

### DIFF
--- a/Realm/RLMAccessor.mm
+++ b/Realm/RLMAccessor.mm
@@ -228,9 +228,9 @@ static inline void RLMSetValue(__unsafe_unretained RLMObjectBase *const obj, NSU
         // make sure it is the correct type
         RLMObjectSchema *valSchema = val->_objectSchema;
         RLMObjectSchema *objSchema = obj->_objectSchema;
-        if (![[objSchema.properties[colIndex] objectClassName] isEqualToString:valSchema.className]) {
+        if (![[objSchema propertyForTableColumn:colIndex].objectClassName isEqualToString:valSchema.className]) {
             @throw RLMException(@"Can't set object of type '%@' to property of type '%@'",
-                                valSchema.className, [objSchema.properties[colIndex] objectClassName]);
+                                valSchema.className, [objSchema propertyForTableColumn:colIndex].objectClassName);
         }
         RLMObjectBase *link = RLMGetLinkedObjectForValue(obj->_realm, valSchema.className, val, RLMCreationOptionsPromoteUnmanaged);
         obj->_row.set_link(colIndex, link->_row.get_index());

--- a/Realm/RLMObjectSchema.mm
+++ b/Realm/RLMObjectSchema.mm
@@ -42,7 +42,7 @@ using namespace realm;
     // table accessor optimization
     realm::TableRef _table;
     NSArray *_swiftGenericProperties;
-    std::vector<RLMProperty *> _propertiesInTableColOrder;
+    std::vector<RLMProperty *> _propertiesInTableOrder;
 }
 
 - (instancetype)initWithClassName:(NSString *)objectClassName objectClass:(Class)objectClass properties:(NSArray *)properties {
@@ -63,7 +63,7 @@ using namespace realm;
 // create property map when setting property array
 -(void)setProperties:(NSArray *)properties {
     _properties = properties;
-    _propertiesInTableColOrder.clear();
+    _propertiesInTableOrder.clear();
     [self _propertiesDidChange];
 }
 
@@ -349,7 +349,7 @@ using namespace realm;
     schema->_allPropertiesByName = _allPropertiesByName;
     schema->_primaryKeyProperty = _primaryKeyProperty;
     schema->_swiftGenericProperties = _swiftGenericProperties;
-    schema->_propertiesInTableColOrder = _propertiesInTableColOrder;
+    schema->_propertiesInTableOrder = _propertiesInTableOrder;
 
     // _table not copied as it's realm::Group-specific
     return schema;
@@ -444,18 +444,18 @@ using namespace realm;
 }
 
 - (RLMProperty *)propertyForTableColumn:(size_t)tableCol {
-    if (_propertiesInTableColOrder.empty()) {
-        _propertiesInTableColOrder.resize(_properties.count, nil);
+    if (_propertiesInTableOrder.empty()) {
+        _propertiesInTableOrder.resize(_properties.count, nil);
         for (RLMProperty *property in _properties) {
             auto col = property.column;
-            if (col >= _propertiesInTableColOrder.size()) {
-                _propertiesInTableColOrder.resize(col + 1, nil);
+            if (col >= _propertiesInTableOrder.size()) {
+                _propertiesInTableOrder.resize(col + 1, nil);
             }
-            _propertiesInTableColOrder[col] = property;
+            _propertiesInTableOrder[col] = property;
         }
     }
 
-    return tableCol < _propertiesInTableColOrder.size() ? _propertiesInTableColOrder[tableCol] : nil;
+    return tableCol < _propertiesInTableOrder.size() ? _propertiesInTableOrder[tableCol] : nil;
 }
 
 - (NSArray *)swiftGenericProperties {

--- a/Realm/RLMObjectSchema_Private.h
+++ b/Realm/RLMObjectSchema_Private.h
@@ -39,7 +39,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, readwrite, nullable) RLMProperty *primaryKeyProperty;
 
-@property (nonatomic, readonly) NSArray<RLMProperty *> *propertiesInDeclaredOrder;
 @property (nonatomic, copy) NSArray<RLMProperty *> *computedProperties;
 @property (nonatomic, readonly) NSArray<RLMProperty *> *swiftGenericProperties;
 
@@ -48,7 +47,7 @@ NS_ASSUME_NONNULL_BEGIN
 // returns a cached or new schema for a given object class
 + (instancetype)schemaForObjectClass:(Class)objectClass;
 
-- (void)sortPropertiesByColumn;
+- (RLMProperty *)propertyForTableColumn:(size_t)tableCol;
 
 @end
 

--- a/Realm/RLMObjectStore.mm
+++ b/Realm/RLMObjectStore.mm
@@ -293,7 +293,7 @@ RLMObjectBase *RLMCreateObjectInRealmWithValue(RLMRealm *realm, NSString *classN
     if (NSArray *array = RLMDynamicCast<NSArray>(value)) {
         // get or create our accessor
         bool created;
-        NSArray *props = objectSchema.propertiesInDeclaredOrder;
+        NSArray *props = objectSchema.properties;
         auto primaryGetter = [=](__unsafe_unretained RLMProperty *const p) {
             return array[[props indexOfObject:p]];
         };

--- a/Realm/RLMObservation.mm
+++ b/Realm/RLMObservation.mm
@@ -332,7 +332,7 @@ void RLMTrackDeletions(__unsafe_unretained RLMRealm *const realm, dispatch_block
                     continue;
                 }
 
-                RLMProperty *prop = observer->getObjectSchema().properties[link.origin_col_ndx];
+                RLMProperty *prop = [observer->getObjectSchema() propertyForTableColumn:link.origin_col_ndx];
                 NSString *name = prop.name;
                 if (prop.type != RLMPropertyTypeArray) {
                     changes.push_back({observer, name});
@@ -466,8 +466,8 @@ void RLMWillChange(std::vector<realm::BindingContext::ObserverState> const& obse
         NSMutableIndexSet *indexes = [NSMutableIndexSet new];
         for (auto const& o : observed) {
             forEach(o, [&](size_t i, auto const& change, RLMObservationInfo *info) {
-                info->willChange([info->getObjectSchema().properties[i] name],
-                                 convert(change.kind), convert(change.indices, indexes));
+                auto property = [info->getObjectSchema() propertyForTableColumn:i];
+                info->willChange(property.name, convert(change.kind), convert(change.indices, indexes));
             });
         }
     }
@@ -483,8 +483,8 @@ void RLMDidChange(std::vector<realm::BindingContext::ObserverState> const& obser
         NSMutableIndexSet *indexes = [NSMutableIndexSet new];
         for (auto const& o : reverse(observed)) {
             forEach(o, [&](size_t i, auto const& change, RLMObservationInfo *info) {
-                info->didChange([info->getObjectSchema().properties[i] name],
-                                convert(change.kind), convert(change.indices, indexes));
+                auto property = [info->getObjectSchema() propertyForTableColumn:i];
+                info->didChange(property.name, convert(change.kind), convert(change.indices, indexes));
             });
         }
     }

--- a/Realm/RLMProperty.mm
+++ b/Realm/RLMProperty.mm
@@ -508,7 +508,6 @@ static bool rawTypeIsComputedProperty(NSString *rawType) {
     prop->_isPrimary = _isPrimary;
     prop->_swiftIvar = _swiftIvar;
     prop->_optional = _optional;
-    prop->_declarationIndex = _declarationIndex;
     prop->_linkOriginPropertyName = _linkOriginPropertyName;
 
     return prop;

--- a/Realm/RLMProperty_Private.h
+++ b/Realm/RLMProperty_Private.h
@@ -71,7 +71,6 @@ BOOL RLMPropertyTypeIsComputed(RLMPropertyType propertyType);
 @property (nonatomic, copy) NSString *objcRawType;
 @property (nonatomic, assign) BOOL isPrimary;
 @property (nonatomic, assign) Ivar swiftIvar;
-@property (nonatomic, assign) NSUInteger declarationIndex;
 
 // getter and setter names
 @property (nonatomic, copy) NSString *getterName;

--- a/Realm/RLMRealm.mm
+++ b/Realm/RLMRealm.mm
@@ -174,9 +174,6 @@ static void RLMCopyColumnMapping(RLMObjectSchema *targetSchema, const ObjectSche
         RLMProperty *targetProp = targetSchema[@(prop.name.c_str())];
         targetProp.column = prop.table_column;
     }
-
-    // re-order properties
-    [targetSchema sortPropertiesByColumn];
 }
 
 static void RLMRealmSetSchemaAndAlign(RLMRealm *realm, RLMSchema *targetSchema) {

--- a/Realm/Tests/ObjectTests.m
+++ b/Realm/Tests/ObjectTests.m
@@ -1893,7 +1893,7 @@ static void testDatesInRange(NSTimeInterval from, NSTimeInterval to, void (^chec
 
         RLMRealm *realm = [self realmWithTestPathAndSchema:schema];
         [realm beginWriteTransaction];
-        [PrimaryStringObject createOrUpdateInRealm:realm withValue:@[@"a", @5]];
+        [PrimaryStringObject createOrUpdateInRealm:realm withValue:@[@5, @"a"]];
         [realm commitWriteTransaction];
     }
 

--- a/Realm/Tests/QueryTests.m
+++ b/Realm/Tests/QueryTests.m
@@ -17,7 +17,11 @@
 ////////////////////////////////////////////////////////////////////////////
 
 #import "RLMTestCase.h"
+
+#import "RLMObjectSchema_Private.h"
+#import "RLMRealmConfiguration_Private.h"
 #import "RLMRealm_Dynamic.h"
+#import "RLMSchema_Private.h"
 
 #pragma mark - Test Objects
 
@@ -388,9 +392,13 @@
     return results;
 }
 
+- (RLMRealm *)realm {
+    return [RLMRealm defaultRealm];
+}
+
 - (void)testBasicQuery
 {
-    RLMRealm *realm = [RLMRealm defaultRealm];
+    RLMRealm *realm = [self realm];
 
     [realm beginWriteTransaction];
     [PersonObject createInRealm:realm withValue:@[@"Fiel", @27]];
@@ -412,7 +420,7 @@
 
 -(void)testQueryBetween
 {
-    RLMRealm *realm = [RLMRealm defaultRealm];
+    RLMRealm *realm = [self realm];
 
     NSDate *date1 = [NSDate date];
     NSDate *date2 = [date1 dateByAddingTimeInterval:1];
@@ -451,7 +459,7 @@
 
 - (void)testQueryWithDates
 {
-    RLMRealm *realm = [RLMRealm defaultRealm];
+    RLMRealm *realm = [self realm];
 
     NSDate *date1 = [NSDate date];
     NSDate *date2 = [date1 dateByAddingTimeInterval:1];
@@ -476,7 +484,7 @@
 
 - (void)testDefaultRealmQuery
 {
-    RLMRealm *realm = [RLMRealm defaultRealm];
+    RLMRealm *realm = [self realm];
 
     [realm beginWriteTransaction];
     [PersonObject createInRealm:realm withValue:@[@"Fiel", @27]];
@@ -496,7 +504,7 @@
 
 - (void)testArrayQuery
 {
-    RLMRealm *realm = [RLMRealm defaultRealm];
+    RLMRealm *realm = [self realm];
 
     [realm beginWriteTransaction];
     [PersonObject createInRealm:realm withValue:@[@"Fiel", @27]];
@@ -541,7 +549,7 @@
 
 - (void)testQuerySorting
 {
-    RLMRealm *realm = [RLMRealm defaultRealm];
+    RLMRealm *realm = [self realm];
 
     NSDate *date1 = [NSDate date];
     NSDate *date2 = [date1 dateByAddingTimeInterval:1];
@@ -598,7 +606,7 @@
 }
 
 - (void)testSortByMultipleColumns {
-    RLMRealm *realm = [RLMRealm defaultRealm];
+    RLMRealm *realm = [self realm];
     [realm beginWriteTransaction];
     DogObject *a1 = [DogObject createInDefaultRealmWithValue:@[@"a", @1]];
     DogObject *a2 = [DogObject createInDefaultRealmWithValue:@[@"a", @2]];
@@ -628,7 +636,7 @@
 }
 
 - (void)testSortedLinkViewWithDeletion {
-    RLMRealm *realm = [RLMRealm defaultRealm];
+    RLMRealm *realm = [self realm];
 
     NSDate *date1 = [NSDate date];
     NSDate *date2 = [date1 dateByAddingTimeInterval:1];
@@ -669,7 +677,7 @@
 }
 
 - (void)testQueryingSortedQueryPreservesOrder {
-    RLMRealm *realm = [RLMRealm defaultRealm];
+    RLMRealm *realm = [self realm];
 
     [realm beginWriteTransaction];
     for (int i = 0; i < 5; ++i) {
@@ -700,7 +708,7 @@
 
 - (void)testTwoColumnComparison
 {
-    RLMRealm *realm = [RLMRealm defaultRealm];
+    RLMRealm *realm = [self realm];
 
     [realm beginWriteTransaction];
 
@@ -804,7 +812,7 @@
 
 - (void)testStringBeginsWith
 {
-    RLMRealm *realm = [RLMRealm defaultRealm];
+    RLMRealm *realm = [self realm];
 
     [realm beginWriteTransaction];
     StringObject *so = [StringObject createInRealm:realm withValue:(@[@"abc"])];
@@ -834,7 +842,7 @@
 
 - (void)testStringEndsWith
 {
-    RLMRealm *realm = [RLMRealm defaultRealm];
+    RLMRealm *realm = [self realm];
 
     [realm beginWriteTransaction];
     StringObject *so = [StringObject createInRealm:realm withValue:(@[@"abc"])];
@@ -864,7 +872,7 @@
 
 - (void)testStringContains
 {
-    RLMRealm *realm = [RLMRealm defaultRealm];
+    RLMRealm *realm = [self realm];
 
     [realm beginWriteTransaction];
     StringObject *so = [StringObject createInRealm:realm withValue:(@[@"abc"])];
@@ -898,7 +906,7 @@
 
 - (void)testStringEquality
 {
-    RLMRealm *realm = [RLMRealm defaultRealm];
+    RLMRealm *realm = [self realm];
 
     [realm beginWriteTransaction];
     StringObject *so = [StringObject createInRealm:realm withValue:(@[@"abc"])];
@@ -927,7 +935,7 @@
 
 - (void)testFloatQuery
 {
-    RLMRealm *realm = [RLMRealm defaultRealm];
+    RLMRealm *realm = [self realm];
 
     [realm beginWriteTransaction];
     [FloatObject createInRealm:realm withValue:@[@1.7f]];
@@ -950,7 +958,7 @@
 
 - (void)testLiveQueriesInsideTransaction
 {
-    RLMRealm *realm = [RLMRealm defaultRealm];
+    RLMRealm *realm = [self realm];
 
     [realm beginWriteTransaction];
     {
@@ -992,7 +1000,7 @@
 
 - (void)testLiveQueriesBetweenTransactions
 {
-    RLMRealm *realm = [RLMRealm defaultRealm];
+    RLMRealm *realm = [self realm];
 
     [realm beginWriteTransaction];
     [self.queryObjectClass createInRealm:realm withValue:@[@YES, @YES, @1, @2, @23.0f, @1.7f,  @0.0,  @5.55, @"", @""]];
@@ -1043,7 +1051,7 @@
 }
 
 - (void)makeDogWithName:(NSString *)name owner:(NSString *)ownerName {
-    RLMRealm *realm = [RLMRealm defaultRealm];
+    RLMRealm *realm = [self realm];
 
     OwnerObject *owner = [[OwnerObject alloc] init];
     owner.name = ownerName;
@@ -1056,7 +1064,7 @@
 }
 
 - (void)makeDogWithAge:(int)age owner:(NSString *)ownerName {
-    RLMRealm *realm = [RLMRealm defaultRealm];
+    RLMRealm *realm = [self realm];
 
     OwnerObject *owner = [[OwnerObject alloc] init];
     owner.name = ownerName;
@@ -1081,7 +1089,7 @@
     RLMRealm *testRealm = [self realmWithTestPath];
     [self makeDogWithName:@"Harvie" owner:@"Tim"];
 
-    RLMRealm *defaultRealm = [RLMRealm defaultRealm];
+    RLMRealm *defaultRealm = [self realm];
     DogObject *dog = [[DogObject alloc] init];
     dog.dogName = @"Fido";
     [defaultRealm beginWriteTransaction];
@@ -1093,7 +1101,7 @@
 
 - (void)testLinkQueryString
 {
-    RLMRealm *realm = [RLMRealm defaultRealm];
+    RLMRealm *realm = [self realm];
 
     [self makeDogWithName:@"Harvie" owner:@"Tim"];
     RLMAssertCount(OwnerObject, 1U, @"dog.dogName  = 'Harvie'");
@@ -1169,7 +1177,7 @@
 
 - (void)testLinkQueryAllTypes
 {
-    RLMRealm *realm = [RLMRealm defaultRealm];
+    RLMRealm *realm = [self realm];
 
     NSDate *now = [NSDate dateWithTimeIntervalSince1970:100000];
 
@@ -1216,7 +1224,7 @@
 
 - (void)testLinkQueryMany
 {
-    RLMRealm *realm = [RLMRealm defaultRealm];
+    RLMRealm *realm = [self realm];
 
     ArrayPropertyObject *arrPropObj1 = [[ArrayPropertyObject alloc] init];
     arrPropObj1.name = @"Test";
@@ -1261,7 +1269,7 @@
 
 - (void)testMultiLevelLinkQuery
 {
-    RLMRealm *realm = [RLMRealm defaultRealm];
+    RLMRealm *realm = [self realm];
 
     [realm beginWriteTransaction];
     CircleObject *circle = nil;
@@ -1286,7 +1294,7 @@
 
 - (void)testArrayMultiLevelLinkQuery
 {
-    RLMRealm *realm = [RLMRealm defaultRealm];
+    RLMRealm *realm = [self realm];
 
     [realm beginWriteTransaction];
     CircleObject *circle = nil;
@@ -1318,7 +1326,7 @@
 
 - (void)testMultiLevelBackLinkQuery
 {
-    RLMRealm *realm = [RLMRealm defaultRealm];
+    RLMRealm *realm = [self realm];
 
     [realm beginWriteTransaction];
     LinkChain1 *root1 = [LinkChain1 createInRealm:realm withValue:@{@"value": @1, @"next": @[@[]]}];
@@ -1339,7 +1347,7 @@
 
 - (void)testQueryWithObjects
 {
-    RLMRealm *realm = [RLMRealm defaultRealm];
+    RLMRealm *realm = [self realm];
 
     NSDate *date1 = [NSDate date];
     NSDate *date2 = [date1 dateByAddingTimeInterval:1];
@@ -1385,7 +1393,7 @@
 }
 
 - (void)testCompoundOrQuery {
-    RLMRealm *realm = [RLMRealm defaultRealm];
+    RLMRealm *realm = [self realm];
 
     [realm beginWriteTransaction];
     [PersonObject createInRealm:realm withValue:@[@"Tim", @29]];
@@ -1397,7 +1405,7 @@
 }
 
 - (void)testCompoundAndQuery {
-    RLMRealm *realm = [RLMRealm defaultRealm];
+    RLMRealm *realm = [self realm];
 
     [realm beginWriteTransaction];
     [PersonObject createInRealm:realm withValue:@[@"Tim", @29]];
@@ -1426,7 +1434,7 @@
 
 - (void)testINPredicate
 {
-    RLMRealm *realm = [RLMRealm defaultRealm];
+    RLMRealm *realm = [self realm];
 
     [realm beginWriteTransaction];
     StringObject *so = [StringObject createInRealm:realm withValue:(@[@"abc"])];
@@ -1550,7 +1558,7 @@
 
 - (void)testArrayIn
 {
-    RLMRealm *realm = [RLMRealm defaultRealm];
+    RLMRealm *realm = [self realm];
     [realm beginWriteTransaction];
 
     ArrayPropertyObject *arr = [ArrayPropertyObject createInRealm:realm withValue:@[@"name", @[], @[]]];
@@ -1575,7 +1583,7 @@
 }
 
 - (void)testQueryChaining {
-    RLMRealm *realm = [RLMRealm defaultRealm];
+    RLMRealm *realm = [self realm];
 
     [realm beginWriteTransaction];
     [PersonObject createInRealm:realm withValue:@[@"Tim", @29]];
@@ -1588,7 +1596,7 @@
 }
 
 - (void)testLinkViewQuery {
-    RLMRealm *realm = [RLMRealm defaultRealm];
+    RLMRealm *realm = [self realm];
 
     [realm beginWriteTransaction];
     [CompanyObject createInRealm:realm
@@ -1607,7 +1615,7 @@
 }
 
 - (void)testLinkViewQueryLifetime {
-    RLMRealm *realm = [RLMRealm defaultRealm];
+    RLMRealm *realm = [self realm];
 
     [realm beginWriteTransaction];
     [CompanyObject createInRealm:realm
@@ -1635,7 +1643,7 @@
 }
 
 - (void)testLinkViewQueryLiveUpdate {
-    RLMRealm *realm = [RLMRealm defaultRealm];
+    RLMRealm *realm = [self realm];
 
     [realm beginWriteTransaction];
     [CompanyObject createInRealm:realm
@@ -1675,7 +1683,7 @@
 
 - (void)testConstantPredicates
 {
-    RLMRealm *realm = [RLMRealm defaultRealm];
+    RLMRealm *realm = [self realm];
 
     [realm beginWriteTransaction];
     [PersonObject createInRealm:realm withValue:@[@"Fiel", @27]];
@@ -1692,7 +1700,7 @@
 
 - (void)testEmptyCompoundPredicates
 {
-    RLMRealm *realm = [RLMRealm defaultRealm];
+    RLMRealm *realm = [self realm];
 
     [realm beginWriteTransaction];
     [PersonObject createInRealm:realm withValue:@[@"Fiel", @27]];
@@ -1709,7 +1717,7 @@
 
 - (void)testComparisonsWithKeyPathOnRHS
 {
-    RLMRealm *realm = [RLMRealm defaultRealm];
+    RLMRealm *realm = [self realm];
 
     [realm beginWriteTransaction];
 
@@ -1760,7 +1768,7 @@
 
 - (void)testLinksToDeletedOrMovedObject
 {
-    RLMRealm *realm = [RLMRealm defaultRealm];
+    RLMRealm *realm = [self realm];
     [realm beginWriteTransaction];
 
     DogObject *fido = [DogObject createInRealm:realm withValue:@[ @"Fido", @3 ]];
@@ -1796,7 +1804,7 @@
 
 - (void)testQueryOnDeletedArrayProperty
 {
-    RLMRealm *realm = [RLMRealm defaultRealm];
+    RLMRealm *realm = [self realm];
     [realm beginWriteTransaction];
     IntObject *io = [IntObject createInRealm:realm withValue:@[@0]];
     ArrayPropertyObject *array = [ArrayPropertyObject createInRealm:realm withValue:@[@"", @[], @[io]]];
@@ -1815,7 +1823,7 @@
 
 - (void)testSubqueries
 {
-    RLMRealm *realm = [RLMRealm defaultRealm];
+    RLMRealm *realm = [self realm];
 
     [realm beginWriteTransaction];
     CompanyObject *first = [CompanyObject createInRealm:realm
@@ -1839,7 +1847,7 @@
 }
 
 - (void)testLinkingObjects {
-    RLMRealm *realm = [RLMRealm defaultRealm];
+    RLMRealm *realm = [self realm];
 
     [realm beginWriteTransaction];
 
@@ -1980,7 +1988,7 @@
 
 - (void)testQueryOnNullableStringColumn {
     void (^testWithStringClass)(Class) = ^(Class stringObjectClass) {
-        RLMRealm *realm = [RLMRealm defaultRealm];
+        RLMRealm *realm = [self realm];
         [realm transactionWithBlock:^{
             [stringObjectClass createInRealm:realm withValue:@[@"a"]];
             [stringObjectClass createInRealm:realm withValue:@[NSNull.null]];
@@ -2037,7 +2045,7 @@
 
 - (void)testQueryingOnLinkToNullableStringColumn {
     void (^testWithStringClass)(Class, Class) = ^(Class stringLinkClass, Class stringObjectClass) {
-        RLMRealm *realm = [RLMRealm defaultRealm];
+        RLMRealm *realm = [self realm];
         [realm transactionWithBlock:^{
             [stringLinkClass createInRealm:realm withValue:@[[stringObjectClass createInRealm:realm withValue:@[@"a"]]]];
             [stringLinkClass createInRealm:realm withValue:@[[stringObjectClass createInRealm:realm withValue:@[NSNull.null]]]];
@@ -2070,7 +2078,7 @@
 }
 
 - (void)testSortingColumnsWithNull {
-    RLMRealm *realm = [RLMRealm defaultRealm];
+    RLMRealm *realm = [self realm];
     [realm beginWriteTransaction];
 
     {
@@ -2118,7 +2126,7 @@
 }
 
 - (void)testCountOnCollection {
-    RLMRealm *realm = [RLMRealm defaultRealm];
+    RLMRealm *realm = [self realm];
     [realm beginWriteTransaction];
 
     IntegerArrayPropertyObject *arr = [IntegerArrayPropertyObject createInRealm:realm withValue:@[ @1, @[]]];
@@ -2157,7 +2165,7 @@
 }
 
 - (void)testAggregateCollectionOperators {
-    RLMRealm *realm = [RLMRealm defaultRealm];
+    RLMRealm *realm = [self realm];
     [realm beginWriteTransaction];
 
     IntegerArrayPropertyObject *arr = [IntegerArrayPropertyObject createInRealm:realm withValue:@[ @1111, @[] ]];
@@ -2228,7 +2236,7 @@ struct NullTestData {
 };
 
 - (void)testPrimitiveOperatorsOnAllNullablePropertyTypes {
-    RLMRealm *realm = [RLMRealm defaultRealm];
+    RLMRealm *realm = [self realm];
 
     // nil on LHS is currently not supported by core
     XCTAssertThrows([AllOptionalTypes objectsWhere:@"nil = boolObj"]);
@@ -2337,7 +2345,7 @@ struct NullTestData {
 
 - (void)testINPredicateOnNullWithNonNullValues
 {
-    RLMRealm *realm = [RLMRealm defaultRealm];
+    RLMRealm *realm = [self realm];
 
     [realm beginWriteTransaction];
     [AllOptionalTypes createInRealm:realm withValue:@[@YES, @1, @1, @1, @"abc",
@@ -2410,7 +2418,7 @@ struct NullTestData {
 
 - (void)testINPredicateOnNullWithNullValues
 {
-    RLMRealm *realm = [RLMRealm defaultRealm];
+    RLMRealm *realm = [self realm];
 
     [realm beginWriteTransaction];
     [AllOptionalTypes createInRealm:realm withValue:@[NSNull.null, NSNull.null,
@@ -2497,5 +2505,33 @@ struct NullTestData {
     CFRunLoopRun();
     [(RLMNotificationToken *)token stop];
     return results;
+}
+@end
+
+@interface QueryWithReversedColumnOrderTests : QueryTests
+@end
+
+@implementation QueryWithReversedColumnOrderTests
+- (RLMRealm *)realm {
+    @autoreleasepool {
+        NSArray *classNames = @[@"AllTypesObject", @"QueryObject",
+                                @"PersonObject", @"DogObject",
+                                @"EmployeeObject", @"CompanyObject"];
+        RLMSchema *schema = [RLMSchema.sharedSchema copy];
+        for (NSString *className in classNames) {
+            [self reverseProperties:schema[className]];
+        }
+        RLMRealmConfiguration *config = [RLMRealmConfiguration defaultConfiguration];
+        config.customSchema = schema;
+        [RLMRealm realmWithConfiguration:config error:nil];
+    }
+
+    return RLMRealm.defaultRealm;
+}
+
+- (RLMObjectSchema *)reverseProperties:(RLMObjectSchema *)source {
+    RLMObjectSchema *objectSchema = [source copy];
+    objectSchema.properties = objectSchema.properties.reverseObjectEnumerator.allObjects;
+    return objectSchema;
 }
 @end


### PR DESCRIPTION
This makes things a bit less weird when constructing a schema manually for the
dynamic API (since the properties array visible to you will actually match what
you passed in), is required to support having the array of properties be a
subset of the table columns, and simplifies handling columns being rearranged a bit.

Also a little faster since it's O(N) rather than O(N log N), but if you have
enough properties for it to be even remotely noticeable something has gone very
wrong.

@bdash 