### PR TITLE
Bring in recent changes from the object store

### DIFF
--- a/Realm.xcodeproj/project.pbxproj
+++ b/Realm.xcodeproj/project.pbxproj
@@ -144,6 +144,7 @@
 		5D3E1A311C1FD1D2002913BA /* RLMPredicateUtil.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 5D3E1A2C1C1FC6D5002913BA /* RLMPredicateUtil.hpp */; };
 		5D432B8D1CC0713F00A610A9 /* LinkingObjectsTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5D432B8C1CC0713F00A610A9 /* LinkingObjectsTests.mm */; };
 		5D432B8E1CC0713F00A610A9 /* LinkingObjectsTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5D432B8C1CC0713F00A610A9 /* LinkingObjectsTests.mm */; };
+		5D5AF7FD1D3D8F9C003036AB /* compiler.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 5D5AF7FC1D3D8F9C003036AB /* compiler.hpp */; };
 		5D6156EE1BE0689200A4BD3F /* Realm.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5D659ED91BE04556006515A0 /* Realm.framework */; };
 		5D6156FB1BE08E7E00A4BD3F /* PerformanceTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 3F04EA2D1992BEE400C2CE2E /* PerformanceTests.m */; };
 		5D6157051BE13CBB00A4BD3F /* strip-frameworks.sh in Resources */ = {isa = PBXBuildFile; fileRef = E81C393E1AE5CE6A00F03B56 /* strip-frameworks.sh */; };
@@ -570,6 +571,7 @@
 		5D3E1A2C1C1FC6D5002913BA /* RLMPredicateUtil.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = RLMPredicateUtil.hpp; sourceTree = "<group>"; };
 		5D3E1A2D1C1FC6D5002913BA /* RLMPredicateUtil.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = RLMPredicateUtil.mm; sourceTree = "<group>"; };
 		5D432B8C1CC0713F00A610A9 /* LinkingObjectsTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = LinkingObjectsTests.mm; sourceTree = "<group>"; };
+		5D5AF7FC1D3D8F9C003036AB /* compiler.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = compiler.hpp; path = ObjectStore/util/compiler.hpp; sourceTree = "<group>"; };
 		5D6156F51BE077E600A4BD3F /* RLMPlatform.h.in */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = RLMPlatform.h.in; sourceTree = "<group>"; };
 		5D6156F71BE07B6B00A4BD3F /* TestHost.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = TestHost.xcconfig; sourceTree = "<group>"; };
 		5D659E6D1BE0398E006515A0 /* Base.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Base.xcconfig; sourceTree = "<group>"; };
@@ -914,6 +916,7 @@
 			isa = PBXGroup;
 			children = (
 				5DB591A61D063DF8001D8F93 /* atomic_shared_ptr.hpp */,
+				5D5AF7FC1D3D8F9C003036AB /* compiler.hpp */,
 				5DB591A71D063DF8001D8F93 /* format.cpp */,
 				5DB591A81D063DF8001D8F93 /* format.hpp */,
 			);
@@ -1159,6 +1162,7 @@
 				3F9801AF1C90FD2D000A8B07 /* results_notifier.hpp in Headers */,
 				5DB591A91D063DF8001D8F93 /* atomic_shared_ptr.hpp in Headers */,
 				5D659EA71BE04556006515A0 /* RLMAccessor.h in Headers */,
+				5D5AF7FD1D3D8F9C003036AB /* compiler.hpp in Headers */,
 				5D659EA81BE04556006515A0 /* RLMAnalytics.hpp in Headers */,
 				5D659EA91BE04556006515A0 /* RLMArray.h in Headers */,
 				5D659EAA1BE04556006515A0 /* RLMArray_Private.h in Headers */,

