### PR TITLE
[DynamicObject] Fix to fail retrieving `List` from `DynamicObject`

### DIFF
--- a/RealmSwift/List.swift
+++ b/RealmSwift/List.swift
@@ -130,10 +130,10 @@ public final class List<T: Object>: ListBase {
     }
 
     /// Returns the first object in the list, or `nil` if the list is empty.
-    public var first: T? { return _rlmArray.firstObject() as! T? }
+    public var first: T? { return unsafeBitCast(_rlmArray.firstObject(), to: Optional<T>.self) }
 
     /// Returns the last object in the list, or `nil` if the list is empty.
-    public var last: T? { return _rlmArray.lastObject() as! T? }
+    public var last: T? { return unsafeBitCast(_rlmArray.lastObject(), to: Optional<T>.self) }
 
     // MARK: KVC
 
@@ -639,7 +639,7 @@ public final class List<T: Object>: ListBase {
     public subscript(index: Int) -> T {
         get {
             throwForNegativeIndex(index)
-            return _rlmArray[UInt(index)] as! T
+            return unsafeBitCast(_rlmArray[UInt(index)], T.self)
         }
         set {
             throwForNegativeIndex(index)
@@ -648,10 +648,10 @@ public final class List<T: Object>: ListBase {
     }
 
     /// Returns the first object in the list, or `nil` if the list is empty.
-    public var first: T? { return _rlmArray.firstObject() as! T? }
+    public var first: T? { return unsafeBitCast(_rlmArray.firstObject(), Optional<T>.self) }
 
     /// Returns the last object in the list, or `nil` if the list is empty.
-    public var last: T? { return _rlmArray.lastObject() as! T? }
+    public var last: T? { return unsafeBitCast(_rlmArray.lastObject(), Optional<T>.self) }
 
     // MARK: KVC
 

--- a/RealmSwift/RealmCollection.swift
+++ b/RealmSwift/RealmCollection.swift
@@ -34,7 +34,7 @@ public final class RLMIterator<T: Object>: IteratorProtocol {
 
     /// Advance to the next element and return it, or `nil` if no next element exists.
     public func next() -> T? { // swiftlint:disable:this valid_docs
-        let accessor = generatorBase.next() as! T?
+        let accessor = unsafeBitCast(generatorBase.next() as! Object?, to: Optional<T>.self)
         if let accessor = accessor {
             RLMInitializeSwiftAccessorGenerics(accessor)
         }
@@ -817,7 +817,7 @@ public final class RLMGenerator<T: Object>: GeneratorType {
 
     /// Advance to the next element and return it, or `nil` if no next element exists.
     public func next() -> T? { // swiftlint:disable:this valid_docs
-        let accessor = generatorBase.next() as! T?
+        let accessor = unsafeBitCast(generatorBase.next() as! Object?, Optional<T>.self)
         if let accessor = accessor {
             RLMInitializeSwiftAccessorGenerics(accessor)
         }

--- a/RealmSwift/Tests/RealmTests.swift
+++ b/RealmSwift/Tests/RealmTests.swift
@@ -515,6 +515,28 @@ class RealmTests: TestCase {
         XCTAssertEqual((object["optObjectCol"] as? SwiftBoolObject)?.boolCol, true)
     }
 
+    func testIterateDynamicObjects() {
+        try! Realm().write {
+            for _ in 1..<3 {
+                try! Realm().create(SwiftObject.self)
+            }
+        }
+
+        let objects = try! Realm().dynamicObjects("SwiftObject")
+        let dictionary = SwiftObject.defaultValues()
+
+        for object in objects {
+            XCTAssertEqual(object["boolCol"] as? NSNumber, dictionary["boolCol"] as! NSNumber?)
+            XCTAssertEqual(object["intCol"] as? NSNumber, dictionary["intCol"] as! NSNumber?)
+            XCTAssertEqual(object["floatCol"] as? NSNumber, dictionary["floatCol"] as! NSNumber?)
+            XCTAssertEqual(object["doubleCol"] as? NSNumber, dictionary["doubleCol"] as! NSNumber?)
+            XCTAssertEqual(object["stringCol"] as! String?, dictionary["stringCol"] as! String?)
+            XCTAssertEqual(object["binaryCol"] as! NSData?, dictionary["binaryCol"] as! NSData?)
+            XCTAssertEqual(object["dateCol"] as! Date?, dictionary["dateCol"] as! Date?)
+            XCTAssertEqual((object["objectCol"] as? SwiftBoolObject)?.boolCol, false)
+        }
+    }
+
     func testIntPrimaryKey() {
         func testIntPrimaryKey<O: Object>(for type: O.Type)
             where O: SwiftPrimaryKeyObjectType, O.PrimaryKey: ExpressibleByIntegerLiteral {
@@ -1257,6 +1279,28 @@ class RealmTests: TestCase {
         XCTAssertEqual(object["optBinaryCol"] as! NSData?, dictionary["optBinaryCol"] as! NSData?)
         XCTAssertEqual(object["optDateCol"] as! NSDate?, dictionary["optDateCol"] as! NSDate?)
         XCTAssertEqual(object["optObjectCol"]?.boolCol, true)
+    }
+
+    func testIterateDynamicObjects() {
+        try! Realm().write {
+            for _ in 1..<3 {
+                try! Realm().create(SwiftObject)
+            }
+        }
+
+        let objects = try! Realm().dynamicObjects("SwiftObject")
+        let dictionary = SwiftObject.defaultValues()
+
+        for object in objects {
+            XCTAssertEqual(object["boolCol"] as? NSNumber, dictionary["boolCol"] as! NSNumber?)
+            XCTAssertEqual(object["intCol"] as? NSNumber, dictionary["intCol"] as! NSNumber?)
+            XCTAssertEqual(object["floatCol"] as? NSNumber, dictionary["floatCol"] as! Float?)
+            XCTAssertEqual(object["doubleCol"] as? NSNumber, dictionary["doubleCol"] as! Double?)
+            XCTAssertEqual(object["stringCol"] as! String?, dictionary["stringCol"] as! String?)
+            XCTAssertEqual(object["binaryCol"] as! NSData?, dictionary["binaryCol"] as! NSData?)
+            XCTAssertEqual(object["dateCol"] as! NSDate?, dictionary["dateCol"] as! NSDate?)
+            XCTAssertEqual(object["objectCol"]?.boolCol, false)
+        }
     }
 
     func testIntPrimaryKey() {

--- a/RealmSwift/Tests/RealmTests.swift
+++ b/RealmSwift/Tests/RealmTests.swift
@@ -537,6 +537,33 @@ class RealmTests: TestCase {
         }
     }
 
+    func testDynamicObjectListProperties() {
+        try! Realm().write {
+            try! Realm().create(SwiftArrayPropertyObject.self, value: ["string", [["array"]], [[2]]])
+        }
+
+        let object = try! Realm().dynamicObjects("SwiftArrayPropertyObject")[0]
+
+        XCTAssertEqual(object["name"] as? String, "string")
+
+        let array = object["array"] as! List<DynamicObject>
+        XCTAssertEqual(array.first!["stringCol"] as? String, "array")
+        XCTAssertEqual(array.last!["stringCol"] as? String, "array")
+
+        for object in array {
+            XCTAssertEqual(object["stringCol"] as? String, "array")
+        }
+
+        let intArray = object["intArray"] as! List<DynamicObject>
+        XCTAssertEqual(intArray[0]["intCol"] as? Int, 2)
+        XCTAssertEqual(intArray.first!["intCol"] as? Int, 2)
+        XCTAssertEqual(intArray.last!["intCol"] as? Int, 2)
+
+        for object in intArray {
+            XCTAssertEqual(object["intCol"] as? Int, 2)
+        }
+    }
+
     func testIntPrimaryKey() {
         func testIntPrimaryKey<O: Object>(for type: O.Type)
             where O: SwiftPrimaryKeyObjectType, O.PrimaryKey: ExpressibleByIntegerLiteral {
@@ -1300,6 +1327,34 @@ class RealmTests: TestCase {
             XCTAssertEqual(object["binaryCol"] as! NSData?, dictionary["binaryCol"] as! NSData?)
             XCTAssertEqual(object["dateCol"] as! NSDate?, dictionary["dateCol"] as! NSDate?)
             XCTAssertEqual(object["objectCol"]?.boolCol, false)
+        }
+    }
+
+    func testDynamicObjectListProperties() {
+        try! Realm().write {
+            try! Realm().create(SwiftArrayPropertyObject.self, value: ["string", [["array"]], [[2]]])
+        }
+
+        let object = try! Realm().dynamicObjects("SwiftArrayPropertyObject")[0]
+
+        XCTAssertEqual(object["name"] as? String, "string")
+
+        let array = object["array"] as! List<DynamicObject>
+        XCTAssertEqual(array[0]["stringCol"] as? String, "array")
+        XCTAssertEqual(array.first!["stringCol"] as? String, "array")
+        XCTAssertEqual(array.last!["stringCol"] as? String, "array")
+
+        for object in array {
+            XCTAssertEqual(object["stringCol"] as? String, "array")
+        }
+
+        let intArray = object["intArray"] as! List<DynamicObject>
+        XCTAssertEqual(intArray[0]["intCol"] as? Int, 2)
+        XCTAssertEqual(intArray.first!["intCol"] as? Int, 2)
+        XCTAssertEqual(intArray.last!["intCol"] as? Int, 2)
+
+        for object in intArray {
+            XCTAssertEqual(object["intCol"] as? Int, 2)
         }
     }
 


### PR DESCRIPTION
The following code will crash because cannot cast `List<T>` to `List<DynamicObject>`

```
let array = object["array"] as! List<DynamicObject>
```

results.rlmResults.objectSchema.accessorClass = DynamicObject.self
This PR to fix that to assign objectSchema of `Results` `accessorClass` to `DynamicObject.self`

Also subscripting, `first()`, and `last()` methods of `List<DynamicObject>` will fail with same cast error. This will be fixed to use unsafeBitCast() instead force cast.

Related #2848

CC @bdash @mrackwitz
