### PR TITLE
Fix handling of Swift 3 properties which are renamed when bridged to obj-c

### DIFF
--- a/Realm/RLMProperty.mm
+++ b/Realm/RLMProperty.mm
@@ -279,7 +279,7 @@ static bool rawTypeIsComputedProperty(NSString *rawType) {
     }
 }
 
-- (bool)parseObjcProperty:(objc_property_t)property {
+- (bool)parseObjcProperty:(objc_property_t)property isSwift:(bool)isSwift {
     unsigned int count;
     objc_property_attribute_t *attrs = property_copyAttributeList(property, &count);
 
@@ -303,6 +303,11 @@ static bool rawTypeIsComputedProperty(NSString *rawType) {
                 break;
             case 'S':
                 _setterName = @(attrs[i].value);
+                break;
+            case 'V': // backing ivar name
+                if (isSwift) {
+                    _getterName = @(attrs[i].value);
+                }
                 break;
             default:
                 break;
@@ -331,7 +336,7 @@ static bool rawTypeIsComputedProperty(NSString *rawType) {
         _linkOriginPropertyName = linkPropertyDescriptor.propertyName;
     }
 
-    if ([self parseObjcProperty:property]) {
+    if ([self parseObjcProperty:property isSwift:true]) {
         return nil;
     }
 
@@ -406,7 +411,7 @@ static bool rawTypeIsComputedProperty(NSString *rawType) {
         _linkOriginPropertyName = linkPropertyDescriptor.propertyName;
     }
 
-    bool isReadOnly = [self parseObjcProperty:property];
+    bool isReadOnly = [self parseObjcProperty:property isSwift:false];
     bool isComputedProperty = rawTypeIsComputedProperty(_objcRawType);
     if (isReadOnly && !isComputedProperty) {
         return nil;

--- a/RealmSwift/Tests/ObjectCreationTests.swift
+++ b/RealmSwift/Tests/ObjectCreationTests.swift
@@ -483,6 +483,16 @@ class ObjectCreationTests: TestCase {
         XCTAssertEqual(existingObject.intCol, 2)
     }
 
+    func testCreateObjectWithRemappedName() {
+        let realm = try! Realm()
+        try! realm.write {
+            let obj = realm.createObject(ofType: SwiftTranslatedGetterObject.self, populatedWith: ["true": true])
+            XCTAssertTrue(obj.isTrue)
+            obj.isTrue = false
+            XCTAssertFalse(obj.isTrue)
+        }
+    }
+
     // MARK: Private utilities
     private func verifySwiftObjectWithArrayLiteral(_ object: SwiftObject, array: [AnyObject], boolObjectValue: Bool,
                                                    boolObjectListValues: [Bool]) {
@@ -1072,6 +1082,16 @@ class ObjectCreationTests: TestCase {
 
         XCTAssertNotNil(object.realm)
         XCTAssertNotNil(nilObject.realm)
+    }
+
+    func testCreateObjectWithRemappedName() {
+        let realm = try! Realm()
+        try! realm.write {
+            let obj = realm.create(SwiftTranslatedGetterObject.self, value: ["isTrue": true])
+            XCTAssertTrue(obj.isTrue)
+            obj.isTrue = false
+            XCTAssertFalse(obj.isTrue)
+        }
     }
 
     // MARK: Private utilities

--- a/RealmSwift/Tests/ObjectSchemaInitializationTests.swift
+++ b/RealmSwift/Tests/ObjectSchemaInitializationTests.swift
@@ -186,6 +186,10 @@ class ObjectSchemaInitializationTests: TestCase {
     func testNonRealmOptionalTypesDeclaredAsRealmOptional() {
         assertThrows(RLMObjectSchema(forObjectClass: SwiftObjectWithNonRealmOptionalType.self))
     }
+
+    func testBoolPropertyStartingWithIs() {
+        XCTAssertEqual(SwiftTranslatedGetterObject().objectSchema.properties[0].name, "true")
+    }
 }
 
 class SwiftFakeObject: NSObject {
@@ -444,6 +448,10 @@ class ObjectSchemaInitializationTests: TestCase {
 
     func testNonRealmOptionalTypesDeclaredAsRealmOptional() {
         assertThrows(RLMObjectSchema(forObjectClass: SwiftObjectWithNonRealmOptionalType.self))
+    }
+
+    func testBoolPropertyStartingWithIs() {
+        XCTAssertEqual(SwiftTranslatedGetterObject().objectSchema.properties[0].name, "isTrue")
     }
 }
 

--- a/RealmSwift/Tests/SwiftTestObjects.swift
+++ b/RealmSwift/Tests/SwiftTestObjects.swift
@@ -38,6 +38,10 @@ class SwiftLongObject: Object {
     dynamic var longCol: Int64 = 0
 }
 
+class SwiftTranslatedGetterObject: Object {
+    dynamic var isTrue: Bool = false
+}
+
 class SwiftObject: Object {
     dynamic var boolCol = false
     dynamic var intCol = 123
@@ -422,6 +426,10 @@ class SwiftIntObject: Object {
 
 class SwiftLongObject: Object {
     dynamic var longCol: Int64 = 0
+}
+
+class SwiftTranslatedGetterObject: Object {
+    dynamic var isTrue: Bool = false
 }
 
 class SwiftObject: Object {


### PR DESCRIPTION
Fixes #3773.