### PR TITLE
Automatically ignore computed properties when building schema

### DIFF
--- a/Realm/RLMObjectSchema.mm
+++ b/Realm/RLMObjectSchema.mm
@@ -126,20 +126,6 @@ using namespace realm;
     }]];
     schema.computedProperties = computedProperties;
 
-    // verify that we didn't add any properties twice due to inheritance
-    if (allProperties.count != [NSSet setWithArray:[allProperties valueForKey:@"name"]].count) {
-        NSCountedSet *countedPropertyNames = [NSCountedSet setWithArray:[allProperties valueForKey:@"name"]];
-        NSSet *duplicatePropertyNames = [countedPropertyNames filteredSetUsingPredicate:[NSPredicate predicateWithBlock:^BOOL(id object, NSDictionary *) {
-            return [countedPropertyNames countForObject:object] > 1;
-        }]];
-
-        if (duplicatePropertyNames.count == 1) {
-            @throw RLMException(@"Property '%@' is declared multiple times in the class hierarchy of '%@'", duplicatePropertyNames.allObjects.firstObject, className);
-        } else {
-            @throw RLMException(@"Object '%@' has properties that are declared multiple times in its class hierarchy: '%@'", className, [duplicatePropertyNames.allObjects componentsJoinedByString:@"', '"]);
-        }
-    }
-
     if (NSString *primaryKey = [objectClass primaryKey]) {
         for (RLMProperty *prop in schema.properties) {
             if ([primaryKey isEqualToString:prop.name]) {

--- a/Realm/RLMProperty.mm
+++ b/Realm/RLMProperty.mm
@@ -35,7 +35,7 @@ BOOL RLMPropertyTypeIsComputed(RLMPropertyType propertyType) {
     return propertyType == RLMPropertyTypeLinkingObjects;
 }
 
-static bool rawTypeIsComputedProperty(NSString *rawType) {
+static bool rawTypeShouldBeTreatedAsComputedProperty(NSString *rawType) {
     if ([rawType isEqualToString:@"@\"RLMLinkingObjects\""] || [rawType hasPrefix:@"@\"RLMLinkingObjects<"]) {
         return true;
     }
@@ -268,18 +268,23 @@ static bool rawTypeIsComputedProperty(NSString *rawType) {
     }
 }
 
-- (bool)parseObjcProperty:(objc_property_t)property isSwift:(bool)isSwift {
+typedef NS_OPTIONS(short, RLMPropertyAttributes) {
+    RLMPropertyAttributeReadOnly = 1 << 0,
+    RLMPropertyAttributeComputed = 1 << 1
+};
+
+- (RLMPropertyAttributes)parseObjcProperty:(objc_property_t)property isSwift:(bool)isSwift {
     unsigned int count;
     objc_property_attribute_t *attrs = property_copyAttributeList(property, &count);
 
-    bool isReadOnly = false;
+    RLMPropertyAttributes attributes = RLMPropertyAttributeComputed;
     for (size_t i = 0; i < count; ++i) {
         switch (*attrs[i].name) {
             case 'T':
                 _objcRawType = @(attrs[i].value);
                 break;
             case 'R':
-                isReadOnly = true;
+                attributes |= RLMPropertyAttributeReadOnly;
                 break;
             case 'N':
                 // nonatomic
@@ -294,6 +299,7 @@ static bool rawTypeIsComputedProperty(NSString *rawType) {
                 _setterName = @(attrs[i].value);
                 break;
             case 'V': // backing ivar name
+                attributes &= ~RLMPropertyAttributeComputed;
                 if (isSwift) {
                     _getterName = @(attrs[i].value);
                 }
@@ -304,7 +310,7 @@ static bool rawTypeIsComputedProperty(NSString *rawType) {
     }
     free(attrs);
 
-    return isReadOnly;
+    return attributes;
 }
 
 - (instancetype)initSwiftPropertyWithName:(NSString *)name
@@ -415,9 +421,9 @@ static bool rawTypeIsComputedProperty(NSString *rawType) {
         _linkOriginPropertyName = linkPropertyDescriptor.propertyName;
     }
 
-    bool isReadOnly = [self parseObjcProperty:property isSwift:false];
-    bool isComputedProperty = rawTypeIsComputedProperty(_objcRawType);
-    if (isReadOnly && !isComputedProperty) {
+    RLMPropertyAttributes attributes = [self parseObjcProperty:property isSwift:false];
+    bool shouldBeTreatedAsComputedProperty = rawTypeShouldBeTreatedAsComputedProperty(_objcRawType);
+    if (attributes && !shouldBeTreatedAsComputedProperty) {
         return nil;
     }
 
@@ -426,7 +432,7 @@ static bool rawTypeIsComputedProperty(NSString *rawType) {
                              "Add to ignoredPropertyNames: method to ignore.", self.name);
     }
 
-    if (!isReadOnly && isComputedProperty) {
+    if (!(attributes & RLMPropertyAttributeReadOnly) && shouldBeTreatedAsComputedProperty) {
         @throw RLMException(@"Property '%@' must be declared as readonly as %@ properties cannot be written to.",
                             self.name, RLMTypeToString(_type));
     }

--- a/Realm/Tests/ObjectTests.m
+++ b/Realm/Tests/ObjectTests.m
@@ -1081,11 +1081,13 @@ static void testDatesInRange(NSTimeInterval from, NSTimeInterval to, void (^chec
     Class objectClass = objc_allocateClassPair(RLMObject.class, "RuntimeGeneratedObject", 0);
     objc_property_attribute_t objectColAttrs[] = {
         { "T", "@\"RuntimeGeneratedObject\"" },
+        { "V", "objectCol" },
     };
     class_addIvar(objectClass, "objectCol", sizeof(id), alignof(id), "@\"RuntimeGeneratedObject\"");
     class_addProperty(objectClass, "objectCol", objectColAttrs, sizeof(objectColAttrs) / sizeof(objc_property_attribute_t));
     objc_property_attribute_t intColAttrs[] = {
         { "T", "i" },
+        { "V", "intCol" },
     };
     class_addIvar(objectClass, "intCol", sizeof(int), alignof(int), "i");
     class_addProperty(objectClass, "intCol", intColAttrs, sizeof(intColAttrs) / sizeof(objc_property_attribute_t));

--- a/Realm/Tests/RLMTestObjects.h
+++ b/Realm/Tests/RLMTestObjects.h
@@ -322,6 +322,13 @@ RLM_ARRAY_TYPE(PersonObject);
 @property (readonly) RLMLinkingObjects *parents;
 @end
 
+#pragma mark ComputedPropertyNotExplicitlyIgnoredObject
+
+@interface ComputedPropertyNotExplicitlyIgnoredObject : RLMObject
+@property NSString *_URLBacking;
+@property NSURL *URL;
+@end
+
 #pragma mark FakeObject
 
 @interface FakeObject : NSObject

--- a/Realm/Tests/RLMTestObjects.m
+++ b/Realm/Tests/RLMTestObjects.m
@@ -251,3 +251,17 @@
 + (NSDictionary *)linkingObjectsProperties { return nil; }
 + (BOOL)shouldIncludeInDefaultSchema { return NO; }
 @end
+
+#pragma mark ComputedPropertyNotExplicitlyIgnoredObject
+
+@implementation ComputedPropertyNotExplicitlyIgnoredObject
+
+- (NSURL *)URL {
+    return [NSURL URLWithString:self._URLBacking];
+}
+
+- (void)setURL:(NSURL *)URL {
+    self._URLBacking = URL.absoluteString;
+}
+
+@end

--- a/Realm/Tests/SchemaTests.mm
+++ b/Realm/Tests/SchemaTests.mm
@@ -65,39 +65,6 @@ RLM_ARRAY_TYPE(SchemaTestClassSecondChild)
 @implementation SchemaTestClassLink
 @end
 
-@interface SchemaTestClassWithSingleDuplicatePropertyBase : FakeObject
-@property NSString *string;
-@end
-
-@implementation SchemaTestClassWithSingleDuplicatePropertyBase
-@end
-
-@interface SchemaTestClassWithSingleDuplicateProperty : SchemaTestClassWithSingleDuplicatePropertyBase
-@property NSString *string;
-@end
-
-@implementation SchemaTestClassWithSingleDuplicateProperty
-@dynamic string;
-@end
-
-@interface SchemaTestClassWithMultipleDuplicatePropertiesBase : FakeObject
-@property NSString *string;
-@property int integer;
-@end
-
-@implementation SchemaTestClassWithMultipleDuplicatePropertiesBase
-@end
-
-@interface SchemaTestClassWithMultipleDuplicateProperties : SchemaTestClassWithMultipleDuplicatePropertiesBase
-@property NSString *string;
-@property int integer;
-@end
-
-@implementation SchemaTestClassWithMultipleDuplicateProperties
-@dynamic string;
-@dynamic integer;
-@end
-
 @interface UnindexableProperty : FakeObject
 @property double unindexable;
 @end
@@ -573,12 +540,6 @@ RLM_ARRAY_TYPE(NotARealClass)
                                               @"\t}\n"
                                               @"}");
 
-}
-
-- (void)testClassWithDuplicateProperties
-{
-    RLMAssertThrowsWithReasonMatching([RLMObjectSchema schemaForObjectClass:SchemaTestClassWithSingleDuplicateProperty.class], @"'string' .* multiple times .* 'SchemaTestClassWithSingleDuplicateProperty'");
-    RLMAssertThrowsWithReasonMatching([RLMObjectSchema schemaForObjectClass:SchemaTestClassWithMultipleDuplicateProperties.class], @"'SchemaTestClassWithMultipleDuplicateProperties' .* declared multiple times");
 }
 
 - (void)testClassWithInvalidPrimaryKey {

--- a/Realm/Tests/Swift/SwiftTestObjects.swift
+++ b/Realm/Tests/Swift/SwiftTestObjects.swift
@@ -153,6 +153,18 @@ class SwiftIgnoredLazyVarObject : RLMObject {
     override class func ignoredProperties() -> [String] { return ["ignoredVar"] }
 }
 
+class SwiftComputedPropertyNotExplicitlyIgnoredObject: RLMObject {
+    dynamic var _urlBacking = ""
+    var url: NSURL? {
+        get {
+            return NSURL(string: _urlBacking)
+        }
+        set {
+            _urlBacking = newValue?.absoluteString ?? ""
+        }
+    }
+}
+
 #else
 
 class SwiftStringObject: RLMObject {
@@ -286,6 +298,18 @@ class SwiftLazyVarObject : RLMObject {
 class SwiftIgnoredLazyVarObject : RLMObject {
     dynamic lazy var ignoredVar : String = "hello world"
     override class func ignoredProperties() -> [String] { return ["ignoredVar"] }
+}
+
+class SwiftComputedPropertyNotExplicitlyIgnoredObject: RLMObject {
+    dynamic var _urlBacking = ""
+    var url: NSURL? {
+        get {
+            return NSURL(string: _urlBacking)
+        }
+        set {
+            _urlBacking = newValue?.absoluteString ?? ""
+        }
+    }
 }
 
 #endif

--- a/RealmSwift/Tests/SwiftTestObjects.swift
+++ b/RealmSwift/Tests/SwiftTestObjects.swift
@@ -411,6 +411,18 @@ class SwiftConvenienceInitializerObject: Object {
     }
 }
 
+class SwiftComputedPropertyNotExplicitlyIgnoredObject: Object {
+    dynamic var _urlBacking = ""
+    var url: NSURL? {
+        get {
+            return NSURL(string: _urlBacking)
+        }
+        set {
+            _urlBacking = newValue?.absoluteString ?? ""
+        }
+    }
+}
+
 #else
 
 class SwiftStringObject: Object {
@@ -801,6 +813,19 @@ class SwiftConvenienceInitializerObject: Object {
     convenience init(stringCol: String) {
         self.init()
         self.stringCol = stringCol
+    }
+}
+
+
+class SwiftComputedPropertyNotExplicitlyIgnoredObject: Object {
+    dynamic var _urlBacking = ""
+    var url: NSURL? {
+        get {
+            return NSURL(string: _urlBacking)
+        }
+        set {
+            _urlBacking = newValue?.absoluteString ?? ""
+        }
     }
 }
 


### PR DESCRIPTION
Ignores properties not backed by ivars in both Swift and Objective-C (https://github.com/realm/realm-cocoa/issues/2840). Also makes testing for duplicate properties unnecessary since both cannot be ivar backed (https://github.com/realm/realm-cocoa/pull/1867).

//cc @bdash @tgoyne @mrackwitz @jpsim 
