### PR TITLE
Fix `migrateRealm:` to follow Cocoa error conventions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@ x.x.x Release notes (yyyy-MM-dd)
 
 ### API breaking changes
 
-* None.
+* Deprecated `migrateRealm:` in favor of new `performMigrationForConfiguration:error:` method
+  that follows Cocoa's' NSError conventions.
 
 ### Enhancements
 

--- a/Realm/RLMRealm.h
+++ b/Realm/RLMRealm.h
@@ -476,7 +476,7 @@ typedef void (^RLMMigrationBlock)(RLMMigration *migration, uint64_t oldSchemaVer
 
  @see                 RLMMigration
  */
-+ (nullable NSError *)migrateRealm:(RLMRealmConfiguration *)configuration;
++ (BOOL)migrateRealm:(RLMRealmConfiguration *)configuration error:(NSError **)error;
 
 @end
 

--- a/Realm/RLMRealm.h
+++ b/Realm/RLMRealm.h
@@ -476,7 +476,22 @@ typedef void (^RLMMigrationBlock)(RLMMigration *migration, uint64_t oldSchemaVer
 
  @see                 RLMMigration
  */
-+ (BOOL)migrateRealm:(RLMRealmConfiguration *)configuration error:(NSError **)error;
++ (nullable NSError *)migrateRealm:(RLMRealmConfiguration *)configuration
+__deprecated_msg("Use `performMigrationForConfiguration:error:`") NS_REFINED_FOR_SWIFT;
+
+/**
+ Performs the given Realm configuration's migration block on a Realm at the given path.
+
+ This method is called automatically when opening a Realm for the first time and does
+ not need to be called explicitly. You can choose to call this method to control
+ exactly when and how migrations are performed.
+
+ @param configuration The Realm configuration used to open and migrate the Realm.
+ @return              The error that occurred while applying the migration, if any.
+
+ @see                 RLMMigration
+ */
++ (BOOL)performMigrationForConfiguration:(RLMRealmConfiguration *)configuration error:(NSError **)error;
 
 @end
 

--- a/Realm/RLMRealm.mm
+++ b/Realm/RLMRealm.mm
@@ -693,16 +693,21 @@ REALM_NOINLINE void RLMRealmTranslateException(NSError **error) {
     }
 }
 
-+ (NSError *)migrateRealm:(RLMRealmConfiguration *)configuration {
++ (BOOL)migrateRealm:(RLMRealmConfiguration *)configuration error:(NSError **)error {
+
     if (RLMGetAnyCachedRealmForPath(configuration.config.path)) {
         @throw RLMException(@"Cannot migrate Realms that are already open.");
     }
 
+    NSError *localError; // Prevents autorelease
+    BOOL success;
     @autoreleasepool {
-        NSError *error = nil;
-        [RLMRealm realmWithConfiguration:configuration error:&error];
-        return error;
+        success = [RLMRealm realmWithConfiguration:configuration error:&localError] != nil;
     }
+    if (!success && error) {
+        *error = localError; // Must set outside pool otherwise will free anyway
+    }
+    return success;
 }
 
 - (RLMObject *)createObject:(NSString *)className withValue:(id)value {

--- a/Realm/RLMRealm.mm
+++ b/Realm/RLMRealm.mm
@@ -693,8 +693,14 @@ REALM_NOINLINE void RLMRealmTranslateException(NSError **error) {
     }
 }
 
-+ (BOOL)migrateRealm:(RLMRealmConfiguration *)configuration error:(NSError **)error {
++ (nullable NSError *)migrateRealm:(RLMRealmConfiguration *)configuration {
+    // Preserves backwards compatibility
+    NSError *error;
+    [self performMigrationForConfiguration:configuration error:&error];
+    return error;
+}
 
++ (BOOL)performMigrationForConfiguration:(RLMRealmConfiguration *)configuration error:(NSError **)error {
     if (RLMGetAnyCachedRealmForPath(configuration.config.path)) {
         @throw RLMException(@"Cannot migrate Realms that are already open.");
     }

--- a/Realm/Tests/EncryptionTests.mm
+++ b/Realm/Tests/EncryptionTests.mm
@@ -207,11 +207,11 @@
         migrationRan = YES;
     };
 
-    XCTAssertFalse([RLMRealm migrateRealm:configuration error:nil]);
+    XCTAssertFalse([RLMRealm performMigrationForConfiguration:configuration error:nil]);
     XCTAssertFalse(migrationRan);
 
     configuration.encryptionKey = key;
-    XCTAssertTrue([RLMRealm migrateRealm:configuration error:nil]);
+    XCTAssertTrue([RLMRealm performMigrationForConfiguration:configuration error:nil]);
     XCTAssertTrue(migrationRan);
 }
 

--- a/Realm/Tests/EncryptionTests.mm
+++ b/Realm/Tests/EncryptionTests.mm
@@ -207,11 +207,11 @@
         migrationRan = YES;
     };
 
-    XCTAssertNotNil([RLMRealm migrateRealm:configuration]);
+    XCTAssertFalse([RLMRealm migrateRealm:configuration error:nil]);
     XCTAssertFalse(migrationRan);
 
     configuration.encryptionKey = key;
-    XCTAssertNil([RLMRealm migrateRealm:configuration]);
+    XCTAssertTrue([RLMRealm migrateRealm:configuration error:nil]);
     XCTAssertTrue(migrationRan);
 }
 

