### PR TITLE
Changing Realm Swift's Error type to just be a typealias for RLMError

### DIFF
--- a/RealmSwift/Error.swift
+++ b/RealmSwift/Error.swift
@@ -21,106 +21,29 @@ import Realm
 #if swift(>=3.0)
 
 /**
-Enumeration that describes the error codes within the Realm error domain.
-The values can be used to catch a variety of _recoverable_ errors, especially those
-happening when initializing a Realm instance.
+ `Error` is an enum representing all recoverable errors. It is associated with the Realm error domain specified in
+ `RLMErrorDomain`.
 
-    let realm: Realm?
-    do {
-        realm = Realm()
-    } catch RealmSwift.Error.IncompatibleLockFile() {
-        print("Realm Browser app may be attached to Realm on device?")
-    }
+ `Error` is a Swift `ErrorType`:
 
-*/
-public enum Error: ErrorProtocol {
-    // swiftlint:disable variable_name
-    /// :nodoc:
-    public var _code: Int {
-        return rlmError.rawValue
-    }
+ ```swift
+ let realm: Realm?
+ do {
+     realm = try Realm()
+ } catch RealmSwift.Error.incompatibleLockFile() {
+     print("Incompatible lock file. The Realm Browser app might be attached to a Realm on the device.")
+ }
+ ```
+ */
+public typealias Error = RLMError
 
-    /// :nodoc:
-    public var _domain: String {
-        return RLMErrorDomain
-    }
-    // swiftlint:enable variable_name
-
-    /// The RLMError value, which can be used to derive the error's code.
-    private var rlmError: RLMError {
-        switch self {
-        case .Fail:
-            return .fail
-        case .FileAccess:
-            return .fileAccess
-        case .FilePermissionDenied:
-            return .filePermissionDenied
-        case .FileExists:
-            return .fileExists
-        case .FileNotFound:
-            return .fileNotFound
-        case .IncompatibleLockFile:
-            return .incompatibleLockFile
-        case .FileFormatUpgradeRequired:
-            return .fileFormatUpgradeRequired
-        case .AddressSpaceExhausted:
-            return .addressSpaceExhausted
-        case .SchemaMismatch:
-            return .schemaMismatch
-        }
-    }
-
-    /// Error thrown by Realm if no other specific error is returned when a realm is opened.
-    case Fail
-
-    /// Error thrown by Realm for any I/O related exception scenarios when a realm is opened.
-    case FileAccess
-
-    /// Error thrown by Realm if the user does not have permission to open or create
-    /// the specified file in the specified access mode when the realm is opened.
-    case FilePermissionDenied
-
-    /// Error thrown by Realm if the file already exists when a copy should be written.
-    case FileExists
-
-    /// Error thrown by Realm if no file was found when a realm was opened as
-    /// read-only or if the directory part of the specified path was not found
-    /// when a copy should be written.
-    case FileNotFound
-
-    /// Error thrown by Realm if the database file is currently open in another process which
-    /// cannot share with the current process due to an architecture mismatch.
-    case IncompatibleLockFile
-
-    /// Error thrown by Realm if a file format upgrade is required to open the file,
-    /// but upgrades were explicitly disabled.
-    case FileFormatUpgradeRequired
-
-    /// Error thrown by Realm if there is insufficient available address space.
-    case AddressSpaceExhausted
-
-    /** Error thrown by Realm if there is a schema version mismatch, so that a migration is required. */
-    case SchemaMismatch
-}
-
-// MARK: Equatable
-
-extension Error: Equatable {}
-
-/// Returns whether the two errors are identical
-public func == (lhs: ErrorProtocol, rhs: ErrorProtocol) -> Bool { // swiftlint:disable:this valid_docs
-    return lhs._code == rhs._code
-        && lhs._domain == rhs._domain
-}
+extension Error : ErrorProtocol { }
 
 // MARK: Pattern Matching
 
