### PR TITLE
Updates for compatibility with Xcode 8 beta 2

### DIFF
--- a/RealmSwift/LinkingObjects.swift
+++ b/RealmSwift/LinkingObjects.swift
@@ -384,7 +384,6 @@ public final class LinkingObjects<T: Object>: LinkingObjectsBase {
      - parameter block: The block to be called with the evaluated linking objects and change information.
      - returns: A token which must be held for as long as you want updates to be delivered.
      */
-    @warn_unused_result(message:"You must hold on to the NotificationToken returned from addNotificationBlock")
     public func addNotificationBlock(block: ((RealmCollectionChange<LinkingObjects>) -> Void)) -> NotificationToken {
         return rlmResults.addNotificationBlock { results, change, error in
             block(RealmCollectionChange.fromObjc(value: self, change: change, error: error))

--- a/RealmSwift/Tests/ListTests.swift
+++ b/RealmSwift/Tests/ListTests.swift
@@ -71,7 +71,7 @@ class ListTests: TestCase {
 
     override class func defaultTestSuite() -> XCTestSuite {
         // Don't run tests for the base class
-        if isEqual(ListTests) {
+        if isEqual(ListTests.self) {
             return XCTestSuite(name: "empty")
         }
         return super.defaultTestSuite()

--- a/RealmSwift/Tests/PerformanceTests.swift
+++ b/RealmSwift/Tests/PerformanceTests.swift
@@ -92,7 +92,7 @@ class SwiftPerformanceTests: TestCase {
 
     private func copyRealmToTestPath(_ realm: Realm) -> Realm {
         do {
-            try FileManager.default().removeItem(at: testRealmURL())
+            try FileManager.default.removeItem(at: testRealmURL())
         } catch let error as NSError {
             XCTAssertTrue(error.domain == NSCocoaErrorDomain && error.code == 4)
         } catch {
@@ -478,7 +478,7 @@ class SwiftPerformanceTests: TestCase {
             self.startMeasuring()
             try! realm.write { object.intCol += 1 }
             while object.intCol < stopValue {
-                RunLoop.current().run(mode: RunLoopMode.defaultRunLoopMode, before: NSDate.distantFuture())
+                RunLoop.current.run(mode: RunLoopMode.defaultRunLoopMode, before: NSDate.distantFuture)
             }
             queue.sync() {}
             self.stopMeasuring()

--- a/RealmSwift/Tests/RealmCollectionTypeTests.swift
+++ b/RealmSwift/Tests/RealmCollectionTypeTests.swift
@@ -128,7 +128,7 @@ class RealmCollectionTypeTests: TestCase {
 
     override class func defaultTestSuite() -> XCTestSuite {
         // Don't run tests for the base class
-        if isEqual(RealmCollectionTypeTests) {
+        if isEqual(RealmCollectionTypeTests.self) {
             return XCTestSuite(name: "empty")
         }
         return super.defaultTestSuite()
@@ -459,7 +459,7 @@ class RealmCollectionTypeTests: TestCase {
 class ResultsTests: RealmCollectionTypeTests {
     override class func defaultTestSuite() -> XCTestSuite {
         // Don't run tests for the base class
-        if isEqual(ResultsTests) {
+        if isEqual(ResultsTests.self) {
             return XCTestSuite(name: "empty")
         }
         return super.defaultTestSuite()
@@ -636,7 +636,7 @@ class ResultsFromLinkViewTests: ResultsTests {
 class ListRealmCollectionTypeTests: RealmCollectionTypeTests {
     override class func defaultTestSuite() -> XCTestSuite {
         // Don't run tests for the base class
-        if isEqual(ListRealmCollectionTypeTests) {
+        if isEqual(ListRealmCollectionTypeTests.self) {
             return XCTestSuite(name: "empty")
         }
         return super.defaultTestSuite()

--- a/RealmSwift/Tests/RealmTests.swift
+++ b/RealmSwift/Tests/RealmTests.swift
@@ -62,8 +62,8 @@ class RealmTests: TestCase {
             }
         }
 
-        let fileManager = FileManager.default()
-        try! fileManager.setAttributes([ FileAttributeKey.immutable.rawValue: true ], ofItemAtPath: testRealmURL().path!)
+        let fileManager = FileManager.default
+        try! fileManager.setAttributes([ FileAttributeKey.immutable: true ], ofItemAtPath: testRealmURL().path!)
 
         // Should not be able to open read-write
         assertFails(Error.FileAccess) {
@@ -76,7 +76,7 @@ class RealmTests: TestCase {
             XCTAssertEqual(1, realm.allObjects(ofType: SwiftStringObject.self).count)
         }
 
-        try! fileManager.setAttributes([ FileAttributeKey.immutable.rawValue: false ], ofItemAtPath: testRealmURL().path!)
+        try! fileManager.setAttributes([ FileAttributeKey.immutable: false ], ofItemAtPath: testRealmURL().path!)
     }
 
     func testReadOnlyRealmMustExist() {
@@ -92,17 +92,17 @@ class RealmTests: TestCase {
         }
 
         // Make Realm at test path temporarily unreadable
-        let fileManager = FileManager.default()
+        let fileManager = FileManager.default
         let permissions = try! fileManager
-            .attributesOfItem(atPath: testRealmURL().path!)[FileAttributeKey.posixPermissions.rawValue] as! NSNumber
-        try! fileManager.setAttributes([ FileAttributeKey.posixPermissions.rawValue: 0000 ],
+            .attributesOfItem(atPath: testRealmURL().path!)[FileAttributeKey.posixPermissions] as! NSNumber
+        try! fileManager.setAttributes([ FileAttributeKey.posixPermissions: 0000 ],
                                        ofItemAtPath: testRealmURL().path!)
 
         assertFails(Error.FilePermissionDenied) {
             try Realm(fileURL: testRealmURL())
         }
 
-        try! fileManager.setAttributes([FileAttributeKey.posixPermissions.rawValue: permissions], ofItemAtPath: testRealmURL().path!)
+        try! fileManager.setAttributes([FileAttributeKey.posixPermissions: permissions], ofItemAtPath: testRealmURL().path!)
     }
 
     #if DEBUG
@@ -152,7 +152,7 @@ class RealmTests: TestCase {
             _ = try! Realm()
         }
 
-        FileManager.default().createFile(atPath: defaultRealmURL().path!,
+        FileManager.default.createFile(atPath: defaultRealmURL().path!,
             contents:"a".data(using: String.Encoding.utf8, allowLossyConversion: false),
             attributes: nil)
 
@@ -472,7 +472,7 @@ class RealmTests: TestCase {
         XCTAssertEqual(object["stringCol"] as! String?, dictionary["stringCol"] as! String?)
         XCTAssertEqual(object["binaryCol"] as! NSData?, dictionary["binaryCol"] as! NSData?)
         XCTAssertEqual(object["dateCol"] as! NSDate?, dictionary["dateCol"] as! NSDate?)
-        XCTAssertEqual(object["objectCol"]?.boolCol, false)
+        XCTAssertEqual((object["objectCol"] as? SwiftBoolObject)?.boolCol, false)
     }
 
     func testDynamicObjectOptionalProperties() {
@@ -494,7 +494,7 @@ class RealmTests: TestCase {
         XCTAssertEqual(object["optNSStringCol"] as! String?, dictionary["optNSStringCol"] as! String?)
         XCTAssertEqual(object["optBinaryCol"] as! NSData?, dictionary["optBinaryCol"] as! NSData?)
         XCTAssertEqual(object["optDateCol"] as! NSDate?, dictionary["optDateCol"] as! NSDate?)
-        XCTAssertEqual(object["optObjectCol"]?.boolCol, true)
+        XCTAssertEqual((object["optObjectCol"] as? SwiftBoolObject)?.boolCol, true)
     }
 
     func testObjectForPrimaryKey() {
@@ -732,7 +732,7 @@ class RealmTests: TestCase {
             let copy = try! Realm(fileURL: fileURL)
             XCTAssertEqual(1, copy.allObjects(ofType: SwiftObject.self).count)
         }
-        try! FileManager.default().removeItem(at: fileURL)
+        try! FileManager.default.removeItem(at: fileURL)
     }
 
     func testEquals() {

--- a/RealmSwift/Tests/TestCase.swift
+++ b/RealmSwift/Tests/TestCase.swift
@@ -52,7 +52,7 @@ class TestCase: XCTestCase {
 #endif
         do {
             // Clean up any potentially lingering Realm files from previous runs
-            try FileManager.default().removeItem(atPath: RLMRealmPathForFile(""))
+            try FileManager.default.removeItem(atPath: RLMRealmPathForFile(""))
         } catch {
             // The directory might not actually already exist, so not an error
         }
@@ -67,11 +67,11 @@ class TestCase: XCTestCase {
         testDir = RLMRealmPathForFile(realmFilePrefix())
 
         do {
-            try FileManager.default().removeItem(atPath: testDir)
+            try FileManager.default.removeItem(atPath: testDir)
         } catch {
             // The directory shouldn't actually already exist, so not an error
         }
-        try! FileManager.default().createDirectory(at: URL(fileURLWithPath: testDir, isDirectory: true),
+        try! FileManager.default.createDirectory(at: URL(fileURLWithPath: testDir, isDirectory: true),
                                                      withIntermediateDirectories: true, attributes: nil)
 
         let config = Realm.Configuration(fileURL: defaultRealmURL())
@@ -88,7 +88,7 @@ class TestCase: XCTestCase {
         resetRealmState()
 
         do {
-            try FileManager.default().removeItem(atPath: testDir)
+            try FileManager.default.removeItem(atPath: testDir)
         } catch {
             XCTFail("Unable to delete realm files")
         }


### PR DESCRIPTION
Pretty straightforward. I don't think Swift recognizes `warn_unused_result` anymore, since the default behavior was switched around.

@tgoyne @jpsim @JadenGeller @bdash 