### PR TITLE
use Yaml Axis Jenkins Plugin

### DIFF
--- a/.jenkins.yml
+++ b/.jenkins.yml
@@ -1,0 +1,37 @@
+# Yaml Axis Plugin
+# https://wiki.jenkins-ci.org/display/JENKINS/Yaml+Axis+Plugin
+
+swift_version:
+  - 2.2
+target:
+  - osx
+  - ios-device-objc
+  - ios-device-swift
+  - docs
+  - ios-static
+  - ios-dynamic
+  - ios-swift
+  - osx-swift
+  - watchos
+  - cocoapods
+  - swiftlint
+  - tvos
+  - tvos-device
+  - osx-encryption
+configuration:
+  - Debug
+  - Release
+
+exclude:
+  - target: ios-device-objc
+    configuration: Debug
+  - target: ios-device-swift
+    configuration: Debug
+  - target: docs
+    configuration: Debug
+  - target: cocoapods
+    configuration: Debug
+  - target: swiftlint
+    configuration: Debug
+  - target: tvos-device
+    configuration: Debug


### PR DESCRIPTION
this will allow us to:
- keep more Jenkins configuration in SCM
- use a nicer syntax to specify the matrix & exclusions
- test job changes in an isolated PR first before applying globally

unfortunately, the plugin doesn't support touchstone builds, but now that we have significantly more CI machines, I think it's a worthwhile tradeoff.

/cc @bdash @tgoyne 