-/**
-Explicitly implement pattern matching for `Realm.Error`, so that the instances can be used in the
-`do … syntax`.
-*/
-public func ~= (lhs: Error, rhs: ErrorProtocol) -> Bool { // swiftlint:disable:this valid_docs
-    return lhs == rhs
+public func ~=(lhs: Error, rhs: ErrorProtocol) -> Bool { // swiftlint:disable:this valid_docs
+    // Explicitly implement pattern matching for `Error`, so `Error`s can be caught by `catch { }` blocks.
+    return lhs._code == rhs._code && rhs._domain == RLMErrorDomain
 }
 
 #else

--- a/RealmSwift/Tests/MigrationTests.swift
+++ b/RealmSwift/Tests/MigrationTests.swift
@@ -112,7 +112,7 @@ class MigrationTests: TestCase {
     }
 
     func testSchemaVersionAtURL() {
-        assertFails(.Fail) {
+        assertFails(.fail) {
             // Version should throw before Realm creation
             try schemaVersionAtURL(defaultRealmURL())
         }
@@ -120,7 +120,7 @@ class MigrationTests: TestCase {
         _ = try! Realm()
         XCTAssertEqual(0, try! schemaVersionAtURL(defaultRealmURL()),
                        "Initial version should be 0")
-        assertFails(.Fail) {
+        assertFails(.fail) {
             try schemaVersionAtURL(URL(fileURLWithPath: "/dev/null"))
         }
     }
@@ -455,7 +455,7 @@ class MigrationTests: TestCase {
 
         let config = Realm.Configuration(fileURL: defaultRealmURL(), objectTypes: [SwiftEmployeeObject.self])
         autoreleasepool {
-            assertFails(.SchemaMismatch) {
+            assertFails(.schemaMismatch) {
                 try Realm(configuration: config)
             }
         }
@@ -498,7 +498,7 @@ class MigrationTests: TestCase {
         class_replaceMethod(metaClass, #selector(RLMObjectBase.sharedSchema), imp, "@@:")
 
         autoreleasepool {
-            assertFails(.SchemaMismatch) {
+            assertFails(.schemaMismatch) {
                 try Realm()
             }
         }

--- a/RealmSwift/Tests/RealmTests.swift
+++ b/RealmSwift/Tests/RealmTests.swift
@@ -49,7 +49,7 @@ class RealmTests: TestCase {
     }
 
     func testOpeningInvalidPathThrows() {
-        assertFails(Error.FileAccess) {
+        assertFails(.fileAccess) {
             try Realm(configuration: Realm.Configuration(fileURL: URL(fileURLWithPath: "/dev/null/foo")))
         }
     }
@@ -66,7 +66,7 @@ class RealmTests: TestCase {
         try! fileManager.setAttributes([ FileAttributeKey.immutable: true ], ofItemAtPath: testRealmURL().path!)
 
         // Should not be able to open read-write
-        assertFails(Error.FileAccess) {
+        assertFails(.fileAccess) {
             try Realm(fileURL: testRealmURL())
         }
 
@@ -80,7 +80,7 @@ class RealmTests: TestCase {
     }
 
     func testReadOnlyRealmMustExist() {
-        assertFails(Error.FileNotFound) {
+        assertFails(.fileNotFound) {
             try Realm(configuration:
                 Realm.Configuration(fileURL: defaultRealmURL(), readOnly: true))
         }
@@ -98,7 +98,7 @@ class RealmTests: TestCase {
         try! fileManager.setAttributes([ FileAttributeKey.posixPermissions: 0000 ],
                                        ofItemAtPath: testRealmURL().path!)
 
-        assertFails(Error.FilePermissionDenied) {
+        assertFails(.filePermissionDenied) {
             try Realm(fileURL: testRealmURL())
         }
 
@@ -156,7 +156,7 @@ class RealmTests: TestCase {
             contents:"a".data(using: String.Encoding.utf8, allowLossyConversion: false),
             attributes: nil)
 
-        assertFails(Error.FileAccess) {
+        assertFails(.fileAccess) {
             _ = try Realm()
             XCTFail("Realm creation should have failed")
         }


### PR DESCRIPTION
There's no real good reason to have `Error` in Realm Swift be its own separate enum. Having an `==` for non-specific `ErrorProtocol` instances is also kind of problematic.

@tgoyne @jpsim @bdash @JadenGeller 