### PR TITLE
Fix createOrUpdate when column order does not match property order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ x.x.x Release notes (yyyy-MM-dd)
 ### Bugfixes
 
 * Fix a crash when reading the shared schema from an observed Swift object.
+* Fix crashes or incorrect results when passing an array of values to
+  `createOrUpdate` after reordering the class's properties.
 
 1.0.1 Release notes (2016-06-12)
 =============================================================

--- a/Realm/RLMObjectStore.mm
+++ b/Realm/RLMObjectStore.mm
@@ -293,11 +293,13 @@ RLMObjectBase *RLMCreateObjectInRealmWithValue(RLMRealm *realm, NSString *classN
     if (NSArray *array = RLMDynamicCast<NSArray>(value)) {
         // get or create our accessor
         bool created;
-        auto primaryGetter = [=](__unsafe_unretained RLMProperty *const p) { return array[p.column]; };
+        NSArray *props = objectSchema.propertiesInDeclaredOrder;
+        auto primaryGetter = [=](__unsafe_unretained RLMProperty *const p) {
+            return array[[props indexOfObject:p]];
+        };
         object->_row = (*objectSchema.table)[RLMCreateOrGetRowForObject(objectSchema, primaryGetter, createOrUpdate, created)];
 
         // populate
-        NSArray *props = objectSchema.propertiesInDeclaredOrder;
         for (NSUInteger i = 0; i < array.count; i++) {
             RLMProperty *prop = props[i];
             // skip primary key when updating since it doesn't change

--- a/Realm/Tests/ObjectTests.m
+++ b/Realm/Tests/ObjectTests.m
@@ -18,6 +18,9 @@
 
 #import "RLMTestCase.h"
 
+#import "RLMObjectSchema_Private.h"
+#import "RLMSchema_Private.h"
+
 #import <libkern/OSAtomic.h>
 #import <math.h>
 #import <objc/runtime.h>
@@ -1880,6 +1883,33 @@ static void testDatesInRange(NSTimeInterval from, NSTimeInterval to, void (^chec
     [realm commitWriteTransaction];
 }
 
+- (void)testCreateOrUpdateWithReorderedColumns {
+    @autoreleasepool {
+        // Create a Realm file with the properties in reverse order
+        RLMObjectSchema *objectSchema = [RLMObjectSchema schemaForObjectClass:PrimaryStringObject.class];
+        objectSchema.properties = @[objectSchema.properties[1], objectSchema.properties[0]];
+        RLMSchema *schema = [RLMSchema new];
+        schema.objectSchema = @[objectSchema];
+
+        RLMRealm *realm = [self realmWithTestPathAndSchema:schema];
+        [realm beginWriteTransaction];
+        [PrimaryStringObject createOrUpdateInRealm:realm withValue:@[@"a", @5]];
+        [realm commitWriteTransaction];
+    }
+
+    RLMRealm *realm = [self realmWithTestPath];
+    [realm beginWriteTransaction];
+
+    XCTAssertEqual([PrimaryStringObject objectInRealm:realm forPrimaryKey:@"a"].intCol, 5);
+
+    // Values in array are used in property declaration order, not table column order
+    [PrimaryStringObject createOrUpdateInRealm:realm withValue:@[@"a", @6]];
+    XCTAssertEqual([PrimaryStringObject objectInRealm:realm forPrimaryKey:@"a"].intCol, 6);
+
+    [PrimaryStringObject createOrUpdateInRealm:realm withValue:@{@"stringCol": @"a", @"intCol": @7}];
+    XCTAssertEqual([PrimaryStringObject objectInRealm:realm forPrimaryKey:@"a"].intCol, 7);
+    [realm commitWriteTransaction];
+}
 
 - (void)testObjectInSet {
     [[RLMRealm defaultRealm] beginWriteTransaction];


### PR DESCRIPTION
It was incorrectly using the table column as an index in the input array for the primary key value.

@bdash @jpsim 