### PR TITLE
Introduce `RLMNotification` typedef with Swift annotation

### DIFF
--- a/Realm/RLMConstants.h
+++ b/Realm/RLMConstants.h
@@ -18,6 +18,14 @@
 
 #import <Foundation/Foundation.h>
 
+// For compatibility with Xcode 7, before extensible string enums were introduced,
+#ifdef NS_EXTENSIBLE_STRING_ENUM
+#define RLM_EXTENSIBLE_STRING_ENUM_CASE_SWIFT_NAME(_, extensible_string_enum) NS_SWIFT_NAME(extensible_string_enum)
+#else
+#define NS_EXTENSIBLE_STRING_ENUM
+#define RLM_EXTENSIBLE_STRING_ENUM_CASE_SWIFT_NAME(fully_qualified, _) NS_SWIFT_NAME(fully_qualified)
+#endif
+
 #pragma mark - Enums
 
 /**
@@ -125,6 +133,11 @@ typedef NS_ENUM(NSInteger, RLMError) {
 #pragma mark - Notification Constants
 
 /**
+ A notification indicating that changes were made to a Realm.
+*/
+typedef NSString * RLMNotification NS_EXTENSIBLE_STRING_ENUM;
+
+/**
  This notification is posted by a Realm when the data in that Realm has changed.
 
  More specifically, this notification is posted after a Realm has been refreshed to
@@ -132,12 +145,13 @@ typedef NS_ENUM(NSInteger, RLMError) {
  `-[RLMRealm refresh]` is called, after an implicit refresh from `-[RLMRealm beginWriteTransaction]`,
  or after a local write transaction is completed.
  */
-extern NSString * const RLMRealmRefreshRequiredNotification;
+extern RLMNotification const RLMRealmRefreshRequiredNotification
+RLM_EXTENSIBLE_STRING_ENUM_CASE_SWIFT_NAME(RLMRealmRefreshRequiredNotification, RefreshRequired);
 
 /**
  This notification is posted by a Realm when a write transaction has been
  committed to a Realm on a different thread for the same file.
- 
+
  It is not posted if `-[RLMRealm autorefresh]` is enabled, or if the Realm is
  refreshed before the notification has a chance to run.
 
@@ -147,7 +161,8 @@ extern NSString * const RLMRealmRefreshRequiredNotification;
  files. This is because Realm must keep an extra copy of the data for the stale
  Realm.
  */
-extern NSString * const RLMRealmDidChangeNotification;
+extern RLMNotification const RLMRealmDidChangeNotification
+RLM_EXTENSIBLE_STRING_ENUM_CASE_SWIFT_NAME(RLMRealmDidChangeNotification, DidChange);
 
 #pragma mark - Other Constants
 

--- a/Realm/RLMConstants.m
+++ b/Realm/RLMConstants.m
@@ -18,8 +18,8 @@
 
 #import <Realm/RLMConstants.h>
 
-NSString * const RLMRealmRefreshRequiredNotification = @"RLMRealmRefreshRequiredNotification";
-NSString * const RLMRealmDidChangeNotification = @"RLMRealmDidChangeNotification";
+RLMNotification const RLMRealmRefreshRequiredNotification = @"RLMRealmRefreshRequiredNotification";
+RLMNotification const RLMRealmDidChangeNotification = @"RLMRealmDidChangeNotification";
 
 NSString * const RLMErrorDomain = @"io.realm";
 

--- a/Realm/RLMRealm.h
+++ b/Realm/RLMRealm.h
@@ -17,6 +17,7 @@
 ////////////////////////////////////////////////////////////////////////////
 
 #import <Foundation/Foundation.h>
+#import "RLMConstants.h"
 
 @class RLMRealmConfiguration, RLMObject, RLMSchema, RLMMigration, RLMNotificationToken;
 
@@ -120,7 +121,7 @@ NS_ASSUME_NONNULL_BEGIN
  
  @see `-[RLMRealm addNotificationBlock:]`
  */
-typedef void (^RLMNotificationBlock)(NSString *notification, RLMRealm *realm);
+typedef void (^RLMNotificationBlock)(RLMNotification notification, RLMRealm *realm);
 
 #pragma mark - Receiving Notification when a Realm Changes
 
@@ -136,7 +137,7 @@ typedef void (^RLMNotificationBlock)(NSString *notification, RLMRealm *realm);
 
  The block has the following definition:
 
-     typedef void(^RLMNotificationBlock)(NSString *notification, RLMRealm *realm);
+     typedef void(^RLMNotificationBlock)(RLMNotification notification, RLMRealm *realm);
 
  It receives the following parameters:
 

--- a/Realm/RLMRealm.mm
+++ b/Realm/RLMRealm.mm
@@ -49,7 +49,7 @@ using util::File;
 
 @interface RLMRealm ()
 @property (nonatomic, strong) NSHashTable *notificationHandlers;
