### PR TITLE
Fixing documentation for Swift 3 APIs

### DIFF
--- a/Realm.xcodeproj/project.pbxproj
+++ b/Realm.xcodeproj/project.pbxproj
@@ -61,6 +61,7 @@
 		02AFB4671A80343600E11938 /* ResultsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 02AFB4621A80343600E11938 /* ResultsTests.m */; };
 		02AFB4681A80343600E11938 /* ResultsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 02AFB4621A80343600E11938 /* ResultsTests.m */; };
 		02E334C31A5F41C7009F8810 /* DynamicTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E81A1FBA1955FE0100FDED82 /* DynamicTests.m */; };
+		1AB605D31D495927007F53DE /* RealmCollection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AB605D21D495927007F53DE /* RealmCollection.swift */; };
 		2973CCF91C175AB400FEA0FA /* fileformat-pre-null.realm in Resources */ = {isa = PBXBuildFile; fileRef = 29B7FDF71C0DE76B0023224E /* fileformat-pre-null.realm */; };
 		297FBEFB1C19F696009D1118 /* RLMTestCaseUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 297FBEFA1C19F696009D1118 /* RLMTestCaseUtils.swift */; };
 		297FBEFF1C19F844009D1118 /* TestUtils.mm in Sources */ = {isa = PBXBuildFile; fileRef = 297FBEFE1C19F844009D1118 /* TestUtils.mm */; };
@@ -243,7 +244,6 @@
 		5D660FF61BE98D670021E04F /* Optional.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D660FE81BE98D670021E04F /* Optional.swift */; };
 		5D660FF71BE98D670021E04F /* Property.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D660FE91BE98D670021E04F /* Property.swift */; };
 		5D660FF81BE98D670021E04F /* Realm.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D660FEA1BE98D670021E04F /* Realm.swift */; };
-		5D660FF91BE98D670021E04F /* RealmCollectionType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D660FEB1BE98D670021E04F /* RealmCollectionType.swift */; };
 		5D660FFA1BE98D670021E04F /* RealmConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D660FEC1BE98D670021E04F /* RealmConfiguration.swift */; };
 		5D660FFB1BE98D670021E04F /* Results.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D660FED1BE98D670021E04F /* Results.swift */; };
 		5D660FFC1BE98D670021E04F /* Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D660FEE1BE98D670021E04F /* Schema.swift */; };
@@ -509,6 +509,7 @@
 		02B8EF5B19E7048D0045A93D /* RLMCollection.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RLMCollection.h; sourceTree = "<group>"; };
 		02E334C21A5F3C45009F8810 /* module.modulemap */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.module-map"; path = module.modulemap; sourceTree = "<group>"; };
 		02E334C41A5F4923009F8810 /* RLMRealm_Private.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = RLMRealm_Private.hpp; sourceTree = "<group>"; };
+		1AB605D21D495927007F53DE /* RealmCollection.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RealmCollection.swift; sourceTree = "<group>"; };
 		26F3CA681986CC86004623E1 /* SwiftPropertyTypeTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwiftPropertyTypeTest.swift; sourceTree = "<group>"; };
 		297FBEFA1C19F696009D1118 /* RLMTestCaseUtils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RLMTestCaseUtils.swift; sourceTree = "<group>"; };
 		297FBEFD1C19F844009D1118 /* TestUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TestUtils.h; path = Realm/Tests/TestUtils.h; sourceTree = SOURCE_ROOT; };
@@ -608,7 +609,6 @@
 		5D660FE81BE98D670021E04F /* Optional.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Optional.swift; sourceTree = "<group>"; };
 		5D660FE91BE98D670021E04F /* Property.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Property.swift; sourceTree = "<group>"; };
 		5D660FEA1BE98D670021E04F /* Realm.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Realm.swift; sourceTree = "<group>"; };
-		5D660FEB1BE98D670021E04F /* RealmCollectionType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RealmCollectionType.swift; sourceTree = "<group>"; };
 		5D660FEC1BE98D670021E04F /* RealmConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RealmConfiguration.swift; sourceTree = "<group>"; };
 		5D660FED1BE98D670021E04F /* Results.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Results.swift; sourceTree = "<group>"; };
 		5D660FEE1BE98D670021E04F /* Schema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Schema.swift; sourceTree = "<group>"; };
@@ -891,7 +891,7 @@
 				5D660FE81BE98D670021E04F /* Optional.swift */,
 				5D660FE91BE98D670021E04F /* Property.swift */,
 				5D660FEA1BE98D670021E04F /* Realm.swift */,
-				5D660FEB1BE98D670021E04F /* RealmCollectionType.swift */,
+				1AB605D21D495927007F53DE /* RealmCollection.swift */,
 				5D660FEC1BE98D670021E04F /* RealmConfiguration.swift */,
 				5D660FED1BE98D670021E04F /* Results.swift */,
 				5D660FEE1BE98D670021E04F /* Schema.swift */,
@@ -1820,10 +1820,10 @@
 				5D660FF31BE98D670021E04F /* Migration.swift in Sources */,
 				5D660FF41BE98D670021E04F /* Object.swift in Sources */,
 				5D660FF51BE98D670021E04F /* ObjectSchema.swift in Sources */,
+				1AB605D31D495927007F53DE /* RealmCollection.swift in Sources */,
 				5D660FF61BE98D670021E04F /* Optional.swift in Sources */,
 				5D660FF71BE98D670021E04F /* Property.swift in Sources */,
 				5D660FF81BE98D670021E04F /* Realm.swift in Sources */,
-				5D660FF91BE98D670021E04F /* RealmCollectionType.swift in Sources */,
 				5D660FFA1BE98D670021E04F /* RealmConfiguration.swift in Sources */,
 				5D660FFB1BE98D670021E04F /* Results.swift in Sources */,
 				5D660FFC1BE98D670021E04F /* Schema.swift in Sources */,

--- a/Realm/RLMObject.h
+++ b/Realm/RLMObject.h
@@ -96,7 +96,7 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark - Creating & Initializing Objects
 
 /**
- Initializes an unmanaged instance of a Realm object.
+ Creates an unmanaged instance of a Realm object.
 
  Call `addObject:` on an `RLMRealm` instance to add an unmanaged object into that Realm.
  
@@ -106,7 +106,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 
 /**
- Initializes an unmanaged instance of a Realm object.
+ Creates an unmanaged instance of a Realm object.
  
  Pass in an `NSArray` or `NSDictionary` instance to set the values of the object's properties.
 
@@ -413,7 +413,7 @@ NS_ASSUME_NONNULL_BEGIN
 
  @param object  The object to compare the receiver to.
 
- @return    A Boolean indicating whether the object represents the same object as the receiver.
+ @return    Whether the object represents the same object as the receiver.
  */
 - (BOOL)isEqualToObject:(RLMObject *)object;
 

--- a/Realm/RLMObjectSchema.h
+++ b/Realm/RLMObjectSchema.h
@@ -63,8 +63,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable RLMProperty *)objectForKeyedSubscript:(NSString *)propertyName;
 
 /**
-  Returns a Boolean value that indicates whether two `RLMObjectSchema` instances are equal.
-*/
+ Returns whether two `RLMObjectSchema` instances are equal.
+ */
 - (BOOL)isEqualToObjectSchema:(RLMObjectSchema *)objectSchema;
 
 @end

--- a/Realm/RLMProperty.h
+++ b/Realm/RLMProperty.h
@@ -90,7 +90,7 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark - Methods
 
 /**
- Returns a Boolean value that indicates whether a given property object is equal to the receiver.
+ Returns whether a given property object is equal to the receiver.
  */
 - (BOOL)isEqualToProperty:(RLMProperty *)property;
 

--- a/Realm/RLMSchema.h
+++ b/Realm/RLMSchema.h
@@ -68,7 +68,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (RLMObjectSchema *)objectForKeyedSubscript:(NSString *)className;
 
 /**
- Returns a Boolean value that indicates whether two `RLMSchema` instances are equivalent.
+ Returns whether two `RLMSchema` instances are equivalent.
  */
 - (BOOL)isEqualToSchema:(RLMSchema *)schema;
 

