### PR TITLE
Fix `schmaVersionAtURL:encryptionKey:error` to throw when imported into Swift

### DIFF
--- a/Realm/RLMRealm.h
+++ b/Realm/RLMRealm.h
@@ -462,7 +462,8 @@ typedef void (^RLMMigrationBlock)(RLMMigration *migration, uint64_t oldSchemaVer
 
  @return The version of the Realm at `fileURL`, or `RLMNotVersioned` if the version cannot be read.
  */
-+ (uint64_t)schemaVersionAtURL:(NSURL *)fileURL encryptionKey:(nullable NSData *)key error:(NSError **)error;
++ (uint64_t)schemaVersionAtURL:(NSURL *)fileURL encryptionKey:(nullable NSData *)key error:(NSError **)error
+NS_REFINED_FOR_SWIFT;
 
 /**
  Performs the given Realm configuration's migration block on a Realm at the given path.

--- a/Realm/Swift/RLMSupport.swift
+++ b/Realm/Swift/RLMSupport.swift
@@ -19,6 +19,17 @@
 import Realm
 
 #if swift(>=3.0)
+    extension RLMRealm {
+        public class func schemaVersion(at url: URL, usingEncryptionKey key: Data? = nil) throws -> UInt64 {
+            var error: NSError?
+            let version = __schemaVersion(at: url, encryptionKey: key, error: &error)
+            guard version != RLMNotVersioned else {
+                throw error!
+            }
+            return version
+        }
+    }
+
     extension RLMObject {
         // Swift query convenience functions
         public class func objectsWhere(predicateFormat: String, _ args: CVarArg...) -> RLMResults<RLMObject> {
@@ -78,6 +89,17 @@ import Realm
     }
 
 #else
+    extension RLMRealm {
+        @nonobjc public class func schemaVersionAtURL(url: NSURL, encryptionKey key: NSData? = nil,
+                                                      error: NSErrorPointer) -> UInt64 {
+            return __schemaVersionAtURL(url, encryptionKey: key, error: error)
+        }
+    }
+
+    func test() {
+        RLMRealm.schemaVersionAtURL(NSURL(), encryptionKey: nil, error: nil)
+    }
+
     extension RLMObject {
         // Swift query convenience functions
         public class func objectsWhere(predicateFormat: String, _ args: CVarArgType...) -> RLMResults {

--- a/RealmSwift/Migration.swift
+++ b/RealmSwift/Migration.swift
@@ -55,10 +55,10 @@ Get the schema version for a Realm at a given local URL.
 - returns: The version of the Realm at `fileURL`.
 */
 public func schemaVersionAtURL(_ fileURL: URL, encryptionKey: Data? = nil) throws -> UInt64 {
-    var error: NSError? = nil
-    let version = RLMRealm.schemaVersion(at: fileURL, encryptionKey: encryptionKey, error: &error)
-    if let error = error {
-        throw error
+    var error: NSError?
+    let version = RLMRealm.__schemaVersion(at: fileURL, encryptionKey: encryptionKey, error: &error)
+    guard version != RLMNotVersioned else {
+        throw error!
     }
     return version
 }
@@ -258,10 +258,10 @@ public typealias MigrationObjectEnumerateBlock = (oldObject: MigrationObject?, n
  - returns: The version of the Realm at `fileURL`.
 */
 public func schemaVersionAtURL(fileURL: NSURL, encryptionKey: NSData? = nil) throws -> UInt64 {
-    var error: NSError? = nil
-    let version = RLMRealm.schemaVersionAtURL(fileURL, encryptionKey: encryptionKey, error: &error)
-    if let error = error {
-        throw error
+    var error: NSError?
+    let version = RLMRealm.__schemaVersionAtURL(fileURL, encryptionKey: encryptionKey, error: &error)
+    guard version != RLMNotVersioned else {
+        throw error!
     }
     return version
 }


### PR DESCRIPTION
Fixes an issue where `schemaVersionAtURL:encryptionKey:error`, when used in Swift from the Objective-C API, would not import as throwing. Also, this now check return value to determine if there's an error in accordance to Cocoa conventions.

Fixes https://github.com/realm/realm-cocoa/issues/3816