### PR TITLE
Support Xcode 8 beta 4

### DIFF
--- a/Realm/RLMConstants.h
+++ b/Realm/RLMConstants.h
@@ -29,8 +29,10 @@
 
 #if __has_attribute(ns_error_domain)
 #define RLM_ERROR_ENUM(type, name, domain) \
-    enum name : type name; \
-    enum __attribute__((ns_error_domain(domain))) name : type
+    _Pragma("clang diagnostic push") \
+    _Pragma("clang diagnostic ignored \"-Wignored-attributes\"") \
+    NS_ENUM(type, __attribute__((ns_error_domain(domain))) name) \
+    _Pragma("clang diagnostic pop")
 #else
 #define RLM_ERROR_ENUM(type, name, domain) NS_ENUM(type, name)
 #endif

--- a/Realm/RLMConstants.h
+++ b/Realm/RLMConstants.h
@@ -27,6 +27,15 @@
 #define RLM_EXTENSIBLE_STRING_ENUM_CASE_SWIFT_NAME(fully_qualified, _) NS_SWIFT_NAME(fully_qualified)
 #endif
 
+#if __has_attribute(ns_error_domain)
+#define RLM_ERROR_ENUM(type, name, domain) \
+    enum name : type name; \
+    enum __attribute__((ns_error_domain(domain))) name : type
+#else
+#define RLM_ERROR_ENUM(type, name, domain) NS_ENUM(type, name)
+#endif
+
+
 #pragma mark - Enums
 
 /**
@@ -74,11 +83,17 @@ typedef NS_ENUM(int32_t, RLMPropertyType) {
     RLMPropertyTypeLinkingObjects = 14,
 };
 
+/** An error domain identifying Realm-specific errors. */
+extern NSString * const RLMErrorDomain;
+
+/** An error domain identifying non-specific system errors. */
+extern NSString * const RLMUnknownSystemErrorDomain;
+
 /**
  `RLMError` is an enumeration representing all recoverable errors. It is associated with the
  Realm error domain specified in `RLMErrorDomain`.
  */
