### PR TITLE
Fix tests with Xcode 8 beta 2

### DIFF
--- a/Realm/Tests/MigrationTests.mm
+++ b/Realm/Tests/MigrationTests.mm
@@ -610,13 +610,13 @@ RLM_ARRAY_TYPE(MigrationObject);
     RLMAssertRealmSchemaMatchesTable(self, realm);
 
     // verify schema for both objects
-    NSArray *properties = defaultObj.objectSchema.properties;
+    NSArray<RLMProperty *> *properties = defaultObj.objectSchema.properties;
     for (NSUInteger i = 0; i < properties.count; i++) {
-        XCTAssertEqual([properties[i] column], i);
+        XCTAssertEqual(properties[i].column, i);
     }
     properties = obj.objectSchema.properties;
     for (NSUInteger i = 0; i < properties.count; i++) {
-        XCTAssertEqual([properties[i] column], i);
+        XCTAssertEqual(properties[i].column, i);
     }
 
     // re-check that things still work for the realm with the swapped order

--- a/RealmSwift/Tests/PerformanceTests.swift
+++ b/RealmSwift/Tests/PerformanceTests.swift
@@ -411,8 +411,7 @@ class SwiftPerformanceTests: TestCase {
                     let realm = inMemoryRealm("test")
                     let object = realm.allObjects(ofType: SwiftIntObject.self).first!
                     var token: NotificationToken! = nil
-                    // AZ: TODO: is this right?
-                    CFRunLoopPerformBlock(CFRunLoopGetCurrent(), CFRunLoopMode.defaultMode as! CFTypeRef) {
+                    CFRunLoopPerformBlock(CFRunLoopGetCurrent(), CFRunLoopMode.defaultMode.rawValue) {
                         token = realm.addNotificationBlock { _, _ in
                             if object.intCol == stopValue {
                                 CFRunLoopStop(CFRunLoopGetCurrent())
@@ -451,8 +450,7 @@ class SwiftPerformanceTests: TestCase {
                     let realm = inMemoryRealm("test")
                     let object = realm.allObjects(ofType: SwiftIntObject.self).first!
                     var token: NotificationToken! = nil
-                    // AZ: TODO: is this right?
-                    CFRunLoopPerformBlock(CFRunLoopGetCurrent(), CFRunLoopMode.defaultMode as! CFTypeRef) {
+                    CFRunLoopPerformBlock(CFRunLoopGetCurrent(), CFRunLoopMode.defaultMode.rawValue) {
                         token = realm.addNotificationBlock { _, _ in
                             if object.intCol == stopValue {
                                 CFRunLoopStop(CFRunLoopGetCurrent())


### PR DESCRIPTION
* The macOS 10.12 SDK includes a new class that declares a `column` property with different return type so it's now necessary to be explicit about the type of the object that we're accessing the `column` property on.
* Attempting to cast `CFRunLoopMode.defaultMode` to `CFTypeRef` aborts at runtime. Using the raw value of the enum works correctly.