### PR TITLE
stop handling uncaught exceptions

### DIFF
--- a/Realm/RLMRealm.mm
+++ b/Realm/RLMRealm.mm
@@ -117,7 +117,6 @@ NSData *RLMRealmValidatedEncryptionKey(NSData *key) {
     initialized = true;
 
     RLMCheckForUpdates();
-    RLMInstallUncaughtExceptionHandler();
     RLMSendAnalytics();
 }
 

--- a/Realm/RLMRealmUtil.hpp
+++ b/Realm/RLMRealmUtil.hpp
@@ -35,8 +35,4 @@ RLMRealm *RLMGetAnyCachedRealmForPath(std::string const& path);
 // Clear the weak cache of Realms
 void RLMClearRealmCache();
 
-// Install an uncaught exception handler that cancels write transactions
-// for all cached realms on the current thread
-void RLMInstallUncaughtExceptionHandler();
-
 std::unique_ptr<realm::BindingContext> RLMCreateBindingContext(RLMRealm *realm);


### PR DESCRIPTION
Addresses #3822.

This used to be necessary to work around the lack of robust mutexes, causing a write lock to be held indefinitely. This is no longer useful.

/cc @tgoyne @bdash 