### PR TITLE
Improve `RLMRealm` Swift interface for initialization and transactions

### DIFF
--- a/Realm/RLMRealm.h
+++ b/Realm/RLMRealm.h
@@ -53,6 +53,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark - Creating & Initializing a Realm
 
+- (instancetype)init
+NS_UNAVAILABLE;
+
 /**
  Obtains an instance of the default Realm.
 
@@ -67,7 +70,29 @@ NS_ASSUME_NONNULL_BEGIN
 
  @return The default `RLMRealm` instance for the current thread.
  */
-+ (instancetype)defaultRealm;
++ (instancetype)defaultRealm
+NS_REFINED_FOR_SWIFT;
+
+/**
+ Obtains an instance of the default Realm.
+
+ The default Realm is used by the `RLMObject` class methods
+ which do not take an `RLMRealm` parameter, but is otherwise not special. The
+ default Realm is persisted as *default.realm* under the *Documents* directory of
+ your Application on iOS, and in your application's *Application Support*
+ directory on OS X.
+
+ The default Realm is created using the default `RLMRealmConfiguration`, which
+ can be changed via `+[RLMRealmConfiguration setDefaultConfiguration:]`.
+
+ @param error         If an error occurs, upon return contains an `NSError` object
+                      that describes the problem. If you are not interested in
+                      possible errors, pass in `NULL`.
+
+ @return The default `RLMRealm` instance for the current thread.
+ */
++ (nullable instancetype)defaultRealmWithError:(NSError **)error
+NS_SWIFT_NAME(init());
 
 /**
  Obtains an `RLMRealm` instance with the given configuration.
@@ -102,7 +127,8 @@ NS_ASSUME_NONNULL_BEGIN
             created, updated, or removed. Doing so might cause a large number of write transactions to be created,
             degrading performance. Instead, always prefer performing multiple updates during a single transaction.
  */
-@property (nonatomic, readonly) BOOL inWriteTransaction;
+@property (nonatomic, readonly) BOOL inWriteTransaction
+NS_SWIFT_NAME(isInWriteTransaction);
 
 /**
  The `RLMRealmConfiguration` object that was used to create this `RLMRealm` instance.
@@ -177,7 +203,8 @@ typedef void (^RLMNotificationBlock)(RLMNotification notification, RLMRealm *rea
  Realm participating in the write transaction is kept alive until the write transaction
  is committed.
  */
-- (void)beginWriteTransaction;
+- (void)beginWriteTransaction
+NS_SWIFT_NAME(beginWrite());
 
 /**
  Commits all write operations in the current write transaction, and ends the 
@@ -185,7 +212,8 @@ typedef void (^RLMNotificationBlock)(RLMNotification notification, RLMRealm *rea
 
  @warning This method may only be called during a write transaction.
  */
-- (void)commitWriteTransaction NS_SWIFT_UNAVAILABLE("");
+- (void)commitWriteTransaction
+NS_REFINED_FOR_SWIFT;
 
 /**
  Commits all write operations in the current write transaction, and ends the
@@ -199,7 +227,8 @@ typedef void (^RLMNotificationBlock)(RLMNotification notification, RLMRealm *rea
 
  @return Whether the transaction succeeded.
  */
-- (BOOL)commitWriteTransaction:(NSError **)error;
+- (BOOL)commitWriteTransaction:(NSError **)error
+NS_SWIFT_NAME(commitWrite());
 
 /**
  Reverts all writes made during the current write transaction and ends the transaction.
@@ -226,14 +255,16 @@ typedef void (^RLMNotificationBlock)(RLMNotification notification, RLMRealm *rea
 
  @warning This method may only be called during a write transaction.
  */
-- (void)cancelWriteTransaction;
+- (void)cancelWriteTransaction
+NS_SWIFT_NAME(cancelWrite());
 
 /**
  Performs actions contained within the given block inside a write transaction.
  
  @see `[RLMRealm transactionWithBlock:error:]`
  */
-- (void)transactionWithBlock:(__attribute__((noescape)) void(^)(void))block NS_SWIFT_UNAVAILABLE("");
+- (void)transactionWithBlock:(__attribute__((noescape)) void(^)(void))block
+NS_REFINED_FOR_SWIFT;
 
 /**
  Performs actions contained within the given block inside a write transaction.
@@ -255,7 +286,8 @@ typedef void (^RLMNotificationBlock)(RLMNotification notification, RLMRealm *rea
 
  @return Whether the transaction succeeded.
  */
-- (BOOL)transactionWithBlock:(__attribute__((noescape)) void(^)(void))block error:(NSError **)error;
+- (BOOL)transactionWithBlock:(__attribute__((noescape)) void(^)(void))block error:(NSError **)error
+NS_SWIFT_NAME(write(_:));
 
 /**
  Updates the Realm and outstanding objects managed by the Realm to point to the most recent data.
@@ -294,7 +326,8 @@ typedef void (^RLMNotificationBlock)(RLMNotification notification, RLMRealm *rea
 
  Defaults to `YES`.
  */
-@property (nonatomic) BOOL autorefresh;
+@property (nonatomic) BOOL autorefresh
+NS_SWIFT_NAME(shouldAutorefresh);
 
 /**
  Writes a compacted and optionally encrypted copy of the Realm to the given local URL.
@@ -312,7 +345,8 @@ typedef void (^RLMNotificationBlock)(RLMNotification notification, RLMRealm *rea
 
  @return `YES` if the Realm was successfully written to disk, `NO` if an error occurred.
 */
