### PR TITLE
Check for implicitly unwrapped relationships in `getOptionalProperties`

### DIFF
--- a/RealmSwift/Object.swift
+++ b/RealmSwift/Object.swift
@@ -391,7 +391,7 @@ public class ObjectUtil: NSObject {
                 properties[name] = NSNumber(value: PropertyType.bool.rawValue)
             } else if prop.value as? RLMOptionalBase != nil {
                 throwRealmException("'\(type)' is not a a valid RealmOptional type.")
-            } else if mirror.displayStyle == .optional {
+            } else if mirror.displayStyle == .optional || type is NilLiteralConvertible.Type {
                 properties[name] = NSNull()
             }
             return properties

--- a/RealmSwift/Tests/ObjectSchemaInitializationTests.swift
+++ b/RealmSwift/Tests/ObjectSchemaInitializationTests.swift
@@ -182,6 +182,15 @@ class ObjectSchemaInitializationTests: TestCase {
         let types = Set(schema.properties.map { $0.type })
         XCTAssertEqual(types, Set([.string, .string, .data, .date, .object, .int, .float, .double, .bool]))
     }
+    
+    func testImplicitlyUnwrappedOptionalsAreParsedAsOptionals() {
+        let schema = SwiftImplicitlyUnwrappedOptionalObject().objectSchema
+        XCTAssertTrue(schema["optObjectCol"]!.isOptional)
+        XCTAssertTrue(schema["optNSStringCol"]!.isOptional)
+        XCTAssertTrue(schema["optStringCol"]!.isOptional)
+        XCTAssertTrue(schema["optBinaryCol"]!.isOptional)
+        XCTAssertTrue(schema["optDateCol"]!.isOptional)
+    }
 
     func testNonRealmOptionalTypesDeclaredAsRealmOptional() {
         assertThrows(RLMObjectSchema(forObjectClass: SwiftObjectWithNonRealmOptionalType.self))

--- a/RealmSwift/Tests/SwiftTestObjects.swift
+++ b/RealmSwift/Tests/SwiftTestObjects.swift
@@ -87,6 +87,7 @@ class SwiftImplicitlyUnwrappedOptionalObject: Object {
     dynamic var optStringCol: String!
     dynamic var optBinaryCol: NSData!
     dynamic var optDateCol: NSDate!
+    dynamic var optObjectCol: SwiftBoolObject!
 }
 
 class SwiftOptionalDefaultValuesObject: Object {


### PR DESCRIPTION
Quick, potential fix for #3768

Playing around in a playground I found that `childMirror.displayStyle` for a `T!` (where `T: Object`) is `.enum` while `childMirror.displayStyle` for `T?` is `.optional` using Swift 3.0. Haven't explicitly tested on any previous Swift version, but I assume this is what's causing the problem.

Also haven't verified that the specific implicitly unwrapped properties in my app works, but it does at least launch now.