### PR TITLE
Rework query building to not use column numbers from RLMProperty

### DIFF
--- a/Realm/RLMArrayLinkView.mm
+++ b/Realm/RLMArrayLinkView.mm
@@ -357,20 +357,20 @@ static void RLMInsertObject(RLMArrayLinkView *ar, RLMObject *object, NSUInteger 
 }
 
 - (RLMResults *)sortedResultsUsingDescriptors:(NSArray *)properties {
-    auto order = RLMSortOrderFromDescriptors(_objectSchema, properties);
+    auto order = RLMSortOrderFromDescriptors(*_objectSchema.table, properties);
     auto results = translateErrors([&] { return _backingList.sort(std::move(order)); });
     return [RLMResults resultsWithObjectSchema:_objectSchema results:std::move(results)];
 }
 
 - (RLMResults *)objectsWithPredicate:(NSPredicate *)predicate {
-    auto query = RLMPredicateToQuery(predicate, _objectSchema, _realm.schema);
+    auto query = RLMPredicateToQuery(predicate, _objectSchema, _realm.schema, *_realm.group);
     auto results = translateErrors([&] { return _backingList.filter(std::move(query)); });
     return [RLMResults resultsWithObjectSchema:_objectSchema results:std::move(results)];
 }
 
 - (NSUInteger)indexOfObjectWithPredicate:(NSPredicate *)predicate {
     auto query = translateErrors([&] { return _backingList.get_query(); });
-    query.and_query(RLMPredicateToQuery(predicate, _objectSchema, _realm.schema));
+    query.and_query(RLMPredicateToQuery(predicate, _objectSchema, _realm.schema, *_realm.group));
     return RLMConvertNotFound(query.find());
 }
 

--- a/Realm/RLMObjectStore.mm
+++ b/Realm/RLMObjectStore.mm
@@ -388,9 +388,7 @@ RLMResults *RLMGetObjects(RLMRealm *realm, NSString *objectClassName, NSPredicat
     }
 
     if (predicate) {
-        realm::Query query = RLMPredicateToQuery(predicate, objectSchema, realm.schema);
-
-        // create and populate array
+        realm::Query query = RLMPredicateToQuery(predicate, objectSchema, realm.schema, *realm.group);
         return [RLMResults resultsWithObjectSchema:objectSchema
                                            results:realm::Results(realm->_realm, std::move(query))];
     }

--- a/Realm/RLMProperty.mm
+++ b/Realm/RLMProperty.mm
@@ -31,17 +31,6 @@ BOOL RLMPropertyTypeIsNullable(RLMPropertyType propertyType) {
     return propertyType != RLMPropertyTypeArray && propertyType != RLMPropertyTypeLinkingObjects;
 }
 
-BOOL RLMPropertyTypeIsNumeric(RLMPropertyType propertyType) {
-    switch (propertyType) {
-        case RLMPropertyTypeInt:
-        case RLMPropertyTypeFloat:
-        case RLMPropertyTypeDouble:
-            return YES;
-        default:
-            return NO;
-    }
-}
-
 BOOL RLMPropertyTypeIsComputed(RLMPropertyType propertyType) {
     return propertyType == RLMPropertyTypeLinkingObjects;
 }

--- a/Realm/RLMProperty_Private.h
+++ b/Realm/RLMProperty_Private.h
@@ -22,8 +22,7 @@
 
 @class RLMObjectBase;
 
-FOUNDATION_EXTERN BOOL RLMPropertyTypeIsNullable(RLMPropertyType propertyType);
-FOUNDATION_EXTERN BOOL RLMPropertyTypeIsNumeric(RLMPropertyType propertyType);
+BOOL RLMPropertyTypeIsNullable(RLMPropertyType propertyType);
 BOOL RLMPropertyTypeIsComputed(RLMPropertyType propertyType);
 
 // private property interface

--- a/Realm/RLMQueryUtil.hpp
+++ b/Realm/RLMQueryUtil.hpp
@@ -17,27 +17,26 @@
 ////////////////////////////////////////////////////////////////////////////
 
 #import <Foundation/Foundation.h>
+
 #import <vector>
 
 namespace realm {
+    class Group;
     class Query;
-    struct SortOrder;
     class Table;
-    class TableView;
+    struct SortOrder;
 }
 