-- (BOOL)writeCopyToURL:(NSURL *)fileURL encryptionKey:(nullable NSData *)key error:(NSError **)error;
+- (BOOL)writeCopyToURL:(NSURL *)fileURL encryptionKey:(nullable NSData *)key error:(NSError **)error
+NS_SWIFT_NAME(writeCopy(toFile:withEncryptionKey:));
 
 /**
  Invalidates all `RLMObject`s, `RLMResults`, `RLMLinkingObjects`, and `RLMArray`s managed by the Realm.

--- a/Realm/RLMRealm.mm
+++ b/Realm/RLMRealm.mm
@@ -150,7 +150,11 @@ NSData *RLMRealmValidatedEncryptionKey(NSData *key) {
 }
 
 + (instancetype)defaultRealm {
-    return [RLMRealm realmWithConfiguration:[RLMRealmConfiguration rawDefaultConfiguration] error:nil];
+    return [RLMRealm defaultRealmWithError:nil];
+}
+
++ (nullable instancetype)defaultRealmWithError:(NSError **)error {
+    return [RLMRealm realmWithConfiguration:[RLMRealmConfiguration rawDefaultConfiguration] error:error];
 }
 
 + (instancetype)realmWithURL:(NSURL *)fileURL {

--- a/Realm/Tests/Swift/SwiftArrayPropertyTests.swift
+++ b/Realm/Tests/Swift/SwiftArrayPropertyTests.swift
@@ -131,9 +131,9 @@ class SwiftArrayPropertyTests: RLMTestCase {
     //        array.array.addObject(obj)
     //        array.array.addObject(obj)
     //
-    //        realm.beginWriteTransaction()
+    //        realm.beginWrite()
     //        realm.addObject(array)
-    //        try! realm.commitWriteTransaction()
+    //        try! realm.commitWrite()
     //
     //        XCTAssertEqual(array.array.count, UInt(2), "Should have two elements in array")
     //        XCTAssertEqual((array.array[0] as SwiftStringObject).stringCol, "a", "First element should have property value 'a'")
@@ -262,9 +262,9 @@ class SwiftArrayPropertyTests: RLMTestCase {
         string.stringCol = "string"
 
         let realm = realmWithTestPath()
-        realm.beginWriteTransaction()
+        realm.beginWrite()
         realm.addObject(string)
-        try! realm.commitWriteTransaction()
+        try! realm.commitWrite()
 
         XCTAssertEqual(SwiftStringObject.allObjectsInRealm(realm).count, UInt(1), "There should be a single SwiftStringObject in the realm")
 
@@ -274,10 +274,10 @@ class SwiftArrayPropertyTests: RLMTestCase {
         XCTAssertEqual(array.array.count, UInt(1))
         XCTAssertEqual((array.array.firstObject() as! SwiftStringObject).stringCol, "string")
 
-        realm.beginWriteTransaction()
+        realm.beginWrite()
         realm.addObject(array)
         array.array.addObject(string)
-        try! realm.commitWriteTransaction()
+        try! realm.commitWrite()
 
         let arrayObjects = SwiftArrayPropertyObject.allObjectsInRealm(realm)
 
@@ -289,7 +289,7 @@ class SwiftArrayPropertyTests: RLMTestCase {
     func testPopulateEmptyArray() {
         let realm = realmWithTestPath()
 
-        realm.beginWriteTransaction()
+        realm.beginWrite()
         let array = SwiftArrayPropertyObject.createInRealm(realm, withValue: ["arrayObject", [], []]);
         XCTAssertNotNil(array.array, "Should be able to get an empty array")
         XCTAssertEqual(array.array.count, UInt(0), "Should start with no array elements")
@@ -299,7 +299,7 @@ class SwiftArrayPropertyTests: RLMTestCase {
         array.array.addObject(obj)
         array.array.addObject(SwiftStringObject.createInRealm(realm, withValue: ["b"]))
         array.array.addObject(obj)
-        try! realm.commitWriteTransaction()
+        try! realm.commitWrite()
 
         XCTAssertEqual(array.array.count, UInt(3), "Should have three elements in array")
         XCTAssertEqual((array.array[0] as! SwiftStringObject).stringCol, "a", "First element should have property value 'a'")
@@ -313,7 +313,7 @@ class SwiftArrayPropertyTests: RLMTestCase {
 
     func testModifyDetatchedArray() {
         let realm = realmWithTestPath()
-        realm.beginWriteTransaction()
+        realm.beginWrite()
         let arObj = SwiftArrayPropertyObject.createInRealm(realm, withValue: ["arrayObject", [], []])
         XCTAssertNotNil(arObj.array, "Should be able to get an empty array")
         XCTAssertEqual(arObj.array.count, UInt(0), "Should start with no array elements")
@@ -323,7 +323,7 @@ class SwiftArrayPropertyTests: RLMTestCase {
         let array = arObj.array
         array.addObject(obj)
         array.addObject(SwiftStringObject.createInRealm(realm, withValue: ["b"]))
-        try! realm.commitWriteTransaction()
+        try! realm.commitWrite()
 
         XCTAssertEqual(array.count, UInt(2), "Should have two elements in array")
         XCTAssertEqual((array[0] as! SwiftStringObject).stringCol, "a", "First element should have property value 'a'")
@@ -333,14 +333,14 @@ class SwiftArrayPropertyTests: RLMTestCase {
     func testInsertMultiple() {
         let realm = realmWithTestPath()
 
-        realm.beginWriteTransaction()
+        realm.beginWrite()
 
         let obj = SwiftArrayPropertyObject.createInRealm(realm, withValue: ["arrayObject", [], []])
         let child1 = SwiftStringObject.createInRealm(realm, withValue: ["a"])
         let child2 = SwiftStringObject()
         child2.stringCol = "b"
         obj.array.addObjects([child2, child1])
-        try! realm.commitWriteTransaction()
+        try! realm.commitWrite()
 
         let children = SwiftStringObject.allObjectsInRealm(realm)
         XCTAssertEqual((children[0] as! SwiftStringObject).stringCol, "a", "First child should be 'a'")
@@ -376,9 +376,9 @@ class SwiftArrayPropertyTests: RLMTestCase {
         string.stringCol = "string"
 
         let realm = realmWithTestPath()
-        realm.beginWriteTransaction()
+        realm.beginWrite()
         realm.addObject(string)
-        try! realm.commitWriteTransaction()
+        try! realm.commitWrite()
 
         XCTAssertEqual(StringObject.allObjectsInRealm(realm).count, UInt(1), "There should be a single StringObject in the realm")
 
@@ -386,9 +386,9 @@ class SwiftArrayPropertyTests: RLMTestCase {
         array.name = "arrayObject"
         array.array.addObject(string)
 
-        realm.beginWriteTransaction()
+        realm.beginWrite()
         realm.addObject(array)
-        try! realm.commitWriteTransaction()
+        try! realm.commitWrite()
 
         let arrayObjects = ArrayPropertyObject.allObjectsInRealm(realm)
 
@@ -400,7 +400,7 @@ class SwiftArrayPropertyTests: RLMTestCase {
     func testPopulateEmptyArray_objc() {
         let realm = realmWithTestPath()
 
-        realm.beginWriteTransaction()
+        realm.beginWrite()
         let array = ArrayPropertyObject.createInRealm(realm, withValue: ["arrayObject", [], []]);
         XCTAssertNotNil(array.array, "Should be able to get an empty array")
         XCTAssertEqual(array.array.count, UInt(0), "Should start with no array elements")
@@ -410,7 +410,7 @@ class SwiftArrayPropertyTests: RLMTestCase {
         array.array.addObject(obj)
         array.array.addObject(StringObject.createInRealm(realm, withValue: ["b"]))
         array.array.addObject(obj)
-        try! realm.commitWriteTransaction()
+        try! realm.commitWrite()
 
         XCTAssertEqual(array.array.count, UInt(3), "Should have three elements in array")
         XCTAssertEqual((array.array[0] as! StringObject).stringCol!, "a", "First element should have property value 'a'")
@@ -426,7 +426,7 @@ class SwiftArrayPropertyTests: RLMTestCase {
 
     func testModifyDetatchedArray_objc() {
         let realm = realmWithTestPath()
-        realm.beginWriteTransaction()
+        realm.beginWrite()
         let arObj = ArrayPropertyObject.createInRealm(realm, withValue: ["arrayObject", [], []])
         XCTAssertNotNil(arObj.array, "Should be able to get an empty array")
         XCTAssertEqual(arObj.array.count, UInt(0), "Should start with no array elements")
@@ -436,7 +436,7 @@ class SwiftArrayPropertyTests: RLMTestCase {
         let array = arObj.array
         array.addObject(obj)
         array.addObject(StringObject.createInRealm(realm, withValue: ["b"]))
-        try! realm.commitWriteTransaction()
+        try! realm.commitWrite()
 
         XCTAssertEqual(array.count, UInt(2), "Should have two elements in array")
         XCTAssertEqual((array[0] as! StringObject).stringCol!, "a", "First element should have property value 'a'")
@@ -446,14 +446,14 @@ class SwiftArrayPropertyTests: RLMTestCase {
     func testInsertMultiple_objc() {
         let realm = realmWithTestPath()
 
-        realm.beginWriteTransaction()
+        realm.beginWrite()
 
         let obj = ArrayPropertyObject.createInRealm(realm, withValue: ["arrayObject", [], []])
         let child1 = StringObject.createInRealm(realm, withValue: ["a"])
         let child2 = StringObject()
         child2.stringCol = "b"
         obj.array.addObjects([child2, child1])
-        try! realm.commitWriteTransaction()
+        try! realm.commitWrite()
 
         let children = StringObject.allObjectsInRealm(realm)
         XCTAssertEqual((children[0] as! StringObject).stringCol!, "a", "First child should be 'a'")
@@ -472,9 +472,9 @@ class SwiftArrayPropertyTests: RLMTestCase {
         array.array.addObject(obj)
         array.array.addObject(obj)
 
-        realm.beginWriteTransaction()
+        realm.beginWrite()
         realm.addObject(array)
-        try! realm.commitWriteTransaction()
+        try! realm.commitWrite()
 
         XCTAssertEqual(array.array.count, UInt(2), "Should have two elements in array")
         XCTAssertEqual((array.array[0] as! StringObject).stringCol!, "a", "First element should have property value 'a'")

--- a/Realm/Tests/Swift/SwiftArrayTests.swift
+++ b/Realm/Tests/Swift/SwiftArrayTests.swift
@@ -168,7 +168,7 @@ class SwiftArrayTests: RLMTestCase {
     func testArrayDescription() {
         let realm = realmWithTestPath()
 
-        realm.beginWriteTransaction()
+        realm.beginWrite()
 
         for _ in 0..<1012 {
             let person = SwiftEmployeeObject()
@@ -194,7 +194,7 @@ class SwiftArrayTests: RLMTestCase {
     func testDeleteLinksAndObjectsInArray() {
         let realm = realmWithTestPath()
 
-        realm.beginWriteTransaction()
+        realm.beginWrite()
 
         let po1 = SwiftEmployeeObject()
         po1.age = 40
@@ -251,7 +251,7 @@ class SwiftArrayTests: RLMTestCase {
         XCTAssertEqual(peopleInCompany.count, UInt(2), "2 links")
         peopleInCompany.removeAllObjects()
         XCTAssertEqual(peopleInCompany.count, UInt(0), "0 remaining links")
-        try! realm.commitWriteTransaction()
+        try! realm.commitWrite()
     }
 
     // Objective-C models
@@ -398,7 +398,7 @@ class SwiftArrayTests: RLMTestCase {
     func testArrayDescription_objc() {
         let realm = realmWithTestPath()
 
-        realm.beginWriteTransaction()
+        realm.beginWrite()
 
         for _ in 0..<1012 {
             let person = EmployeeObject()
@@ -432,7 +432,7 @@ class SwiftArrayTests: RLMTestCase {
     func testDeleteLinksAndObjectsInArray_objc() {
         let realm = realmWithTestPath()
 
-        realm.beginWriteTransaction()
+        realm.beginWrite()
 
         let po1 = makeEmployee(realm, 40, "Joe", true)
         _ = makeEmployee(realm, 30, "John", false)
@@ -528,7 +528,7 @@ class SwiftArrayTests: RLMTestCase {
     func testFastEnumeration() {
         let realm = realmWithTestPath()
 
-        realm.beginWriteTransaction()
+        realm.beginWrite()
 
         let dateMinInput = NSDate()
         let dateMaxInput = dateMinInput.dateByAddingTimeInterval(1000)
@@ -544,7 +544,7 @@ class SwiftArrayTests: RLMTestCase {
         SwiftAggregateObject.createInRealm(realm, withValue: [10, 1.2 as Float, 0 as Double, true, dateMinInput])
         SwiftAggregateObject.createInRealm(realm, withValue: [10, 1.2 as Float, 0 as Double, true, dateMinInput])
 
-        try! realm.commitWriteTransaction()
+        try! realm.commitWrite()
 
         let result = SwiftAggregateObject.objectsInRealm(realm, "intCol < %d", 100)
         XCTAssertEqual(result.count, UInt(10), "10 objects added")
@@ -563,7 +563,7 @@ class SwiftArrayTests: RLMTestCase {
     func testObjectAggregate() {
         let realm = realmWithTestPath()
 
-        realm.beginWriteTransaction()
+        realm.beginWrite()
 
         let dateMinInput = NSDate()
         let dateMaxInput = dateMinInput.dateByAddingTimeInterval(1000)
@@ -579,7 +579,7 @@ class SwiftArrayTests: RLMTestCase {
         SwiftAggregateObject.createInRealm(realm, withValue: [0, 1.2 as Float, 0 as Double, true, dateMinInput])
         SwiftAggregateObject.createInRealm(realm, withValue: [0, 1.2 as Float, 0 as Double, true, dateMinInput])
 
-        try! realm.commitWriteTransaction()
+        try! realm.commitWrite()
 
         let noArray = SwiftAggregateObject.objectsInRealm(realm, "boolCol == NO")
         let yesArray = SwiftAggregateObject.objectsInRealm(realm, "boolCol == YES")
@@ -664,7 +664,7 @@ class SwiftArrayTests: RLMTestCase {
     func testArrayDescription() {
         let realm = realmWithTestPath()
 
-        realm.beginWriteTransaction()
+        realm.beginWrite()
 
         for _ in 0..<1012 {
             let person = SwiftEmployeeObject()
@@ -674,7 +674,7 @@ class SwiftArrayTests: RLMTestCase {
             realm.addObject(person)
         }
 
-        try! realm.commitWriteTransaction()
+        try! realm.commitWrite()
 
         let description = SwiftEmployeeObject.allObjectsInRealm(realm).description
 
@@ -690,7 +690,7 @@ class SwiftArrayTests: RLMTestCase {
     func testDeleteLinksAndObjectsInArray() {
         let realm = realmWithTestPath()
 
-        realm.beginWriteTransaction()
+        realm.beginWrite()
 
         let po1 = SwiftEmployeeObject()
         po1.age = 40
@@ -715,14 +715,14 @@ class SwiftArrayTests: RLMTestCase {
         realm.addObject(company)
         company.employees.addObjects(SwiftEmployeeObject.allObjectsInRealm(realm))
 
-        try! realm.commitWriteTransaction()
+        try! realm.commitWrite()
 
         let peopleInCompany = company.employees
         XCTAssertEqual(peopleInCompany.count, UInt(3), "No links should have been deleted")
 
-        realm.beginWriteTransaction()
+        realm.beginWrite()
         peopleInCompany.removeObjectAtIndex(1) // Should delete link to employee
-        try! realm.commitWriteTransaction()
+        try! realm.commitWrite()
 
         XCTAssertEqual(peopleInCompany.count, UInt(2), "link deleted when accessing via links")
 
@@ -738,7 +738,7 @@ class SwiftArrayTests: RLMTestCase {
         XCTAssertEqual(test.hired, po3.hired, "Should be equal")
         // XCTAssertEqual(test, po3, "Should be equal") //FIXME, should work. Asana : https://app.asana.com/0/861870036984/13123030433568
 
-        realm.beginWriteTransaction()
+        realm.beginWrite()
         peopleInCompany.removeLastObject()
         XCTAssertEqual(peopleInCompany.count, UInt(1), "1 remaining link")
         peopleInCompany.replaceObjectAtIndex(0, withObject: po2)
@@ -747,7 +747,7 @@ class SwiftArrayTests: RLMTestCase {
         XCTAssertEqual(peopleInCompany.count, UInt(2), "2 links")
         peopleInCompany.removeAllObjects()
         XCTAssertEqual(peopleInCompany.count, UInt(0), "0 remaining links")
-        try! realm.commitWriteTransaction()
+        try! realm.commitWrite()
     }
 
     // Objective-C models
@@ -755,7 +755,7 @@ class SwiftArrayTests: RLMTestCase {
     func testFastEnumeration_objc() {
         let realm = realmWithTestPath()
 
-        realm.beginWriteTransaction()
+        realm.beginWrite()
 
         let dateMinInput = NSDate()
         let dateMaxInput = dateMinInput.dateByAddingTimeInterval(1000)
@@ -771,7 +771,7 @@ class SwiftArrayTests: RLMTestCase {
         AggregateObject.createInRealm(realm, withValue: [10, 1.2 as Float, 0 as Double, true, dateMinInput])
         AggregateObject.createInRealm(realm, withValue: [10, 1.2 as Float, 0 as Double, true, dateMinInput])
 
-        try! realm.commitWriteTransaction()
+        try! realm.commitWrite()
 
         let result = AggregateObject.objectsInRealm(realm, "intCol < %d", 100)
         XCTAssertEqual(result.count, UInt(10), "10 objects added")
@@ -790,7 +790,7 @@ class SwiftArrayTests: RLMTestCase {
     func testObjectAggregate_objc() {
         let realm = realmWithTestPath()
 
-        realm.beginWriteTransaction()
+        realm.beginWrite()
 
         let dateMinInput = NSDate()
         let dateMaxInput = dateMinInput.dateByAddingTimeInterval(1000)
@@ -806,7 +806,7 @@ class SwiftArrayTests: RLMTestCase {
         AggregateObject.createInRealm(realm, withValue: [0, 1.2 as Float, 0 as Double, true, dateMinInput])
         AggregateObject.createInRealm(realm, withValue: [0, 1.2 as Float, 0 as Double, true, dateMinInput])
 
-        try! realm.commitWriteTransaction()
+        try! realm.commitWrite()
 
         let noArray = AggregateObject.objectsInRealm(realm, "boolCol == NO")
         let yesArray = AggregateObject.objectsInRealm(realm, "boolCol == YES")
@@ -891,7 +891,7 @@ class SwiftArrayTests: RLMTestCase {
     func testArrayDescription_objc() {
         let realm = realmWithTestPath()
 
-        realm.beginWriteTransaction()
+        realm.beginWrite()
 
         for _ in 0..<1012 {
             let person = EmployeeObject()
@@ -901,7 +901,7 @@ class SwiftArrayTests: RLMTestCase {
             realm.addObject(person)
         }
 
-        try! realm.commitWriteTransaction()
+        try! realm.commitWrite()
 
         let description = EmployeeObject.allObjectsInRealm(realm).description
         XCTAssertTrue((description as NSString).rangeOfString("name").location != Foundation.NSNotFound, "property names should be displayed when calling \"description\" on RLMArray")
@@ -925,7 +925,7 @@ class SwiftArrayTests: RLMTestCase {
     func testDeleteLinksAndObjectsInArray_objc() {
         let realm = realmWithTestPath()
 
-        realm.beginWriteTransaction()
+        realm.beginWrite()
 
         let po1 = makeEmployee(realm, 40, "Joe", true)
         _ = makeEmployee(realm, 30, "John", false)
@@ -936,14 +936,14 @@ class SwiftArrayTests: RLMTestCase {
         realm.addObject(company)
         company.employees.addObjects(EmployeeObject.allObjectsInRealm(realm))
 
-        try! realm.commitWriteTransaction()
+        try! realm.commitWrite()
 
         let peopleInCompany = company.employees
         XCTAssertEqual(peopleInCompany.count, UInt(3), "No links should have been deleted")
 
-        realm.beginWriteTransaction()
+        realm.beginWrite()
         peopleInCompany.removeObjectAtIndex(1) // Should delete link to employee
-        try! realm.commitWriteTransaction()
+        try! realm.commitWrite()
 
         XCTAssertEqual(peopleInCompany.count, UInt(2), "link deleted when accessing via links")
 
@@ -966,11 +966,11 @@ class SwiftArrayTests: RLMTestCase {
     func testIndexOfObject_objc() {
         let realm = realmWithTestPath()
 
-        realm.beginWriteTransaction()
+        realm.beginWrite()
         let po1 = makeEmployee(realm, 40, "Joe", true)
         let po2 = makeEmployee(realm, 30, "John", false)
         let po3 = makeEmployee(realm, 25, "Jill", true)
-        try! realm.commitWriteTransaction()
+        try! realm.commitWrite()
 
         let results = EmployeeObject.objectsInRealm(realm, "hired = YES")
         XCTAssertEqual(UInt(2), results.count)
@@ -982,11 +982,11 @@ class SwiftArrayTests: RLMTestCase {
     func testIndexOfObjectWhere_objc() {
         let realm = realmWithTestPath()
 
-        realm.beginWriteTransaction()
+        realm.beginWrite()
         makeEmployee(realm, 40, "Joe", true)
         makeEmployee(realm, 30, "John", false)
         makeEmployee(realm, 25, "Jill", true)
-        try! realm.commitWriteTransaction()
+        try! realm.commitWrite()
 
         let results = EmployeeObject.objectsInRealm(realm, "hired = YES")
         XCTAssertEqual(UInt(2), results.count)
@@ -998,11 +998,11 @@ class SwiftArrayTests: RLMTestCase {
     func testSortingExistingQuery_objc() {
         let realm = realmWithTestPath()
 
-        realm.beginWriteTransaction()
+        realm.beginWrite()
         makeEmployee(realm, 20, "A", true)
         makeEmployee(realm, 30, "B", false)
         makeEmployee(realm, 40, "C", true)
-        try! realm.commitWriteTransaction()
+        try! realm.commitWrite()
 
         let sortedByAge = EmployeeObject.allObjectsInRealm(realm).sortedResultsUsingProperty("age", ascending: true)
         let sortedByName = sortedByAge.sortedResultsUsingProperty("name", ascending: false)

--- a/Realm/Tests/Swift/SwiftDynamicTests.swift
+++ b/Realm/Tests/Swift/SwiftDynamicTests.swift
@@ -192,10 +192,10 @@ class SwiftDynamicTests: RLMTestCase {
         autoreleasepool {
             // open realm in autoreleasepool to create tables and then dispose
             let realm = RLMRealm(URL: RLMTestRealmURL())
-            realm.beginWriteTransaction()
+            realm.beginWrite()
             SwiftDynamicObject.createInRealm(realm, withValue: ["column1", 1])
             SwiftDynamicObject.createInRealm(realm, withValue: ["column2", 2])
-            try! realm.commitWriteTransaction()
+            try! realm.commitWrite()
         }
         let dyrealm = realmWithTestPathAndSchema(nil)
         XCTAssertNotNil(dyrealm, "realm should not be nil")
@@ -218,10 +218,10 @@ class SwiftDynamicTests: RLMTestCase {
         autoreleasepool {
             // open realm in autoreleasepool to create tables and then dispose
             let realm = RLMRealm(URL: RLMTestRealmURL())
-            realm.beginWriteTransaction()
+            realm.beginWrite()
             SwiftDynamicObject.createInRealm(realm, withValue: ["column1", 1])
             SwiftDynamicObject.createInRealm(realm, withValue: ["column2", 2])
-            try! realm.commitWriteTransaction()
+            try! realm.commitWrite()
         }
 
         // verify properties
@@ -238,10 +238,10 @@ class SwiftDynamicTests: RLMTestCase {
         autoreleasepool {
             // open realm in autoreleasepool to create tables and then dispose
             let realm = RLMRealm(URL: RLMTestRealmURL())
-            realm.beginWriteTransaction()
+            realm.beginWrite()
             DynamicObject.createInRealm(realm, withValue: ["column1", 1])
             DynamicObject.createInRealm(realm, withValue: ["column2", 2])
-            try! realm.commitWriteTransaction()
+            try! realm.commitWrite()
         }
         let dyrealm = realmWithTestPathAndSchema(nil)
         XCTAssertNotNil(dyrealm, "realm should not be nil")
@@ -264,10 +264,10 @@ class SwiftDynamicTests: RLMTestCase {
         autoreleasepool {
             // open realm in autoreleasepool to create tables and then dispose
             let realm = RLMRealm(URL: RLMTestRealmURL())
-            realm.beginWriteTransaction()
+            realm.beginWrite()
             DynamicObject.createInRealm(realm, withValue: ["column1", 1])
             DynamicObject.createInRealm(realm, withValue: ["column2", 2])
-            try! realm.commitWriteTransaction()
+            try! realm.commitWrite()
         }
 
         // verify properties
@@ -312,10 +312,10 @@ class SwiftDynamicTests: RLMTestCase {
         autoreleasepool {
             // open realm in autoreleasepool to create tables and then dispose
             let realm = self.realmWithTestPath()
-            realm.beginWriteTransaction()
+            realm.beginWrite()
             AllTypesObject.createInRealm(realm, withValue: obj1)
             AllTypesObject.createInRealm(realm, withValue: obj2)
-            try! realm.commitWriteTransaction()
+            try! realm.commitWrite()
         }
 
         // verify properties

--- a/Realm/Tests/Swift/SwiftLinkTests.swift
+++ b/Realm/Tests/Swift/SwiftLinkTests.swift
@@ -128,10 +128,10 @@ class SwiftLinkTests: RLMTestCase {
 //        obj.data = "a"
 //        obj.next = obj
 //
-//        realm.beginWriteTransaction()
+//        realm.beginWrite()
 //        realm.addObject(obj)
 //        obj.next.data = "b"
-//        try! realm.commitWriteTransaction()
+//        try! realm.commitWrite()
 //
 //        let obj2 = SwiftCircleObject.allObjectsInRealm(realm).firstObject() as SwiftCircleObject
 //        XCTAssertEqual(obj2.data, "b", "data should be 'b'")
@@ -223,10 +223,10 @@ class SwiftLinkTests: RLMTestCase {
 //        obj.data = "a"
 //        obj.next = obj
 //
-//        realm.beginWriteTransaction()
+//        realm.beginWrite()
 //        realm.addObject(obj)
 //        obj.next.data = "b"
-//        try! realm.commitWriteTransaction()
+//        try! realm.commitWrite()
 //
 //        let obj2 = CircleObject.allObjectsInRealm(realm).firstObject() as CircleObject
 //        XCTAssertEqual(obj2.data, "b", "data should be 'b'")
@@ -248,9 +248,9 @@ class SwiftLinkTests: RLMTestCase {
         owner.dog = SwiftDogObject()
         owner.dog!.dogName = "Harvie"
 
-        realm.beginWriteTransaction()
+        realm.beginWrite()
         realm.addObject(owner)
-        try! realm.commitWriteTransaction()
+        try! realm.commitWrite()
 
         let owners = SwiftOwnerObject.allObjectsInRealm(realm)
         let dogs = SwiftDogObject.allObjectsInRealm(realm)
@@ -271,17 +271,17 @@ class SwiftLinkTests: RLMTestCase {
         owner.dog = SwiftDogObject()
         owner.dog!.dogName = "Harvie"
 
-        realm.beginWriteTransaction()
+        realm.beginWrite()
         realm.addObject(owner)
-        try! realm.commitWriteTransaction()
+        try! realm.commitWrite()
 
         XCTAssertEqual(SwiftOwnerObject.allObjectsInRealm(realm).count, UInt(1), "Expecting 1 owner")
         XCTAssertEqual(SwiftDogObject.allObjectsInRealm(realm).count, UInt(1), "Expecting 1 dog")
 
-        realm.beginWriteTransaction()
+        realm.beginWrite()
         let fiel = SwiftOwnerObject.createInRealm(realm, withValue: ["Fiel", NSNull()])
         fiel.dog = owner.dog
-        try! realm.commitWriteTransaction()
+        try! realm.commitWrite()
 
         XCTAssertEqual(SwiftOwnerObject.allObjectsInRealm(realm).count, UInt(2), "Expecting 2 owners")
         XCTAssertEqual(SwiftDogObject.allObjectsInRealm(realm).count, UInt(1), "Expecting 1 dog")
@@ -295,16 +295,16 @@ class SwiftLinkTests: RLMTestCase {
         owner.dog = SwiftDogObject()
         owner.dog!.dogName = "Harvie"
 
-        realm.beginWriteTransaction()
+        realm.beginWrite()
         realm.addObject(owner)
-        try! realm.commitWriteTransaction()
+        try! realm.commitWrite()
 
         XCTAssertEqual(SwiftOwnerObject.allObjectsInRealm(realm).count, UInt(1), "Expecting 1 owner")
         XCTAssertEqual(SwiftDogObject.allObjectsInRealm(realm).count, UInt(1), "Expecting 1 dog")
 
-        realm.beginWriteTransaction()
+        realm.beginWrite()
         realm.deleteObject(owner.dog!)
-        try! realm.commitWriteTransaction()
+        try! realm.commitWrite()
 
         XCTAssertNil(owner.dog, "Dog should be nullified when deleted")
 
@@ -327,9 +327,9 @@ class SwiftLinkTests: RLMTestCase {
 
         XCTAssertEqual(0, target.backlinks!.count)
 
-        realm.beginWriteTransaction()
+        realm.beginWrite()
         realm.addObject(source)
-        try! realm.commitWriteTransaction()
+        try! realm.commitWrite()
 
         XCTAssertEqual(1, target.backlinks!.count)
         XCTAssertEqual(1234, (target.backlinks!.firstObject() as! SwiftLinkSourceObject).id)
@@ -363,9 +363,9 @@ class SwiftLinkTests: RLMTestCase {
         owner.dog = DogObject()
         owner.dog.dogName = "Harvie"
 
-        realm.beginWriteTransaction()
+        realm.beginWrite()
         realm.addObject(owner)
-        try! realm.commitWriteTransaction()
+        try! realm.commitWrite()
 
         let owners = OwnerObject.allObjectsInRealm(realm)
         let dogs = DogObject.allObjectsInRealm(realm)
@@ -386,17 +386,17 @@ class SwiftLinkTests: RLMTestCase {
         owner.dog = DogObject()
         owner.dog.dogName = "Harvie"
 
-        realm.beginWriteTransaction()
+        realm.beginWrite()
         realm.addObject(owner)
-        try! realm.commitWriteTransaction()
+        try! realm.commitWrite()
 
         XCTAssertEqual(OwnerObject.allObjectsInRealm(realm).count, UInt(1), "Expecting 1 owner")
         XCTAssertEqual(DogObject.allObjectsInRealm(realm).count, UInt(1), "Expecting 1 dog")
 
-        realm.beginWriteTransaction()
+        realm.beginWrite()
         let fiel = OwnerObject.createInRealm(realm, withValue: ["Fiel", NSNull()])
         fiel.dog = owner.dog
-        try! realm.commitWriteTransaction()
+        try! realm.commitWrite()
 
         XCTAssertEqual(OwnerObject.allObjectsInRealm(realm).count, UInt(2), "Expecting 2 owners")
         XCTAssertEqual(DogObject.allObjectsInRealm(realm).count, UInt(1), "Expecting 1 dog")
@@ -410,16 +410,16 @@ class SwiftLinkTests: RLMTestCase {
         owner.dog = DogObject()
         owner.dog.dogName = "Harvie"
 
-        realm.beginWriteTransaction()
+        realm.beginWrite()
         realm.addObject(owner)
-        try! realm.commitWriteTransaction()
+        try! realm.commitWrite()
 
         XCTAssertEqual(OwnerObject.allObjectsInRealm(realm).count, UInt(1), "Expecting 1 owner")
         XCTAssertEqual(DogObject.allObjectsInRealm(realm).count, UInt(1), "Expecting 1 dog")
 
-        realm.beginWriteTransaction()
+        realm.beginWrite()
         realm.deleteObject(owner.dog)
-        try! realm.commitWriteTransaction()
+        try! realm.commitWrite()
 
         XCTAssertNil(owner.dog, "Dog should be nullified when deleted")
 

--- a/Realm/Tests/Swift/SwiftObjectInterfaceTests.swift
+++ b/Realm/Tests/Swift/SwiftObjectInterfaceTests.swift
@@ -270,7 +270,7 @@ class SwiftObjectInterfaceTests: RLMTestCase {
         XCTAssertEqual(objects.count, UInt(2), "Should have 2 objects")
         XCTAssertEqual((objects[0] as! SwiftPrimaryStringObject).intCol, 3, "Value should be 3");
 
-        try! realm.commitWriteTransaction()
+        try! realm.commitWrite()
     }
 
     // if this fails (and you haven't changed the test module name), the checks
@@ -326,7 +326,7 @@ class SwiftObjectInterfaceTests: RLMTestCase {
 
     func testSwiftObject() {
         let realm = realmWithTestPath()
-        realm.beginWriteTransaction()
+        realm.beginWrite()
 
         let obj = SwiftObject()
         realm.addObject(obj)
@@ -341,7 +341,7 @@ class SwiftObjectInterfaceTests: RLMTestCase {
         obj.objectCol = SwiftBoolObject()
         obj.objectCol.boolCol = true
         obj.arrayCol.addObject(obj.objectCol)
-        try! realm.commitWriteTransaction()
+        try! realm.commitWrite()
 
         let data = NSString(string: "abcd").dataUsingEncoding(NSUTF8StringEncoding)
 
@@ -360,9 +360,9 @@ class SwiftObjectInterfaceTests: RLMTestCase {
 
     func testDefaultValueSwiftObject() {
         let realm = realmWithTestPath()
-        realm.beginWriteTransaction()
+        realm.beginWrite()
         realm.addObject(SwiftObject())
-        try! realm.commitWriteTransaction()
+        try! realm.commitWrite()
 
         let data = NSString(string: "a").dataUsingEncoding(NSUTF8StringEncoding)
 
@@ -380,9 +380,9 @@ class SwiftObjectInterfaceTests: RLMTestCase {
 
     func testMergedDefaultValuesSwiftObject() {
         let realm = self.realmWithTestPath()
-        realm.beginWriteTransaction()
+        realm.beginWrite()
         SwiftDefaultObject.createInRealm(realm, withValue: NSDictionary())
-        try! realm.commitWriteTransaction()
+        try! realm.commitWrite()
 
         let object = SwiftDefaultObject.allObjectsInRealm(realm).firstObject() as! SwiftDefaultObject
         XCTAssertEqual(object.intCol, 2, "defaultPropertyValues should override native property default value")
@@ -394,18 +394,18 @@ class SwiftObjectInterfaceTests: RLMTestCase {
         XCTAssertEqual("SwiftStringObject", SwiftStringObject.className())
         XCTAssertEqual("SwiftStringObjectSubclass", SwiftStringObjectSubclass.className())
 
-        let realm = RLMRealm.defaultRealm()
-        realm.beginWriteTransaction()
+        let realm = try! RLMRealm()
+        realm.beginWrite()
         SwiftStringObject.createInDefaultRealmWithValue(["string"])
 
         SwiftStringObjectSubclass.createInDefaultRealmWithValue(["string", "string2"])
-        try! realm.commitWriteTransaction()
+        try! realm.commitWrite()
 
         // ensure creation in proper table
         XCTAssertEqual(UInt(1), SwiftStringObjectSubclass.allObjects().count)
         XCTAssertEqual(UInt(1), SwiftStringObject.allObjects().count)
 
-        try! realm.transactionWithBlock {
+        try! realm.write {
             // create self referencing subclass
             let sub = SwiftSelfRefrencingSubclass.createInDefaultRealmWithValue(["string", []])
             let sub2 = SwiftSelfRefrencingSubclass()
@@ -423,7 +423,7 @@ class SwiftObjectInterfaceTests: RLMTestCase {
         XCTAssertEqual(3.3, no.doubleCol!)
         XCTAssertEqual(true, no.boolCol!)
 
-        try! realm.transactionWithBlock {
+        try! realm.write {
             realm.addObject(no)
             no.intCol = nil
             no.floatCol = nil
@@ -436,7 +436,7 @@ class SwiftObjectInterfaceTests: RLMTestCase {
         XCTAssertNil(no.doubleCol)
         XCTAssertNil(no.boolCol)
 
-        try! realm.transactionWithBlock {
+        try! realm.write {
             no.intCol = 1.1
             no.floatCol = 2.2 as Float
             no.doubleCol = 3.3
@@ -451,7 +451,7 @@ class SwiftObjectInterfaceTests: RLMTestCase {
 
     func testOptionalSwiftProperties() {
         let realm = realmWithTestPath()
-        try! realm.transactionWithBlock { realm.addObject(SwiftOptionalObject()) }
+        try! realm.write { realm.addObject(SwiftOptionalObject()) }
 
         let firstObj = SwiftOptionalObject.allObjectsInRealm(realm).firstObject() as! SwiftOptionalObject
         XCTAssertNil(firstObj.optObjectCol)
@@ -460,7 +460,7 @@ class SwiftObjectInterfaceTests: RLMTestCase {
         XCTAssertNil(firstObj.optBinaryCol)
         XCTAssertNil(firstObj.optDateCol)
 
-        try! realm.transactionWithBlock {
+        try! realm.write {
             firstObj.optObjectCol = SwiftBoolObject()
             firstObj.optObjectCol!.boolCol = true
 
@@ -475,7 +475,7 @@ class SwiftObjectInterfaceTests: RLMTestCase {
         XCTAssertEqual(firstObj.optBinaryCol!, NSData(bytes: "hi", length: 2))
         XCTAssertEqual(firstObj.optDateCol!,  NSDate(timeIntervalSinceReferenceDate: 10))
 
-        try! realm.transactionWithBlock {
+        try! realm.write {
             firstObj.optObjectCol = nil
             firstObj.optStringCol = nil
             firstObj.optNSStringCol = nil
@@ -499,23 +499,23 @@ class SwiftObjectInterfaceTests: RLMTestCase {
     // so we test to make sure models with custom accessors can still be accessed
     func testCustomAccessors() {
         let realm = realmWithTestPath()
-        realm.beginWriteTransaction()
+        realm.beginWrite()
         let ca = CustomAccessorsObject.createInRealm(realm, withValue: ["name", 2])
         XCTAssertEqual(ca.name!, "name", "name property should be name.")
         ca.age = 99
         XCTAssertEqual(ca.age, Int32(99), "age property should be 99")
-        try! realm.commitWriteTransaction()
+        try! realm.commitWrite()
     }
 
     func testClassExtension() {
         let realm = realmWithTestPath()
 
-        realm.beginWriteTransaction()
+        realm.beginWrite()
         let bObject = BaseClassStringObject()
         bObject.intCol = 1
         bObject.stringCol = "stringVal"
         realm.addObject(bObject)
-        try! realm.commitWriteTransaction()
+        try! realm.commitWrite()
 
         let objectFromRealm = BaseClassStringObject.allObjectsInRealm(realm)[0] as! BaseClassStringObject
         XCTAssertEqual(objectFromRealm.intCol, Int32(1), "Should be 1")
@@ -523,8 +523,8 @@ class SwiftObjectInterfaceTests: RLMTestCase {
     }
 
     func testCreateOrUpdate() {
-        let realm = RLMRealm.defaultRealm()
-        realm.beginWriteTransaction()
+        let realm = try! RLMRealm()
+        realm.beginWrite()
         SwiftPrimaryStringObject.createOrUpdateInDefaultRealmWithValue(["string", 1])
         let objects = SwiftPrimaryStringObject.allObjects();
         XCTAssertEqual(objects.count, UInt(1), "Should have 1 object");
@@ -537,7 +537,7 @@ class SwiftObjectInterfaceTests: RLMTestCase {
         XCTAssertEqual(objects.count, UInt(2), "Should have 2 objects")
         XCTAssertEqual((objects[0] as! SwiftPrimaryStringObject).intCol, 3, "Value should be 3");
 
-        try! realm.commitWriteTransaction()
+        try! realm.commitWrite()
     }
 
     // if this fails (and you haven't changed the test module name), the checks

--- a/Realm/Tests/Swift/SwiftPropertyTypeTest.swift
+++ b/Realm/Tests/Swift/SwiftPropertyTypeTest.swift
@@ -43,9 +43,9 @@ class SwiftPropertyTypeTest: RLMTestCase {
         XCTAssertEqual((objects[1] as! SwiftLongObject).longCol, intNumber, "2 ^ 31 - 1 expected")
         XCTAssertEqual((objects[2] as! SwiftLongObject).longCol, negativeLongNumber, "-2 ^ 34 expected")
         
-        realm.beginWriteTransaction()
+        realm.beginWrite()
         (objects[0] as! SwiftLongObject).longCol = updatedLongNumber
-        try! realm.commitWriteTransaction()
+        try! realm.commitWrite()
         
         XCTAssertEqual((objects[0] as! SwiftLongObject).longCol, updatedLongNumber, "After update: 2 ^ 33 expected")
     }
@@ -135,11 +135,11 @@ class SwiftPropertyTypeTest: RLMTestCase {
         
         let realm = realmWithTestPath()
         
-        realm.beginWriteTransaction()
+        realm.beginWrite()
         SwiftLongObject.createInRealm(realm, withValue: [NSNumber(longLong: longNumber)])
         SwiftLongObject.createInRealm(realm, withValue: [NSNumber(longLong: intNumber)])
         SwiftLongObject.createInRealm(realm, withValue: [NSNumber(longLong: negativeLongNumber)])
-        try! realm.commitWriteTransaction()
+        try! realm.commitWrite()
         
         let objects = SwiftLongObject.allObjectsInRealm(realm)
         XCTAssertEqual(objects.count, UInt(3), "3 rows expected")
@@ -147,9 +147,9 @@ class SwiftPropertyTypeTest: RLMTestCase {
         XCTAssertEqual((objects[1] as! SwiftLongObject).longCol, intNumber, "2 ^ 31 - 1 expected")
         XCTAssertEqual((objects[2] as! SwiftLongObject).longCol, negativeLongNumber, "-2 ^ 34 expected")
         
-        realm.beginWriteTransaction()
+        realm.beginWrite()
         (objects[0] as! SwiftLongObject).longCol = updatedLongNumber
-        try! realm.commitWriteTransaction()
+        try! realm.commitWrite()
         
         XCTAssertEqual((objects[0] as! SwiftLongObject).longCol, updatedLongNumber, "After update: 2 ^ 33 expected")
     }
@@ -162,7 +162,7 @@ class SwiftPropertyTypeTest: RLMTestCase {
         let v32 = Int32(1) << 30
         // 1 << 40 doesn't auto-promote to Int64 on 32-bit platforms
         let v64 = Int64(1) << 40
-        try! realm.transactionWithBlock() {
+        try! realm.write {
             let obj = SwiftAllIntSizesObject()
 
             obj.int8  = v8
@@ -191,7 +191,7 @@ class SwiftPropertyTypeTest: RLMTestCase {
         let v32 = Int32(1) << 30
         // 1 << 40 doesn't auto-promote to Int64 on 32-bit platforms
         let v64 = Int64(1) << 40
-        try! realm.transactionWithBlock() {
+        try! realm.write {
             let obj = AllIntSizesObject()
 
             obj.int16 = v16
@@ -212,7 +212,7 @@ class SwiftPropertyTypeTest: RLMTestCase {
 
     func testLazyVarProperties() {
         let realm = realmWithTestPath()
-        let succeeded : Void? = try? realm.transactionWithBlock() {
+        let succeeded : Void? = try? realm.write {
             realm.addObject(SwiftLazyVarObject())
         }
         XCTAssertNotNil(succeeded, "Writing an NSObject-based object with an lazy property should work.")
@@ -220,7 +220,7 @@ class SwiftPropertyTypeTest: RLMTestCase {
 
     func testIgnoredLazyVarProperties() {
         let realm = realmWithTestPath()
-        let succeeded : Void? = try? realm.transactionWithBlock() {
+        let succeeded : Void? = try? realm.write {
             realm.addObject(SwiftIgnoredLazyVarObject())
         }
         XCTAssertNotNil(succeeded, "Writing an object with an ignored lazy property should work.")

--- a/Realm/Tests/Swift/SwiftRealmTests.swift
+++ b/Realm/Tests/Swift/SwiftRealmTests.swift
@@ -272,31 +272,31 @@ class SwiftRealmTests: RLMTestCase {
 
     func testEmptyWriteTransaction() {
         let realm = realmWithTestPath()
-        realm.beginWriteTransaction()
-        try! realm.commitWriteTransaction()
+        realm.beginWrite()
+        try! realm.commitWrite()
     }
 
     // Swift models
 
     func testRealmAddAndRemoveObjects() {
         let realm = realmWithTestPath()
-        realm.beginWriteTransaction()
+        realm.beginWrite()
         SwiftStringObject.createInRealm(realm, withValue: ["a"])
         SwiftStringObject.createInRealm(realm, withValue: ["b"])
         SwiftStringObject.createInRealm(realm, withValue: ["c"])
         XCTAssertEqual(SwiftStringObject.allObjectsInRealm(realm).count, UInt(3), "Expecting 3 objects")
-        try! realm.commitWriteTransaction()
+        try! realm.commitWrite()
 
         // test again after write transaction
         var objects = SwiftStringObject.allObjectsInRealm(realm)
         XCTAssertEqual(objects.count, UInt(3), "Expecting 3 objects")
         XCTAssertEqual((objects[0] as! SwiftStringObject).stringCol, "a", "Expecting column to be 'a'")
 
-        realm.beginWriteTransaction()
+        realm.beginWrite()
         realm.deleteObject(objects[2] as! SwiftStringObject)
         realm.deleteObject(objects[0] as! SwiftStringObject)
         XCTAssertEqual(SwiftStringObject.allObjectsInRealm(realm).count, UInt(1), "Expecting 1 object")
-        try! realm.commitWriteTransaction()
+        try! realm.commitWrite()
 
         objects = SwiftStringObject.allObjectsInRealm(realm)
         XCTAssertEqual(objects.count, UInt(1), "Expecting 1 object")
@@ -315,9 +315,9 @@ class SwiftRealmTests: RLMTestCase {
 
         dispatchAsync {
             let realm = self.realmWithTestPath()
-            realm.beginWriteTransaction()
+            realm.beginWrite()
             SwiftStringObject.createInRealm(realm, withValue: ["string"])
-            try! realm.commitWriteTransaction()
+            try! realm.commitWrite()
         }
         waitForExpectationsWithTimeout(2.0, handler: nil)
         token.stop()
@@ -332,16 +332,16 @@ class SwiftRealmTests: RLMTestCase {
         let realm = realmWithTestPath()
 
         let object = SwiftIgnoredPropertiesObject()
-        realm.beginWriteTransaction()
+        realm.beginWrite()
         object.name = "@fz"
         object.age = 31
         realm.addObject(object)
-        try! realm.commitWriteTransaction()
+        try! realm.commitWrite()
 
         // This shouldn't do anything.
-        realm.beginWriteTransaction()
+        realm.beginWrite()
         object.runtimeProperty = NSObject()
-        try! realm.commitWriteTransaction()
+        try! realm.commitWrite()
 
         let objects = SwiftIgnoredPropertiesObject.allObjectsInRealm(realm)
         XCTAssertEqual(objects.count, UInt(1), "There should be 1 object of type SwiftIgnoredPropertiesObject")
@@ -366,7 +366,7 @@ class SwiftRealmTests: RLMTestCase {
 
         dispatchAsync {
             let realm = self.realmWithTestPath()
-            try! realm.transactionWithBlock() {
+            try! realm.write {
                 var obj = SwiftIntObject()
                 obj.intCol = 2;
                 realm.addObject(obj)
@@ -393,9 +393,9 @@ class SwiftRealmTests: RLMTestCase {
         dispatchAsync {
             let realm = self.realmWithTestPath()
             let obj = SwiftStringObject(value: ["string"])
-            realm.beginWriteTransaction()
+            realm.beginWrite()
             realm.addObject(obj)
-            try! realm.commitWriteTransaction()
+            try! realm.commitWrite()
 
             let objects = SwiftStringObject.allObjectsInRealm(realm)
             XCTAssertEqual(objects.count, UInt(1), "There should be 1 object of type StringObject")
@@ -415,23 +415,23 @@ class SwiftRealmTests: RLMTestCase {
 
     func testRealmAddAndRemoveObjects_objc() {
         let realm = realmWithTestPath()
-        realm.beginWriteTransaction()
+        realm.beginWrite()
         StringObject.createInRealm(realm, withValue: ["a"])
         StringObject.createInRealm(realm, withValue: ["b"])
         StringObject.createInRealm(realm, withValue: ["c"])
         XCTAssertEqual(StringObject.allObjectsInRealm(realm).count, UInt(3), "Expecting 3 objects")
-        try! realm.commitWriteTransaction()
+        try! realm.commitWrite()
 
         // test again after write transaction
         var objects = StringObject.allObjectsInRealm(realm)
         XCTAssertEqual(objects.count, UInt(3), "Expecting 3 objects")
         XCTAssertEqual((objects[0] as! StringObject).stringCol!, "a", "Expecting column to be 'a'")
 
-        realm.beginWriteTransaction()
+        realm.beginWrite()
         realm.deleteObject(objects[2] as! StringObject)
         realm.deleteObject(objects[0] as! StringObject)
         XCTAssertEqual(StringObject.allObjectsInRealm(realm).count, UInt(1), "Expecting 1 object")
-        try! realm.commitWriteTransaction()
+        try! realm.commitWrite()
 
         objects = StringObject.allObjectsInRealm(realm)
         XCTAssertEqual(objects.count, UInt(1), "Expecting 1 object")
@@ -452,9 +452,9 @@ class SwiftRealmTests: RLMTestCase {
 
         dispatchAsync {
             let realm = self.realmWithTestPath()
-            realm.beginWriteTransaction()
+            realm.beginWrite()
             StringObject.createInRealm(realm, withValue: ["string"])
-            try! realm.commitWriteTransaction()
+            try! realm.commitWrite()
         }
         waitForExpectationsWithTimeout(2.0, handler: nil)
         token.stop()
@@ -478,7 +478,7 @@ class SwiftRealmTests: RLMTestCase {
         dispatchAsync {
             let realm = self.realmWithTestPath()
             let obj = StringObject(value: ["string"])
-            try! realm.transactionWithBlock() {
+            try! realm.write {
                 realm.addObject(obj)
             }
 

--- a/Realm/Tests/Swift/SwiftSchemaTests.swift
+++ b/Realm/Tests/Swift/SwiftSchemaTests.swift
@@ -164,7 +164,7 @@ class IgnoredLinkPropertyObject : RLMObject {
 class SwiftRecursingSchemaTestObject : RLMObject {
     dynamic var propertyWithIllegalDefaultValue: SwiftIntObject? = {
         if mayAccessSchema {
-            let realm = RLMRealm.defaultRealm()
+            let realm = try! RLMRealm()
             return SwiftIntObject.allObjects().firstObject() as! SwiftIntObject?
         } else {
             return nil
@@ -205,7 +205,7 @@ class SwiftSchemaTests: RLMMultiProcessTestCase {
         config.objectClasses = [IgnoredLinkPropertyObject.self]
         config.inMemoryIdentifier = #function
         let r = try! RLMRealm(configuration: config)
-        try! r.transactionWithBlock {
+        try! r.write {
             IgnoredLinkPropertyObject.createInRealm(r, withValue: [1])
         }
     }
@@ -243,7 +243,7 @@ class SwiftSchemaTests: RLMMultiProcessTestCase {
         config.inMemoryIdentifier = #function
         let _ = try! RLMRealm(configuration: config)
         let r = try! RLMRealm(configuration: RLMRealmConfiguration.defaultConfiguration())
-        try! r.transactionWithBlock {
+        try! r.write {
             IgnoredLinkPropertyObject.createInRealm(r, withValue: [1])
         }
     }

--- a/Realm/Tests/Swift/SwiftUnicodeTests.swift
+++ b/Realm/Tests/Swift/SwiftUnicodeTests.swift
@@ -95,9 +95,9 @@ class SwiftUnicodeTests: RLMTestCase {
 
     func testUTF8StringContents() {
         let realm = realmWithTestPath()
-        realm.beginWriteTransaction()
+        realm.beginWrite()
         SwiftStringObject.createInRealm(realm, withValue: [utf8TestString])
-        try! realm.commitWriteTransaction()
+        try! realm.commitWrite()
 
         let obj1 = SwiftStringObject.allObjectsInRealm(realm).firstObject() as! SwiftStringObject
         XCTAssertEqual(obj1.stringCol, utf8TestString, "Storing and retrieving a string with UTF8 content should work")
@@ -108,9 +108,9 @@ class SwiftUnicodeTests: RLMTestCase {
 
     func testUTF8PropertyWithUTF8StringContents() {
         let realm = realmWithTestPath()
-        realm.beginWriteTransaction()
+        realm.beginWrite()
         SwiftUTF8Object.createInRealm(realm, withValue: [utf8TestString])
-        try! realm.commitWriteTransaction()
+        try! realm.commitWrite()
 
         let obj1 = SwiftUTF8Object.allObjectsInRealm(realm).firstObject() as! SwiftUTF8Object
         XCTAssertEqual(obj1.柱колоéнǢкƱаم👍, utf8TestString, "Storing and retrieving a string with UTF8 content should work")
@@ -124,9 +124,9 @@ class SwiftUnicodeTests: RLMTestCase {
 
     func testUTF8StringContents_objc() {
         let realm = realmWithTestPath()
-        realm.beginWriteTransaction()
+        realm.beginWrite()
         StringObject.createInRealm(realm, withValue: [utf8TestString])
-        try! realm.commitWriteTransaction()
+        try! realm.commitWrite()
 
         let obj1 = StringObject.allObjectsInRealm(realm).firstObject() as! StringObject
         XCTAssertEqual(obj1.stringCol, utf8TestString, "Storing and retrieving a string with UTF8 content should work")
@@ -137,9 +137,9 @@ class SwiftUnicodeTests: RLMTestCase {
 
     func testUTF8PropertyWithUTF8StringContents_objc() {
         let realm = realmWithTestPath()
-        realm.beginWriteTransaction()
+        realm.beginWrite()
         UTF8Object.createInRealm(realm, withValue: [utf8TestString])
-        try! realm.commitWriteTransaction()
+        try! realm.commitWrite()
 
         let obj1 = UTF8Object.allObjectsInRealm(realm).firstObject() as! UTF8Object
         XCTAssertEqual(obj1.柱колоéнǢкƱаم, utf8TestString, "Storing and retrieving a string with UTF8 content should work")

--- a/RealmSwift/Realm.swift
+++ b/RealmSwift/Realm.swift
@@ -114,7 +114,7 @@ public final class Realm {
     - throws: An NSError if the transaction could not be written.
     */
     public func write(block: @noescape () -> Void) throws {
-        try rlmRealm.transaction(block)
+        try rlmRealm.write(block)
     }
 
     /**
@@ -137,7 +137,7 @@ public final class Realm {
     is committed.
     */
     public func beginWrite() {
-        rlmRealm.beginWriteTransaction()
+        rlmRealm.beginWrite()
     }
 
     /**
@@ -149,7 +149,7 @@ public final class Realm {
     - throws: An NSError if the transaction could not be written.
     */
     public func commitWrite() throws {
-        try rlmRealm.commitWriteTransaction()
+        try rlmRealm.commitWrite()
     }
 
     /**
@@ -180,7 +180,7 @@ public final class Realm {
     Calling this when not in a write transaction will throw an exception.
     */
     public func cancelWrite() {
-        rlmRealm.cancelWriteTransaction()
+        rlmRealm.cancelWrite()
     }
 
     /**
@@ -192,7 +192,7 @@ public final class Realm {
                transaction when possible.
     */
     public var isInWriteTransaction: Bool {
-        return rlmRealm.inWriteTransaction
+        return rlmRealm.isInWriteTransaction
     }
 
     // MARK: Adding and Creating objects
