### PR TITLE
[DynamicObjects] Fix to fail iterating Results of DynamicObject

### DIFF
--- a/RealmSwift/RealmCollection.swift
+++ b/RealmSwift/RealmCollection.swift
@@ -34,7 +34,7 @@ public final class RLMIterator<T: Object>: IteratorProtocol {
 
     /// Advance to the next element and return it, or `nil` if no next element exists.
     public func next() -> T? { // swiftlint:disable:this valid_docs
-        let accessor = generatorBase.next() as! T?
+        let accessor = unsafeBitCast(generatorBase.next() as! Object?, to: Optional<T>.self)
         if let accessor = accessor {
             RLMInitializeSwiftAccessorGenerics(accessor)
         }
@@ -817,7 +817,7 @@ public final class RLMGenerator<T: Object>: GeneratorType {
 
     /// Advance to the next element and return it, or `nil` if no next element exists.
     public func next() -> T? { // swiftlint:disable:this valid_docs
-        let accessor = generatorBase.next() as! T?
+        let accessor = unsafeBitCast(generatorBase.next() as! Object?, Optional<T>.self)
         if let accessor = accessor {
             RLMInitializeSwiftAccessorGenerics(accessor)
         }

--- a/RealmSwift/Tests/RealmTests.swift
+++ b/RealmSwift/Tests/RealmTests.swift
@@ -515,6 +515,28 @@ class RealmTests: TestCase {
         XCTAssertEqual((object["optObjectCol"] as? SwiftBoolObject)?.boolCol, true)
     }
 
+    func testIterateDynamicObjects() {
+        try! Realm().write {
+            for _ in 1..<3 {
+                try! Realm().create(SwiftObject.self)
+            }
+        }
+
+        let objects = try! Realm().dynamicObjects("SwiftObject")
+        let dictionary = SwiftObject.defaultValues()
+
+        for object in objects {
+            XCTAssertEqual(object["boolCol"] as? NSNumber, dictionary["boolCol"] as! NSNumber?)
+            XCTAssertEqual(object["intCol"] as? NSNumber, dictionary["intCol"] as! NSNumber?)
+            XCTAssertEqual(object["floatCol"] as? NSNumber, dictionary["floatCol"] as! NSNumber?)
+            XCTAssertEqual(object["doubleCol"] as? NSNumber, dictionary["doubleCol"] as! NSNumber?)
+            XCTAssertEqual(object["stringCol"] as! String?, dictionary["stringCol"] as! String?)
+            XCTAssertEqual(object["binaryCol"] as! NSData?, dictionary["binaryCol"] as! NSData?)
+            XCTAssertEqual(object["dateCol"] as! Date?, dictionary["dateCol"] as! Date?)
+            XCTAssertEqual((object["objectCol"] as? SwiftBoolObject)?.boolCol, false)
+        }
+    }
+
     func testIntPrimaryKey() {
         func testIntPrimaryKey<O: Object>(for type: O.Type)
             where O: SwiftPrimaryKeyObjectType, O.PrimaryKey: ExpressibleByIntegerLiteral {
@@ -1257,6 +1279,28 @@ class RealmTests: TestCase {
         XCTAssertEqual(object["optBinaryCol"] as! NSData?, dictionary["optBinaryCol"] as! NSData?)
         XCTAssertEqual(object["optDateCol"] as! NSDate?, dictionary["optDateCol"] as! NSDate?)
         XCTAssertEqual(object["optObjectCol"]?.boolCol, true)
+    }
+
+    func testIterateDynamicObjects() {
+        try! Realm().write {
+            for _ in 1..<3 {
+                try! Realm().create(SwiftObject)
+            }
+        }
+
+        let objects = try! Realm().dynamicObjects("SwiftObject")
+        let dictionary = SwiftObject.defaultValues()
+
+        for object in objects {
+            XCTAssertEqual(object["boolCol"] as? NSNumber, dictionary["boolCol"] as! NSNumber?)
+            XCTAssertEqual(object["intCol"] as? NSNumber, dictionary["intCol"] as! NSNumber?)
+            XCTAssertEqual(object["floatCol"] as? NSNumber, dictionary["floatCol"] as! Float?)
+            XCTAssertEqual(object["doubleCol"] as? NSNumber, dictionary["doubleCol"] as! Double?)
+            XCTAssertEqual(object["stringCol"] as! String?, dictionary["stringCol"] as! String?)
+            XCTAssertEqual(object["binaryCol"] as! NSData?, dictionary["binaryCol"] as! NSData?)
+            XCTAssertEqual(object["dateCol"] as! NSDate?, dictionary["dateCol"] as! NSDate?)
+            XCTAssertEqual(object["objectCol"]?.boolCol, false)
+        }
     }
 
     func testIntPrimaryKey() {


### PR DESCRIPTION
The following code will crash because cannot cast `Results<T>` to `Results<DynamicObject>`

```
let objects = try! Realm().dynamicObjects("SwiftObject")
for object in objects {
```

This PR to fix that to use `unsafeBitCast()` instead force cast.

Related https://github.com/realm/realm-cocoa/pull/2848

CC @bdash @mrackwitz 
