### PR TITLE
Update to support Xcode 8 beta 3

### DIFF
--- a/Configuration/Base.xcconfig
+++ b/Configuration/Base.xcconfig
@@ -45,3 +45,7 @@ MACOSX_DEPLOYMENT_TARGET = 10.9;
 IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 WATCHOS_DEPLOYMENT_TARGET = 2.0;
 TVOS_DEPLOYMENT_TARGET = 9.0;
+
+// SWIFT_VERSION is only recognized by Xcode 8 and higher.
+// Prior versions of Xcode support only one Swift version.
+SWIFT_VERSION = 3.0;

--- a/Realm.xcodeproj/project.pbxproj
+++ b/Realm.xcodeproj/project.pbxproj
@@ -1437,14 +1437,10 @@
 						CreatedOnToolsVersion = 7.2;
 					};
 					5D659E7D1BE04556006515A0 = {
-						DevelopmentTeam = QX5CR2FTN2;
-						DevelopmentTeamName = "Realm ApS";
 						ProvisioningStyle = Automatic;
 					};
 					5D660FCB1BE98C560021E04F = {
 						CreatedOnToolsVersion = 7.1;
-						DevelopmentTeam = QX5CR2FTN2;
-						DevelopmentTeamName = "Realm ApS";
 						LastSwiftMigration = 0800;
 						ProvisioningStyle = Automatic;
 					};
@@ -1456,8 +1452,6 @@
 						ProvisioningStyle = Automatic;
 					};
 					5DD7557B1BE056DE002800DA = {
-						DevelopmentTeam = QX5CR2FTN2;
-						DevelopmentTeamName = "Realm ApS";
 						ProvisioningStyle = Automatic;
 					};
 					C04B4BD71B55C47600FAE58E = {

--- a/Realm/RLMProperty.mm
+++ b/Realm/RLMProperty.mm
@@ -268,7 +268,7 @@ static bool rawTypeIsComputedProperty(NSString *rawType) {
     }
 }
 