@@ -519,10 +519,10 @@ public final class Realm {
     */
     public var shouldAutorefresh: Bool {
         get {
-            return rlmRealm.autorefresh
+            return rlmRealm.shouldAutorefresh
         }
         set {
-            rlmRealm.autorefresh = newValue
+            rlmRealm.shouldAutorefresh = newValue
         }
     }
 
@@ -580,7 +580,7 @@ public final class Realm {
     - throws: An NSError if the copy could not be written.
     */
     public func writeCopy(toFileURL url: URL, encryptionKey: Data? = nil) throws {
-        try rlmRealm.writeCopy(to: url, encryptionKey: encryptionKey)
+        try rlmRealm.writeCopy(toFile: url, withEncryptionKey: encryptionKey)
     }
 
     // MARK: Internal
@@ -801,7 +801,7 @@ public final class Realm {
      is committed.
      */
     public func beginWrite() {
-        rlmRealm.beginWriteTransaction()
+        rlmRealm.beginWrite()
     }
 
     /**
@@ -812,7 +812,7 @@ public final class Realm {
      - throws: An `NSError` if the transaction could not be written.
      */
     public func commitWrite() throws {
-        try rlmRealm.commitWriteTransaction()
+        try rlmRealm.commitWrite()
     }
 
     /**
@@ -843,7 +843,7 @@ public final class Realm {
      - warning: This method may only be called during a write transaction.
      */
     public func cancelWrite() {
-        rlmRealm.cancelWriteTransaction()
+        rlmRealm.cancelWrite()
     }
 
     /**
@@ -854,7 +854,7 @@ public final class Realm {
                 degrading performance. Instead, always prefer performing multiple updates during a single transaction.
      */
     public var inWriteTransaction: Bool {
-        return rlmRealm.inWriteTransaction
+        return rlmRealm.isInWriteTransaction
     }
 
     // MARK: Adding and Creating objects
@@ -1176,10 +1176,10 @@ public final class Realm {
      */
     public var autorefresh: Bool {
         get {
-            return rlmRealm.autorefresh
+            return rlmRealm.shouldAutorefresh
         }
         set {
-            rlmRealm.autorefresh = newValue
+            rlmRealm.shouldAutorefresh = newValue
         }
     }
 
@@ -1234,7 +1234,7 @@ public final class Realm {
      - throws: An `NSError` if the copy could not be written.
      */
     public func writeCopyToURL(fileURL: NSURL, encryptionKey: NSData? = nil) throws {
-        try rlmRealm.writeCopyToURL(fileURL, encryptionKey: encryptionKey)
+        try rlmRealm.writeCopy(toFile: fileURL, withEncryptionKey: encryptionKey)
     }
 
     // MARK: Internal

--- a/RealmSwift/Tests/MigrationTests.swift
+++ b/RealmSwift/Tests/MigrationTests.swift
@@ -303,7 +303,7 @@ class MigrationTests: TestCase {
         autoreleasepool {
             let realm = realmWithSingleClassProperties(defaultRealmURL(),
                 className: "DeletedClass", properties: [])
-            try! realm.transaction {
+            try! realm.write {
                 realm.createObject("DeletedClass", withValue: [])
             }
         }
@@ -330,7 +330,7 @@ class MigrationTests: TestCase {
             autoreleasepool {
                 let realm = realmWithSingleClassProperties(defaultRealmURL(), className: "SwiftStringObject",
                     properties: [prop!])
-                try! realm.transaction {
+                try! realm.write {
                     realm.createObject("SwiftStringObject", withValue: ["a"])
                 }
             }
@@ -796,7 +796,7 @@ class MigrationTests: TestCase {
         autoreleasepool {
             let realm = realmWithSingleClassProperties(defaultRealmURL(),
                 className: "DeletedClass", properties: [])
-            try! realm.transactionWithBlock {
+            try! realm.write {
                 realm.createObject("DeletedClass", withValue: [])
             }
         }
@@ -823,7 +823,7 @@ class MigrationTests: TestCase {
             autoreleasepool {
                 let realm = realmWithSingleClassProperties(defaultRealmURL(), className: "SwiftStringObject",
                     properties: [prop])
-                try! realm.transactionWithBlock {
+                try! realm.write {
                     realm.createObject("SwiftStringObject", withValue: ["a"])
                 }
             }


### PR DESCRIPTION
Annotates `RLMRealm` members for better import into Swift as part of https://github.com/realm/realm-cocoa/issues/3790. Note that this is a source-breaking change for Swift users of Realm Objective-C. If we care to not break source compatibility for that particular user base, then we should delay merging this until a large version bump.