--- a/Realm/Tests/MigrationTests.mm
+++ b/Realm/Tests/MigrationTests.mm
@@ -171,7 +171,7 @@ RLM_ARRAY_TYPE(MigrationObject);
         config.fileURL = RLMTestRealmURL();
         config.schemaVersion = 1;
         config.migrationBlock = block;
-        XCTAssertNil([RLMRealm migrateRealm:config]);
+        XCTAssertTrue([RLMRealm migrateRealm:config error:nil]);
 
         RLMRealm *realm = [RLMRealm realmWithConfiguration:config error:nil];
         RLMAssertRealmSchemaMatchesTable(self, realm);
@@ -185,7 +185,7 @@ RLM_ARRAY_TYPE(MigrationObject);
         config.fileURL = RLMTestRealmURL();
         config.schemaVersion = 1;
         config.migrationBlock = block;
-        XCTAssertNotNil([RLMRealm migrateRealm:config]);
+        XCTAssertFalse([RLMRealm migrateRealm:config error:nil]);
     }
 }
 
@@ -252,7 +252,9 @@ RLM_ARRAY_TYPE(MigrationObject);
                         className:(NSString *)className oldName:(NSString *)oldName newName:(NSString *)newName {
     RLMRealmConfiguration *config = [self renameConfigurationWithObjectSchemas:objectSchemas className:className
                                                                        oldName:oldName newName:newName];
-    XCTAssertTrue([[[RLMRealm migrateRealm:config] localizedDescription] rangeOfString:errorMessage].location != NSNotFound);
+    NSError *error;
+    [RLMRealm migrateRealm:config error:&error];
+    XCTAssertTrue([[error localizedDescription] rangeOfString:errorMessage].location != NSNotFound);
 }
 
 - (void)assertPropertyRenameError:(NSString *)errorMessage
@@ -277,9 +279,11 @@ RLM_ARRAY_TYPE(MigrationObject);
                                                                        oldName:beforeProperty.name newName:afterProperty.name];
 
     if (errorMessage) {
-        XCTAssertEqualObjects([[RLMRealm migrateRealm:config] localizedDescription], errorMessage);
+        NSError *error;
+        [RLMRealm migrateRealm:config error:&error];
+        XCTAssertEqualObjects([error localizedDescription], errorMessage);
     } else {
-        XCTAssertNil([RLMRealm migrateRealm:config]);
+        XCTAssertTrue([RLMRealm migrateRealm:config error:nil]);
         XCTAssertEqualObjects(@"0", [[[StringObject allObjectsInRealm:[RLMRealm realmWithConfiguration:config error:nil]] firstObject] stringCol]);
     }
 }
@@ -681,7 +685,7 @@ RLM_ARRAY_TYPE(MigrationObject);
         XCTFail(@"Migration block should not have been called");
     };
     @autoreleasepool { XCTAssertNoThrow([RLMRealm realmWithConfiguration:config error:nil]); }