-- (void)sendNotifications:(NSString *)notification;
+- (void)sendNotifications:(RLMNotification)notification;
 @end
 
 void RLMDisableSyncToDisk() {
@@ -443,7 +443,7 @@ REALM_NOINLINE void RLMRealmTranslateException(NSError **error) {
     return token;
 }
 
-- (void)sendNotifications:(NSString *)notification {
+- (void)sendNotifications:(RLMNotification)notification {
     NSAssert(!_realm->config().read_only, @"Read-only realms do not have notifications");
 
     NSUInteger count = _notificationHandlers.count;

--- a/Realm/RLMRealm_Private.h
+++ b/Realm/RLMRealm_Private.h
@@ -41,7 +41,7 @@ void RLMRealmTranslateException(NSError **error);
 - (void)unregisterEnumerator:(RLMFastEnumerator *)enumerator;
 - (void)detachAllEnumerators;
 
-- (void)sendNotifications:(NSString *)notification;
+- (void)sendNotifications:(RLMNotification)notification;
 - (void)verifyThread;
 - (void)verifyNotificationsAreSupported;
 

--- a/Realm/Tests/AsyncTests.mm
+++ b/Realm/Tests/AsyncTests.mm
@@ -326,7 +326,7 @@
         @autoreleasepool {
             __block RLMNotificationToken *token;
             CFRunLoopPerformBlock(CFRunLoopGetCurrent(), kCFRunLoopDefaultMode, ^{
-                token = [RLMRealm.defaultRealm addNotificationBlock:^(NSString *notification, RLMRealm *realm) {
+                token = [RLMRealm.defaultRealm addNotificationBlock:^(RLMNotification notification, RLMRealm *realm) {
                     CFRunLoopStop(CFRunLoopGetCurrent());
                     dispatch_semaphore_signal(sema);
                     [token stop];
@@ -775,7 +775,7 @@
 - (void)testAddingNewQueryWithinRealmNotificationBlock {
     __block RLMNotificationToken *queryToken;
     __block XCTestExpectation *exp;
-    auto realmToken = [RLMRealm.defaultRealm addNotificationBlock:^(NSString *notification, RLMRealm *realm) {
+    auto realmToken = [RLMRealm.defaultRealm addNotificationBlock:^(RLMNotification notification, RLMRealm *realm) {
         CFRunLoopStop(CFRunLoopGetCurrent());
         exp = [self expectationWithDescription:@"query notification"];
         queryToken = [IntObject.allObjects addNotificationBlock:^(RLMResults *results, RLMCollectionChange *change, NSError *e) {

--- a/Realm/Tests/InterprocessTests.m
+++ b/Realm/Tests/InterprocessTests.m
@@ -126,7 +126,7 @@
 
 - (void)testBackgroundProcessDoesNotTriggerSpuriousNotifications {
     RLMRealm *realm = [RLMRealm defaultRealm];
-    RLMNotificationToken *token = [realm addNotificationBlock:^(__unused NSString *notification, __unused RLMRealm *realm) {
+    RLMNotificationToken *token = [realm addNotificationBlock:^(__unused RLMNotification notification, __unused RLMRealm *realm) {
         XCTFail(@"Notification should not have been triggered");
     }];
 

--- a/Realm/Tests/RLMTestCase.h
+++ b/Realm/Tests/RLMTestCase.h
@@ -42,7 +42,7 @@ NSData *RLMGenerateKey(void);
 - (void)deleteFiles;
 - (void)deleteRealmFileAtURL:(NSURL *)fileURL;
 
-- (void)waitForNotification:(NSString *)expectedNote realm:(RLMRealm *)realm block:(dispatch_block_t)block;
+- (void)waitForNotification:(RLMNotification)expectedNote realm:(RLMRealm *)realm block:(dispatch_block_t)block;
 
 - (id)nonLiteralNil;
 

--- a/RealmSwift/Realm.swift
+++ b/RealmSwift/Realm.swift
@@ -475,10 +475,13 @@ public final class Realm {
     */
     public func addNotificationBlock(block: NotificationBlock) -> NotificationToken {
         return rlmRealm.addNotificationBlock { rlmNotification, _ in
-            if rlmNotification == NSNotification.Name.RLMRealmDidChange.rawValue {
-                block(notification: Notification.DidChange, realm: self)
-            } else if rlmNotification == NSNotification.Name.RLMRealmRefreshRequired.rawValue {
-                block(notification: Notification.RefreshRequired, realm: self)
+            switch rlmNotification {
+            case RLMNotification.DidChange:
+                block(notification: .DidChange, realm: self)
+            case RLMNotification.RefreshRequired:
+                block(notification: .RefreshRequired, realm: self)
+            default:
+                fatalError("Unhandled notification type: \(rlmNotification)")
             }
         }
     }
@@ -1130,10 +1133,13 @@ public final class Realm {
     @warn_unused_result(message="You must hold on to the NotificationToken returned from addNotificationBlock")
     public func addNotificationBlock(block: NotificationBlock) -> NotificationToken {
         return rlmRealm.addNotificationBlock { rlmNotification, _ in
-            if rlmNotification == RLMRealmDidChangeNotification {
-                block(notification: Notification.DidChange, realm: self)
-            } else if rlmNotification == RLMRealmRefreshRequiredNotification {
-                block(notification: Notification.RefreshRequired, realm: self)
+            switch rlmNotification {
+            case RLMRealmDidChangeNotification:
+                block(notification: .DidChange, realm: self)
+            case RLMRealmRefreshRequiredNotification:
+                block(notification: .RefreshRequired, realm: self)
+            default:
+                fatalError("Unhandled notification type: \(rlmNotification)")
             }
         }
     }


### PR DESCRIPTION
The importer will automatically convert our notification string constants into a Swift enum with `String` raw values. This is an improvement to the Objective-C API when used in Swift. Since this requires a feature only available in Xcode 8, this will _not_ break the API for existing users until they upgrade to Swift 3 (which is a breaking change anyway).

This is an incremental change that's necessary if we decide to go through with https://github.com/realm/realm-cocoa/issues/3790.