### PR TITLE
Replace RLMUpdateQueryWithPredicate with RLMPredicateToQuery

### DIFF
--- a/Realm/RLMArrayLinkView.mm
+++ b/Realm/RLMArrayLinkView.mm
@@ -363,15 +363,14 @@ static void RLMInsertObject(RLMArrayLinkView *ar, RLMObject *object, NSUInteger 
 }
 
 - (RLMResults *)objectsWithPredicate:(NSPredicate *)predicate {
-    auto query = translateErrors([&] { return _backingList.get_query(); });
-    RLMUpdateQueryWithPredicate(&query, predicate, _realm.schema, _objectSchema);
-    return [RLMResults resultsWithObjectSchema:_objectSchema
-                                       results:_backingList.filter(std::move(query))];
+    auto query = RLMPredicateToQuery(predicate, _objectSchema, _realm.schema);
+    auto results = translateErrors([&] { return _backingList.filter(std::move(query)); });
+    return [RLMResults resultsWithObjectSchema:_objectSchema results:std::move(results)];
 }
 
 - (NSUInteger)indexOfObjectWithPredicate:(NSPredicate *)predicate {
     auto query = translateErrors([&] { return _backingList.get_query(); });
-    RLMUpdateQueryWithPredicate(&query, predicate, _realm.schema, _objectSchema);
+    query.and_query(RLMPredicateToQuery(predicate, _objectSchema, _realm.schema));
     return RLMConvertNotFound(query.find());
 }
 

--- a/Realm/RLMObjectStore.mm
+++ b/Realm/RLMObjectStore.mm
@@ -388,8 +388,7 @@ RLMResults *RLMGetObjects(RLMRealm *realm, NSString *objectClassName, NSPredicat
     }
 
     if (predicate) {
-        realm::Query query = objectSchema.table->where();
-        RLMUpdateQueryWithPredicate(&query, predicate, realm.schema, objectSchema);
+        realm::Query query = RLMPredicateToQuery(predicate, objectSchema, realm.schema);
 
         // create and populate array
         return [RLMResults resultsWithObjectSchema:objectSchema

--- a/Realm/RLMQueryUtil.hpp
+++ b/Realm/RLMQueryUtil.hpp
@@ -33,9 +33,8 @@ namespace realm {
 extern NSString * const RLMPropertiesComparisonTypeMismatchException;
 extern NSString * const RLMUnsupportedTypesFoundInPropertyComparisonException;
 
-// apply the given predicate to the passed in query, returning the updated query
-void RLMUpdateQueryWithPredicate(realm::Query *query, NSPredicate *predicate, RLMSchema *schema,
-                                 RLMObjectSchema *objectSchema);
+realm::Query RLMPredicateToQuery(NSPredicate *predicate, RLMObjectSchema *objectSchema,
+                                 RLMSchema *schema);
 
 // return property - throw for invalid column name
 RLMProperty *RLMValidatedProperty(RLMObjectSchema *objectSchema, NSString *columnName);

--- a/Realm/RLMResults.mm
+++ b/Realm/RLMResults.mm
@@ -173,7 +173,7 @@ static inline void RLMResultsValidateInWriteTransaction(__unsafe_unretained RLMR
     }
 
     Query query = translateErrors([&] { return _results.get_query(); });
-    RLMUpdateQueryWithPredicate(&query, predicate, _realm.schema, _objectSchema);
+    query.and_query(RLMPredicateToQuery(predicate, _objectSchema, _realm.schema));
 
     query.sync_view_if_needed();
 
@@ -327,8 +327,7 @@ static inline void RLMResultsValidateInWriteTransaction(__unsafe_unretained RLMR
         if (_results.get_mode() == Results::Mode::Empty) {
             return self;
         }
-        auto query = _objectSchema.table->where();
-        RLMUpdateQueryWithPredicate(&query, predicate, _realm.schema, _objectSchema);
+        auto query = RLMPredicateToQuery(predicate, _objectSchema, _realm.schema);
         return [RLMResults resultsWithObjectSchema:_objectSchema
                                            results:_results.filter(std::move(query))];
     });


### PR DESCRIPTION
Muting the query in-place used to be required due to issues with Query's node
ownership logic, but that's all been fixed and returning a new Query makes some
of the call sites nicer and none of them worse.

@bdash 