### PR TITLE
Renaming a few Swift 3 methods

### DIFF
--- a/RealmSwift/Migration.swift
+++ b/RealmSwift/Migration.swift
@@ -127,7 +127,7 @@ public final class Migration {
     - returns: The created object.
     */
     @discardableResult
-    public func createObject(ofType typeName: String, populatedWith value: AnyObject = [:]) -> MigrationObject {
+    public func createObject(_ typeName: String, from value: AnyObject = [:]) -> MigrationObject {
         return unsafeBitCast(rlmMigration.createObject(typeName, withValue: value), to: MigrationObject.self)
     }
 
@@ -202,7 +202,7 @@ extension Migration {
     @available(*, unavailable, renamed:"enumerateObjects(ofType:_:)")
     public func enumerate(_ objectClassName: String, _ block: MigrationObjectEnumerateBlock) { }
 
-    @available(*, unavailable, renamed:"createObject(ofType:populatedWith:)")
+    @available(*, unavailable, renamed:"createObject(_:from:)")
     public func create(_ className: String, value: AnyObject = [:]) -> MigrationObject {
         fatalError()
     }

--- a/RealmSwift/Realm.swift
+++ b/RealmSwift/Realm.swift
@@ -263,7 +263,7 @@ public final class Realm {
     - returns: The created object.
     */
     @discardableResult
-    public func createObject<T: Object>(ofType type: T.Type, populatedWith value: AnyObject = [:], update: Bool = false) -> T {
+    public func create<T: Object>(_ type: T.Type, from value: AnyObject = [:], update: Bool = false) -> T {
         let typeName = (type as Object.Type).className()
         if update && schema[typeName]?.primaryKeyProperty == nil {
             throwRealmException("'\(typeName)' does not have a primary key and can not be updated")
@@ -300,7 +300,7 @@ public final class Realm {
     :nodoc:
     */
     @discardableResult
-    public func createDynamicObject(ofType typeName: String, populatedWith value: AnyObject = [:], update: Bool = false) -> DynamicObject {
+    public func createDynamicObject(ofType typeName: String, from value: AnyObject = [:], update: Bool = false) -> DynamicObject {
         if update && schema[typeName]?.primaryKeyProperty == nil {
             throwRealmException("'\(typeName)' does not have a primary key and can not be updated")
         }
@@ -378,7 +378,7 @@ public final class Realm {
 
     - returns: All objects of the given type in Realm.
     */
-    public func allObjects<T: Object>(ofType type: T.Type) -> Results<T> {
+    public func objects<T: Object>(ofType type: T.Type) -> Results<T> {
         return Results<T>(RLMGetObjects(rlmRealm, (type as Object.Type).className(), nil))
     }
 
@@ -397,7 +397,7 @@ public final class Realm {
 
     :nodoc:
     */
-    public func allDynamicObjects(ofType typeName: String) -> Results<DynamicObject> {
+    public func dynamicObjects(ofType typeName: String) -> Results<DynamicObject> {
         return Results<DynamicObject>(RLMGetObjects(rlmRealm, typeName, nil))
     }
 
@@ -638,10 +638,10 @@ extension Realm {
     @available(*, unavailable, renamed:"isInWriteTransaction")
     public var inWriteTransaction : Bool { fatalError() }
 
-    @available(*, unavailable, renamed:"createObject(ofType:populatedWith:update:)")
+    @available(*, unavailable, renamed:"create(_:from:update:)")
     public func create<T: Object>(_ type: T.Type, value: AnyObject = [:], update: Bool = false) -> T { fatalError() }
 
-    @available(*, unavailable, renamed:"createDynamicObject(ofType:populatedWith:update:)")
+    @available(*, unavailable, renamed:"createDynamicObject(ofType:from:update:)")
     public func dynamicCreate(_ className: String, value: AnyObject = [:], update: Bool = false) -> DynamicObject {
         fatalError()
     }
@@ -655,10 +655,10 @@ extension Realm {
     @available(*, unavailable, renamed:"deleteAllObjects()")
     public func deleteAll() { }
 
-    @available(*, unavailable, renamed:"allObjects(ofType:)")
+    @available(*, unavailable, renamed:"objects(ofType:)")
     public func objects<T: Object>(_ type: T.Type) -> Results<T> { fatalError() }
 
-    @available(*, unavailable, renamed:"allDynamicObjects(ofType:)")
+    @available(*, unavailable, renamed:"dynamicObjects(ofType:)")
     public func dynamicObjects(_ className: String) -> Results<DynamicObject> { fatalError() }
 
     @available(*, unavailable, renamed:"object(ofType:forPrimaryKey:)")

--- a/RealmSwift/Tests/ListTests.swift
+++ b/RealmSwift/Tests/ListTests.swift
@@ -133,7 +133,7 @@ class ListTests: TestCase {
         guard let array = array, let str1 = str1, let str2 = str2 else {
             fatalError("Test precondition failure")
         }
-        array.append(objectsIn: realmWithTestPath().allObjects(ofType: SwiftStringObject.self))
+        array.append(objectsIn: realmWithTestPath().objects(ofType: SwiftStringObject.self))
         XCTAssertEqual(Int(2), array.count)
         XCTAssertEqual(str1, array[0])
         XCTAssertEqual(str2, array[1])
@@ -314,7 +314,7 @@ class ListTests: TestCase {
         if let realm = array.realm {
             array.append(objectsIn: [str1, str2])
 
-            let otherArray = realm.allObjects(ofType: SwiftArrayPropertyObject.self).first!.array
+            let otherArray = realm.objects(ofType: SwiftArrayPropertyObject.self).first!.array
             XCTAssertEqual(Int(2), otherArray.count)
         }
     }
@@ -329,7 +329,7 @@ class ListTests: TestCase {
         let obj = SwiftStringObject()
         obj.stringCol = "a"
         array.append(obj)
-        array.append(realmWithTestPath().createObject(ofType: SwiftStringObject.self, populatedWith: ["b"]))
+        array.append(realmWithTestPath().createObject(SwiftStringObject.self, from: ["b"]))
         array.append(obj)
 
         XCTAssertEqual(array.count, 3)
@@ -401,7 +401,7 @@ class ListNewlyCreatedTests: ListTests {
     override func createArray() -> SwiftArrayPropertyObject {
         let realm = realmWithTestPath()
         realm.beginWrite()
-        let array = realm.createObject(ofType: SwiftArrayPropertyObject.self, populatedWith: ["name", [], []])
+        let array = realm.createObject(SwiftArrayPropertyObject.self, from: ["name", [], []])
         try! realm.commitWrite()
 
         XCTAssertNotNil(array.realm)
@@ -411,7 +411,7 @@ class ListNewlyCreatedTests: ListTests {
     override func createArrayWithLinks() -> SwiftListOfSwiftObject {
         let realm = try! Realm()
         realm.beginWrite()
-        let array = realm.createObject(ofType: SwiftListOfSwiftObject.self)
+        let array = realm.createObject(SwiftListOfSwiftObject.self)
         try! realm.commitWrite()
 
         XCTAssertNotNil(array.realm)
@@ -423,9 +423,9 @@ class ListRetrievedTests: ListTests {
     override func createArray() -> SwiftArrayPropertyObject {
         let realm = realmWithTestPath()
         realm.beginWrite()
-        realm.createObject(ofType: SwiftArrayPropertyObject.self, populatedWith: ["name", [], []])
+        realm.createObject(SwiftArrayPropertyObject.self, from: ["name", [], []])
         try! realm.commitWrite()
-        let array = realm.allObjects(ofType: SwiftArrayPropertyObject.self).first!
+        let array = realm.objects(ofType: SwiftArrayPropertyObject.self).first!
 
         XCTAssertNotNil(array.realm)
         return array
@@ -434,9 +434,9 @@ class ListRetrievedTests: ListTests {
     override func createArrayWithLinks() -> SwiftListOfSwiftObject {
         let realm = try! Realm()
         realm.beginWrite()
-        realm.createObject(ofType: SwiftListOfSwiftObject.self)
+        realm.createObject(SwiftListOfSwiftObject.self)
         try! realm.commitWrite()
-        let array = realm.allObjects(ofType: SwiftListOfSwiftObject.self).first!
+        let array = realm.objects(ofType: SwiftListOfSwiftObject.self).first!
 
         XCTAssertNotNil(array.realm)
         return array

--- a/RealmSwift/Tests/MigrationTests.swift
+++ b/RealmSwift/Tests/MigrationTests.swift
@@ -171,7 +171,7 @@ class MigrationTests: TestCase {
         autoreleasepool {
             // add object
             try! Realm().write {
-                try! Realm().createObject(ofType: SwiftStringObject.self, populatedWith: ["string"])
+                try! Realm().createObject(SwiftStringObject.self, from: ["string"])
                 return
             }
         }
@@ -192,7 +192,7 @@ class MigrationTests: TestCase {
 
         autoreleasepool {
             try! Realm().write {
-                try! Realm().createObject(ofType: SwiftArrayPropertyObject.self, populatedWith: ["string", [["array"]], [[2]]])
+                try! Realm().createObject(SwiftArrayPropertyObject.self, from: ["string", [["array"]], [[2]]])
             }
         }
 
@@ -262,14 +262,14 @@ class MigrationTests: TestCase {
         }
 
         migrateAndTestDefaultRealm() { migration, oldSchemaVersion in
-            migration.createObject(ofType: "SwiftStringObject", populatedWith: ["string"])
-            migration.createObject(ofType: "SwiftStringObject", populatedWith: ["stringCol": "string"])
-            migration.createObject(ofType: "SwiftStringObject")
+            migration.createObject("SwiftStringObject", from: ["string"])
+            migration.createObject("SwiftStringObject", from: ["stringCol": "string"])
+            migration.createObject("SwiftStringObject")
 
-            self.assertThrows(migration.createObject(ofType: "NoSuchObject", populatedWith: []))
+            self.assertThrows(migration.createObject("NoSuchObject", from: []))
         }
 
-        let objects = try! Realm().allObjects(ofType: SwiftStringObject.self)
+        let objects = try! Realm().objects(ofType: SwiftStringObject.self)
         XCTAssertEqual(objects.count, 3)
 
         XCTAssertEqual(objects[0].stringCol, "string")
@@ -280,8 +280,8 @@ class MigrationTests: TestCase {
     func testDelete() {
         autoreleasepool {
             try! Realm().write {
-                try! Realm().createObject(ofType: SwiftStringObject.self, populatedWith: ["string1"])
-                try! Realm().createObject(ofType: SwiftStringObject.self, populatedWith: ["string2"])
+                try! Realm().createObject(SwiftStringObject.self, from: ["string1"])
+                try! Realm().createObject(SwiftStringObject.self, from: ["string2"])
                 return
             }
         }
@@ -296,7 +296,7 @@ class MigrationTests: TestCase {
             })
         }
 
-        XCTAssertEqual(try! Realm().allObjects(ofType: SwiftStringObject.self).count, 1)
+        XCTAssertEqual(try! Realm().objects(ofType: SwiftStringObject.self).count, 1)
     }
 
     func testDeleteData() {
@@ -316,7 +316,7 @@ class MigrationTests: TestCase {
             XCTAssertTrue(migration.deleteData(forType: "DeletedClass"))
             XCTAssertFalse(migration.deleteData(forType: "NoSuchClass"))
 
-            migration.createObject(ofType: SwiftStringObject.className(), populatedWith: ["migration"])
+            migration.createObject(SwiftStringObject.className(), from: ["migration"])
             XCTAssertTrue(migration.deleteData(forType: SwiftStringObject.className()))
         }
 
@@ -407,7 +407,7 @@ class MigrationTests: TestCase {
                 list[0]["boolCol"] = true
                 list.append(newObj!["objectCol"] as! MigrationObject)
 
-                let trueObj = migration.createObject(ofType: SwiftBoolObject.className(), populatedWith: [true])
+                let trueObj = migration.createObject(SwiftBoolObject.className(), from: [true])
                 list.append(trueObj)
 
                 // verify list property
@@ -432,7 +432,7 @@ class MigrationTests: TestCase {
         try! Realm().refresh()
 
         // check edited values
-        let object = try! Realm().allObjects(ofType: SwiftObject.self).first!
+        let object = try! Realm().objects(ofType: SwiftObject.self).first!
         XCTAssertEqual(object.boolCol, false)
         XCTAssertEqual(object.intCol, 1)
         XCTAssertEqual(object.floatCol, 1.0 as Float)
@@ -445,7 +445,7 @@ class MigrationTests: TestCase {
         XCTAssertEqual(object.arrayCol[1].boolCol, true)
 
         // make sure we added new bool objects as object property and in the list
-        XCTAssertEqual(try! Realm().allObjects(ofType: SwiftBoolObject.self).count, 4)
+        XCTAssertEqual(try! Realm().objects(ofType: SwiftBoolObject.self).count, 4)
     }
 
     func testFailOnSchemaMismatch() {

--- a/RealmSwift/Tests/ObjectAccessorTests.swift
+++ b/RealmSwift/Tests/ObjectAccessorTests.swift
@@ -79,8 +79,8 @@ class ObjectAccessorTests: TestCase {
     func testPersistedAccessors() {
         let realm = try! Realm()
         realm.beginWrite()
-        let object = realm.createObject(ofType: SwiftObject.self)
-        let optionalObject = realm.createObject(ofType: SwiftOptionalObject.self)
+        let object = realm.createObject(SwiftObject.self)
+        let optionalObject = realm.createObject(SwiftOptionalObject.self)
         setAndTestAllProperties(object)
         setAndTestAllOptionalProperties(optionalObject)
         try! realm.commitWrite()
@@ -139,7 +139,7 @@ class ObjectAccessorTests: TestCase {
             testObject()
         }
 
-        let obj = realm.allObjects(ofType: SwiftAllIntSizesObject.self).first!
+        let obj = realm.objects(ofType: SwiftAllIntSizesObject.self).first!
         XCTAssertEqual(obj.int8, v8)
         XCTAssertEqual(obj.int16, v16)
         XCTAssertEqual(obj.int32, v32)
@@ -155,12 +155,12 @@ class ObjectAccessorTests: TestCase {
         let realm = realmWithTestPath()
 
         realm.beginWrite()
-        realm.createObject(ofType: SwiftLongObject.self, populatedWith: [NSNumber(value: longNumber)])
-        realm.createObject(ofType: SwiftLongObject.self, populatedWith: [NSNumber(value: intNumber)])
-        realm.createObject(ofType: SwiftLongObject.self, populatedWith: [NSNumber(value: negativeLongNumber)])
+        realm.createObject(SwiftLongObject.self, from: [NSNumber(value: longNumber)])
+        realm.createObject(SwiftLongObject.self, from: [NSNumber(value: intNumber)])
+        realm.createObject(SwiftLongObject.self, from: [NSNumber(value: negativeLongNumber)])
         try! realm.commitWrite()
 
-        let objects = realm.allObjects(ofType: SwiftLongObject.self)
+        let objects = realm.objects(ofType: SwiftLongObject.self)
         XCTAssertEqual(objects.count, Int(3), "3 rows expected")
         XCTAssertEqual(objects[0].longCol, longNumber, "2 ^ 34 expected")
         XCTAssertEqual(objects[1].longCol, intNumber, "2 ^ 31 - 1 expected")
@@ -196,7 +196,7 @@ class ObjectAccessorTests: TestCase {
             realm.add(object2)
         }
 
-        let objects = realm.allObjects(ofType: SwiftObject.self)
+        let objects = realm.objects(ofType: SwiftObject.self)
 
         let firstObject = objects.first
         XCTAssertEqual(2, firstObject!.arrayCol.count)
@@ -216,8 +216,8 @@ class ObjectAccessorTests: TestCase {
     func testSettingOptionalPropertyOnDeletedObjectsThrows() {
         let realm = try! Realm()
         try! realm.write {
-            let obj = realm.createObject(ofType: SwiftOptionalObject.self)
-            let copy = realm.allObjects(ofType: SwiftOptionalObject.self).first!
+            let obj = realm.createObject(SwiftOptionalObject.self)
+            let copy = realm.objects(ofType: SwiftOptionalObject.self).first!
             realm.delete(obj)
 
             self.assertThrows(copy.optIntCol.value = 1)

--- a/RealmSwift/Tests/ObjectCreationTests.swift
+++ b/RealmSwift/Tests/ObjectCreationTests.swift
@@ -157,14 +157,14 @@ class ObjectCreationTests: TestCase {
 
     func testCreateWithDefaults() {
         let realm = try! Realm()
-        assertThrows(realm.createObject(ofType: SwiftObject.self), "Must be in write transaction")
+        assertThrows(realm.createObject(SwiftObject.self), "Must be in write transaction")
 
         var object: SwiftObject!
-        let objects = realm.allObjects(ofType: SwiftObject.self)
+        let objects = realm.objects(ofType: SwiftObject.self)
         XCTAssertEqual(0, objects.count)
         try! realm.write {
             // test create with all defaults
-            object = realm.createObject(ofType: SwiftObject.self)
+            object = realm.createObject(SwiftObject.self)
             return
         }
         verifySwiftObjectWithDictionaryLiteral(object, dictionary: SwiftObject.defaultValues(), boolObjectValue: false,
@@ -179,7 +179,7 @@ class ObjectCreationTests: TestCase {
     func testCreateWithOptionalWithoutDefaults() {
         let realm = try! Realm()
         try! realm.write {
-            let object = realm.createObject(ofType: SwiftOptionalObject.self)
+            let object = realm.createObject(SwiftOptionalObject.self)
             for prop in object.objectSchema.properties {
                 XCTAssertNil(object[prop.name])
             }
@@ -189,7 +189,7 @@ class ObjectCreationTests: TestCase {
     func testCreateWithOptionalDefaults() {
         let realm = try! Realm()
         try! realm.write {
-            let object = realm.createObject(ofType: SwiftOptionalDefaultValuesObject.self)
+            let object = realm.createObject(SwiftOptionalDefaultValuesObject.self)
             self.verifySwiftOptionalObjectWithDictionaryLiteral(object,
                 dictionary: SwiftOptionalDefaultValuesObject.defaultValues(), boolObjectValue: true)
         }
@@ -198,7 +198,7 @@ class ObjectCreationTests: TestCase {
     func testCreateWithOptionalIgnoredProperties() {
         let realm = try! Realm()
         try! realm.write {
-            let object = realm.createObject(ofType: SwiftOptionalIgnoredPropertiesObject.self)
+            let object = realm.createObject(SwiftOptionalIgnoredPropertiesObject.self)
             let properties = object.objectSchema.properties
             XCTAssertEqual(properties.count, 1)
             XCTAssertEqual(properties[0].name, "id")
@@ -227,7 +227,7 @@ class ObjectCreationTests: TestCase {
                 var values = baselineValues
                 values[props[propNum].name] = validValue
                 try! Realm().beginWrite()
-                let object = try! Realm().createObject(ofType: SwiftObject.self, populatedWith: values as AnyObject)
+                let object = try! Realm().createObject(SwiftObject.self, from: values as AnyObject)
                 verifySwiftObjectWithDictionaryLiteral(object, dictionary: values, boolObjectValue: true,
                     boolObjectListValues: [true, false])
                 try! Realm().commitWrite()
@@ -243,7 +243,7 @@ class ObjectCreationTests: TestCase {
                 var values = baselineValues
                 values[props[propNum].name] = invalidValue
                 try! Realm().beginWrite()
-                assertThrows(try! Realm().createObject(ofType: SwiftObject.self, populatedWith: values as AnyObject), "Invalid property value")
+                assertThrows(try! Realm().createObject(SwiftObject.self, from: values as AnyObject), "Invalid property value")
                 try! Realm().cancelWrite()
             }
         }
@@ -253,7 +253,7 @@ class ObjectCreationTests: TestCase {
         // test with dictionary with mix of default and one specified value
         let realm = try! Realm()
         realm.beginWrite()
-        let objectWithInt = realm.createObject(ofType: SwiftObject.self, populatedWith: ["intCol": 200])
+        let objectWithInt = realm.createObject(SwiftObject.self, from: ["intCol": 200])
         try! realm.commitWrite()
 
         let valueDict = defaultSwiftObjectValuesWithReplacements(["intCol": 200])
@@ -274,7 +274,7 @@ class ObjectCreationTests: TestCase {
                 var values = baselineValues
                 values[propNum] = validValue
                 try! Realm().beginWrite()
-                let object = try! Realm().createObject(ofType: SwiftObject.self, populatedWith: values as AnyObject)
+                let object = try! Realm().createObject(SwiftObject.self, from: values as AnyObject)
                 verifySwiftObjectWithArrayLiteral(object, array: values, boolObjectValue: true,
                     boolObjectListValues: [true, false])
                 try! Realm().commitWrite()
@@ -291,7 +291,7 @@ class ObjectCreationTests: TestCase {
                 values[propNum] = invalidValue
 
                 try! Realm().beginWrite()
-                assertThrows(try! Realm().createObject(ofType: SwiftObject.self, populatedWith: values as AnyObject),
+                assertThrows(try! Realm().createObject(SwiftObject.self, from: values as AnyObject),
                     "Invalid property value '\(invalidValue)' for property number \(propNum)")
                 try! Realm().cancelWrite()
             }
@@ -301,25 +301,25 @@ class ObjectCreationTests: TestCase {
     func testCreateWithKVCObject() {
         // test with kvc object
         try! Realm().beginWrite()
-        let objectWithInt = try! Realm().createObject(ofType: SwiftObject.self, populatedWith: ["intCol": 200])
-        let objectWithKVCObject = try! Realm().createObject(ofType: SwiftObject.self, populatedWith: objectWithInt)
+        let objectWithInt = try! Realm().createObject(SwiftObject.self, from: ["intCol": 200])
+        let objectWithKVCObject = try! Realm().createObject(SwiftObject.self, from: objectWithInt)
         let valueDict = defaultSwiftObjectValuesWithReplacements(["intCol": 200])
         try! Realm().commitWrite()
 
         verifySwiftObjectWithDictionaryLiteral(objectWithKVCObject, dictionary: valueDict, boolObjectValue: false,
             boolObjectListValues: [])
-        XCTAssertEqual(try! Realm().allObjects(ofType: SwiftObject.self).count, 2, "Object should have been copied")
+        XCTAssertEqual(try! Realm().objects(ofType: SwiftObject.self).count, 2, "Object should have been copied")
     }
 
     func testCreateWithNestedObjects() {
         let standalone = SwiftPrimaryStringObject(value: ["p0", 11])
 
         try! Realm().beginWrite()
-        let objectWithNestedObjects = try! Realm().createObject(ofType: SwiftLinkToPrimaryStringObject.self, populatedWith: ["p1", ["p1", 11],
+        let objectWithNestedObjects = try! Realm().createObject(SwiftLinkToPrimaryStringObject.self, from: ["p1", ["p1", 11],
             [standalone]])
         try! Realm().commitWrite()
 
-        let stringObjects = try! Realm().allObjects(ofType: SwiftPrimaryStringObject.self)
+        let stringObjects = try! Realm().objects(ofType: SwiftPrimaryStringObject.self)
         XCTAssertEqual(stringObjects.count, 2)
         let persistedObject = stringObjects.first!
 
@@ -330,7 +330,7 @@ class ObjectCreationTests: TestCase {
 
         let standalone1 = SwiftPrimaryStringObject(value: ["p3", 11])
         try! Realm().beginWrite()
-        assertThrows(try! Realm().createObject(ofType: SwiftLinkToPrimaryStringObject.self, populatedWith: ["p3", ["p3", 11], [standalone1]]),
+        assertThrows(try! Realm().createObject(SwiftLinkToPrimaryStringObject.self, from: ["p3", ["p3", 11], [standalone1]]),
             "Should throw with duplicate primary key")
         try! Realm().commitWrite()
     }
@@ -338,11 +338,11 @@ class ObjectCreationTests: TestCase {
     func testUpdateWithNestedObjects() {
         let standalone = SwiftPrimaryStringObject(value: ["primary", 11])
         try! Realm().beginWrite()
-        let object = try! Realm().createObject(ofType: SwiftLinkToPrimaryStringObject.self, populatedWith: ["otherPrimary", ["primary", 12],
+        let object = try! Realm().createObject(SwiftLinkToPrimaryStringObject.self, from: ["otherPrimary", ["primary", 12],
             [["primary", 12]]], update: true)
         try! Realm().commitWrite()
 
-        let stringObjects = try! Realm().allObjects(ofType: SwiftPrimaryStringObject.self)
+        let stringObjects = try! Realm().objects(ofType: SwiftPrimaryStringObject.self)
         XCTAssertEqual(stringObjects.count, 1)
         let persistedObject = object.object!
 
@@ -366,11 +366,11 @@ class ObjectCreationTests: TestCase {
         ]
 
         realmWithTestPath().beginWrite()
-        let otherRealmObject = realmWithTestPath().createObject(ofType: SwiftObject.self, populatedWith: values as AnyObject)
+        let otherRealmObject = realmWithTestPath().createObject(SwiftObject.self, from: values as AnyObject)
         try! realmWithTestPath().commitWrite()
 
         try! Realm().beginWrite()
-        let object = try! Realm().createObject(ofType: SwiftObject.self, populatedWith: otherRealmObject)
+        let object = try! Realm().createObject(SwiftObject.self, from: otherRealmObject)
         try! Realm().commitWrite()
 
         XCTAssertNotEqual(otherRealmObject, object)
@@ -397,12 +397,12 @@ class ObjectCreationTests: TestCase {
         var realmAObject: SwiftListOfSwiftObject!
         try! realmA.write {
             let array = [SwiftObject(value: values as AnyObject), SwiftObject(value: values as AnyObject)]
-            realmAObject = realmA.createObject(ofType: SwiftListOfSwiftObject.self, populatedWith: ["array": array as AnyObject])
+            realmAObject = realmA.createObject(SwiftListOfSwiftObject.self, from: ["array": array as AnyObject])
         }
 
         var realmBObject: SwiftListOfSwiftObject!
         try! realmB.write {
-            realmBObject = realmB.createObject(ofType: SwiftListOfSwiftObject.self, populatedWith: realmAObject)
+            realmBObject = realmB.createObject(SwiftListOfSwiftObject.self, from: realmAObject)
         }
 
         XCTAssertNotEqual(realmAObject, realmBObject)
@@ -415,18 +415,18 @@ class ObjectCreationTests: TestCase {
 
     func testUpdateWithObjectsFromAnotherRealm() {
         realmWithTestPath().beginWrite()
-        let otherRealmObject = realmWithTestPath().createObject(ofType: SwiftLinkToPrimaryStringObject.self,
-                                                                populatedWith: ["primary", NSNull(), [["2", 2], ["4", 4]]])
+        let otherRealmObject = realmWithTestPath().createObject(SwiftLinkToPrimaryStringObject.self,
+                                                                from: ["primary", NSNull(), [["2", 2], ["4", 4]]])
         try! realmWithTestPath().commitWrite()
 
         try! Realm().beginWrite()
-        try! Realm().createObject(ofType: SwiftLinkToPrimaryStringObject.self, populatedWith: ["primary", ["10", 10], [["11", 11]]])
-        let object = try! Realm().createObject(ofType: SwiftLinkToPrimaryStringObject.self, populatedWith: otherRealmObject, update: true)
+        try! Realm().createObject(SwiftLinkToPrimaryStringObject.self, from: ["primary", ["10", 10], [["11", 11]]])
+        let object = try! Realm().createObject(SwiftLinkToPrimaryStringObject.self, from: otherRealmObject, update: true)
         try! Realm().commitWrite()
 
         XCTAssertNotEqual(otherRealmObject, object) // the object from the other realm should be copied into this realm
-        XCTAssertEqual(try! Realm().allObjects(ofType: SwiftLinkToPrimaryStringObject.self).count, 1)
-        XCTAssertEqual(try! Realm().allObjects(ofType: SwiftPrimaryStringObject.self).count, 4)
+        XCTAssertEqual(try! Realm().objects(ofType: SwiftLinkToPrimaryStringObject.self).count, 1)
+        XCTAssertEqual(try! Realm().objects(ofType: SwiftPrimaryStringObject.self).count, 4)
     }
 
     func testCreateWithNSNullLinks() {
@@ -443,7 +443,7 @@ class ObjectCreationTests: TestCase {
         ]
 
         realmWithTestPath().beginWrite()
-        let object = realmWithTestPath().createObject(ofType: SwiftObject.self, populatedWith: values as AnyObject)
+        let object = realmWithTestPath().createObject(SwiftObject.self, from: values as AnyObject)
         try! realmWithTestPath().commitWrite()
 
         XCTAssert(object.objectCol == nil) // XCTAssertNil caused a NULL deref inside _swift_getClass
@@ -456,7 +456,7 @@ class ObjectCreationTests: TestCase {
     // MARK: Add tests
     func testAddWithExisingNestedObjects() {
         try! Realm().beginWrite()
-        let existingObject = try! Realm().createObject(ofType: SwiftBoolObject.self)
+        let existingObject = try! Realm().createObject(SwiftBoolObject.self)
         try! Realm().commitWrite()
 
         try! Realm().beginWrite()
@@ -471,7 +471,7 @@ class ObjectCreationTests: TestCase {
 
     func testAddAndUpdateWithExisingNestedObjects() {
         try! Realm().beginWrite()
-        let existingObject = try! Realm().createObject(ofType: SwiftPrimaryStringObject.self, populatedWith: ["primary", 1])
+        let existingObject = try! Realm().createObject(SwiftPrimaryStringObject.self, from: ["primary", 1])
         try! Realm().commitWrite()
 
         try! Realm().beginWrite()
@@ -550,7 +550,7 @@ class ObjectCreationTests: TestCase {
     // swiftlint:disable:next cyclomatic_complexity
     private func validValuesForSwiftObjectType(_ type: PropertyType) -> [AnyObject] {
         try! Realm().beginWrite()
-        let persistedObject = try! Realm().createObject(ofType: SwiftBoolObject.self, populatedWith: [true])
+        let persistedObject = try! Realm().createObject(SwiftBoolObject.self, from: [true])
         try! Realm().commitWrite()
         switch type {
             case .bool:     return [true, NSNumber(value: 0 as Int), NSNumber(value: 1 as Int)]
@@ -576,7 +576,7 @@ class ObjectCreationTests: TestCase {
     // swiftlint:disable:next cyclomatic_complexity
     private func invalidValuesForSwiftObjectType(_ type: PropertyType) -> [AnyObject] {
         try! Realm().beginWrite()
-        let persistedObject = try! Realm().createObject(ofType: SwiftIntObject.self)
+        let persistedObject = try! Realm().createObject(SwiftIntObject.self)
         try! Realm().commitWrite()
         switch type {
             case .bool:     return ["invalid", NSNumber(value: 2 as Int), NSNumber(value: 1.1 as Float), NSNumber(value: 11.1 as Double)]

--- a/RealmSwift/Tests/ObjectTests.swift
+++ b/RealmSwift/Tests/ObjectTests.swift
@@ -35,7 +35,7 @@ class ObjectTests: TestCase {
         let realm = try! Realm()
         var persisted: SwiftStringObject!
         try! realm.write {
-            persisted = realm.createObject(ofType: SwiftStringObject.self, populatedWith: [:])
+            persisted = realm.createObject(SwiftStringObject.self, from: [:])
             XCTAssertNotNil(persisted.realm)
             XCTAssertEqual(realm, persisted.realm!)
         }
@@ -176,7 +176,7 @@ class ObjectTests: TestCase {
 
         test(SwiftObject())
         try! Realm().write {
-            let persistedObject = try! Realm().createObject(ofType: SwiftObject.self, populatedWith: [:])
+            let persistedObject = try! Realm().createObject(SwiftObject.self, from: [:])
             test(persistedObject)
         }
     }
@@ -273,7 +273,7 @@ class ObjectTests: TestCase {
         autoreleasepool {
             let realm = self.realmWithTestPath()
             try! realm.write {
-                _ = realm.createObject(ofType: SwiftObject.self)
+                _ = realm.createObject(SwiftObject.self)
             }
         }
         autoreleasepool {
@@ -301,13 +301,13 @@ class ObjectTests: TestCase {
         }
 
         withMigrationObject { migrationObject, migration in
-            let boolObject = migration.createObject(ofType: "SwiftBoolObject", populatedWith: [true])
+            let boolObject = migration.createObject("SwiftBoolObject", from: [true])
             self.dynamicSetAndTestAllTypes(setter, getter: getter, object: migrationObject, boolObject: boolObject)
         }
 
         setAndTestAllTypes(setter, getter: getter, object: SwiftObject())
         try! Realm().write {
-            let persistedObject = try! Realm().createObject(ofType: SwiftObject.self, populatedWith: [:])
+            let persistedObject = try! Realm().createObject(SwiftObject.self, from: [:])
             self.setAndTestAllTypes(setter, getter: getter, object: persistedObject)
         }
     }
@@ -322,13 +322,13 @@ class ObjectTests: TestCase {
         }
 
         withMigrationObject { migrationObject, migration in
-            let boolObject = migration.createObject(ofType: "SwiftBoolObject", populatedWith: [true])
+            let boolObject = migration.createObject("SwiftBoolObject", from: [true])
             self.dynamicSetAndTestAllTypes(setter, getter: getter, object: migrationObject, boolObject: boolObject)
         }
 
         setAndTestAllTypes(setter, getter: getter, object: SwiftObject())
         try! Realm().write {
-            let persistedObject = try! Realm().createObject(ofType: SwiftObject.self, populatedWith: [:])
+            let persistedObject = try! Realm().createObject(SwiftObject.self, from: [:])
             self.setAndTestAllTypes(setter, getter: getter, object: persistedObject)
         }
     }

--- a/RealmSwift/Tests/PerformanceTests.swift
+++ b/RealmSwift/Tests/PerformanceTests.swift
@@ -25,8 +25,8 @@ private func createStringObjects(_ factor: Int) -> Realm {
     let realm = inMemoryRealm(factor.description)
     try! realm.write {
         for _ in 0..<(1000 * factor) {
-            realm.createObject(ofType: SwiftStringObject.self, populatedWith: ["a"])
-            realm.createObject(ofType: SwiftStringObject.self, populatedWith: ["b"])
+            realm.createObject(SwiftStringObject.self, from: ["a"])
+            realm.createObject(SwiftStringObject.self, from: ["b"])
         }
     }
     return realm
@@ -125,7 +125,7 @@ class SwiftPerformanceTests: TestCase {
             self.startMeasuring()
             for _ in 0..<50 {
                 try! realm.write {
-                    _ = realm.createObject(ofType: SwiftStringObject.self, populatedWith: ["a"])
+                    _ = realm.createObject(SwiftStringObject.self, from: ["a"])
                 }
             }
             self.stopMeasuring()
@@ -139,7 +139,7 @@ class SwiftPerformanceTests: TestCase {
             self.startMeasuring()
             try! realm.write {
                 for _ in 0..<5000 {
-                    realm.createObject(ofType: SwiftStringObject.self, populatedWith: ["a"])
+                    realm.createObject(SwiftStringObject.self, from: ["a"])
                 }
             }
             self.stopMeasuring()
@@ -151,7 +151,7 @@ class SwiftPerformanceTests: TestCase {
         let realm = copyRealmToTestPath(largeRealm)
         measure {
             for _ in 0..<50 {
-                let results = realm.allObjects(ofType: SwiftStringObject.self).filter(using: "stringCol = 'a'")
+                let results = realm.objects(ofType: SwiftStringObject.self).filter(using: "stringCol = 'a'")
                 _ = results.count
             }
         }
@@ -161,7 +161,7 @@ class SwiftPerformanceTests: TestCase {
         let realm = copyRealmToTestPath(mediumRealm)
         measure {
             for _ in 0..<50 {
-                let results = realm.allObjects(ofType: SwiftStringObject.self).filter(using: "stringCol = 'a'")
+                let results = realm.objects(ofType: SwiftStringObject.self).filter(using: "stringCol = 'a'")
                 _ = results.first
                 _ = results.count
             }
@@ -171,7 +171,7 @@ class SwiftPerformanceTests: TestCase {
     func testEnumerateAndAccessQuery() {
         let realm = copyRealmToTestPath(largeRealm)
         measure {
-            for stringObject in realm.allObjects(ofType: SwiftStringObject.self).filter(using: "stringCol = 'a'") {
+            for stringObject in realm.objects(ofType: SwiftStringObject.self).filter(using: "stringCol = 'a'") {
                 _ = stringObject.stringCol
             }
         }
@@ -180,7 +180,7 @@ class SwiftPerformanceTests: TestCase {
     func testEnumerateAndAccessAll() {
         let realm = copyRealmToTestPath(largeRealm)
         measure {
-            for stringObject in realm.allObjects(ofType: SwiftStringObject.self) {
+            for stringObject in realm.objects(ofType: SwiftStringObject.self) {
                 _ = stringObject.stringCol
             }
         }
@@ -189,7 +189,7 @@ class SwiftPerformanceTests: TestCase {
     func testEnumerateAndAccessAllSlow() {
         let realm = copyRealmToTestPath(largeRealm)
         measure {
-            let results = realm.allObjects(ofType: SwiftStringObject.self)
+            let results = realm.objects(ofType: SwiftStringObject.self)
             for i in 0..<results.count {
                 _ = results[i].stringCol
             }
@@ -199,8 +199,8 @@ class SwiftPerformanceTests: TestCase {
     func testEnumerateAndAccessArrayProperty() {
         let realm = copyRealmToTestPath(largeRealm)
         realm.beginWrite()
-        let arrayPropertyObject = realm.createObject(ofType: SwiftArrayPropertyObject.self,
-                                                     populatedWith: ["name", realm.allObjects(ofType: SwiftStringObject.self).map { $0 } as NSArray, []])
+        let arrayPropertyObject = realm.createObject(SwiftArrayPropertyObject.self,
+                                                     from: ["name", realm.objects(ofType: SwiftStringObject.self).map { $0 } as NSArray, []])
         try! realm.commitWrite()
 
         measure {
@@ -213,8 +213,8 @@ class SwiftPerformanceTests: TestCase {
     func testEnumerateAndAccessArrayPropertySlow() {
         let realm = copyRealmToTestPath(largeRealm)
         realm.beginWrite()
-        let arrayPropertyObject = realm.createObject(ofType: SwiftArrayPropertyObject.self,
-                                                     populatedWith: ["name", realm.allObjects(ofType: SwiftStringObject.self).map { $0 } as NSArray, []])
+        let arrayPropertyObject = realm.createObject(SwiftArrayPropertyObject.self,
+                                                     from: ["name", realm.objects(ofType: SwiftStringObject.self).map { $0 } as NSArray, []])
         try! realm.commitWrite()
 
         measure {
@@ -229,7 +229,7 @@ class SwiftPerformanceTests: TestCase {
         let realm = copyRealmToTestPath(largeRealm)
         measure {
             try! realm.write {
-                for stringObject in realm.allObjects(ofType: SwiftStringObject.self) {
+                for stringObject in realm.objects(ofType: SwiftStringObject.self) {
                     stringObject.stringCol = "c"
                 }
             }
@@ -240,7 +240,7 @@ class SwiftPerformanceTests: TestCase {
         let realm = copyRealmToTestPath(largeRealm)
         measure {
             try! realm.write {
-                for stringObject in realm.allObjects(ofType: SwiftStringObject.self).filter(using: "stringCol != 'b'") {
+                for stringObject in realm.objects(ofType: SwiftStringObject.self).filter(using: "stringCol != 'b'") {
                     stringObject.stringCol = "c"
                 }
             }
@@ -252,7 +252,7 @@ class SwiftPerformanceTests: TestCase {
             let realm = self.copyRealmToTestPath(largeRealm)
             self.startMeasuring()
             try! realm.write {
-                realm.delete(realm.allObjects(ofType: SwiftStringObject.self))
+                realm.delete(realm.objects(ofType: SwiftStringObject.self))
             }
             self.stopMeasuring()
         }
@@ -263,7 +263,7 @@ class SwiftPerformanceTests: TestCase {
             let realm = self.copyRealmToTestPath(mediumRealm)
             self.startMeasuring()
             try! realm.write {
-                realm.delete(realm.allObjects(ofType: SwiftStringObject.self).filter(using: "stringCol = 'a' OR stringCol = 'b'"))
+                realm.delete(realm.objects(ofType: SwiftStringObject.self).filter(using: "stringCol = 'a' OR stringCol = 'b'"))
             }
             self.stopMeasuring()
         }
@@ -272,7 +272,7 @@ class SwiftPerformanceTests: TestCase {
     func testManualDeletion() {
         inMeasureBlock {
             let realm = self.copyRealmToTestPath(mediumRealm)
-            let objects = realm.allObjects(ofType: SwiftStringObject.self).map { $0 }
+            let objects = realm.objects(ofType: SwiftStringObject.self).map { $0 }
             self.startMeasuring()
             try! realm.write {
                 realm.delete(objects)
@@ -285,12 +285,12 @@ class SwiftPerformanceTests: TestCase {
         let realm = realmWithTestPath()
         try! realm.write {
             for i in 0..<1000 {
-                realm.createObject(ofType: SwiftStringObject.self, populatedWith: [i.description] as AnyObject)
+                realm.createObject(SwiftStringObject.self, from: [i.description] as AnyObject)
             }
         }
         measure {
             for i in 0..<1000 {
-                _ = realm.allObjects(ofType: SwiftStringObject.self).filter(using: "stringCol = %@", i.description as AnyObject).first
+                _ = realm.objects(ofType: SwiftStringObject.self).filter(using: "stringCol = %@", i.description as AnyObject).first
             }
         }
     }
@@ -299,12 +299,12 @@ class SwiftPerformanceTests: TestCase {
         let realm = realmWithTestPath()
         try! realm.write {
             for i in 0..<1000 {
-                realm.createObject(ofType: SwiftIndexedPropertiesObject.self, populatedWith: [i.description as AnyObject, i as AnyObject])
+                realm.createObject(SwiftIndexedPropertiesObject.self, from: [i.description as AnyObject, i as AnyObject])
             }
         }
         measure {
             for i in 0..<1000 {
-                _ = realm.allObjects(ofType: SwiftIndexedPropertiesObject.self).filter(using: "stringCol = %@", i.description as AnyObject).first
+                _ = realm.objects(ofType: SwiftIndexedPropertiesObject.self).filter(using: "stringCol = %@", i.description as AnyObject).first
             }
         }
     }
@@ -314,14 +314,14 @@ class SwiftPerformanceTests: TestCase {
         realm.beginWrite()
         var ids = [Int]()
         for i in 0..<10000 {
-            realm.createObject(ofType: SwiftIntObject.self, populatedWith: [i as AnyObject])
+            realm.createObject(SwiftIntObject.self, from: [i as AnyObject])
             if i % 2 != 0 {
                 ids.append(i)
             }
         }
         try! realm.commitWrite()
         measure {
-            _ = realm.allObjects(ofType: SwiftIntObject.self).filter(using: "intCol IN %@", ids as AnyObject).first
+            _ = realm.objects(ofType: SwiftIntObject.self).filter(using: "intCol IN %@", ids as AnyObject).first
         }
     }
 
@@ -330,11 +330,11 @@ class SwiftPerformanceTests: TestCase {
         try! realm.write {
             for _ in 0..<8000 {
                 let randomNumber = Int(arc4random_uniform(UInt32(INT_MAX)))
-                realm.createObject(ofType: SwiftIntObject.self, populatedWith: [randomNumber as AnyObject])
+                realm.createObject(SwiftIntObject.self, from: [randomNumber as AnyObject])
             }
         }
         measure {
-            _ = realm.allObjects(ofType: SwiftIntObject.self).sorted(onProperty: "intCol", ascending: true).last
+            _ = realm.objects(ofType: SwiftIntObject.self).sorted(onProperty: "intCol", ascending: true).last
         }
     }
 
@@ -368,7 +368,7 @@ class SwiftPerformanceTests: TestCase {
         inMeasureBlock {
             let realm = inMemoryRealm("test")
             realm.beginWrite()
-            let object = realm.createObject(ofType: SwiftIntObject.self)
+            let object = realm.createObject(SwiftIntObject.self)
             try! realm.commitWrite()
 
             self.startMeasuring()
@@ -383,7 +383,7 @@ class SwiftPerformanceTests: TestCase {
         inMeasureBlock {
             let realm = inMemoryRealm("test")
             realm.beginWrite()
-            let object = realm.createObject(ofType: SwiftIntObject.self)
+            let object = realm.createObject(SwiftIntObject.self)
             try! realm.commitWrite()
 
             let token = realm.addNotificationBlock { _, _ in }
@@ -401,7 +401,7 @@ class SwiftPerformanceTests: TestCase {
         inMeasureBlock {
             let realm = inMemoryRealm("test")
             realm.beginWrite()
-            let object = realm.createObject(ofType: SwiftIntObject.self)
+            let object = realm.createObject(SwiftIntObject.self)
             try! realm.commitWrite()
 
             let queue = DispatchQueue(label: "background")
@@ -409,7 +409,7 @@ class SwiftPerformanceTests: TestCase {
             queue.async {
                 autoreleasepool {
                     let realm = inMemoryRealm("test")
-                    let object = realm.allObjects(ofType: SwiftIntObject.self).first!
+                    let object = realm.objects(ofType: SwiftIntObject.self).first!
                     var token: NotificationToken! = nil
                     CFRunLoopPerformBlock(CFRunLoopGetCurrent(), CFRunLoopMode.defaultMode.rawValue) {
                         token = realm.addNotificationBlock { _, _ in
@@ -442,13 +442,13 @@ class SwiftPerformanceTests: TestCase {
         inMeasureBlock {
             let realm = inMemoryRealm("test")
             realm.beginWrite()
-            let object = realm.createObject(ofType: SwiftIntObject.self)
+            let object = realm.createObject(SwiftIntObject.self)
             try! realm.commitWrite()
 
             queue.async {
                 autoreleasepool {
                     let realm = inMemoryRealm("test")
-                    let object = realm.allObjects(ofType: SwiftIntObject.self).first!
+                    let object = realm.objects(ofType: SwiftIntObject.self).first!
                     var token: NotificationToken! = nil
                     CFRunLoopPerformBlock(CFRunLoopGetCurrent(), CFRunLoopMode.defaultMode.rawValue) {
                         token = realm.addNotificationBlock { _, _ in

--- a/RealmSwift/Tests/RealmCollectionTypeTests.swift
+++ b/RealmSwift/Tests/RealmCollectionTypeTests.swift
@@ -265,7 +265,7 @@ class RealmCollectionTypeTests: TestCase {
         try! realm.write {
             realm.add(outerArray)
         }
-        XCTAssertEqual(1, outerArray.array.filter(using: "ANY array IN %@", realm.allObjects(ofType: SwiftObject.self)).count)
+        XCTAssertEqual(1, outerArray.array.filter(using: "ANY array IN %@", realm.objects(ofType: SwiftObject.self)).count)
     }
 
     func testFilterResults() {
@@ -275,7 +275,7 @@ class RealmCollectionTypeTests: TestCase {
         try! realm.write {
             realm.add(array)
         }
-        XCTAssertEqual(1, realm.allObjects(ofType: SwiftListOfSwiftObject.self).filter(using: "ANY array IN %@", realm.allObjects(ofType: SwiftObject.self)).count)
+        XCTAssertEqual(1, realm.objects(ofType: SwiftListOfSwiftObject.self).filter(using: "ANY array IN %@", realm.objects(ofType: SwiftObject.self)).count)
     }
 
     func testFilterPredicate() {
@@ -492,7 +492,7 @@ class ResultsTests: RealmCollectionTypeTests {
     func addObjectToResults() {
         let realm = realmWithTestPath()
         try! realm.write {
-            realm.createObject(ofType: CTTStringObjectWithLink.self, populatedWith: ["a"])
+            realm.createObject(CTTStringObjectWithLink.self, from: ["a"])
         }
     }
 
@@ -570,7 +570,7 @@ class ResultsWithCustomInitializerTest: TestCase {
             realm.add(SwiftCustomInitializerObject(stringVal: "A"))
         }
 
-        let collection = realm.allObjects(ofType: SwiftCustomInitializerObject.self)
+        let collection = realm.objects(ofType: SwiftCustomInitializerObject.self)
         let expected = Array(collection.map { $0.stringCol })
         let actual = collection.value(forKey: "stringCol") as! [String]!
         XCTAssertEqual(expected, actual!)
@@ -581,24 +581,24 @@ class ResultsWithCustomInitializerTest: TestCase {
 class ResultsFromTableTests: ResultsTests {
 
     override func collectionBaseInWriteTransaction() -> Results<CTTStringObjectWithLink> {
-        return realmWithTestPath().allObjects(ofType: CTTStringObjectWithLink.self)
+        return realmWithTestPath().objects(ofType: CTTStringObjectWithLink.self)
     }
 
     override func getAggregateableCollection() -> AnyRealmCollection<CTTAggregateObject> {
         _ = makeAggregateableObjects()
-        return AnyRealmCollection(realmWithTestPath().allObjects(ofType: CTTAggregateObject.self))
+        return AnyRealmCollection(realmWithTestPath().objects(ofType: CTTAggregateObject.self))
     }
 }
 
 class ResultsFromTableViewTests: ResultsTests {
 
     override func collectionBaseInWriteTransaction() -> Results<CTTStringObjectWithLink> {
-        return realmWithTestPath().allObjects(ofType: CTTStringObjectWithLink.self).filter(using: "stringCol != ''")
+        return realmWithTestPath().objects(ofType: CTTStringObjectWithLink.self).filter(using: "stringCol != ''")
     }
 
     override func getAggregateableCollection() -> AnyRealmCollection<CTTAggregateObject> {
         _ = makeAggregateableObjects()
-        return AnyRealmCollection(realmWithTestPath().allObjects(ofType: CTTAggregateObject.self).filter(using: "trueCol == true"))
+        return AnyRealmCollection(realmWithTestPath().objects(ofType: CTTAggregateObject.self).filter(using: "trueCol == true"))
     }
 }
 
@@ -608,7 +608,7 @@ class ResultsFromLinkViewTests: ResultsTests {
         guard let str1 = str1, let str2 = str2 else {
             fatalError("Test precondition failed")
         }
-        let array = realmWithTestPath().createObject(ofType: CTTStringList.self, populatedWith: [[str1, str2]])
+        let array = realmWithTestPath().createObject(CTTStringList.self, from: [[str1, str2]])
         return array.array.filter(using: Predicate(value: true))
     }
 
@@ -625,8 +625,8 @@ class ResultsFromLinkViewTests: ResultsTests {
     override func addObjectToResults() {
         let realm = realmWithTestPath()
         try! realm.write {
-            let array = realm.allObjects(ofType: CTTStringList.self).last!
-            array.array.append(realm.createObject(ofType: CTTStringObjectWithLink.self, populatedWith: ["a"]))
+            let array = realm.objects(ofType: CTTStringList.self).last!
+            array.array.append(realm.createObject(CTTStringObjectWithLink.self, from: ["a"]))
         }
     }
 }
@@ -869,15 +869,15 @@ class ListNewlyCreatedRealmCollectionTypeTests: ListRealmCollectionTypeTests {
         guard let str1 = str1, let str2 = str2 else {
             fatalError("Test precondition failure - a property was unexpectedly nil")
         }
-        let array = realmWithTestPath().createObject(ofType: CTTStringList.self, populatedWith: [[str1, str2] as AnyObject])
+        let array = realmWithTestPath().createObject(CTTStringList.self, from: [[str1, str2] as AnyObject])
         return array.array
     }
 
     override func getAggregateableCollection() -> AnyRealmCollection<CTTAggregateObject> {
         var list: CTTAggregateObjectList?
         try! realmWithTestPath().write {
-            list = realmWithTestPath().createObject(ofType: CTTAggregateObjectList.self,
-                                                    populatedWith: [makeAggregateableObjectsInWriteTransaction()])
+            list = realmWithTestPath().createObject(CTTAggregateObjectList.self,
+                                                    from: [makeAggregateableObjectsInWriteTransaction()])
         }
         return AnyRealmCollection(list!.list)
     }
@@ -888,17 +888,17 @@ class ListRetrievedRealmCollectionTypeTests: ListRealmCollectionTypeTests {
         guard let str1 = str1, let str2 = str2 else {
             fatalError("Test precondition failure - a property was unexpectedly nil")
         }
-        _ = realmWithTestPath().createObject(ofType: CTTStringList.self, populatedWith: [[str1, str2] as AnyObject])
-        let array = realmWithTestPath().allObjects(ofType: CTTStringList.self).first!
+        _ = realmWithTestPath().createObject(CTTStringList.self, from: [[str1, str2] as AnyObject])
+        let array = realmWithTestPath().objects(ofType: CTTStringList.self).first!
         return array.array
     }
 
     override func getAggregateableCollection() -> AnyRealmCollection<CTTAggregateObject> {
         var list: CTTAggregateObjectList?
         try! realmWithTestPath().write {
-            _ = realmWithTestPath().createObject(ofType: CTTAggregateObjectList.self,
-                                                 populatedWith: [makeAggregateableObjectsInWriteTransaction()])
-            list = realmWithTestPath().allObjects(ofType: CTTAggregateObjectList.self).first
+            _ = realmWithTestPath().createObject(CTTAggregateObjectList.self,
+                                                 from: [makeAggregateableObjectsInWriteTransaction()])
+            list = realmWithTestPath().objects(ofType: CTTAggregateObjectList.self).first
         }
         return AnyRealmCollection(list!.list)
     }
@@ -906,8 +906,8 @@ class ListRetrievedRealmCollectionTypeTests: ListRealmCollectionTypeTests {
 
 class LinkingObjectsCollectionTypeTests: RealmCollectionTypeTests {
     func collectionBaseInWriteTransaction() -> LinkingObjects<CTTStringObjectWithLink> {
-        let target = realmWithTestPath().createObject(ofType: CTTLinkTarget.self, populatedWith: [0])
-        for object in realmWithTestPath().allObjects(ofType: CTTStringObjectWithLink.self) {
+        let target = realmWithTestPath().createObject(CTTLinkTarget.self, from: [0])
+        for object in realmWithTestPath().objects(ofType: CTTStringObjectWithLink.self) {
             object.linkCol = target
         }
         return target.stringObjects
@@ -929,7 +929,7 @@ class LinkingObjectsCollectionTypeTests: RealmCollectionTypeTests {
         var target: CTTLinkTarget?
         try! realmWithTestPath().write {
             let objects = makeAggregateableObjectsInWriteTransaction()
-            target = realmWithTestPath().createObject(ofType: CTTLinkTarget.self, populatedWith: [0])
+            target = realmWithTestPath().createObject(CTTLinkTarget.self, from: [0])
             for object in objects {
                 object.linkCol = target
             }

--- a/RealmSwift/Tests/RealmTests.swift
+++ b/RealmSwift/Tests/RealmTests.swift
@@ -37,13 +37,13 @@ class RealmTests: TestCase {
             XCTAssertEqual(try! Realm().configuration.readOnly, false)
 
             try! Realm().write {
-                try! Realm().createObject(ofType: SwiftIntObject.self, populatedWith: [100])
+                try! Realm().createObject(SwiftIntObject.self, from: [100])
             }
         }
         let config = Realm.Configuration(fileURL: defaultRealmURL(), readOnly: true)
         let readOnlyRealm = try! Realm(configuration: config)
         XCTAssertEqual(true, readOnlyRealm.configuration.readOnly)
-        XCTAssertEqual(1, readOnlyRealm.allObjects(ofType: SwiftIntObject.self).count)
+        XCTAssertEqual(1, readOnlyRealm.objects(ofType: SwiftIntObject.self).count)
 
         assertThrows(try! Realm(), "Realm has different readOnly settings")
     }
@@ -58,7 +58,7 @@ class RealmTests: TestCase {
         autoreleasepool {
             let realm = try! Realm(fileURL: testRealmURL())
             try! realm.write {
-                realm.createObject(ofType: SwiftStringObject.self, populatedWith: ["a"])
+                realm.createObject(SwiftStringObject.self, from: ["a"])
             }
         }
 
@@ -73,7 +73,7 @@ class RealmTests: TestCase {
         assertSucceeds {
             let realm = try Realm(configuration:
                 Realm.Configuration(fileURL: testRealmURL(), readOnly: true))
-            XCTAssertEqual(1, realm.allObjects(ofType: SwiftStringObject.self).count)
+            XCTAssertEqual(1, realm.objects(ofType: SwiftStringObject.self).count)
         }
 
         try! fileManager.setAttributes([ FileAttributeKey.immutable: false ], ofItemAtPath: testRealmURL().path!)
@@ -129,14 +129,14 @@ class RealmTests: TestCase {
         XCTAssert(realm.isEmpty, "Realm should be empty on creation.")
 
         realm.beginWrite()
-        realm.createObject(ofType: SwiftStringObject.self, populatedWith: ["a"])
+        realm.createObject(SwiftStringObject.self, from: ["a"])
         XCTAssertFalse(realm.isEmpty, "Realm should not be empty within a write transaction after adding an object.")
         realm.cancelWrite()
 
         XCTAssertTrue(realm.isEmpty, "Realm should be empty after canceling a write transaction that added an object.")
 
         realm.beginWrite()
-        realm.createObject(ofType: SwiftStringObject.self, populatedWith: ["a"])
+        realm.createObject(SwiftStringObject.self, from: ["a"])
         try! realm.commitWrite()
         XCTAssertFalse(realm.isEmpty,
             "Realm should not be empty after committing a write transaction that added an object.")
@@ -166,23 +166,23 @@ class RealmTests: TestCase {
         autoreleasepool {
             let realm = inMemoryRealm("identifier")
             try! realm.write {
-                realm.createObject(ofType: SwiftIntObject.self, populatedWith: [1])
+                realm.createObject(SwiftIntObject.self, from: [1])
                 return
             }
         }
         let realm = inMemoryRealm("identifier")
-        XCTAssertEqual(realm.allObjects(ofType: SwiftIntObject.self).count, 0)
+        XCTAssertEqual(realm.objects(ofType: SwiftIntObject.self).count, 0)
 
         try! realm.write {
-            realm.createObject(ofType: SwiftIntObject.self, populatedWith: [1])
-            XCTAssertEqual(realm.allObjects(ofType: SwiftIntObject.self).count, 1)
+            realm.createObject(SwiftIntObject.self, from: [1])
+            XCTAssertEqual(realm.objects(ofType: SwiftIntObject.self).count, 1)
 
-            inMemoryRealm("identifier").createObject(ofType: SwiftIntObject.self, populatedWith: [1])
-            XCTAssertEqual(realm.allObjects(ofType: SwiftIntObject.self).count, 2)
+            inMemoryRealm("identifier").createObject(SwiftIntObject.self, from: [1])
+            XCTAssertEqual(realm.objects(ofType: SwiftIntObject.self).count, 2)
         }
 
         let realm2 = inMemoryRealm("identifier2")
-        XCTAssertEqual(realm2.allObjects(ofType: SwiftIntObject.self).count, 0)
+        XCTAssertEqual(realm2.objects(ofType: SwiftIntObject.self).count, 0)
     }
 
     func testInitCustomClassList() {
@@ -197,25 +197,25 @@ class RealmTests: TestCase {
         try! Realm().write {
             self.assertThrows(try! Realm().beginWrite())
             self.assertThrows(try! Realm().write { })
-            try! Realm().createObject(ofType: SwiftStringObject.self, populatedWith: ["1"])
-            XCTAssertEqual(try! Realm().allObjects(ofType: SwiftStringObject.self).count, 1)
+            try! Realm().createObject(SwiftStringObject.self, from: ["1"])
+            XCTAssertEqual(try! Realm().objects(ofType: SwiftStringObject.self).count, 1)
         }
-        XCTAssertEqual(try! Realm().allObjects(ofType: SwiftStringObject.self).count, 1)
+        XCTAssertEqual(try! Realm().objects(ofType: SwiftStringObject.self).count, 1)
     }
 
     func testDynamicWrite() {
         try! Realm().write {
             self.assertThrows(try! Realm().beginWrite())
             self.assertThrows(try! Realm().write { })
-            try! Realm().createDynamicObject(ofType: "SwiftStringObject", populatedWith: ["1"])
-            XCTAssertEqual(try! Realm().allObjects(ofType: SwiftStringObject.self).count, 1)
+            try! Realm().createDynamicObject(ofType: "SwiftStringObject", from: ["1"])
+            XCTAssertEqual(try! Realm().objects(ofType: SwiftStringObject.self).count, 1)
         }
-        XCTAssertEqual(try! Realm().allObjects(ofType: SwiftStringObject.self).count, 1)
+        XCTAssertEqual(try! Realm().objects(ofType: SwiftStringObject.self).count, 1)
     }
 
     func testDynamicWriteSubscripting() {
         try! Realm().beginWrite()
-        let object = try! Realm().createDynamicObject(ofType: "SwiftStringObject", populatedWith: ["1"])
+        let object = try! Realm().createDynamicObject(ofType: "SwiftStringObject", from: ["1"])
         try! Realm().commitWrite()
 
         XCTAssertNotNil(object, "Dynamic Object Creation Failed")
@@ -229,33 +229,33 @@ class RealmTests: TestCase {
         assertThrows(try! Realm().beginWrite())
         try! Realm().cancelWrite()
         try! Realm().beginWrite()
-        try! Realm().createObject(ofType: SwiftStringObject.self, populatedWith: ["1"])
-        XCTAssertEqual(try! Realm().allObjects(ofType: SwiftStringObject.self).count, 1)
+        try! Realm().createObject(SwiftStringObject.self, from: ["1"])
+        XCTAssertEqual(try! Realm().objects(ofType: SwiftStringObject.self).count, 1)
     }
 
     func testCommitWrite() {
         try! Realm().beginWrite()
-        try! Realm().createObject(ofType: SwiftStringObject.self, populatedWith: ["1"])
+        try! Realm().createObject(SwiftStringObject.self, from: ["1"])
         try! Realm().commitWrite()
-        XCTAssertEqual(try! Realm().allObjects(ofType: SwiftStringObject.self).count, 1)
+        XCTAssertEqual(try! Realm().objects(ofType: SwiftStringObject.self).count, 1)
         try! Realm().beginWrite()
     }
 
     func testCancelWrite() {
         assertThrows(try! Realm().cancelWrite())
         try! Realm().beginWrite()
-        try! Realm().createObject(ofType: SwiftStringObject.self, populatedWith: ["1"])
+        try! Realm().createObject(SwiftStringObject.self, from: ["1"])
         try! Realm().cancelWrite()
-        XCTAssertEqual(try! Realm().allObjects(ofType: SwiftStringObject.self).count, 0)
+        XCTAssertEqual(try! Realm().objects(ofType: SwiftStringObject.self).count, 0)
 
         try! Realm().write {
             self.assertThrows(self.realmWithTestPath().cancelWrite())
-            let object = try! Realm().createObject(ofType: SwiftStringObject.self)
+            let object = try! Realm().createObject(SwiftStringObject.self)
             try! Realm().cancelWrite()
             XCTAssertTrue(object.isInvalidated)
-            XCTAssertEqual(try! Realm().allObjects(ofType: SwiftStringObject.self).count, 0)
+            XCTAssertEqual(try! Realm().objects(ofType: SwiftStringObject.self).count, 0)
         }
-        XCTAssertEqual(try! Realm().allObjects(ofType: SwiftStringObject.self).count, 0)
+        XCTAssertEqual(try! Realm().objects(ofType: SwiftStringObject.self).count, 0)
     }
 
     func testInWriteTransaction() {
@@ -278,16 +278,16 @@ class RealmTests: TestCase {
     func testAddSingleObject() {
         let realm = try! Realm()
         assertThrows(_ = realm.add(SwiftObject()))
-        XCTAssertEqual(0, realm.allObjects(ofType: SwiftObject.self).count)
+        XCTAssertEqual(0, realm.objects(ofType: SwiftObject.self).count)
         var defaultRealmObject: SwiftObject!
         try! realm.write {
             defaultRealmObject = SwiftObject()
             realm.add(defaultRealmObject)
-            XCTAssertEqual(1, realm.allObjects(ofType: SwiftObject.self).count)
+            XCTAssertEqual(1, realm.objects(ofType: SwiftObject.self).count)
             realm.add(defaultRealmObject)
-            XCTAssertEqual(1, realm.allObjects(ofType: SwiftObject.self).count)
+            XCTAssertEqual(1, realm.objects(ofType: SwiftObject.self).count)
         }
-        XCTAssertEqual(1, realm.allObjects(ofType: SwiftObject.self).count)
+        XCTAssertEqual(1, realm.objects(ofType: SwiftObject.self).count)
 
         let testRealm = realmWithTestPath()
         try! testRealm.write {
@@ -297,16 +297,16 @@ class RealmTests: TestCase {
 
     func testAddWithUpdateSingleObject() {
         let realm = try! Realm()
-        XCTAssertEqual(0, realm.allObjects(ofType: SwiftPrimaryStringObject.self).count)
+        XCTAssertEqual(0, realm.objects(ofType: SwiftPrimaryStringObject.self).count)
         var defaultRealmObject: SwiftPrimaryStringObject!
         try! realm.write {
             defaultRealmObject = SwiftPrimaryStringObject()
             realm.add(defaultRealmObject, update: true)
-            XCTAssertEqual(1, realm.allObjects(ofType: SwiftPrimaryStringObject.self).count)
+            XCTAssertEqual(1, realm.objects(ofType: SwiftPrimaryStringObject.self).count)
             realm.add(SwiftPrimaryStringObject(), update: true)
-            XCTAssertEqual(1, realm.allObjects(ofType: SwiftPrimaryStringObject.self).count)
+            XCTAssertEqual(1, realm.objects(ofType: SwiftPrimaryStringObject.self).count)
         }
-        XCTAssertEqual(1, realm.allObjects(ofType: SwiftPrimaryStringObject.self).count)
+        XCTAssertEqual(1, realm.objects(ofType: SwiftPrimaryStringObject.self).count)
 
         let testRealm = realmWithTestPath()
         try! testRealm.write {
@@ -317,33 +317,33 @@ class RealmTests: TestCase {
     func testAddMultipleObjects() {
         let realm = try! Realm()
         assertThrows(_ = realm.add([SwiftObject(), SwiftObject()]))
-        XCTAssertEqual(0, realm.allObjects(ofType: SwiftObject.self).count)
+        XCTAssertEqual(0, realm.objects(ofType: SwiftObject.self).count)
         try! realm.write {
             let objs = [SwiftObject(), SwiftObject()]
             realm.add(objs)
-            XCTAssertEqual(2, realm.allObjects(ofType: SwiftObject.self).count)
+            XCTAssertEqual(2, realm.objects(ofType: SwiftObject.self).count)
         }
-        XCTAssertEqual(2, realm.allObjects(ofType: SwiftObject.self).count)
+        XCTAssertEqual(2, realm.objects(ofType: SwiftObject.self).count)
 
         let testRealm = realmWithTestPath()
         try! testRealm.write {
-            self.assertThrows(_ = testRealm.add(realm.allObjects(ofType: SwiftObject.self)))
+            self.assertThrows(_ = testRealm.add(realm.objects(ofType: SwiftObject.self)))
         }
     }
 
     func testAddWithUpdateMultipleObjects() {
         let realm = try! Realm()
-        XCTAssertEqual(0, realm.allObjects(ofType: SwiftPrimaryStringObject.self).count)
+        XCTAssertEqual(0, realm.objects(ofType: SwiftPrimaryStringObject.self).count)
         try! realm.write {
             let objs = [SwiftPrimaryStringObject(), SwiftPrimaryStringObject()]
             realm.add(objs, update: true)
-            XCTAssertEqual(1, realm.allObjects(ofType: SwiftPrimaryStringObject.self).count)
+            XCTAssertEqual(1, realm.objects(ofType: SwiftPrimaryStringObject.self).count)
         }
-        XCTAssertEqual(1, realm.allObjects(ofType: SwiftPrimaryStringObject.self).count)
+        XCTAssertEqual(1, realm.objects(ofType: SwiftPrimaryStringObject.self).count)
 
         let testRealm = realmWithTestPath()
         try! testRealm.write {
-            self.assertThrows(_ = testRealm.add(realm.allObjects(ofType: SwiftPrimaryStringObject.self), update: true))
+            self.assertThrows(_ = testRealm.add(realm.objects(ofType: SwiftPrimaryStringObject.self), update: true))
         }
     }
 
@@ -351,20 +351,20 @@ class RealmTests: TestCase {
 
     func testDeleteSingleObject() {
         let realm = try! Realm()
-        XCTAssertEqual(0, realm.allObjects(ofType: SwiftObject.self).count)
+        XCTAssertEqual(0, realm.objects(ofType: SwiftObject.self).count)
         assertThrows(_ = realm.delete(SwiftObject()))
         var defaultRealmObject: SwiftObject!
         try! realm.write {
             defaultRealmObject = SwiftObject()
             self.assertThrows(_ = realm.delete(defaultRealmObject))
-            XCTAssertEqual(0, realm.allObjects(ofType: SwiftObject.self).count)
+            XCTAssertEqual(0, realm.objects(ofType: SwiftObject.self).count)
             realm.add(defaultRealmObject)
-            XCTAssertEqual(1, realm.allObjects(ofType: SwiftObject.self).count)
+            XCTAssertEqual(1, realm.objects(ofType: SwiftObject.self).count)
             realm.delete(defaultRealmObject)
-            XCTAssertEqual(0, realm.allObjects(ofType: SwiftObject.self).count)
+            XCTAssertEqual(0, realm.objects(ofType: SwiftObject.self).count)
         }
         assertThrows(_ = realm.delete(defaultRealmObject))
-        XCTAssertEqual(0, realm.allObjects(ofType: SwiftObject.self).count)
+        XCTAssertEqual(0, realm.objects(ofType: SwiftObject.self).count)
 
         let testRealm = realmWithTestPath()
         assertThrows(_ = testRealm.delete(defaultRealmObject))
@@ -375,16 +375,16 @@ class RealmTests: TestCase {
 
     func testDeleteSequenceOfObjects() {
         let realm = try! Realm()
-        XCTAssertEqual(0, realm.allObjects(ofType: SwiftObject.self).count)
+        XCTAssertEqual(0, realm.objects(ofType: SwiftObject.self).count)
         var objs: [SwiftObject]!
         try! realm.write {
             objs = [SwiftObject(), SwiftObject()]
             realm.add(objs)
-            XCTAssertEqual(2, realm.allObjects(ofType: SwiftObject.self).count)
+            XCTAssertEqual(2, realm.objects(ofType: SwiftObject.self).count)
             realm.delete(objs)
-            XCTAssertEqual(0, realm.allObjects(ofType: SwiftObject.self).count)
+            XCTAssertEqual(0, realm.objects(ofType: SwiftObject.self).count)
         }
-        XCTAssertEqual(0, realm.allObjects(ofType: SwiftObject.self).count)
+        XCTAssertEqual(0, realm.objects(ofType: SwiftObject.self).count)
 
         let testRealm = realmWithTestPath()
         assertThrows(_ = testRealm.delete(objs))
@@ -395,74 +395,74 @@ class RealmTests: TestCase {
 
     func testDeleteListOfObjects() {
         let realm = try! Realm()
-        XCTAssertEqual(0, realm.allObjects(ofType: SwiftCompanyObject.self).count)
+        XCTAssertEqual(0, realm.objects(ofType: SwiftCompanyObject.self).count)
         try! realm.write {
             let obj = SwiftCompanyObject()
             obj.employees.append(SwiftEmployeeObject())
             realm.add(obj)
-            XCTAssertEqual(1, realm.allObjects(ofType: SwiftEmployeeObject.self).count)
+            XCTAssertEqual(1, realm.objects(ofType: SwiftEmployeeObject.self).count)
             realm.delete(obj.employees)
             XCTAssertEqual(0, obj.employees.count)
-            XCTAssertEqual(0, realm.allObjects(ofType: SwiftEmployeeObject.self).count)
+            XCTAssertEqual(0, realm.objects(ofType: SwiftEmployeeObject.self).count)
         }
-        XCTAssertEqual(0, realm.allObjects(ofType: SwiftEmployeeObject.self).count)
+        XCTAssertEqual(0, realm.objects(ofType: SwiftEmployeeObject.self).count)
     }
 
     func testDeleteResults() {
         let realm = try! Realm(fileURL: testRealmURL())
-        XCTAssertEqual(0, realm.allObjects(ofType: SwiftCompanyObject.self).count)
+        XCTAssertEqual(0, realm.objects(ofType: SwiftCompanyObject.self).count)
         try! realm.write {
             realm.add(SwiftIntObject(value: [1]))
             realm.add(SwiftIntObject(value: [1]))
             realm.add(SwiftIntObject(value: [2]))
-            XCTAssertEqual(3, realm.allObjects(ofType: SwiftIntObject.self).count)
-            realm.delete(realm.allObjects(ofType: SwiftIntObject.self).filter(using: "intCol = 1"))
-            XCTAssertEqual(1, realm.allObjects(ofType: SwiftIntObject.self).count)
+            XCTAssertEqual(3, realm.objects(ofType: SwiftIntObject.self).count)
+            realm.delete(realm.objects(ofType: SwiftIntObject.self).filter(using: "intCol = 1"))
+            XCTAssertEqual(1, realm.objects(ofType: SwiftIntObject.self).count)
         }
-        XCTAssertEqual(1, realm.allObjects(ofType: SwiftIntObject.self).count)
+        XCTAssertEqual(1, realm.objects(ofType: SwiftIntObject.self).count)
     }
 
     func testDeleteAll() {
         let realm = try! Realm()
         try! realm.write {
             realm.add(SwiftObject())
-            XCTAssertEqual(1, realm.allObjects(ofType: SwiftObject.self).count)
+            XCTAssertEqual(1, realm.objects(ofType: SwiftObject.self).count)
             realm.deleteAllObjects()
-            XCTAssertEqual(0, realm.allObjects(ofType: SwiftObject.self).count)
+            XCTAssertEqual(0, realm.objects(ofType: SwiftObject.self).count)
         }
-        XCTAssertEqual(0, realm.allObjects(ofType: SwiftObject.self).count)
+        XCTAssertEqual(0, realm.objects(ofType: SwiftObject.self).count)
     }
 
     func testObjects() {
         try! Realm().write {
-            try! Realm().createObject(ofType: SwiftIntObject.self, populatedWith: [100])
-            try! Realm().createObject(ofType: SwiftIntObject.self, populatedWith: [200])
-            try! Realm().createObject(ofType: SwiftIntObject.self, populatedWith: [300])
+            try! Realm().createObject(SwiftIntObject.self, from: [100])
+            try! Realm().createObject(SwiftIntObject.self, from: [200])
+            try! Realm().createObject(SwiftIntObject.self, from: [300])
         }
 
-        XCTAssertEqual(0, try! Realm().allObjects(ofType: SwiftStringObject.self).count)
-        XCTAssertEqual(3, try! Realm().allObjects(ofType: SwiftIntObject.self).count)
-        assertThrows(try! Realm().allObjects(ofType: Object.self))
+        XCTAssertEqual(0, try! Realm().objects(ofType: SwiftStringObject.self).count)
+        XCTAssertEqual(3, try! Realm().objects(ofType: SwiftIntObject.self).count)
+        assertThrows(try! Realm().objects(ofType: Object.self))
     }
 
     func testDynamicObjects() {
         try! Realm().write {
-            try! Realm().createObject(ofType: SwiftIntObject.self, populatedWith: [100])
-            try! Realm().createObject(ofType: SwiftIntObject.self, populatedWith: [200])
-            try! Realm().createObject(ofType: SwiftIntObject.self, populatedWith: [300])
+            try! Realm().createObject(SwiftIntObject.self, from: [100])
+            try! Realm().createObject(SwiftIntObject.self, from: [200])
+            try! Realm().createObject(SwiftIntObject.self, from: [300])
         }
 
-        XCTAssertEqual(0, try! Realm().allDynamicObjects(ofType: "SwiftStringObject").count)
-        XCTAssertEqual(3, try! Realm().allDynamicObjects(ofType: "SwiftIntObject").count)
-        assertThrows(try! Realm().allDynamicObjects(ofType: "Object"))
+        XCTAssertEqual(0, try! Realm().dynamicObjects(ofType: "SwiftStringObject").count)
+        XCTAssertEqual(3, try! Realm().dynamicObjects(ofType: "SwiftIntObject").count)
+        assertThrows(try! Realm().dynamicObjects(ofType: "Object"))
     }
 
     func testDynamicObjectProperties() {
         try! Realm().write {
-            try! Realm().createObject(ofType: SwiftObject.self)
+            try! Realm().createObject(SwiftObject.self)
         }
 
-        let object = try! Realm().allDynamicObjects(ofType: "SwiftObject")[0]
+        let object = try! Realm().dynamicObjects(ofType: "SwiftObject")[0]
         let dictionary = SwiftObject.defaultValues()
 
         XCTAssertEqual(object["boolCol"] as? NSNumber, dictionary["boolCol"] as! NSNumber?)
@@ -477,10 +477,10 @@ class RealmTests: TestCase {
 
     func testDynamicObjectOptionalProperties() {
         try! Realm().write {
-            try! Realm().createObject(ofType: SwiftOptionalDefaultValuesObject.self)
+            try! Realm().createObject(SwiftOptionalDefaultValuesObject.self)
         }
 
-        let object = try! Realm().allDynamicObjects(ofType: "SwiftOptionalDefaultValuesObject")[0]
+        let object = try! Realm().dynamicObjects(ofType: "SwiftOptionalDefaultValuesObject")[0]
         let dictionary = SwiftOptionalDefaultValuesObject.defaultValues()
 
         XCTAssertEqual(object["optIntCol"] as? NSNumber, dictionary["optIntCol"] as! NSNumber?)
@@ -511,20 +511,20 @@ class RealmTests: TestCase {
 
         let realm = try! Realm()
         try! realm.write {
-            realm.createObject(ofType: SwiftPrimaryStringObject.self, populatedWith: ["a", 1])
-            realm.createObject(ofType: SwiftPrimaryStringObject.self, populatedWith: ["b", 2])
+            realm.createObject(SwiftPrimaryStringObject.self, from: ["a", 1])
+            realm.createObject(SwiftPrimaryStringObject.self, from: ["b", 2])
 
-            realm.createObject(ofType: SwiftPrimaryOptionalStringObject.self, populatedWith: [NSNull(), 1])
-            realm.createObject(ofType: SwiftPrimaryOptionalStringObject.self, populatedWith: ["b", 2])
+            realm.createObject(SwiftPrimaryOptionalStringObject.self, from: [NSNull(), 1])
+            realm.createObject(SwiftPrimaryOptionalStringObject.self, from: ["b", 2])
 
             func createIntObject(_ objectType: Object.Type) {
-                realm.createObject(ofType: objectType, populatedWith: ["a", 1])
-                realm.createObject(ofType: objectType, populatedWith: ["b", 2])
+                realm.createObject(objectType, from: ["a", 1])
+                realm.createObject(objectType, from: ["b", 2])
             }
 
             func createOptionalIntObject(_ objectType: Object.Type) {
-                realm.createObject(ofType: objectType, populatedWith: ["a", NSNull()])
-                realm.createObject(ofType: objectType, populatedWith: ["b", 2])
+                realm.createObject(objectType, from: ["a", NSNull()])
+                realm.createObject(objectType, from: ["b", 2])
             }
 
             for type in intTypes {
@@ -588,8 +588,8 @@ class RealmTests: TestCase {
     func testDynamicObjectForPrimaryKey() {
         let realm = try! Realm()
         try! realm.write {
-            realm.createObject(ofType: SwiftPrimaryStringObject.self, populatedWith: ["a", 1])
-            realm.createObject(ofType: SwiftPrimaryStringObject.self, populatedWith: ["b", 2])
+            realm.createObject(SwiftPrimaryStringObject.self, from: ["a", 1])
+            realm.createObject(SwiftPrimaryStringObject.self, from: ["b", 2])
         }
 
         XCTAssertNotNil(realm.dynamicObject(ofType: "SwiftPrimaryStringObject", forPrimaryKey: "a"))
@@ -599,7 +599,7 @@ class RealmTests: TestCase {
     func testDynamicObjectForPrimaryKeySubscripting() {
         let realm = try! Realm()
         try! realm.write {
-            realm.createObject(ofType: SwiftPrimaryStringObject.self, populatedWith: ["a", 1])
+            realm.createObject(SwiftPrimaryStringObject.self, from: ["a", 1])
         }
 
         let object = realm.dynamicObject(ofType: "SwiftPrimaryStringObject", forPrimaryKey: "a")
@@ -653,14 +653,14 @@ class RealmTests: TestCase {
         dispatchSyncNewThread {
             let realm = try! Realm()
             try! realm.write {
-                realm.createObject(ofType: SwiftStringObject.self, populatedWith: ["string"])
+                realm.createObject(SwiftStringObject.self, from: ["string"])
             }
         }
         waitForExpectations(timeout: 1, handler: nil)
         token.stop()
 
         // get object
-        let results = realm.allObjects(ofType: SwiftStringObject.self
+        let results = realm.objects(ofType: SwiftStringObject.self
         )
         XCTAssertEqual(results.count, Int(1), "There should be 1 object of type StringObject")
         XCTAssertEqual(results[0].stringCol, "string", "Value of first column should be 'string'")
@@ -678,12 +678,12 @@ class RealmTests: TestCase {
             notificationFired.fulfill()
         }
 
-        let results = realm.allObjects(ofType: SwiftStringObject.self)
+        let results = realm.objects(ofType: SwiftStringObject.self)
         XCTAssertEqual(results.count, Int(0), "There should be 1 object of type StringObject")
 
         dispatchSyncNewThread {
             try! Realm().write {
-                try! Realm().createObject(ofType: SwiftStringObject.self, populatedWith: ["string"])
+                try! Realm().createObject(SwiftStringObject.self, from: ["string"])
                 return
             }
         }
@@ -713,7 +713,7 @@ class RealmTests: TestCase {
             realm.add(SwiftObject())
             return
         }
-        XCTAssertEqual(realm.allObjects(ofType: SwiftObject.self).count, 2)
+        XCTAssertEqual(realm.objects(ofType: SwiftObject.self).count, 2)
         XCTAssertEqual(object.isInvalidated, true)
     }
 
@@ -730,7 +730,7 @@ class RealmTests: TestCase {
         }
         autoreleasepool {
             let copy = try! Realm(fileURL: fileURL)
-            XCTAssertEqual(1, copy.allObjects(ofType: SwiftObject.self).count)
+            XCTAssertEqual(1, copy.objects(ofType: SwiftObject.self).count)
         }
         try! FileManager.default.removeItem(at: fileURL)
     }

--- a/RealmSwift/Tests/SwiftLinkTests.swift
+++ b/RealmSwift/Tests/SwiftLinkTests.swift
@@ -33,8 +33,8 @@ class SwiftLinkTests: TestCase {
 
         try! realm.write { realm.add(owner) }
 
-        let owners = realm.allObjects(ofType: SwiftOwnerObject.self)
-        let dogs = realm.allObjects(ofType: SwiftDogObject.self)
+        let owners = realm.objects(ofType: SwiftOwnerObject.self)
+        let dogs = realm.objects(ofType: SwiftDogObject.self)
         XCTAssertEqual(owners.count, Int(1), "Expecting 1 owner")
         XCTAssertEqual(dogs.count, Int(1), "Expecting 1 dog")
         XCTAssertEqual(owners[0].name, "Tim", "Tim is named Tim")
@@ -53,16 +53,16 @@ class SwiftLinkTests: TestCase {
 
         try! realm.write { realm.add(owner) }
 
-        XCTAssertEqual(realm.allObjects(ofType: SwiftOwnerObject.self).count, Int(1), "Expecting 1 owner")
-        XCTAssertEqual(realm.allObjects(ofType: SwiftDogObject.self).count, Int(1), "Expecting 1 dog")
+        XCTAssertEqual(realm.objects(ofType: SwiftOwnerObject.self).count, Int(1), "Expecting 1 owner")
+        XCTAssertEqual(realm.objects(ofType: SwiftDogObject.self).count, Int(1), "Expecting 1 dog")
 
         realm.beginWrite()
-        let fiel = realm.createObject(ofType: SwiftOwnerObject.self, populatedWith: ["Fiel", NSNull()])
+        let fiel = realm.createObject(SwiftOwnerObject.self, from: ["Fiel", NSNull()])
         fiel.dog = owner.dog
         try! realm.commitWrite()
 
-        XCTAssertEqual(realm.allObjects(ofType: SwiftOwnerObject.self).count, Int(2), "Expecting 2 owners")
-        XCTAssertEqual(realm.allObjects(ofType: SwiftDogObject.self).count, Int(1), "Expecting 1 dog")
+        XCTAssertEqual(realm.objects(ofType: SwiftOwnerObject.self).count, Int(2), "Expecting 2 owners")
+        XCTAssertEqual(realm.objects(ofType: SwiftDogObject.self).count, Int(1), "Expecting 1 dog")
     }
 
     func testLinkRemoval() {
@@ -75,18 +75,18 @@ class SwiftLinkTests: TestCase {
 
         try! realm.write { realm.add(owner) }
 
-        XCTAssertEqual(realm.allObjects(ofType: SwiftOwnerObject.self).count, Int(1), "Expecting 1 owner")
-        XCTAssertEqual(realm.allObjects(ofType: SwiftDogObject.self).count, Int(1), "Expecting 1 dog")
+        XCTAssertEqual(realm.objects(ofType: SwiftOwnerObject.self).count, Int(1), "Expecting 1 owner")
+        XCTAssertEqual(realm.objects(ofType: SwiftDogObject.self).count, Int(1), "Expecting 1 dog")
 
         try! realm.write { realm.delete(owner.dog!) }
 
         XCTAssertNil(owner.dog, "Dog should be nullified when deleted")
 
         // refresh owner and check
-        let owner2 = realm.allObjects(ofType: SwiftOwnerObject.self).first!
+        let owner2 = realm.objects(ofType: SwiftOwnerObject.self).first!
         XCTAssertNotNil(owner2, "Should have 1 owner")
         XCTAssertNil(owner2.dog, "Dog should be nullified when deleted")
-        XCTAssertEqual(realm.allObjects(ofType: SwiftDogObject.self).count, Int(0), "Expecting 0 dogs")
+        XCTAssertEqual(realm.objects(ofType: SwiftDogObject.self).count, Int(0), "Expecting 0 dogs")
     }
 
     func testLinkingObjects() {

--- a/RealmSwift/Tests/SwiftUnicodeTests.swift
+++ b/RealmSwift/Tests/SwiftUnicodeTests.swift
@@ -28,32 +28,32 @@ class SwiftUnicodeTests: TestCase {
         let realm = realmWithTestPath()
 
         try! realm.write {
-            realm.createObject(ofType: SwiftStringObject.self, populatedWith: [utf8TestString] as AnyObject)
+            realm.createObject(SwiftStringObject.self, from: [utf8TestString] as AnyObject)
             return
         }
 
-        let obj1 = realm.allObjects(ofType: SwiftStringObject.self).first!
+        let obj1 = realm.objects(ofType: SwiftStringObject.self).first!
         XCTAssertEqual(obj1.stringCol, utf8TestString)
 
-        let obj2 = realm.allObjects(ofType: SwiftStringObject.self).filter(using: "stringCol == %@", utf8TestString as AnyObject).first!
+        let obj2 = realm.objects(ofType: SwiftStringObject.self).filter(using: "stringCol == %@", utf8TestString as AnyObject).first!
         XCTAssertEqual(obj1, obj2)
         XCTAssertEqual(obj2.stringCol, utf8TestString)
 
-        XCTAssertEqual(Int(0), realm.allObjects(ofType: SwiftStringObject.self).filter(using: "stringCol != %@", utf8TestString as AnyObject).count)
+        XCTAssertEqual(Int(0), realm.objects(ofType: SwiftStringObject.self).filter(using: "stringCol != %@", utf8TestString as AnyObject).count)
     }
 
     func testUTF8PropertyWithUTF8StringContents() {
         let realm = realmWithTestPath()
         try! realm.write {
-            realm.createObject(ofType: SwiftUTF8Object.self, populatedWith: [utf8TestString] as AnyObject)
+            realm.createObject(SwiftUTF8Object.self, from: [utf8TestString] as AnyObject)
             return
         }
 
-        let obj1 = realm.allObjects(ofType: SwiftUTF8Object.self).first!
+        let obj1 = realm.objects(ofType: SwiftUTF8Object.self).first!
         XCTAssertEqual(obj1.柱колоéнǢкƱаم👍, utf8TestString,
             "Storing and retrieving a string with UTF8 content should work")
 
-        let obj2 = realm.allObjects(ofType: SwiftUTF8Object.self).filter(using: "%K == %@", "柱колоéнǢкƱаم👍", utf8TestString as AnyObject).first!
+        let obj2 = realm.objects(ofType: SwiftUTF8Object.self).filter(using: "%K == %@", "柱колоéнǢкƱаم👍", utf8TestString as AnyObject).first!
         XCTAssertEqual(obj1, obj2, "Querying a realm searching for a string with UTF8 content should work")
     }
 }


### PR DESCRIPTION
@bdash @jadengeller @jpsim @tgoyne 

Changes:
- 'createObject(ofType:populatedWith:)' is now 'createObject(_:from:)'
- 'createDynamicObject(ofType:populatedWith:)' is now 'createDynamicObject(ofType:from:)'
- 'allObjects(ofType:)' is now 'objects(ofType:)'
- 'allDynamicObjects(ofType:)' is now 'dynamicObjects(ofType:)'