-    @autoreleasepool { XCTAssertNil([RLMRealm migrateRealm:config]); }
+    @autoreleasepool { XCTAssertTrue([RLMRealm migrateRealm:config error:nil]); }
 }
 
 - (void)testMigrationBlockCalledWhenSchemaVersionHasChanged {
@@ -699,7 +703,7 @@ RLM_ARRAY_TYPE(MigrationObject);
 
     migrationCalled = false;
     config.schemaVersion = 3;
-    @autoreleasepool { XCTAssertNil([RLMRealm migrateRealm:config]); }
+    @autoreleasepool { XCTAssertTrue([RLMRealm migrateRealm:config error:nil]); }
     XCTAssertTrue(migrationCalled);
 }
 
@@ -1093,7 +1097,7 @@ RLM_ARRAY_TYPE(MigrationObject);
         config.fileURL = RLMTestRealmURL();
         config.customSchema = [self schemaWithObjects:@[ objectSchema ]];
         config.schemaVersion = 1;
-        XCTAssertNil([RLMRealm migrateRealm:config]);
+        XCTAssertTrue([RLMRealm migrateRealm:config error:nil]);
 
         realm = [RLMRealm realmWithConfiguration:config error:nil];
         RLMAssertRealmSchemaMatchesTable(self, realm);
@@ -1141,7 +1145,7 @@ RLM_ARRAY_TYPE(MigrationObject);
         [migration createObject:RequiredPropertiesObject.className withValue:@[@"World", [NSData data], [NSDate date]]];
     };
 
-    XCTAssertNil([RLMRealm migrateRealm:config]);
+    XCTAssertTrue([RLMRealm migrateRealm:config error:nil]);
     RLMRealm *realm = [RLMRealm realmWithConfiguration:config error:nil];
 
     RLMResults *allObjects = [RequiredPropertiesObject allObjectsInRealm:realm];
@@ -1280,7 +1284,7 @@ RLM_ARRAY_TYPE(MigrationObject);
         }];
         migrationCalled = true;
     };
-    XCTAssertNil([RLMRealm migrateRealm:config]);
+    XCTAssertTrue([RLMRealm migrateRealm:config error:nil]);
     XCTAssertTrue(migrationCalled);
 #endif
 }
@@ -1324,7 +1328,7 @@ RLM_ARRAY_TYPE(MigrationObject);
             XCTAssertEqualObjects([oldObject.description stringByReplacingOccurrencesOfString:@"before_" withString:@""], newObject.description);
         }];
     }];
-    XCTAssertNil([RLMRealm migrateRealm:config]);
+    XCTAssertTrue([RLMRealm migrateRealm:config error:nil]);
 
     RLMRealm *realm = [RLMRealm realmWithConfiguration:config error:nil];
     RLMAssertRealmSchemaMatchesTable(self, realm);
@@ -1386,7 +1390,7 @@ RLM_ARRAY_TYPE(MigrationObject);
         }
     };
 
-    XCTAssertNil([RLMRealm migrateRealm:config]);
+    XCTAssertTrue([RLMRealm migrateRealm:config error:nil]);
     XCTAssertTrue(migrationCalled);
     XCTAssertEqualObjects(@"0", [[[StringObject allObjectsInRealm:[RLMRealm realmWithConfiguration:config error:nil]] firstObject] stringCol]);
 }

--- a/Realm/Tests/MigrationTests.mm
+++ b/Realm/Tests/MigrationTests.mm
@@ -171,7 +171,7 @@ RLM_ARRAY_TYPE(MigrationObject);
         config.fileURL = RLMTestRealmURL();
         config.schemaVersion = 1;
         config.migrationBlock = block;
-        XCTAssertTrue([RLMRealm migrateRealm:config error:nil]);
+        XCTAssertTrue([RLMRealm performMigrationForConfiguration:config error:nil]);
 
         RLMRealm *realm = [RLMRealm realmWithConfiguration:config error:nil];
         RLMAssertRealmSchemaMatchesTable(self, realm);
@@ -185,7 +185,7 @@ RLM_ARRAY_TYPE(MigrationObject);
         config.fileURL = RLMTestRealmURL();
         config.schemaVersion = 1;
         config.migrationBlock = block;
-        XCTAssertFalse([RLMRealm migrateRealm:config error:nil]);
+        XCTAssertFalse([RLMRealm performMigrationForConfiguration:config error:nil]);
     }
 }
 
@@ -253,7 +253,7 @@ RLM_ARRAY_TYPE(MigrationObject);
     RLMRealmConfiguration *config = [self renameConfigurationWithObjectSchemas:objectSchemas className:className
                                                                        oldName:oldName newName:newName];
     NSError *error;
