### PR TITLE
[ISSUE_TEMPLATE] Make use of details html element

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,17 +1,17 @@
-> We LOVE to help with any issues or bugs you have!
->
-> **Questions**: If you have questions about how to use Realm, ask on 
-> [StackOverflow](http://stackoverflow.com/questions/ask?tags=realm).
-> We monitor the `realm` tag.
->
-> **Feature Request**: Just fill in the first two sections below.
->
-> **Bugs**: To help you as fast as possible with an issue please describe your issue
-> and the steps you have taken to reproduce it in as many details as possible.
->
-> Thanks for helping us help you! :-)
->
-> Please remove this line and all above before submitting.
+<details><summary>
+We LOVE to help with any issues or bugs you have!
+</summary>
+**Questions**: If you have questions about how to use Realm, ask on 
+[StackOverflow](http://stackoverflow.com/questions/ask?tags=realm).
+We monitor the `realm` tag.
+
+**Feature Request**: Just fill in the first two sections below.
+
+**Bugs**: To help you as fast as possible with an issue please describe your issue
+and the steps you have taken to reproduce it in as many details as possible.
+
+Thanks for helping us help you! :-)
+</details>
 
 ## Goals
 
@@ -32,11 +32,13 @@ What are steps we can follow to reproduce this issue?
 
 ## Code Sample
 
+<details open>
 Provide a code sample or test case that highlights the issue.
 If relevant, include your model definitions.
 For larger code samples, links to external gists/repositories are preferred.
 Alternatively share confidentially via mail to help@realm.io.
 Full Xcode projects that we can compile ourselves are ideal!
+</details>
 
 ## Version of Realm and Tooling
 

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -23,8 +23,10 @@ What did you expected to happen?
 
 ## Actual Results
 
+<details open>
 What did happened instead?  
 e.g. the stack trace of a crash
+</details>
 
 ## Steps to Reproduce
 


### PR DESCRIPTION
I [noticed](https://gist.github.com/orta/057eab0832773aa299a6ebd39187ab06) that the `<details>` HTML tag is supported by GitHub-flavoured Markdown and thought that might be a neat way to get the intro of our issue template out of the way without bothering users creating issues to remove that part. In addition to that we can use it to collapse longer sections. 😳

/c @jpsim @bmunkholm 