-- (bool)parseObjcProperty:(objc_property_t)property isSwift:(bool)isSwift {
+- (bool)parseObjcProperty:(objc_property_t)property {
     unsigned int count;
     objc_property_attribute_t *attrs = property_copyAttributeList(property, &count);
 
@@ -292,11 +292,6 @@ static bool rawTypeIsComputedProperty(NSString *rawType) {
                 break;
             case 'S':
                 _setterName = @(attrs[i].value);
-                break;
-            case 'V': // backing ivar name
-                if (isSwift) {
-                    _getterName = @(attrs[i].value);
-                }
                 break;
             default:
                 break;
@@ -325,7 +320,7 @@ static bool rawTypeIsComputedProperty(NSString *rawType) {
         _linkOriginPropertyName = linkPropertyDescriptor.propertyName;
     }
 
-    if ([self parseObjcProperty:property isSwift:true]) {
+    if ([self parseObjcProperty:property]) {
         return nil;
     }
 
@@ -418,7 +413,7 @@ static bool rawTypeIsComputedProperty(NSString *rawType) {
         _linkOriginPropertyName = linkPropertyDescriptor.propertyName;
     }
 
-    bool isReadOnly = [self parseObjcProperty:property isSwift:false];
+    bool isReadOnly = [self parseObjcProperty:property];
     bool isComputedProperty = rawTypeIsComputedProperty(_objcRawType);
     if (isReadOnly && !isComputedProperty) {
         return nil;

--- a/Realm/Tests/Swift/SwiftRealmTests.swift
+++ b/Realm/Tests/Swift/SwiftRealmTests.swift
@@ -68,7 +68,7 @@ class SwiftRealmTests: RLMTestCase {
         let realm = realmWithTestPath()
 
         // we have two notifications, one for opening the realm, and a second when performing our transaction
-        let notificationFired = expectation(withDescription: "notification fired")
+        let notificationFired = expectation(description: "notification fired")
         let token = realm.addNotificationBlock { note, realm in
             XCTAssertNotNil(realm, "Realm should not be nil")
             notificationFired.fulfill()
@@ -80,7 +80,7 @@ class SwiftRealmTests: RLMTestCase {
             _ = SwiftStringObject.create(in: realm, withValue: ["string"])
             try! realm.commitWriteTransaction()
         }
-        waitForExpectations(withTimeout: 2.0, handler: nil)
+        waitForExpectations(timeout: 2.0, handler: nil)
         token.stop()
 
         // get object
@@ -116,7 +116,7 @@ class SwiftRealmTests: RLMTestCase {
         let realm = realmWithTestPath()
         let objs = SwiftIntObject.allObjects(in: realm)
         let objects = SwiftIntObject.allObjects(in: realm).sortedResults(usingProperty: "intCol", ascending: true)
-        let updateComplete = expectation(withDescription: "background update complete")
+        let updateComplete = expectation(description: "background update complete")
 
         let token = realm.addNotificationBlock() { (_, _) in
             XCTAssertEqual(objs.count, UInt(2))
@@ -138,14 +138,14 @@ class SwiftRealmTests: RLMTestCase {
             }
         }
 
-        waitForExpectations(withTimeout: 2.0, handler: nil)
+        waitForExpectations(timeout: 2.0, handler: nil)
         token.stop()
     }
 
     func testRealmIsUpdatedImmediatelyAfterBackgroundUpdate() {
         let realm = realmWithTestPath()
 
-        let notificationFired = expectation(withDescription: "notification fired")
+        let notificationFired = expectation(description: "notification fired")
         let token = realm.addNotificationBlock { note, realm in
             XCTAssertNotNil(realm, "Realm should not be nil")
             notificationFired.fulfill()
@@ -163,7 +163,7 @@ class SwiftRealmTests: RLMTestCase {
             XCTAssertEqual((objects[0] as! SwiftStringObject).stringCol, "string", "Value of first column should be 'string'")
         }
 
-        waitForExpectations(withTimeout: 2.0, handler: nil)
+        waitForExpectations(timeout: 2.0, handler: nil)
         token.stop()
 
         // get object
@@ -203,7 +203,7 @@ class SwiftRealmTests: RLMTestCase {
         let realm = realmWithTestPath()
 
         // we have two notifications, one for opening the realm, and a second when performing our transaction
-        let notificationFired = expectation(withDescription: "notification fired")
+        let notificationFired = expectation(description: "notification fired")
         let token = realm.addNotificationBlock { note, realm in
             XCTAssertNotNil(realm, "Realm should not be nil")
             if note == RLMNotification.DidChange {
@@ -217,7 +217,7 @@ class SwiftRealmTests: RLMTestCase {
             _ = StringObject.create(in: realm, withValue: ["string"])
             try! realm.commitWriteTransaction()
         }
-        waitForExpectations(withTimeout: 2.0, handler: nil)
+        waitForExpectations(timeout: 2.0, handler: nil)
         token.stop()
 
         // get object
@@ -230,7 +230,7 @@ class SwiftRealmTests: RLMTestCase {
         let realm = realmWithTestPath()
 
         // we have two notifications, one for opening the realm, and a second when performing our transaction
-        let notificationFired = expectation(withDescription: "notification fired")
+        let notificationFired = expectation(description: "notification fired")
         let token = realm.addNotificationBlock { note, realm in
             XCTAssertNotNil(realm, "Realm should not be nil")
             notificationFired.fulfill()
@@ -248,7 +248,7 @@ class SwiftRealmTests: RLMTestCase {
             XCTAssertEqual((objects[0] as! StringObject).stringCol!, "string", "Value of first column should be 'string'")
         }
 
-        waitForExpectations(withTimeout: 2.0, handler: nil)
+        waitForExpectations(timeout: 2.0, handler: nil)
         token.stop()
 
         // get object

--- a/RealmSwift/LinkingObjects.swift
+++ b/RealmSwift/LinkingObjects.swift
@@ -39,7 +39,7 @@ public class LinkingObjectsBase: NSObject, NSFastEnumeration {
 
     internal var rlmResults: RLMResults<RLMObject> {
         if cachedRLMResults == nil {
-            if let object = self.object, property = self.property {
+            if let object = self.object, let property = self.property {
                 cachedRLMResults = RLMDynamicGet(object.object, property)! as? RLMResults
                 self.object = nil
                 self.property = nil

--- a/RealmSwift/Tests/ListTests.swift
+++ b/RealmSwift/Tests/ListTests.swift
@@ -90,7 +90,7 @@ class ListTests: TestCase {
     }
 
     func testFastEnumerationWithMutation() {
-        guard let array = array, str1 = str1, str2 = str2 else {
+        guard let array = array, let str1 = str1, let str2 = str2 else {
             fatalError("Test precondition failure")
         }
 
@@ -106,7 +106,7 @@ class ListTests: TestCase {
     }
 
     func testAppendObject() {
-        guard let array = array, str1 = str1, str2 = str2 else {
+        guard let array = array, let str1 = str1, let str2 = str2 else {
             fatalError("Test precondition failure")
         }
         for str in [str1, str2, str1] {
@@ -119,7 +119,7 @@ class ListTests: TestCase {
     }
 
     func testAppendArray() {
-        guard let array = array, str1 = str1, str2 = str2 else {
+        guard let array = array, let str1 = str1, let str2 = str2 else {
             fatalError("Test precondition failure")
         }
         array.append(objectsIn: [str1, str2, str1])
@@ -130,7 +130,7 @@ class ListTests: TestCase {
     }
 
     func testAppendResults() {
-        guard let array = array, str1 = str1, str2 = str2 else {
+        guard let array = array, let str1 = str1, let str2 = str2 else {
             fatalError("Test precondition failure")
         }
         array.append(objectsIn: realmWithTestPath().allObjects(ofType: SwiftStringObject.self))
@@ -140,7 +140,7 @@ class ListTests: TestCase {
     }
 
     func testInsert() {
-        guard let array = array, str1 = str1, str2 = str2 else {
+        guard let array = array, let str1 = str1, let str2 = str2 else {
             fatalError("Test precondition failure")
         }
 
@@ -160,7 +160,7 @@ class ListTests: TestCase {
     }
 
     func testRemoveAtIndex() {
-        guard let array = array, str1 = str1, str2 = str2 else {
+        guard let array = array, let str1 = str1, let str2 = str2 else {
             fatalError("Test precondition failure")
         }
 
@@ -175,7 +175,7 @@ class ListTests: TestCase {
     }
 
     func testRemoveLast() {
-        guard let array = array, str1 = str1, str2 = str2 else {
+        guard let array = array, let str1 = str1, let str2 = str2 else {
             fatalError("Test precondition failure")
         }
 
@@ -193,7 +193,7 @@ class ListTests: TestCase {
     }
 
     func testRemoveAll() {
-        guard let array = array, str1 = str1, str2 = str2 else {
+        guard let array = array, let str1 = str1, let str2 = str2 else {
             fatalError("Test precondition failure")
         }
 
@@ -207,7 +207,7 @@ class ListTests: TestCase {
     }
 
     func testReplace() {
-        guard let array = array, str1 = str1, str2 = str2 else {
+        guard let array = array, let str1 = str1, let str2 = str2 else {
             fatalError("Test precondition failure")
         }
 
@@ -228,7 +228,7 @@ class ListTests: TestCase {
     }
 
     func testMove() {
-        guard let array = array, str1 = str1, str2 = str2 else {
+        guard let array = array, let str1 = str1, let str2 = str2 else {
             fatalError("Test precondition failure")
         }
 
@@ -254,7 +254,7 @@ class ListTests: TestCase {
     }
 
     func testReplaceRange() {
-        guard let array = array, str1 = str1, str2 = str2 else {
+        guard let array = array, let str1 = str1, let str2 = str2 else {
             fatalError("Test precondition failure")
         }
 
@@ -285,7 +285,7 @@ class ListTests: TestCase {
     }
 
     func testSwap() {
-        guard let array = array, str1 = str1, str2 = str2 else {
+        guard let array = array, let str1 = str1, let str2 = str2 else {
             fatalError("Test precondition failure")
         }
 
@@ -308,7 +308,7 @@ class ListTests: TestCase {
     }
 
     func testChangesArePersisted() {
-        guard let array = array, str1 = str1, str2 = str2 else {
+        guard let array = array, let str1 = str1, let str2 = str2 else {
             fatalError("Test precondition failure")
         }
         if let realm = array.realm {

--- a/RealmSwift/Tests/MigrationTests.swift
+++ b/RealmSwift/Tests/MigrationTests.swift
@@ -135,7 +135,7 @@ class MigrationTests: TestCase {
         migrateAndTestRealm(testRealmURL(), shouldRun: false, autoMigration: false)
 
         // test auto-migration
-        migrateAndTestRealm(testRealmURL(), schemaVersion: 2, shouldRun: true, autoMigration: true)
+        migrateAndTestRealm(testRealmURL(), shouldRun: true, schemaVersion: 2, autoMigration: true)
     }
 
     func testMigrationProperties() {

--- a/RealmSwift/Tests/ObjectCreationTests.swift
+++ b/RealmSwift/Tests/ObjectCreationTests.swift
@@ -484,16 +484,6 @@ class ObjectCreationTests: TestCase {
         XCTAssertEqual(existingObject.intCol, 2)
     }
 
-    func testCreateObjectWithRemappedName() {
-        let realm = try! Realm()
-        try! realm.write {
-            let obj = realm.createObject(ofType: SwiftTranslatedGetterObject.self, populatedWith: ["true": true])
-            XCTAssertTrue(obj.isTrue)
-            obj.isTrue = false
-            XCTAssertFalse(obj.isTrue)
-        }
-    }
-
     // MARK: Private utilities
     private func verifySwiftObjectWithArrayLiteral(_ object: SwiftObject, array: [AnyObject], boolObjectValue: Bool,
                                                    boolObjectListValues: [Bool]) {
@@ -1084,16 +1074,6 @@ class ObjectCreationTests: TestCase {
 
         XCTAssertNotNil(object.realm)
         XCTAssertNotNil(nilObject.realm)
-    }
-
-    func testCreateObjectWithRemappedName() {
-        let realm = try! Realm()
-        try! realm.write {
-            let obj = realm.create(SwiftTranslatedGetterObject.self, value: ["isTrue": true])
-            XCTAssertTrue(obj.isTrue)
-            obj.isTrue = false
-            XCTAssertFalse(obj.isTrue)
-        }
     }
 
     // MARK: Private utilities

--- a/RealmSwift/Tests/ObjectSchemaInitializationTests.swift
+++ b/RealmSwift/Tests/ObjectSchemaInitializationTests.swift
@@ -204,10 +204,6 @@ class ObjectSchemaInitializationTests: TestCase {
     func testNonRealmOptionalTypesDeclaredAsRealmOptional() {
         assertThrows(RLMObjectSchema(forObjectClass: SwiftObjectWithNonRealmOptionalType.self))
     }
-
-    func testBoolPropertyStartingWithIs() {
-        XCTAssertEqual(SwiftTranslatedGetterObject().objectSchema.properties[0].name, "true")
-    }
 }
 
 class SwiftFakeObject: NSObject {
@@ -483,10 +479,6 @@ class ObjectSchemaInitializationTests: TestCase {
 
     func testNonRealmOptionalTypesDeclaredAsRealmOptional() {
         assertThrows(RLMObjectSchema(forObjectClass: SwiftObjectWithNonRealmOptionalType.self))
-    }
-
-    func testBoolPropertyStartingWithIs() {
-        XCTAssertEqual(SwiftTranslatedGetterObject().objectSchema.properties[0].name, "isTrue")
     }
 }
 

--- a/RealmSwift/Tests/RealmCollectionTypeTests.swift
+++ b/RealmSwift/Tests/RealmCollectionTypeTests.swift
@@ -160,7 +160,7 @@ class RealmCollectionTypeTests: TestCase {
     }
 
     func testIndexOfObject() {
-        guard let collection = collection, str1 = str1, str2 = str2 else {
+        guard let collection = collection, let str1 = str1, let str2 = str2 else {
             fatalError("Test precondition failed")
         }
         XCTAssertEqual(0, collection.index(of: str1)!)
@@ -407,7 +407,7 @@ class RealmCollectionTypeTests: TestCase {
             fatalError("Test precondition failed")
         }
 
-        let theExpectation = expectation(withDescription: "")
+        let theExpectation = expectation(description: "")
         let token = collection.addNotificationBlock { (changes: RealmCollectionChange) in
             switch changes {
             case .Initial(let collection):
@@ -423,7 +423,7 @@ class RealmCollectionTypeTests: TestCase {
 
             theExpectation.fulfill()
         }
-        waitForExpectations(withTimeout: 1, handler: nil)
+        waitForExpectations(timeout: 1, handler: nil)
 
         token.stop()
     }
@@ -499,7 +499,7 @@ class ResultsTests: RealmCollectionTypeTests {
     func testNotificationBlockUpdating() {
         let collection = collectionBase()
 
-        var theExpectation = expectation(withDescription: "")
+        var theExpectation = expectation(description: "")
         var calls = 0
         let token = collection.addNotificationBlock { (changes: RealmCollectionChange) in
             switch changes {
@@ -518,11 +518,11 @@ class ResultsTests: RealmCollectionTypeTests {
             calls += 1
             theExpectation.fulfill()
         }
-        waitForExpectations(withTimeout: 1, handler: nil)
+        waitForExpectations(timeout: 1, handler: nil)
 
-        theExpectation = expectation(withDescription: "")
+        theExpectation = expectation(description: "")
         addObjectToResults()
-        waitForExpectations(withTimeout: 1, handler: nil)
+        waitForExpectations(timeout: 1, handler: nil)
 
         token.stop()
     }
@@ -530,7 +530,7 @@ class ResultsTests: RealmCollectionTypeTests {
     func testNotificationBlockChangeIndices() {
         let collection = collectionBase()
 
-        var theExpectation = expectation(withDescription: "")
+        var theExpectation = expectation(description: "")
         var calls = 0
         let token = collection.addNotificationBlock { (change: RealmCollectionChange) in
             switch change {
@@ -553,11 +553,11 @@ class ResultsTests: RealmCollectionTypeTests {
             calls += 1
             theExpectation.fulfill()
         }
-        waitForExpectations(withTimeout: 1, handler: nil)
+        waitForExpectations(timeout: 1, handler: nil)
 
-        theExpectation = expectation(withDescription: "")
+        theExpectation = expectation(description: "")
         addObjectToResults()
-        waitForExpectations(withTimeout: 1, handler: nil)
+        waitForExpectations(timeout: 1, handler: nil)
 
         token.stop()
     }
@@ -605,7 +605,7 @@ class ResultsFromTableViewTests: ResultsTests {
 class ResultsFromLinkViewTests: ResultsTests {
 
     override func collectionBaseInWriteTransaction() -> Results<CTTStringObjectWithLink> {
-        guard let str1 = str1, str2 = str2 else {
+        guard let str1 = str1, let str2 = str2 else {
             fatalError("Test precondition failed")
         }
         let array = realmWithTestPath().createObject(ofType: CTTStringList.self, populatedWith: [[str1, str2]])
@@ -677,7 +677,7 @@ class ListRealmCollectionTypeTests: RealmCollectionTypeTests {
     func testAddNotificationBlockDirect() {
         let collection = collectionBase()
 
-        let theExpectation = expectation(withDescription: "")
+        let theExpectation = expectation(description: "")
         let token = collection.addNotificationBlock { (changes: RealmCollectionChange) in
             switch changes {
             case .Initial(let list):
@@ -692,7 +692,7 @@ class ListRealmCollectionTypeTests: RealmCollectionTypeTests {
             }
             theExpectation.fulfill()
         }
-        waitForExpectations(withTimeout: 1, handler: nil)
+        waitForExpectations(timeout: 1, handler: nil)
 
         token.stop()
     }
@@ -700,7 +700,7 @@ class ListRealmCollectionTypeTests: RealmCollectionTypeTests {
 
 class ListStandaloneRealmCollectionTypeTests: ListRealmCollectionTypeTests {
     override func collectionBaseInWriteTransaction() -> List<CTTStringObjectWithLink> {
-        guard let str1 = str1, str2 = str2 else {
+        guard let str1 = str1, let str2 = str2 else {
             fatalError("Test precondition failed")
         }
         return CTTStringList(value: [[str1, str2]]).array
@@ -725,7 +725,7 @@ class ListStandaloneRealmCollectionTypeTests: ListRealmCollectionTypeTests {
     }
 
     override func testIndexOfObject() {
-        guard let collection = collection, str1 = str1, str2 = str2 else {
+        guard let collection = collection, let str1 = str1, let str2 = str2 else {
             fatalError("Test precondition failed")
         }
         XCTAssertEqual(0, collection.index(of: str1)!)
@@ -846,7 +846,7 @@ class ListStandaloneRealmCollectionTypeTests: ListRealmCollectionTypeTests {
 
 class ListNewlyAddedRealmCollectionTypeTests: ListRealmCollectionTypeTests {
     override func collectionBaseInWriteTransaction() -> List<CTTStringObjectWithLink> {
-        guard let str1 = str1, str2 = str2 else {
+        guard let str1 = str1, let str2 = str2 else {
             fatalError("Test precondition failure - a property was unexpectedly nil")
         }
         let array = CTTStringList(value: [[str1, str2] as AnyObject])
@@ -866,7 +866,7 @@ class ListNewlyAddedRealmCollectionTypeTests: ListRealmCollectionTypeTests {
 
 class ListNewlyCreatedRealmCollectionTypeTests: ListRealmCollectionTypeTests {
     override func collectionBaseInWriteTransaction() -> List<CTTStringObjectWithLink> {
-        guard let str1 = str1, str2 = str2 else {
+        guard let str1 = str1, let str2 = str2 else {
             fatalError("Test precondition failure - a property was unexpectedly nil")
         }
         let array = realmWithTestPath().createObject(ofType: CTTStringList.self, populatedWith: [[str1, str2] as AnyObject])
@@ -885,7 +885,7 @@ class ListNewlyCreatedRealmCollectionTypeTests: ListRealmCollectionTypeTests {
 
 class ListRetrievedRealmCollectionTypeTests: ListRealmCollectionTypeTests {
     override func collectionBaseInWriteTransaction() -> List<CTTStringObjectWithLink> {
-        guard let str1 = str1, str2 = str2 else {
+        guard let str1 = str1, let str2 = str2 else {
             fatalError("Test precondition failure - a property was unexpectedly nil")
         }
         _ = realmWithTestPath().createObject(ofType: CTTStringList.self, populatedWith: [[str1, str2] as AnyObject])

--- a/RealmSwift/Tests/RealmTests.swift
+++ b/RealmSwift/Tests/RealmTests.swift
@@ -644,7 +644,7 @@ class RealmTests: TestCase {
 
         // test that autoreresh is applied
         // we have two notifications, one for opening the realm, and a second when performing our transaction
-        let notificationFired = expectation(withDescription: "notification fired")
+        let notificationFired = expectation(description: "notification fired")
         let token = realm.addNotificationBlock { _, realm in
             XCTAssertNotNil(realm, "Realm should not be nil")
             notificationFired.fulfill()
@@ -656,7 +656,7 @@ class RealmTests: TestCase {
                 realm.createObject(ofType: SwiftStringObject.self, populatedWith: ["string"])
             }
         }
-        waitForExpectations(withTimeout: 1, handler: nil)
+        waitForExpectations(timeout: 1, handler: nil)
         token.stop()
 
         // get object
@@ -672,7 +672,7 @@ class RealmTests: TestCase {
 
         // test that autoreresh is not applied
         // we have two notifications, one for opening the realm, and a second when performing our transaction
-        let notificationFired = expectation(withDescription: "notification fired")
+        let notificationFired = expectation(description: "notification fired")
         let token = realm.addNotificationBlock { _, realm in
             XCTAssertNotNil(realm, "Realm should not be nil")
             notificationFired.fulfill()
@@ -687,7 +687,7 @@ class RealmTests: TestCase {
                 return
             }
         }
-        waitForExpectations(withTimeout: 1, handler: nil)
+        waitForExpectations(timeout: 1, handler: nil)
         token.stop()
 
         XCTAssertEqual(results.count, Int(0), "There should be 1 object of type StringObject")

--- a/RealmSwift/Tests/SwiftTestObjects.swift
+++ b/RealmSwift/Tests/SwiftTestObjects.swift
@@ -38,10 +38,6 @@ class SwiftLongObject: Object {
     dynamic var longCol: Int64 = 0
 }
 
-class SwiftTranslatedGetterObject: Object {
-    dynamic var isTrue: Bool = false
-}
-
 class SwiftObject: Object {
     dynamic var boolCol = false
     dynamic var intCol = 123
@@ -429,10 +425,6 @@ class SwiftIntObject: Object {
 
 class SwiftLongObject: Object {
     dynamic var longCol: Int64 = 0
-}
-
-class SwiftTranslatedGetterObject: Object {
-    dynamic var isTrue: Bool = false
 }
 
 class SwiftObject: Object {


### PR DESCRIPTION
- [x] Accommodate changes to Objective-C method importing
- [x] Avoid warnings about missing `let` within `guard` statements.
- [x] Fix / remove tests related to the special handling of `is`-prefixed properties that has been removed.
- [x] Remove specification of development team on framework targets as it's no longer necessary. The team is still specified on test and app targets.