-    [RLMRealm migrateRealm:config error:&error];
+    [RLMRealm performMigrationForConfiguration:config error:&error];
     XCTAssertTrue([[error localizedDescription] rangeOfString:errorMessage].location != NSNotFound);
 }
 
@@ -280,10 +280,10 @@ RLM_ARRAY_TYPE(MigrationObject);
 
     if (errorMessage) {
         NSError *error;
-        [RLMRealm migrateRealm:config error:&error];
+        [RLMRealm performMigrationForConfiguration:config error:&error];
         XCTAssertEqualObjects([error localizedDescription], errorMessage);
     } else {
-        XCTAssertTrue([RLMRealm migrateRealm:config error:nil]);
+        XCTAssertTrue([RLMRealm performMigrationForConfiguration:config error:nil]);
         XCTAssertEqualObjects(@"0", [[[StringObject allObjectsInRealm:[RLMRealm realmWithConfiguration:config error:nil]] firstObject] stringCol]);
     }
 }
@@ -685,7 +685,7 @@ RLM_ARRAY_TYPE(MigrationObject);
         XCTFail(@"Migration block should not have been called");
     };
     @autoreleasepool { XCTAssertNoThrow([RLMRealm realmWithConfiguration:config error:nil]); }
-    @autoreleasepool { XCTAssertTrue([RLMRealm migrateRealm:config error:nil]); }
+    @autoreleasepool { XCTAssertTrue([RLMRealm performMigrationForConfiguration:config error:nil]); }
 }
 
 - (void)testMigrationBlockCalledWhenSchemaVersionHasChanged {
@@ -703,7 +703,7 @@ RLM_ARRAY_TYPE(MigrationObject);
 
     migrationCalled = false;
     config.schemaVersion = 3;
-    @autoreleasepool { XCTAssertTrue([RLMRealm migrateRealm:config error:nil]); }
+    @autoreleasepool { XCTAssertTrue([RLMRealm performMigrationForConfiguration:config error:nil]); }
     XCTAssertTrue(migrationCalled);
 }
 
@@ -1097,7 +1097,7 @@ RLM_ARRAY_TYPE(MigrationObject);
         config.fileURL = RLMTestRealmURL();
         config.customSchema = [self schemaWithObjects:@[ objectSchema ]];
         config.schemaVersion = 1;
-        XCTAssertTrue([RLMRealm migrateRealm:config error:nil]);
+        XCTAssertTrue([RLMRealm performMigrationForConfiguration:config error:nil]);
 
         realm = [RLMRealm realmWithConfiguration:config error:nil];
         RLMAssertRealmSchemaMatchesTable(self, realm);
@@ -1145,7 +1145,7 @@ RLM_ARRAY_TYPE(MigrationObject);
         [migration createObject:RequiredPropertiesObject.className withValue:@[@"World", [NSData data], [NSDate date]]];
     };
 
-    XCTAssertTrue([RLMRealm migrateRealm:config error:nil]);
+    XCTAssertTrue([RLMRealm performMigrationForConfiguration:config error:nil]);
     RLMRealm *realm = [RLMRealm realmWithConfiguration:config error:nil];
 
     RLMResults *allObjects = [RequiredPropertiesObject allObjectsInRealm:realm];
@@ -1284,7 +1284,7 @@ RLM_ARRAY_TYPE(MigrationObject);
         }];
         migrationCalled = true;
     };
-    XCTAssertTrue([RLMRealm migrateRealm:config error:nil]);
+    XCTAssertTrue([RLMRealm performMigrationForConfiguration:config error:nil]);
     XCTAssertTrue(migrationCalled);
 #endif
 }
@@ -1328,7 +1328,7 @@ RLM_ARRAY_TYPE(MigrationObject);
             XCTAssertEqualObjects([oldObject.description stringByReplacingOccurrencesOfString:@"before_" withString:@""], newObject.description);
         }];
     }];
-    XCTAssertTrue([RLMRealm migrateRealm:config error:nil]);
+    XCTAssertTrue([RLMRealm performMigrationForConfiguration:config error:nil]);
 
     RLMRealm *realm = [RLMRealm realmWithConfiguration:config error:nil];
     RLMAssertRealmSchemaMatchesTable(self, realm);