-typedef NS_ENUM(NSInteger, RLMError) {
+typedef RLM_ERROR_ENUM(NSInteger, RLMError, RLMErrorDomain) {
     /** Denotes a general error that occurred when trying to open a Realm. */
     RLMErrorFail                  = 1,
 
@@ -169,12 +184,6 @@ RLM_EXTENSIBLE_STRING_ENUM_CASE_SWIFT_NAME(RLMRealmDidChangeNotification, DidCha
 
 /** The schema version used for uninitialized Realms */
 extern const uint64_t RLMNotVersioned;
-
-/** An error domain identifying Realm-specific errors. */
-extern NSString * const RLMErrorDomain;
-
-/** An error domain identifying non-specific system errors. */
-extern NSString * const RLMUnknownSystemErrorDomain;
 
 /** The corresponding value is the name of an exception thrown by Realm. */
 extern NSString * const RLMExceptionName;

--- a/Realm/Swift/RLMSupport.swift
+++ b/Realm/Swift/RLMSupport.swift
@@ -33,13 +33,13 @@ import Realm
     extension RLMObject {
         // Swift query convenience functions
         public class func objects(where predicateFormat: String, _ args: CVarArg...) -> RLMResults<RLMObject> {
-            return objects(with: Predicate(format: predicateFormat, arguments: getVaList(args)))
+            return objects(with: NSPredicate(format: predicateFormat, arguments: getVaList(args)))
         }
 
         public class func objects(in realm: RLMRealm,
                                   where predicateFormat: String,
                                   _ args: CVarArg...) -> RLMResults<RLMObject> {
-            return objects(in: realm, with: Predicate(format: predicateFormat, arguments: getVaList(args)))
+            return objects(in: realm, with: NSPredicate(format: predicateFormat, arguments: getVaList(args)))
         }
     }
 
@@ -80,11 +80,11 @@ import Realm
     extension RLMCollection {
         // Swift query convenience functions
         public func indexOfObject(where predicateFormat: String, _ args: CVarArg...) -> UInt {
-            return indexOfObject(with: Predicate(format: predicateFormat, arguments: getVaList(args)))
+            return indexOfObject(with: NSPredicate(format: predicateFormat, arguments: getVaList(args)))
         }
 
         public func objects(where predicateFormat: String, _ args: CVarArg...) -> RLMResults<RLMObject> {
-            return objects(with: Predicate(format: predicateFormat, arguments: getVaList(args)))
+            return objects(with: NSPredicate(format: predicateFormat, arguments: getVaList(args)))
         }
     }
 

--- a/RealmSwift/Error.swift
+++ b/RealmSwift/Error.swift
@@ -28,100 +28,13 @@ happening when initializing a Realm instance.
     let realm: Realm?
     do {
         realm = Realm()
-    } catch RealmSwift.Error.IncompatibleLockFile() {
+    } catch RealmSwift.Error.incompatibleLockFile {
         print("Realm Browser app may be attached to Realm on device?")
     }
 
 */
-public enum Error: ErrorProtocol {
-    // swiftlint:disable variable_name
-    /// :nodoc:
-    public var _code: Int {
-        return rlmError.rawValue
-    }
 
-    /// :nodoc:
-    public var _domain: String {
-        return RLMErrorDomain
-    }
-    // swiftlint:enable variable_name
-
-    /// The RLMError value, which can be used to derive the error's code.
-    private var rlmError: RLMError {
-        switch self {
-        case .Fail:
-            return .fail
-        case .FileAccess:
-            return .fileAccess
-        case .FilePermissionDenied:
-            return .filePermissionDenied
-        case .FileExists:
-            return .fileExists
-        case .FileNotFound:
-            return .fileNotFound
-        case .IncompatibleLockFile:
-            return .incompatibleLockFile
-        case .FileFormatUpgradeRequired:
-            return .fileFormatUpgradeRequired
-        case .AddressSpaceExhausted:
-            return .addressSpaceExhausted
-        case .SchemaMismatch:
-            return .schemaMismatch
-        }
-    }
-
-    /// Error thrown by Realm if no other specific error is returned when a realm is opened.
-    case Fail
-
-    /// Error thrown by Realm for any I/O related exception scenarios when a realm is opened.
-    case FileAccess
-
-    /// Error thrown by Realm if the user does not have permission to open or create
-    /// the specified file in the specified access mode when the realm is opened.
-    case FilePermissionDenied
-
-    /// Error thrown by Realm if the file already exists when a copy should be written.
-    case FileExists
-
-    /// Error thrown by Realm if no file was found when a realm was opened as
-    /// read-only or if the directory part of the specified path was not found
-    /// when a copy should be written.
-    case FileNotFound
-
-    /// Error thrown by Realm if the database file is currently open in another process which
-    /// cannot share with the current process due to an architecture mismatch.
-    case IncompatibleLockFile
-
-    /// Error thrown by Realm if a file format upgrade is required to open the file,
-    /// but upgrades were explicitly disabled.
-    case FileFormatUpgradeRequired
-
-    /// Error thrown by Realm if there is insufficient available address space.
-    case AddressSpaceExhausted
-
-    /** Error thrown by Realm if there is a schema version mismatch, so that a migration is required. */
-    case SchemaMismatch
-}
-
-// MARK: Equatable
-
-extension Error: Equatable {}
-
-/// Returns whether the two errors are identical
-public func == (lhs: ErrorProtocol, rhs: ErrorProtocol) -> Bool { // swiftlint:disable:this valid_docs
-    return lhs._code == rhs._code
-        && lhs._domain == rhs._domain
-}
-
-// MARK: Pattern Matching
-
-/**
-Explicitly implement pattern matching for `Realm.Error`, so that the instances can be used in the
-`do … syntax`.
-*/
-public func ~= (lhs: Error, rhs: ErrorProtocol) -> Bool { // swiftlint:disable:this valid_docs
-    return lhs == rhs
-}
+public typealias Error = RLMError
 
 #else
 

--- a/RealmSwift/Error.swift
+++ b/RealmSwift/Error.swift
@@ -33,8 +33,113 @@ happening when initializing a Realm instance.
     }
 
 */
+public struct Error {
+    public enum Code : Int {
+        /// Error thrown by Realm if no other specific error is returned when a realm is opened.
+        case fail
 
-public typealias Error = RLMError
+        /// Error thrown by Realm for any I/O related exception scenarios when a realm is opened.
+        case fileAccess
+
+        /// Error thrown by Realm if the user does not have permission to open or create
+        /// the specified file in the specified access mode when the realm is opened.
+        case filePermissionDenied
+
+        /// Error thrown by Realm if the file already exists when a copy should be written.
+        case fileExists
+
+        /// Error thrown by Realm if no file was found when a realm was opened as
+        /// read-only or if the directory part of the specified path was not found
+        /// when a copy should be written.
+        case fileNotFound
+
+        /// Error thrown by Realm if the database file is currently open in another process which
+        /// cannot share with the current process due to an architecture mismatch.
+        case incompatibleLockFile
+
+        /// Error thrown by Realm if a file format upgrade is required to open the file,
+        /// but upgrades were explicitly disabled.
+        case fileFormatUpgradeRequired
+
+        /// Error thrown by Realm if there is insufficient available address space.
+        case addressSpaceExhausted
+
+        /// Error thrown by Realm if there is a schema version mismatch, so that a migration is required.
+        case schemaMismatch
+    }
+
+    /// - see: `Error.Code.fail`
+    public static let fail: Code = .fail
+
+    /// - see: `Error.Code.fileAccess`
+    public static let fileAccess: Code = .fileAccess
+
+    /// - see: `Error.Code.filePermissionDenied`
+    public static let filePermissionDenied: Code = .filePermissionDenied
+
+    /// - see: `Error.Code.fileExists`
+    public static let fileExists: Code = .fileExists
+
+    /// - see: `Error.Code.fileNotFound`
+    public static let fileNotFound: Code = .fileNotFound
+
+    /// - see: `Error.Code.incompatibleLockFile`
+    public static let incompatibleLockFile: Code = .incompatibleLockFile
+
+    /// - see: `Error.Code.fileFormatUpgradeRequired`
+    public static let fileFormatUpgradeRequired: Code = .fileFormatUpgradeRequired
+
+    /// - see: `Error.Code.addressSpaceExhausted`
+    public static let addressSpaceExhausted: Code = .addressSpaceExhausted
+
+    /// - see: `Error.Code.schemaMismatch`
+    public static let schemaMismatch: Code = .schemaMismatch
+
+    public var code: Code {
+        let rlmError = _nsError as! RLMError
+        switch rlmError.code {
+        case .fail:
+            return .fail
+        case .fileAccess:
+            return .fileAccess
+        case .filePermissionDenied:
+            return .filePermissionDenied
+        case .fileExists:
+            return .fileExists
+        case .fileNotFound:
+            return .fileNotFound
+        case .incompatibleLockFile:
+            return .incompatibleLockFile
+        case .fileFormatUpgradeRequired:
+            return .fileFormatUpgradeRequired
+        case .addressSpaceExhausted:
+            return .addressSpaceExhausted
+        case .schemaMismatch:
+            return .schemaMismatch
+        }
+    }
+
+    /// :nodoc:
+    public var _nsError: NSError
+
+    /// :nodoc:
+    public init(_nsError error: NSError) {
+        _nsError = error
+    }
+}
+
+/// :nodoc:
+// Provide bridging from errors with domain RLMErrorDomain to Error.
+extension Error : _BridgedStoredNSError {
+    /// :nodoc:
+    public static var _nsErrorDomain = RLMErrorDomain
+}
+
+/// :nodoc:
+extension Error.Code : _ErrorCodeProtocol {
+    /// :nodoc:
+    public typealias _ErrorType = RLMError
+}
 
 #else
 

--- a/RealmSwift/LinkingObjects.swift
+++ b/RealmSwift/LinkingObjects.swift
@@ -139,7 +139,7 @@ public final class LinkingObjects<T: Object>: LinkingObjectsBase {
 
      - returns: The index of the first matching object, or `nil` if no objects match.
      */
-    public func indexOfObject(for predicate: Predicate) -> Int? {
+    public func indexOfObject(for predicate: NSPredicate) -> Int? {
         return notFoundToNil(index: rlmResults.indexOfObject(with: predicate))
     }
 
@@ -152,8 +152,8 @@ public final class LinkingObjects<T: Object>: LinkingObjectsBase {
      - returns: The index of the first matching object, or `nil` if no objects match.
      */
     public func indexOfObject(for predicateFormat: String, _ args: AnyObject...) -> Int? {
-        return notFoundToNil(index: rlmResults.indexOfObject(with: Predicate(format: predicateFormat,
-                                                                             argumentArray: args)))
+        return notFoundToNil(index: rlmResults.indexOfObject(with: NSPredicate(format: predicateFormat,
+                                                                               argumentArray: args)))
     }
 
     // MARK: Object Retrieval
@@ -228,7 +228,7 @@ public final class LinkingObjects<T: Object>: LinkingObjectsBase {
      - returns: Results containing objects that match the given predicate.
      */
     public func filter(using predicateFormat: String, _ args: AnyObject...) -> Results<T> {
-        return Results<T>(rlmResults.objects(with: Predicate(format: predicateFormat, argumentArray: args)))
+        return Results<T>(rlmResults.objects(with: NSPredicate(format: predicateFormat, argumentArray: args)))
     }
 
     /**
@@ -238,7 +238,7 @@ public final class LinkingObjects<T: Object>: LinkingObjectsBase {
 
      - returns: Results containing objects that match the given predicate.
      */
-    public func filter(using predicate: Predicate) -> Results<T> {
+    public func filter(using predicate: NSPredicate) -> Results<T> {
         return Results<T>(rlmResults.objects(with: predicate))
     }
 
@@ -435,13 +435,13 @@ extension LinkingObjects {
     public var invalidated : Bool { fatalError() }
 
     @available(*, unavailable, renamed:"indexOfObject(for:)")
-    public func index(of predicate: Predicate) -> Int? { fatalError() }
+    public func index(of predicate: NSPredicate) -> Int? { fatalError() }
 
     @available(*, unavailable, renamed:"indexOfObject(for:_:)")
     public func index(of predicateFormat: String, _ args: AnyObject...) -> Int? { fatalError() }
 
     @available(*, unavailable, renamed:"filter(using:)")
-    public func filter(_ predicate: Predicate) -> Results<T> { fatalError() }
+    public func filter(_ predicate: NSPredicate) -> Results<T> { fatalError() }
 
     @available(*, unavailable, renamed:"filter(using:_:)")
     public func filter(_ predicateFormat: String, _ args: AnyObject...) -> Results<T> { fatalError() }

--- a/RealmSwift/List.swift
+++ b/RealmSwift/List.swift
@@ -95,7 +95,7 @@ public final class List<T: Object>: ListBase {
 
     - returns: The index of the first matching object, or `nil` if no objects match.
     */
-    public func indexOfObject(for predicate: Predicate) -> Int? {
+    public func indexOfObject(for predicate: NSPredicate) -> Int? {
         return notFoundToNil(index: _rlmArray.indexOfObject(with: predicate))
     }
 
@@ -109,7 +109,7 @@ public final class List<T: Object>: ListBase {
     - returns: The index of the first matching object, or `nil` if no objects match.
     */
     public func indexOfObject(for predicateFormat: String, _ args: AnyObject...) -> Int? {
-        return indexOfObject(for: Predicate(format: predicateFormat, argumentArray: args))
+        return indexOfObject(for: NSPredicate(format: predicateFormat, argumentArray: args))
     }
 
     // MARK: Object Retrieval
@@ -189,7 +189,7 @@ public final class List<T: Object>: ListBase {
     - returns: `Results` containing elements that match the given predicate.
     */
     public func filter(using predicateFormat: String, _ args: AnyObject...) -> Results<T> {
-        return Results<T>(_rlmArray.objects(with: Predicate(format: predicateFormat, argumentArray: args)))
+        return Results<T>(_rlmArray.objects(with: NSPredicate(format: predicateFormat, argumentArray: args)))
     }
 
     /**
@@ -199,7 +199,7 @@ public final class List<T: Object>: ListBase {
 
     - returns: `Results` containing elements that match the given predicate.
     */
-    public func filter(using predicate: Predicate) -> Results<T> {
+    public func filter(using predicate: NSPredicate) -> Results<T> {
         return Results<T>(_rlmArray.objects(with: predicate))
     }
 
@@ -240,7 +240,7 @@ public final class List<T: Object>: ListBase {
     - returns: The minimum value for the property amongst objects in the List, or `nil` if the List is empty.
     */
     public func minimumValue<U: MinMaxType>(ofProperty property: String) -> U? {
-        return filter(using: Predicate(value: true)).minimumValue(ofProperty: property)
+        return filter(using: NSPredicate(value: true)).minimumValue(ofProperty: property)
     }
 
     /**
@@ -253,7 +253,7 @@ public final class List<T: Object>: ListBase {
     - returns: The maximum value for the property amongst objects in the List, or `nil` if the List is empty.
     */
     public func maximumValue<U: MinMaxType>(ofProperty property: String) -> U? {
-        return filter(using: Predicate(value: true)).maximumValue(ofProperty: property)
+        return filter(using: NSPredicate(value: true)).maximumValue(ofProperty: property)
     }
 
     /**
@@ -266,7 +266,7 @@ public final class List<T: Object>: ListBase {
     - returns: The sum of the given property over all objects in the List.
     */
     public func sum<U: AddableType>(ofProperty property: String) -> U {
-        return filter(using: Predicate(value: true)).sum(ofProperty: property)
+        return filter(using: NSPredicate(value: true)).sum(ofProperty: property)
     }
 
     /**
@@ -279,7 +279,7 @@ public final class List<T: Object>: ListBase {
     - returns: The average of the given property over all objects in the List, or `nil` if the List is empty.
     */
     public func average<U: AddableType>(ofProperty property: String) -> U? {
-        return filter(using: Predicate(value: true)).average(ofProperty: property)
+        return filter(using: NSPredicate(value: true)).average(ofProperty: property)
     }
 
     // MARK: Mutation
@@ -538,13 +538,13 @@ extension List {
     public var invalidated : Bool { fatalError() }
 
     @available(*, unavailable, renamed:"indexOfObject(for:)")
-    public func index(of predicate: Predicate) -> Int? { fatalError() }
+    public func index(of predicate: NSPredicate) -> Int? { fatalError() }
 
     @available(*, unavailable, renamed:"indexOfObject(for:_:)")
     public func index(of predicateFormat: String, _ args: AnyObject...) -> Int? { fatalError() }
 
     @available(*, unavailable, renamed:"filter(using:)")
-    public func filter(_ predicate: Predicate) -> Results<T> { fatalError() }
+    public func filter(_ predicate: NSPredicate) -> Results<T> { fatalError() }
 
     @available(*, unavailable, renamed:"filter(using:_:)")
     public func filter(_ predicateFormat: String, _ args: AnyObject...) -> Results<T> { fatalError() }

--- a/RealmSwift/Object.swift
+++ b/RealmSwift/Object.swift
@@ -391,7 +391,7 @@ public class ObjectUtil: NSObject {
                 properties[name] = NSNumber(value: PropertyType.bool.rawValue)
             } else if prop.value as? RLMOptionalBase != nil {
                 throwRealmException("'\(type)' is not a a valid RealmOptional type.")
-            } else if mirror.displayStyle == .optional || type is NilLiteralConvertible.Type {
+            } else if mirror.displayStyle == .optional || type is ExpressibleByNilLiteral.Type {
                 properties[name] = NSNull()
             }
             return properties

--- a/RealmSwift/RealmCollectionType.swift
+++ b/RealmSwift/RealmCollectionType.swift
@@ -163,7 +163,7 @@ public protocol RealmCollection: RandomAccessCollection, LazyCollectionProtocol,
 
     - returns: The index of the first matching object, or `nil` if no objects match.
     */
-    func indexOfObject(for predicate: Predicate) -> Int?
+    func indexOfObject(for predicate: NSPredicate) -> Int?
 
     /**
     Returns the index of the first object matching the given predicate,
@@ -195,7 +195,7 @@ public protocol RealmCollection: RandomAccessCollection, LazyCollectionProtocol,
 
     - returns: `Results` containing collection elements that match the given predicate.
     */
-    func filter(using predicate: Predicate) -> Results<Element>
+    func filter(using predicate: NSPredicate) -> Results<Element>
 
 
     // MARK: Sorting
@@ -371,10 +371,10 @@ private class _AnyRealmCollectionBase<T: Object> {
     var count: Int { fatalError() }
     var description: String { fatalError() }
     func index(of object: Element) -> Int? { fatalError() }
-    func indexOfObject(for predicate: Predicate) -> Int? { fatalError() }
+    func indexOfObject(for predicate: NSPredicate) -> Int? { fatalError() }
     func indexOfObject(for predicateFormat: String, _ args: AnyObject...) -> Int? { fatalError() }
     func filter(using predicateFormat: String, _ args: AnyObject...) -> Results<Element> { fatalError() }
-    func filter(using predicate: Predicate) -> Results<Element> { fatalError() }
+    func filter(using predicate: NSPredicate) -> Results<Element> { fatalError() }
     func sorted(onProperty property: String, ascending: Bool) -> Results<Element> { fatalError() }
     func sorted<S: Sequence where S.Iterator.Element == SortDescriptor>(with sortDescriptors: S) -> Results<Element> {
         fatalError()
@@ -438,7 +438,7 @@ private final class _AnyRealmCollection<C: RealmCollection>: _AnyRealmCollection
 
     - returns: The index of the first matching object, or `nil` if no objects match.
     */
-    override func indexOfObject(for predicate: Predicate) -> Int? { return base.indexOfObject(for: predicate) }
+    override func indexOfObject(for predicate: NSPredicate) -> Int? { return base.indexOfObject(for: predicate) }
 
     /**
     Returns the index of the first object matching the given predicate,
@@ -450,7 +450,7 @@ private final class _AnyRealmCollection<C: RealmCollection>: _AnyRealmCollection
     - returns: The index of the first matching object, or `nil` if no objects match.
     */
     override func indexOfObject(for predicateFormat: String, _ args: AnyObject...) -> Int? {
-        return base.indexOfObject(for: Predicate(format: predicateFormat, argumentArray: args))
+        return base.indexOfObject(for: NSPredicate(format: predicateFormat, argumentArray: args))
     }
 
     // MARK: Filtering
@@ -463,7 +463,7 @@ private final class _AnyRealmCollection<C: RealmCollection>: _AnyRealmCollection
     - returns: `Results` containing collection elements that match the given predicate.
     */
     override func filter(using predicateFormat: String, _ args: AnyObject...) -> Results<C.Element> {
-        return base.filter(using: Predicate(format: predicateFormat, argumentArray: args))
+        return base.filter(using: NSPredicate(format: predicateFormat, argumentArray: args))
     }
 
     /**
@@ -473,7 +473,7 @@ private final class _AnyRealmCollection<C: RealmCollection>: _AnyRealmCollection
 
     - returns: `Results` containing collection elements that match the given predicate.
     */
-    override func filter(using predicate: Predicate) -> Results<C.Element> { return base.filter(using: predicate) }
+    override func filter(using predicate: NSPredicate) -> Results<C.Element> { return base.filter(using: predicate) }
 
 
     // MARK: Sorting
@@ -697,7 +697,7 @@ public final class AnyRealmCollection<T: Object>: RealmCollection {
 
     - returns: The index of the first matching object, or `nil` if no objects match.
     */
-    public func indexOfObject(for predicate: Predicate) -> Int? { return base.indexOfObject(for: predicate) }
+    public func indexOfObject(for predicate: NSPredicate) -> Int? { return base.indexOfObject(for: predicate) }
 
     /**
     Returns the index of the first object matching the given predicate,
@@ -709,7 +709,7 @@ public final class AnyRealmCollection<T: Object>: RealmCollection {
     - returns: The index of the first matching object, or `nil` if no objects match.
     */
     public func indexOfObject(for predicateFormat: String, _ args: AnyObject...) -> Int? {
-        return base.indexOfObject(for: Predicate(format: predicateFormat, argumentArray: args))
+        return base.indexOfObject(for: NSPredicate(format: predicateFormat, argumentArray: args))
     }
 
     // MARK: Filtering
@@ -722,7 +722,7 @@ public final class AnyRealmCollection<T: Object>: RealmCollection {
     - returns: `Results` containing collection elements that match the given predicate.
     */
     public func filter(using predicateFormat: String, _ args: AnyObject...) -> Results<Element> {
-        return base.filter(using: Predicate(format: predicateFormat, argumentArray: args))
+        return base.filter(using: NSPredicate(format: predicateFormat, argumentArray: args))
     }
 
     /**
@@ -732,7 +732,7 @@ public final class AnyRealmCollection<T: Object>: RealmCollection {
 
     - returns: `Results` containing collection elements that match the given predicate.
     */
-    public func filter(using predicate: Predicate) -> Results<Element> { return base.filter(using: predicate) }
+    public func filter(using predicate: NSPredicate) -> Results<Element> { return base.filter(using: predicate) }
 
 
     // MARK: Sorting
@@ -946,13 +946,13 @@ extension AnyRealmCollection {
     public var invalidated : Bool { fatalError() }
 
     @available(*, unavailable, renamed:"indexOfObject(for:)")
-    public func index(of predicate: Predicate) -> Int? { fatalError() }
+    public func index(of predicate: NSPredicate) -> Int? { fatalError() }
 
     @available(*, unavailable, renamed:"indexOfObject(for:_:)")
     public func index(of predicateFormat: String, _ args: AnyObject...) -> Int? { fatalError() }
 
     @available(*, unavailable, renamed:"filter(using:)")
-    public func filter(_ predicate: Predicate) -> Results<T> { fatalError() }
+    public func filter(_ predicate: NSPredicate) -> Results<T> { fatalError() }
 
     @available(*, unavailable, renamed:"filter(using:_:)")
     public func filter(_ predicateFormat: String, _ args: AnyObject...) -> Results<T> { fatalError() }

--- a/RealmSwift/Results.swift
+++ b/RealmSwift/Results.swift
@@ -134,7 +134,7 @@ public final class Results<T: Object>: NSObject, NSFastEnumeration {
 
     - returns: The index of the first matching object, or `nil` if no objects match.
     */
-    public func indexOfObject(for predicate: Predicate) -> Int? {
+    public func indexOfObject(for predicate: NSPredicate) -> Int? {
         return notFoundToNil(index: rlmResults.indexOfObject(with: predicate))
     }
 
@@ -147,8 +147,8 @@ public final class Results<T: Object>: NSObject, NSFastEnumeration {
     - returns: The index of the first matching object, or `nil` if no objects match.
     */
     public func indexOfObject(for predicateFormat: String, _ args: AnyObject...) -> Int? {
-        return notFoundToNil(index: rlmResults.indexOfObject(with: Predicate(format: predicateFormat,
-                                                                             argumentArray: args)))
+        return notFoundToNil(index: rlmResults.indexOfObject(with: NSPredicate(format: predicateFormat,
+                                                                               argumentArray: args)))
     }
 
     // MARK: Object Retrieval
@@ -219,7 +219,7 @@ public final class Results<T: Object>: NSObject, NSFastEnumeration {
     - returns: Results containing objects that match the given predicate.
     */
     public func filter(using predicateFormat: String, _ args: AnyObject...) -> Results<T> {
-        return Results<T>(rlmResults.objects(with: Predicate(format: predicateFormat, argumentArray: args)))
+        return Results<T>(rlmResults.objects(with: NSPredicate(format: predicateFormat, argumentArray: args)))
     }
 
     /**
@@ -229,7 +229,7 @@ public final class Results<T: Object>: NSObject, NSFastEnumeration {
 
     - returns: Results containing objects that match the given predicate.
     */
-    public func filter(using predicate: Predicate) -> Results<T> {
+    public func filter(using predicate: NSPredicate) -> Results<T> {
         return Results<T>(rlmResults.objects(with: predicate))
     }
 
@@ -419,13 +419,13 @@ extension Results {
     public var invalidated : Bool { fatalError() }
 
     @available(*, unavailable, renamed:"indexOfObject(for:)")
-    public func index(of predicate: Predicate) -> Int? { fatalError() }
+    public func index(of predicate: NSPredicate) -> Int? { fatalError() }
 
     @available(*, unavailable, renamed:"indexOfObject(for:_:)")
     public func index(of predicateFormat: String, _ args: AnyObject...) -> Int? { fatalError() }
 
     @available(*, unavailable, renamed:"filter(using:)")
-    public func filter(_ predicate: Predicate) -> Results<T> { fatalError() }
+    public func filter(_ predicate: NSPredicate) -> Results<T> { fatalError() }
 
     @available(*, unavailable, renamed:"filter(using:_:)")
     public func filter(_ predicateFormat: String, _ args: AnyObject...) -> Results<T> { fatalError() }

--- a/RealmSwift/SortDescriptor.swift
+++ b/RealmSwift/SortDescriptor.swift
@@ -86,7 +86,7 @@ public func == (lhs: SortDescriptor, rhs: SortDescriptor) -> Bool {
 
 // MARK: StringLiteralConvertible
 
-extension SortDescriptor: StringLiteralConvertible {
+extension SortDescriptor: ExpressibleByStringLiteral {
 
     /// `StringLiteralType`. Required for `StringLiteralConvertible` conformance.
     public typealias UnicodeScalarLiteralType = StringLiteralType

--- a/RealmSwift/Tests/MigrationTests.swift
+++ b/RealmSwift/Tests/MigrationTests.swift
@@ -112,7 +112,7 @@ class MigrationTests: TestCase {
     }
 
     func testSchemaVersionAtURL() {
-        assertFails(.Fail) {
+        assertFails(.fail) {
             // Version should throw before Realm creation
             try schemaVersionAtURL(defaultRealmURL())
         }
@@ -120,7 +120,7 @@ class MigrationTests: TestCase {
         _ = try! Realm()
         XCTAssertEqual(0, try! schemaVersionAtURL(defaultRealmURL()),
                        "Initial version should be 0")
-        assertFails(.Fail) {
+        assertFails(.fail) {
             try schemaVersionAtURL(URL(fileURLWithPath: "/dev/null"))
         }
     }
@@ -457,7 +457,7 @@ class MigrationTests: TestCase {
 
         let config = Realm.Configuration(fileURL: defaultRealmURL(), objectTypes: [SwiftEmployeeObject.self])
         autoreleasepool {
-            assertFails(.SchemaMismatch) {
+            assertFails(.schemaMismatch) {
                 try Realm(configuration: config)
             }
         }
@@ -500,7 +500,7 @@ class MigrationTests: TestCase {
         class_replaceMethod(metaClass, #selector(RLMObjectBase.sharedSchema), imp, "@@:")
 
         autoreleasepool {
-            assertFails(.SchemaMismatch) {
+            assertFails(.schemaMismatch) {
                 try Realm()
             }
         }

--- a/RealmSwift/Tests/RealmCollectionTypeTests.swift
+++ b/RealmSwift/Tests/RealmCollectionTypeTests.swift
@@ -175,9 +175,9 @@ class RealmCollectionTypeTests: TestCase {
         guard let collection = collection else {
             fatalError("Test precondition failed")
         }
-        let pred1 = Predicate(format: "stringCol = '1'")
-        let pred2 = Predicate(format: "stringCol = '2'")
-        let pred3 = Predicate(format: "stringCol = '3'")
+        let pred1 = NSPredicate(format: "stringCol = '1'")
+        let pred2 = NSPredicate(format: "stringCol = '2'")
+        let pred3 = NSPredicate(format: "stringCol = '3'")
 
         XCTAssertEqual(0, collection.indexOfObject(for: pred1)!)
         XCTAssertEqual(1, collection.indexOfObject(for: pred2)!)
@@ -282,9 +282,9 @@ class RealmCollectionTypeTests: TestCase {
         guard let collection = collection else {
             fatalError("Test precondition failed")
         }
-        let pred1 = Predicate(format: "stringCol = '1'")
-        let pred2 = Predicate(format: "stringCol = '2'")
-        let pred3 = Predicate(format: "stringCol = '3'")
+        let pred1 = NSPredicate(format: "stringCol = '1'")
+        let pred2 = NSPredicate(format: "stringCol = '2'")
+        let pred3 = NSPredicate(format: "stringCol = '3'")
 
         XCTAssertEqual(1, collection.filter(using: pred1).count)
         XCTAssertEqual(1, collection.filter(using: pred2).count)
@@ -609,7 +609,7 @@ class ResultsFromLinkViewTests: ResultsTests {
             fatalError("Test precondition failed")
         }
         let array = realmWithTestPath().createObject(ofType: CTTStringList.self, populatedWith: [[str1, str2]])
-        return array.array.filter(using: Predicate(value: true))
+        return array.array.filter(using: NSPredicate(value: true))
     }
 
     override func getAggregateableCollection() -> AnyRealmCollection<CTTAggregateObject> {
@@ -619,7 +619,7 @@ class ResultsFromLinkViewTests: ResultsTests {
             realmWithTestPath().add(list!)
             list!.list.append(objectsIn: makeAggregateableObjectsInWriteTransaction())
         }
-        return AnyRealmCollection(list!.list.filter(using: Predicate(value: true)))
+        return AnyRealmCollection(list!.list.filter(using: NSPredicate(value: true)))
     }
 
     override func addObjectToResults() {
@@ -779,8 +779,8 @@ class ListStandaloneRealmCollectionTypeTests: ListRealmCollectionTypeTests {
         guard let collection = collection else {
             fatalError("Test precondition failed")
         }
-        let pred1 = Predicate(format: "stringCol = '1'")
-        let pred2 = Predicate(format: "noSuchCol = '2'")
+        let pred1 = NSPredicate(format: "stringCol = '1'")
+        let pred2 = NSPredicate(format: "noSuchCol = '2'")
 
         assertThrows(collection.filter(using: pred1))
         assertThrows(collection.filter(using: pred2))

--- a/RealmSwift/Tests/RealmTests.swift
+++ b/RealmSwift/Tests/RealmTests.swift
@@ -49,7 +49,7 @@ class RealmTests: TestCase {
     }
 
     func testOpeningInvalidPathThrows() {
-        assertFails(Error.FileAccess) {
+        assertFails(.fileAccess) {
             try Realm(configuration: Realm.Configuration(fileURL: URL(fileURLWithPath: "/dev/null/foo")))
         }
     }
@@ -63,10 +63,10 @@ class RealmTests: TestCase {
         }
 
         let fileManager = FileManager.default
-        try! fileManager.setAttributes([ FileAttributeKey.immutable: true ], ofItemAtPath: testRealmURL().path!)
+        try! fileManager.setAttributes([ FileAttributeKey.immutable: true ], ofItemAtPath: testRealmURL().path)
 
         // Should not be able to open read-write
-        assertFails(Error.FileAccess) {
+        assertFails(.fileAccess) {
             try Realm(fileURL: testRealmURL())
         }
 
@@ -76,11 +76,11 @@ class RealmTests: TestCase {
             XCTAssertEqual(1, realm.allObjects(ofType: SwiftStringObject.self).count)
         }
 
-        try! fileManager.setAttributes([ FileAttributeKey.immutable: false ], ofItemAtPath: testRealmURL().path!)
+        try! fileManager.setAttributes([ FileAttributeKey.immutable: false ], ofItemAtPath: testRealmURL().path)
     }
 
     func testReadOnlyRealmMustExist() {
-        assertFails(Error.FileNotFound) {
+        assertFails(.fileNotFound) {
             try Realm(configuration:
                 Realm.Configuration(fileURL: defaultRealmURL(), readOnly: true))
         }
@@ -94,15 +94,15 @@ class RealmTests: TestCase {
         // Make Realm at test path temporarily unreadable
         let fileManager = FileManager.default
         let permissions = try! fileManager
-            .attributesOfItem(atPath: testRealmURL().path!)[FileAttributeKey.posixPermissions] as! NSNumber
+            .attributesOfItem(atPath: testRealmURL().path)[FileAttributeKey.posixPermissions] as! NSNumber
         try! fileManager.setAttributes([ FileAttributeKey.posixPermissions: 0000 ],
-                                       ofItemAtPath: testRealmURL().path!)
+                                       ofItemAtPath: testRealmURL().path)
 
-        assertFails(Error.FilePermissionDenied) {
+        assertFails(.filePermissionDenied) {
             try Realm(fileURL: testRealmURL())
         }
 
-        try! fileManager.setAttributes([FileAttributeKey.posixPermissions: permissions], ofItemAtPath: testRealmURL().path!)
+        try! fileManager.setAttributes([FileAttributeKey.posixPermissions: permissions], ofItemAtPath: testRealmURL().path)
     }
 
     #if DEBUG
@@ -152,11 +152,11 @@ class RealmTests: TestCase {
             _ = try! Realm()
         }
 
-        FileManager.default.createFile(atPath: defaultRealmURL().path!,
+        FileManager.default.createFile(atPath: defaultRealmURL().path,
             contents:"a".data(using: String.Encoding.utf8, allowLossyConversion: false),
             attributes: nil)
 
-        assertFails(Error.FileAccess) {
+        assertFails(.fileAccess) {
             _ = try Realm()
             XCTFail("Realm creation should have failed")
         }
@@ -722,7 +722,7 @@ class RealmTests: TestCase {
         try! realm.write {
             realm.add(SwiftObject())
         }
-        let fileURL = try! defaultRealmURL().deletingLastPathComponent().appendingPathComponent("copy.realm")
+        let fileURL = defaultRealmURL().deletingLastPathComponent().appendingPathComponent("copy.realm")
         do {
             try realm.writeCopy(toFileURL: fileURL)
         } catch {

--- a/RealmSwift/Tests/TestCase.swift
+++ b/RealmSwift/Tests/TestCase.swift
@@ -142,7 +142,7 @@ class TestCase: XCTestCase {
             _ = try block()
             XCTFail("Expected to catch <\(expectedError)>, but no error was thrown.",
                 file: fileName, line: lineNumber)
-        } catch expectedError {
+        } catch let e as RealmSwift.Error where e.code == expectedError {
             // Success!
         } catch {
             XCTFail("Expected to catch <\(expectedError)>, but instead caught <\(error)>.",

--- a/RealmSwift/Tests/TestCase.swift
+++ b/RealmSwift/Tests/TestCase.swift
@@ -81,8 +81,8 @@ class TestCase: XCTestCase {
         autoreleasepool { super.invokeTest() }
 
         if !exceptionThrown {
-            XCTAssertFalse(RLMHasCachedRealmForPath(defaultRealmURL().path!))
-            XCTAssertFalse(RLMHasCachedRealmForPath(testRealmURL().path!))
+            XCTAssertFalse(RLMHasCachedRealmForPath(defaultRealmURL().path))
+            XCTAssertFalse(RLMHasCachedRealmForPath(testRealmURL().path))
         }
 
         resetRealmState()
@@ -135,7 +135,7 @@ class TestCase: XCTestCase {
         }
     }
 
-    func assertFails<T>(_ expectedError: Error, _ message: String? = nil,
+    func assertFails<T>(_ expectedError: RealmSwift.Error.Code, _ message: String? = nil,
                         fileName: StaticString = #file, lineNumber: UInt = #line,
                         block: @noescape () throws -> T) {
         do {
@@ -169,7 +169,7 @@ class TestCase: XCTestCase {
 
     private func realmURLForFile(_ fileName: String) -> URL {
         let directory = URL(fileURLWithPath: testDir, isDirectory: true)
-        return try! directory.appendingPathComponent(fileName, isDirectory: false)
+        return directory.appendingPathComponent(fileName, isDirectory: false)
     }
 }
 

--- a/RealmSwift/Util.swift
+++ b/RealmSwift/Util.swift
@@ -41,7 +41,7 @@ internal func throwForNegativeIndex(_ int: Int, parameterName: String = "index")
 }
 
 internal func gsub(pattern: String, template: String, string: String, error: NSErrorPointer = nil) -> String? {
-    let regex = try? RegularExpression(pattern: pattern, options: [])
+    let regex = try? NSRegularExpression(pattern: pattern, options: [])
     return regex?.stringByReplacingMatches(in: string, options: [],
                                            range: NSRange(location: 0, length: string.utf16.count),
                                            withTemplate: template)


### PR DESCRIPTION
This is almost entirely Swift changes. The changes break down into a couple of categories:

* `NSPredicate` and `NSRegularExpression` regained their `NS` prefix.
* `FooLiteralConvertible` protocols are now `ExpressibleByFooLiteral`.
* `URL.path` is no longer nullable.
* SE-0112 has changed how `NSError` is bridged.

To accommodate SE-0112 I've changed how our Objective-C framework defines `RLMError` to add the `ns_error_domain` attribute. This results in Swift importing it per the policy described in SE-0112, removing the need to implement our own Swift wrapper for it.