### PR TITLE
Fix code signing with Xcode 8

### DIFF
--- a/Configuration/Base.xcconfig
+++ b/Configuration/Base.xcconfig
@@ -39,6 +39,8 @@ WARNING_CFLAGS = -Wmismatched-tags -Wunused-private-field;
 OTHER_CPLUSPLUSFLAGS = $(OTHER_CPLUSPLUSFLAGS) -isystem core/include -IRealm/ObjectStore;
 
 CODE_SIGN_IDENTITY[sdk=iphone*] = iPhone Developer;
+CODE_SIGNING_REQUIRED[sdk=macosx] = NO;
+
 MACOSX_DEPLOYMENT_TARGET = 10.9;
 IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 WATCHOS_DEPLOYMENT_TARGET = 2.0;

--- a/Realm.xcodeproj/project.pbxproj
+++ b/Realm.xcodeproj/project.pbxproj
@@ -1431,9 +1431,11 @@
 					};
 					5D660FCB1BE98C560021E04F = {
 						CreatedOnToolsVersion = 7.1;
+						LastSwiftMigration = 0800;
 					};
 					5D660FD71BE98C7C0021E04F = {
 						CreatedOnToolsVersion = 7.1;
+						LastSwiftMigration = 0800;
 					};
 					C04B4BD71B55C47600FAE58E = {
 						CreatedOnToolsVersion = 6.4;
@@ -1446,6 +1448,7 @@
 					};
 					E8D89BA21955FC6D00CF2B9A = {
 						CreatedOnToolsVersion = 6.0;
+						LastSwiftMigration = 0800;
 						TestTargetID = E8D89B971955FC6D00CF2B9A;
 					};
 				};

--- a/Realm.xcodeproj/project.pbxproj
+++ b/Realm.xcodeproj/project.pbxproj
@@ -1425,17 +1425,36 @@
 				TargetAttributes = {
 					3F1A5E711992EB7400F45F4C = {
 						CreatedOnToolsVersion = 6.0;
+						DevelopmentTeam = QX5CR2FTN2;
+						DevelopmentTeamName = "Realm ApS";
+						ProvisioningStyle = Automatic;
 					};
 					5D0A40841C62ACCC00BBB612 = {
 						CreatedOnToolsVersion = 7.2;
 					};
+					5D659E7D1BE04556006515A0 = {
+						DevelopmentTeam = QX5CR2FTN2;
+						DevelopmentTeamName = "Realm ApS";
+						ProvisioningStyle = Automatic;
+					};
 					5D660FCB1BE98C560021E04F = {
 						CreatedOnToolsVersion = 7.1;
+						DevelopmentTeam = QX5CR2FTN2;
+						DevelopmentTeamName = "Realm ApS";
 						LastSwiftMigration = 0800;
+						ProvisioningStyle = Automatic;
 					};
 					5D660FD71BE98C7C0021E04F = {
 						CreatedOnToolsVersion = 7.1;
+						DevelopmentTeam = QX5CR2FTN2;
+						DevelopmentTeamName = "Realm ApS";
 						LastSwiftMigration = 0800;
+						ProvisioningStyle = Automatic;
+					};
+					5DD7557B1BE056DE002800DA = {
+						DevelopmentTeam = QX5CR2FTN2;
+						DevelopmentTeamName = "Realm ApS";
+						ProvisioningStyle = Automatic;
 					};
 					C04B4BD71B55C47600FAE58E = {
 						CreatedOnToolsVersion = 6.4;
@@ -1445,10 +1464,16 @@
 					};
 					E856D1DE195614A400FB2FCF = {
 						CreatedOnToolsVersion = 6.0;
+						DevelopmentTeam = QX5CR2FTN2;
+						DevelopmentTeamName = "Realm ApS";
+						ProvisioningStyle = Automatic;
 					};
 					E8D89BA21955FC6D00CF2B9A = {
 						CreatedOnToolsVersion = 6.0;
+						DevelopmentTeam = QX5CR2FTN2;
+						DevelopmentTeamName = "Realm ApS";
 						LastSwiftMigration = 0800;
+						ProvisioningStyle = Automatic;
 						TestTargetID = E8D89B971955FC6D00CF2B9A;
 					};
 				};


### PR DESCRIPTION
Automatic provisioning is enabled for the targets that require signing (frameworks, tests, and test host). Signing is explicitly disabled on OS X as it is not necessary for our purposes.
    
Both of Xcode 8's approaches to provisioning appear to require hard-coding a development team identifier in the project file. This will likely prevent people outside of Realm from building from source using Xcode 8 without first changing the team used for code signing for each target via Xcode's target editor. Hopefully this situation is improved before Xcode 8 GMs.
    
These changes have no effect on Xcode 7's behavior.