@@ -1390,7 +1390,7 @@ RLM_ARRAY_TYPE(MigrationObject);
         }
     };
 
-    XCTAssertTrue([RLMRealm migrateRealm:config error:nil]);
+    XCTAssertTrue([RLMRealm performMigrationForConfiguration:config error:nil]);
     XCTAssertTrue(migrationCalled);
     XCTAssertEqualObjects(@"0", [[[StringObject allObjectsInRealm:[RLMRealm realmWithConfiguration:config error:nil]] firstObject] stringCol]);
 }

--- a/Realm/Tests/RealmTests.mm
+++ b/Realm/Tests/RealmTests.mm
@@ -1625,7 +1625,7 @@
 
     RLMRealmConfiguration *configuration = [RLMRealmConfiguration defaultConfiguration];
     configuration.fileURL = realm.configuration.fileURL;
-    XCTAssertThrows([RLMRealm migrateRealm:configuration error:nil]);
+    XCTAssertThrows([RLMRealm performMigrationForConfiguration:configuration error:nil]);
 }
 
 - (void)testNotificationPipeBufferOverfull {

--- a/Realm/Tests/RealmTests.mm
+++ b/Realm/Tests/RealmTests.mm
@@ -1625,7 +1625,7 @@
 
     RLMRealmConfiguration *configuration = [RLMRealmConfiguration defaultConfiguration];
     configuration.fileURL = realm.configuration.fileURL;
-    XCTAssertThrows([RLMRealm migrateRealm:configuration]);
+    XCTAssertThrows([RLMRealm migrateRealm:configuration error:nil]);
 }
 
 - (void)testNotificationPipeBufferOverfull {

--- a/RealmSwift/Migration.swift
+++ b/RealmSwift/Migration.swift
@@ -275,10 +275,10 @@ public func schemaVersionAtURL(fileURL: NSURL, encryptionKey: NSData? = nil) thr
 
  - parameter configuration: The Realm configuration used to open and migrate the Realm.
 
- - returns: An `NSError` that describes an error that occurred while applying the migration, if any.
+ - throws: An `NSError` that describes an error that occurred while applying the migration, if any.
 */
-public func migrateRealm(configuration: Realm.Configuration = Realm.Configuration.defaultConfiguration) -> NSError? {
-    return RLMRealm.migrateRealm(configuration.rlmConfiguration)
+public func migrateRealm(configuration: Realm.Configuration = Realm.Configuration.defaultConfiguration) throws {
+    return try RLMRealm.migrateRealm(configuration.rlmConfiguration)
 }
 
 

--- a/RealmSwift/Migration.swift
+++ b/RealmSwift/Migration.swift
@@ -63,28 +63,22 @@ public func schemaVersionAtURL(_ fileURL: URL, encryptionKey: Data? = nil) throw
     return version
 }
 
-/**
-Performs the configuration's migration block on the Realm created by the given
-configuration.
+extension Realm {
+    /**
+     Performs the given Realm configuration's migration block on a Realm at the given path.
 
-This method is called automatically when opening a Realm for the first time and does
-not need to be called explicitly. You can choose to call this method to control
-exactly when and how migrations are performed.
+     This method is called automatically when opening a Realm for the first time and does
+     not need to be called explicitly. You can choose to call this method to control
+     exactly when and how migrations are performed.
 
-- parameter configuration: The Realm.Configuration used to create the Realm to be
-                           migrated, and containing the schema version and migration
-                           block used to perform the migration.
+     - parameter configuration: The Realm configuration used to open and migrate the Realm.
 
-- returns: `nil` if the migration was successful, or an `NSError` object that describes the problem
-           that occurred otherwise.
-*/
-@discardableResult
-public func migrateRealm(_ configuration: Realm.Configuration = Realm.Configuration.defaultConfiguration) throws {
-    if let error = RLMRealm.migrateRealm(configuration.rlmConfiguration) {
-        throw error
+     - throws: An `NSError` that describes an error that occurred while applying the migration, if any.
+     */
+    public static func performMigration(for configuration: Realm.Configuration = Realm.Configuration.defaultConfiguration) throws {
+        try RLMRealm.performMigration(for: configuration.rlmConfiguration)
     }
 }
-
 
 /**
 `Migration` is the object passed into a user-defined `MigrationBlock` when updating the version
@@ -275,12 +269,35 @@ public func schemaVersionAtURL(fileURL: NSURL, encryptionKey: NSData? = nil) thr
 
  - parameter configuration: The Realm configuration used to open and migrate the Realm.
 
- - throws: An `NSError` that describes an error that occurred while applying the migration, if any.
+ - returns: An `NSError` that describes an error that occurred while applying the migration, if any.
 */
-public func migrateRealm(configuration: Realm.Configuration = Realm.Configuration.defaultConfiguration) throws {
-    return try RLMRealm.migrateRealm(configuration.rlmConfiguration)
+@available(*, deprecated=1.0.2, renamed="Realm.performMigration(for:)")
+public func migrateRealm(configuration: Realm.Configuration = Realm.Configuration.defaultConfiguration) -> NSError? {
+    // Preserves backwards compatibility
+    do {
+        try Realm.performMigration(for: configuration)
+        return nil
+    } catch let error as NSError {
+        return error
+    }
 }
 
+extension Realm {
+    /**
+     Performs the given Realm configuration's migration block on a Realm at the given path.
+
+     This method is called automatically when opening a Realm for the first time and does
+     not need to be called explicitly. You can choose to call this method to control
+     exactly when and how migrations are performed.
+
+     - parameter configuration: The Realm configuration used to open and migrate the Realm.
+
+     - throws: An `NSError` that describes an error that occurred while applying the migration, if any.
+     */
+    public static func performMigration(for configuration: Realm.Configuration = Realm.Configuration.defaultConfiguration) throws {
+        try RLMRealm.performMigrationForConfiguration(configuration.rlmConfiguration)
+    }
+}
 
 /**
  `Migration` instances encapsulate information intended to facilitate a schema migration.

--- a/RealmSwift/Tests/MigrationTests.swift
+++ b/RealmSwift/Tests/MigrationTests.swift
@@ -569,7 +569,7 @@ class MigrationTests: TestCase {
                 _ = try! Realm(configuration: config)
             }
         } else {
-            migrateRealm(config)
+            try! migrateRealm(config)
         }
 
         XCTAssertEqual(didRun, shouldRun)
@@ -592,7 +592,7 @@ class MigrationTests: TestCase {
                                          migrationBlock: { _, _ in didRun = true })
         Realm.Configuration.defaultConfiguration = config
 
-        migrateRealm()
+        try! migrateRealm()
 
         XCTAssertEqual(didRun, true)
         XCTAssertEqual(1, try! schemaVersionAtURL(defaultRealmURL()))

--- a/RealmSwift/Tests/MigrationTests.swift
+++ b/RealmSwift/Tests/MigrationTests.swift
@@ -75,7 +75,7 @@ class MigrationTests: TestCase {
                 _ = try! Realm(configuration: config)
             }
         } else {
-            try! migrateRealm(config)
+            try! Realm.performMigration(for: config)
         }
 
         XCTAssertEqual(didRun, shouldRun)
@@ -98,7 +98,7 @@ class MigrationTests: TestCase {
                                          migrationBlock: { _, _ in didRun = true })
         Realm.Configuration.defaultConfiguration = config
 
-        try! migrateRealm()
+        try! Realm.performMigration()
 
         XCTAssertEqual(didRun, true)
         XCTAssertEqual(1, try! schemaVersionAtURL(defaultRealmURL()))
@@ -569,7 +569,7 @@ class MigrationTests: TestCase {
                 _ = try! Realm(configuration: config)
             }
         } else {
-            try! migrateRealm(config)
+            try! Realm.performMigration(for: config)
         }
 
         XCTAssertEqual(didRun, shouldRun)
@@ -592,7 +592,7 @@ class MigrationTests: TestCase {
                                          migrationBlock: { _, _ in didRun = true })
         Realm.Configuration.defaultConfiguration = config
 
-        try! migrateRealm()
+        try! Realm.performMigration()
 
         XCTAssertEqual(didRun, true)
         XCTAssertEqual(1, try! schemaVersionAtURL(defaultRealmURL()))


### PR DESCRIPTION
Cocoa methods ought to use an error parameter rather than returning an error. This also allows Swift to import the function as throwing.

Fixes https://github.com/realm/realm-cocoa/issues/3816