### PR TITLE
Removed check for `RLMDynamicRealm`, a nonexistent class

### DIFF
--- a/Realm/Tests/Swift/SwiftDynamicTests.swift
+++ b/Realm/Tests/Swift/SwiftDynamicTests.swift
@@ -40,7 +40,6 @@ class SwiftDynamicTests: RLMTestCase {
         }
         let dyrealm = realm(withTestPathAndSchema: nil)
         XCTAssertNotNil(dyrealm, "realm should not be nil")
-        XCTAssertTrue(dyrealm is RLMRealm, "realm should be of class RLMDynamicRealm")
 
         // verify schema
         let dynSchema = dyrealm.schema[SwiftDynamicObject.className()]
@@ -86,7 +85,6 @@ class SwiftDynamicTests: RLMTestCase {
         }
         let dyrealm = realm(withTestPathAndSchema: nil)
         XCTAssertNotNil(dyrealm, "realm should not be nil")
-        XCTAssertTrue(dyrealm is RLMRealm, "realm should be of class RLMDynamicRealm")
 
         // verify schema
         let dynSchema = dyrealm.schema[DynamicObject.className()]
@@ -245,7 +243,6 @@ class SwiftDynamicTests: RLMTestCase {
         }
         let dyrealm = realmWithTestPathAndSchema(nil)
         XCTAssertNotNil(dyrealm, "realm should not be nil")
-        XCTAssertTrue(dyrealm.isKindOfClass(RLMRealm), "realm should be of class RLMDynamicRealm")
 
         // verify schema
         let dynSchema = dyrealm.schema[DynamicObject.className()]


### PR DESCRIPTION
The checks are actually only checking that it was a `RLMRealm`, which is statically known to be true and thus unnecessary. I assume they historically checked for a `RLMDynamicRealm`, but this class doesn't seem to exist anymore.

@tgoyne @bdash