--- a/RealmSwift/LinkingObjects.swift
+++ b/RealmSwift/LinkingObjects.swift
@@ -60,53 +60,53 @@ public class LinkingObjectsBase: NSObject, NSFastEnumeration {
 }
 
 /**
- LinkingObjects is an auto-updating container type that represents a collection of objects that
- link to a given object.
+ `LinkingObjects` is an auto-updating container type. It represents zero or more objects that are linked to its owning
+ model object through a property relationship.
 
- LinkingObjects can be queried with the same predicates as `List<T>` and `Results<T>`.
+ `LinkingObjects` can be queried with the same predicates as `List<T>` and `Results<T>`.
 
- LinkingObjects always reflect the current state of the Realm on the current thread,
- including during write transactions on the current thread. The one exception to
- this is when using `for...in` enumeration, which will always enumerate over the
- linking objects when the enumeration is begun, even if some of them are deleted or
+ `LinkingObjects` always reflects the current state of the Realm on the current thread, including during write
+ transactions on the current thread. The one exception to this is when using `for...in` enumeration, which will always
+ enumerate over the linking objects that were present when the enumeration is begun, even if some of them are deleted or
  modified to no longer link to the target object during the enumeration.
 
- LinkingObjects can only be used as a property on `Object` models. The property must
- be declared as `let` and cannot be `dynamic`.
+ `LinkingObjects` can only be used as a property on `Object` models. Properties of this type must be declared as `let`
+ and cannot be `dynamic`.
  */
 public final class LinkingObjects<T: Object>: LinkingObjectsBase {
-    /// Element type contained in this collection.
+    /// The type of the objects represented by the linking objects.
     public typealias Element = T
 
     // MARK: Properties
 
-    /// Returns the Realm these linking objects are associated with.
+    /// The Realm which manages the linking objects, or `nil` if the linking objects are unmanaged.
     public var realm: Realm? { return rlmResults.isAttached ? Realm(rlmResults.realm) : nil }
 
-    /// Indicates if the linking objects can no longer be accessed.
+    /// Indicates if the linking objects are no longer valid.
     ///
-    /// Linking objects can no longer be accessed if `invalidate` is called on the containing `Realm`.
+    /// The linking objects become invalid if `invalidate()` is called on the containing `realm` instance.
+    ///
+    /// An invalidated linking objects can be accessed, but will always be empty.
     public var isInvalidated: Bool { return rlmResults.isInvalidated }
 
-    /// Returns the number of objects in these linking objects.
+    /// The number of linking objects.
     public var count: Int { return Int(rlmResults.count) }
 
     // MARK: Initializers
 
     /**
-     Creates a LinkingObjects. This initializer should only be called when
-     declaring a property on a Realm model.
+     Creates an instance of a `LinkingObjects`. This initializer should only be called when declaring a property on a
+     Realm model.
 
-     - parameter type:         The originating type linking to this object type.
-     - parameter propertyName: The property name of the incoming relationship
-                               this LinkingObjects should refer to.
-    */
+     - parameter type:         The type of the object owning the property the linking objects should refer to.
+     - parameter propertyName: The property name of the property the linking objects should refer to.
+     */
     public init(fromType type: T.Type, property propertyName: String) {
         let className = (T.self as Object.Type).className()
         super.init(fromClassName: className, property: propertyName)
     }
 
-    /// Returns a human-readable description of the objects contained in these linking objects.
+    /// A human-readable description of the objects represented by the linking objects.
     public override var description: String {
         let type = "LinkingObjects<\(rlmResults.objectClassName)>"
         return gsub(pattern: "RLMResults <0x[a-z0-9]+>", template: type, string: rlmResults.description) ?? type
@@ -115,35 +115,27 @@ public final class LinkingObjects<T: Object>: LinkingObjectsBase {
     // MARK: Index Retrieval
 
     /**
-     Returns the index of the given object, or `nil` if the object is not present.
+     Returns the index of an object in the linking objects, or `nil` if the object is not present.
 
      - parameter object: The object whose index is being queried.
-
-     - returns: The index of the given object, or `nil` if the object is not present.
      */
     public func index(of object: T) -> Int? {
         return notFoundToNil(index: rlmResults.index(of: object.unsafeCastToRLMObject()))
     }
 
     /**
-     Returns the index of the first object matching the given predicate,
-     or `nil` if no objects match.
+     Returns the index of the first object matching the given predicate, or `nil` if no objects match.
 
-     - parameter predicate: The predicate to filter the objects.
-
-     - returns: The index of the first matching object, or `nil` if no objects match.
+     - parameter predicate: The predicate with which to filter the objects.
      */
     public func index(matching predicate: NSPredicate) -> Int? {
         return notFoundToNil(index: rlmResults.indexOfObject(with: predicate))
     }
 
     /**
-     Returns the index of the first object matching the given predicate,
-     or `nil` if no objects match.
+     Returns the index of the first object matching the given predicate, or `nil` if no objects match.
 
-     - parameter predicateFormat: The predicate format string which can accept variable arguments.
-
-     - returns: The index of the first matching object, or `nil` if no objects match.
+     - parameter predicateFormat: A predicate format string, optionally followed by a variable number of arguments.
      */
     public func index(matching predicateFormat: String, _ args: Any...) -> Int? {
         return notFoundToNil(index: rlmResults.indexOfObject(with: NSPredicate(format: predicateFormat,
@@ -156,8 +148,6 @@ public final class LinkingObjects<T: Object>: LinkingObjectsBase {
      Returns the object at the given `index`.
 
      - parameter index: The index.
-
-     - returns: The object at the given `index`.
      */
     public subscript(index: Int) -> T {
         get {
@@ -166,47 +156,40 @@ public final class LinkingObjects<T: Object>: LinkingObjectsBase {
         }
     }
 
-    /// Returns the first object in the collection, or `nil` if empty.
+    /// Returns the first object in the linking objects, or `nil` if the linking objects are empty.
     public var first: T? { return unsafeBitCast(rlmResults.firstObject(), to: Optional<T>.self) }
 
-    /// Returns the last object in the collection, or `nil` if empty.
+    /// Returns the last object in the linking objects, or `nil` if the linking objects are empty.
     public var last: T? { return unsafeBitCast(rlmResults.lastObject(), to: Optional<T>.self) }
 
     // MARK: KVC
 
     /**
-     Returns an Array containing the results of invoking `valueForKey(_:)` using key on each of the
-     collection's objects.
+     Returns an `Array` containing the results of invoking `valueForKey(_:)` with `key` on each of the linking objects.
 
-     - parameter key: The name of the property.
-
-     - returns: Array containing the results of invoking `valueForKey(_:)` using key on each of the
-       collection's objects.
+     - parameter key: The name of the property whose values are desired.
      */
     public override func value(forKey key: String) -> Any? {
         return value(forKeyPath: key)
     }
 
     /**
-     Returns an Array containing the results of invoking `valueForKeyPath(_:)` using keyPath on each of the
-     collection's objects.
+     Returns an `Array` containing the results of invoking `valueForKeyPath(_:)` with `keyPath` on each of the linking
+     objects.
 
-     - parameter keyPath: The key path to the property.
-
-     - returns: Array containing the results of invoking `valueForKeyPath(_:)` using keyPath on each of the
-       collection's objects.
+     - parameter keyPath: The key path to the property whose values are desired.
      */
     public override func value(forKeyPath keyPath: String) -> Any? {
         return rlmResults.value(forKeyPath: keyPath)
     }
 
     /**
-     Invokes `setValue(_:forKey:)` on each of the collection's objects using the specified value and key.
+     Invokes `setValue(_:forKey:)` on each of the linking objects using the specified `value` and `key`.
 
-     - warning: This method can only be called during a write transaction.
+     - warning: This method may only be called during a write transaction.
 
-     - parameter value: The object value.
-     - parameter key:   The name of the property.
+     - parameter value: The value to set the property to.
+     - parameter key:   The name of the property whose value should be set on each object.
      */
     public override func setValue(_ value: Any?, forKey key: String) {
         return rlmResults.setValue(value, forKeyPath: key)
@@ -215,22 +198,18 @@ public final class LinkingObjects<T: Object>: LinkingObjectsBase {
     // MARK: Filtering
 
     /**
-     Filters the collection to the objects that match the given predicate.
+     Returns a `Results` containing all objects matching the given predicate in the linking objects.
 
-     - parameter predicateFormat: The predicate format string which can accept variable arguments.
-
-     - returns: Results containing objects that match the given predicate.
+     - parameter predicateFormat: A predicate format string, optionally followed by a variable number of arguments.
      */
     public func filter(_ predicateFormat: String, _ args: Any...) -> Results<T> {
         return Results<T>(rlmResults.objects(with: NSPredicate(format: predicateFormat, argumentArray: args)))
     }
 
     /**
-     Filters the collection to the objects that match the given predicate.
+     Returns a `Results` containing all objects matching the given predicate in the linking objects.
 
-     - parameter predicate: The predicate to filter the objects.
-
-     - returns: Results containing objects that match the given predicate.
+     - parameter predicate: The predicate with which to filter the objects.
      */
     public func filter(_ predicate: NSPredicate) -> Results<T> {
         return Results<T>(rlmResults.objects(with: predicate))
@@ -239,23 +218,31 @@ public final class LinkingObjects<T: Object>: LinkingObjectsBase {
     // MARK: Sorting
 
     /**
-     Returns `Results` with elements sorted by the given property name.
+     Returns a `Results` containing all the linking objects, but sorted.
 
-     - parameter property:  The property name to sort by.
-     - parameter ascending: The direction to sort by.
+     Objects are sorted based on the values of the given property. For example, to sort a collection of `Student`s from
+     youngest to oldest based on their `age` property, you might call
+     `students.sorted(byProperty: "age", ascending: true)`.
 
-     - returns: `Results` with elements sorted by the given property name.
+     - warning: Collections may only be sorted by properties of boolean, `Date`, `NSDate`, single and double-precision
+                floating point, integer, and string types.
+
+     - parameter property:  The name of the property to sort by.
+     - parameter ascending: The direction to sort in.
      */
     public func sorted(byProperty property: String, ascending: Bool = true) -> Results<T> {
         return sorted(by: [SortDescriptor(property: property, ascending: ascending)])
     }
 
     /**
-     Returns `Results` with elements sorted by the given sort descriptors.
+     Returns a `Results` containing all the linking objects, but sorted.
 
-     - parameter sortDescriptors: `SortDescriptor`s to sort by.
+     - warning: Collections may only be sorted by properties of boolean, `Date`, `NSDate`, single and double-precision
+                floating point, integer, and string types.
 
-     - returns: `Results` with elements sorted by the given sort descriptors.
+     - see: `sorted(byProperty:ascending:)`
+
+     - parameter sortDescriptors: A sequence of `SortDescriptor`s to sort by.
      */
     public func sorted<S: Sequence>(by sortDescriptors: S) -> Results<T> where S.Iterator.Element == SortDescriptor {
         return Results<T>(rlmResults.sortedResults(using: sortDescriptors.map { $0.rlmSortDescriptorValue }))
@@ -264,55 +251,47 @@ public final class LinkingObjects<T: Object>: LinkingObjectsBase {
     // MARK: Aggregate Operations
 
     /**
-     Returns the minimum value of the given property.
+     Returns the minimum (lowest) value of the given property among all the linking objects, or `nil` if the linking
+     objects are empty.
 
-     - warning: Only names of properties of a type conforming to the `MinMaxType` protocol can be used.
+     - warning: Only a property whose type conforms to the `MinMaxType` protocol can be specified.
 
-     - parameter property: The name of a property conforming to `MinMaxType` to look for a minimum on.
-
-     - returns: The minimum value for the property amongst objects in the collection, or `nil` if the collection
-       is empty.
+     - parameter property: The name of a property whose minimum value is desired.
      */
     public func min<U: MinMaxType>(ofProperty property: String) -> U? {
         return rlmResults.min(ofProperty: property).map(dynamicBridgeCast)
     }
 
     /**
-     Returns the maximum value of the given property.
+     Returns the maximum (highest) value of the given property among all the linking objects, or `nil` if the linking
+     objects are empty.
 
-     - warning: Only names of properties of a type conforming to the `MinMaxType` protocol can be used.
+     - warning: Only a property whose type conforms to the `MinMaxType` protocol can be specified.
 
-     - parameter property: The name of a property conforming to `MinMaxType` to look for a maximum on.
-
-     - returns: The maximum value for the property amongst objects in the collection, or `nil` if the collection
-       is empty.
+     - parameter property: The name of a property whose minimum value is desired.
      */
     public func max<U: MinMaxType>(ofProperty property: String) -> U? {
         return rlmResults.max(ofProperty: property).map(dynamicBridgeCast)
     }
 
     /**
-     Returns the sum of the given property for objects in the collection.
+     Returns the sum of the values of a given property over all the linking objects.
 
-     - warning: Only names of properties of a type conforming to the `AddableType` protocol can be used.
+     - warning: Only a property whose type conforms to the `AddableType` protocol can be specified.
 
-     - parameter property: The name of a property conforming to `AddableType` to calculate sum on.
-
-     - returns: The sum of the given property over all objects in the collection.
+     - parameter property: The name of a property whose values should be summed.
      */
     public func sum<U: AddableType>(ofProperty property: String) -> U {
         return dynamicBridgeCast(fromObjectiveC: rlmResults.sum(ofProperty: property))
     }
 
     /**
-     Returns the average of the given property for objects in the collection.
+     Returns the average value of a given property over all the linking objects, or `nil` if the linking objects are
+     empty.
 
-     - warning: Only names of properties of a type conforming to the `AddableType` protocol can be used.
+     - warning: Only the name of a property whose type conforms to the `AddableType` protocol can be specified.
 
-     - parameter property: The name of a property conforming to `AddableType` to calculate average on.
-
-     - returns: The average of the given property over all objects in the collection, or `nil` if the collection
-       is empty.
+     - parameter property: The name of a property whose average value should be calculated.
      */
     public func average<U: AddableType>(ofProperty property: String) -> U? {
         return rlmResults.average(ofProperty: property).map(dynamicBridgeCast)
@@ -321,61 +300,58 @@ public final class LinkingObjects<T: Object>: LinkingObjectsBase {
     // MARK: Notifications
 
     /**
-     Register a block to be called each time the LinkingObjects changes.
+     Registers a block to be called each time the collection changes.
 
-     The block will be asynchronously called with the initial set of objects, and then
-     called again after each write transaction which changes either any of the
-     objects in the collection, or which objects are in the collection.
+     The block will be asynchronously called with the initial results, and then called again after each write
+     transaction which changes either any of the objects in the collection, or which objects are in the collection.
 
-     This version of this method reports which of the objects in the collection were
-     added, removed, or modified in each write transaction as indices within the
-     collection. See the RealmCollectionChange documentation for more information on
-     the change information supplied and an example of how to use it to update
-     a UITableView.
+     The `change` parameter that is passed to the block reports, in the form of indices within the collection, which of
+     the objects were added, removed, or modified during each write transaction. See the `RealmCollectionChange`
+     documentation for more information on the change information supplied and an example of how to use it to update a
+     `UITableView`.
 
-     At the time when the block is called, the LinkingObjects object will be fully
-     evaluated and up-to-date, and as long as you do not perform a write transaction
-     on the same thread or explicitly call realm.refresh(), accessing it will never
+     At the time when the block is called, the collection will be fully evaluated and up-to-date, and as long as you do
+     not perform a write transaction on the same thread or explicitly call `realm.refresh()`, accessing it will never
      perform blocking work.
 
-     Notifications are delivered via the standard run loop, and so can't be
-     delivered while the run loop is blocked by other activity. When
-     notifications can't be delivered instantly, multiple notifications may be
-     coalesced into a single notification. This can include the notification
-     with the initial set of objects. For example, the following code performs a write
-     transaction immediately after adding the notification block, so there is no
-     opportunity for the initial notification to be delivered first. As a
-     result, the initial notification will reflect the state of the Realm after
-     the write transaction.
+     Notifications are delivered via the standard run loop, and so can't be delivered while the run loop is blocked by
+     other activity. When notifications can't be delivered instantly, multiple notifications may be coalesced into a
+     single notification. This can include the notification with the initial collection.
 
-         let dog = realm.objects(Dog).first!
-         let owners = dog.owners
-         print("owners.count: \(owners.count)") // => 0
-         let token = owners.addNotificationBlock { (changes: RealmCollectionChange) in
-             switch changes {
-                 case .Initial(let owners):
-                     // Will print "owners.count: 1"
-                     print("owners.count: \(owners.count)")
-                     break
-                 case .Update:
-                     // Will not be hit in this example
-                     break
-                 case .Error:
-                     break
-             }
+     For example, the following code performs a write transaction immediately after adding the notification block, so
+     there is no opportunity for the initial notification to be delivered first. As a result, the initial notification
+     will reflect the state of the Realm after the write transaction.
+
+     ```swift
+     let results = realm.objects(Dog.self)
+     print("dogs.count: \(dogs?.count)") // => 0
+     let token = dogs.addNotificationBlock { changes in
+         switch changes {
+         case .initial(let dogs):
+             // Will print "dogs.count: 1"
+             print("dogs.count: \(dogs.count)")
+             break
+         case .update:
+             // Will not be hit in this example
+             break
+         case .error:
+             break
          }
-         try! realm.write {
-             realm.add(Person.self, value: ["name": "Mark", dogs: [dog]])
-         }
-         // end of runloop execution context
+     }
+     try! realm.write {
+         let dog = Dog()
+         dog.name = "Rex"
+         person.dogs.append(dog)
+     }
+     // end of run loop execution context
+     ```
 
-     You must retain the returned token for as long as you want updates to continue
-     to be sent to the block. To stop receiving updates, call stop() on the token.
+     You must retain the returned token for as long as you want updates to be sent to the block. To stop receiving
+     updates, call `stop()` on the token.
 
-     - warning: This method cannot be called during a write transaction, or when
-     the source realm is read-only.
+     - warning: This method cannot be called during a write transaction, or when the containing Realm is read-only.
 
-     - parameter block: The block to be called with the evaluated linking objects and change information.
+     - parameter block: The block to be called whenever a change occurs.
      - returns: A token which must be held for as long as you want updates to be delivered.
      */
     public func addNotificationBlock(_ block: @escaping (RealmCollectionChange<LinkingObjects>) -> Void) -> NotificationToken {
@@ -388,7 +364,7 @@ public final class LinkingObjects<T: Object>: LinkingObjectsBase {
 extension LinkingObjects : RealmCollection {
     // MARK: Sequence Support
 
-    /// Returns a `GeneratorOf<T>` that yields successive elements in the results.
+    /// Returns an iterator that yields successive elements in the linking objects.
     public func makeIterator() -> RLMIterator<T> {
         return RLMIterator(collection: rlmResults)
     }
@@ -496,8 +472,8 @@ public class LinkingObjectsBase: NSObject, NSFastEnumeration {
 }
 
 /**
- `LinkingObjects` is an auto-updating container type. It represents a collection of objects that
- link to its parent object.
+ `LinkingObjects` is an auto-updating container type. It represents zero or more objects that are linked to its owning
+ model object through a property relationship.
 
  `LinkingObjects` can be queried with the same predicates as `List<T>` and `Results<T>`.
 
@@ -516,34 +492,34 @@ public final class LinkingObjects<T: Object>: LinkingObjectsBase {
 
     // MARK: Properties
 
-    /// The Realm which manages this linking objects collection, or `nil` if the collection is unmanaged.
+    /// The Realm which manages the linking objects, or `nil` if the linking objects are unmanaged.
     public var realm: Realm? { return rlmResults.attached ? Realm(rlmResults.realm) : nil }
 
-    /// Indicates if the linking objects collection is no longer valid.
+    /// Indicates if the linking objects are no longer valid.
     ///
-    /// The linking objects collection becomes invalid if `invalidate` is called on the containing `realm`.
+    /// The linking objects become invalid if `invalidate()` is called on the containing `realm` instance.
     ///
     /// An invalidated linking objects can be accessed, but will always be empty.
     public var invalidated: Bool { return rlmResults.invalidated }
 
-    /// The number of objects in the linking objects.
+    /// The number of linking objects.
     public var count: Int { return Int(rlmResults.count) }
 
     // MARK: Initializers
 
     /**
-     Creates an instance of a `LinkingObjects`. This initializer should only be called when
-     declaring a property on a Realm model.
+     Creates an instance of a `LinkingObjects`. This initializer should only be called when declaring a property on a
+     Realm model.
 
-     - parameter type:         The type of the object owning the property this `LinkingObjects` should refer to.
-     - parameter propertyName: The property name of the property this `LinkingObjects` should refer to.
+     - parameter type:         The type of the object owning the property the linking objects should refer to.
+     - parameter propertyName: The property name of the property the linking objects should refer to.
     */
     public init(fromType type: T.Type, property propertyName: String) {
         let className = (T.self as Object.Type).className()
         super.init(fromClassName: className, property: propertyName)
     }
 
-    /// Returns a description of the objects contained within the linking objects.
+    /// Returns a description of the linking objects.
     public override var description: String {
         let type = "LinkingObjects<\(rlmResults.objectClassName)>"
         return gsub("RLMResults <0x[a-z0-9]+>", template: type, string: rlmResults.description) ?? type
@@ -552,7 +528,7 @@ public final class LinkingObjects<T: Object>: LinkingObjectsBase {
     // MARK: Index Retrieval
 
     /**
-     Returns the index of an object in the linking objects collection, or `nil` if the object is not present.
+     Returns the index of an object in the linking objects, or `nil` if the object is not present.
 
      - parameter object: The object whose index is being queried.
      */
@@ -585,8 +561,6 @@ public final class LinkingObjects<T: Object>: LinkingObjectsBase {
      Returns the object at the given `index`.
 
      - parameter index: The index.
-
-     - returns: The object at the given `index`.
      */
     public subscript(index: Int) -> T {
         get {
@@ -595,17 +569,16 @@ public final class LinkingObjects<T: Object>: LinkingObjectsBase {
         }
     }
 
-    /// Returns the first object in the linking objects collection, or `nil` if the collection is empty.
+    /// Returns the first object in the linking objects, or `nil` if the linking objects are empty.
     public var first: T? { return unsafeBitCast(rlmResults.firstObject(), Optional<T>.self) }
 
-    /// Returns the last object in the linking objects collection, or `nil` if collection is empty.
+    /// Returns the last object in the linking objects, or `nil` if the linking objects are empty.
     public var last: T? { return unsafeBitCast(rlmResults.lastObject(), Optional<T>.self) }
 
     // MARK: KVC
 
     /**
-     Returns an `Array` containing the results of invoking `valueForKey(_:)` with `key` on each of the linking objects
-     collection's objects.
+     Returns an `Array` containing the results of invoking `valueForKey(_:)` with `key` on each of the linking objects.
 
      - parameter key: The name of the property whose values are desired.
      */
@@ -615,7 +588,7 @@ public final class LinkingObjects<T: Object>: LinkingObjectsBase {
 
     /**
      Returns an `Array` containing the results of invoking `valueForKeyPath(_:)` with `keyPath` on each of the linking
-     objects collection's objects.
+     objects.
 
      - parameter keyPath: The key path to the property whose values are desired.
      */
@@ -624,8 +597,7 @@ public final class LinkingObjects<T: Object>: LinkingObjectsBase {
     }
 
     /**
-     Invokes `setValue(_:forKey:)` on each of the linking objects collection's objects using the specified `value` and
-     `key`.
+     Invokes `setValue(_:forKey:)` on each of the linking objects using the specified `value` and `key`.
 
      - warning: This method may only be called during a write transaction.
 
@@ -639,7 +611,7 @@ public final class LinkingObjects<T: Object>: LinkingObjectsBase {
     // MARK: Filtering
 
     /**
-     Returns a `Results` containing all objects matching the given predicate in the linking objects collection.
+     Returns a `Results` containing all objects matching the given predicate in the linking objects.
 
      - parameter predicateFormat: A predicate format string, optionally followed by a variable number of arguments.
      */
@@ -648,7 +620,7 @@ public final class LinkingObjects<T: Object>: LinkingObjectsBase {
     }
 
     /**
-     Returns a `Results` containing all objects matching the given predicate in the linking objects collection.
+     Returns a `Results` containing all objects matching the given predicate in the linking objects.
 
      - parameter predicate: The predicate with which to filter the objects.
      */
@@ -659,28 +631,29 @@ public final class LinkingObjects<T: Object>: LinkingObjectsBase {
     // MARK: Sorting
 
     /**
-     Returns a `Results` containing the objects in the linking objects collection, but sorted.
+     Returns a `Results` containing all the linking objects, but sorted.
 
      Objects are sorted based on the values of the given property. For example, to sort a collection of `Student`s from
-     youngest to oldest based on their `age` property, you might call `students.sorted("age", ascending: true)`.
+     youngest to oldest based on their `age` property, you might call
+     `students.sorted(byProperty: "age", ascending: true)`.
 
-     - warning: Collections may only be sorted by properties of boolean, `NSDate`, single and double-precision floating
-                point, integer, and string types.
+     - warning: Collections may only be sorted by properties of boolean, `Date`, `NSDate`, single and double-precision
+                floating point, integer, and string types.
 
      - parameter property:  The name of the property to sort by.
      - parameter ascending: The direction to sort in.
      */
-    public func sorted(property: String, ascending: Bool = true) -> Results<T> {
+    public func sorted(byProperty: String, ascending: Bool = true) -> Results<T> {
         return sorted([SortDescriptor(property: property, ascending: ascending)])
     }
 
     /**
-     Returns a `Results` containing the objects in the linking objects collection, but sorted.
+     Returns a `Results` containing all the linking objects, but sorted.
 
-     - warning: Collections may only be sorted by properties of boolean, `NSDate`, single and double-precision floating
-                point, integer, and string types.
+     - warning: Collections may only be sorted by properties of boolean, `Date`, `NSDate`, single and double-precision
+                floating point, integer, and string types.
 
-     - see: `sorted(_:ascending:)`
+     - see: `sorted(byProperty:ascending:)`
 
      - parameter sortDescriptors: A sequence of `SortDescriptor`s to sort by.
      */
@@ -691,55 +664,47 @@ public final class LinkingObjects<T: Object>: LinkingObjectsBase {
     // MARK: Aggregate Operations
 
     /**
-     Returns the minimum (lowest) value of the given property among all the objects represented by the linking objects
-     collection.
+     Returns the minimum (lowest) value of the given property among all the linking objects, or `nil` if the linking
+     objects are empty.
 
      - warning: Only a property whose type conforms to the `MinMaxType` protocol can be specified.
 
      - parameter property: The name of a property whose minimum value is desired.
-
-     - returns: The minimum value of the property, or `nil` if the collection is empty.
      */
     public func min<U: MinMaxType>(property: String) -> U? {
         return rlmResults.minOfProperty(property).map(dynamicBridgeCast)
     }
 
     /**
-     Returns the maximum (highest) value of the given property among all the objects represented by the linking objects
-     collection.
+     Returns the maximum (highest) value of the given property among all the linking objects, or `nil` if the linking
+     objects are empty.
 
      - warning: Only a property whose type conforms to the `MinMaxType` protocol can be specified.
 
      - parameter property: The name of a property whose minimum value is desired.
-
-     - returns: The maximum value of the property, or `nil` if the collection is empty.
      */
     public func max<U: MinMaxType>(property: String) -> U? {
         return rlmResults.maxOfProperty(property).map(dynamicBridgeCast)
     }
 
     /**
-     Returns the sum of the values of a given property over all the objects represented by the linking objects
-     collection.
+     Returns the sum of the values of a given property over all the linking objects.
 
      - warning: Only a property whose type conforms to the `AddableType` protocol can be specified.
 
      - parameter property: The name of a property whose values should be summed.
-
-     - returns: The sum of the given property.
      */
     public func sum<U: AddableType>(property: String) -> U {
         return dynamicBridgeCast(fromObjectiveC: rlmResults.sumOfProperty(property))
     }
 
     /**
-     Returns the average value of a given property over all the objects represented by the linking objects collection.
+     Returns the average value of a given property over all the linking objects, or `nil` if the linking objects are
+     empty.
 
      - warning: Only the name of a property whose type conforms to the `AddableType` protocol can be specified.
 
      - parameter property: The name of a property whose average value should be calculated.
-
-     - returns: The average value of the given property, or `nil` if the collection is empty.
      */
     public func average<U: AddableType>(property: String) -> U? {
         return rlmResults.averageOfProperty(property).map(dynamicBridgeCast)
@@ -768,11 +733,11 @@ public final class LinkingObjects<T: Object>: LinkingObjectsBase {
      delivered while the run loop is blocked by other activity. When
      notifications can't be delivered instantly, multiple notifications may be
      coalesced into a single notification. This can include the notification
-     with the initial set of objects. For example, the following code performs a write
-     transaction immediately after adding the notification block, so there is no
-     opportunity for the initial notification to be delivered first. As a
-     result, the initial notification will reflect the state of the Realm after
-     the write transaction.
+     with the initial set of objects.
+
+     For example, the following code performs a write transaction immediately after adding the notification block, so
+     there is no opportunity for the initial notification to be delivered first. As a result, the initial notification
+     will reflect the state of the Realm after the write transaction.
 
      ```swift
      let dog = realm.objects(Dog.self).first!
@@ -800,11 +765,10 @@ public final class LinkingObjects<T: Object>: LinkingObjectsBase {
      You must retain the returned token for as long as you want updates to be sent to the block. To stop receiving
      updates, call `stop()` on the token.
 
-     - warning: This method cannot be called during a write transaction, or when
-     the containing Realm is read-only.
+     - warning: This method cannot be called during a write transaction, or when the containing Realm is read-only.
 
      - parameter block: The block to be called whenever a change occurs.
-     - returns: A token which must be retained for as long as you want updates to be delivered.
+     - returns: A token which must be held for as long as you want updates to be delivered.
      */
     @warn_unused_result(message="You must hold on to the NotificationToken returned from addNotificationBlock")
     public func addNotificationBlock(block: (RealmCollectionChange<LinkingObjects> -> Void)) -> NotificationToken {

--- a/RealmSwift/LinkingObjects.swift
+++ b/RealmSwift/LinkingObjects.swift
@@ -634,26 +634,25 @@ public final class LinkingObjects<T: Object>: LinkingObjectsBase {
      Returns a `Results` containing all the linking objects, but sorted.
 
      Objects are sorted based on the values of the given property. For example, to sort a collection of `Student`s from
-     youngest to oldest based on their `age` property, you might call
-     `students.sorted(byProperty: "age", ascending: true)`.
+     youngest to oldest based on their `age` property, you might call `students.sorted("age", ascending: true)`.
 
-     - warning: Collections may only be sorted by properties of boolean, `Date`, `NSDate`, single and double-precision
-                floating point, integer, and string types.
+     - warning: Collections may only be sorted by properties of boolean, `NSDate`, single and double-precision floating
+                point, integer, and string types.
 
      - parameter property:  The name of the property to sort by.
      - parameter ascending: The direction to sort in.
      */
-    public func sorted(byProperty: String, ascending: Bool = true) -> Results<T> {
+    public func sorted(property: String, ascending: Bool = true) -> Results<T> {
         return sorted([SortDescriptor(property: property, ascending: ascending)])
     }
 
     /**
      Returns a `Results` containing all the linking objects, but sorted.
 
-     - warning: Collections may only be sorted by properties of boolean, `Date`, `NSDate`, single and double-precision
-                floating point, integer, and string types.
+     - warning: Collections may only be sorted by properties of boolean, `NSDate`, single and double-precision floating
+                point, integer, and string types.
 
-     - see: `sorted(byProperty:ascending:)`
+     - see: `sorted(_:ascending:)`
 
      - parameter sortDescriptors: A sequence of `SortDescriptor`s to sort by.
      */

--- a/RealmSwift/List.swift
+++ b/RealmSwift/List.swift
@@ -713,26 +713,25 @@ public final class List<T: Object>: ListBase {
      Returns a `Results` containing the objects in the list, but sorted.
 
      Objects are sorted based on the values of the given property. For example, to sort a list of `Student`s from
-     youngest to oldest based on their `age` property, you might call
-     `students.sorted(byProperty: "age", ascending: true)`.
+     youngest to oldest based on their `age` property, you might call `students.sorted("age", ascending: true)`.
 
-     - warning: Lists may only be sorted by properties of boolean, `Date`, `NSDate`, single and double-precision
-                floating point, integer, and string types.
+     - warning: Lists may only be sorted by properties of boolean, `NSDate`, single and double-precision floating point,
+                integer, and string types.
 
      - parameter property:  The name of the property to sort by.
      - parameter ascending: The direction to sort in.
      */
-    public func sorted(byProperty: String, ascending: Bool = true) -> Results<T> {
+    public func sorted(property: String, ascending: Bool = true) -> Results<T> {
         return sorted([SortDescriptor(property: property, ascending: ascending)])
     }
 
     /**
      Returns a `Results` containing the objects in the list, but sorted.
 
-     - warning: Lists may only be sorted by properties of boolean, `Date`, `NSDate`, single and double-precision
-                floating point, integer, and string types.
+     - warning: Lists may only be sorted by properties of boolean, `NSDate`, single and double-precision floating point,
+                integer, and string types.
 
-     - see: `sorted(byProperty:ascending:)`
+     - see: `sorted(_:ascending:)`
 
      - parameter sortDescriptors: A sequence of `SortDescriptor`s to sort by.
      */

--- a/RealmSwift/List.swift
+++ b/RealmSwift/List.swift
@@ -43,33 +43,35 @@ public class ListBase: RLMListBase {
 }
 
 /**
-`List<T>` is the container type in Realm used to define to-many relationships.
+ `List` is the container type in Realm used to define to-many relationships.
 
-Lists hold a single `Object` subclass (`T`) which defines the "type" of the List.
+ Like Swift's `Array`, `List` is a generic type that is parameterized on the type of `Object` it stores.
 
-Lists can be filtered and sorted with the same predicates as `Results<T>`.
+ Unlike Swift's native collections, `List`s are reference types, and are only immutable if the Realm that manages them
+ is opened as read-only.
 
-When added as a property on `Object` models, the property must be declared as `let` and cannot be `dynamic`.
-*/
+ Lists can be filtered and sorted with the same predicates as `Results<T>`.
+
+ Properties of `List` type defined on `Object` subclasses must be declared as `let` and cannot be `dynamic`.
+ */
 public final class List<T: Object>: ListBase {
 
-    /// Element type contained in this collection.
+    /// The type of the elements contained within the collection.
     public typealias Element = T
 
     // MARK: Properties
 
-    /// The Realm the objects in this List belong to, or `nil` if the List's
-    /// owning object does not belong to a Realm (the List is standalone).
+    /// The Realm which manages the list, or `nil` if the list is unmanaged.
     public var realm: Realm? {
         return _rlmArray.realm.map { Realm($0) }
     }
 
-    /// Indicates if the List can no longer be accessed.
+    /// Indicates if the list can no longer be accessed.
     public var isInvalidated: Bool { return _rlmArray.isInvalidated }
 
     // MARK: Initializers
 
-    /// Creates a `List` that holds objects of type `T`.
+    /// Creates a `List` that holds Realm model objects of type `T`.
     public override init() {
         super.init(array: RLMArray(objectClassName: (T.self as Object.Type).className()))
     }
@@ -81,36 +83,27 @@ public final class List<T: Object>: ListBase {
     // MARK: Index Retrieval
 
     /**
-    Returns the index of the given object, or `nil` if the object is not in the List.
+     Returns the index of an object in the list, or `nil` if the object is not present.
 
-    - parameter object: The object whose index is being queried.
-
-    - returns: The index of the given object, or `nil` if the object is not in the List.
-    */
+     - parameter object: An object to find.
+     */
     public func index(of object: T) -> Int? {
         return notFoundToNil(index: _rlmArray.index(of: object.unsafeCastToRLMObject()))
     }
 
     /**
-    Returns the index of the first object matching the given predicate,
-    or `nil` no objects match.
+     Returns the index of the first object in the list matching the predicate, or `nil` if no objects match.
 
-    - parameter predicate: The `NSPredicate` used to filter the objects.
-
-    - returns: The index of the first matching object, or `nil` if no objects match.
+     - parameter predicate: The predicate with which to filter the objects.
     */
     public func index(matching predicate: NSPredicate) -> Int? {
         return notFoundToNil(index: _rlmArray.indexOfObject(with: predicate))
     }
 
     /**
-    Returns the index of the first object matching the given predicate,
-    or `nil` if no objects match.
-
-    - parameter predicateFormat: The predicate format string, optionally
-                                 followed by a variable number of arguments.
-
-    - returns: The index of the first matching object, or `nil` if no objects match.
+     Returns the index of the first object in the list matching the predicate, or `nil` if no objects match.
+   
+     - parameter predicateFormat: A predicate format string, optionally followed by a variable number of arguments.
     */
     public func index(matching predicateFormat: String, _ args: Any...) -> Int? {
         return index(matching: NSPredicate(format: predicateFormat, argumentArray: args))
@@ -119,15 +112,12 @@ public final class List<T: Object>: ListBase {
     // MARK: Object Retrieval
 
     /**
-    Returns the object at the given `index` on get.
-    Replaces the object at the given `index` on set.
+     Returns the object at the given index (get), or replaces the object at the given index (set).
 
-    - warning: You can only set an object during a write transaction.
+     - warning: You can only set an object during a write transaction.
 
-    - parameter index: The index.
-
-    - returns: The object at the given `index`.
-    */
+     - parameter index: The index of the object to retrieve or replace.
+     */
     public subscript(position: Int) -> T {
         get {
             throwForNegativeIndex(position)
@@ -139,45 +129,39 @@ public final class List<T: Object>: ListBase {
         }
     }
 
-    /// Returns the first object in the List, or `nil` if empty.
+    /// Returns the first object in the list, or `nil` if the list is empty.
     public var first: T? { return _rlmArray.firstObject() as! T? }
 
-    /// Returns the last object in the List, or `nil` if empty.
+    /// Returns the last object in the list, or `nil` if the list is empty.
     public var last: T? { return _rlmArray.lastObject() as! T? }
 
     // MARK: KVC
 
     /**
-    Returns an Array containing the results of invoking `valueForKey(_:)` using key on each of the collection's objects.
-
-    - parameter key: The name of the property.
-
-    - returns: Array containing the results of invoking `valueForKey(_:)` using key on each of the collection's objects.
+     Returns an `Array` containing the results of invoking `valueForKey(_:)` using `key` on each of the collection's
+     objects.
     */
     public override func value(forKey key: String) -> Any? {
         return value(forKeyPath: key)
     }
 
     /**
-     Returns an Array containing the results of invoking `valueForKeyPath(_:)` using keyPath on each of the
+     Returns an `Array` containing the results of invoking `valueForKeyPath(_:)` using `keyPath` on each of the
      collection's objects.
 
-     - parameter keyPath: The key path to the property.
-
-     - returns: Array containing the results of invoking `valueForKeyPath(_:)` using keyPath on each of the
-     collection's objects.
+     - parameter keyPath: The key path to the property whose values are desired.
      */
     public override func value(forKeyPath keyPath: String) -> Any? {
         return _rlmArray.value(forKeyPath: keyPath)
     }
 
     /**
-    Invokes `setValue(_:forKey:)` on each of the collection's objects using the specified value and key.
+     Invokes `setValue(_:forKey:)` on each of the collection's objects using the specified `value` and `key`.
 
-    - warning: This method can only be called during a write transaction.
+     - warning: This method can only be called during a write transaction.
 
-    - parameter value: The object value.
-    - parameter key:   The name of the property.
+     - parameter value: The object value.
+     - parameter key:   The name of the property whose value should be set on each object.
     */
     public override func setValue(_ value: Any?, forKey key: String) {
         return _rlmArray.setValue(value, forKeyPath: key)
@@ -186,23 +170,19 @@ public final class List<T: Object>: ListBase {
     // MARK: Filtering
 
     /**
-    Returns `Results` containing elements that match the given predicate.
+     Returns a `Results` containing all objects matching the given predicate in the list.
 
-    - parameter predicateFormat: The predicate format string which can accept variable arguments.
-
-    - returns: `Results` containing elements that match the given predicate.
+     - parameter predicateFormat: A predicate format string, optionally followed by a variable number of arguments.
     */
     public func filter(_ predicateFormat: String, _ args: Any...) -> Results<T> {
         return Results<T>(_rlmArray.objects(with: NSPredicate(format: predicateFormat, argumentArray: args)))
     }
 
     /**
-    Returns `Results` containing elements that match the given predicate.
+     Returns a `Results` containing all objects matching the given predicate in the list.
 
-    - parameter predicate: The predicate to filter the objects.
-
-    - returns: `Results` containing elements that match the given predicate.
-    */
+     - parameter predicate: The predicate with which to filter the objects.
+     */
     public func filter(_ predicate: NSPredicate) -> Results<T> {
         return Results<T>(_rlmArray.objects(with: predicate))
     }
@@ -210,23 +190,29 @@ public final class List<T: Object>: ListBase {
     // MARK: Sorting
 
     /**
-    Returns `Results` containing elements sorted by the given property.
+     Returns a `Results` containing the objects in the list, but sorted.
 
-    - parameter property:  The property name to sort by.
-    - parameter ascending: The direction to sort by.
+     Objects are sorted based on the values of the given property. For example, to sort a list of `Student`s from
+     youngest to oldest based on their `age` property, you might call
+     `students.sorted(byProperty: "age", ascending: true)`.
 
-    - returns: `Results` containing elements sorted by the given property.
-    */
+     - warning: Lists may only be sorted by properties of boolean, `Date`, `NSDate`, single and double-precision
+                floating point, integer, and string types.
+
+     - parameter property:  The name of the property to sort by.
+     - parameter ascending: The direction to sort in.
+     */
     public func sorted(byProperty property: String, ascending: Bool = true) -> Results<T> {
         return sorted(by: [SortDescriptor(property: property, ascending: ascending)])
     }
 
     /**
-    Returns `Results` with elements sorted by the given sort descriptors.
+     Returns a `Results` containing the objects in the list, but sorted.
 
-    - parameter sortDescriptors: `SortDescriptor`s to sort by.
+     - warning: Lists may only be sorted by properties of boolean, `Date`, `NSDate`, single and double-precision
+                floating point, integer, and string types.
 
-    - returns: `Results` with elements sorted by the given sort descriptors.
+     - see: `sorted(byProperty:ascending:)`
     */
     public func sorted<S: Sequence>(by sortDescriptors: S) -> Results<T> where S.Iterator.Element == SortDescriptor {
         return Results<T>(_rlmArray.sortedResults(using: sortDescriptors.map { $0.rlmSortDescriptorValue }))
@@ -235,53 +221,47 @@ public final class List<T: Object>: ListBase {
     // MARK: Aggregate Operations
 
     /**
-    Returns the minimum value of the given property.
+     Returns the minimum (lowest) value of the given property among all the objects in the list, or `nil` if the list is
+     empty.
 
-    - warning: Only names of properties of a type conforming to the `MinMaxType` protocol can be used.
+     - warning: Only a property whose type conforms to the `MinMaxType` protocol can be specified.
 
-    - parameter property: The name of a property conforming to `MinMaxType` to look for a minimum on.
-
-    - returns: The minimum value for the property amongst objects in the List, or `nil` if the List is empty.
-    */
+     - parameter property: The name of a property whose minimum value is desired.
+     */
     public func min<U: MinMaxType>(ofProperty property: String) -> U? {
         return filter(NSPredicate(value: true)).min(ofProperty: property)
     }
 
     /**
-    Returns the maximum value of the given property.
+     Returns the maximum (highest) value of the given property among all the objects in the list, or `nil` if the list
+     is empty.
 
-    - warning: Only names of properties of a type conforming to the `MinMaxType` protocol can be used.
+     - warning: Only a property whose type conforms to the `MinMaxType` protocol can be specified.
 
-    - parameter property: The name of a property conforming to `MinMaxType` to look for a maximum on.
-
-    - returns: The maximum value for the property amongst objects in the List, or `nil` if the List is empty.
-    */
+     - parameter property: The name of a property whose maximum value is desired.
+     */
     public func max<U: MinMaxType>(ofProperty property: String) -> U? {
         return filter(NSPredicate(value: true)).max(ofProperty: property)
     }
 
     /**
-    Returns the sum of the given property for objects in the List.
+     Returns the sum of the values of a given property over all the objects in the list.
 
-    - warning: Only names of properties of a type conforming to the `AddableType` protocol can be used.
+     - warning: Only a property whose type conforms to the `AddableType` protocol can be specified.
 
-    - parameter property: The name of a property conforming to `AddableType` to calculate sum on.
-
-    - returns: The sum of the given property over all objects in the List.
-    */
+     - parameter property: The name of a property whose values should be summed.
+     */
     public func sum<U: AddableType>(ofProperty property: String) -> U {
         return filter(NSPredicate(value: true)).sum(ofProperty: property)
     }
 
     /**
-    Returns the average of the given property for objects in the List.
+     Returns the average value of a given property over all the objects in the list, or `nil` if the list is empty.
 
-    - warning: Only names of properties of a type conforming to the `AddableType` protocol can be used.
+     - warning: Only a property whose type conforms to the `AddableType` protocol can be specified.
 
-    - parameter property: The name of a property conforming to `AddableType` to calculate average on.
-
-    - returns: The average of the given property over all objects in the List, or `nil` if the List is empty.
-    */
+     - parameter property: The name of a property whose average value should be calculated.
+     */
     public func average<U: AddableType>(ofProperty property: String) -> U? {
         return filter(NSPredicate(value: true)).average(ofProperty: property)
     }
@@ -289,23 +269,23 @@ public final class List<T: Object>: ListBase {
     // MARK: Mutation
 
     /**
-    Appends the given object to the end of the List. If the object is from a
-    different Realm it is copied to the List's Realm.
+     Appends the given object to the end of the list.
 
-    - warning: This method can only be called during a write transaction.
+     If the object is managed by a different Realm than the receiver, a copy is made and added to the Realm managing
+     the receiver.
 
-    - parameter object: An object.
-    */
+     - warning: This method may only be called during a write transaction.
+
+     - parameter object: An object.
+     */
     public func append(_ object: T) {
         _rlmArray.add(object.unsafeCastToRLMObject())
     }
 
     /**
-    Appends the objects in the given sequence to the end of the List.
+     Appends the objects in the given sequence to the end of the list.
 
-    - warning: This method can only be called during a write transaction.
-
-    - parameter objects: A sequence of objects.
+     - warning: This method may only be called during a write transaction.
     */
     public func append<S: Sequence>(objectsIn objects: S) where S.Iterator.Element == T {
         for obj in objects {
@@ -314,77 +294,77 @@ public final class List<T: Object>: ListBase {
     }
 
     /**
-    Inserts the given object at the given index.
+     Inserts an object at the given index.
 
-    - warning: This method can only be called during a write transaction.
-    - warning: Throws an exception when called with an index smaller than zero
-               or greater than or equal to the number of objects in the List.
+     - warning: This method may only be called during a write transaction.
 
-    - parameter object: An object.
-    - parameter index:  The index at which to insert the object.
-    */
+     - warning: This method will throw an exception if called with an invalid index.
+
+     - parameter object: An object.
+     - parameter index:  The index at which to insert the object.
+     */
     public func insert(_ object: T, at index: Int) {
         throwForNegativeIndex(index)
         _rlmArray.insert(object.unsafeCastToRLMObject(), at: UInt(index))
     }
 
     /**
-    Removes the object at the given index from the List. Does not remove the object from the Realm.
+     Removes an object at the given index. The object is not removed from the Realm that manages it.
 
-    - warning: This method can only be called during a write transaction.
-    - warning: Throws an exception when called with an index smaller than zero
-               or greater than or equal to the number of objects in the List.
+     - warning: This method may only be called during a write transaction.
 
-    - parameter index: The index at which to remove the object.
-    */
+     - warning: This method will throw an exception if called with an invalid index.
+
+     - parameter index: The index at which to remove the object.
+     */
     public func remove(objectAtIndex index: Int) {
         throwForNegativeIndex(index)
         _rlmArray.removeObject(at: UInt(index))
     }
 
     /**
-    Removes the last object in the List. Does not remove the object from the Realm.
+     Removes the last object in the list. The object is not removed from the Realm that manages it.
 
-    - warning: This method can only be called during a write transaction.
-    */
+     - warning: This method may only be called during a write transaction.
+     */
     public func removeLast() {
         _rlmArray.removeLastObject()
     }
 
     /**
-    Removes all objects from the List. Does not remove the objects from the Realm.
+     Removes all objects from the list. The objects are not removed from the Realm that manages them.
 
-    - warning: This method can only be called during a write transaction.
-    */
+     - warning: This method may only be called during a write transaction.
+     */
     public func removeAll() {
         _rlmArray.removeAllObjects()
     }
 
     /**
-    Replaces an object at the given index with a new object.
+     Replaces an object at the given index with a new object.
 
-    - warning: This method can only be called during a write transaction.
-    - warning: Throws an exception when called with an index smaller than zero
-               or greater than or equal to the number of objects in the List.
+     - warning: This method may only be called during a write transaction.
 
-    - parameter index:  The index of the object to be replaced.
-    - parameter object: An object to replace at the specified index.
-    */
+     - warning: This method will throw an exception if called with an invalid index.
+
+     - parameter index:  The index of the object to be replaced.
+     - parameter object: An object.
+     */
     public func replace(index: Int, object: T) {
         throwForNegativeIndex(index)
         _rlmArray.replaceObject(at: UInt(index), with: object.unsafeCastToRLMObject())
     }
 
     /**
-    Moves the object at the given source index to the given destination index.
+     Moves the object at the given source index to the given destination index.
 
-    - warning: This method can only be called during a write transaction.
-    - warning: Throws an exception when called with an index smaller than zero or greater than
-               or equal to the number of objects in the List.
+     - warning: This method may only be called during a write transaction.
 
-    - parameter from:  The index of the object to be moved.
-    - parameter to:    index to which the object at `from` should be moved.
-    */
+     - warning: This method will throw an exception if called with invalid indices.
+
+     - parameter from:  The index of the object to be moved.
+     - parameter to:    index to which the object at `from` should be moved.
+     */
     public func move(from: Int, to: Int) { // swiftlint:disable:this variable_name
         throwForNegativeIndex(from)
         throwForNegativeIndex(to)
@@ -392,14 +372,15 @@ public final class List<T: Object>: ListBase {
     }
 
     /**
-    Exchanges the objects in the List at given indexes.
+     Exchanges the objects in the list at given indices.
 
-    - warning: Throws an exception when either index exceeds the bounds of the List.
-    - warning: This method can only be called during a write transaction.
+     - warning: This method may only be called during a write transaction.
 
-    - parameter index1: The index of the object with which to replace the object at index `index2`.
-    - parameter index2: The index of the object with which to replace the object at index `index1`.
-    */
+     - warning: This method will throw an exception if called with invalid indices.
+
+     - parameter index1: The index of the object which should replace the object at index `index2`.
+     - parameter index2: The index of the object which should replace the object at index `index1`.
+     */
     public func swap(index1: Int, _ index2: Int) {
         throwForNegativeIndex(index1, parameterName: "index1")
         throwForNegativeIndex(index2, parameterName: "index2")
@@ -409,65 +390,60 @@ public final class List<T: Object>: ListBase {
     // MARK: Notifications
 
     /**
-    Register a block to be called each time the List changes.
+     Registers a block to be called each time the collection changes.
 
-    The block will be asynchronously called with the initial list, and then
-    called again after each write transaction which changes the list or any of
-    the items in the list.
+     The block will be asynchronously called with the initial results, and then called again after each write
+     transaction which changes either any of the objects in the collection, or which objects are in the collection.
 
-    This version of this method reports which of the objects in the List were
-    added, removed, or modified in each write transaction as indices within the
-    List. See the RealmCollectionChange documentation for more information on
-    the change information supplied and an example of how to use it to update
-    a UITableView.
+     The `change` parameter that is passed to the block reports, in the form of indices within the collection, which of
+     the objects were added, removed, or modified during each write transaction. See the `RealmCollectionChange`
+     documentation for more information on the change information supplied and an example of how to use it to update a
+     `UITableView`.
 
-    The block is called on the same thread as it was added on, and can only
-    be added on threads which are currently within a run loop. Unless you are
-    specifically creating and running a run loop on a background thread, this
-    will normally only be the main thread.
+     At the time when the block is called, the collection will be fully evaluated and up-to-date, and as long as you do
+     not perform a write transaction on the same thread or explicitly call `realm.refresh()`, accessing it will never
+     perform blocking work.
 
-    Notifications can't be delivered as long as the run loop is blocked by
-    other activity. When notifications can't be delivered instantly, multiple
-    notifications may be coalesced into a single notification. This can include
-    the notification with the initial list. For example, the following code
-    performs a write transaction immediately after adding the notification block,
-    so there is no opportunity for the initial notification to be delivered first.
-    As a result, the initial notification will reflect the state of the Realm
-    after the write transaction, and will not include change information.
+     Notifications are delivered via the standard run loop, and so can't be delivered while the run loop is blocked by
+     other activity. When notifications can't be delivered instantly, multiple notifications may be coalesced into a
+     single notification. This can include the notification with the initial collection.
 
-        let person = realm.objects(Person).first!
-        print("dogs.count: \(person.dogs.count)") // => 0
-        let token = person.dogs.addNotificationBlock { (changes: RealmCollectionChange) in
-            switch changes {
-                case .Initial(let dogs):
-                    // Will print "dogs.count: 1"
-                    print("dogs.count: \(dogs.count)")
-                    break
-                case .Update:
-                    // Will not be hit in this example
-                    break
-                case .Error:
-                    break
-            }
-        }
-        try! realm.write {
-            let dog = Dog()
-            dog.name = "Rex"
-            person.dogs.append(dog)
-        }
-        // end of run loop execution context
+     For example, the following code performs a write transaction immediately after adding the notification block, so
+     there is no opportunity for the initial notification to be delivered first. As a result, the initial notification
+     will reflect the state of the Realm after the write transaction.
 
-    You must retain the returned token for as long as you want updates to continue
-    to be sent to the block. To stop receiving updates, call stop() on the token.
+     ```swift
+     let results = realm.objects(Dog.self)
+     print("dogs.count: \(dogs?.count)") // => 0
+     let token = dogs.addNotificationBlock { changes in
+         switch changes {
+         case .initial(let dogs):
+             // Will print "dogs.count: 1"
+             print("dogs.count: \(dogs.count)")
+             break
+         case .update:
+             // Will not be hit in this example
+             break
+         case .error:
+             break
+         }
+     }
+     try! realm.write {
+         let dog = Dog()
+         dog.name = "Rex"
+         person.dogs.append(dog)
+     }
+     // end of run loop execution context
+     ```
 
-     - warning: This method cannot be called during a write transaction, or when
-                the source realm is read-only.
-     - warning: This method can only be called on Lists which are stored on an
-                Object which has been added to or retrieved from a Realm.
+     You must retain the returned token for as long as you want updates to be sent to the block. To stop receiving
+     updates, call `stop()` on the token.
 
-    - parameter block: The block to be called each time the list changes.
-    - returns: A token which must be held for as long as you want notifications to be delivered.
-    */
+     - warning: This method cannot be called during a write transaction, or when the containing Realm is read-only.
+
+     - parameter block: The block to be called whenever a change occurs.
+     - returns: A token which must be held for as long as you want updates to be delivered.
+     */
     public func addNotificationBlock(_ block: @escaping (RealmCollectionChange<List>) -> ()) -> NotificationToken {
         return _rlmArray.addNotificationBlock { list, change, error in
             block(RealmCollectionChange.fromObjc(value: self, change: change, error: error))
@@ -486,7 +462,7 @@ extension List : RealmCollection, RangeReplaceableCollection {
     // MARK: RangeReplaceableCollection Support
 
     /**
-    Replace the given `subRange` of elements with `newElements`.
+     Replace the given `subRange` of elements with `newElements`.
 
     - parameter subRange:    The range of elements to be replaced.
     - parameter newElements: The new elements to be inserted into the List.
@@ -659,8 +635,6 @@ public final class List<T: Object>: ListBase {
      - warning: You can only set an object during a write transaction.
 
      - parameter index: The index of the object to retrieve or replace.
-
-     - returns: The object at the given index.
      */
     public subscript(index: Int) -> T {
         get {
@@ -718,7 +692,7 @@ public final class List<T: Object>: ListBase {
     /**
      Returns a `Results` containing all objects matching the given predicate in the list.
 
-     - parameter predicateFormat: A predicate format string; variable arguments are supported.
+     - parameter predicateFormat: A predicate format string, optionally followed by a variable number of arguments.
     */
     public func filter(predicateFormat: String, _ args: AnyObject...) -> Results<T> {
         return Results<T>(_rlmArray.objectsWithPredicate(NSPredicate(format: predicateFormat, argumentArray: args)))
@@ -739,25 +713,26 @@ public final class List<T: Object>: ListBase {
      Returns a `Results` containing the objects in the list, but sorted.
 
      Objects are sorted based on the values of the given property. For example, to sort a list of `Student`s from
-     youngest to oldest based on their `age` property, you might call `students.sorted("age", ascending: true)`.
+     youngest to oldest based on their `age` property, you might call
+     `students.sorted(byProperty: "age", ascending: true)`.
 
-     - warning: Lists may only be sorted by properties of boolean, `NSDate`, single and double-precision floating point,
-                integer, and string types.
+     - warning: Lists may only be sorted by properties of boolean, `Date`, `NSDate`, single and double-precision
+                floating point, integer, and string types.
 
      - parameter property:  The name of the property to sort by.
      - parameter ascending: The direction to sort in.
      */
-    public func sorted(property: String, ascending: Bool = true) -> Results<T> {
+    public func sorted(byProperty: String, ascending: Bool = true) -> Results<T> {
         return sorted([SortDescriptor(property: property, ascending: ascending)])
     }
 
     /**
      Returns a `Results` containing the objects in the list, but sorted.
 
-     - warning: Lists may only be sorted by properties of boolean, `NSDate`, single and double-precision floating point,
-                integer, and string types.
+     - warning: Lists may only be sorted by properties of boolean, `Date`, `NSDate`, single and double-precision
+                floating point, integer, and string types.
 
-     - see: `sorted(_:ascending:)`
+     - see: `sorted(byProperty:ascending:)`
 
      - parameter sortDescriptors: A sequence of `SortDescriptor`s to sort by.
      */
@@ -768,26 +743,24 @@ public final class List<T: Object>: ListBase {
     // MARK: Aggregate Operations
 
     /**
-     Returns the minimum (lowest) value of the given property among all the objects in the list.
+     Returns the minimum (lowest) value of the given property among all the objects in the list, or `nil` if the list is
+     empty.
 
     - warning: Only a property whose type conforms to the `MinMaxType` protocol can be specified.
 
     - parameter property: The name of a property whose minimum value is desired.
-
-    - returns: The minimum value of the property, or `nil` if the list is empty.
     */
     public func min<U: MinMaxType>(property: String) -> U? {
         return filter(NSPredicate(value: true)).min(property)
     }
 
     /**
-     Returns the maximum (highest) value of the given property among all the objects in the list.
+     Returns the maximum (highest) value of the given property among all the objects in the list, or `nil` if the list
+     is empty.
 
      - warning: Only a property whose type conforms to the `MinMaxType` protocol can be specified.
 
      - parameter property: The name of a property whose maximum value is desired.
-
-     - returns: The maximum value of the property, or `nil` if the list is empty.
      */
     public func max<U: MinMaxType>(property: String) -> U? {
         return filter(NSPredicate(value: true)).max(property)
@@ -799,21 +772,17 @@ public final class List<T: Object>: ListBase {
      - warning: Only a property whose type conforms to the `AddableType` protocol can be specified.
 
      - parameter property: The name of a property whose values should be summed.
-
-     - returns: The sum of the given property.
      */
     public func sum<U: AddableType>(property: String) -> U {
         return filter(NSPredicate(value: true)).sum(property)
     }
 
     /**
-     Returns the average value of a given property over all the objects in the list.
+     Returns the average value of a given property over all the objects in the list, or `nil` if the list is empty.
 
      - warning: Only a property whose type conforms to the `AddableType` protocol can be specified.
 
      - parameter property: The name of a property whose average value should be calculated.
-
-     - returns: The average value of the given property, or `nil` if the list is empty.
      */
     public func average<U: AddableType>(property: String) -> U? {
         return filter(NSPredicate(value: true)).average(property)
@@ -964,11 +933,11 @@ public final class List<T: Object>: ListBase {
      Notifications can't be delivered as long as the run loop is blocked by
      other activity. When notifications can't be delivered instantly, multiple
      notifications may be coalesced into a single notification. This can include
-     the notification with the initial list. For example, the following code
-     performs a write transaction immediately after adding the notification block,
-     so there is no opportunity for the initial notification to be delivered first.
-     As a result, the initial notification will reflect the state of the Realm
-     after the write transaction, and will not include change information.
+     the notification with the initial list.
+     
+     For example, the following code performs a write transaction immediately after adding the notification block, so
+     there is no opportunity for the initial notification to be delivered first. As a result, the initial notification
+     will reflect the state of the Realm after the write transaction, and will not include change information.
 
      ```swift
      let person = realm.objects(Person.self).first!
@@ -997,8 +966,7 @@ public final class List<T: Object>: ListBase {
      You must retain the returned token for as long as you want updates to be sent to the block. To stop receiving
      updates, call `stop()` on the token.
 
-     - warning: This method cannot be called during a write transaction, or when
-     the containing Realm is read-only.
+     - warning: This method cannot be called during a write transaction, or when the containing Realm is read-only.
      - warning: This method may only be called on a managed list.
 
      - parameter block: The block to be called each time the list changes.

--- a/RealmSwift/List.swift
+++ b/RealmSwift/List.swift
@@ -102,7 +102,7 @@ public final class List<T: Object>: ListBase {
 
     /**
      Returns the index of the first object in the list matching the predicate, or `nil` if no objects match.
-   
+
      - parameter predicateFormat: A predicate format string, optionally followed by a variable number of arguments.
     */
     public func index(matching predicateFormat: String, _ args: Any...) -> Int? {
@@ -745,10 +745,10 @@ public final class List<T: Object>: ListBase {
      Returns the minimum (lowest) value of the given property among all the objects in the list, or `nil` if the list is
      empty.
 
-    - warning: Only a property whose type conforms to the `MinMaxType` protocol can be specified.
+     - warning: Only a property whose type conforms to the `MinMaxType` protocol can be specified.
 
-    - parameter property: The name of a property whose minimum value is desired.
-    */
+     - parameter property: The name of a property whose minimum value is desired.
+     */
     public func min<U: MinMaxType>(property: String) -> U? {
         return filter(NSPredicate(value: true)).min(property)
     }
@@ -933,7 +933,7 @@ public final class List<T: Object>: ListBase {
      other activity. When notifications can't be delivered instantly, multiple
      notifications may be coalesced into a single notification. This can include
      the notification with the initial list.
-     
+
      For example, the following code performs a write transaction immediately after adding the notification block, so
      there is no opportunity for the initial notification to be delivered first. As a result, the initial notification
      will reflect the state of the Realm after the write transaction, and will not include change information.

--- a/RealmSwift/Migration.swift
+++ b/RealmSwift/Migration.swift
@@ -23,37 +23,35 @@ import Realm.Private
 #if swift(>=3.0)
 
 /**
-Migration block used to migrate a Realm.
+ The type of a migration block used to migrate a Realm.
 
-- parameter migration: `Migration` object used to perform the migration. The
-                       migration object allows you to enumerate and alter any
-                       existing objects which require migration.
-- parameter oldSchemaVersion: The schema version of the `Realm` being migrated.
-*/
+ - parameter migration:  A `Migration` object used to perform the migration. The migration object allows you to
+                         enumerate and alter any existing objects which require migration.
+
+ - parameter oldSchemaVersion: The schema version of the Realm being migrated.
+ */
 public typealias MigrationBlock = (_ migration: Migration, _ oldSchemaVersion: UInt64) -> Void
 
-/// Object class used during migrations.
+/// An object class used during migrations.
 public typealias MigrationObject = DynamicObject
 
 /**
-Provides both the old and new versions of an object in this Realm. Object properties can only be
-accessed using subscripting.
+ A block type which provides both the old and new versions of an object in the Realm. Object
+ properties can only be accessed using subscripting.
 
-- parameter oldObject: Object in original `Realm` (read-only).
-- parameter newObject: Object in migrated `Realm` (read-write).
-*/
+ - parameter oldObject: The object from the original Realm (read-only).
+ - parameter newObject: The object from the migrated Realm (read-write).
+ */
 public typealias MigrationObjectEnumerateBlock = (_ oldObject: MigrationObject?, _ newObject: MigrationObject?) -> Void
 
 /**
-Get the schema version for a Realm at a given local URL.
+ Returns the schema version for a Realm at a given local URL.
 
-- parameter fileURL:       Local URL to a Realm file.
-- parameter encryptionKey: Optional 64-byte encryption key for encrypted Realms.
+ - parameter fileURL:       Local URL to a Realm file.
+ - parameter encryptionKey: 64-byte key used to encrypt the file, or `nil` if it is unencrypted.
 
-- throws: An NSError that describes the problem.
-
-- returns: The version of the Realm at `fileURL`.
-*/
+ - throws: An `NSError` that describes the problem.
+ */
 public func schemaVersionAtURL(_ fileURL: URL, encryptionKey: Data? = nil) throws -> UInt64 {
     var error: NSError?
     let version = RLMRealm.__schemaVersion(at: fileURL, encryptionKey: encryptionKey, error: &error)
@@ -67,13 +65,10 @@ extension Realm {
     /**
      Performs the given Realm configuration's migration block on a Realm at the given path.
 
-     This method is called automatically when opening a Realm for the first time and does
-     not need to be called explicitly. You can choose to call this method to control
-     exactly when and how migrations are performed.
+     This method is called automatically when opening a Realm for the first time and does not need to be called
+     explicitly. You can choose to call this method to control exactly when and how migrations are performed.
 
      - parameter configuration: The Realm configuration used to open and migrate the Realm.
-
-     - throws: An `NSError` that describes an error that occurred while applying the migration, if any.
      */
     public static func performMigration(for configuration: Realm.Configuration = Realm.Configuration.defaultConfiguration) throws {
         try RLMRealm.performMigration(for: configuration.rlmConfiguration)
@@ -81,19 +76,20 @@ extension Realm {
 }
 
 /**
-`Migration` is the object passed into a user-defined `MigrationBlock` when updating the version
-of a `Realm` instance.
+ `Migration` instances encapsulate information intended to facilitate a schema migration.
 
-This object provides access to the previous and current `Schema`s for this migration.
-*/
+ A `Migration` instance is passed into a user-defined `MigrationBlock` block when updating the version of a Realm. This
+ instance provides access to the old and new database schemas, the objects in the Realm, and provides functionality for
+ modifying the Realm during the migration.
+ */
 public final class Migration {
 
     // MARK: Properties
 
-    /// The migration's old `Schema`, describing the `Realm` before applying a migration.
+    /// The old schema, describing the Realm before applying a migration.
     public var oldSchema: Schema { return Schema(rlmMigration.oldSchema) }
 
-    /// The migration's new `Schema`, describing the `Realm` after applying a migration.
+    /// The new schema, describing the Realm after applying a migration.
     public var newSchema: Schema { return Schema(rlmMigration.newSchema) }
 
     internal var rlmMigration: RLMMigration
@@ -101,12 +97,12 @@ public final class Migration {
     // MARK: Altering Objects During a Migration
 
     /**
-    Enumerates objects of a given type in this Realm, providing both the old and new versions of
-    each object. Object properties can be accessed using subscripting.
+     Enumerates all the objects of a given type in this Realm, providing both the old and new versions of each object.
+     Properties on an object can be accessed using subscripting.
 
-    - parameter objectClassName: The name of the `Object` class to enumerate.
-    - parameter block:           The block providing both the old and new versions of an object in this Realm.
-    */
+     - parameter objectClassName: The name of the `Object` class to enumerate.
+     - parameter block:           The block providing both the old and new versions of an object in this Realm.
+     */
     public func enumerateObjects(ofType typeName: String, _ block: MigrationObjectEnumerateBlock) {
         rlmMigration.enumerateObjects(typeName) { oldObject, newObject in
             block(unsafeBitCast(oldObject, to: MigrationObject.self),
@@ -115,56 +111,62 @@ public final class Migration {
     }
 
     /**
-    Create an `Object` of type `className` in the Realm being migrated.
+     Creates and returns an `Object` of type `className` in the Realm being migrated.
 
-    - parameter className: The name of the `Object` class to create.
-    - parameter value:     The object used to populate the new `Object`. This can be any key/value coding
-                           compliant object, or a JSON object such as those returned from the methods in
-                           `NSJSONSerialization`, or an `Array` with one object for each persisted
-                           property. An exception will be thrown if any required properties are not
-                           present and no default is set.
+     The `value` argument is used to populate the object. It can be a key-value coding compliant object, an array or
+     dictionary returned from the methods in `NSJSONSerialization`, or an `Array` containing one element for each
+     managed property. An exception will be thrown if any required properties are not present and those properties were
+     not defined with default values.
 
-    - returns: The created object.
-    */
+     When passing in an `Array` as the `value` argument, all properties must be present, valid and in the same order as
+     the properties defined in the model.
+
+     - parameter className: The name of the `Object` class to create.
+     - parameter value:     The value used to populate the created object.
+
+     - returns: The newly created object.
+     */
     @discardableResult
     public func create(_ typeName: String, value: Any = [:]) -> MigrationObject {
         return unsafeBitCast(rlmMigration.createObject(typeName, withValue: value), to: MigrationObject.self)
     }
 
     /**
-    Delete an object from a Realm during a migration. This can be called within
-    `enumerate(_:block:)`.
+     Deletes an object from a Realm during a migration.
 
-    - parameter object: Object to be deleted from the Realm being migrated.
-    */
+     It is permitted to call this method from within the block passed to `enumerate(_:block:)`.
+
+     - parameter object: An object to be deleted from the Realm being migrated.
+     */
     public func delete(_ object: MigrationObject) {
         RLMDeleteObjectFromRealm(object, RLMObjectBaseRealm(object)!)
     }
 
     /**
-    Deletes the data for the class with the given name.
-    This deletes all objects of the given class, and if the Object subclass no longer exists in your program,
-    cleans up any remaining metadata for the class in the Realm file.
+     Deletes the data for the class with the given name.
 
-    - parameter objectClassName: The name of the Object class to delete.
+     All objects of the given class will be deleted. If the `Object` subclass no longer exists in your program, any
+     remaining metadata for the class will be removed from the Realm file.
 
-    - returns: `true` if there was any data to delete.
-    */
+     - parameter objectClassName: The name of the `Object` class to delete.
+
+     - returns: A Boolean value indicating whether there was any data to delete.
+     */
     @discardableResult
     public func deleteData(forType typeName: String) -> Bool {
         return rlmMigration.deleteData(forClassName: typeName)
     }
 
     /**
-    Rename property of the given class from `oldName` to `newName`.
+     Renames a property of the given class from `oldName` to `newName`.
 
-    - parameter className: Class for which the property is to be renamed. Must be present
-                           in both the old and new Realm schemas.
-    - parameter oldName:   Old name for the property to be renamed. Must not be present
-                           in the new Realm.
-    - parameter newName:   New name for the property to be renamed. Must not be present
-                           in the old Realm.
-    */
+     - parameter className:  The name of the class whose property should be renamed. This class must be present
+                             in both the old and new Realm schemas.
+     - parameter oldName:    The old name for the property to be renamed. There must not be a property with this name in
+                             the class as defined by the new Realm schema.
+     - parameter newName:    The new name for the property to be renamed. There must not be a property with this name in
+                             the class as defined by the old Realm schema.
+     */
     public func renameProperty(onType typeName: String, from oldName: String, to newName: String) {
         rlmMigration.renameProperty(forClass: typeName, oldName: oldName, newName: newName)
     }
@@ -216,7 +218,7 @@ extension Migration {
 /**
  The type of a migration block used to migrate a Realm.
 
- - parameter migration:  A `RLMMigration` object used to perform the migration. The
+ - parameter migration:  A `Migration` object used to perform the migration. The
                          migration object allows you to enumerate and alter any
                          existing objects which require migration.
 
@@ -317,7 +319,7 @@ public final class Migration {
 
     /**
      Enumerates all the objects of a given type in this Realm, providing both the old and new versions of
-     each object. Object properties can be accessed using subscripting.
+     each object. Properties on an object can be accessed using subscripting.
 
      - parameter objectClassName: The name of the `Object` class to enumerate.
      - parameter block:           The block providing both the old and new versions of an object in this Realm.

--- a/RealmSwift/Object.swift
+++ b/RealmSwift/Object.swift
@@ -23,75 +23,82 @@ import Realm.Private
 #if swift(>=3.0)
 
 /**
-In Realm you define your model classes by subclassing `Object` and adding properties to be persisted.
-You then instantiate and use your custom subclasses instead of using the Object class directly.
+ `Object` is a class used to define Realm model objects.
 
-```swift
-class Dog: Object {
-    dynamic var name: String = ""
-    dynamic var adopted: Bool = false
-    let siblings = List<Dog>()
-}
-```
+ In Realm you define your model classes by subclassing `Object` and adding properties to be managed.
+ You then instantiate and use your custom subclasses instead of using the `Object` class directly.
 
-### Supported property types
+ ```swift
+ class Dog: Object {
+     dynamic var name: String = ""
+     dynamic var adopted: Bool = false
+     let siblings = List<Dog>()
+ }
+ ```
 
-- `String`, `NSString`
-- `Int`
-- `Int8`, `Int16`, `Int32`, `Int64`
-- `Float`
-- `Double`
-- `Bool`
-- `Date`, `NSDate`
-- `Data`, `NSData`
-- `RealmOptional<T>` for optional numeric properties
-- `Object` subclasses for to-one relationships
-- `List<T: Object>` for to-many relationships
+ ### Supported property types
 
-`String`, `NSString`, `Date`, `NSDate`, `Data`, `NSData` and `Object` subclass properties
-can be optional. `Int`, `Int8`, Int16`, Int32`, `Int64`, `Float`, `Double`, `Bool`
-and `List` properties cannot. To store an optional number, instead use
-`RealmOptional<Int>`, `RealmOptional<Float>`, `RealmOptional<Double>`, or
-`RealmOptional<Bool>` instead, which wraps an optional value of the generic type.
+ - `String`, `NSString`
+ - `Int`
+ - `Int8`, `Int16`, `Int32`, `Int64`
+ - `Float`
+ - `Double`
+ - `Bool`
+ - `Date`, `NSDate`
+ - `Data`, `NSData`
+ - `RealmOptional<T>` for optional numeric properties
+ - `Object` subclasses, to model many-to-one relationships
+ - `List<T>`, to model many-to-many relationships
 
-All property types except for `List` and `RealmOptional` *must* be declared as
-`dynamic var`. `List` and `RealmOptional` properties must be declared as
-non-dynamic `let` properties.
+ `String`, `NSString`, `Date`, `NSDate`, `Data`, `NSData` and `Object` subclass properties can be declared as optional.
+ `Int`, `Int8`, `Int16`, Int32`, `Int64`, `Float`, `Double`, `Bool`, and `List` properties cannot. To store an optional
+ number, use `RealmOptional<Int>`, `RealmOptional<Float>`, `RealmOptional<Double>`, or `RealmOptional<Bool>` instead,
+ which wraps an optional numeric value.
 
-### Querying
+ All property types except for `List` and `RealmOptional` *must* be declared as `dynamic var`. `List` and
+ `RealmOptional` properties must be declared as non-dynamic `let` properties. Swift `lazy` properties are not allowed.
 
-You can gets `Results` of an Object subclass via the `objects(_:)` instance
-method on `Realm`.
+ Note that none of the restrictions listed above apply to properties that are configured to be ignored by Realm.
 
-### Relationships
+ ### Querying
 
-See our [Cocoa guide](http://realm.io/docs/cocoa) for more details.
-*/
+ You can retrieve all objects of a given type from a Realm by calling the `objects(_:)` instance method.
+ 
+ ### Relationships
+ 
+ See our [Cocoa guide](http://realm.io/docs/cocoa) for more details.
+ */
 @objc(RealmSwiftObject)
 open class Object: RLMObjectBase {
 
     // MARK: Initializers
 
     /**
-    Initialize a standalone (unpersisted) `Object`.
-    Call `add(_:)` on a `Realm` to add standalone objects to a realm.
+     Creates an unmanaged instance of a Realm object.
 
-    - see: Realm().add(_:)
-    */
+     Call `add(_:)` on a `Realm` instance to add an unmanaged object into that Realm.
+
+     - see: `Realm().add(_:)`
+     */
     public override required init() {
         super.init()
     }
 
     /**
-    Initialize a standalone (unpersisted) `Object` with values from an `Array<Any>` or
-    `Dictionary<String, Any>`.
-    Call `add(_:)` on a `Realm` to add standalone objects to a realm.
+     Creates an unmanaged instance of a Realm object.
 
-    - parameter value: The value used to populate the object. This can be any key/value coding compliant
-                       object, or a JSON object such as those returned from the methods in `NSJSONSerialization`,
-                       or an `Array` with one object for each persisted property. An exception will be
-                       thrown if any required properties are not present and no default is set.
-    */
+     The `value` argument is used to populate the object. It can be a key-value coding compliant object, an array or
+     dictionary returned from the methods in `NSJSONSerialization`, or an `Array` containing one element for each
+     managed property. An exception will be thrown if any required properties are not present and those properties were
+     not defined with default values.
+
+     When passing in an `Array` as the `value` argument, all properties must be present, valid and in the same order as
+     the properties defined in the model.
+
+     Call `add(_:)` on a `Realm` instance to add an unmanaged object into that Realm.
+
+     - parameter value:  The value used to populate the object.
+     */
     public init(value: Any) {
         type(of: self).sharedSchema() // ensure this class' objectSchema is loaded in the partialSharedSchema
         super.init(value: value, schema: RLMSchema.partialShared())
@@ -100,8 +107,7 @@ open class Object: RLMObjectBase {
 
     // MARK: Properties
 
-    /// The `Realm` this object belongs to, or `nil` if the object
-    /// does not belong to a realm (the object is standalone).
+    /// The Realm which manages the object, or `nil` if the object is unmanaged.
     public var realm: Realm? {
         if let rlmReam = RLMObjectBaseRealm(self) {
             return Realm(rlmReam)
@@ -109,18 +115,18 @@ open class Object: RLMObjectBase {
         return nil
     }
 
-    /// The `ObjectSchema` which lists the persisted properties for this object.
+    /// The object schema which lists the managed properties for the object.
     public var objectSchema: ObjectSchema {
         return ObjectSchema(RLMObjectBaseObjectSchema(self)!)
     }
 
-    /// Indicates if an object can no longer be accessed.
+    /// Indicates if the object can no longer be accessed because it is now invalid.
     ///
-    /// An object can no longer be accessed if the object has been deleted from the containing
-    /// `realm` or if `invalidate` is called on the containing `realm`.
+    /// An object can no longer be accessed if the object has been deleted from the Realm that manages it, or if
+    /// `invalidate()` is called on that Realm.
     open override var isInvalidated: Bool { return super.isInvalidated }
 
-    /// Returns a human-readable description of this object.
+    /// A human-readable description of the object.
     open override var description: String { return super.description }
 
     #if os(OSX)
@@ -143,31 +149,32 @@ open class Object: RLMObjectBase {
     // MARK: Object Customization
 
     /**
-    Override to designate a property as the primary key for an `Object` subclass. Only properties of
-    type String and Int can be designated as the primary key. Primary key
-    properties enforce uniqueness for each value whenever the property is set which incurs some overhead.
-    Indexes are created automatically for primary key properties.
+     Override this method to specify the name of a property to be used as the primary key.
 
-    - returns: Name of the property designated as the primary key, or `nil` if the model has no primary key.
-    */
+     Only properties of types `String` and `Int` can be designated as the primary key. Primary key properties enforce
+     uniqueness for each value whenever the property is set, which incurs minor overhead. Indexes are created
+     automatically for primary key properties.
+
+     - returns: The name of the property designated as the primary key, or `nil` if the model has no primary key.
+     */
     open class func primaryKey() -> String? { return nil }
 
     /**
-    Override to return an array of property names to ignore. These properties will not be persisted
-    and are treated as transient.
+     Override this method to specify the names of properties to ignore. These properties will not be managed by
+     the Realm that manages the object.
 
-    - returns: `Array` of property names to ignore.
-    */
+     - returns: An array of property names to ignore.
+     */
     open class func ignoredProperties() -> [String] { return [] }
 
     /**
-    Return an array of property names for properties which should be indexed.
-    Only supported for string, integer, boolean and date properties.
+     Returns an array of property names for properties which should be indexed.
 
-    - returns: `Array` of property names to index.
-    */
+     Only string, integer, boolean, `Date`, and `NSDate` properties are supported.
+
+     - returns: An array of property names.
+     */
     open class func indexedProperties() -> [String] { return [] }
-
 
     // MARK: Key-Value Coding & Subscripting
 
@@ -191,20 +198,18 @@ open class Object: RLMObjectBase {
     // MARK: Dynamic list
 
     /**
-    This method is useful only in specialized circumstances, for example, when building
-    components that integrate with Realm. If you are simply building an app on Realm, it is
-    recommended to use instance variables or cast the KVC returns.
+     Returns a list of `DynamicObject`s for a given property name.
 
-    Returns a List of DynamicObjects for a property name
+     - warning:  This method is useful only in specialized circumstances, for example, when building
+     components that integrate with Realm. If you are simply building an app on Realm, it is
+     recommended to use instance variables or cast the values returned from key-value coding.
 
-    - warning: This method is useful only in specialized circumstances
+     - parameter propertyName: The name of the property.
 
-    - parameter propertyName: The name of the property to get a List<DynamicObject>
+     - returns: A list of `DynamicObject`s.
 
-    - returns: A List of DynamicObjects
-
-    :nodoc:
-    */
+     :nodoc:
+     */
     public func dynamicList(_ propertyName: String) -> List<DynamicObject> {
         return unsafeBitCast(RLMDynamicGetByName(self, propertyName, true) as! RLMListBase,
                              to: List<DynamicObject>.self)
@@ -213,13 +218,13 @@ open class Object: RLMObjectBase {
     // MARK: Equatable
 
     /**
-    Returns whether both objects are equal.
+     Returns whether two Realm objects are equal.
 
-    Objects are considered equal when they are both from the same Realm and point to the same
-    underlying object in the database.
+     Objects are considered equal if and only if they are both managed by the same Realm and point to the same
+     underlying object in the database.
 
-    - parameter object: Object to compare for equality.
-    */
+     - parameter object: The object to compare the receiver to.
+     */
     open override func isEqual(_ object: Any?) -> Bool {
         return RLMObjectBaseAreEqual(self as RLMObjectBase?, object as? RLMObjectBase)
     }
@@ -408,7 +413,9 @@ public class ObjectUtil: NSObject {
  optional numeric value.
 
  All property types except for `List` and `RealmOptional` *must* be declared as `dynamic var`. `List` and
- `RealmOptional` properties must be declared as non-dynamic `let` properties.
+ `RealmOptional` properties must be declared as non-dynamic `let` properties. Swift `lazy` properties are not allowed.
+
+ Note that none of the restrictions listed above apply to properties that are configured to be ignored by Realm.
 
  ### Querying
 
@@ -420,11 +427,10 @@ public class ObjectUtil: NSObject {
 */
 @objc(RealmSwiftObject)
 public class Object: RLMObjectBase {
-
     // MARK: Initializers
 
     /**
-     Initializes an unmanaged instance of a Realm object.
+     Creates an unmanaged instance of a Realm object.
 
      Call `add(_:)` on a `Realm` instance to add an unmanaged object into that Realm.
 
@@ -435,7 +441,7 @@ public class Object: RLMObjectBase {
     }
 
     /**
-     Initializes an unmanaged instance of a Realm object.
+     Creates an unmanaged instance of a Realm object.
 
      The `value` argument is used to populate the object. It can be a key-value coding compliant object, an array or
      dictionary returned from the methods in `NSJSONSerialization`, or an `Array` containing one element for each
@@ -473,7 +479,7 @@ public class Object: RLMObjectBase {
     /// Indicates if the object can no longer be accessed because it is now invalid.
     ///
     /// An object can no longer be accessed if the object has been deleted from the Realm that manages it, or if
-    /// `invalidate` is called on that Realm.
+    /// `invalidate()` is called on that Realm.
     public override var invalidated: Bool { return super.invalidated }
 
     /// Returns a human-readable description of the object.

--- a/RealmSwift/Object.swift
+++ b/RealmSwift/Object.swift
@@ -63,9 +63,9 @@ import Realm.Private
  ### Querying
 
  You can retrieve all objects of a given type from a Realm by calling the `objects(_:)` instance method.
- 
+
  ### Relationships
- 
+
  See our [Cocoa guide](http://realm.io/docs/cocoa) for more details.
  */
 @objc(RealmSwiftObject)

--- a/RealmSwift/ObjectSchema.swift
+++ b/RealmSwift/ObjectSchema.swift
@@ -22,28 +22,31 @@ import Realm
 #if swift(>=3.0)
 
 /**
-This class represents Realm model object schemas.
+ This class represents Realm model object schemas.
 
-When using Realm, `ObjectSchema` objects allow performing migrations and
-introspecting the database's schema.
+ When using Realm, `ObjectSchema` instances allow performing migrations and introspecting the database's schema.
 
-`ObjectSchema`s map to tables in the core database.
-*/
+ Object schemas map to tables in the core database.
+ */
 public final class ObjectSchema: CustomStringConvertible {
 
     // MARK: Properties
 
     internal let rlmObjectSchema: RLMObjectSchema
 
-    /// Array of persisted `Property` objects for an object.
+    /**
+     An array of `Property` instances representing the managed properties of a class described by the schema.
+
+     - see: `Property`
+     */
     public var properties: [Property] {
         return rlmObjectSchema.properties.map { Property($0) }
     }
 
-    /// The name of the class this schema describes.
+    /// The name of the class the schema describes.
     public var className: String { return rlmObjectSchema.className }
 
-    /// The property that serves as the primary key, if there is a primary key.
+    /// The property which serves as the primary key for the class the schema describes, if any.
     public var primaryKeyProperty: Property? {
         if let rlmProperty = rlmObjectSchema.primaryKeyProperty {
             return Property(rlmProperty)
@@ -51,7 +54,7 @@ public final class ObjectSchema: CustomStringConvertible {
         return nil
     }
 
-    /// Returns a human-readable description of the properties contained in this object schema.
+    /// A human-readable description of the properties contained in the object schema.
     public var description: String { return rlmObjectSchema.description }
 
     // MARK: Initializers

--- a/RealmSwift/Optional.swift
+++ b/RealmSwift/Optional.swift
@@ -20,7 +20,7 @@ import Realm
 
 #if swift(>=3.0)
 
-/// Types that can be represented in a `RealmOptional`.
+/// A protocol describing types that can parameterize a `RealmOptional`.
 public protocol RealmOptionalType {}
 extension Int: RealmOptionalType {}
 extension Int8: RealmOptionalType {}
@@ -32,14 +32,13 @@ extension Double: RealmOptionalType {}
 extension Bool: RealmOptionalType {}
 
 /**
-A `RealmOptional` represents a optional value for types that can't be directly
-declared as `dynamic` in Swift, such as `Int`s, `Float`, `Double`, and `Bool`.
+ A `RealmOptional` instance represents a optional value for types that can't be directly declared as `dynamic` in Swift,
+ such as `Int`, `Float`, `Double`, and `Bool`.
 
-It encapsulates a value in its `value` property, which is the only way to mutate
-a `RealmOptional` property on an `Object`.
-*/
+ To change the underlying value stored by a `RealmOptional` instance, mutate the instance's `value` property.
+ */
 public final class RealmOptional<T: RealmOptionalType>: RLMOptionalBase {
-    /// The value this optional represents.
+    /// The value the optional represents.
     public var value: T? {
         get {
             return underlyingValue.map(dynamicBridgeCast)
@@ -50,10 +49,10 @@ public final class RealmOptional<T: RealmOptionalType>: RLMOptionalBase {
     }
 
     /**
-    Creates a `RealmOptional` with the given default value (defaults to `nil`).
+     Creates a `RealmOptional` instance encapsulating the given default value.
 
-    - parameter value: The default value for this optional.
-    */
+     - parameter value: The value to store in the optional, or `nil` if not specified.
+     */
     public init(_ value: T? = nil) {
         super.init()
         self.value = value

--- a/RealmSwift/Property.swift
+++ b/RealmSwift/Property.swift
@@ -22,35 +22,36 @@ import Realm
 #if swift(>=3.0)
 
 /**
-This class represents properties persisted to Realm in an `ObjectSchema`.
+ `Property` instances represent properties managed by a Realm in the context of an object schema. Such properties may be
+ persisted to a Realm file or computed from other data in the Realm.
 
-When using Realm, `Property` objects allow performing migrations and
-introspecting the database's schema.
+ When using Realm, property instances allow performing migrations and introspecting the database's schema.
 
-These properties map to columns in the core database.
-*/
+ Property instances map to columns in the core database.
+ */
 public final class Property: CustomStringConvertible {
 
     // MARK: Properties
 
     internal let rlmProperty: RLMProperty
 
-    /// Property name.
+    /// The name of the property.
     public var name: String { return rlmProperty.name }
 
-    /// Property type.
+    /// The type of the property.
     public var type: PropertyType { return rlmProperty.type }
 
-    /// Whether this property is indexed.
+    /// Indicates whether this property is indexed.
     public var isIndexed: Bool { return rlmProperty.indexed }
 
-    /// Whether this property is optional (can contain `nil` values).
+    /// Indicates whether this property is optional. (Note that certain numeric types must be wrapped in a
+    /// `RealmOptional` instance in order to be declared as optional.)
     public var isOptional: Bool { return rlmProperty.optional }
 
-    /// Object class name - specify object types for `Object` and `List` properties.
+    /// For `Object` and `List` properties, the name of the class of object stored in the property.
     public var objectClassName: String? { return rlmProperty.objectClassName }
 
-    /// Returns a human-readable description of this property.
+    /// A human-readable description of the property object.
     public var description: String { return rlmProperty.description }
 
     // MARK: Initializers
@@ -83,11 +84,11 @@ extension Property {
 
 /**
  `Property` instances represent properties managed by a Realm in the context of an object schema. Such properties may be
- persisted to a Realm file or computed from other data from the Realm.
+ persisted to a Realm file or computed from other data in the Realm.
 
- When using Realm, `Property` instances allow performing migrations and introspecting the database's schema.
+ When using Realm, property instances allow performing migrations and introspecting the database's schema.
 
- These property instances map to columns in the core database.
+ Property instances map to columns in the core database.
 */
 public final class Property: CustomStringConvertible {
 

--- a/RealmSwift/Realm.swift
+++ b/RealmSwift/Realm.swift
@@ -23,72 +23,72 @@ import Realm.Private
 #if swift(>=3.0)
 
 /**
-A Realm instance (also referred to as "a realm") represents a Realm
-database.
+ A `Realm` instance (also referred to as "a Realm") represents a Realm database.
 
-Realms can either be stored on disk (see `init(path:)`) or in
-memory (see `Configuration`).
+ Realms can either be stored on disk (see `init(path:)`) or in memory (see `Configuration`).
 
-Realm instances are cached internally, and constructing equivalent Realm
-objects (with the same path or identifier) produces limited overhead.
+ `Realm` instances are cached internally, and constructing equivalent `Realm` objects (for example, by using the same
+ path or identifier) produces limited overhead.
 
-If you specifically want to ensure a Realm object is
-destroyed (for example, if you wish to open a realm, check some property, and
-then possibly delete the realm file and re-open it), place the code which uses
-the realm within an `autoreleasepool {}` and ensure you have no other
-strong references to it.
+ If you specifically want to ensure a `Realm` instance is destroyed (for example, if you wish to open a Realm, check
+ some property, and then possibly delete the Realm file and re-open it), place the code which uses the Realm within an
+ `autoreleasepool {}` and ensure you have no other strong references to it.
 
-- warning: Realm instances are not thread safe and can not be shared across
-           threads or dispatch queues. You must construct a new instance on each thread you want
-           to interact with the realm on. For dispatch queues, this means that you must
-           call it in each block which is dispatched, as a queue is not guaranteed to run
-           on a consistent thread.
-*/
+ - warning: `Realm` instances are not thread safe and cannot be shared across threads or dispatch queues. You must
+ construct a new instance for each thread in which a Realm will be accessed. For dispatch queues, this means
+ that you must construct a new instance in each block which is dispatched, as a queue is not guaranteed to
+ run all of its blocks on the same thread.
+ */
 public final class Realm {
 
     // MARK: Properties
 
-    /// The Schema used by this realm.
+    /// The `Schema` used by the Realm.
     public var schema: Schema { return Schema(rlmRealm.schema) }
 
-    /// Returns the `Configuration` that was used to create this `Realm` instance.
+    /// The `Configuration` value that was used to create the `Realm` instance.
     public var configuration: Configuration { return Configuration.fromRLMRealmConfiguration(rlmConfiguration: rlmRealm.configuration) }
 
-    /// Indicates if this Realm contains any objects.
+    /// Indicates if the Realm contains any objects.
     public var isEmpty: Bool { return rlmRealm.isEmpty }
 
     // MARK: Initializers
 
     /**
-    Obtains a Realm instance with the default Realm configuration, which can be
-    changed by setting `Realm.Configuration.defaultConfiguration`.
+     Obtains an instance of the default Realm.
 
-    - throws: An NSError if the Realm could not be initialized.
-    */
+     The default Realm is persisted as *default.realm* under the *Documents* directory of your Application on iOS, and
+     in your application's *Application Support* directory on OS X.
+
+     The default Realm is created using the default `Configuration`, which can be changed by setting the
+     `Realm.Configuration.defaultConfiguration` property to a new value.
+
+     - throws: An `NSError` if the Realm could not be initialized.
+     */
     public convenience init() throws {
         let rlmRealm = try RLMRealm(configuration: RLMRealmConfiguration.default())
         self.init(rlmRealm)
     }
 
     /**
-    Obtains a Realm instance with the given configuration.
+     Obtains a `Realm` instance with the given configuration.
 
-    - parameter configuration: The configuration to use when creating the Realm instance.
+     - parameter configuration: A configuration value to use when creating the Realm.
 
-    - throws: An NSError if the Realm could not be initialized.
-    */
+     - throws: An `NSError` if the Realm could not be initialized.
+     */
     public convenience init(configuration: Configuration) throws {
         let rlmRealm = try RLMRealm(configuration: configuration.rlmConfiguration)
         self.init(rlmRealm)
     }
 
     /**
-    Obtains a Realm instance persisted at the specified file URL.
+     Obtains a `Realm` instance persisted at a specified file URL.
 
-    - parameter fileURL: Local URL to the realm file.
+     - parameter fileURL: The local URL of the file the Realm should be saved at.
 
-    - throws: An NSError if the Realm could not be initialized.
-    */
+     - throws: An `NSError` if the Realm could not be initialized.
+     */
     public convenience init(fileURL: URL) throws {
         var configuration = Configuration.defaultConfiguration
         configuration.fileURL = fileURL
@@ -98,99 +98,95 @@ public final class Realm {
     // MARK: Transactions
 
     /**
-    Performs actions contained within the given block inside a write transaction.
+     Performs actions contained within the given block inside a write transaction.
 
-    Write transactions cannot be nested, and trying to execute a write transaction
-    on a `Realm` which is already in a write transaction will throw an exception.
-    Calls to `write` from `Realm` instances in other threads will block
-    until the current write transaction completes.
+     If the block throws an error, the transaction will be canceled, reverting any writes made in the block before the
+     error was thrown.
 
-    Before executing the write transaction, `write` updates the `Realm` to the
-    latest Realm version, as if `refresh()` was called, and generates notifications
-    if applicable. This has no effect if the `Realm` was already up to date.
+     Write transactions cannot be nested, and trying to execute a write transaction on a Realm which is already
+     participating in a write transaction will throw an error. Calls to `write` from `Realm` instances in other threads
+     will block until the current write transaction completes.
 
-    - parameter block: The block to be executed inside a write transaction.
+     Before executing the write transaction, `write` updates the `Realm` instance to the latest Realm version, as if
+     `refresh()` had been called, and generates notifications if applicable. This has no effect if the Realm was already
+     up to date.
 
-    - throws: An NSError if the transaction could not be written.
-    */
+     - parameter block: The block containing actions to perform.
+
+     - throws: An `NSError` if the transaction could not be completed successfully.
+               If `block` throws, the function throws the propagated `ErrorType` instead.
+     */
     public func write(_ block: () -> Void) throws {
         try rlmRealm.transaction(block)
     }
 
     /**
-    Begins a write transaction in a `Realm`.
+     Begins a write transaction on the Realm.
 
-    Only one write transaction can be open at a time. Write transactions cannot be
-    nested, and trying to begin a write transaction on a `Realm` which is
-    already in a write transaction will throw an exception. Calls to
-    `beginWrite` from `Realm` instances in other threads will block
-    until the current write transaction completes.
+     Only one write transaction can be open at a time. Write transactions cannot be nested, and trying to begin a write
+     transaction on a Realm which is already in a write transaction will throw an error. Calls to `beginWrite` from
+     `Realm` instances in other threads will block until the current write transaction completes.
 
-    Before beginning the write transaction, `beginWrite` updates the
-    `Realm` to the latest Realm version, as if `refresh()` was called, and
-    generates notifications if applicable. This has no effect if the `Realm`
-    was already up to date.
+     Before beginning the write transaction, `beginWrite` updates the `Realm` instance to the latest Realm version, as
+     if `refresh()` had been called, and generates notifications if applicable. This has no effect if the Realm was
+     already up to date.
 
-    It is rarely a good idea to have write transactions span multiple cycles of
-    the run loop, but if you do wish to do so you will need to ensure that the
-    `Realm` in the write transaction is kept alive until the write transaction
-    is committed.
-    */
+     It is rarely a good idea to have write transactions span multiple cycles of the run loop, but if you do wish to do
+     so you will need to ensure that the Realm in the write transaction is kept alive until the write transaction is
+     committed.
+     */
     public func beginWrite() {
         rlmRealm.beginWriteTransaction()
     }
 
     /**
-    Commits all writes operations in the current write transaction, and ends
-    the transaction.
+     Commits all write operations in the current write transaction, and ends the transaction.
 
-    Calling this when not in a write transaction will throw an exception.
+     - warning: This method may only be called during a write transaction.
 
-    - throws: An NSError if the transaction could not be written.
-    */
+     - throws: An `NSError` if the transaction could not be written.
+     */
     public func commitWrite() throws {
         try rlmRealm.commitWriteTransaction()
     }
 
     /**
-    Reverts all writes made in the current write transaction and end the transaction.
+     Reverts all writes made in the current write transaction and ends the transaction.
 
-    This rolls back all objects in the Realm to the state they were in at the
-    beginning of the write transaction, and then ends the transaction.
+     This rolls back all objects in the Realm to the state they were in at the beginning of the write transaction, and
+     then ends the transaction.
 
-    This restores the data for deleted objects, but does not revive invalidated
-    object instances. Any `Object`s which were added to the Realm will be
-    invalidated rather than switching back to standalone objects.
-    Given the following code:
+     This restores the data for deleted objects, but does not revive invalidated object instances. Any `Object`s which 
+     were added to the Realm will be invalidated rather than becoming unmanaged.
 
-    ```swift
-    let oldObject = objects(ObjectType).first!
-    let newObject = ObjectType()
+     Given the following code:
 
-    realm.beginWrite()
-    realm.add(newObject)
-    realm.delete(oldObject)
-    realm.cancelWrite()
-    ```
+     ```swift
+     let oldObject = objects(ObjectType).first!
+     let newObject = ObjectType()
 
-    Both `oldObject` and `newObject` will return `true` for `invalidated`,
-    but re-running the query which provided `oldObject` will once again return
-    the valid object.
+     realm.beginWrite()
+     realm.add(newObject)
+     realm.delete(oldObject)
+     realm.cancelWrite()
+     ```
 
-    Calling this when not in a write transaction will throw an exception.
-    */
+     Both `oldObject` and `newObject` will return `true` for `isInvalidated`, but re-running the query which provided
+     `oldObject` will once again return the valid object.
+
+     - warning: This method may only be called during a write transaction.
+     */
     public func cancelWrite() {
         rlmRealm.cancelWriteTransaction()
     }
 
     /**
-    Indicates if this Realm is currently in a write transaction.
+     Indicates whether the Realm is currently in a write transaction.
 
-    - warning: Wrapping mutating operations in a write transaction if this property returns `false`
-               may cause a large number of write transactions to be created, which could negatively
-               impact Realm's performance. Always prefer performing multiple mutations in a single
-               transaction when possible.
-    */
+     - warning:  Do not simply check this property and then start a write transaction whenever an object needs to be
+                 created, updated, or removed. Doing so might cause a large number of write transactions to be created,
+                 degrading performance. Instead, always prefer performing multiple updates during a single transaction.
+     */
     public var isInWriteTransaction: Bool {
         return rlmRealm.inWriteTransaction
     }
@@ -198,24 +194,22 @@ public final class Realm {
     // MARK: Adding and Creating objects
 
     /**
-    Adds or updates an object to be persisted it in this Realm.
+     Adds or updates an existing object into the Realm.
 
-    When 'update' is 'true', the object must have a primary key. If no objects exist in
-    the Realm instance with the same primary key value, the object is inserted. Otherwise,
-    the existing object is updated with any changed values.
+     Only pass `true` to `update` if the object has a primary key. If no objects exist in the Realm with the same
+     primary key value, the object is inserted. Otherwise, the existing object is updated with any changed values.
 
-    When added, all (child) relationships referenced by this object will also be
-    added to the Realm if they are not already in it. If the object or any related
-    objects already belong to a different Realm an exception will be thrown. Use one
-    of the `create` functions to insert a copy of a persisted object into a different
-    Realm.
+     When added, all child relationships referenced by this object will also be added to the Realm if they are not
+     already in it. If the object or any related objects are already being managed by a different Realm an error will be
+     thrown. Instead, use one of the `create` functions to insert a copy of a managed object into a different Realm.
 
-    The object to be added must be valid and cannot have been previously deleted
-    from a Realm (i.e. `invalidated` must be false).
+     The object to be added must be valid and cannot have been previously deleted from a Realm (i.e. `isInvalidated`
+     must be `false`).
 
-    - parameter object: Object to be added to this Realm.
-    - parameter update: If true will try to update existing objects with the same primary key.
-    */
+     - parameter object: The object to be added to this Realm.
+     - parameter update: If `true`, the Realm will try to find an existing copy of the object (with the same primary
+                         key), and update it. Otherwise, the object will be added.
+     */
     public func add(_ object: Object, update: Bool = false) {
         if update && object.objectSchema.primaryKeyProperty == nil {
             throwRealmException("'\(object.objectSchema.className)' does not have a primary key and can not be updated")
@@ -224,15 +218,15 @@ public final class Realm {
     }
 
     /**
-    Adds or updates objects in the given sequence to be persisted it in this Realm.
+     Adds or updates all the objects in a collection into the Realm.
 
-    - see: add(_:update:)
+     - see: `add(_:update:)`
 
-    - warning: This method can only be called during a write transaction.
+     - warning: This method may only be called during a write transaction.
 
-    - parameter objects: A sequence which contains objects to be added to this Realm.
-    - parameter update: If true will try to update existing objects with the same primary key.
-    */
+     - parameter objects: A sequence which contains objects to be added to the Realm.
+     - parameter update: If `true`, objects that are already in the Realm will be updated instead of added anew.
+     */
     public func add<S: Sequence>(_ objects: S, update: Bool = false) where S.Iterator.Element: Object {
         for obj in objects {
             add(obj, update: update)
@@ -240,28 +234,29 @@ public final class Realm {
     }
 
     /**
-    Create an `Object` with the given value.
+     Creates or updates a Realm object with a given value, adding it to the Realm and returning it.
 
-    Creates or updates an instance of this object and adds it to the `Realm` populating
-    the object with the given value.
+     Only pass `true` to `update` if the object has a primary key. If no objects exist in
+     the Realm with the same primary key value, the object is inserted. Otherwise,
+     the existing object is updated with any changed values.
 
-    When 'update' is 'true', the object must have a primary key. If no objects exist in
-    the Realm instance with the same primary key value, the object is inserted. Otherwise,
-    the existing object is updated with any changed values.
+     The `value` argument can be a key-value coding compliant object, an array or dictionary returned from the methods
+     in `NSJSONSerialization`, or an `Array` containing one element for each managed property. An exception will be
+     thrown if any required properties are not present and those properties were not defined with default values. Do not
+     pass in a `LinkingObjects` instance, either by itself or as a member of a collection.
 
-    - warning: This method can only be called during a write transaction.
+     When passing in an `Array` as the `value` argument, all properties must be present, valid and in the same order as
+     the properties defined in the model.
 
-    - parameter type:   The object type to create.
-    - parameter value:  The value used to populate the object. This can be any key/value coding compliant
-                        object, or a JSON dictionary such as those returned from the methods in `NSJSONSerialization`,
-                        or an `Array` with one object for each persisted property. An exception will be
-                        thrown if any required properties are not present and no default is set.
-                        When passing in an `Array`, all properties must be present,
-                        valid and in the same order as the properties defined in the model.
-    - parameter update: If true will try to update existing objects with the same primary key.
+     - warning: This method may only be called during a write transaction.
 
-    - returns: The created object.
-    */
+     - parameter type:   The type of the object to create.
+     - parameter value:  The value used to populate the object.
+     - parameter update: If `true`, the Realm will try to find an existing copy of the object (with the same primary
+                         key), and update it. Otherwise, the object will be added.
+
+     - returns: The newly created object.
+     */
     @discardableResult
     public func create<T: Object>(_ type: T.Type, value: Any = [:], update: Bool = false) -> T {
         let typeName = (type as Object.Type).className()
@@ -272,33 +267,35 @@ public final class Realm {
     }
 
     /**
-    This method is useful only in specialized circumstances, for example, when building
-    components that integrate with Realm. If you are simply building an app on Realm, it is
-    recommended to use the typed method `create(_:value:update:)`.
+     This method is useful only in specialized circumstances, for example, when building
+     components that integrate with Realm. If you are simply building an app on Realm, it is
+     recommended to use the typed method `create(_:value:update:)`.
 
-    Creates or updates an object with the given class name and adds it to the `Realm`, populating
-    the object with the given value.
+     Creates or updates an object with the given class name and adds it to the `Realm`, populating
+     the object with the given value.
 
-    When 'update' is 'true', the object must have a primary key. If no objects exist in
-    the Realm instance with the same primary key value, the object is inserted. Otherwise,
-    the existing object is updated with any changed values.
+     When 'update' is 'true', the object must have a primary key. If no objects exist in
+     the Realm instance with the same primary key value, the object is inserted. Otherwise,
+     the existing object is updated with any changed values.
 
-    - warning: This method can only be called during a write transaction.
+     The `value` argument is used to populate the object. It can be a key-value coding compliant object, an array or
+     dictionary returned from the methods in `NSJSONSerialization`, or an `Array` containing one element for each
+     managed property. An exception will be thrown if any required properties are not present and those properties were
+     not defined with default values.
 
-    - parameter className:  The class name of the object to create.
-    - parameter value:      The value used to populate the object. This can be any key/value coding compliant
-    object, or a JSON dictionary such as those returned from the methods in `NSJSONSerialization`,
-    or an `Array` with one object for each persisted property. An exception will be
-    thrown if any required properties are not present and no default is set.
+     When passing in an `Array` as the `value` argument, all properties must be present, valid and in the same order as
+     the properties defined in the model.
 
-    When passing in an `Array`, all properties must be present,
-    valid and in the same order as the properties defined in the model.
-    - parameter update:     If true will try to update existing objects with the same primary key.
+     - warning: This method can only be called during a write transaction.
 
-    - returns: The created object.
+     - parameter className:  The class name of the object to create.
+     - parameter value:      The value used to populate the object.
+     - parameter update:     If true will try to update existing objects with the same primary key.
 
-    :nodoc:
-    */
+     - returns: The created object.
+     
+     :nodoc:
+     */
     @discardableResult
     public func dynamicCreate(_ typeName: String, value: Any = [:], update: Bool = false) -> DynamicObject {
         if update && schema[typeName]?.primaryKeyProperty == nil {
@@ -310,24 +307,24 @@ public final class Realm {
     // MARK: Deleting objects
 
     /**
-    Deletes the given object from this Realm.
+     Deletes an object from the Realm. Once the object is deleted it is considered invalidated.
 
-    - warning: This method can only be called during a write transaction.
+     - warning: This method may only be called during a write transaction.
 
-    - parameter object: The object to be deleted.
-    */
+     - parameter object: The object to be deleted.
+     */
     public func delete(_ object: Object) {
         RLMDeleteObjectFromRealm(object, rlmRealm)
     }
 
     /**
-    Deletes the given objects from this Realm.
+     Deletes zero or more objects from the Realm.
 
-    - warning: This method can only be called during a write transaction.
+     - warning: This method may only be called during a write transaction.
 
-    - parameter objects: The objects to be deleted. This can be a `List<Object>`, `Results<Object>`,
-                         or any other enumerable SequenceType which generates Object.
-    */
+     - parameter objects:   The objects to be deleted. This can be a `List<Object>`, `Results<Object>`, or any other
+                            Swift `Sequence` whose elements are `Object`s.
+     */
     public func delete<S: Sequence>(_ objects: S) where S.Iterator.Element: Object {
         for obj in objects {
             delete(obj)
@@ -335,36 +332,36 @@ public final class Realm {
     }
 
     /**
-    Deletes the given objects from this Realm.
+     Deletes zero or more objects from the Realm.
 
-    - warning: This method can only be called during a write transaction.
+     - warning: This method may only be called during a write transaction.
 
-    - parameter objects: The objects to be deleted. Must be `List<Object>`.
+     - parameter objects: A list of objects to delete.
 
-    :nodoc:
-    */
+     :nodoc:
+     */
     public func delete<T: Object>(_ objects: List<T>) {
         rlmRealm.deleteObjects(objects._rlmArray)
     }
 
     /**
-    Deletes the given objects from this Realm.
+     Deletes zero or more objects from the Realm.
 
-    - warning: This method can only be called during a write transaction.
+     - warning: This method may only be called during a write transaction.
 
-    - parameter objects: The objects to be deleted. Must be `Results<Object>`.
+     - parameter objects: A `Results` containing the objects to be deleted.
 
-    :nodoc:
-    */
+     :nodoc:
+     */
     public func delete<T: Object>(_ objects: Results<T>) {
         rlmRealm.deleteObjects(objects.rlmResults)
     }
 
     /**
-    Deletes all objects from this Realm.
+     Deletes all objects from the Realm.
 
-    - warning: This method can only be called during a write transaction.
-    */
+     - warning: This method may only be called during a write transaction.
+     */
     public func deleteAll() {
         RLMDeleteAllObjectsFromRealm(rlmRealm)
     }
@@ -372,49 +369,44 @@ public final class Realm {
     // MARK: Object Retrieval
 
     /**
-    Returns all objects of the given type in the Realm.
+     Returns all objects of the given type stored in the Realm.
 
-    - parameter type: The type of the objects to be returned.
+     - parameter type: The type of the objects to be returned.
 
-    - returns: All objects of the given type in Realm.
-    */
+     - returns: A `Results` containing the objects.
+     */
     public func objects<T: Object>(_ type: T.Type) -> Results<T> {
         return Results<T>(RLMGetObjects(rlmRealm, (type as Object.Type).className(), nil))
     }
 
     /**
-    This method is useful only in specialized circumstances, for example, when building
-    components that integrate with Realm. If you are simply building an app on Realm, it is
-    recommended to use the typed method `objects(type:)`.
+     This method is useful only in specialized circumstances, for example, when building
+     components that integrate with Realm. If you are simply building an app on Realm, it is
+     recommended to use the typed method `objects(type:)`.
 
-    Returns all objects for a given class name in the Realm.
+     Returns all objects for a given class name in the Realm.
 
-    - warning: This method is useful only in specialized circumstances.
+     - parameter typeName: The class name of the objects to be returned.
+     - returns: All objects for the given class name as dynamic objects
 
-    - parameter typeName: The class name of the objects to be returned.
-
-    - returns: All objects for the given class name as dynamic objects
-
-    :nodoc:
-    */
+     :nodoc:
+     */
     public func dynamicObjects(_ typeName: String) -> Results<DynamicObject> {
         return Results<DynamicObject>(RLMGetObjects(rlmRealm, typeName, nil))
     }
 
     /**
-    Get an object with the given primary key.
+     Retrieves the single instance of a given object type with the given primary key from the Realm.
 
-    Returns `nil` if no object exists with the given primary key.
+     This method requires that `primaryKey()` be overridden on the given object class.
 
-    This method requires that `primaryKey()` be overridden on the given subclass.
+     - see: `Object.primaryKey()`
 
-    - see: Object.primaryKey()
+     - parameter type: The type of the object to be returned.
+     - parameter key:  The primary key of the desired object.
 
-    - parameter type: The type of the objects to be returned.
-    - parameter key:  The primary key of the desired object.
-
-    - returns: An object of type `type` or `nil` if an object with the given primary key does not exist.
-    */
+     - returns: An object of type `type`, or `nil` if no instance with the given primary key exists.
+     */
     public func object<T: Object, K>(ofType type: T.Type, forPrimaryKey key: K) -> T? {
         return unsafeBitCast(RLMGetObject(rlmRealm, (type as Object.Type).className(),
                                           dynamicBridgeCast(fromSwift: key)) as! RLMObjectBase?,
@@ -422,27 +414,27 @@ public final class Realm {
     }
 
     /**
-    This method is useful only in specialized circumstances, for example, when building
-    components that integrate with Realm. If you are simply building an app on Realm, it is
-    recommended to use the typed method `objectForPrimaryKey(_:key:)`.
+     This method is useful only in specialized circumstances, for example, when building
+     components that integrate with Realm. If you are simply building an app on Realm, it is
+     recommended to use the typed method `objectForPrimaryKey(_:key:)`.
 
-    Get a dynamic object with the given class name and primary key.
+     Get a dynamic object with the given class name and primary key.
 
-    Returns `nil` if no object exists with the given class name and primary key.
+     Returns `nil` if no object exists with the given class name and primary key.
 
-    This method requires that `primaryKey()` be overridden on the given subclass.
+     This method requires that `primaryKey()` be overridden on the given subclass.
 
-    - see: Object.primaryKey()
+     - see: Object.primaryKey()
 
-    - warning: This method is useful only in specialized circumstances.
+     - warning: This method is useful only in specialized circumstances.
 
-    - parameter className:  The class name of the object to be returned.
-    - parameter key:        The primary key of the desired object.
+     - parameter className:  The class name of the object to be returned.
+     - parameter key:        The primary key of the desired object.
 
-    - returns: An object of type `DynamicObject` or `nil` if an object with the given primary key does not exist.
-
-    :nodoc:
-    */
+     - returns: An object of type `DynamicObject` or `nil` if an object with the given primary key does not exist.
+     
+     :nodoc:
+     */
     public func dynamicObject(ofType typeName: String, forPrimaryKey key: Any) -> DynamicObject? {
         return unsafeBitCast(RLMGetObject(rlmRealm, typeName, key) as! RLMObjectBase?, to: Optional<DynamicObject>.self)
     }
@@ -450,38 +442,33 @@ public final class Realm {
     // MARK: Notifications
 
     /**
-    Add a notification handler for changes in this Realm.
+     Adds a notification handler for changes made to this Realm, and returns a notification token.
 
-    Notification handlers are called after each write transaction is committed,
-    independent from the thread or process.
+     Notification handlers are called after each write transaction is committed, independent of the thread or process.
 
-    The block is called on the same thread as it was added on, and can only
-    be added on threads which are currently within a run loop. Unless you are
-    specifically creating and running a run loop on a background thread, this
-    normally will only be the main thread.
+     Handler blocks are called on the same thread that they were added on, and may only be added on threads which are
+     currently within a run loop. Unless you are specifically creating and running a run loop on a background thread,
+     this will normally only be the main thread.
 
-    Notifications can't be delivered as long as the runloop is blocked by
-    other activity. When notifications can't be delivered instantly, multiple
-    notifications may be coalesced.
+     Notifications can't be delivered as long as the run loop is blocked by other activity. When notifications can't be
+     delivered instantly, multiple notifications may be coalesced.
 
-    You must retain the returned token for as long as you want updates to continue
-    to be sent to the block. To stop receiving updates, call stop() on the token.
+     You must retain the returned token for as long as you want updates to be sent to the block. To stop receiving
+     updates, call `stop()` on the token.
 
-    - parameter block: A block which is called to process Realm notifications.
-                       It receives the following parameters:
+     - parameter block: A block which is called to process Realm notifications. It receives the following parameters:
+                        `notification`: the incoming notification; `realm`: the Realm for which the notification
+                        occurred.
 
-                       - `Notification`: The incoming notification.
-                       - `Realm`:        The realm for which this notification occurred.
-
-    - returns: A token which must be held for as long as you want notifications to be delivered.
-    */
+     - returns: A token which must be held for as long as you wish to continue receiving change notifications.
+     */
     public func addNotificationBlock(_ block: @escaping NotificationBlock) -> NotificationToken {
         return rlmRealm.addNotificationBlock { rlmNotification, _ in
             switch rlmNotification {
             case RLMNotification.DidChange:
-                block(.DidChange, self)
+                block(.didChange, self)
             case RLMNotification.RefreshRequired:
-                block(.RefreshRequired, self)
+                block(.refreshRequired, self)
             default:
                 fatalError("Unhandled notification type: \(rlmNotification)")
             }
@@ -491,34 +478,28 @@ public final class Realm {
     // MARK: Autorefresh and Refresh
 
     /**
-    Whether this Realm automatically updates when changes happen in other threads.
+     Set this property to `true` to automatically update this Realm when changes happen in other threads.
 
-    If set to `true` (the default), changes made on other threads will be reflected
-    in this Realm on the next cycle of the run loop after the changes are
-    committed.  If set to `false`, you must manually call `refresh()` on the Realm to
-    update it to get the latest version.
+     If set to `true` (the default), changes made on other threads will be reflected in this Realm on the next cycle of
+     the run loop after the changes are committed.  If set to `false`, you must manually call `refresh()` on the Realm
+     to update it to get the latest data.
 
-    Note that by default, background threads do not have an active run loop and you
-    will need to manually call `refresh()` in order to update to the latest version,
-    even if `autorefresh` is set to `true`.
+     Note that by default, background threads do not have an active run loop and you will need to manually call
+     `refresh()` in order to update to the latest version, even if `autorefresh` is set to `true`.
 
-    Even with this enabled, you can still call `refresh()` at any time to update the
-    Realm before the automatic refresh would occur.
+     Even with this property enabled, you can still call `refresh()` at any time to update the Realm before the
+     automatic refresh would occur.
 
-    Notifications are sent when a write transaction is committed whether or not
-    this is enabled.
+     Notifications are sent when a write transaction is committed whether or not automatic refreshing is enabled.
 
-    Disabling this on a `Realm` without any strong references to it will not
-    have any effect, and it will switch back to YES the next time the `Realm`
-    object is created. This is normally irrelevant as it means that there is
-    nothing to refresh (as persisted `Object`s, `List`s, and `Results` have strong
-    references to the containing `Realm`), but it means that setting
-    `Realm().autorefresh = false` in
-    `application(_:didFinishLaunchingWithOptions:)` and only later storing Realm
-    objects will not work.
+     Disabling `autorefresh` on a `Realm` without any strong references to it will not have any effect, and
+     `autorefresh` will revert back to `true` the next time the Realm is created. This is normally irrelevant as it
+     means that there is nothing to refresh (as managed `Object`s, `List`s, and `Results` have strong references to the
+     `Realm` that manages them), but it means that setting `autorefresh = false` in
+     `application(_:didFinishLaunchingWithOptions:)` and only later storing Realm objects will not work.
 
-    Defaults to true.
-    */
+     Defaults to `true`.
+     */
     public var autorefresh: Bool {
         get {
             return rlmRealm.autorefresh
@@ -529,12 +510,11 @@ public final class Realm {
     }
 
     /**
-    Update a `Realm` and outstanding objects to point to the most recent
-    data for this `Realm`.
+     Updates the Realm and outstanding objects managed by the Realm to point to the most recent data.
 
-    - returns: Whether the realm had any updates.
-               Note that this may return true even if no data has actually changed.
-    */
+     - returns: Whether there were any updates for the Realm. Note that `true` may be returned even if no data actually
+     changed.
+     */
     @discardableResult
     public func refresh() -> Bool {
         return rlmRealm.refresh()
@@ -543,25 +523,24 @@ public final class Realm {
     // MARK: Invalidation
 
     /**
-    Invalidate all `Object`s and `Results` read from this Realm.
+     Invalidates all `Object`s, `Results`, `LinkingObjects`, and `List`s managed by the Realm.
 
-    A Realm holds a read lock on the version of the data accessed by it, so
-    that changes made to the Realm on different threads do not modify or delete the
-    data seen by this Realm. Calling this method releases the read lock,
-    allowing the space used on disk to be reused by later write transactions rather
-    than growing the file. This method should be called before performing long
-    blocking operations on a background thread on which you previously read data
-    from the Realm which you no longer need.
+     A Realm holds a read lock on the version of the data accessed by it, so
+     that changes made to the Realm on different threads do not modify or delete the
+     data seen by this Realm. Calling this method releases the read lock,
+     allowing the space used on disk to be reused by later write transactions rather
+     than growing the file. This method should be called before performing long
+     blocking operations on a background thread on which you previously read data
+     from the Realm which you no longer need.
 
-    All `Object`, `Results` and `List` instances obtained from this
-    `Realm` on the current thread are invalidated, and can not longer be used.
-    The `Realm` itself remains valid, and a new read transaction is implicitly
-    begun the next time data is read from the Realm.
+     All `Object`, `Results` and `List` instances obtained from this `Realm` instance on the current thread are
+     invalidated. `Object`s and `Array`s cannot be used. `Results` will become empty. The Realm itself remains valid,
+     and a new read transaction is implicitly begun the next time data is read from the Realm.
 
-    Calling this method multiple times in a row without reading any data from the
-    Realm, or before ever reading any data from the Realm is a no-op. This method
-    cannot be called on a read-only Realm.
-    */
+     Calling this method multiple times in a row without reading any data from the
+     Realm, or before ever reading any data from the Realm, is a no-op. This method
+     may not be called on a read-only Realm.
+     */
     public func invalidate() {
         rlmRealm.invalidate()
     }
@@ -569,18 +548,18 @@ public final class Realm {
     // MARK: Writing a Copy
 
     /**
-    Write an encrypted and compacted copy of the Realm to the given local URL.
+     Writes a compacted and optionally encrypted copy of the Realm to the given local URL.
 
-    The destination file cannot already exist.
+     The destination file cannot already exist.
 
-    Note that if this is called from within a write transaction it writes the
-    *current* data, and not data when the last write transaction was committed.
+     Note that if this method is called from within a write transaction, the *current* data is written, not the data
+     from the point when the previous write transaction was committed.
 
-    - parameter fileURL:       Local URL to save the Realm to.
-    - parameter encryptionKey: Optional 64-byte encryption key to encrypt the new file with.
+     - parameter fileURL:       Local URL to save the Realm to.
+     - parameter encryptionKey: Optional 64-byte encryption key to encrypt the new file with.
 
-    - throws: An NSError if the copy could not be written.
-    */
+     - throws: An `NSError` if the copy could not be written.
+     */
     public func writeCopy(toFile fileURL: URL, encryptionKey: Data? = nil) throws {
         try rlmRealm.writeCopy(to: fileURL, encryptionKey: encryptionKey)
     }
@@ -598,7 +577,7 @@ public final class Realm {
 
 extension Realm: Equatable { }
 
-/// Returns whether the two realms are equal.
+/// Returns whether two `Realm` isntances are equal.
 public func == (lhs: Realm, rhs: Realm) -> Bool { // swiftlint:disable:this valid_docs
     return lhs.rlmRealm == rhs.rlmRealm
 }
@@ -606,32 +585,33 @@ public func == (lhs: Realm, rhs: Realm) -> Bool { // swiftlint:disable:this vali
 // MARK: Notifications
 
 extension Realm {
-    /// A notification due to changes to a realm.
+    /// A notification indicating that changes were made to a Realm.
     public enum Notification: String {
         /**
-        Posted when the data in a realm has changed.
+         This notification is posted when the data in a Realm has changed.
 
-        DidChange is posted after a realm has been refreshed to reflect a write transaction, i.e. when
-        an autorefresh occurs, `refresh()` is called, after an implicit refresh from
-        `write(_:)`/`beginWrite()`, and after a local write transaction is committed.
-        */
-        case DidChange = "RLMRealmDidChangeNotification"
+         `didChange` is posted after a Realm has been refreshed to reflect a write transaction, This can happen when an
+         autorefresh occurs, `refresh()` is called, after an implicit refresh from `write(_:)`/`beginWrite()`, or after
+         a local write transaction is committed.
+         */
+        case didChange = "RLMRealmDidChangeNotification"
 
         /**
-        Posted when a write transaction has been committed to a Realm on a different thread for the same
-        file. This is not posted if `autorefresh` is enabled or if the Realm is refreshed before the
-        notification has a chance to run.
+         This notification is posted when a write transaction has been committed to a Realm on a different thread for
+         the same file.
 
-        Realms with autorefresh disabled should normally have a handler for this notification which
-        calls `refresh()` after doing some work.
-        While not refreshing is allowed, it may lead to large Realm files as Realm has to keep an extra
-        copy of the data for the un-refreshed Realm.
-        */
-        case RefreshRequired = "RLMRealmRefreshRequiredNotification"
+         It is not posted if `autorefresh` is enabled, or if the Realm is refreshed before the notification has a chance
+         to run.
+
+         Realms with autorefresh disabled should normally install a handler for this notification which calls
+         `refresh()` after doing some work. Refreshing the Realm is optional, but not refreshing the Realm may lead to
+         large Realm files. This is because an extra copy of the data must be kept for the stale Realm.
+         */
+        case refreshRequired = "RLMRealmRefreshRequiredNotification"
     }
 }
 
-/// Closure to run when the data in a Realm was modified.
+/// The type of a block to run for notification purposes when the data in a Realm is modified.
 public typealias NotificationBlock = (_ notification: Realm.Notification, _ realm: Realm) -> Void
 
 
@@ -963,7 +943,7 @@ public final class Realm {
     }
 
     /**
-     Deletes one or more objects from the Realm.
+     Deletes zero or more objects from the Realm.
 
      - warning: This method may only be called during a write transaction.
 
@@ -977,7 +957,7 @@ public final class Realm {
     }
 
     /**
-     Deletes one or more objects from the Realm.
+     Deletes zero or more objects from the Realm.
 
      - warning: This method may only be called during a write transaction.
 
@@ -990,7 +970,7 @@ public final class Realm {
     }
 
     /**
-     Deletes one or more objects from the Realm.
+     Deletes zero or more objects from the Realm.
 
      - warning: This method may only be called during a write transaction.
 
@@ -1106,7 +1086,7 @@ public final class Realm {
                         `notification`: the incoming notification; `realm`: the Realm for which the notification
                         occurred.
 
-     - returns: A token which must be retained for as long as you wish to continue receiving change notifications.
+     - returns: A token which must be held for as long as you wish to continue receiving change notifications.
      */
     @warn_unused_result(message="You must hold on to the NotificationToken returned from addNotificationBlock")
     public func addNotificationBlock(block: NotificationBlock) -> NotificationToken {
@@ -1259,7 +1239,7 @@ public enum Notification: String {
 
      Realms with autorefresh disabled should normally install a handler for this notification which calls `refresh()`
      after doing some work. Refreshing the Realm is optional, but not refreshing the Realm may lead to large Realm
-     files. This is because Realm must keep an extra copy of the data for the stale Realm.
+     files. This is because an extra copy of the data must be kept for the stale Realm.
     */
     case RefreshRequired = "RLMRealmRefreshRequiredNotification"
 }

--- a/RealmSwift/Realm.swift
+++ b/RealmSwift/Realm.swift
@@ -156,7 +156,7 @@ public final class Realm {
      This rolls back all objects in the Realm to the state they were in at the beginning of the write transaction, and
      then ends the transaction.
 
-     This restores the data for deleted objects, but does not revive invalidated object instances. Any `Object`s which 
+     This restores the data for deleted objects, but does not revive invalidated object instances. Any `Object`s which
      were added to the Realm will be invalidated rather than becoming unmanaged.
 
      Given the following code:
@@ -293,7 +293,7 @@ public final class Realm {
      - parameter update:     If true will try to update existing objects with the same primary key.
 
      - returns: The created object.
-     
+
      :nodoc:
      */
     @discardableResult
@@ -432,7 +432,7 @@ public final class Realm {
      - parameter key:        The primary key of the desired object.
 
      - returns: An object of type `DynamicObject` or `nil` if an object with the given primary key does not exist.
-     
+
      :nodoc:
      */
     public func dynamicObject(ofType typeName: String, forPrimaryKey key: Any) -> DynamicObject? {

--- a/RealmSwift/RealmCollection.swift
+++ b/RealmSwift/RealmCollection.swift
@@ -594,7 +594,7 @@ public final class AnyRealmCollection<T: Object>: RealmCollection {
 
      - warning:  Collections may only be sorted by properties of boolean, `Date`, `NSDate`, single and double-precision
                  floating point, integer, and string types.
-       
+
      - see: `sorted(byProperty:ascending:)`
 
      - parameter sortDescriptors: A sequence of `SortDescriptor`s to sort by.
@@ -1493,7 +1493,7 @@ public final class AnyRealmCollection<T: Object>: RealmCollectionType {
      notifications can't be delivered instantly, multiple notifications may be
      coalesced into a single notification. This can include the notification
      with the initial collection.
-     
+
      For example, the following code performs a write
      transaction immediately after adding the notification block, so there is no
      opportunity for the initial notification to be delivered first. As a

--- a/RealmSwift/RealmCollection.swift
+++ b/RealmSwift/RealmCollection.swift
@@ -22,8 +22,8 @@ import Realm
 #if swift(>=3.0)
 
 /**
-Encapsulates iteration state and interface for iteration over a `RealmCollection`.
-*/
+ An iterator for a `RealmCollection` instance.
+ */
 public final class RLMIterator<T: Object>: IteratorProtocol {
     private var i: UInt = 0
     private let generatorBase: NSFastEnumerationIterator
@@ -43,318 +43,306 @@ public final class RLMIterator<T: Object>: IteratorProtocol {
 }
 
 /**
- RealmCollectionChange is passed to the notification blocks for Realm
- collections, and reports the current state of the collection and what changes
- were made to the collection since the last time the notification was called.
+ A `RealmCollectionChange` value encapsulates information about changes to collections
+ that are reported by Realm notifications.
 
- The arrays of indices in the .Update case follow UITableView's batching
- conventions, and can be passed as-is to a table view's batch update functions
- after converting to index paths in the appropriate section. For example, for a
- simple one-section table view, you can do the following:
+ The change information is available in two formats: a simple array of row
+ indices in the collection for each type of change, and an array of index paths
+ in a requested section suitable for passing directly to `UITableView`'s batch
+ update methods.
 
-    self.notificationToken = results.addNotificationBlock { changes
-        switch changes {
-        case .Initial:
-            // Results are now populated and can be accessed without blocking the UI
-            self.tableView.reloadData()
-            break
-        case .Update(_, let deletions, let insertions, let modifications):
-            // Query results have changed, so apply them to the TableView
-            self.tableView.beginUpdates()
-            self.tableView.insertRowsAtIndexPaths(insertions.map { NSIndexPath(forRow: $0, inSection: 0) },
-                withRowAnimation: .Automatic)
-            self.tableView.deleteRowsAtIndexPaths(deletions.map { NSIndexPath(forRow: $0, inSection: 0) },
-                withRowAnimation: .Automatic)
-            self.tableView.reloadRowsAtIndexPaths(modifications.map { NSIndexPath(forRow: $0, inSection: 0) },
-                withRowAnimation: .Automatic)
-            self.tableView.endUpdates()
-            break
-        case .Error(let err):
-            // An error occurred while opening the Realm file on the background worker thread
-            fatalError("\(err)")
-            break
-        }
-    }
+ The arrays of indices in the `.Update` case follow `UITableView`'s batching
+ conventions, and can be passed as-is to a table view's batch update functions after being converted to index paths.
+ For example, for a simple one-section table view, you can do the following:
+
+ ```swift
+ self.notificationToken = results.addNotificationBlock { changes in
+     switch changes {
+     case .initial:
+         // Results are now populated and can be accessed without blocking the UI
+         self.tableView.reloadData()
+         break
+     case .update(_, let deletions, let insertions, let modifications):
+         // Query results have changed, so apply them to the TableView
+         self.tableView.beginUpdates()
+         self.tableView.insertRowsAtIndexPaths(insertions.map { NSIndexPath(forRow: $0, inSection: 0) },
+            withRowAnimation: .Automatic)
+         self.tableView.deleteRowsAtIndexPaths(deletions.map { NSIndexPath(forRow: $0, inSection: 0) },
+            withRowAnimation: .Automatic)
+         self.tableView.reloadRowsAtIndexPaths(modifications.map { NSIndexPath(forRow: $0, inSection: 0) },
+            withRowAnimation: .Automatic)
+         self.tableView.endUpdates()
+         break
+     case .error(let err):
+         // An error occurred while opening the Realm file on the background worker thread
+         fatalError("\(err)")
+         break
+     }
+ }
+ ```
  */
 public enum RealmCollectionChange<T> {
-    /// The initial run of the query has completed (if applicable), and the
-    /// collection can now be used without performing any blocking work.
-    case Initial(T)
+    /**
+     `.initial` indicates that the initial run of the query has completed (if applicable), and the collection can now be
+     used without performing any blocking work.
+     */
+    case initial(T)
 
-    /// A write transaction has been committed which either changed which objects
-    /// are in the collection and/or modified one or more of the objects in the
-    /// collection.
-    ///
-    /// All three of the change arrays are always sorted in ascending order.
-    ///
-    /// - parameter deletions:     The indices in the previous version of the collection
-    ///                            which were removed from this one.
-    /// - parameter insertions:    The indices in the new collection which were added in
-    ///                            this version.
-    /// - parameter modifications: The indices of the objects in the new collection which
-    ///                            were modified in this version.
-    case Update(T, deletions: [Int], insertions: [Int], modifications: [Int])
+    /**
+     `.update` indicates that a write transaction has been committed which either changed which objects
+     are in the collection, and/or modified one or more of the objects in the collection.
 
-    /// If an error occurs, notification blocks are called one time with a
-    /// .Error result and an NSError with details. Currently the only thing
-    /// that can fail is opening the Realm on a background worker thread to
-    /// calculate the change set.
-    case Error(Swift.Error)
+     All three of the change arrays are always sorted in ascending order.
+
+     - parameter deletions:     The indices in the previous version of the collection which were removed from this one.
+     - parameter insertions:    The indices in the new collection which were added in this version.
+     - parameter modifications: The indices of the objects in the new collection which were modified in this version.
+     */
+    case update(T, deletions: [Int], insertions: [Int], modifications: [Int])
+
+    /**
+     If an error occurs, notification blocks are called one time with a `.error` result and an `NSError` containing
+     details about the error. This can only currently happen if the Realm is opened on a background worker thread to
+     calculate the change set.
+     */
+    case error(Swift.Error)
 
     static func fromObjc(value: T, change: RLMCollectionChange?, error: Swift.Error?) -> RealmCollectionChange {
         if let error = error {
-            return .Error(error)
+            return .error(error)
         }
         if let change = change {
-            return .Update(value,
+            return .update(value,
                 deletions: change.deletions as [Int],
                 insertions: change.insertions as [Int],
                 modifications: change.modifications as [Int])
         }
-        return .Initial(value)
+        return .initial(value)
     }
 }
 
 /**
-A homogenous collection of `Object`s which can be retrieved, filtered, sorted,
-and operated upon.
+ A homogenous collection of `Object`s which can be retrieved, filtered, sorted, and operated upon.
 */
 public protocol RealmCollection: RandomAccessCollection, LazyCollectionProtocol, CustomStringConvertible {
 
-    /// Element type contained in this collection.
+    /// The type of the objects contained in the collection.
     associatedtype Element: Object
 
 
     // MARK: Properties
 
-    /// The Realm the objects in this collection belong to, or `nil` if the
-    /// collection's owning object does not belong to a realm (the collection is
-    /// standalone).
+    /// The Realm which manages the collection, or `nil` for unmanaged collections.
     var realm: Realm? { get }
 
-    /// Indicates if the collection can no longer be accessed.
-    ///
-    /// The collection can no longer be accessed if `invalidate` is called on the containing `Realm`.
+    /**
+     Indicates if the collection can no longer be accessed.
+
+     The collection can no longer be accessed if `invalidate()` is called on the `Realm` that manages the collection.
+     */
     var isInvalidated: Bool { get }
 
-    /// Returns the number of objects in this collection.
+    /// The number of objects in the collection.
     var count: Int { get }
 
-    /// Returns a human-readable description of the objects contained in this collection.
+    /// A human-readable description of the objects contained in the collection.
     var description: String { get }
 
 
     // MARK: Index Retrieval
 
     /**
-    Returns the index of the given object, or `nil` if the object is not in the collection.
+     Returns the index of an object in the collection, or `nil` if the object is not present.
 
-    - parameter object: The object whose index is being queried.
-
-    - returns: The index of the given object, or `nil` if the object is not in the collection.
-    */
+     - parameter object: An object.
+     */
     func index(of object: Element) -> Int?
 
     /**
-    Returns the index of the first object matching the given predicate,
-    or `nil` no objects match.
+     Returns the index of the first object matching the predicate, or `nil` if no objects match.
 
-    - parameter predicate: The `NSPredicate` used to filter the objects.
-
-    - returns: The index of the first matching object, or `nil` if no objects match.
-    */
+     - parameter predicate: The predicate to use to filter the objects.
+     */
     func index(matching predicate: NSPredicate) -> Int?
 
     /**
-    Returns the index of the first object matching the given predicate,
-    or `nil` if no objects match.
+     Returns the index of the first object matching the predicate, or `nil` if no objects match.
 
-    - parameter predicateFormat: The predicate format string, optionally followed by a variable number
-    of arguments.
-
-    - returns: The index of the first matching object, or `nil` if no objects match.
-    */
+     - parameter predicateFormat: A predicate format string, optionally followed by a variable number of arguments.
+     */
     func index(matching predicateFormat: String, _ args: Any...) -> Int?
 
 
     // MARK: Filtering
 
     /**
-    Returns `Results` containing collection elements that match the given predicate.
+     Returns a `Results` containing all objects matching the given predicate in the collection.
 
-    - parameter predicateFormat: The predicate format string which can accept variable arguments.
-
-    - returns: `Results` containing collection elements that match the given predicate.
-    */
+     - parameter predicateFormat: A predicate format string, optionally followed by a variable number of arguments.
+     */
     func filter(_ predicateFormat: String, _ args: Any...) -> Results<Element>
 
     /**
-    Returns `Results` containing collection elements that match the given predicate.
+     Returns a `Results` containing all objects matching the given predicate in the collection.
 
-    - parameter predicate: The predicate to filter the objects.
-
-    - returns: `Results` containing collection elements that match the given predicate.
-    */
+     - parameter predicate: The predicate to use to filter the objects.
+     */
     func filter(_ predicate: NSPredicate) -> Results<Element>
 
 
     // MARK: Sorting
 
     /**
-    Returns `Results` containing collection elements sorted by the given property.
+     Returns a `Results` containing the objects in the collection, but sorted.
 
-    - parameter property:  The property name to sort by.
-    - parameter ascending: The direction to sort by.
+     Objects are sorted based on the values of the given property. For example, to sort a collection of `Student`s from
+     youngest to oldest based on their `age` property, you might call
+     `students.sorted(byProperty: "age", ascending: true)`.
 
-    - returns: `Results` containing collection elements sorted by the given property.
-    */
+     - warning: Collections may only be sorted by properties of boolean, `Date`, `NSDate`, single and double-precision
+                floating point, integer, and string types.
+
+     - parameter property:  The name of the property to sort by.
+     - parameter ascending: The direction to sort in.
+     */
     func sorted(byProperty property: String, ascending: Bool) -> Results<Element>
 
     /**
-    Returns `Results` with elements sorted by the given sort descriptors.
+     Returns a `Results` containing the objects in the collection, but sorted.
 
-    - parameter sortDescriptors: `SortDescriptor`s to sort by.
+     - warning: Collections may only be sorted by properties of boolean, `Date`, `NSDate`, single and double-precision
+                floating point, integer, and string types.
 
-    - returns: `Results` with elements sorted by the given sort descriptors.
-    */
+     - see: `sorted(byProperty:ascending:)`
+
+     - parameter sortDescriptors: A sequence of `SortDescriptor`s to sort by.
+     */
     func sorted<S: Sequence>(by sortDescriptors: S) -> Results<Element> where S.Iterator.Element == SortDescriptor
-
 
     // MARK: Aggregate Operations
 
     /**
-    Returns the minimum value of the given property.
+     Returns the minimum (lowest) value of the given property among all the objects in the collection, or `nil` if the
+     collection is empty.
 
-    - warning: Only names of properties of a type conforming to the `MinMaxType` protocol can be used.
+     - warning: Only a property whose type conforms to the `MinMaxType` protocol can be specified.
 
-    - parameter property: The name of a property conforming to `MinMaxType` to look for a minimum on.
-
-    - returns: The minimum value for the property amongst objects in the collection, or `nil` if the
-               collection is empty.
-    */
+     - parameter property: The name of a property whose minimum value is desired.
+     */
     func min<U: MinMaxType>(ofProperty property: String) -> U?
 
     /**
-    Returns the maximum value of the given property.
+     Returns the maximum (highest) value of the given property among all the objects in the collection, or `nil` if the
+     collection is empty.
 
-    - warning: Only names of properties of a type conforming to the `MinMaxType` protocol can be used.
+     - warning: Only a property whose type conforms to the `MinMaxType` protocol can be specified.
 
-    - parameter property: The name of a property conforming to `MinMaxType` to look for a maximum on.
-
-    - returns: The maximum value for the property amongst objects in the collection, or `nil` if the
-               collection is empty.
-    */
+     - parameter property: The name of a property whose minimum value is desired.
+     */
     func max<U: MinMaxType>(ofProperty property: String) -> U?
 
     /**
-    Returns the sum of the given property for objects in the collection.
+    Returns the sum of the given property for objects in the collection, or `nil` if the collection is empty.
 
     - warning: Only names of properties of a type conforming to the `AddableType` protocol can be used.
 
     - parameter property: The name of a property conforming to `AddableType` to calculate sum on.
-
-    - returns: The sum of the given property over all objects in the collection.
     */
     func sum<U: AddableType>(ofProperty property: String) -> U
 
     /**
-    Returns the average of the given property for objects in the collection.
+     Returns the sum of the values of a given property over all the objects in the collection.
 
-    - warning: Only names of properties of a type conforming to the `AddableType` protocol can be used.
+     - warning: Only a property whose type conforms to the `AddableType` protocol can be specified.
 
-    - parameter property: The name of a property conforming to `AddableType` to calculate average on.
-
-    - returns: The average of the given property over all objects in the collection, or `nil` if the
-               collection is empty.
-    */
+     - parameter property: The name of a property whose values should be summed.
+     */
     func average<U: AddableType>(ofProperty property: String) -> U?
 
 
     // MARK: Key-Value Coding
 
     /**
-    Returns an Array containing the results of invoking `valueForKey(_:)` using key on each of the collection's objects.
+     Returns an `Array` containing the results of invoking `valueForKey(_:)` with `key` on each of the collection's
+     objects.
 
-    - parameter key: The name of the property.
-
-    - returns: Array containing the results of invoking `valueForKey(_:)` using key on each of the collection's objects.
-    */
+     - parameter key: The name of the property whose values are desired.
+     */
     func value(forKey key: String) -> Any?
 
     /**
-     Returns an Array containing the results of invoking `valueForKeyPath(_:)` using keyPath on each of the
+     Returns an `Array` containing the results of invoking `valueForKeyPath(_:)` with `keyPath` on each of the
      collection's objects.
 
-     - parameter keyPath: The key path to the property.
-
-     - returns: Array containing the results of invoking `valueForKeyPath(_:)` using keyPath on each of the
-     collection's objects.
+     - parameter keyPath: The key path to the property whose values are desired.
      */
     func value(forKeyPath keyPath: String) -> Any?
 
     /**
-    Invokes `setValue(_:forKey:)` on each of the collection's objects using the specified value and key.
+     Invokes `setValue(_:forKey:)` on each of the collection's objects using the specified `value` and `key`.
 
-    - warning: This method can only be called during a write transaction.
+     - warning: This method may only be called during a write transaction.
 
-    - parameter value: The object value.
-    - parameter key:   The name of the property.
-    */
+     - parameter value: The object value.
+     - parameter key:   The name of the property whose value should be set on each object.
+     */
     func setValue(_ value: Any?, forKey key: String)
 
     // MARK: Notifications
 
     /**
-     Register a block to be called each time the collection changes.
+     Registers a block to be called each time the collection changes.
 
-     The block will be asynchronously called with the initial results, and then
-     called again after each write transaction which changes either any of the
-     objects in the collection, or which objects are in the collection.
+     The block will be asynchronously called with the initial results, and then called again after each write
+     transaction which changes either any of the objects in the collection, or which objects are in the collection.
 
-     At the time when the block is called, the collection object will be fully
-     evaluated and up-to-date, and as long as you do not perform a write
-     transaction on the same thread or explicitly call realm.refresh(),
-     accessing it will never perform blocking work.
+     The `change` parameter that is passed to the block reports, in the form of indices within the collection, which of
+     the objects were added, removed, or modified during each write transaction. See the `RealmCollectionChange`
+     documentation for more information on the change information supplied and an example of how to use it to update a
+     `UITableView`.
 
-     Notifications are delivered via the standard run loop, and so can't be
-     delivered while the run loop is blocked by other activity. When
-     notifications can't be delivered instantly, multiple notifications may be
-     coalesced into a single notification. This can include the notification
-     with the initial collection. For example, the following code performs a write
-     transaction immediately after adding the notification block, so there is no
-     opportunity for the initial notification to be delivered first. As a
-     result, the initial notification will reflect the state of the Realm after
-     the write transaction.
+     At the time when the block is called, the collection will be fully evaluated and up-to-date, and as long as you do
+     not perform a write transaction on the same thread or explicitly call `realm.refresh()`, accessing it will never
+     perform blocking work.
 
-         let results = realm.objects(Dog)
-         print("dogs.count: \(dogs?.count)") // => 0
-         let token = dogs.addNotificationBlock { (changes: RealmCollectionChange) in
-             switch changes {
-                 case .Initial(let dogs):
-                     // Will print "dogs.count: 1"
-                     print("dogs.count: \(dogs.count)")
-                     break
-                 case .Update:
-                     // Will not be hit in this example
-                     break
-                 case .Error:
-                     break
-             }
+     Notifications are delivered via the standard run loop, and so can't be delivered while the run loop is blocked by
+     other activity. When notifications can't be delivered instantly, multiple notifications may be coalesced into a
+     single notification. This can include the notification with the initial collection.
+
+     For example, the following code performs a write transaction immediately after adding the notification block, so
+     there is no opportunity for the initial notification to be delivered first. As a result, the initial notification
+     will reflect the state of the Realm after the write transaction.
+
+     ```swift
+     let results = realm.objects(Dog.self)
+     print("dogs.count: \(dogs?.count)") // => 0
+     let token = dogs.addNotificationBlock { changes in
+     switch changes {
+         case .initial(let dogs):
+             // Will print "dogs.count: 1"
+             print("dogs.count: \(dogs.count)")
+             break
+         case .update:
+             // Will not be hit in this example
+             break
+         case .error:
+             break
          }
-         try! realm.write {
-             let dog = Dog()
-             dog.name = "Rex"
-             person.dogs.append(dog)
-         }
-         // end of run loop execution context
+     }
+     try! realm.write {
+         let dog = Dog()
+         dog.name = "Rex"
+         person.dogs.append(dog)
+     }
+     // end of run loop execution context
+     ```
 
-     You must retain the returned token for as long as you want updates to continue
-     to be sent to the block. To stop receiving updates, call stop() on the token.
+     You must retain the returned token for as long as you want updates to be sent to the block. To stop receiving
+     updates, call `stop()` on the token.
 
-     - warning: This method cannot be called during a write transaction, or when
-                the source realm is read-only.
+     - warning: This method cannot be called during a write transaction, or when the containing Realm is read-only.
 
-     - parameter block: The block to be called with the evaluated collection and change information.
+     - parameter block: The block to be called whenever a change occurs.
      - returns: A token which must be held for as long as you want updates to be delivered.
      */
     func addNotificationBlock(_ block: @escaping (RealmCollectionChange<Self>) -> Void) -> NotificationToken
@@ -402,101 +390,36 @@ private final class _AnyRealmCollection<C: RealmCollection>: _AnyRealmCollection
 
     // MARK: Properties
 
-    /// The Realm the objects in this collection belong to, or `nil` if the
-    /// collection's owning object does not belong to a realm (the collection is
-    /// standalone).
     override var realm: Realm? { return base.realm }
-
-    /// Indicates if the collection can no longer be accessed.
-    ///
-    /// The collection can no longer be accessed if `invalidate` is called on the containing `Realm`.
     override var isInvalidated: Bool { return base.isInvalidated }
-
-    /// Returns the number of objects in this collection.
     override var count: Int { return base.count }
-
-    /// Returns a human-readable description of the objects contained in this collection.
     override var description: String { return base.description }
 
 
     // MARK: Index Retrieval
 
-    /**
-    Returns the index of the given object, or `nil` if the object is not in the collection.
-
-    - parameter object: The object whose index is being queried.
-
-    - returns: The index of the given object, or `nil` if the object is not in the collection.
-    */
     override func index(of object: C.Element) -> Int? { return base.index(of: object) }
 
-    /**
-    Returns the index of the first object matching the given predicate,
-    or `nil` no objects match.
-
-    - parameter predicate: The `NSPredicate` used to filter the objects.
-
-    - returns: The index of the first matching object, or `nil` if no objects match.
-    */
     override func index(matching predicate: NSPredicate) -> Int? { return base.index(matching: predicate) }
 
-    /**
-    Returns the index of the first object matching the given predicate,
-    or `nil` if no objects match.
-
-    - parameter predicateFormat: The predicate format string, optionally followed by a variable number
-    of arguments.
-
-    - returns: The index of the first matching object, or `nil` if no objects match.
-    */
     override func index(matching predicateFormat: String, _ args: Any...) -> Int? {
         return base.index(matching: NSPredicate(format: predicateFormat, argumentArray: args))
     }
 
     // MARK: Filtering
 
-    /**
-    Returns `Results` containing collection elements that match the given predicate.
-
-    - parameter predicateFormat: The predicate format string which can accept variable arguments.
-
-    - returns: `Results` containing collection elements that match the given predicate.
-    */
     override func filter(_ predicateFormat: String, _ args: Any...) -> Results<C.Element> {
         return base.filter(NSPredicate(format: predicateFormat, argumentArray: args))
     }
 
-    /**
-    Returns `Results` containing collection elements that match the given predicate.
-
-    - parameter predicate: The predicate to filter the objects.
-
-    - returns: `Results` containing collection elements that match the given predicate.
-    */
     override func filter(_ predicate: NSPredicate) -> Results<C.Element> { return base.filter(predicate) }
-
 
     // MARK: Sorting
 
-    /**
-    Returns `Results` containing collection elements sorted by the given property.
-
-    - parameter property:  The property name to sort by.
-    - parameter ascending: The direction to sort by.
-
-    - returns: `Results` containing collection elements sorted by the given property.
-    */
     override func sorted(byProperty property: String, ascending: Bool) -> Results<C.Element> {
         return base.sorted(byProperty: property, ascending: ascending)
     }
 
-    /**
-    Returns `Results` with elements sorted by the given sort descriptors.
-
-    - parameter sortDescriptors: `SortDescriptor`s to sort by.
-
-    - returns: `Results` with elements sorted by the given sort descriptors.
-    */
     override func sorted<S: Sequence>
         (by sortDescriptors: S) -> Results<C.Element> where S.Iterator.Element == SortDescriptor {
         return base.sorted(by: sortDescriptors)
@@ -505,57 +428,18 @@ private final class _AnyRealmCollection<C: RealmCollection>: _AnyRealmCollection
 
     // MARK: Aggregate Operations
 
-    /**
-    Returns the minimum value of the given property.
-
-    - warning: Only names of properties of a type conforming to the `MinMaxType` protocol can be used.
-
-    - parameter property: The name of a property conforming to `MinMaxType` to look for a minimum on.
-
-    - returns: The minimum value for the property amongst objects in the collection, or `nil` if the
-               collection is empty.
-    */
     override func min<U: MinMaxType>(ofProperty property: String) -> U? {
         return base.min(ofProperty: property)
     }
 
-    /**
-    Returns the maximum value of the given property.
-
-    - warning: Only names of properties of a type conforming to the `MinMaxType` protocol can be used.
-
-    - parameter property: The name of a property conforming to `MinMaxType` to look for a maximum on.
-
-    - returns: The maximum value for the property amongst objects in the collection, or `nil` if the
-               collection is empty.
-    */
     override func max<U: MinMaxType>(ofProperty property: String) -> U? {
         return base.max(ofProperty: property)
     }
 
-    /**
-    Returns the sum of the given property for objects in the collection.
-
-    - warning: Only names of properties of a type conforming to the `AddableType` protocol can be used.
-
-    - parameter property: The name of a property conforming to `AddableType` to calculate sum on.
-
-    - returns: The sum of the given property over all objects in the collection.
-    */
     override func sum<U: AddableType>(ofProperty property: String) -> U {
         return base.sum(ofProperty: property)
     }
 
-    /**
-    Returns the average of the given property for objects in the collection.
-
-    - warning: Only names of properties of a type conforming to the `AddableType` protocol can be used.
-
-    - parameter property: The name of a property conforming to `AddableType` to calculate average on.
-
-    - returns: The average of the given property over all objects in the collection, or `nil` if the
-               collection is empty.
-    */
     override func average<U: AddableType>(ofProperty property: String) -> U? {
         return base.average(ofProperty: property)
     }
@@ -563,19 +447,11 @@ private final class _AnyRealmCollection<C: RealmCollection>: _AnyRealmCollection
 
     // MARK: Sequence Support
 
-    /**
-    Returns the object at the given `index`.
-
-    - parameter index: The index.
-
-    - returns: The object at the given `index`.
-    */
     override subscript(position: Int) -> C.Element {
         // FIXME: it should be possible to avoid this force-casting
         return unsafeBitCast(base[position as! C.Index], to: C.Element.self)
     }
 
-    /// Returns a `RLMIterator` that yields successive elements in the collection.
     override func makeIterator() -> RLMIterator<Element> {
         // FIXME: it should be possible to avoid this force-casting
         return base.makeIterator() as! RLMIterator<Element>
@@ -584,16 +460,11 @@ private final class _AnyRealmCollection<C: RealmCollection>: _AnyRealmCollection
 
     // MARK: Collection Support
 
-    /// The position of the first element in a non-empty collection.
-    /// Identical to endIndex in an empty collection.
     override var startIndex: Int {
         // FIXME: it should be possible to avoid this force-casting
         return base.startIndex as! Int
     }
 
-    /// The collection's "past the end" position.
-    /// endIndex is not a valid argument to subscript, and is always reachable from startIndex by
-    /// zero or more applications of successor().
     override var endIndex: Int {
         // FIXME: it should be possible to avoid this force-casting
         return base.endIndex as! Int
@@ -602,34 +473,10 @@ private final class _AnyRealmCollection<C: RealmCollection>: _AnyRealmCollection
 
     // MARK: Key-Value Coding
 
-    /**
-    Returns an Array containing the results of invoking `valueForKey(_:)` using key on each of the collection's objects.
-
-    - parameter key: The name of the property.
-
-    - returns: Array containing the results of invoking `valueForKey(_:)` using key on each of the collection's objects.
-    */
     override func value(forKey key: String) -> Any? { return base.value(forKey: key) }
 
-    /**
-     Returns an Array containing the results of invoking `valueForKeyPath(_:)` using keyPath on each of the
-     collection's objects.
-
-     - parameter keyPath: The key path to the property.
-
-     - returns: Array containing the results of invoking `valueForKeyPath(_:)` using keyPath on each of the
-       collection's objects.
-     */
     override func value(forKeyPath keyPath: String) -> Any? { return base.value(forKeyPath: keyPath) }
 
-    /**
-    Invokes `setValue(_:forKey:)` on each of the collection's objects using the specified value and key.
-
-    - warning: This method can only be called during a write transaction.
-
-    - parameter value: The object value.
-    - parameter key:   The name of the property.
-    */
     override func setValue(_ value: Any?, forKey key: String) { base.setValue(value, forKey: key) }
 
     // MARK: Notifications
@@ -640,74 +487,64 @@ private final class _AnyRealmCollection<C: RealmCollection>: _AnyRealmCollection
 }
 
 /**
-A type-erased `RealmCollection`.
+ A type-erased `RealmCollection`.
 
-Forwards operations to an arbitrary underlying collection having the same
-Element type, hiding the specifics of the underlying `RealmCollection`.
-*/
+ Instances of `RealmCollection` forward operations to an opaque underlying collection having the same `Element` type.
+ */
 public final class AnyRealmCollection<T: Object>: RealmCollection {
 
     public func index(after i: Int) -> Int { return i + 1 }
     public func index(before i: Int) -> Int { return i - 1 }
 
-    /// Element type contained in this collection.
+    /// The type of the objects contained in the collection.
     public typealias Element = T
     private let base: _AnyRealmCollectionBase<T>
 
-    /// Creates an AnyRealmCollection wrapping `base`.
+    /// Creates an `AnyRealmCollection` wrapping `base`.
     public init<C: RealmCollection>(_ base: C) where C.Element == T {
         self.base = _AnyRealmCollection(base: base)
     }
 
     // MARK: Properties
 
-    /// The Realm the objects in this collection belong to, or `nil` if the
-    /// collection's owning object does not belong to a realm (the collection is
-    /// standalone).
+    /// The Realm which manages the collection, or `nil` if the collection is unmanaged.
     public var realm: Realm? { return base.realm }
 
-    /// Indicates if the collection can no longer be accessed.
-    ///
-    /// The collection can no longer be accessed if `invalidate` is called on the containing `Realm`.
+    /**
+     Indicates if the collection can no longer be accessed.
+
+     The collection can no longer be accessed if `invalidate()` is called on the containing `realm`.
+     */
     public var isInvalidated: Bool { return base.isInvalidated }
 
-    /// Returns the number of objects in this collection.
+    /// The number of objects in the collection.
     public var count: Int { return base.count }
 
-    /// Returns a human-readable description of the objects contained in this collection.
+    /// A human-readable description of the objects contained in the collection.
     public var description: String { return base.description }
 
 
     // MARK: Index Retrieval
 
     /**
-    Returns the index of the given object, or `nil` if the object is not in the collection.
+     Returns the index of the given object, or `nil` if the object is not in the collection.
 
-    - parameter object: The object whose index is being queried.
-
-    - returns: The index of the given object, or `nil` if the object is not in the collection.
-    */
+     - parameter object: An object.
+     */
     public func index(of object: Element) -> Int? { return base.index(of: object) }
 
     /**
-    Returns the index of the first object matching the given predicate,
-    or `nil` no objects match.
+     Returns the index of the first object matching the given predicate, or `nil` if no objects match.
 
-    - parameter predicate: The `NSPredicate` used to filter the objects.
-
-    - returns: The index of the first matching object, or `nil` if no objects match.
-    */
+     - parameter predicate: The predicate with which to filter the objects.
+     */
     public func index(matching predicate: NSPredicate) -> Int? { return base.index(matching: predicate) }
 
     /**
-    Returns the index of the first object matching the given predicate,
-    or `nil` if no objects match.
+     Returns the index of the first object matching the given predicate, or `nil` if no objects match.
 
-    - parameter predicateFormat: The predicate format string, optionally followed by a variable number
-    of arguments.
-
-    - returns: The index of the first matching object, or `nil` if no objects match.
-    */
+     - parameter predicateFormat: A predicate format string, optionally followed by a variable number of arguments.
+     */
     public func index(matching predicateFormat: String, _ args: Any...) -> Int? {
         return base.index(matching: NSPredicate(format: predicateFormat, argumentArray: args))
     }
@@ -715,47 +552,53 @@ public final class AnyRealmCollection<T: Object>: RealmCollection {
     // MARK: Filtering
 
     /**
-    Returns `Results` containing collection elements that match the given predicate.
+     Returns a `Results` containing all objects matching the given predicate in the collection.
 
-    - parameter predicateFormat: The predicate format string which can accept variable arguments.
-
-    - returns: `Results` containing collection elements that match the given predicate.
-    */
+     - parameter predicateFormat: A predicate format string, optionally followed by a variable number of arguments.
+     */
     public func filter(_ predicateFormat: String, _ args: Any...) -> Results<Element> {
         return base.filter(NSPredicate(format: predicateFormat, argumentArray: args))
     }
 
     /**
-    Returns `Results` containing collection elements that match the given predicate.
+     Returns a `Results` containing all objects matching the given predicate in the collection.
 
-    - parameter predicate: The predicate to filter the objects.
+     - parameter predicate: The predicate with which to filter the objects.
 
-    - returns: `Results` containing collection elements that match the given predicate.
-    */
+     - returns: A `Results` containing objects that match the given predicate.
+     */
     public func filter(_ predicate: NSPredicate) -> Results<Element> { return base.filter(predicate) }
 
 
     // MARK: Sorting
 
     /**
-    Returns `Results` containing collection elements sorted by the given property.
+     Returns a `Results` containing the objects in the collection, but sorted.
 
-    - parameter property:  The property name to sort by.
-    - parameter ascending: The direction to sort by.
+     Objects are sorted based on the values of the given property. For example, to sort a collection of `Student`s from
+     youngest to oldest based on their `age` property, you might call
+     `students.sorted(byProperty: "age", ascending: true)`.
 
-    - returns: `Results` containing collection elements sorted by the given property.
-    */
+     - warning:  Collections may only be sorted by properties of boolean, `Date`, `NSDate`, single and double-precision
+                 floating point, integer, and string types.
+
+     - parameter property:  The name of the property to sort by.
+     - parameter ascending: The direction to sort in.
+     */
     public func sorted(byProperty property: String, ascending: Bool) -> Results<Element> {
         return base.sorted(byProperty: property, ascending: ascending)
     }
 
     /**
-    Returns `Results` with elements sorted by the given sort descriptors.
+     Returns a `Results` containing the objects in the collection, but sorted.
 
-    - parameter sortDescriptors: `SortDescriptor`s to sort by.
+     - warning:  Collections may only be sorted by properties of boolean, `Date`, `NSDate`, single and double-precision
+                 floating point, integer, and string types.
+       
+     - see: `sorted(byProperty:ascending:)`
 
-    - returns: `Results` with elements sorted by the given sort descriptors.
-    */
+     - parameter sortDescriptors: A sequence of `SortDescriptor`s to sort by.
+     */
     public func sorted<S: Sequence>(by sortDescriptors: S) -> Results<Element>
         where S.Iterator.Element == SortDescriptor {
         return base.sorted(by: sortDescriptors)
@@ -765,66 +608,56 @@ public final class AnyRealmCollection<T: Object>: RealmCollection {
     // MARK: Aggregate Operations
 
     /**
-    Returns the minimum value of the given property.
+     Returns the minimum (lowest) value of the given property among all the objects in the collection, or `nil` if the
+     collection is empty.
 
-    - warning: Only names of properties of a type conforming to the `MinMaxType` protocol can be used.
+     - warning: Only a property whose type conforms to the `MinMaxType` protocol can be specified.
 
-    - parameter property: The name of a property conforming to `MinMaxType` to look for a minimum on.
-
-    - returns: The minimum value for the property amongst objects in the collection, or `nil` if the
-               collection is empty.
-    */
+     - parameter property: The name of a property whose minimum value is desired.
+     */
     public func min<U: MinMaxType>(ofProperty property: String) -> U? {
         return base.min(ofProperty: property)
     }
 
     /**
-    Returns the maximum value of the given property.
+     Returns the maximum (highest) value of the given property among all the objects in the collection, or `nil` if the
+     collection is empty.
 
-    - warning: Only names of properties of a type conforming to the `MinMaxType` protocol can be used.
+     - warning: Only a property whose type conforms to the `MinMaxType` protocol can be specified.
 
-    - parameter property: The name of a property conforming to `MinMaxType` to look for a maximum on.
-
-    - returns: The maximum value for the property amongst objects in the collection, or `nil` if the
-               collection is empty.
-    */
+     - parameter property: The name of a property whose minimum value is desired.
+     */
     public func max<U: MinMaxType>(ofProperty property: String) -> U? {
         return base.max(ofProperty: property)
     }
 
     /**
-    Returns the sum of the given property for objects in the collection.
+     Returns the sum of the values of a given property over all the objects in the collection.
 
-    - warning: Only names of properties of a type conforming to the `AddableType` protocol can be used.
+     - warning: Only a property whose type conforms to the `AddableType` protocol can be specified.
 
-    - parameter property: The name of a property conforming to `AddableType` to calculate sum on.
-
-    - returns: The sum of the given property over all objects in the collection.
-    */
+     - parameter property: The name of a property whose values should be summed.
+     */
     public func sum<U: AddableType>(ofProperty property: String) -> U { return base.sum(ofProperty: property) }
 
     /**
-    Returns the average of the given property for objects in the collection.
+     Returns the average value of a given property over all the objects in the collection, or `nil` if the collection is
+     empty.
 
-    - warning: Only names of properties of a type conforming to the `AddableType` protocol can be used.
+     - warning: Only the name of a property whose type conforms to the `AddableType` protocol can be specified.
 
-    - parameter property: The name of a property conforming to `AddableType` to calculate average on.
-
-    - returns: The average of the given property over all objects in the collection, or `nil` if the
-               collection is empty.
-    */
+     - parameter property: The name of a property whose average value should be calculated.
+     */
     public func average<U: AddableType>(ofProperty property: String) -> U? { return base.average(ofProperty: property) }
 
 
     // MARK: Sequence Support
 
     /**
-    Returns the object at the given `index`.
+     Returns the object at the given `index`.
 
-    - parameter index: The index.
-
-    - returns: The object at the given `index`.
-    */
+     - parameter index: The index.
+     */
     public subscript(position: Int) -> T { return base[position] }
 
     /// Returns a `RLMIterator` that yields successive elements in the collection.
@@ -846,88 +679,86 @@ public final class AnyRealmCollection<T: Object>: RealmCollection {
     // MARK: Key-Value Coding
 
     /**
-    Returns an Array containing the results of invoking `valueForKey(_:)` using key on each of the collection's objects.
+     Returns an `Array` containing the results of invoking `valueForKey(_:)` with `key` on each of the collection's
+     objects.
 
-    - parameter key: The name of the property.
-
-    - returns: Array containing the results of invoking `valueForKey(_:)` using key on each of the collection's objects.
-    */
+     - parameter key: The name of the property whose values are desired.
+     */
     public func value(forKey key: String) -> Any? { return base.value(forKey: key) }
 
     /**
-     Returns an Array containing the results of invoking `valueForKeyPath(_:)` using keyPath on each of the
+     Returns an `Array` containing the results of invoking `valueForKeyPath(_:)` with `keyPath` on each of the
      collection's objects.
 
-     - parameter keyPath: The key path to the property.
-
-     - returns: Array containing the results of invoking `valueForKeyPath(_:)` using keyPath on each of the
-     collection's objects.
+     - parameter keyPath: The key path to the property whose values are desired.
      */
     public func value(forKeyPath keyPath: String) -> Any? { return base.value(forKeyPath: keyPath) }
 
     /**
-    Invokes `setValue(_:forKey:)` on each of the collection's objects using the specified value and key.
+     Invokes `setValue(_:forKey:)` on each of the collection's objects using the specified `value` and `key`.
 
-    - warning: This method can only be called during a write transaction.
+     - warning: This method may only be called during a write transaction.
 
-    - parameter value: The object value.
-    - parameter key:   The name of the property.
-    */
+     - parameter value: The value to set the property to.
+     - parameter key:   The name of the property whose value should be set on each object.
+     */
     public func setValue(_ value: Any?, forKey key: String) { base.setValue(value, forKey: key) }
 
     // MARK: Notifications
 
     /**
-     Register a block to be called each time the collection changes.
+     Registers a block to be called each time the collection changes.
 
-     The block will be asynchronously called with the initial results, and then
-     called again after each write transaction which changes either any of the
-     objects in the collection, or which objects are in the collection.
+     The block will be asynchronously called with the initial results, and then called again after each write
+     transaction which changes either any of the objects in the collection, or which objects are in the collection.
 
-     At the time when the block is called, the collection object will be fully
-     evaluated and up-to-date, and as long as you do not perform a write
-     transaction on the same thread or explicitly call realm.refresh(),
-     accessing it will never perform blocking work.
+     The `change` parameter that is passed to the block reports, in the form of indices within the collection, which of
+     the objects were added, removed, or modified during each write transaction. See the `RealmCollectionChange`
+     documentation for more information on the change information supplied and an example of how to use it to update a
+     `UITableView`.
 
-     Notifications are delivered via the standard run loop, and so can't be
-     delivered while the run loop is blocked by other activity. When
-     notifications can't be delivered instantly, multiple notifications may be
-     coalesced into a single notification. This can include the notification
-     with the initial collection. For example, the following code performs a write
-     transaction immediately after adding the notification block, so there is no
-     opportunity for the initial notification to be delivered first. As a
-     result, the initial notification will reflect the state of the Realm after
-     the write transaction.
+     At the time when the block is called, the collection will be fully evaluated and up-to-date, and as long as you do
+     not perform a write transaction on the same thread or explicitly call `realm.refresh()`, accessing it will never
+     perform blocking work.
 
-         let results = realm.objects(Dog)
-         print("dogs.count: \(dogs?.count)") // => 0
-         let token = dogs.addNotificationBlock { (changes: RealmCollectionChange) in
-             switch changes {
-                 case .Initial(let dogs):
-                     // Will print "dogs.count: 1"
-                     print("dogs.count: \(dogs.count)")
-                     break
-                 case .Update:
-                     // Will not be hit in this example
-                     break
-                 case .Error:
-                     break
-             }
+     Notifications are delivered via the standard run loop, and so can't be delivered while the run loop is blocked by
+     other activity. When notifications can't be delivered instantly, multiple notifications may be coalesced into a
+     single notification. This can include the notification with the initial collection.
+
+     For example, the following code performs a write transaction immediately after adding the notification block, so
+     there is no opportunity for the initial notification to be delivered first. As a result, the initial notification
+     will reflect the state of the Realm after the write transaction.
+
+     ```swift
+     let results = realm.objects(Dog.self)
+     print("dogs.count: \(dogs?.count)") // => 0
+     let token = dogs.addNotificationBlock { changes in
+         switch changes {
+         case .initial(let dogs):
+             // Will print "dogs.count: 1"
+             print("dogs.count: \(dogs.count)")
+             break
+         case .update:
+             // Will not be hit in this example
+             break
+         case .error:
+             break
          }
-         try! realm.write {
-             let dog = Dog()
-             dog.name = "Rex"
-             person.dogs.append(dog)
-         }
-         // end of run loop execution context
+     }
+     try! realm.write {
+         let dog = Dog()
+         dog.name = "Rex"
+         person.dogs.append(dog)
+     }
+     // end of run loop execution context
+     ```
 
-     You must retain the returned token for as long as you want updates to continue
-     to be sent to the block. To stop receiving updates, call stop() on the token.
+     You must retain the returned token for as long as you want updates to be sent to the block. To stop receiving
+     updates, call `stop()` on the token.
 
-     - warning: This method cannot be called during a write transaction, or when
-                the source realm is read-only.
+     - warning: This method cannot be called during a write transaction, or when the containing Realm is read-only.
 
-     - parameter block: The block to be called with the evaluated collection and change information.
+     - parameter block: The block to be called whenever a change occurs.
      - returns: A token which must be held for as long as you want updates to be delivered.
      */
     public func addNotificationBlock(_ block: @escaping (RealmCollectionChange<AnyRealmCollection>) -> ())
@@ -1087,7 +918,7 @@ public protocol RealmCollectionType: CollectionType, CustomStringConvertible {
 
     /// Indicates if the collection can no longer be accessed.
     ///
-    /// The collection can no longer be accessed if `invalidate` is called on the `Realm` that manages the collection.
+    /// The collection can no longer be accessed if `invalidate()` is called on the `Realm` that manages the collection.
     var invalidated: Bool { get }
 
     /// The number of objects in the collection.
@@ -1127,8 +958,6 @@ public protocol RealmCollectionType: CollectionType, CustomStringConvertible {
      Returns all objects matching the given predicate in the collection.
 
      - parameter predicateFormat: A predicate format string, optionally followed by a variable number of arguments.
-
-     - returns: A `Results` containing objects that match the given predicate.
      */
     func filter(predicateFormat: String, _ args: AnyObject...) -> Results<Element>
 
@@ -1136,8 +965,6 @@ public protocol RealmCollectionType: CollectionType, CustomStringConvertible {
      Returns all objects matching the given predicate in the collection.
 
      - parameter predicate: The predicate to use to filter the objects.
-
-     - returns: A `Results` containing objects that match the given predicate.
      */
     func filter(predicate: NSPredicate) -> Results<Element>
 
@@ -1148,23 +975,24 @@ public protocol RealmCollectionType: CollectionType, CustomStringConvertible {
      Returns a `Results` containing the objects in the collection, but sorted.
 
      Objects are sorted based on the values of the given property. For example, to sort a collection of `Student`s from
-     youngest to oldest based on their `age` property, you might call `students.sorted("age", ascending: true)`.
+     youngest to oldest based on their `age` property, you might call
+     `students.sorted(byProperty: "age", ascending: true)`.
 
-     - warning: Collections may only be sorted by properties of boolean, `NSDate`, single and double-precision floating
-                point, integer, and string types.
+     - warning: Collections may only be sorted by properties of boolean, `Date`, `NSDate`, single and double-precision
+                floating point, integer, and string types.
 
      - parameter property:  The name of the property to sort by.
      - parameter ascending: The direction to sort in.
      */
-    func sorted(property: String, ascending: Bool) -> Results<Element>
+    func sorted(byProperty: String, ascending: Bool) -> Results<Element>
 
     /**
      Returns a `Results` containing the objects in the collection, but sorted.
 
-     - warning: Collections may only be sorted by properties of boolean, `NSDate`, single and double-precision floating
-                point, integer, and string types.
+     - warning: Collections may only be sorted by properties of boolean, `Date`, `NSDate`, single and double-precision
+                floating point, integer, and string types.
 
-     - see: `sorted(_:ascending:)`
+     - see: `sorted(byProperty:ascending:)`
 
      - parameter sortDescriptors: A sequence of `SortDescriptor`s to sort by.
      */
@@ -1174,24 +1002,22 @@ public protocol RealmCollectionType: CollectionType, CustomStringConvertible {
     // MARK: Aggregate Operations
 
     /**
-     Returns the minimum (lowest) value of the given property among all the objects represented by the collection.
+     Returns the minimum (lowest) value of the given property among all the objects in the collection, or `nil` if the
+     collection is empty.
 
      - warning: Only a property whose type conforms to the `MinMaxType` protocol can be specified.
 
      - parameter property: The name of a property whose minimum value is desired.
-
-     - returns: The minimum value of the property, or `nil` if the collection is empty.
      */
     func min<U: MinMaxType>(property: String) -> U?
 
     /**
-     Returns the maximum (highest) value of the given property among all the objects represented by the collection.
+     Returns the maximum (highest) value of the given property among all the objects in the collection, or `nil` if the
+     collection is empty.
 
      - warning: Only a property whose type conforms to the `MinMaxType` protocol can be specified.
 
      - parameter property: The name of a property whose minimum value is desired.
-
-     - returns: The maximum value of the property, or `nil` if the collection is empty.
      */
     func max<U: MinMaxType>(property: String) -> U?
 
@@ -1201,19 +1027,16 @@ public protocol RealmCollectionType: CollectionType, CustomStringConvertible {
      - warning: Only a property whose type conforms to the `AddableType` protocol can be specified.
 
      - parameter property: The name of a property whose values should be summed.
-
-     - returns: The sum of the given property.
      */
     func sum<U: AddableType>(property: String) -> U
 
     /**
-     Returns the average value of a given property over all the objects represented by the collection.
+     Returns the average value of a given property over all the objects in the collection, or `nil` if the collection is
+     empty.
 
      - warning: Only the name of a property whose type conforms to the `AddableType` protocol can be specified.
 
      - parameter property: The name of a property whose average value should be calculated.
-
-     - returns: The average value of the given property, or `nil` if the collection is empty.
      */
     func average<U: AddableType>(property: String) -> U?
 
@@ -1306,7 +1129,7 @@ public protocol RealmCollectionType: CollectionType, CustomStringConvertible {
                 the containing Realm is read-only.
 
      - parameter block: The block to be called whenever a change occurs.
-     - returns: A token which must be retained for as long as you want updates to be delivered.
+     - returns: A token which must be held for as long as you want updates to be delivered.
      */
     func addNotificationBlock(block: (RealmCollectionChange<Self>) -> Void) -> NotificationToken
 
@@ -1351,175 +1174,60 @@ private final class _AnyRealmCollection<C: RealmCollectionType>: _AnyRealmCollec
         self.base = base
     }
 
-    // TODO (az): copyedit private docstrings
-    // MARK: Properties
-
-    /// The Realm the objects in this collection belong to, or `nil` if the
-    /// collection's owning object does not belong to a realm (the collection is
-    /// unmanaged).
     override var realm: Realm? { return base.realm }
-
-    /// Indicates if the collection can no longer be accessed.
-    ///
-    /// The collection can no longer be accessed if `invalidate` is called on the containing `Realm`.
     override var invalidated: Bool { return base.invalidated }
-
-    /// Returns the number of objects in this collection.
     override var count: Int { return base.count }
-
-    /// Returns a human-readable description of the objects contained in this collection.
     override var description: String { return base.description }
 
 
     // MARK: Index Retrieval
 
-    /**
-    Returns the index of the given object, or `nil` if the object is not in the collection.
-
-    - parameter object: The object whose index is being queried.
-    */
     override func indexOf(object: C.Element) -> Int? { return base.indexOf(object) }
 
-    /**
-    Returns the index of the first object matching the given predicate, or `nil` no objects match.
-
-    - parameter predicate: The `NSPredicate` used to filter the objects.
-    */
     override func indexOf(predicate: NSPredicate) -> Int? { return base.indexOf(predicate) }
 
-    /**
-    Returns the index of the first object matching the given predicate, or `nil` if no objects match.
-
-    - parameter predicateFormat: A predicate format string, optionally followed by a variable number
-                                 of arguments.
-    */
     override func indexOf(predicateFormat: String, _ args: AnyObject...) -> Int? {
         return base.indexOf(NSPredicate(format: predicateFormat, argumentArray: args))
     }
 
     // MARK: Filtering
 
-    /**
-    Returns a `Results` containing collection elements that match the given predicate.
-
-     - parameter predicateFormat: A predicate format string, optionally followed by a variable number
-                                  of arguments.
-
-    - returns: `Results` containing collection elements that match the given predicate.
-    */
     override func filter(predicateFormat: String, _ args: AnyObject...) -> Results<C.Element> {
         return base.filter(NSPredicate(format: predicateFormat, argumentArray: args))
     }
 
-    /**
-    Returns a `Results` containing collection elements that match the given predicate.
-
-    - parameter predicate: The predicate to use to filter the objects.
-
-    - returns: `Results` containing collection elements that match the given predicate.
-    */
     override func filter(predicate: NSPredicate) -> Results<C.Element> { return base.filter(predicate) }
 
 
     // MARK: Sorting
 
-    /**
-     Returns a `Results` containing the objects in the collection, but sorted.
-
-     Objects are sorted based on the values of the given property. For example, to sort a collection of `Student`s from
-     youngest to oldest based on their `age` property, you might call `students.sorted("age", ascending: true)`.
-
-     - warning: Collections may only be sorted by properties of boolean, `NSDate`, single and double-precision floating
-                point, integer, and string types.
-
-     - parameter property:  The name of the property to sort by.
-     - parameter ascending: The direction to sort in.
-     */
     override func sorted(property: String, ascending: Bool) -> Results<C.Element> {
         return base.sorted(property, ascending: ascending)
     }
 
-    /**
-     Returns a `Results` containing the objects in the collection, but sorted.
-
-     - warning: Collections may only be sorted by properties of boolean, `NSDate`, single and double-precision floating
-                point, integer, and string types.
-
-     - see: `sorted(_:ascending:)`
-
-     - parameter sortDescriptors: A sequence of `SortDescriptor`s to sort by.
-     */
     override func sorted<S: SequenceType where S.Generator.Element == SortDescriptor>
                         (sortDescriptors: S) -> Results<C.Element> {
         return base.sorted(sortDescriptors)
     }
 
-
     // MARK: Aggregate Operations
 
-    /**
-    Returns the minimum value of the given property.
-
-    - warning: Only names of properties of a type conforming to the `MinMaxType` protocol can be used.
-
-    - parameter property: The name of a property conforming to `MinMaxType` to look for a minimum on.
-
-    - returns: The minimum value of the property amongst objects in the collection, or `nil` if the
-               collection is empty.
-    */
     override func min<U: MinMaxType>(property: String) -> U? { return base.min(property) }
 
-    /**
-    Returns the maximum value of the given property.
-
-    - warning: Only names of properties of a type conforming to the `MinMaxType` protocol can be used.
-
-    - parameter property: The name of a property conforming to `MinMaxType` to look for a maximum on.
-
-    - returns: The maximum value of the property amongst objects in the collection, or `nil` if the
-               collection is empty.
-    */
     override func max<U: MinMaxType>(property: String) -> U? { return base.max(property) }
 
-    /**
-    Returns the sum of the given property for objects in the collection.
-
-    - warning: Only names of properties of a type conforming to the `AddableType` protocol can be used.
-
-    - parameter property: The name of a property conforming to `AddableType` to calculate sum on.
-
-    - returns: The sum of the given property over all objects in the collection.
-    */
     override func sum<U: AddableType>(property: String) -> U { return base.sum(property) }
 
-    /**
-    Returns the average of the given property for objects in the collection.
-
-    - warning: Only names of properties of a type conforming to the `AddableType` protocol can be used.
-
-    - parameter property: The name of a property conforming to `AddableType` to calculate average on.
-
-    - returns: The average of the given property over all objects in the collection, or `nil` if the
-               collection is empty.
-    */
     override func average<U: AddableType>(property: String) -> U? { return base.average(property) }
 
 
     // MARK: Sequence Support
 
-    /**
-    Returns the object at the given `index`.
-
-    - parameter index: The index.
-
-    - returns: The object at the given `index`.
-    */
     override subscript(index: Int) -> C.Element {
         // FIXME: it should be possible to avoid this force-casting
         return unsafeBitCast(base[index as! C.Index], C.Element.self)
     }
 
-    /// Returns an `RLMGenerator` that yields successive elements in the collection.
     override func generate() -> RLMGenerator<Element> {
         // FIXME: it should be possible to avoid this force-casting
         return base.generate() as! RLMGenerator<Element>
@@ -1528,16 +1236,11 @@ private final class _AnyRealmCollection<C: RealmCollectionType>: _AnyRealmCollec
 
     // MARK: Collection Support
 
-    /// The position of the first element in a non-empty collection.
-    /// Identical to endIndex in an empty collection.
     override var startIndex: Int {
         // FIXME: it should be possible to avoid this force-casting
         return base.startIndex as! Int
     }
 
-    /// The collection's "past the end" position.
-    /// endIndex is not a valid argument to subscript, and is always reachable from startIndex by
-    /// zero or more applications of successor().
     override var endIndex: Int {
         // FIXME: it should be possible to avoid this force-casting
         return base.endIndex as! Int
@@ -1546,34 +1249,10 @@ private final class _AnyRealmCollection<C: RealmCollectionType>: _AnyRealmCollec
 
     // MARK: Key-Value Coding
 
-    /**
-    Returns an Array containing the results of invoking `valueForKey(_:)` using key on each of the collection's objects.
-
-    - parameter key: The name of the property.
-
-    - returns: Array containing the results of invoking `valueForKey(_:)` using key on each of the collection's objects.
-    */
     override func valueForKey(key: String) -> AnyObject? { return base.valueForKey(key) }
 
-    /**
-     Returns an Array containing the results of invoking `valueForKeyPath(_:)` using keyPath on each of the
-     collection's objects.
-
-     - parameter keyPath: The key path to the property.
-
-     - returns: Array containing the results of invoking `valueForKeyPath(_:)` using keyPath on each of the
-       collection's objects.
-     */
     override func valueForKeyPath(keyPath: String) -> AnyObject? { return base.valueForKeyPath(keyPath) }
 
-    /**
-    Invokes `setValue(_:forKey:)` on each of the collection's objects using the specified value and key.
-
-    - warning: This method can only be called during a write transaction.
-
-    - parameter value: The object value.
-    - parameter key:   The name of the property.
-    */
     override func setValue(value: AnyObject?, forKey key: String) { base.setValue(value, forKey: key) }
 
     // MARK: Notifications
@@ -1607,7 +1286,7 @@ public final class AnyRealmCollection<T: Object>: RealmCollectionType {
 
     /// Indicates if the collection can no longer be accessed.
     ///
-    /// The collection can no longer be accessed if `invalidate` is called on the containing `realm`.
+    /// The collection can no longer be accessed if `invalidate()` is called on the containing `realm`.
     public var invalidated: Bool { return base.invalidated }
 
     /// The number of objects in the collection.
@@ -1657,8 +1336,6 @@ public final class AnyRealmCollection<T: Object>: RealmCollectionType {
      Returns a `Results` containing all objects matching the given predicate in the collection.
 
      - parameter predicate: The predicate with which to filter the objects.
-
-     - returns: A `Results` containing objects that match the given predicate.
      */
     public func filter(predicate: NSPredicate) -> Results<Element> { return base.filter(predicate) }
 
@@ -1669,25 +1346,26 @@ public final class AnyRealmCollection<T: Object>: RealmCollectionType {
      Returns a `Results` containing the objects in the collection, but sorted.
 
      Objects are sorted based on the values of the given property. For example, to sort a collection of `Student`s from
-     youngest to oldest based on their `age` property, you might call `students.sorted("age", ascending: true)`.
+     youngest to oldest based on their `age` property, you might call
+     `students.sorted(byProperty: "age", ascending: true)`.
 
-     - warning: Collections may only be sorted by properties of boolean, `NSDate`, single and double-precision floating
-                point, integer, and string types.
+     - warning: Collections may only be sorted by properties of boolean, `Date`, `NSDate`, single and double-precision
+                floating point, integer, and string types.
 
      - parameter property:  The name of the property to sort by.
      - parameter ascending: The direction to sort in.
      */
-    public func sorted(property: String, ascending: Bool) -> Results<Element> {
+    public func sorted(byProperty: String, ascending: Bool) -> Results<Element> {
         return base.sorted(property, ascending: ascending)
     }
 
     /**
      Returns a `Results` containing the objects in the collection, but sorted.
 
-     - warning: Collections may only be sorted by properties of boolean, `NSDate`, single and double-precision floating
-                point, integer, and string types.
+     - warning: Collections may only be sorted by properties of boolean, `Date`, `NSDate`, single and double-precision
+                floating point, integer, and string types.
 
-     - see: `sorted(_:ascending:)`
+     - see: `sorted(byProperty:ascending:)`
 
      - parameter sortDescriptors: A sequence of `SortDescriptor`s to sort by.
      */
@@ -1700,46 +1378,41 @@ public final class AnyRealmCollection<T: Object>: RealmCollectionType {
     // MARK: Aggregate Operations
 
     /**
-     Returns the minimum (lowest) value of the given property among all the objects represented by the collection.
+     Returns the minimum (lowest) value of the given property among all the objects in the collection, or `nil` if the
+     collection is empty.
 
      - warning: Only a property whose type conforms to the `MinMaxType` protocol can be specified.
 
      - parameter property: The name of a property whose minimum value is desired.
-
-     - returns: The minimum value of the property, or `nil` if the collection is empty.
      */
     public func min<U: MinMaxType>(property: String) -> U? { return base.min(property) }
 
     /**
-     Returns the maximum (highest) value of the given property among all the objects represented by the collection.
+     Returns the maximum (highest) value of the given property among all the objects in the collection, or `nil` if the
+     collection is empty.
 
      - warning: Only a property whose type conforms to the `MinMaxType` protocol can be specified.
 
      - parameter property: The name of a property whose minimum value is desired.
-
-     - returns: The maximum value of the property, or `nil` if the collection is empty.
      */
     public func max<U: MinMaxType>(property: String) -> U? { return base.max(property) }
 
     /**
-     Returns the sum of the values of a given property over all the objects represented by the collection.
+     Returns the sum of the values of a given property over all the objects in the collection.
 
      - warning: Only a property whose type conforms to the `AddableType` protocol can be specified.
 
      - parameter property: The name of a property whose values should be summed.
-
-     - returns: The sum of the given property.
      */
     public func sum<U: AddableType>(property: String) -> U { return base.sum(property) }
 
     /**
-     Returns the average value of a given property over all the objects represented by the collection.
+     Returns the average value of a given property over all the objects in the collection, or `nil` if the collection is
+     empty.
 
      - warning: Only the name of a property whose type conforms to the `AddableType` protocol can be specified.
 
      - parameter property: The name of a property whose average value should be calculated.
-
-     - returns: The average value of the given property, or `nil` if the collection is empty.
      */
     public func average<U: AddableType>(property: String) -> U? { return base.average(property) }
 
@@ -1749,9 +1422,7 @@ public final class AnyRealmCollection<T: Object>: RealmCollectionType {
     /**
      Returns the object at the given `index`.
 
-     - parameter index: The index.
-
-     - returns: The object at the given `index`.
+     - parameter index: An index to retrieve or set an object from.
     */
     public subscript(index: Int) -> T { return base[index] }
 
@@ -1778,8 +1449,6 @@ public final class AnyRealmCollection<T: Object>: RealmCollectionType {
      objects.
 
      - parameter key: The name of the property whose values are desired.
-
-     - returns: An `Array` containing the results.
      */
     public func valueForKey(key: String) -> AnyObject? { return base.valueForKey(key) }
 
@@ -1788,8 +1457,6 @@ public final class AnyRealmCollection<T: Object>: RealmCollectionType {
      collection's objects.
 
      - parameter keyPath: The key path to the property whose values are desired.
-
-     - returns: An `Array` containing the results.
      */
     public func valueForKeyPath(keyPath: String) -> AnyObject? { return base.valueForKeyPath(keyPath) }
 
@@ -1826,7 +1493,9 @@ public final class AnyRealmCollection<T: Object>: RealmCollectionType {
      delivered while the run loop is blocked by other activity. When
      notifications can't be delivered instantly, multiple notifications may be
      coalesced into a single notification. This can include the notification
-     with the initial collection. For example, the following code performs a write
+     with the initial collection.
+     
+     For example, the following code performs a write
      transaction immediately after adding the notification block, so there is no
      opportunity for the initial notification to be delivered first. As a
      result, the initial notification will reflect the state of the Realm after
@@ -1859,11 +1528,10 @@ public final class AnyRealmCollection<T: Object>: RealmCollectionType {
      You must retain the returned token for as long as you want updates to be sent to the block. To stop receiving
      updates, call `stop()` on the token.
 
-     - warning: This method cannot be called during a write transaction, or when
-                the containing Realm is read-only.
+     - warning: This method cannot be called during a write transaction, or when the containing Realm is read-only.
 
      - parameter block: The block to be called whenever a change occurs.
-     - returns: A token which must be retained for as long as you want updates to be delivered.
+     - returns: A token which must be held for as long as you want updates to be delivered.
      */
     public func addNotificationBlock(block: (RealmCollectionChange<AnyRealmCollection>) -> ())
         -> NotificationToken { return base._addNotificationBlock(block) }

--- a/RealmSwift/RealmCollection.swift
+++ b/RealmSwift/RealmCollection.swift
@@ -1346,26 +1346,25 @@ public final class AnyRealmCollection<T: Object>: RealmCollectionType {
      Returns a `Results` containing the objects in the collection, but sorted.
 
      Objects are sorted based on the values of the given property. For example, to sort a collection of `Student`s from
-     youngest to oldest based on their `age` property, you might call
-     `students.sorted(byProperty: "age", ascending: true)`.
+     youngest to oldest based on their `age` property, you might call `students.sorted("age", ascending: true)`.
 
-     - warning: Collections may only be sorted by properties of boolean, `Date`, `NSDate`, single and double-precision
-                floating point, integer, and string types.
+     - warning: Collections may only be sorted by properties of boolean, `NSDate`, single and double-precision floating
+                point, integer, and string types.
 
      - parameter property:  The name of the property to sort by.
      - parameter ascending: The direction to sort in.
      */
-    public func sorted(byProperty: String, ascending: Bool) -> Results<Element> {
+    public func sorted(property: String, ascending: Bool) -> Results<Element> {
         return base.sorted(property, ascending: ascending)
     }
 
     /**
      Returns a `Results` containing the objects in the collection, but sorted.
 
-     - warning: Collections may only be sorted by properties of boolean, `Date`, `NSDate`, single and double-precision
-                floating point, integer, and string types.
+     - warning: Collections may only be sorted by properties of boolean, `NSDate`, single and double-precision floating
+                point, integer, and string types.
 
-     - see: `sorted(byProperty:ascending:)`
+     - see: `sorted(_:ascending:)`
 
      - parameter sortDescriptors: A sequence of `SortDescriptor`s to sort by.
      */

--- a/RealmSwift/RealmConfiguration.swift
+++ b/RealmSwift/RealmConfiguration.swift
@@ -24,22 +24,23 @@ import Realm.Private
 
 extension Realm {
     /**
-    A `Realm.Configuration` is used to describe the different options used to
-    create a `Realm` instance.
+     A `Configuration` instance describes the different options used to create an instance of a Realm.
 
-    `Realm.Configuration` instances are just plain Swift structs, and unlike
-    `Realm` and `Object`s can be freely shared between threads. Creating
-    configuration objects for class subsets (by setting the `objectTypes`
-    property) can be expensive, and so you will normally want to cache and reuse
-    a single configuration object for each distinct configuration that you are
-    using rather than creating a new one each time you open a `Realm`.
-    */
+     `Configuration` instances are just plain Swift structs. Unlike `Realm`s and `Object`s, they can be freely shared
+     between threads as long as you do not mutate them.
+
+     Creating configuration values for class subsets (by setting the `objectClasses` property) can be expensive. Because
+     of this, you will normally want to cache and reuse a single configuration value for each distinct configuration
+     rather than creating a new value each time you open a Realm.
+     */
     public struct Configuration {
 
         // MARK: Default Configuration
 
-        /// Returns the default Realm.Configuration used to create Realms when no other
-        /// configuration is explicitly specified (i.e. `Realm()`).
+        /**
+         The default `Configuration` used to create Realms when no configuration is explicitly specified (i.e.
+         `Realm()`)
+         */
         public static var defaultConfiguration: Configuration {
             get {
                 return fromRLMRealmConfiguration(rlmConfiguration: RLMRealmConfiguration.default())
@@ -52,17 +53,17 @@ extension Realm {
         // MARK: Initialization
 
         /**
-        Initializes a `Realm.Configuration`, suitable for creating new `Realm` instances.
+         Creates a `Configuration` which can be used to create new `Realm` instances.
 
-        - parameter fileURL:            The local URL to the realm file.
-        - parameter inMemoryIdentifier: A string used to identify a particular in-memory Realm.
-        - parameter encryptionKey:      64-byte key to use to encrypt the data.
-        - parameter readOnly:           Whether the Realm is read-only (must be true for read-only files).
-        - parameter schemaVersion:      The current schema version.
-        - parameter migrationBlock:     The block which migrates the Realm to the current version.
-        - parameter deleteRealmIfMigrationNeeded: If `true`, recreate the Realm file with the provided
-                                                  schema if a migration is required.
-        - parameter objectTypes:        The subset of `Object` subclasses persisted in the Realm.
+         - parameter fileURL:            The local URL to the Realm file.
+         - parameter inMemoryIdentifier: A string used to identify a particular in-memory Realm.
+         - parameter encryptionKey:      An optional 64-byte key to use to encrypt the data.
+         - parameter readOnly:           Whether the Realm is read-only (must be true for read-only files).
+         - parameter schemaVersion:      The current schema version.
+         - parameter migrationBlock:     The block which migrates the Realm to the current version.
+         - parameter deleteRealmIfMigrationNeeded: If `true`, recreate the Realm file with the provided
+         schema if a migration is required.
+         - parameter objectTypes:        The subset of `Object` subclasses persisted in the Realm.
         */
         public init(fileURL: URL? = URL(fileURLWithPath: RLMRealmPathForFile("default.realm"), isDirectory: false),
             inMemoryIdentifier: String? = nil,
@@ -86,8 +87,7 @@ extension Realm {
 
         // MARK: Configuration Properties
 
-        /// The local URL to the realm file.
-        /// Mutually exclusive with `inMemoryIdentifier`.
+        /// The local URL of the Realm file. Mutually exclusive with `inMemoryIdentifier`.
         public var fileURL: URL? {
             set {
                 _inMemoryIdentifier = nil
@@ -100,8 +100,7 @@ extension Realm {
 
         private var _path: String?
 
-        /// A string used to identify a particular in-memory Realm.
-        /// Mutually exclusive with `path`.
+        /// A string used to identify a particular in-memory Realm. Mutually exclusive with `fileURL`.
         public var inMemoryIdentifier: String? {
             set {
                 _path = nil
@@ -114,10 +113,18 @@ extension Realm {
 
         private var _inMemoryIdentifier: String? = nil
 
-        /// 64-byte key to use to encrypt the data.
+        /// A 64-byte key to use to encrypt the data, or `nil` if encryption is not enabled.
         public var encryptionKey: Data? = nil
 
-        /// Whether the Realm is read-only (must be true for read-only files).
+        /**
+         Whether to open the Realm in read-only mode.
+
+         This is required to be able to open Realm files which are not writeable or are in a directory which is not
+         writeable. This should only be used on files which will not be modified by anyone while they are open, and not
+         just to get a read-only view of a file which may be written to by another thread or process. Opening in
+         read-only mode requires disabling Realm's reader/writer coordination, so committing a write transaction from
+         another process will result in crashes.
+         */
         public var readOnly: Bool = false
 
         /// The current schema version.
@@ -127,16 +134,16 @@ extension Realm {
         public var migrationBlock: MigrationBlock? = nil
 
         /**
-        Recreate the Realm file with the provided schema if a migration is required.
-        This is the case when the stored schema differs from the provided schema or
-        the stored schema version differs from the version on this configuration.
-        This deletes the file if a migration would otherwise be required or run.
+         Whether to recreate the Realm file with the provided schema if a migration is required. This is the case when
+         the stored schema differs from the provided schema or the stored schema version differs from the version on
+         this configuration. Setting this property to `true` deletes the file if a migration would otherwise be required
+         or executed.
 
-        - note: This doesn't disable file format migrations.
-        */
+         - note: Setting this property to `true` doesn't disable file format migrations.
+         */
         public var deleteRealmIfMigrationNeeded: Bool = false
 
-        /// The classes persisted in the Realm.
+        /// The classes managed by the Realm.
         public var objectTypes: [Object.Type]? {
             set {
                 self.customSchema = newValue.map { RLMSchema(objectClasses: $0) }
@@ -149,7 +156,7 @@ extension Realm {
         /// A custom schema to use for the Realm.
         private var customSchema: RLMSchema? = nil
 
-        /// Allows to disable automatic format upgrades when accessing the Realm.
+        /// If `true`, disables automatic format upgrades when accessing the Realm.
         internal var disableFormatUpgrade: Bool = false
 
         // MARK: Private Methods
@@ -196,7 +203,7 @@ extension Realm {
 // MARK: CustomStringConvertible
 
 extension Realm.Configuration: CustomStringConvertible {
-    /// Returns a human-readable description of the configuration.
+    /// A human-readable description of the configuration value.
     public var description: String {
         return gsub(pattern: "\\ARLMRealmConfiguration",
                     template: "Realm.Configuration",
@@ -238,18 +245,18 @@ extension Realm {
         // MARK: Initialization
 
         /**
-        Initializes a `Realm.Configuration`, suitable for creating new `Realm` instances.
+         Creates a `Configuration` which can be used to create new `Realm` instances.
 
-        - parameter fileURL:            The local URL to the Realm file.
-        - parameter inMemoryIdentifier: A string used to identify a particular in-memory Realm.
-        - parameter encryptionKey:      An optional 64-byte key to use to encrypt the data.
-        - parameter readOnly:           Whether the Realm is read-only (must be true for read-only files).
-        - parameter schemaVersion:      The current schema version.
-        - parameter migrationBlock:     The block which migrates the Realm to the current version.
-        - parameter deleteRealmIfMigrationNeeded: If `true`, recreate the Realm file with the provided
-                                                  schema if a migration is required.
-        - parameter objectTypes:        The subset of `Object` subclasses managed by the Realm.
-        */
+         - parameter fileURL:            The local URL to the Realm file.
+         - parameter inMemoryIdentifier: A string used to identify a particular in-memory Realm.
+         - parameter encryptionKey:      An optional 64-byte key to use to encrypt the data.
+         - parameter readOnly:           Whether the Realm is read-only (must be true for read-only files).
+         - parameter schemaVersion:      The current schema version.
+         - parameter migrationBlock:     The block which migrates the Realm to the current version.
+         - parameter deleteRealmIfMigrationNeeded: If `true`, recreate the Realm file with the provided
+         schema if a migration is required.
+         - parameter objectTypes:        The subset of `Object` subclasses managed by the Realm.
+         */
         public init(fileURL: NSURL? = NSURL(fileURLWithPath: RLMRealmPathForFile("default.realm"), isDirectory: false),
             inMemoryIdentifier: String? = nil,
             encryptionKey: NSData? = nil,

--- a/RealmSwift/Results.swift
+++ b/RealmSwift/Results.swift
@@ -73,7 +73,7 @@ extension Int64: AddableType {}
 
  Once the results have been evaluated or a notification block has been added, the results are eagerly kept up-to-date,
  with the work done to keep them up-to-date done on a background thread whenever possible.
- 
+
  Results instances cannot be directly instantiated.
  */
 public final class Results<T: Object>: NSObject, NSFastEnumeration {
@@ -131,7 +131,7 @@ public final class Results<T: Object>: NSObject, NSFastEnumeration {
 
     /**
      Returns the index of the first object matching the predicate, or `nil` if no objects match.
-   
+
      - parameter predicate: The predicate with which to filter the objects.
      */
     public func index(matching predicate: NSPredicate) -> Int? {
@@ -140,7 +140,7 @@ public final class Results<T: Object>: NSObject, NSFastEnumeration {
 
     /**
      Returns the index of the first object matching the predicate, or `nil` if no objects match.
-   
+
      - parameter predicateFormat: A predicate format string, optionally followed by a variable number of arguments.
      */
     public func index(matching predicateFormat: String, _ args: Any...) -> Int? {
@@ -243,7 +243,7 @@ public final class Results<T: Object>: NSObject, NSFastEnumeration {
 
      - warning: Collections may only be sorted by properties of boolean, `Date`, `NSDate`, single and double-precision
                 floating point, integer, and string types.
-   
+
      - see: `sorted(byProperty:ascending:)`
 
      - parameter sortDescriptors: A sequence of `SortDescriptor`s to sort by.

--- a/RealmSwift/Results.swift
+++ b/RealmSwift/Results.swift
@@ -22,7 +22,11 @@ import Realm
 #if swift(>=3.0)
 // MARK: MinMaxType
 
-/// Types which can be used for min()/max().
+/**
+ Types of properties which can be used with the minimum and maximum value APIs.
+
+ - see: `min(ofProperty:)`, `max(ofProperty:)`
+ */
 public protocol MinMaxType {}
 extension NSNumber: MinMaxType {}
 extension Double: MinMaxType {}
@@ -37,7 +41,11 @@ extension NSDate: MinMaxType {}
 
 // MARK: AddableType
 
-/// Types which can be used for average()/sum().
+/**
+ Types of properties which can be used with the sum and average value APIs.
+
+ - see: `sum(ofProperty:)`, `average(ofProperty:)`
+ */
 public protocol AddableType {}
 extension NSNumber: AddableType {}
 extension Double: AddableType {}
@@ -49,34 +57,30 @@ extension Int32: AddableType {}
 extension Int64: AddableType {}
 
 /**
-Results is an auto-updating container type in Realm returned from object queries.
+ `Results` is an auto-updating container type in Realm returned from object queries.
 
-Results can be queried with the same predicates as `List<T>` and you can chain
-queries to further filter query results.
+ `Results` can be queried with the same predicates as `List<T>`, and you can chain queries to further filter query
+ results.
 
-Results always reflect the current state of the Realm on the current thread,
-including during write transactions on the current thread. The one exception to
-this is when using `for...in` enumeration, which will always enumerate over the
- objects which matched the query when the enumeration is begun, even if
-some of them are deleted or modified to be excluded by the filter during the
-enumeration.
+ `Results` always reflect the current state of the Realm on the current thread, including during write transactions on
+ the current thread. The one exception to this is when using `for...in` enumeration, which will always enumerate over
+ the objects which matched the query when the enumeration is begun, even if some of them are deleted or modified to be
+ excluded by the filter during the enumeration.
 
-Results are initially lazily evaluated, and only run queries when the result
-of the query is requested. This means that chaining several temporary
-Results to sort and filter your data does not perform any extra work
-processing the intermediate state.
+ `Results` are lazily evaluated the first time they are accessed; they only run queries when the result of the query is
+ requested. This means that chaining several temporary `Results` to sort and filter your data does not perform any
+ unnecessary work processing the intermediate state.
 
-Once the results have been evaluated or a notification block has been added,
-the results are eagerly kept up-to-date, with the work done to keep them
-up-to-date done on a background thread whenever possible.
-
-Results cannot be created directly.
-*/
+ Once the results have been evaluated or a notification block has been added, the results are eagerly kept up-to-date,
+ with the work done to keep them up-to-date done on a background thread whenever possible.
+ 
+ Results instances cannot be directly instantiated.
+ */
 public final class Results<T: Object>: NSObject, NSFastEnumeration {
 
     internal let rlmResults: RLMResults<RLMObject>
 
-    /// Returns a human-readable description of the objects contained in these results.
+    /// A human-readable description of the objects represented by the results.
     public override var description: String {
         let type = "Results<\(rlmResults.objectClassName)>"
         return gsub(pattern: "RLMResults <0x[a-z0-9]+>", template: type, string: rlmResults.description) ?? type
@@ -91,23 +95,23 @@ public final class Results<T: Object>: NSObject, NSFastEnumeration {
         return Int(rlmResults.countByEnumerating(with: state, objects: buffer, count: UInt(len)))
     }
 
-    /// Element type contained in this collection.
+    /// The type of the objects described by the results.
     public typealias Element = T
 
     // MARK: Properties
 
-    /// Returns the Realm these results are associated with.
-    /// Despite returning an `Optional<Realm>` in order to conform to
-    /// `RealmCollection`, it will always return `.Some()` since a `Results`
-    /// cannot exist independently from a `Realm`.
+    /// The Realm which manages this results. Note that this property will never return `nil`.
     public var realm: Realm? { return Realm(rlmResults.realm) }
 
-    /// Indicates if the results can no longer be accessed.
-    ///
-    /// Results can no longer be accessed if `invalidate` is called on the containing `Realm`.
+    /**
+     Indicates if the results are no longer valid.
+
+     The results becomes invalid if `invalidate()` is called on the containing `realm`. An invalidated results can be
+     accessed, but will always be empty.
+     */
     public var isInvalidated: Bool { return rlmResults.isInvalidated }
 
-    /// Returns the number of objects in these results.
+    /// The number of objects in the results.
     public var count: Int { return Int(rlmResults.count) }
 
     // MARK: Initializers
@@ -119,36 +123,26 @@ public final class Results<T: Object>: NSObject, NSFastEnumeration {
     // MARK: Index Retrieval
 
     /**
-    Returns the index of the given object, or `nil` if the object is not in the results.
-
-    - parameter object: The object whose index is being queried.
-
-    - returns: The index of the given object, or `nil` if the object is not in the results.
-    */
+     Returns the index of the given object in the results, or `nil` if the object is not present.
+     */
     public func index(of object: T) -> Int? {
         return notFoundToNil(index: rlmResults.index(of: object.unsafeCastToRLMObject()))
     }
 
     /**
-    Returns the index of the first object matching the given predicate,
-    or `nil` if no objects match.
-
-    - parameter predicate: The predicate to filter the objects.
-
-    - returns: The index of the first matching object, or `nil` if no objects match.
-    */
+     Returns the index of the first object matching the predicate, or `nil` if no objects match.
+   
+     - parameter predicate: The predicate with which to filter the objects.
+     */
     public func index(matching predicate: NSPredicate) -> Int? {
         return notFoundToNil(index: rlmResults.indexOfObject(with: predicate))
     }
 
     /**
-    Returns the index of the first object matching the given predicate,
-    or `nil` if no objects match.
-
-    - parameter predicateFormat: The predicate format string which can accept variable arguments.
-
-    - returns: The index of the first matching object, or `nil` if no objects match.
-    */
+     Returns the index of the first object matching the predicate, or `nil` if no objects match.
+   
+     - parameter predicateFormat: A predicate format string, optionally followed by a variable number of arguments.
+     */
     public func index(matching predicateFormat: String, _ args: Any...) -> Int? {
         return notFoundToNil(index: rlmResults.indexOfObject(with: NSPredicate(format: predicateFormat,
                                                                                argumentArray: args)))
@@ -157,57 +151,50 @@ public final class Results<T: Object>: NSObject, NSFastEnumeration {
     // MARK: Object Retrieval
 
     /**
-    Returns the object at the given `index`.
+     Returns the object at the given `index`.
 
-    - parameter index: The index.
-
-    - returns: The object at the given `index`.
-    */
+     - parameter index: The index.
+     */
     public subscript(position: Int) -> T {
         throwForNegativeIndex(position)
         return unsafeBitCast(rlmResults.object(at: UInt(position)), to: T.self)
     }
 
-    /// Returns the first object in the results, or `nil` if empty.
+    /// Returns the first object in the results, or `nil` if the results are empty.
     public var first: T? { return unsafeBitCast(rlmResults.firstObject(), to: Optional<T>.self) }
 
-    /// Returns the last object in the results, or `nil` if empty.
+    /// Returns the last object in the results, or `nil` if the results are empty.
     public var last: T? { return unsafeBitCast(rlmResults.lastObject(), to: Optional<T>.self) }
 
     // MARK: KVC
 
     /**
-    Returns an Array containing the results of invoking `valueForKey(_:)` using key on each of the collection's objects.
+     Returns an `Array` containing the results of invoking `valueForKey(_:)` with `key` on each of the results.
 
-    - parameter key: The name of the property.
-
-    - returns: Array containing the results of invoking `valueForKey(_:)` using key on each of the collection's objects.
-    */
+     - parameter key: The name of the property whose values are desired.
+     */
     public override func value(forKey key: String) -> Any? {
         return value(forKeyPath: key)
     }
 
     /**
-     Returns an Array containing the results of invoking `valueForKeyPath(_:)` using keyPath on each of the
-     collection's objects.
+     Returns an `Array` containing the results of invoking `valueForKeyPath(_:)` with `keyPath` on each of the results.
 
-     - parameter keyPath: The key path to the property.
-
-     - returns: Array containing the results of invoking `valueForKeyPath(_:)` using keyPath on each of the
-     collection's objects.
+     - parameter keyPath: The key path to the property whose values are desired.
      */
     public override func value(forKeyPath keyPath: String) -> Any? {
         return rlmResults.value(forKeyPath: keyPath)
     }
 
     /**
-    Invokes `setValue(_:forKey:)` on each of the collection's objects using the specified value and key.
+     Invokes `setValue(_:forKey:)` on each of the objects represented by the results using the specified `value` and
+     `key`.
 
-    - warning: This method can only be called during a write transaction.
+     - warning: This method may only be called during a write transaction.
 
-    - parameter value: The object value.
-    - parameter key:   The name of the property.
-    */
+     - parameter value: The object value.
+     - parameter key:   The name of the property whose value should be set on each object.
+     */
     public override func setValue(_ value: Any?, forKey key: String) {
         return rlmResults.setValue(value, forKeyPath: key)
     }
@@ -215,23 +202,19 @@ public final class Results<T: Object>: NSObject, NSFastEnumeration {
     // MARK: Filtering
 
     /**
-    Filters the results to the objects that match the given predicate.
+     Returns a `Results` containing all objects matching the given predicate in the collection.
 
-    - parameter predicateFormat: The predicate format string which can accept variable arguments.
-
-    - returns: Results containing objects that match the given predicate.
-    */
+     - parameter predicateFormat: A predicate format string, optionally followed by a variable number of arguments.
+     */
     public func filter(_ predicateFormat: String, _ args: Any...) -> Results<T> {
         return Results<T>(rlmResults.objects(with: NSPredicate(format: predicateFormat, argumentArray: args)))
     }
 
     /**
-    Filters the results to the objects that match the given predicate.
+     Returns a `Results` containing all objects matching the given predicate in the collection.
 
-    - parameter predicate: The predicate to filter the objects.
-
-    - returns: Results containing objects that match the given predicate.
-    */
+     - parameter predicate: The predicate with which to filter the objects.
+     */
     public func filter(_ predicate: NSPredicate) -> Results<T> {
         return Results<T>(rlmResults.objects(with: predicate))
     }
@@ -239,24 +222,32 @@ public final class Results<T: Object>: NSObject, NSFastEnumeration {
     // MARK: Sorting
 
     /**
-    Returns `Results` with elements sorted by the given property name.
+     Returns a `Results` containing the objects represented by the results, but sorted.
 
-    - parameter property:  The property name to sort by.
-    - parameter ascending: The direction to sort by.
+     Objects are sorted based on the values of the given property. For example, to sort a collection of `Student`s from
+     youngest to oldest based on their `age` property, you might call
+     `students.sorted(byProperty: "age", ascending: true)`.
 
-    - returns: `Results` with elements sorted by the given property name.
-    */
+     - warning: Collections may only be sorted by properties of boolean, `Date`, `NSDate`, single and double-precision
+                floating point, integer, and string types.
+
+     - parameter property:  The name of the property to sort by.
+     - parameter ascending: The direction to sort in.
+     */
     public func sorted(byProperty property: String, ascending: Bool = true) -> Results<T> {
         return sorted(by: [SortDescriptor(property: property, ascending: ascending)])
     }
 
     /**
-    Returns `Results` with elements sorted by the given sort descriptors.
+     Returns a `Results` containing the objects represented by the results, but sorted.
 
-    - parameter sortDescriptors: `SortDescriptor`s to sort by.
+     - warning: Collections may only be sorted by properties of boolean, `Date`, `NSDate`, single and double-precision
+                floating point, integer, and string types.
+   
+     - see: `sorted(byProperty:ascending:)`
 
-    - returns: `Results` with elements sorted by the given sort descriptors.
-    */
+     - parameter sortDescriptors: A sequence of `SortDescriptor`s to sort by.
+     */
     public func sorted<S: Sequence>(by sortDescriptors: S) -> Results<T> where S.Iterator.Element == SortDescriptor {
         return Results<T>(rlmResults.sortedResults(using: sortDescriptors.map { $0.rlmSortDescriptorValue }))
     }
@@ -264,53 +255,45 @@ public final class Results<T: Object>: NSObject, NSFastEnumeration {
     // MARK: Aggregate Operations
 
     /**
-    Returns the minimum value of the given property.
+     Returns the minimum (lowest) value of the given property among all the results, or `nil` if the results are empty.
 
-    - warning: Only names of properties of a type conforming to the `MinMaxType` protocol can be used.
+     - warning: Only a property whose type conforms to the `MinMaxType` protocol can be specified.
 
-    - parameter property: The name of a property conforming to `MinMaxType` to look for a minimum on.
-
-    - returns: The minimum value for the property amongst objects in the Results, or `nil` if the Results is empty.
-    */
+     - parameter property: The name of a property whose minimum value is desired.
+     */
     public func min<U: MinMaxType>(ofProperty property: String) -> U? {
         return rlmResults.min(ofProperty: property).map(dynamicBridgeCast)
     }
 
     /**
-    Returns the maximum value of the given property.
+     Returns the maximum (highest) value of the given property among all the results, or `nil` if the results are empty.
 
-    - warning: Only names of properties of a type conforming to the `MinMaxType` protocol can be used.
+     - warning: Only a property whose type conforms to the `MinMaxType` protocol can be specified.
 
-    - parameter property: The name of a property conforming to `MinMaxType` to look for a maximum on.
-
-    - returns: The maximum value for the property amongst objects in the Results, or `nil` if the Results is empty.
-    */
+     - parameter property: The name of a property whose minimum value is desired.
+     */
     public func max<U: MinMaxType>(ofProperty property: String) -> U? {
         return rlmResults.max(ofProperty: property).map(dynamicBridgeCast)
     }
 
     /**
-    Returns the sum of the given property for objects in the Results.
+     Returns the sum of the values of a given property over all the results.
 
-    - warning: Only names of properties of a type conforming to the `AddableType` protocol can be used.
+     - warning: Only a property whose type conforms to the `AddableType` protocol can be specified.
 
-    - parameter property: The name of a property conforming to `AddableType` to calculate sum on.
-
-    - returns: The sum of the given property over all objects in the Results.
-    */
+     - parameter property: The name of a property whose values should be summed.
+     */
     public func sum<U: AddableType>(ofProperty property: String) -> U {
         return dynamicBridgeCast(fromObjectiveC: rlmResults.sum(ofProperty: property))
     }
 
     /**
-    Returns the average of the given property for objects in the Results.
+     Returns the average value of a given property over all the results, or `nil` if the results are empty.
 
-    - warning: Only names of properties of a type conforming to the `AddableType` protocol can be used.
+     - warning: Only the name of a property whose type conforms to the `AddableType` protocol can be specified.
 
-    - parameter property: The name of a property conforming to `AddableType` to calculate average on.
-
-    - returns: The average of the given property over all objects in the Results, or `nil` if the Results is empty.
-    */
+     - parameter property: The name of a property whose average value should be calculated.
+     */
     public func average<U: AddableType>(ofProperty property: String) -> U? {
         return rlmResults.average(ofProperty: property).map(dynamicBridgeCast)
     }
@@ -318,63 +301,59 @@ public final class Results<T: Object>: NSObject, NSFastEnumeration {
     // MARK: Notifications
 
     /**
-     Register a block to be called each time the Results changes.
+     Registers a block to be called each time the collection changes.
 
-     The block will be asynchronously called with the initial results, and then
-     called again after each write transaction which changes either any of the
-     objects in the results, or which objects are in the results.
+     The block will be asynchronously called with the initial results, and then called again after each write
+     transaction which changes either any of the objects in the collection, or which objects are in the collection.
 
-     This version of this method reports which of the objects in the results were
-     added, removed, or modified in each write transaction as indices within the
-     results. See the RealmCollectionChange documentation for more information on
-     the change information supplied and an example of how to use it to update
-     a UITableView.
+     The `change` parameter that is passed to the block reports, in the form of indices within the collection, which of
+     the objects were added, removed, or modified during each write transaction. See the `RealmCollectionChange`
+     documentation for more information on the change information supplied and an example of how to use it to update a
+     `UITableView`.
 
-     At the time when the block is called, the Results object will be fully
-     evaluated and up-to-date, and as long as you do not perform a write transaction
-     on the same thread or explicitly call realm.refresh(), accessing it will never
+     At the time when the block is called, the collection will be fully evaluated and up-to-date, and as long as you do
+     not perform a write transaction on the same thread or explicitly call `realm.refresh()`, accessing it will never
      perform blocking work.
 
-     Notifications are delivered via the standard run loop, and so can't be
-     delivered while the run loop is blocked by other activity. When
-     notifications can't be delivered instantly, multiple notifications may be
-     coalesced into a single notification. This can include the notification
-     with the initial results. For example, the following code performs a write
-     transaction immediately after adding the notification block, so there is no
-     opportunity for the initial notification to be delivered first. As a
-     result, the initial notification will reflect the state of the Realm after
-     the write transaction.
+     Notifications are delivered via the standard run loop, and so can't be delivered while the run loop is blocked by
+     other activity. When notifications can't be delivered instantly, multiple notifications may be coalesced into a
+     single notification. This can include the notification with the initial collection.
 
-         let dogs = realm.objects(Dog)
-         print("dogs.count: \(dogs?.count)") // => 0
-         let token = dogs.addNotificationBlock { (changes: RealmCollectionChange) in
-             switch changes {
-                 case .Initial(let dogs):
-                     // Will print "dogs.count: 1"
-                     print("dogs.count: \(dogs.count)")
-                     break
-                 case .Update:
-                     // Will not be hit in this example
-                     break
-                 case .Error:
-                     break
-             }
+     For example, the following code performs a write transaction immediately after adding the notification block, so
+     there is no opportunity for the initial notification to be delivered first. As a result, the initial notification
+     will reflect the state of the Realm after the write transaction.
+
+     ```swift
+     let results = realm.objects(Dog.self)
+     print("dogs.count: \(dogs?.count)") // => 0
+     let token = dogs.addNotificationBlock { changes in
+         switch changes {
+         case .initial(let dogs):
+             // Will print "dogs.count: 1"
+             print("dogs.count: \(dogs.count)")
+             break
+         case .update:
+             // Will not be hit in this example
+             break
+         case .error:
+             break
          }
-         try! realm.write {
-             let dog = Dog()
-             dog.name = "Rex"
-             person.dogs.append(dog)
-         }
-         // end of run loop execution context
+     }
+     try! realm.write {
+         let dog = Dog()
+         dog.name = "Rex"
+         person.dogs.append(dog)
+     }
+     // end of run loop execution context
+     ```
 
-     You must retain the returned token for as long as you want updates to continue
-     to be sent to the block. To stop receiving updates, call stop() on the token.
+     You must retain the returned token for as long as you want updates to be sent to the block. To stop receiving
+     updates, call `stop()` on the token.
 
-     - warning: This method cannot be called during a write transaction, or when
-                the source realm is read-only.
+     - warning: This method cannot be called during a write transaction, or when the containing Realm is read-only.
 
-     - parameter block: The block to be called with the evaluated results and change information.
-     - returns: A token which must be held for as long as you want query results to be delivered.
+     - parameter block: The block to be called whenever a change occurs.
+     - returns: A token which must be held for as long as you want updates to be delivered.
      */
     public func addNotificationBlock(_ block: @escaping (RealmCollectionChange<Results>) -> Void) -> NotificationToken {
         return rlmResults.addNotificationBlock { results, change, error in
@@ -455,7 +434,7 @@ extension Results {
 /**
  Types of properties which can be used with the minimum and maximum value APIs.
 
- - see: `min(_:)`, `max(_:)`
+ - see: `min(ofProperty:)`, `max(ofProperty:)`
  */
 public protocol MinMaxType {}
 extension NSNumber: MinMaxType {}
@@ -473,7 +452,7 @@ extension NSDate: MinMaxType {}
 /**
  Types of properties which can be used with the sum and average value APIs.
 
- - see: `sum(_:)`, `average(_:)`
+ - see: `sum(ofProperty:)`, `average(ofProperty:)`
  */
 public protocol AddableType {}
 extension NSNumber: AddableType {}
@@ -529,7 +508,7 @@ public class ResultsBase: NSObject, NSFastEnumeration {
  `Results` are lazily evaluated the first time they are accessed; they only
  run queries when the result of the query is requested. This means that
  chaining several temporary `Results` to sort and filter your data does not
- perform any extra work processing the intermediate state.
+ perform any unnecessary work processing the intermediate state.
 
  Once the results have been evaluated or a notification block has been added,
  the results are eagerly kept up-to-date, with the work done to keep them
@@ -550,7 +529,7 @@ public final class Results<T: Object>: ResultsBase {
     /**
      Indicates if the results collection is no longer valid.
 
-     The results collection becomes invalid if `invalidate` is called on the containing `realm`.
+     The results collection becomes invalid if `invalidate()` is called on the containing `realm`.
      An invalidated results collection can be accessed, but will always be empty.
      */
     public var invalidated: Bool { return rlmResults.invalidated }
@@ -567,7 +546,7 @@ public final class Results<T: Object>: ResultsBase {
     // MARK: Index Retrieval
 
     /**
-     Returns the index of an object in the results collection, or `nil` if the object is not present.
+     Returns the index of an object in the results, or `nil` if the object is not present.
 
      - parameter object: An object.
      */
@@ -587,7 +566,7 @@ public final class Results<T: Object>: ResultsBase {
     /**
      Returns the index of the first object matching the predicate, or `nil` if no objects match.
 
-     - parameter predicateFormat: A predicate format string, optionally followed by a variable number of arguments.`
+     - parameter predicateFormat: A predicate format string, optionally followed by a variable number of arguments.
      */
     public func indexOf(predicateFormat: String, _ args: AnyObject...) -> Int? {
         return notFoundToNil(rlmResults.indexOfObjectWithPredicate(NSPredicate(format: predicateFormat,
@@ -600,8 +579,6 @@ public final class Results<T: Object>: ResultsBase {
      Returns the object at the given `index`.
 
      - parameter index: An index.
-
-     - returns: The object at the given `index`.
      */
     public subscript(index: Int) -> T {
         get {
@@ -610,17 +587,16 @@ public final class Results<T: Object>: ResultsBase {
         }
     }
 
-    /// Returns the first object in the results collection, or `nil` if the collection is empty.
+    /// Returns the first object in the results, or `nil` if the results are empty.
     public var first: T? { return unsafeBitCast(rlmResults.firstObject(), Optional<T>.self) }
 
-    /// Returns the last object in the results collection, or `nil` if the collection is empty.
+    /// Returns the last object in the results, or `nil` if the results are empty.
     public var last: T? { return unsafeBitCast(rlmResults.lastObject(), Optional<T>.self) }
 
     // MARK: KVC
 
     /**
-     Returns an `Array` containing the results of invoking `valueForKey(_:)` with `key` on each of the results
-     collection's objects.
+     Returns an `Array` containing the results of invoking `valueForKey(_:)` with `key` on each of the results.
 
      - parameter key: The name of the property whose values are desired.
      */
@@ -629,8 +605,7 @@ public final class Results<T: Object>: ResultsBase {
     }
 
     /**
-     Returns an `Array` containing the results of invoking `valueForKeyPath(_:)` with `keyPath` on each of the results
-     collection's objects.
+     Returns an `Array` containing the results of invoking `valueForKeyPath(_:)` with `keyPath` on each of the results.
 
      - parameter keyPath: The key path to the property whose values are desired.
      */
@@ -639,7 +614,8 @@ public final class Results<T: Object>: ResultsBase {
     }
 
     /**
-     Invokes `setValue(_:forKey:)` on each of the results collection's objects using the specified `value` and `key`.
+     Invokes `setValue(_:forKey:)` on each of the objects represented by the results using the specified `value` and
+     `key`.
 
      - warning: This method may only be called during a write transaction.
 
@@ -653,7 +629,7 @@ public final class Results<T: Object>: ResultsBase {
     // MARK: Filtering
 
     /**
-     Returns a `Results` containing all objects matching the given predicate in the results collection.
+     Returns a `Results` containing all objects matching the given predicate in the results.
 
      - parameter predicateFormat: A predicate format string, optionally followed by a variable number of arguments.
      */
@@ -662,7 +638,7 @@ public final class Results<T: Object>: ResultsBase {
     }
 
     /**
-     Returns a `Results` containing all objects matching the given predicate in the results collection.
+     Returns a `Results` containing all objects matching the given predicate in the results.
 
      - parameter predicate: The predicate with which to filter the objects.
      */
@@ -673,7 +649,7 @@ public final class Results<T: Object>: ResultsBase {
     // MARK: Sorting
 
     /**
-     Returns a `Results` containing the objects in the results collection, but sorted.
+     Returns a `Results` containing the objects represented by the results, but sorted.
 
      Objects are sorted based on the values of the given property. For example, to sort a collection of `Student`s from
      youngest to oldest based on their `age` property, you might call `students.sorted("age", ascending: true)`.
@@ -689,12 +665,12 @@ public final class Results<T: Object>: ResultsBase {
     }
 
     /**
-     Returns a `Results` containing the objects in the results collection, but sorted.
+     Returns a `Results` containing the objects represented by the results, but sorted.
 
      - warning: Collections may only be sorted by properties of boolean, `NSDate`, single and double-precision floating
                 point, integer, and string types.
 
-     - see: `sorted(_:ascending:)`
+     - see: `sorted(byProperty:ascending:)`
 
      - parameter sortDescriptors: A sequence of `SortDescriptor`s to sort by.
      */
@@ -705,52 +681,44 @@ public final class Results<T: Object>: ResultsBase {
     // MARK: Aggregate Operations
 
     /**
-     Returns the minimum (lowest) value of the given property among all the objects represented by the collection.
+     Returns the minimum (lowest) value of the given property among all the results, or `nil` if the results are empty.
 
      - warning: Only a property whose type conforms to the `MinMaxType` protocol can be specified.
 
      - parameter property: The name of a property whose minimum value is desired.
-
-     - returns: The minimum value of the property, or `nil` if the collection is empty.
      */
     public func min<U: MinMaxType>(property: String) -> U? {
         return rlmResults.minOfProperty(property).map(dynamicBridgeCast)
     }
 
     /**
-     Returns the maximum (highest) value of the given property among all the objects represented by the collection.
+     Returns the maximum (highest) value of the given property among all the results, or `nil` if the results are empty.
 
      - warning: Only a property whose type conforms to the `MinMaxType` protocol can be specified.
 
      - parameter property: The name of a property whose minimum value is desired.
-
-     - returns: The maximum value of the property, or `nil` if the collection is empty.
      */
     public func max<U: MinMaxType>(property: String) -> U? {
         return rlmResults.maxOfProperty(property).map(dynamicBridgeCast)
     }
 
     /**
-     Returns the sum of the values of a given property over all the objects represented by the collection.
+     Returns the sum of the values of a given property over all the results.
 
      - warning: Only a property whose type conforms to the `AddableType` protocol can be specified.
 
      - parameter property: The name of a property whose values should be summed.
-
-     - returns: The sum of the given property.
      */
     public func sum<U: AddableType>(property: String) -> U {
         return dynamicBridgeCast(fromObjectiveC: rlmResults.sumOfProperty(property))
     }
 
     /**
-     Returns the average value of a given property over all the objects represented by the collection.
+     Returns the average value of a given property over all the results, or `nil` if the results are empty.
 
      - warning: Only the name of a property whose type conforms to the `AddableType` protocol can be specified.
 
      - parameter property: The name of a property whose average value should be calculated.
-
-     - returns: The average value of the given property, or `nil` if the collection is empty.
      */
     public func average<U: AddableType>(property: String) -> U? {
         return rlmResults.averageOfProperty(property).map(dynamicBridgeCast)
@@ -759,62 +727,59 @@ public final class Results<T: Object>: ResultsBase {
     // MARK: Notifications
 
     /**
-     Registers a block to be called each time the results collection changes.
+     Registers a block to be called each time the collection changes.
 
-     The block will be asynchronously called with the initial results, and then
-     called again after each write transaction which changes either any of the
-     objects in the collection, or which objects are in the collection.
+     The block will be asynchronously called with the initial results, and then called again after each write
+     transaction which changes either any of the objects in the collection, or which objects are in the collection.
 
-     The `change` parameter that is passed to the block reports, in the form of indices within the
-     collection, which of the objects were added, removed, or modified during each write transaction. See the
-     `RealmCollectionChange` documentation for more information on the change information supplied and an example of how
-     to use it to update a `UITableView`.
+     The `change` parameter that is passed to the block reports, in the form of indices within the collection, which of
+     the objects were added, removed, or modified during each write transaction. See the `RealmCollectionChange`
+     documentation for more information on the change information supplied and an example of how to use it to update a
+     `UITableView`.
 
-     At the time when the block is called, the collection will be fully
-     evaluated and up-to-date, and as long as you do not perform a write
-     transaction on the same thread or explicitly call `realm.refresh()`,
-     accessing it will never perform blocking work.
+     At the time when the block is called, the collection will be fully evaluated and up-to-date, and as long as you do
+     not perform a write transaction on the same thread or explicitly call `realm.refresh()`, accessing it will never
+     perform blocking work.
 
-     Notifications are delivered via the standard run loop, and so can't be
-     delivered while the run loop is blocked by other activity. When
-     notifications can't be delivered instantly, multiple notifications may be
-     coalesced into a single notification. This can include the notification
-     with the initial collection. For example, the following code performs a write
-     transaction immediately after adding the notification block, so there is no
-     opportunity for the initial notification to be delivered first. As a
-     result, the initial notification will reflect the state of the Realm after
-     the write transaction.
+     Notifications are delivered via the standard run loop, and so can't be delivered while the run loop is blocked by
+     other activity. When notifications can't be delivered instantly, multiple notifications may be coalesced into a
+     single notification. This can include the notification with the initial collection.
 
-         let dogs = realm.objects(Dog.self)
-         print("dogs.count: \(dogs?.count)") // => 0
-         let token = dogs.addNotificationBlock { (changes: RealmCollectionChange) in
-             switch changes {
-                 case .Initial(let dogs):
-                     // Will print "dogs.count: 1"
-                     print("dogs.count: \(dogs.count)")
-                     break
-                 case .Update:
-                     // Will not be hit in this example
-                     break
-                 case .Error:
-                     break
-             }
+     For example, the following code performs a write transaction immediately after adding the notification block, so
+     there is no opportunity for the initial notification to be delivered first. As a result, the initial notification
+     will reflect the state of the Realm after the write transaction.
+
+     ```swift
+     let results = realm.objects(Dog.self)
+     print("dogs.count: \(dogs?.count)") // => 0
+     let token = dogs.addNotificationBlock { changes in
+         switch changes {
+         case .Initial(let dogs):
+             // Will print "dogs.count: 1"
+             print("dogs.count: \(dogs.count)")
+             break
+         case .Update:
+             // Will not be hit in this example
+             break
+         case .Error:
+             break
          }
-         try! realm.write {
-             let dog = Dog()
-             dog.name = "Rex"
-             person.dogs.append(dog)
-         }
-         // end of run loop execution context
+     }
+     try! realm.write {
+         let dog = Dog()
+         dog.name = "Rex"
+         person.dogs.append(dog)
+     }
+     // end of run loop execution context
+     ```
 
-     You must retain the returned token for as long as you want updates to continue
-     to be sent to the block. To stop receiving updates, call `stop()` on the token.
+     You must retain the returned token for as long as you want updates to be sent to the block. To stop receiving
+     updates, call `stop()` on the token.
 
-     - warning: This method cannot be called during a write transaction, or when
-                the containing Realm is read-only.
+     - warning: This method cannot be called during a write transaction, or when the containing Realm is read-only.
 
      - parameter block: The block to be called whenever a change occurs.
-     - returns: A token which must be retained for as long as you want updates to be delivered.
+     - returns: A token which must be held for as long as you want updates to be delivered.
      */
     @warn_unused_result(message="You must hold on to the NotificationToken returned from addNotificationBlock")
     public func addNotificationBlock(block: (RealmCollectionChange<Results> -> Void)) -> NotificationToken {

--- a/RealmSwift/Schema.swift
+++ b/RealmSwift/Schema.swift
@@ -22,26 +22,28 @@ import Realm
 #if swift(>=3.0)
 
 /**
-This class represents the collection of model object schemas persisted to Realm.
+ `Schema` instances represent collections of model object schemas managed by a Realm.
 
-When using Realm, `Schema` objects allow performing migrations and
-introspecting the database's schema.
+ When using Realm, `Schema` instances allow performing migrations and introspecting the database's schema.
 
-`Schema`s map to collections of tables in the core database.
-*/
+ Schemas map to collections of tables in the core database.
+ */
 public final class Schema: CustomStringConvertible {
 
     // MARK: Properties
 
     internal let rlmSchema: RLMSchema
 
-    /// `ObjectSchema`s for all object types in this Realm. Meant
-    /// to be used during migrations for dynamic introspection.
+    /**
+     An array of `ObjectSchema`s for all object types in the Realm.
+
+     This property is intended to be used during migrations for dynamic introspection.
+     */
     public var objectSchema: [ObjectSchema] {
         return rlmSchema.objectSchema.map(ObjectSchema.init)
     }
 
-    /// Returns a human-readable description of the object schemas contained in this schema.
+    /// A human-readable description of the object schemas contained within.
     public var description: String { return rlmSchema.description }
 
     // MARK: Initializers
@@ -52,7 +54,7 @@ public final class Schema: CustomStringConvertible {
 
     // MARK: ObjectSchema Retrieval
 
-    /// Returns the object schema with the given class name, if it exists.
+    /// Looks up and returns an `ObjectSchema` for the given class name in the Realm, if it exists.
     public subscript(className: String) -> ObjectSchema? {
         if let rlmObjectSchema = rlmSchema.schema(forClassName: className) {
             return ObjectSchema(rlmObjectSchema)
@@ -119,7 +121,7 @@ public final class Schema: CustomStringConvertible {
 
 extension Schema: Equatable {}
 
-/// Returns a Boolean value that indicates whether two `Schema` instances are equivalent.
+/// Returns whether the two schemas are equal.
 public func == (lhs: Schema, rhs: Schema) -> Bool { // swiftlint:disable:this valid_docs
     return lhs.rlmSchema.isEqualToSchema(rhs.rlmSchema)
 }

--- a/RealmSwift/SortDescriptor.swift
+++ b/RealmSwift/SortDescriptor.swift
@@ -22,22 +22,20 @@ import Realm
 #if swift(>=3.0)
 
 /**
-A `SortDescriptor` stores a property name and a sort order for use with
-`sorted(sortDescriptors:)`. It is similar to `NSSortDescriptor`, but supports
-only the subset of functionality which can be efficiently run by Realm's query
-engine.
-*/
+ A `SortDescriptor` stores a property name and a sort order for use with `sorted(sortDescriptors:)`. It is similar to
+ `NSSortDescriptor`, but supports only the subset of functionality which can be efficiently run by Realm's query engine.
+ */
 public struct SortDescriptor {
 
     // MARK: Properties
 
-    /// The name of the property which this sort descriptor orders results by.
+    /// The name of the property which the sort descriptor orders results by.
     public let property: String
 
     /// Whether this descriptor sorts in ascending or descending order.
     public let ascending: Bool
 
-    /// Converts the receiver to an `RLMSortDescriptor`
+    /// Converts the receiver to an `RLMSortDescriptor`.
     internal var rlmSortDescriptorValue: RLMSortDescriptor {
         return RLMSortDescriptor(property: property, ascending: ascending)
     }
@@ -45,11 +43,11 @@ public struct SortDescriptor {
     // MARK: Initializers
 
     /**
-    Creates a `SortDescriptor` with the given property and ascending values.
+     Creates a sort descriptor with the given property and sort order values.
 
-    - parameter property:  The name of the property which this sort descriptor orders results by.
-    - parameter ascending: Whether this descriptor sorts in ascending or descending order.
-    */
+     - parameter property:  The name of the property which the sort descriptor orders results by.
+     - parameter ascending: Whether the descriptor sorts in ascending or descending order.
+     */
     public init(property: String, ascending: Bool = true) {
         self.property = property
         self.ascending = ascending
@@ -57,7 +55,7 @@ public struct SortDescriptor {
 
     // MARK: Functions
 
-    /// Returns a copy of the `SortDescriptor` with the sort order reversed.
+    /// Returns a copy of the sort descriptor with the sort order reversed.
     public func reversed() -> SortDescriptor {
         return SortDescriptor(property: property, ascending: !ascending)
     }
@@ -66,7 +64,7 @@ public struct SortDescriptor {
 // MARK: CustomStringConvertible
 
 extension SortDescriptor: CustomStringConvertible {
-    /// Returns a human-readable description of the sort descriptor.
+    /// A human-readable description of the sort descriptor.
     public var description: String {
         let direction = ascending ? "ascending" : "descending"
         return "SortDescriptor (property: \(property), direction: \(direction))"
@@ -88,35 +86,32 @@ public func == (lhs: SortDescriptor, rhs: SortDescriptor) -> Bool {
 
 extension SortDescriptor: ExpressibleByStringLiteral {
 
-    /// `StringLiteralType`. Required for `StringLiteralConvertible` conformance.
     public typealias UnicodeScalarLiteralType = StringLiteralType
-
-    /// `StringLiteralType`. Required for `StringLiteralConvertible` conformance.
     public typealias ExtendedGraphemeClusterLiteralType = StringLiteralType
 
     /**
-    Creates a `SortDescriptor` from a `UnicodeScalarLiteralType`.
+     Creates a `SortDescriptor` out of a Unicode scalar literal.
 
-    - parameter unicodeScalarLiteral: Property name literal.
+     - parameter unicodeScalarLiteral: Property name literal.
     */
     public init(unicodeScalarLiteral value: UnicodeScalarLiteralType) {
         self.init(property: value)
     }
 
     /**
-    Creates a `SortDescriptor` from an `ExtendedGraphemeClusterLiteralType`.
+     Creates a `SortDescriptor` out of a character literal.
 
-    - parameter extendedGraphemeClusterLiteral: Property name literal.
-    */
+     - parameter extendedGraphemeClusterLiteral: Property name literal.
+     */
     public init(extendedGraphemeClusterLiteral value: ExtendedGraphemeClusterLiteralType) {
         self.init(property: value)
     }
 
     /**
-    Creates a `SortDescriptor` from a `StringLiteralType`.
+     Creates a `SortDescriptor` out of a string literal.
 
-    - parameter stringLiteral: Property name literal.
-    */
+     - parameter stringLiteral: Property name literal.
+     */
     public init(stringLiteral value: StringLiteralType) {
         self.init(property: value)
     }
@@ -148,7 +143,7 @@ public struct SortDescriptor {
     // MARK: Initializers
 
     /**
-     Initializes a sort descriptor with the given property and sort order values.
+     Creates a sort descriptor with the given property and sort order values.
 
     - parameter property:  The name of the property which the sort descriptor orders results by.
     - parameter ascending: Whether the descriptor sorts in ascending or descending order.

--- a/RealmSwift/Tests/RealmCollectionTypeTests.swift
+++ b/RealmSwift/Tests/RealmCollectionTypeTests.swift
@@ -480,13 +480,13 @@ class RealmCollectionTypeTests: TestCase {
         let theExpectation = expectation(description: "")
         let token = collection.addNotificationBlock { (changes: RealmCollectionChange) in
             switch changes {
-            case .Initial(let collection):
+            case .initial(let collection):
                 XCTAssertEqual(collection.count, 2)
                 break
-            case .Update:
+            case .update:
                 XCTFail("Shouldn't happen")
                 break
-            case .Error:
+            case .error:
                 XCTFail("Shouldn't happen")
                 break
             }
@@ -573,15 +573,15 @@ class ResultsTests: RealmCollectionTypeTests {
         var calls = 0
         let token = collection.addNotificationBlock { (changes: RealmCollectionChange) in
             switch changes {
-            case .Initial(let results):
+            case .initial(let results):
                 XCTAssertEqual(results.count, calls + 2)
                 XCTAssertEqual(results, collection)
                 break
-            case .Update(let results, _, _, _):
+            case .update(let results, _, _, _):
                 XCTAssertEqual(results.count, calls + 2)
                 XCTAssertEqual(results, collection)
                 break
-            case .Error:
+            case .error:
                 XCTFail("Shouldn't happen")
                 break
             }
@@ -604,18 +604,18 @@ class ResultsTests: RealmCollectionTypeTests {
         var calls = 0
         let token = collection.addNotificationBlock { (change: RealmCollectionChange) in
             switch change {
-            case .Initial(let results):
+            case .initial(let results):
                 XCTAssertEqual(calls, 0)
                 XCTAssertEqual(results.count, 2)
                 break
-            case .Update(let results, let deletions, let insertions, let modifications):
+            case .update(let results, let deletions, let insertions, let modifications):
                 XCTAssertEqual(calls, 1)
                 XCTAssertEqual(results.count, 3)
                 XCTAssertEqual(deletions, [])
                 XCTAssertEqual(insertions, [2])
                 XCTAssertEqual(modifications, [])
                 break
-            case .Error(let error):
+            case .error(let error):
                 XCTFail(String(describing: error))
                 break
             }
@@ -750,13 +750,13 @@ class ListRealmCollectionTypeTests: RealmCollectionTypeTests {
         let theExpectation = expectation(description: "")
         let token = collection.addNotificationBlock { (changes: RealmCollectionChange) in
             switch changes {
-            case .Initial(let list):
+            case .initial(let list):
                 XCTAssertEqual(list.count, 2)
                 break
-            case .Update:
+            case .update:
                 XCTFail("Shouldn't happen")
                 break
-            case .Error:
+            case .error:
                 XCTFail("Shouldn't happen")
                 break
             }

--- a/examples/ios/swift-3.0/TableView/TableViewController.swift
+++ b/examples/ios/swift-3.0/TableView/TableViewController.swift
@@ -48,11 +48,11 @@ class TableViewController: UITableViewController {
         // Set results notification block
         self.notificationToken = results.addNotificationBlock { (changes: RealmCollectionChange) in
             switch changes {
-            case .Initial:
+            case .initial:
                 // Results are now populated and can be accessed without blocking the UI
                 self.tableView.reloadData()
                 break
-            case .Update(_, let deletions, let insertions, let modifications):
+            case .update(_, let deletions, let insertions, let modifications):
                 // Query results have changed, so apply them to the TableView
                 self.tableView.beginUpdates()
                 self.tableView.insertRows(at: insertions.map { IndexPath(row: $0, section: 0) }, with: .automatic)
@@ -60,7 +60,7 @@ class TableViewController: UITableViewController {
                 self.tableView.reloadRows(at: modifications.map { IndexPath(row: $0, section: 0) }, with: .automatic)
                 self.tableView.endUpdates()
                 break
-            case .Error(let err):
+            case .error(let err):
                 // An error occurred while opening the Realm file on the background worker thread
                 fatalError("\(err)")
                 break


### PR DESCRIPTION
This is a large and boring change, so don't feel like there's any rush to review it.

@tgoyne @bdash @jpsim @JadenGeller 

Changes:
- Documentation for Swift 3 APIs is now correct
- `Error` in Realm Swift is now just a typealias for the Objective-C error type
- Updated and fixed unit tests