--- a/Realm/ObjectStore/impl/transact_log_handler.cpp
+++ b/Realm/ObjectStore/impl/transact_log_handler.cpp
@@ -64,7 +64,7 @@ class TransactLogValidationMixin {
     REALM_NOINLINE
     void schema_error()
     {
-        throw std::runtime_error("Schema mismatch detected: another process has modified the Realm file's schema in an incompatible way");
+        throw std::logic_error("Schema mismatch detected: another process has modified the Realm file's schema in an incompatible way");
     }
 
     // Throw an exception if the currently modified table already existed before

--- a/Realm/ObjectStore/list.cpp
+++ b/Realm/ObjectStore/list.cpp
@@ -72,7 +72,7 @@ bool List::is_valid() const
 void List::verify_attached() const
 {
     if (!is_valid()) {
-        throw InvalidatedException{};
+        throw InvalidatedException();
     }
 }
 

--- a/Realm/ObjectStore/list.cpp
+++ b/Realm/ObjectStore/list.cpp
@@ -195,6 +195,12 @@ Results List::filter(Query q)
     return Results(m_realm, m_link_view, get_query().and_query(std::move(q)));
 }
 
+Results List::snapshot() const
+{
+    verify_attached();
+    return Results(m_realm, m_link_view).snapshot();
+}
+
 // These definitions rely on that LinkViews are interned by core
 bool List::operator==(List const& rgt) const noexcept
 {

--- a/Realm/ObjectStore/list.cpp
+++ b/Realm/ObjectStore/list.cpp
@@ -20,7 +20,9 @@
 
 #include "impl/list_notifier.hpp"
 #include "impl/realm_coordinator.hpp"
+#include "object_store.hpp"
 #include "results.hpp"
+#include "schema.hpp"
 #include "shared_realm.hpp"
 #include "util/format.hpp"
 
@@ -41,6 +43,19 @@ List::List(std::shared_ptr<Realm> r, LinkViewRef l) noexcept
 : m_realm(std::move(r))
 , m_link_view(std::move(l))
 {
+}
+
+const ObjectSchema& List::get_object_schema() const
+{
+    verify_attached();
+
+    if (!m_object_schema) {
+        auto object_type = ObjectStore::object_type_for_table_name(m_link_view->get_target_table().get_name());
+        auto it = m_realm->config().schema->find(object_type);
+        REALM_ASSERT(it != m_realm->config().schema->end());
+        m_object_schema = &*it;
+    }
+    return *m_object_schema;
 }
 
 Query List::get_query() const

--- a/Realm/ObjectStore/list.hpp
+++ b/Realm/ObjectStore/list.hpp
@@ -75,6 +75,9 @@ public:
     Results sort(SortOrder order);
     Results filter(Query q);
 
+    // Return a Results representing a snapshot of this List.
+    Results snapshot() const;
+
     bool operator==(List const& rgt) const noexcept;
 
     NotificationToken add_notification_callback(CollectionChangeCallback cb);

--- a/Realm/ObjectStore/list.hpp
+++ b/Realm/ObjectStore/list.hpp
@@ -91,8 +91,8 @@ public:
     // The List object has been invalidated (due to the Realm being invalidated,
     // or the containing object being deleted)
     // All non-noexcept functions can throw this
-    struct InvalidatedException : public std::runtime_error {
-        InvalidatedException() : std::runtime_error("Access to invalidated List object") {}
+    struct InvalidatedException : public std::logic_error {
+        InvalidatedException() : std::logic_error("Access to invalidated List object") {}
     };
 
     // The input index parameter was out of bounds

--- a/Realm/ObjectStore/list.hpp
+++ b/Realm/ObjectStore/list.hpp
@@ -50,6 +50,7 @@ public:
 
     const std::shared_ptr<Realm>& get_realm() const { return m_realm; }
     Query get_query() const;
+    const ObjectSchema& get_object_schema() const;
     size_t get_origin_row_index() const;
 
     bool is_valid() const;
@@ -104,6 +105,7 @@ public:
 
 private:
     std::shared_ptr<Realm> m_realm;
+    mutable const ObjectSchema* m_object_schema = nullptr;
     LinkViewRef m_link_view;
     _impl::CollectionNotifier::Handle<_impl::CollectionNotifier> m_notifier;
 

--- a/Realm/ObjectStore/object_store.cpp
+++ b/Realm/ObjectStore/object_store.cpp
@@ -124,7 +124,7 @@ StringData ObjectStore::object_type_for_table_name(StringData table_name) {
 }
 
 std::string ObjectStore::table_name_for_object_type(StringData object_type) {
-    return std::string(c_object_table_prefix) + object_type.data();
+    return std::string(c_object_table_prefix) + static_cast<std::string>(object_type);
 }
 
 TableRef ObjectStore::table_for_object_type(Group *group, StringData object_type) {

--- a/Realm/ObjectStore/property.hpp
+++ b/Realm/ObjectStore/property.hpp
@@ -22,7 +22,7 @@
 #include <string>
 
 namespace realm {
-    enum class PropertyType {
+    enum class PropertyType : unsigned char {
         Int    = 0,
         Bool   = 1,
         Float  = 9,

--- a/Realm/ObjectStore/results.cpp
+++ b/Realm/ObjectStore/results.cpp
@@ -21,23 +21,12 @@
 #include "impl/realm_coordinator.hpp"
 #include "impl/results_notifier.hpp"
 #include "object_store.hpp"
+#include "util/compiler.hpp"
 #include "util/format.hpp"
 
 #include <stdexcept>
 
 using namespace realm;
-
-#ifdef __has_cpp_attribute
-#define REALM_HAS_CCP_ATTRIBUTE(attr) __has_cpp_attribute(attr)
-#else
-#define REALM_HAS_CCP_ATTRIBUTE(attr) 0
-#endif
-
-#if REALM_HAS_CCP_ATTRIBUTE(clang::fallthrough)
-#define REALM_FALLTHROUGH [[clang::fallthrough]]
-#else
-#define REALM_FALLTHROUGH
-#endif
 
 Results::Results() = default;
 Results::~Results() = default;

--- a/Realm/ObjectStore/results.cpp
+++ b/Realm/ObjectStore/results.cpp
@@ -529,7 +529,7 @@ Results::OutOfBoundsIndexException::OutOfBoundsIndexException(size_t r, size_t c
 , requested(r), valid_count(c) {}
 
 Results::UnsupportedColumnTypeException::UnsupportedColumnTypeException(size_t column, const Table* table, const char* operation)
-: std::runtime_error(util::format("Cannot %1 property '%2': operation not supported for '%3' properties",
+: std::logic_error(util::format("Cannot %1 property '%2': operation not supported for '%3' properties",
                                   operation, table->get_column_name(column),
                                   string_for_property_type(static_cast<PropertyType>(table->get_column_type(column)))))
 , column_index(column)

--- a/Realm/ObjectStore/results.cpp
+++ b/Realm/ObjectStore/results.cpp
@@ -73,17 +73,7 @@ Results::Results(SharedRealm r, SortOrder s, TableView tv)
 }
 
 Results::Results(const Results&) = default;
-
-// Cannot be defaulted as TableViewBase::operator= is missing from the core static library.
-// Delegate to the copy constructor and move-assignment operators instead.
-Results& Results::operator=(const Results& other)
-{
-    if (this != &other) {
-        *this = Results(other);
-    }
-
-    return *this;
-}
+Results& Results::operator=(const Results&) = default;
 
 Results::Results(Results&& other)
 : m_realm(std::move(other.m_realm))

--- a/Realm/ObjectStore/results.hpp
+++ b/Realm/ObjectStore/results.hpp
@@ -130,8 +130,8 @@ public:
 
     // The Results object has been invalidated (due to the Realm being invalidated)
     // All non-noexcept functions can throw this
-    struct InvalidatedException : public std::runtime_error {
-        InvalidatedException() : std::runtime_error("Access to invalidated Results objects") {}
+    struct InvalidatedException : public std::logic_error {
+        InvalidatedException() : std::logic_error("Access to invalidated Results objects") {}
     };
 
     // The input index parameter was out of bounds
@@ -142,20 +142,20 @@ public:
     };
 
     // The input Row object is not attached
-    struct DetatchedAccessorException : public std::runtime_error {
-        DetatchedAccessorException() : std::runtime_error("Atempting to access an invalid object") {}
+    struct DetatchedAccessorException : public std::logic_error {
+        DetatchedAccessorException() : std::logic_error("Atempting to access an invalid object") {}
     };
 
     // The input Row object belongs to a different table
-    struct IncorrectTableException : public std::runtime_error {
-        IncorrectTableException(StringData e, StringData a, const std::string &error)
-        : std::runtime_error(error), expected(e), actual(a) {}
+    struct IncorrectTableException : public std::logic_error {
+        IncorrectTableException(StringData e, StringData a, const std::string &error) :
+            std::logic_error(error), expected(e), actual(a) {}
         const StringData expected;
         const StringData actual;
     };
 
     // The requested aggregate operation is not supported for the column type
-    struct UnsupportedColumnTypeException : public std::runtime_error {
+    struct UnsupportedColumnTypeException : public std::logic_error {
         size_t column_index;
         StringData column_name;
         DataType column_type;

--- a/Realm/ObjectStore/results.hpp
+++ b/Realm/ObjectStore/results.hpp
@@ -30,6 +30,7 @@ namespace realm {
 template<typename T> class BasicRowExpr;
 using RowExpr = BasicRowExpr<Table>;
 class Mixed;
+class ObjectSchema;
 
 namespace _impl {
     class ResultsNotifier;
@@ -59,6 +60,12 @@ public:
     Results(Results&&);
     Results& operator=(Results const&);
     Results& operator=(Results&&);
+
+    // Get the Realm
+    SharedRealm get_realm() const { return m_realm; }
+
+    // Object schema describing the vendored object type
+    const ObjectSchema &get_object_schema() const;
 
     // Get a query which will match the same rows as is contained in this Results
     // Returned query will not be valid if the current mode is Empty
@@ -163,8 +170,6 @@ public:
         UnsupportedColumnTypeException(size_t column, const Table* table, const char* operation);
     };
 
-    SharedRealm get_realm() const { return m_realm; }
-
     // Create an async query from this Results
     // The query will be run on a background thread and delivered to the callback,
     // and then rerun after each commit (if needed) and redelivered if it changed
@@ -185,6 +190,7 @@ public:
 
 private:
     SharedRealm m_realm;
+    mutable const ObjectSchema *m_object_schema = nullptr;
     Query m_query;
     TableView m_table_view;
     LinkViewRef m_link_view;

--- a/Realm/ObjectStore/shared_realm.cpp
+++ b/Realm/ObjectStore/shared_realm.cpp
@@ -519,4 +519,4 @@ util::Optional<int> Realm::file_format_upgraded_from_version() const
 }
 
 MismatchedConfigException::MismatchedConfigException(StringData message, StringData path)
-: std::runtime_error(util::format(message.data(), path)) { }
+: std::logic_error(util::format(message.data(), path)) { }

--- a/Realm/ObjectStore/shared_realm.hpp
+++ b/Realm/ObjectStore/shared_realm.hpp
@@ -227,19 +227,19 @@ namespace realm {
         std::string m_underlying;
     };
 
-    class MismatchedConfigException : public std::runtime_error {
+    class MismatchedConfigException : public std::logic_error {
     public:
         MismatchedConfigException(StringData message, StringData path);
     };
 
-    class InvalidTransactionException : public std::runtime_error {
+    class InvalidTransactionException : public std::logic_error {
     public:
-        InvalidTransactionException(std::string message) : std::runtime_error(move(message)) {}
+        InvalidTransactionException(std::string message) : std::logic_error(move(message)) {}
     };
 
-    class IncorrectThreadException : public std::runtime_error {
+    class IncorrectThreadException : public std::logic_error {
     public:
-        IncorrectThreadException() : std::runtime_error("Realm accessed from incorrect thread.") {}
+        IncorrectThreadException() : std::logic_error("Realm accessed from incorrect thread.") {}
     };
 
     class UninitializedRealmException : public std::runtime_error {
@@ -247,9 +247,9 @@ namespace realm {
         UninitializedRealmException(std::string message) : std::runtime_error(move(message)) {}
     };
 
-    class InvalidEncryptionKeyException : public std::runtime_error {
+    class InvalidEncryptionKeyException : public std::logic_error {
     public:
-        InvalidEncryptionKeyException() : std::runtime_error("Encryption key must be 64 bytes.") {}
+        InvalidEncryptionKeyException() : std::logic_error("Encryption key must be 64 bytes.") {}
     };
 }
 

--- a/Realm/ObjectStore/util/compiler.hpp
+++ b/Realm/ObjectStore/util/compiler.hpp
@@ -1,0 +1,34 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2015 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+#ifndef REALM_UTIL_COMPILER_HPP
+#define REALM_UTIL_COMPILER_HPP
+
+#ifdef __has_cpp_attribute
+#define REALM_HAS_CCP_ATTRIBUTE(attr) __has_cpp_attribute(attr)
+#else
+#define REALM_HAS_CCP_ATTRIBUTE(attr) 0
+#endif
+
+#if REALM_HAS_CCP_ATTRIBUTE(clang::fallthrough)
+#define REALM_FALLTHROUGH [[clang::fallthrough]]
+#else
+#define REALM_FALLTHROUGH
+#endif
+
+#endif // REALM_UTIL_COMPILER_HPP

--- a/Realm/ObjectStore/util/compiler.hpp
+++ b/Realm/ObjectStore/util/compiler.hpp
@@ -20,12 +20,12 @@
 #define REALM_UTIL_COMPILER_HPP
 
 #ifdef __has_cpp_attribute
-#define REALM_HAS_CCP_ATTRIBUTE(attr) __has_cpp_attribute(attr)
+#define REALM_HAS_CPP_ATTRIBUTE(attr) __has_cpp_attribute(attr)
 #else
-#define REALM_HAS_CCP_ATTRIBUTE(attr) 0
+#define REALM_HAS_CPP_ATTRIBUTE(attr) 0
 #endif
 
-#if REALM_HAS_CCP_ATTRIBUTE(clang::fallthrough)
+#if REALM_HAS_CPP_ATTRIBUTE(clang::fallthrough)
 #define REALM_FALLTHROUGH [[clang::fallthrough]]
 #else
 #define REALM_FALLTHROUGH

--- a/Realm/RLMAccessor.mm
+++ b/Realm/RLMAccessor.mm
@@ -378,7 +378,7 @@ static inline RLMLinkingObjects *RLMGetLinkingObjects(__unsafe_unretained RLMObj
     RLMObjectSchema *objectSchema = obj->_realm.schema[property.objectClassName];
     RLMProperty *linkingProperty = objectSchema[property.linkOriginPropertyName];
     auto backlinkView = obj->_row.get_table()->get_backlink_view(obj->_row.get_index(), objectSchema.table, linkingProperty.column);
-    realm::Results results(obj->_realm->_realm, {}, std::move(backlinkView));
+    realm::Results results(obj->_realm->_realm, std::move(backlinkView));
     return [RLMLinkingObjects resultsWithObjectSchema:objectSchema results:std::move(results)];
 }
 


### PR DESCRIPTION
This brings `Results` and `List` in sync with their upstream counterparts.