-@class RLMObjectSchema;
-@class RLMProperty;
-@class RLMSchema;
+@class RLMObjectSchema, RLMProperty, RLMSchema, RLMSortDescriptor;
 
 extern NSString * const RLMPropertiesComparisonTypeMismatchException;
 extern NSString * const RLMUnsupportedTypesFoundInPropertyComparisonException;
 
 realm::Query RLMPredicateToQuery(NSPredicate *predicate, RLMObjectSchema *objectSchema,
-                                 RLMSchema *schema);
+                                 RLMSchema *schema, realm::Group &group);
 
 // return property - throw for invalid column name
 RLMProperty *RLMValidatedProperty(RLMObjectSchema *objectSchema, NSString *columnName);
 
 // validate the array of RLMSortDescriptors and convert it to a realm::SortOrder
-realm::SortOrder RLMSortOrderFromDescriptors(RLMObjectSchema *objectSchema, NSArray *descriptors);
+realm::SortOrder RLMSortOrderFromDescriptors(realm::Table& table, NSArray<RLMSortDescriptor *> *descriptors);

--- a/Realm/RLMQueryUtil.mm
+++ b/Realm/RLMQueryUtil.mm
@@ -170,10 +170,10 @@ public:
         static_assert(sizeof...(SubQuery) < 2, "resolve() takes at most one subquery");
         set_link_chain_on_table();
         if (type() != RLMPropertyTypeLinkingObjects) {
-            return m_table->template column<T>(index(), std::move(subquery)...);
+            return m_table->template column<T>(index(), std::forward<SubQuery...>(subquery)...);
         }
         else {
-            return resolve_backlink<T>(std::is_same<T, Link>(), std::move(subquery)...);
+            return resolve_backlink<T>(std::is_same<T, Link>(), std::forward<SubQuery...>(subquery)...);
         }
     }
 
@@ -215,7 +215,7 @@ private:
     auto resolve_backlink(std::true_type, SubQuery&&... subquery) const
     {
         return with_link_origin(m_property, [&](Table& table, size_t col) {
-            return m_table->template column<T>(table, col, std::move(subquery)...);
+            return m_table->template column<T>(table, col, std::forward<SubQuery...>(subquery)...);
         });
     }
 

--- a/Realm/RLMResults.mm
+++ b/Realm/RLMResults.mm
@@ -173,7 +173,7 @@ static inline void RLMResultsValidateInWriteTransaction(__unsafe_unretained RLMR
     }
 
     Query query = translateErrors([&] { return _results.get_query(); });
-    query.and_query(RLMPredicateToQuery(predicate, _objectSchema, _realm.schema));
+    query.and_query(RLMPredicateToQuery(predicate, _objectSchema, _realm.schema, *_realm.group));
 
     query.sync_view_if_needed();
 
@@ -327,7 +327,7 @@ static inline void RLMResultsValidateInWriteTransaction(__unsafe_unretained RLMR
         if (_results.get_mode() == Results::Mode::Empty) {
             return self;
         }
-        auto query = RLMPredicateToQuery(predicate, _objectSchema, _realm.schema);
+        auto query = RLMPredicateToQuery(predicate, _objectSchema, _realm.schema, *_realm.group);
         return [RLMResults resultsWithObjectSchema:_objectSchema
                                            results:_results.filter(std::move(query))];
     });
@@ -344,7 +344,7 @@ static inline void RLMResultsValidateInWriteTransaction(__unsafe_unretained RLMR
         }
 
         return [RLMResults resultsWithObjectSchema:_objectSchema
-                                           results:_results.sort(RLMSortOrderFromDescriptors(_objectSchema, properties))];
+                                           results:_results.sort(RLMSortOrderFromDescriptors(*_objectSchema.table, properties))];
     });
 }
 


### PR DESCRIPTION
Explicitly pass in the Group to the query builder code and look up tables in it and column numbers in the Tables rather than getting those indirectly from RLMObjectSchema and RLMProperty. This eliminates any dependency on the private members of the schema classes and makes the query code ready for runtime schema changes. The slowdown from the extra column number lookups is in the range of a few percent.

Refactor the code by putting most of the free functions into a class that stores the Schema, Query and Group to avoid having to pass around quite so many values to every single function.

@bdash 