### PR TITLE
Redesign table column handling to support runtime schema changes

### DIFF
--- a/Realm.xcodeproj/project.pbxproj
+++ b/Realm.xcodeproj/project.pbxproj
@@ -118,6 +118,10 @@
 		3F9801AF1C90FD2D000A8B07 /* results_notifier.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 3F9801AD1C90FD2D000A8B07 /* results_notifier.hpp */; };
 		3F9801B01C90FD2D000A8B07 /* results_notifier.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3F9801AE1C90FD2D000A8B07 /* results_notifier.cpp */; };
 		3F9801B11C90FD31000A8B07 /* results_notifier.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3F9801AE1C90FD2D000A8B07 /* results_notifier.cpp */; };
+		3F9863BB1D36876B00641C98 /* RLMObjectInfo.mm in Sources */ = {isa = PBXBuildFile; fileRef = 3F9863B91D36876B00641C98 /* RLMObjectInfo.mm */; };
+		3F9863BC1D36876B00641C98 /* RLMObjectInfo.mm in Sources */ = {isa = PBXBuildFile; fileRef = 3F9863B91D36876B00641C98 /* RLMObjectInfo.mm */; };
+		3F9863BD1D36876B00641C98 /* RLMObjectInfo.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 3F9863BA1D36876B00641C98 /* RLMObjectInfo.hpp */; };
+		3F9863BE1D36876B00641C98 /* RLMObjectInfo.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 3F9863BA1D36876B00641C98 /* RLMObjectInfo.hpp */; };
 		3FB4FA1719F5D2740020D53B /* SwiftTestObjects.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8F8D90B196CB8DD00475368 /* SwiftTestObjects.swift */; };
 		3FB4FA1819F5D2740020D53B /* SwiftArrayPropertyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E82FA60A195632F20043A3C3 /* SwiftArrayPropertyTests.swift */; };
 		3FB4FA1919F5D2740020D53B /* SwiftArrayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E82FA60B195632F20043A3C3 /* SwiftArrayTests.swift */; };
@@ -560,6 +564,8 @@
 		3FAE25581B8CEBBE00D01405 /* object_schema.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = object_schema.hpp; sourceTree = "<group>"; };
 		3FBD05FA1B94E1C3004559CF /* index_set.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = index_set.cpp; sourceTree = "<group>"; };
 		3FBD05FB1B94E1C3004559CF /* index_set.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = index_set.hpp; sourceTree = "<group>"; };
+		3F9863B91D36876B00641C98 /* RLMObjectInfo.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = RLMObjectInfo.mm; sourceTree = "<group>"; };
+		3F9863BA1D36876B00641C98 /* RLMObjectInfo.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = RLMObjectInfo.hpp; sourceTree = "<group>"; };
 		3FBEF6781C63D66100F6935B /* RLMCollection_Private.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = RLMCollection_Private.hpp; sourceTree = "<group>"; };
 		3FBEF6791C63D66100F6935B /* RLMCollection.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = RLMCollection.mm; sourceTree = "<group>"; };
 		3FE556421B9A43E5002A1129 /* schema.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = schema.cpp; sourceTree = "<group>"; };
@@ -1056,6 +1062,8 @@
 				023B19571A3BA90D0067FB81 /* RLMObjectBase.h */,
 				023B19581A3BA90D0067FB81 /* RLMObjectBase.mm */,
 				A05FA61E1B62C3900000C9B2 /* RLMObjectBase_Dynamic.h */,
+				3F9863BA1D36876B00641C98 /* RLMObjectInfo.hpp */,
+				3F9863B91D36876B00641C98 /* RLMObjectInfo.mm */,
 				E81A1F711955FC9300FDED82 /* RLMObjectSchema.h */,
 				E81A1F721955FC9300FDED82 /* RLMObjectSchema.mm */,
 				29EDB8E91A7712E500458D80 /* RLMObjectSchema_Private.h */,
@@ -1179,6 +1187,7 @@
 				5D659EB21BE04556006515A0 /* RLMObject_Private.h in Headers */,
 				5D659EB31BE04556006515A0 /* RLMObjectBase.h in Headers */,
 				5D659EB41BE04556006515A0 /* RLMObjectBase_Dynamic.h in Headers */,
+				3F9863BD1D36876B00641C98 /* RLMObjectInfo.hpp in Headers */,
 				5D659EB51BE04556006515A0 /* RLMObjectSchema.h in Headers */,
 				5D659EB61BE04556006515A0 /* RLMObjectSchema_Private.h in Headers */,
 				5D659EB71BE04556006515A0 /* RLMObjectSchema_Private.hpp in Headers */,
@@ -1244,6 +1253,7 @@
 				5DD755B01BE056DE002800DA /* RLMObject_Private.h in Headers */,
 				5DD755B11BE056DE002800DA /* RLMObjectBase.h in Headers */,
 				5DD755B21BE056DE002800DA /* RLMObjectBase_Dynamic.h in Headers */,
+				3F9863BE1D36876B00641C98 /* RLMObjectInfo.hpp in Headers */,
 				5DD755B31BE056DE002800DA /* RLMObjectSchema.h in Headers */,
 				5DD755B41BE056DE002800DA /* RLMObjectSchema_Private.h in Headers */,
 				5DD755B51BE056DE002800DA /* RLMObjectSchema_Private.hpp in Headers */,
@@ -1750,6 +1760,7 @@
 				5D659E8B1BE04556006515A0 /* RLMMigration.mm in Sources */,
 				5D659E8C1BE04556006515A0 /* RLMObject.mm in Sources */,
 				5D659E8D1BE04556006515A0 /* RLMObjectBase.mm in Sources */,
+				3F9863BB1D36876B00641C98 /* RLMObjectInfo.mm in Sources */,
 				5D659E8E1BE04556006515A0 /* RLMObjectSchema.mm in Sources */,
 				5D659E8F1BE04556006515A0 /* RLMObjectStore.mm in Sources */,
 				5D659E901BE04556006515A0 /* RLMObservation.mm in Sources */,
@@ -1850,6 +1861,7 @@
 				5DD755891BE056DE002800DA /* RLMMigration.mm in Sources */,
 				5DD7558A1BE056DE002800DA /* RLMObject.mm in Sources */,
 				5DD7558B1BE056DE002800DA /* RLMObjectBase.mm in Sources */,
+				3F9863BC1D36876B00641C98 /* RLMObjectInfo.mm in Sources */,
 				5DD7558C1BE056DE002800DA /* RLMObjectSchema.mm in Sources */,
 				5DD7558D1BE056DE002800DA /* RLMObjectStore.mm in Sources */,
 				5DD7558E1BE056DE002800DA /* RLMObservation.mm in Sources */,
@@ -1934,6 +1946,7 @@
 				E81A1FE11955FE0100FDED82 /* ObjectInterfaceTests.m in Sources */,
 				021A88361AAFB5CD00EEAC84 /* ObjectSchemaTests.m in Sources */,
 				E81A1FE31955FE0100FDED82 /* ObjectTests.m in Sources */,
+				3F13FA701D343DE100201E9B /* PerformanceTests.m in Sources */,
 				02AFB4631A80343600E11938 /* PropertyTests.m in Sources */,
 				E81A1FE51955FE0100FDED82 /* PropertyTypeTest.mm in Sources */,
 				E81A1FE71955FE0100FDED82 /* QueryTests.m in Sources */,

--- a/Realm.xcodeproj/project.pbxproj
+++ b/Realm.xcodeproj/project.pbxproj
@@ -118,10 +118,10 @@
 		3F9801AF1C90FD2D000A8B07 /* results_notifier.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 3F9801AD1C90FD2D000A8B07 /* results_notifier.hpp */; };
 		3F9801B01C90FD2D000A8B07 /* results_notifier.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3F9801AE1C90FD2D000A8B07 /* results_notifier.cpp */; };
 		3F9801B11C90FD31000A8B07 /* results_notifier.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3F9801AE1C90FD2D000A8B07 /* results_notifier.cpp */; };
-		3F9863BB1D36876B00641C98 /* RLMObjectInfo.mm in Sources */ = {isa = PBXBuildFile; fileRef = 3F9863B91D36876B00641C98 /* RLMObjectInfo.mm */; };
-		3F9863BC1D36876B00641C98 /* RLMObjectInfo.mm in Sources */ = {isa = PBXBuildFile; fileRef = 3F9863B91D36876B00641C98 /* RLMObjectInfo.mm */; };
-		3F9863BD1D36876B00641C98 /* RLMObjectInfo.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 3F9863BA1D36876B00641C98 /* RLMObjectInfo.hpp */; };
-		3F9863BE1D36876B00641C98 /* RLMObjectInfo.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 3F9863BA1D36876B00641C98 /* RLMObjectInfo.hpp */; };
+		3F9863BB1D36876B00641C98 /* RLMClassInfo.mm in Sources */ = {isa = PBXBuildFile; fileRef = 3F9863B91D36876B00641C98 /* RLMClassInfo.mm */; };
+		3F9863BC1D36876B00641C98 /* RLMClassInfo.mm in Sources */ = {isa = PBXBuildFile; fileRef = 3F9863B91D36876B00641C98 /* RLMClassInfo.mm */; };
+		3F9863BD1D36876B00641C98 /* RLMClassInfo.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 3F9863BA1D36876B00641C98 /* RLMClassInfo.hpp */; };
+		3F9863BE1D36876B00641C98 /* RLMClassInfo.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 3F9863BA1D36876B00641C98 /* RLMClassInfo.hpp */; };
 		3FB4FA1719F5D2740020D53B /* SwiftTestObjects.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8F8D90B196CB8DD00475368 /* SwiftTestObjects.swift */; };
 		3FB4FA1819F5D2740020D53B /* SwiftArrayPropertyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E82FA60A195632F20043A3C3 /* SwiftArrayPropertyTests.swift */; };
 		3FB4FA1919F5D2740020D53B /* SwiftArrayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E82FA60B195632F20043A3C3 /* SwiftArrayTests.swift */; };
@@ -564,8 +564,8 @@
 		3FAE25581B8CEBBE00D01405 /* object_schema.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = object_schema.hpp; sourceTree = "<group>"; };
 		3FBD05FA1B94E1C3004559CF /* index_set.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = index_set.cpp; sourceTree = "<group>"; };
 		3FBD05FB1B94E1C3004559CF /* index_set.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = index_set.hpp; sourceTree = "<group>"; };
-		3F9863B91D36876B00641C98 /* RLMObjectInfo.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = RLMObjectInfo.mm; sourceTree = "<group>"; };
-		3F9863BA1D36876B00641C98 /* RLMObjectInfo.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = RLMObjectInfo.hpp; sourceTree = "<group>"; };
+		3F9863B91D36876B00641C98 /* RLMClassInfo.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = RLMClassInfo.mm; sourceTree = "<group>"; };
+		3F9863BA1D36876B00641C98 /* RLMClassInfo.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = RLMClassInfo.hpp; sourceTree = "<group>"; };
 		3FBEF6781C63D66100F6935B /* RLMCollection_Private.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = RLMCollection_Private.hpp; sourceTree = "<group>"; };
 		3FBEF6791C63D66100F6935B /* RLMCollection.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = RLMCollection.mm; sourceTree = "<group>"; };
 		3FE556421B9A43E5002A1129 /* schema.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = schema.cpp; sourceTree = "<group>"; };
@@ -1045,6 +1045,8 @@
 				0237B5421A856F06004ACD57 /* RLMArray_Private.h */,
 				E81A1F651955FC9300FDED82 /* RLMArray_Private.hpp */,
 				E81A1F691955FC9300FDED82 /* RLMArrayLinkView.mm */,
+				3F9863BA1D36876B00641C98 /* RLMClassInfo.hpp */,
+				3F9863B91D36876B00641C98 /* RLMClassInfo.mm */,
 				02B8EF5B19E7048D0045A93D /* RLMCollection.h */,
 				3FBEF6791C63D66100F6935B /* RLMCollection.mm */,
 				3FBEF6781C63D66100F6935B /* RLMCollection_Private.hpp */,
@@ -1062,8 +1064,6 @@
 				023B19571A3BA90D0067FB81 /* RLMObjectBase.h */,
 				023B19581A3BA90D0067FB81 /* RLMObjectBase.mm */,
 				A05FA61E1B62C3900000C9B2 /* RLMObjectBase_Dynamic.h */,
-				3F9863BA1D36876B00641C98 /* RLMObjectInfo.hpp */,
-				3F9863B91D36876B00641C98 /* RLMObjectInfo.mm */,
 				E81A1F711955FC9300FDED82 /* RLMObjectSchema.h */,
 				E81A1F721955FC9300FDED82 /* RLMObjectSchema.mm */,
 				29EDB8E91A7712E500458D80 /* RLMObjectSchema_Private.h */,
@@ -1177,6 +1177,7 @@
 				5D659EA81BE04556006515A0 /* RLMAnalytics.hpp in Headers */,
 				5D659EA91BE04556006515A0 /* RLMArray.h in Headers */,
 				5D659EAA1BE04556006515A0 /* RLMArray_Private.h in Headers */,
+				3F9863BD1D36876B00641C98 /* RLMClassInfo.hpp in Headers */,
 				5D659EAB1BE04556006515A0 /* RLMCollection.h in Headers */,
 				3FBEF67A1C63D66100F6935B /* RLMCollection_Private.hpp in Headers */,
 				5D659EAC1BE04556006515A0 /* RLMConstants.h in Headers */,
@@ -1187,7 +1188,6 @@
 				5D659EB21BE04556006515A0 /* RLMObject_Private.h in Headers */,
 				5D659EB31BE04556006515A0 /* RLMObjectBase.h in Headers */,
 				5D659EB41BE04556006515A0 /* RLMObjectBase_Dynamic.h in Headers */,
-				3F9863BD1D36876B00641C98 /* RLMObjectInfo.hpp in Headers */,
 				5D659EB51BE04556006515A0 /* RLMObjectSchema.h in Headers */,
 				5D659EB61BE04556006515A0 /* RLMObjectSchema_Private.h in Headers */,
 				5D659EB71BE04556006515A0 /* RLMObjectSchema_Private.hpp in Headers */,
@@ -1244,6 +1244,7 @@
 				5DD755A61BE056DE002800DA /* RLMAnalytics.hpp in Headers */,
 				5DD755A71BE056DE002800DA /* RLMArray.h in Headers */,
 				5DD755A81BE056DE002800DA /* RLMArray_Private.h in Headers */,
+				3F9863BE1D36876B00641C98 /* RLMClassInfo.hpp in Headers */,
 				5DD755A91BE056DE002800DA /* RLMCollection.h in Headers */,
 				5DD755AA1BE056DE002800DA /* RLMConstants.h in Headers */,
 				5DD755AC1BE056DE002800DA /* RLMListBase.h in Headers */,
@@ -1253,7 +1254,6 @@
 				5DD755B01BE056DE002800DA /* RLMObject_Private.h in Headers */,
 				5DD755B11BE056DE002800DA /* RLMObjectBase.h in Headers */,
 				5DD755B21BE056DE002800DA /* RLMObjectBase_Dynamic.h in Headers */,
-				3F9863BE1D36876B00641C98 /* RLMObjectInfo.hpp in Headers */,
 				5DD755B31BE056DE002800DA /* RLMObjectSchema.h in Headers */,
 				5DD755B41BE056DE002800DA /* RLMObjectSchema_Private.h in Headers */,
 				5DD755B51BE056DE002800DA /* RLMObjectSchema_Private.hpp in Headers */,
@@ -1754,13 +1754,13 @@
 				5D659E861BE04556006515A0 /* RLMAnalytics.mm in Sources */,
 				5D659E871BE04556006515A0 /* RLMArray.mm in Sources */,
 				5D659E881BE04556006515A0 /* RLMArrayLinkView.mm in Sources */,
+				3F9863BB1D36876B00641C98 /* RLMClassInfo.mm in Sources */,
 				3FBEF67B1C63D66100F6935B /* RLMCollection.mm in Sources */,
 				5D659E891BE04556006515A0 /* RLMConstants.m in Sources */,
 				5D659E8A1BE04556006515A0 /* RLMListBase.mm in Sources */,
 				5D659E8B1BE04556006515A0 /* RLMMigration.mm in Sources */,
 				5D659E8C1BE04556006515A0 /* RLMObject.mm in Sources */,
 				5D659E8D1BE04556006515A0 /* RLMObjectBase.mm in Sources */,
-				3F9863BB1D36876B00641C98 /* RLMObjectInfo.mm in Sources */,
 				5D659E8E1BE04556006515A0 /* RLMObjectSchema.mm in Sources */,
 				5D659E8F1BE04556006515A0 /* RLMObjectStore.mm in Sources */,
 				5D659E901BE04556006515A0 /* RLMObservation.mm in Sources */,
@@ -1855,13 +1855,13 @@
 				5DD755841BE056DE002800DA /* RLMAnalytics.mm in Sources */,
 				5DD755851BE056DE002800DA /* RLMArray.mm in Sources */,
 				5DD755861BE056DE002800DA /* RLMArrayLinkView.mm in Sources */,
+				3F9863BC1D36876B00641C98 /* RLMClassInfo.mm in Sources */,
 				3FBEF67C1C63D66400F6935B /* RLMCollection.mm in Sources */,
 				5DD755871BE056DE002800DA /* RLMConstants.m in Sources */,
 				5DD755881BE056DE002800DA /* RLMListBase.mm in Sources */,
 				5DD755891BE056DE002800DA /* RLMMigration.mm in Sources */,
 				5DD7558A1BE056DE002800DA /* RLMObject.mm in Sources */,
 				5DD7558B1BE056DE002800DA /* RLMObjectBase.mm in Sources */,
-				3F9863BC1D36876B00641C98 /* RLMObjectInfo.mm in Sources */,
 				5DD7558C1BE056DE002800DA /* RLMObjectSchema.mm in Sources */,
 				5DD7558D1BE056DE002800DA /* RLMObjectStore.mm in Sources */,
 				5DD7558E1BE056DE002800DA /* RLMObservation.mm in Sources */,

--- a/Realm/RLMAccessor.h
+++ b/Realm/RLMAccessor.h
@@ -44,11 +44,11 @@ bool RLMIsGeneratedClass(Class cls);
 // Dynamic getters/setters
 //
 FOUNDATION_EXTERN void RLMDynamicValidatedSet(RLMObjectBase *obj, NSString *propName, id __nullable val);
-FOUNDATION_EXTERN RLMProperty *RLMValidatedGetProperty(RLMObjectBase *obj, NSString *propName);
 FOUNDATION_EXTERN id __nullable RLMDynamicGet(RLMObjectBase *obj, RLMProperty *prop);
+FOUNDATION_EXTERN id __nullable RLMDynamicGetByName(RLMObjectBase *obj, NSString *propName, bool asList);
 
 // by property/column
-FOUNDATION_EXTERN void RLMDynamicSet(RLMObjectBase *obj, RLMProperty *prop, id val, RLMCreationOptions options);
+void RLMDynamicSet(RLMObjectBase *obj, RLMProperty *prop, id val, RLMCreationOptions options);
 
 //
 // Class modification

--- a/Realm/RLMAccessor.mm
+++ b/Realm/RLMAccessor.mm
@@ -214,7 +214,7 @@ static inline RLMObjectBase *RLMGetLink(__unsafe_unretained RLMObjectBase *const
         return nil;
     }
     NSUInteger index = obj->_row.get_link(col);
-    return RLMCreateObjectAccessor(obj->_realm, obj->_realm->_info[obj->_objectSchema.properties[colIndex].objectClassName], index);
+    return RLMCreateObjectAccessor(obj->_realm, obj->_info->linkTargetType(colIndex), index);
 }
 
 static inline void RLMSetValue(__unsafe_unretained RLMObjectBase *const obj, NSUInteger colIndex,

--- a/Realm/RLMAccessor.mm
+++ b/Realm/RLMAccessor.mm
@@ -30,6 +30,7 @@
 #import "RLMSchema_Private.h"
 #import "RLMUtil.hpp"
 #import "results.hpp"
+#import "property.hpp"
 
 #import <objc/runtime.h>
 #import <realm/descriptor.hpp>
@@ -57,11 +58,24 @@ typedef NS_ENUM(char, RLMAccessorCode) {
     RLMAccessorCodeBoolObject,
 };
 
-// long getter/setter
-static inline long long RLMGetLong(__unsafe_unretained RLMObjectBase *const obj, NSUInteger colIndex) {
+template<typename T>
+static T get(__unsafe_unretained RLMObjectBase *const obj, NSUInteger index) {
     RLMVerifyAttached(obj);
-    return obj->_row.get_int(colIndex);
+    return obj->_row.get_table()->get<T>(obj->_info->objectSchema->persisted_properties[index].table_column, obj->_row.get_index());
 }
+
+template<typename T>
+static NSNumber *getBoxed(__unsafe_unretained RLMObjectBase *const obj, NSUInteger index) {
+    RLMVerifyAttached(obj);
+    auto col = obj->_info->objectSchema->persisted_properties[index].table_column;
+    if (obj->_row.is_null(col)) {
+        return nil;
+    }
+    return @(obj->_row.get_table()->get<T>(col, obj->_row.get_index()));
+}
+
+
+// long getter/setter
 static inline void RLMSetValue(__unsafe_unretained RLMObjectBase *const obj, NSUInteger colIndex, long long val) {
     RLMVerifyInWriteTransaction(obj);
     obj->_row.set_int(colIndex, val);
@@ -79,30 +93,18 @@ static inline void RLMSetValueUnique(__unsafe_unretained RLMObjectBase *const ob
 }
 
 // float getter/setter
-static inline float RLMGetFloat(__unsafe_unretained RLMObjectBase *const obj, NSUInteger colIndex) {
-    RLMVerifyAttached(obj);
-    return obj->_row.get_float(colIndex);
-}
 static inline void RLMSetValue(__unsafe_unretained RLMObjectBase *const obj, NSUInteger colIndex, float val) {
     RLMVerifyInWriteTransaction(obj);
     obj->_row.set_float(colIndex, val);
 }
 
 // double getter/setter
-static inline double RLMGetDouble(__unsafe_unretained RLMObjectBase *const obj, NSUInteger colIndex) {
-    RLMVerifyAttached(obj);
-    return obj->_row.get_double(colIndex);
-}
 static inline void RLMSetValue(__unsafe_unretained RLMObjectBase *const obj, NSUInteger colIndex, double val) {
     RLMVerifyInWriteTransaction(obj);
     obj->_row.set_double(colIndex, val);
 }
 
 // bool getter/setter
-static inline bool RLMGetBool(__unsafe_unretained RLMObjectBase *const obj, NSUInteger colIndex) {
-    RLMVerifyAttached(obj);
-    return obj->_row.get_bool(colIndex);
-}
 static inline void RLMSetValue(__unsafe_unretained RLMObjectBase *const obj, NSUInteger colIndex, BOOL val) {
     RLMVerifyInWriteTransaction(obj);
     obj->_row.set_bool(colIndex, val);
@@ -110,8 +112,7 @@ static inline void RLMSetValue(__unsafe_unretained RLMObjectBase *const obj, NSU
 
 // string getter/setter
 static inline NSString *RLMGetString(__unsafe_unretained RLMObjectBase *const obj, NSUInteger colIndex) {
-    RLMVerifyAttached(obj);
-    return RLMStringDataToNSString(obj->_row.get_string(colIndex));
+    return RLMStringDataToNSString(get<realm::StringData>(obj, colIndex));
 }
 static inline void RLMSetValue(__unsafe_unretained RLMObjectBase *const obj, NSUInteger colIndex, __unsafe_unretained NSString *const val) {
     RLMVerifyInWriteTransaction(obj);
@@ -143,8 +144,7 @@ static inline void RLMSetValueUnique(__unsafe_unretained RLMObjectBase *const ob
 
 // date getter/setter
 static inline NSDate *RLMGetDate(__unsafe_unretained RLMObjectBase *const obj, NSUInteger colIndex) {
-    RLMVerifyAttached(obj);
-    return RLMTimestampToNSDate(obj->_row.get_timestamp(colIndex));
+    return RLMTimestampToNSDate(get<realm::Timestamp>(obj, colIndex));
 }
 static inline void RLMSetValue(__unsafe_unretained RLMObjectBase *const obj, NSUInteger colIndex, __unsafe_unretained NSDate *const date) {
     RLMVerifyInWriteTransaction(obj);
@@ -158,9 +158,7 @@ static inline void RLMSetValue(__unsafe_unretained RLMObjectBase *const obj, NSU
 
 // data getter/setter
 static inline NSData *RLMGetData(__unsafe_unretained RLMObjectBase *const obj, NSUInteger colIndex) {
-    RLMVerifyAttached(obj);
-    realm::BinaryData data = obj->_row.get_binary(colIndex);
-    return RLMBinaryDataToNSData(data);
+    return RLMBinaryDataToNSData(get<realm::BinaryData>(obj, colIndex));
 }
 static inline void RLMSetValue(__unsafe_unretained RLMObjectBase *const obj, NSUInteger colIndex, __unsafe_unretained NSData *const data) {
     RLMVerifyInWriteTransaction(obj);
@@ -208,49 +206,42 @@ static inline RLMObjectBase *RLMGetLinkedObjectForValue(__unsafe_unretained RLMR
 }
 
 // link getter/setter
-static inline RLMObjectBase *RLMGetLink(__unsafe_unretained RLMObjectBase *const obj, NSUInteger colIndex, __unsafe_unretained NSString *const objectClassName) {
+static inline RLMObjectBase *RLMGetLink(__unsafe_unretained RLMObjectBase *const obj, NSUInteger colIndex) {
     RLMVerifyAttached(obj);
+    auto col = obj->_info->objectSchema->persisted_properties[colIndex].table_column;
 
-    if (obj->_row.is_null_link(colIndex)) {
+    if (obj->_row.is_null_link(col)) {
         return nil;
     }
-    NSUInteger index = obj->_row.get_link(colIndex);
-    return RLMCreateObjectAccessor(obj->_realm, obj->_realm.schema[objectClassName], index);
+    NSUInteger index = obj->_row.get_link(col);
+    return RLMCreateObjectAccessor(obj->_realm, obj->_realm->_info[obj->_objectSchema.properties[colIndex].objectClassName], index);
 }
 
 static inline void RLMSetValue(__unsafe_unretained RLMObjectBase *const obj, NSUInteger colIndex,
                                __unsafe_unretained RLMObjectBase *const val) {
     RLMVerifyInWriteTransaction(obj);
-
     if (!val) {
         obj->_row.nullify_link(colIndex);
+        return;
     }
-    else {
-        // make sure it is the correct type
-        RLMObjectSchema *valSchema = val->_objectSchema;
-        RLMObjectSchema *objSchema = obj->_objectSchema;
-        if (![[objSchema propertyForTableColumn:colIndex].objectClassName isEqualToString:valSchema.className]) {
-            @throw RLMException(@"Can't set object of type '%@' to property of type '%@'",
-                                valSchema.className, [objSchema propertyForTableColumn:colIndex].objectClassName);
-        }
-        RLMObjectBase *link = RLMGetLinkedObjectForValue(obj->_realm, valSchema.className, val, RLMCreationOptionsPromoteUnmanaged);
-        obj->_row.set_link(colIndex, link->_row.get_index());
+
+    RLMObjectBase *link = RLMGetLinkedObjectForValue(obj->_realm, val->_objectSchema.className,
+                                                     val, RLMCreationOptionsPromoteUnmanaged);
+
+    // make sure it is the correct type
+    if (link->_row.get_table() != obj->_row.get_table()->get_link_target(colIndex)) {
+        @throw RLMException(@"Can't set object of type '%@' to property of type '%@'",
+                            val->_objectSchema.className,
+                            obj->_info->propertyForTableColumn(colIndex).objectClassName);
     }
+    obj->_row.set_link(colIndex, link->_row.get_index());
 }
 
 // array getter/setter
-static inline RLMArray *RLMGetArray(__unsafe_unretained RLMObjectBase *const obj,
-                                    NSUInteger colIndex,
-                                    __unsafe_unretained NSString *const objectClassName,
-                                    __unsafe_unretained NSString *const propName) {
+static inline RLMArray *RLMGetArray(__unsafe_unretained RLMObjectBase *const obj, NSUInteger colIndex) {
     RLMVerifyAttached(obj);
-
-    realm::LinkViewRef linkView = obj->_row.get_linklist(colIndex);
-    return [RLMArrayLinkView arrayWithObjectClassName:objectClassName
-                                                 view:linkView
-                                                realm:obj->_realm
-                                                  key:propName
-                                         parentSchema:obj->_objectSchema];
+    auto prop = obj->_info->rlmObjectSchema.properties[colIndex];
+    return [[RLMArrayLinkView alloc] initWithParent:obj property:prop];
 }
 
 static inline void RLMSetValue(__unsafe_unretained RLMObjectBase *const obj, NSUInteger colIndex,
@@ -267,14 +258,6 @@ static inline void RLMSetValue(__unsafe_unretained RLMObjectBase *const obj, NSU
     }
 }
 
-static inline NSNumber<RLMInt> *RLMGetIntObject(__unsafe_unretained RLMObjectBase *const obj, NSUInteger colIndex) {
-    RLMVerifyAttached(obj);
-
-    if (obj->_row.is_null(colIndex)) {
-        return nil;
-    }
-    return @(obj->_row.get_int(colIndex));
-}
 static inline void RLMSetValue(__unsafe_unretained RLMObjectBase *const obj, NSUInteger colIndex,
                                __unsafe_unretained NSNumber<RLMInt> *const intObject) {
     RLMVerifyInWriteTransaction(obj);
@@ -315,14 +298,6 @@ static inline void RLMSetValueUnique(__unsafe_unretained RLMObjectBase *const ob
     }
 }
 
-static inline NSNumber<RLMFloat> *RLMGetFloatObject(__unsafe_unretained RLMObjectBase *const obj, NSUInteger colIndex) {
-    RLMVerifyAttached(obj);
-
-    if (obj->_row.is_null(colIndex)) {
-        return nil;
-    }
-    return @(obj->_row.get_float(colIndex));
-}
 static inline void RLMSetValue(__unsafe_unretained RLMObjectBase *const obj, NSUInteger colIndex,
                                __unsafe_unretained NSNumber<RLMFloat> *const floatObject) {
     RLMVerifyInWriteTransaction(obj);
@@ -335,14 +310,6 @@ static inline void RLMSetValue(__unsafe_unretained RLMObjectBase *const obj, NSU
     }
 }
 
-static inline NSNumber<RLMDouble> *RLMGetDoubleObject(__unsafe_unretained RLMObjectBase *const obj, NSUInteger colIndex) {
-    RLMVerifyAttached(obj);
-
-    if (obj->_row.is_null(colIndex)) {
-        return nil;
-    }
-    return @(obj->_row.get_double(colIndex));
-}
 static inline void RLMSetValue(__unsafe_unretained RLMObjectBase *const obj, NSUInteger colIndex,
                                __unsafe_unretained NSNumber<RLMDouble> *const doubleObject) {
     RLMVerifyInWriteTransaction(obj);
@@ -355,14 +322,6 @@ static inline void RLMSetValue(__unsafe_unretained RLMObjectBase *const obj, NSU
     }
 }
 
-static inline NSNumber<RLMBool> *RLMGetBoolObject(__unsafe_unretained RLMObjectBase *const obj, NSUInteger colIndex) {
-    RLMVerifyAttached(obj);
-
-    if (obj->_row.is_null(colIndex)) {
-        return nil;
-    }
-    return @(obj->_row.get_bool(colIndex));
-}
 static inline void RLMSetValue(__unsafe_unretained RLMObjectBase *const obj, NSUInteger colIndex,
                                __unsafe_unretained NSNumber<RLMBool> *const boolObject) {
     RLMVerifyInWriteTransaction(obj);
@@ -375,12 +334,13 @@ static inline void RLMSetValue(__unsafe_unretained RLMObjectBase *const obj, NSU
     }
 }
 
-static inline RLMLinkingObjects *RLMGetLinkingObjects(__unsafe_unretained RLMObjectBase *const obj, __unsafe_unretained RLMProperty *const property) {
-    RLMObjectSchema *objectSchema = obj->_realm.schema[property.objectClassName];
-    RLMProperty *linkingProperty = objectSchema[property.linkOriginPropertyName];
-    auto backlinkView = obj->_row.get_table()->get_backlink_view(obj->_row.get_index(), objectSchema.table, linkingProperty.column);
+static inline RLMLinkingObjects *RLMGetLinkingObjects(__unsafe_unretained RLMObjectBase *const obj,
+                                                      __unsafe_unretained RLMProperty *const property) {
+    auto& objectInfo = obj->_realm->_info[property.objectClassName];
+    auto linkingProperty = objectInfo.objectSchema->property_for_name(property.linkOriginPropertyName.UTF8String);
+    auto backlinkView = obj->_row.get_table()->get_backlink_view(obj->_row.get_index(), objectInfo.table(), linkingProperty->table_column);
     realm::Results results(obj->_realm->_realm, std::move(backlinkView));
-    return [RLMLinkingObjects resultsWithObjectSchema:objectSchema results:std::move(results)];
+    return [RLMLinkingObjects resultsWithObjectInfo:objectInfo results:std::move(results)];
 }
 
 // any getter/setter
@@ -395,79 +355,77 @@ static inline void RLMSetValue(__unsafe_unretained RLMObjectBase *const obj, NSU
 
 // dynamic getter with column closure
 static IMP RLMAccessorGetter(RLMProperty *prop, RLMAccessorCode accessorCode) {
-    NSUInteger colIndex = prop.column;
-    NSString *name = prop.name;
-    NSString *objectClassName = prop.objectClassName;
+    NSUInteger index = prop.index;
     switch (accessorCode) {
         case RLMAccessorCodeByte:
             return imp_implementationWithBlock(^(__unsafe_unretained RLMObjectBase *const obj) {
-                return (char)RLMGetLong(obj, colIndex);
+                return (char)get<int64_t>(obj, index);
             });
         case RLMAccessorCodeShort:
             return imp_implementationWithBlock(^(__unsafe_unretained RLMObjectBase *const obj) {
-                return (short)RLMGetLong(obj, colIndex);
+                return (short)get<int64_t>(obj, index);
             });
         case RLMAccessorCodeInt:
             return imp_implementationWithBlock(^(__unsafe_unretained RLMObjectBase *const obj) {
-                return (int)RLMGetLong(obj, colIndex);
+                return (int)get<int64_t>(obj, index);
             });
         case RLMAccessorCodeLongLong:
             return imp_implementationWithBlock(^(__unsafe_unretained RLMObjectBase *const obj) {
-                return RLMGetLong(obj, colIndex);
+                return get<int64_t>(obj, index);
             });
         case RLMAccessorCodeLong:
             return imp_implementationWithBlock(^(__unsafe_unretained RLMObjectBase *const obj) {
-                return (long)RLMGetLong(obj, colIndex);
+                return (long)get<int64_t>(obj, index);
             });
         case RLMAccessorCodeFloat:
             return imp_implementationWithBlock(^(__unsafe_unretained RLMObjectBase *const obj) {
-                return RLMGetFloat(obj, colIndex);
+                return get<float>(obj, index);
             });
         case RLMAccessorCodeDouble:
             return imp_implementationWithBlock(^(__unsafe_unretained RLMObjectBase *const obj) {
-                return RLMGetDouble(obj, colIndex);
+                return get<double>(obj, index);
             });
         case RLMAccessorCodeBool:
             return imp_implementationWithBlock(^(__unsafe_unretained RLMObjectBase *const obj) {
-                return RLMGetBool(obj, colIndex);
+                return get<bool>(obj, index);
             });
         case RLMAccessorCodeString:
             return imp_implementationWithBlock(^(__unsafe_unretained RLMObjectBase *const obj) {
-                return RLMGetString(obj, colIndex);
+                return RLMGetString(obj, index);
             });
         case RLMAccessorCodeDate:
             return imp_implementationWithBlock(^(__unsafe_unretained RLMObjectBase *const obj) {
-                return RLMGetDate(obj, colIndex);
+                return RLMGetDate(obj, index);
             });
         case RLMAccessorCodeData:
             return imp_implementationWithBlock(^(__unsafe_unretained RLMObjectBase *const obj) {
-                return RLMGetData(obj, colIndex);
+                return RLMGetData(obj, index);
             });
         case RLMAccessorCodeLink:
             return imp_implementationWithBlock(^id(__unsafe_unretained RLMObjectBase *const obj) {
-                return RLMGetLink(obj, colIndex, objectClassName);
+                return RLMGetLink(obj, index);
             });
         case RLMAccessorCodeArray:
             return imp_implementationWithBlock(^(__unsafe_unretained RLMObjectBase *const obj) {
-                return RLMGetArray(obj, colIndex, objectClassName, name);
+                return RLMGetArray(obj, index);
             });
         case RLMAccessorCodeAny:
             @throw RLMException(@"Cannot create accessor class for schema with Mixed properties");
         case RLMAccessorCodeIntObject:
             return imp_implementationWithBlock(^(__unsafe_unretained RLMObjectBase *const obj) {
-                return RLMGetIntObject(obj, colIndex);
+                return getBoxed<int64_t>(obj, index);
             });
         case RLMAccessorCodeFloatObject:
             return imp_implementationWithBlock(^(__unsafe_unretained RLMObjectBase *const obj) {
-                return RLMGetFloatObject(obj, colIndex);
+                return getBoxed<float>(obj, index);
             });
         case RLMAccessorCodeDoubleObject:
             return imp_implementationWithBlock(^(__unsafe_unretained RLMObjectBase *const obj) {
-                return RLMGetDoubleObject(obj, colIndex);
+                return getBoxed<double>(obj, index);
             });
         case RLMAccessorCodeBoolObject:
             return imp_implementationWithBlock(^(__unsafe_unretained RLMObjectBase *const obj) {
-                return RLMGetBoolObject(obj, colIndex);
+                return getBoxed<bool>(obj, index);
             });
         case RLMAccessorCodeLinkingObjects:
             return imp_implementationWithBlock(^(__unsafe_unretained RLMObjectBase *const obj) {
@@ -478,7 +436,7 @@ static IMP RLMAccessorGetter(RLMProperty *prop, RLMAccessorCode accessorCode) {
 
 template<typename Function>
 static void RLMWrapSetter(__unsafe_unretained RLMObjectBase *const obj, __unsafe_unretained NSString *const name, Function&& f) {
-    if (RLMObservationInfo *info = RLMGetObservationInfo(obj->_observationInfo, obj->_row.get_index(), obj->_objectSchema)) {
+    if (RLMObservationInfo *info = RLMGetObservationInfo(obj->_observationInfo, obj->_row.get_index(), *obj->_info)) {
         info->willChange(name);
         f();
         info->didChange(name);
@@ -490,7 +448,7 @@ static void RLMWrapSetter(__unsafe_unretained RLMObjectBase *const obj, __unsafe
 
 template<typename ArgType, typename StorageType=ArgType>
 static IMP RLMMakeSetter(RLMProperty *prop) {
-    NSUInteger colIndex = prop.column;
+    NSUInteger index = prop.index;
     NSString *name = prop.name;
     if (prop.isPrimary) {
         return imp_implementationWithBlock(^(__unused RLMObjectBase *obj, __unused ArgType val) {
@@ -499,7 +457,7 @@ static IMP RLMMakeSetter(RLMProperty *prop) {
     }
     return imp_implementationWithBlock(^(__unsafe_unretained RLMObjectBase *const obj, ArgType val) {
         RLMWrapSetter(obj, name, [&] {
-            RLMSetValue(obj, colIndex, static_cast<StorageType>(val));
+            RLMSetValue(obj, obj->_info->objectSchema->persisted_properties[index].table_column, static_cast<StorageType>(val));
         });
     });
 }
@@ -784,7 +742,7 @@ void RLMDynamicValidatedSet(RLMObjectBase *obj, NSString *propName, id val) {
 
 void RLMDynamicSet(__unsafe_unretained RLMObjectBase *const obj, __unsafe_unretained RLMProperty *const prop,
                    __unsafe_unretained id const val, RLMCreationOptions creationOptions) {
-    NSUInteger col = prop.column;
+    auto col = obj->_info->tableColumn(prop);
     RLMWrapSetter(obj, prop.name, [&] {
         switch (accessorCodeForType(prop.objcType, prop.type)) {
             case RLMAccessorCodeByte:
@@ -871,26 +829,26 @@ void RLMDynamicSet(__unsafe_unretained RLMObjectBase *const obj, __unsafe_unreta
 }
 
 id RLMDynamicGet(__unsafe_unretained RLMObjectBase *const obj, __unsafe_unretained RLMProperty *const prop) {
-    NSUInteger col = prop.column;
+    auto index = prop.index;
     switch (accessorCodeForType(prop.objcType, prop.type)) {
-        case RLMAccessorCodeByte:         return @((char)RLMGetLong(obj, col));
-        case RLMAccessorCodeShort:        return @((short)RLMGetLong(obj, col));
-        case RLMAccessorCodeInt:          return @((int)RLMGetLong(obj, col));
-        case RLMAccessorCodeLong:         return @((long)RLMGetLong(obj, col));
-        case RLMAccessorCodeLongLong:     return @(RLMGetLong(obj, col));
-        case RLMAccessorCodeFloat:        return @(RLMGetFloat(obj, col));
-        case RLMAccessorCodeDouble:       return @(RLMGetDouble(obj, col));
-        case RLMAccessorCodeBool:         return @(RLMGetBool(obj, col));
-        case RLMAccessorCodeString:       return RLMGetString(obj, col);
-        case RLMAccessorCodeDate:         return RLMGetDate(obj, col);
-        case RLMAccessorCodeData:         return RLMGetData(obj, col);
-        case RLMAccessorCodeLink:         return RLMGetLink(obj, col, prop.objectClassName);
-        case RLMAccessorCodeArray:        return RLMGetArray(obj, col, prop.objectClassName, prop.name);
-        case RLMAccessorCodeAny:          return RLMGetAnyProperty(obj, col);
-        case RLMAccessorCodeIntObject:    return RLMGetIntObject(obj, col);
-        case RLMAccessorCodeFloatObject:  return RLMGetFloatObject(obj, col);
-        case RLMAccessorCodeDoubleObject: return RLMGetDoubleObject(obj, col);
-        case RLMAccessorCodeBoolObject:   return RLMGetBoolObject(obj, col);
+        case RLMAccessorCodeIntObject:
+        case RLMAccessorCodeByte:
+        case RLMAccessorCodeShort:
+        case RLMAccessorCodeInt:
+        case RLMAccessorCodeLong:
+        case RLMAccessorCodeLongLong:     return getBoxed<int64_t>(obj, index);
+        case RLMAccessorCodeFloatObject:
+        case RLMAccessorCodeFloat:        return getBoxed<float>(obj, index);
+        case RLMAccessorCodeDoubleObject:
+        case RLMAccessorCodeDouble:       return getBoxed<double>(obj, index);
+        case RLMAccessorCodeBoolObject:
+        case RLMAccessorCodeBool:         return getBoxed<bool>(obj, index);
+        case RLMAccessorCodeString:       return RLMGetString(obj, index);
+        case RLMAccessorCodeDate:         return RLMGetDate(obj, index);
+        case RLMAccessorCodeData:         return RLMGetData(obj, index);
+        case RLMAccessorCodeLink:         return RLMGetLink(obj, index);
+        case RLMAccessorCodeArray:        return RLMGetArray(obj, index);
+        case RLMAccessorCodeAny:          return RLMGetAnyProperty(obj, index);
         case RLMAccessorCodeLinkingObjects: return RLMGetLinkingObjects(obj, prop);
     }
 }

--- a/Realm/RLMArray.mm
+++ b/Realm/RLMArray.mm
@@ -72,7 +72,7 @@ static void changeArray(__unsafe_unretained RLMArray *const ar, NSKeyValueChange
     changeArray(ar, kind, f, [=] { return is; });
 }
 
-- (instancetype)initWithObjectClassName:(NSString *)objectClassName {
+- (instancetype)initWithObjectClassName:(__unsafe_unretained NSString *const)objectClassName {
     self = [super init];
     if (self) {
         _objectClassName = objectClassName;
@@ -141,7 +141,8 @@ static void RLMValidateMatchingObjectType(RLMArray *array, RLMObject *object) {
                             "This can happen if you try to insert objects into a RLMArray / List from a default value or from an overriden unmanaged initializer (`init()`).");
     }
     if (![array->_objectClassName isEqualToString:object->_objectSchema.className]) {
-        @throw RLMException(@"Object type '%@' does not match RLMArray type '%@'.", object->_objectSchema.className, array->_objectClassName);
+        @throw RLMException(@"Object type '%@' does not match RLMArray type '%@'.",
+                            object->_objectSchema.className, array->_objectClassName);
     }
 }
 

--- a/Realm/RLMArrayLinkView.mm
+++ b/Realm/RLMArrayLinkView.mm
@@ -41,22 +41,22 @@
 @public
     realm::List _backingList;
     RLMRealm *_realm;
-    __unsafe_unretained RLMObjectSchema *_containingObjectSchema;
+    RLMObjectInfo *_objectInfo;
+    RLMObjectInfo *_ownerInfo;
     std::unique_ptr<RLMObservationInfo> _observationInfo;
 }
 
-+ (RLMArrayLinkView *)arrayWithObjectClassName:(NSString *)objectClassName
-                                          view:(realm::LinkViewRef)view
-                                         realm:(RLMRealm *)realm
-                                           key:(NSString *)key
-                                  parentSchema:(RLMObjectSchema *)parentSchema {
-    RLMArrayLinkView *ar = [[RLMArrayLinkView alloc] initWithObjectClassName:objectClassName];
-    ar->_backingList = realm::List(realm->_realm, view);
-    ar->_realm = realm;
-    ar->_objectSchema = ar->_realm.schema[objectClassName];
-    ar->_containingObjectSchema = parentSchema;
-    ar->_key = key;
-    return ar;
+- (RLMArrayLinkView *)initWithParent:(__unsafe_unretained RLMObjectBase *const)parentObject
+                            property:(__unsafe_unretained RLMProperty *const)property {
+    self = [self initWithObjectClassName:property.objectClassName];
+    if (self) {
+        _realm = parentObject->_realm;
+        _backingList = realm::List(_realm->_realm, parentObject->_row.get_linklist(parentObject->_info->tableColumn(property)));
+        _objectInfo = &_realm->_info[_objectClassName];
+        _ownerInfo = parentObject->_info;
+        _key = property.name;
+    }
+    return self;
 }
 
 void RLMValidateArrayObservationKey(__unsafe_unretained NSString *const keyPath,
@@ -74,7 +74,7 @@ void RLMEnsureArrayObservationInfo(std::unique_ptr<RLMObservationInfo>& info,
     RLMValidateArrayObservationKey(keyPath, array);
     if (!info && array.class == [RLMArrayLinkView class]) {
         RLMArrayLinkView *lv = static_cast<RLMArrayLinkView *>(array);
-        info = std::make_unique<RLMObservationInfo>(lv->_containingObjectSchema,
+        info = std::make_unique<RLMObservationInfo>(*lv->_ownerInfo,
                                                     lv->_backingList.get_origin_row_index(),
                                                     observed);
     }
@@ -140,7 +140,7 @@ static void changeArray(__unsafe_unretained RLMArrayLinkView *const ar,
     translateErrors([&] { ar->_backingList.verify_in_transaction(); });
     RLMObservationInfo *info = RLMGetObservationInfo(ar->_observationInfo.get(),
                                                      ar->_backingList.get_origin_row_index(),
-                                                     ar->_containingObjectSchema);
+                                                     *ar->_ownerInfo);
     if (info) {
         NSIndexSet *indexes = is();
         info->willChange(ar->_key, kind, indexes);
@@ -185,6 +185,10 @@ static void changeArray(__unsafe_unretained RLMArrayLinkView *const ar, NSKeyVal
     return translateErrors([&] { return !_backingList.is_valid(); });
 }
 
+- (RLMObjectInfo *)objectInfo {
+    return _objectInfo;
+}
+
 - (BOOL)isEqual:(id)object {
     if (RLMArrayLinkView *linkView = RLMDynamicCast<RLMArrayLinkView>(object)) {
         return linkView->_backingList == _backingList;
@@ -203,7 +207,7 @@ static void changeArray(__unsafe_unretained RLMArrayLinkView *const ar, NSKeyVal
     if (state->state == 0) {
         translateErrors([&] { _backingList.verify_attached(); });
 
-        enumerator = [[RLMFastEnumerator alloc] initWithCollection:self objectSchema:_objectSchema];
+        enumerator = [[RLMFastEnumerator alloc] initWithCollection:self objectSchema:*_objectInfo];
         state->extra[0] = (long)enumerator;
         state->extra[1] = self.count;
     }
@@ -215,7 +219,7 @@ static void changeArray(__unsafe_unretained RLMArrayLinkView *const ar, NSKeyVal
 }
 
 - (id)objectAtIndex:(NSUInteger)index {
-    return RLMCreateObjectAccessor(_realm, _objectSchema,
+    return RLMCreateObjectAccessor(_realm, *_objectInfo,
                                    translateErrors([&] { return _backingList.get(index).get_index(); }));
 }
 
@@ -322,8 +326,8 @@ static void RLMInsertObject(RLMArrayLinkView *ar, RLMObject *object, NSUInteger 
     if ([keyPath hasPrefix:@"@"]) {
         // Delegate KVC collection operators to RLMResults
         auto query = translateErrors([&] { return _backingList.get_query(); });
-        RLMResults *results = [RLMResults resultsWithObjectSchema:_objectSchema
-                                                          results:realm::Results(_realm->_realm, std::move(query))];
+        RLMResults *results = [RLMResults resultsWithObjectInfo:*_objectInfo
+                                                        results:realm::Results(_realm->_realm, std::move(query))];
         return [results valueForKeyPath:keyPath];
     }
     return [super valueForKeyPath:keyPath];
@@ -357,20 +361,20 @@ static void RLMInsertObject(RLMArrayLinkView *ar, RLMObject *object, NSUInteger 
 }
 
 - (RLMResults *)sortedResultsUsingDescriptors:(NSArray *)properties {
-    auto order = RLMSortOrderFromDescriptors(*_objectSchema.table, properties);
+    auto order = RLMSortOrderFromDescriptors(*_objectInfo->table(), properties);
     auto results = translateErrors([&] { return _backingList.sort(std::move(order)); });
-    return [RLMResults resultsWithObjectSchema:_objectSchema results:std::move(results)];
+    return [RLMResults resultsWithObjectInfo:*_objectInfo results:std::move(results)];
 }
 
 - (RLMResults *)objectsWithPredicate:(NSPredicate *)predicate {
-    auto query = RLMPredicateToQuery(predicate, _objectSchema, _realm.schema, _realm.group);
+    auto query = RLMPredicateToQuery(predicate, _objectInfo->rlmObjectSchema, _realm.schema, _realm.group);
     auto results = translateErrors([&] { return _backingList.filter(std::move(query)); });
-    return [RLMResults resultsWithObjectSchema:_objectSchema results:std::move(results)];
+    return [RLMResults resultsWithObjectInfo:*_objectInfo results:std::move(results)];
 }
 
 - (NSUInteger)indexOfObjectWithPredicate:(NSPredicate *)predicate {
     auto query = translateErrors([&] { return _backingList.get_query(); });
-    query.and_query(RLMPredicateToQuery(predicate, _objectSchema, _realm.schema, _realm.group));
+    query.and_query(RLMPredicateToQuery(predicate, _objectInfo->rlmObjectSchema, _realm.schema, _realm.group));
     return RLMConvertNotFound(query.find());
 }
 

--- a/Realm/RLMArrayLinkView.mm
+++ b/Realm/RLMArrayLinkView.mm
@@ -52,7 +52,7 @@
     if (self) {
         _realm = parentObject->_realm;
         _backingList = realm::List(_realm->_realm, parentObject->_row.get_linklist(parentObject->_info->tableColumn(property)));
-        _objectInfo = &_realm->_info[_objectClassName];
+        _objectInfo = &parentObject->_info->linkTargetType(property.index);
         _ownerInfo = parentObject->_info;
         _key = property.name;
     }

--- a/Realm/RLMArrayLinkView.mm
+++ b/Realm/RLMArrayLinkView.mm
@@ -41,8 +41,8 @@
 @public
     realm::List _backingList;
     RLMRealm *_realm;
-    RLMObjectInfo *_objectInfo;
-    RLMObjectInfo *_ownerInfo;
+    RLMClassInfo *_objectInfo;
+    RLMClassInfo *_ownerInfo;
     std::unique_ptr<RLMObservationInfo> _observationInfo;
 }
 
@@ -185,7 +185,7 @@ static void changeArray(__unsafe_unretained RLMArrayLinkView *const ar, NSKeyVal
     return translateErrors([&] { return !_backingList.is_valid(); });
 }
 
-- (RLMObjectInfo *)objectInfo {
+- (RLMClassInfo *)objectInfo {
     return _objectInfo;
 }
 

--- a/Realm/RLMArray_Private.hpp
+++ b/Realm/RLMArray_Private.hpp
@@ -23,23 +23,19 @@
 #import <Realm/RLMResults.h>
 
 #import <realm/link_view_fwd.hpp>
-#import <vector>
 
 namespace realm {
-    class LinkView;
     class Results;
-    class TableView;
-    struct SortOrder;
 }
 
-@class RLMObjectBase;
-@class RLMObjectSchema;
+@class RLMObjectBase, RLMObjectSchema, RLMProperty;
 class RLMObservationInfo;
+struct RLMObjectInfo;
 
 @interface RLMArray () {
-  @protected
+@protected
     NSString *_objectClassName;
-  @public
+@public
     // The name of the property which this RLMArray represents
     NSString *_key;
     __weak RLMObjectBase *_parentObject;
@@ -50,13 +46,7 @@ class RLMObservationInfo;
 // LinkView backed RLMArray subclass
 //
 @interface RLMArrayLinkView : RLMArray <RLMFastEnumerable>
-@property (nonatomic, unsafe_unretained) RLMObjectSchema *objectSchema;
-
-+ (RLMArrayLinkView *)arrayWithObjectClassName:(NSString *)objectClassName
-                                          view:(realm::LinkViewRef)view
-                                         realm:(RLMRealm *)realm
-                                           key:(NSString *)key
-                                  parentSchema:(RLMObjectSchema *)parentSchema;
+- (instancetype)initWithParent:(RLMObjectBase *)parentObject property:(RLMProperty *)property;
 
 // deletes all objects in the RLMArray from their containing realms
 - (void)deleteObjectsFromRealm;
@@ -73,8 +63,8 @@ void RLMEnsureArrayObservationInfo(std::unique_ptr<RLMObservationInfo>& info,
 // RLMResults private methods
 //
 @interface RLMResults () <RLMFastEnumerable>
-+ (instancetype)resultsWithObjectSchema:(RLMObjectSchema *)objectSchema
-                                   results:(realm::Results)results;
++ (instancetype)resultsWithObjectInfo:(RLMObjectInfo&)info
+                              results:(realm::Results)results;
 
 - (void)deleteObjectsFromRealm;
 @end

--- a/Realm/RLMArray_Private.hpp
+++ b/Realm/RLMArray_Private.hpp
@@ -29,8 +29,8 @@ namespace realm {
 }
 
 @class RLMObjectBase, RLMObjectSchema, RLMProperty;
+class RLMClassInfo;
 class RLMObservationInfo;
-struct RLMObjectInfo;
 
 @interface RLMArray () {
 @protected
@@ -63,7 +63,7 @@ void RLMEnsureArrayObservationInfo(std::unique_ptr<RLMObservationInfo>& info,
 // RLMResults private methods
 //
 @interface RLMResults () <RLMFastEnumerable>
-+ (instancetype)resultsWithObjectInfo:(RLMObjectInfo&)info
++ (instancetype)resultsWithObjectInfo:(RLMClassInfo&)info
                               results:(realm::Results)results;
 
 - (void)deleteObjectsFromRealm;

--- a/Realm/RLMClassInfo.hpp
+++ b/Realm/RLMClassInfo.hpp
@@ -48,9 +48,9 @@ template<> struct equal_to<NSString *> {
 
 // The per-RLMRealm object schema information which stores the cached table
 // reference, handles table column lookups, and tracks observed objects
-struct RLMObjectInfo {
+class RLMClassInfo {
 public:
-    RLMObjectInfo(RLMRealm *, RLMObjectSchema *, const realm::ObjectSchema *);
+    RLMClassInfo(RLMRealm *, RLMObjectSchema *, const realm::ObjectSchema *);
 
     __unsafe_unretained RLMRealm *const realm;
     __unsafe_unretained RLMObjectSchema *const rlmObjectSchema;
@@ -73,30 +73,30 @@ public:
     NSUInteger tableColumn(NSString *propertyName) const;
     NSUInteger tableColumn(RLMProperty *property) const;
 
-    RLMObjectInfo &linkTargetType(size_t index);
+    RLMClassInfo &linkTargetType(size_t index);
 
     void releaseTable() { m_table = nullptr; }
 
 private:
     mutable realm::Table *_Nullable m_table = nullptr;
-    std::vector<RLMObjectInfo *> m_linkTargets;
+    std::vector<RLMClassInfo *> m_linkTargets;
 };
 
-// A per-RLMRealm object schema map which stores RLMObjectInfo keyed on the name
+// A per-RLMRealm object schema map which stores RLMClassInfo keyed on the name
 class RLMSchemaInfo {
-    using impl = std::unordered_map<NSString *, RLMObjectInfo>;
+    using impl = std::unordered_map<NSString *, RLMClassInfo>;
 public:
     void init(RLMRealm *realm, RLMSchema *rlmSchema, realm::Schema const& schema);
 
     // Look up by name, throwing if it's not present
-    RLMObjectInfo& operator[](NSString *name);
+    RLMClassInfo& operator[](NSString *name);
 
     impl::iterator begin() noexcept;
     impl::iterator end() noexcept;
     impl::const_iterator begin() const noexcept;
     impl::const_iterator end() const noexcept;
 private:
-    std::unordered_map<NSString *, RLMObjectInfo> m_objects;
+    std::unordered_map<NSString *, RLMClassInfo> m_objects;
 };
 
 NS_ASSUME_NONNULL_END

--- a/Realm/RLMClassInfo.hpp
+++ b/Realm/RLMClassInfo.hpp
@@ -86,7 +86,8 @@ private:
 class RLMSchemaInfo {
     using impl = std::unordered_map<NSString *, RLMClassInfo>;
 public:
-    void init(RLMRealm *realm, RLMSchema *rlmSchema, realm::Schema const& schema);
+    RLMSchemaInfo() = default;
+    RLMSchemaInfo(RLMRealm *realm, RLMSchema *rlmSchema, realm::Schema const& schema);
 
     // Look up by name, throwing if it's not present
     RLMClassInfo& operator[](NSString *name);

--- a/Realm/RLMClassInfo.mm
+++ b/Realm/RLMClassInfo.mm
@@ -89,7 +89,7 @@ RLMClassInfo& RLMSchemaInfo::operator[](NSString *name) {
     return *&it->second;
 }
 
-void RLMSchemaInfo::init(RLMRealm *realm, RLMSchema *rlmSchema, realm::Schema const& schema) {
+RLMSchemaInfo::RLMSchemaInfo(RLMRealm *realm, RLMSchema *rlmSchema, realm::Schema const& schema) {
     REALM_ASSERT(rlmSchema.objectSchema.count == schema.size());
     REALM_ASSERT(m_objects.empty());
 

--- a/Realm/RLMClassInfo.mm
+++ b/Realm/RLMClassInfo.mm
@@ -16,7 +16,7 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-#import "RLMObjectInfo.hpp"
+#import "RLMClassInfo.hpp"
 
 #import "RLMRealm_Private.hpp"
 #import "RLMObjectSchema.h"
@@ -33,18 +33,18 @@
 
 using namespace realm;
 
-RLMObjectInfo::RLMObjectInfo(RLMRealm *realm, RLMObjectSchema *rlmObjectSchema,
+RLMClassInfo::RLMClassInfo(RLMRealm *realm, RLMObjectSchema *rlmObjectSchema,
                              const realm::ObjectSchema *objectSchema)
 : realm(realm), rlmObjectSchema(rlmObjectSchema), objectSchema(objectSchema) { }
 
-realm::Table *RLMObjectInfo::table() const {
+realm::Table *RLMClassInfo::table() const {
     if (!m_table) {
         m_table = ObjectStore::table_for_object_type(realm.group, objectSchema->name).get();
     }
     return m_table;
 }
 
-RLMProperty *RLMObjectInfo::propertyForTableColumn(NSUInteger col) const noexcept {
+RLMProperty *RLMClassInfo::propertyForTableColumn(NSUInteger col) const noexcept {
     auto const& props = objectSchema->persisted_properties;
     for (size_t i = 0; i < props.size(); ++i) {
         if (props[i].table_column == col) {
@@ -54,15 +54,15 @@ RLMProperty *RLMObjectInfo::propertyForTableColumn(NSUInteger col) const noexcep
     return nil;
 }
 
-NSUInteger RLMObjectInfo::tableColumn(NSString *propertyName) const {
+NSUInteger RLMClassInfo::tableColumn(NSString *propertyName) const {
     return tableColumn(RLMValidatedProperty(rlmObjectSchema, propertyName));
 }
 
-NSUInteger RLMObjectInfo::tableColumn(RLMProperty *property) const {
+NSUInteger RLMClassInfo::tableColumn(RLMProperty *property) const {
     return objectSchema->persisted_properties[property.index].table_column;
 }
 
-RLMObjectInfo &RLMObjectInfo::linkTargetType(size_t index) {
+RLMClassInfo &RLMClassInfo::linkTargetType(size_t index) {
     if (index < m_linkTargets.size() && m_linkTargets[index]) {
         return *m_linkTargets[index];
     }
@@ -78,7 +78,7 @@ RLMSchemaInfo::impl::iterator RLMSchemaInfo::end() noexcept { return m_objects.e
 RLMSchemaInfo::impl::const_iterator RLMSchemaInfo::begin() const noexcept { return m_objects.begin(); }
 RLMSchemaInfo::impl::const_iterator RLMSchemaInfo::end() const noexcept { return m_objects.end(); }
 
-RLMObjectInfo& RLMSchemaInfo::operator[](NSString *name) {
+RLMClassInfo& RLMSchemaInfo::operator[](NSString *name) {
     auto it = m_objects.find(name);
     if (it == m_objects.end()) {
         @throw RLMException(@"Object type '%@' is not managed by the Realm. "

--- a/Realm/RLMCollection.mm
+++ b/Realm/RLMCollection.mm
@@ -21,7 +21,7 @@
 #import "RLMArray_Private.h"
 #import "RLMObjectSchema_Private.hpp"
 #import "RLMObjectStore.h"
-#import "RLMObject_Private.h"
+#import "RLMObject_Private.hpp"
 
 #import "collection_notifications.hpp"
 #import "list.hpp"
@@ -39,7 +39,7 @@ static const int RLMEnumerationBufferSize = 16;
     id _strongBuffer[RLMEnumerationBufferSize];
 
     RLMRealm *_realm;
-    RLMObjectSchema *_objectSchema;
+    RLMObjectInfo *_info;
 
     // Collection being enumerated. Only one of these two will be valid: when
     // possible we enumerate the collection directly, but when in a write
@@ -49,11 +49,11 @@ static const int RLMEnumerationBufferSize = 16;
     realm::TableView _tableView;
 }
 
-- (instancetype)initWithCollection:(id<RLMFastEnumerable>)collection objectSchema:(RLMObjectSchema *)objectSchema {
+- (instancetype)initWithCollection:(id<RLMFastEnumerable>)collection objectSchema:(RLMObjectInfo&)info {
     self = [super init];
     if (self) {
         _realm = collection.realm;
-        _objectSchema = objectSchema;
+        _info = &info;
 
         if (_realm.inWriteTransaction) {
             _tableView = [collection tableView];
@@ -92,14 +92,14 @@ static const int RLMEnumerationBufferSize = 16;
 
     NSUInteger batchCount = 0, count = state->extra[1];
 
-    Class accessorClass = _objectSchema.accessorClass;
+    Class accessorClass = _info->rlmObjectSchema.accessorClass;
     for (NSUInteger index = state->state; index < count && batchCount < len; ++index) {
-        RLMObject *accessor = [[accessorClass alloc] initWithRealm:_realm schema:_objectSchema];
+        RLMObject *accessor = RLMCreateManagedAccessor(accessorClass, _realm, _info);
         if (_collection) {
-            accessor->_row = (*_objectSchema.table)[[_collection indexInSource:index]];
+            accessor->_row = (*_info->table())[[_collection indexInSource:index]];
         }
         else if (_tableView.is_row_attached(index)) {
-            accessor->_row = (*_objectSchema.table)[_tableView.get_source_ndx(index)];
+            accessor->_row = (*_info->table())[_tableView.get_source_ndx(index)];
         }
         RLMInitializeSwiftAccessorGenerics(accessor);
         _strongBuffer[batchCount] = accessor;
@@ -138,19 +138,19 @@ NSArray *RLMCollectionValueForKey(id<RLMFastEnumerable> collection, NSString *ke
     }
 
     RLMRealm *realm = collection.realm;
-    RLMObjectSchema *objectSchema = collection.objectSchema;
+    RLMObjectInfo *info = collection.objectInfo;
 
     NSMutableArray *results = [NSMutableArray arrayWithCapacity:count];
     if ([key isEqualToString:@"self"]) {
         for (size_t i = 0; i < count; i++) {
             size_t rowIndex = [collection indexInSource:i];
-            [results addObject:RLMCreateObjectAccessor(realm, objectSchema, rowIndex) ?: NSNull.null];
+            [results addObject:RLMCreateObjectAccessor(realm, *info, rowIndex) ?: NSNull.null];
         }
         return results;
     }
 
-    RLMObjectBase *accessor = [[objectSchema.accessorClass alloc] initWithRealm:realm schema:objectSchema];
-    realm::Table *table = objectSchema.table;
+    RLMObject *accessor = RLMCreateManagedAccessor(info->rlmObjectSchema.accessorClass, realm, info);
+    realm::Table *table = info->table();
     for (size_t i = 0; i < count; i++) {
         size_t rowIndex = [collection indexInSource:i];
         accessor->_row = (*table)[rowIndex];
@@ -168,8 +168,8 @@ void RLMCollectionSetValueForKey(id<RLMFastEnumerable> collection, NSString *key
     }
 
     RLMRealm *realm = collection.realm;
-    RLMObjectSchema *objectSchema = collection.objectSchema;
-    RLMObjectBase *accessor = [[objectSchema.accessorClass alloc] initWithRealm:realm schema:objectSchema];
+    RLMObjectInfo *info = collection.objectInfo;
+    RLMObject *accessor = RLMCreateManagedAccessor(info->rlmObjectSchema.accessorClass, realm, info);
     for (size_t i = 0; i < tv.size(); i++) {
         accessor->_row = tv[i];
         RLMInitializeSwiftAccessorGenerics(accessor);

--- a/Realm/RLMCollection.mm
+++ b/Realm/RLMCollection.mm
@@ -39,7 +39,7 @@ static const int RLMEnumerationBufferSize = 16;
     id _strongBuffer[RLMEnumerationBufferSize];
 
     RLMRealm *_realm;
-    RLMObjectInfo *_info;
+    RLMClassInfo *_info;
 
     // Collection being enumerated. Only one of these two will be valid: when
     // possible we enumerate the collection directly, but when in a write
@@ -49,7 +49,7 @@ static const int RLMEnumerationBufferSize = 16;
     realm::TableView _tableView;
 }
 
-- (instancetype)initWithCollection:(id<RLMFastEnumerable>)collection objectSchema:(RLMObjectInfo&)info {
+- (instancetype)initWithCollection:(id<RLMFastEnumerable>)collection objectSchema:(RLMClassInfo&)info {
     self = [super init];
     if (self) {
         _realm = collection.realm;
@@ -138,7 +138,7 @@ NSArray *RLMCollectionValueForKey(id<RLMFastEnumerable> collection, NSString *ke
     }
 
     RLMRealm *realm = collection.realm;
-    RLMObjectInfo *info = collection.objectInfo;
+    RLMClassInfo *info = collection.objectInfo;
 
     NSMutableArray *results = [NSMutableArray arrayWithCapacity:count];
     if ([key isEqualToString:@"self"]) {
@@ -168,7 +168,7 @@ void RLMCollectionSetValueForKey(id<RLMFastEnumerable> collection, NSString *key
     }
 
     RLMRealm *realm = collection.realm;
-    RLMObjectInfo *info = collection.objectInfo;
+    RLMClassInfo *info = collection.objectInfo;
     RLMObject *accessor = RLMCreateManagedAccessor(info->rlmObjectSchema.accessorClass, realm, info);
     for (size_t i = 0; i < tv.size(); i++) {
         accessor->_row = tv[i];

--- a/Realm/RLMCollection_Private.hpp
+++ b/Realm/RLMCollection_Private.hpp
@@ -27,11 +27,11 @@ namespace realm {
     struct CollectionChangeSet;
     struct NotificationToken;
 }
-@class RLMObjectSchema;
+struct RLMObjectInfo;
 
 @protocol RLMFastEnumerable
 @property (nonatomic, readonly) RLMRealm *realm;
-@property (nonatomic, readonly) RLMObjectSchema *objectSchema;
+@property (nonatomic, readonly) RLMObjectInfo *objectInfo;
 @property (nonatomic, readonly) NSUInteger count;
 
 - (NSUInteger)indexInSource:(NSUInteger)index;
@@ -43,7 +43,7 @@ namespace realm {
 // set of enumerated items
 @interface RLMFastEnumerator : NSObject
 - (instancetype)initWithCollection:(id<RLMFastEnumerable>)collection
-                      objectSchema:(RLMObjectSchema *)objectSchema;
+                      objectSchema:(RLMObjectInfo&)objectSchema;
 
 // Detach this enumerator from the source collection. Must be called before the
 // source collection is changed.

--- a/Realm/RLMCollection_Private.hpp
+++ b/Realm/RLMCollection_Private.hpp
@@ -27,11 +27,11 @@ namespace realm {
     struct CollectionChangeSet;
     struct NotificationToken;
 }
-struct RLMObjectInfo;
+class RLMClassInfo;
 
 @protocol RLMFastEnumerable
 @property (nonatomic, readonly) RLMRealm *realm;
-@property (nonatomic, readonly) RLMObjectInfo *objectInfo;
+@property (nonatomic, readonly) RLMClassInfo *objectInfo;
 @property (nonatomic, readonly) NSUInteger count;
 
 - (NSUInteger)indexInSource:(NSUInteger)index;
@@ -43,7 +43,7 @@ struct RLMObjectInfo;
 // set of enumerated items
 @interface RLMFastEnumerator : NSObject
 - (instancetype)initWithCollection:(id<RLMFastEnumerable>)collection
-                      objectSchema:(RLMObjectInfo&)objectSchema;
+                      objectSchema:(RLMClassInfo&)objectSchema;
 
 // Detach this enumerator from the source collection. Must be called before the
 // source collection is changed.

--- a/Realm/RLMMigration.mm
+++ b/Realm/RLMMigration.mm
@@ -19,7 +19,7 @@
 #import "RLMMigration_Private.h"
 
 #import "RLMAccessor.h"
-#import "RLMObject.h"
+#import "RLMObject_Private.h"
 #import "RLMObjectSchema_Private.hpp"
 #import "RLMObjectStore.h"
 #import "RLMProperty_Private.h"
@@ -27,10 +27,13 @@
 #import "RLMRealm_Private.hpp"
 #import "RLMResults_Private.h"
 #import "RLMSchema_Private.hpp"
+#import "RLMUtil.hpp"
 
 #import "object_store.hpp"
 #import "shared_realm.hpp"
 #import "schema.hpp"
+
+#import <realm/table.hpp>
 
 using namespace realm;
 
@@ -103,14 +106,16 @@ using namespace realm;
 
 - (void)execute:(RLMMigrationBlock)block {
     @autoreleasepool {
-        // disable all primary keys for migration
+        // disable all primary keys for migration and use DynamicObject for all types
         for (RLMObjectSchema *objectSchema in _realm.schema.objectSchema) {
+            objectSchema.accessorClass = RLMDynamicObject.class;
             objectSchema.primaryKeyProperty.isPrimary = NO;
         }
+        for (RLMObjectSchema *objectSchema in _oldRealm.schema.objectSchema) {
+            objectSchema.accessorClass = RLMDynamicObject.class;
+        }
 
-        // apply block and set new schema version
-        uint64_t oldVersion = _oldRealm->_realm->schema_version();
-        block(self, oldVersion);
+        block(self, _oldRealm->_realm->schema_version());
 
         _oldRealm = nil;
         _realm = nil;
@@ -150,17 +155,8 @@ using namespace realm;
 }
 
 - (void)renamePropertyForClass:(NSString *)className oldName:(NSString *)oldName newName:(NSString *)newName {
-    realm::ObjectStore::rename_property(_realm.group, *_schema, className.UTF8String, oldName.UTF8String, newName.UTF8String);
-    ObjectSchema objectStoreSchema(_realm.group, className.UTF8String);
-    RLMObjectSchema *objectSchema = [RLMObjectSchema objectSchemaForObjectStoreSchema:objectStoreSchema];
-    NSMutableArray *mutableObjectSchemas = [NSMutableArray arrayWithArray:_realm.schema.objectSchema];
-    [mutableObjectSchemas replaceObjectAtIndex:[mutableObjectSchemas indexOfObject:_realm.schema[className]]
-                                    withObject:objectSchema];
-    objectSchema.realm = _realm;
-    _realm.schema.objectSchema = [mutableObjectSchemas copy];
-    for (RLMProperty *property in objectSchema.properties) {
-        property.column = objectStoreSchema.property_for_name(property.name.UTF8String)->table_column;
-    }
+    const char *objectType = className.UTF8String;
+    realm::ObjectStore::rename_property(_realm.group, *_schema, objectType, oldName.UTF8String, newName.UTF8String);
 }
 
 @end

--- a/Realm/RLMObject.mm
+++ b/Realm/RLMObject.mm
@@ -187,7 +187,7 @@
 }
 
 - (id)valueForUndefinedKey:(NSString *)key {
-    return RLMDynamicGet(self, RLMValidatedGetProperty(self, key));
+    return RLMDynamicGetByName(self, key, false);
 }
 
 - (void)setValue:(id)value forUndefinedKey:(NSString *)key {

--- a/Realm/RLMObject.mm
+++ b/Realm/RLMObject.mm
@@ -16,13 +16,14 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
+#import "RLMObject_Private.hpp"
+
 #import "RLMAccessor.h"
-#import "RLMObject_Private.h"
 #import "RLMObjectSchema_Private.hpp"
 #import "RLMObjectStore.h"
-#import "RLMSchema_Private.h"
-#import "RLMRealm_Private.hpp"
 #import "RLMQueryUtil.hpp"
+#import "RLMRealm_Private.hpp"
+#import "RLMSchema_Private.h"
 
 // We declare things in RLMObject which are actually implemented in RLMObjectBase
 // for documentation's sake, which leads to -Wunimplemented-method warnings.
@@ -45,8 +46,7 @@
     return [super initWithValue:value schema:schema];
 }
 
-- (instancetype)initWithRealm:(__unsafe_unretained RLMRealm *const)realm
-                       schema:(__unsafe_unretained RLMObjectSchema *const)schema {
+- (instancetype)initWithRealm:(__unsafe_unretained RLMRealm *const)realm schema:(RLMObjectSchema *)schema {
     return [super initWithRealm:realm schema:schema];
 }
 
@@ -198,8 +198,7 @@
 
 @implementation RLMWeakObjectHandle {
     realm::Row _row;
-    RLMRealm *_realm;
-    RLMObjectSchema *_objectSchema;
+    RLMObjectInfo *_info;
     Class _objectClass;
 }
 
@@ -209,15 +208,14 @@
     }
 
     _row = object->_row;
-    _realm = object->_realm;
-    _objectSchema = object->_objectSchema;
+    _info = object->_info;
     _objectClass = object.class;
 
     return self;
 }
 
 - (RLMObjectBase *)object {
-    RLMObjectBase *object = [[_objectClass alloc] initWithRealm:_realm schema:_objectSchema];
+    RLMObjectBase *object = RLMCreateManagedAccessor(_objectClass, _info->realm, _info);
     object->_row = std::move(_row);
     return object;
 }

--- a/Realm/RLMObject.mm
+++ b/Realm/RLMObject.mm
@@ -198,7 +198,7 @@
 
 @implementation RLMWeakObjectHandle {
     realm::Row _row;
-    RLMObjectInfo *_info;
+    RLMClassInfo *_info;
     Class _objectClass;
 }
 

--- a/Realm/RLMObjectBase.mm
+++ b/Realm/RLMObjectBase.mm
@@ -335,7 +335,7 @@ id RLMObjectBaseObjectForKeyedSubscript(RLMObjectBase *object, NSString *key) {
     }
 
     if (object->_realm) {
-        return RLMDynamicGet(object, RLMValidatedGetProperty(object, key));
+        return RLMDynamicGetByName(object, key, false);
     }
     else {
         return [object valueForKey:key];
@@ -425,15 +425,6 @@ Class RLMObjectUtilClass(BOOL isSwift) {
 
 + (NSDictionary *)getLinkingObjectsProperties:(__unused id)obj {
     return nil;
-}
-
-+ (void)initializeListProperty:(__unused RLMObjectBase *)object property:(__unused RLMProperty *)property array:(__unused RLMArray *)array {
-}
-
-+ (void)initializeOptionalProperty:(__unused RLMObjectBase *)object property:(__unused RLMProperty *)property {
-}
-
-+ (void)initializeLinkingObjectsProperty:(__unused RLMObjectBase *)object property:(__unused RLMProperty *)property {
 }
 
 + (NSDictionary *)getOptionalProperties:(__unused id)obj {

--- a/Realm/RLMObjectBase.mm
+++ b/Realm/RLMObjectBase.mm
@@ -35,7 +35,7 @@ using namespace realm;
 
 const NSUInteger RLMDescriptionMaxDepth = 5;
 
-static bool RLMInitializedObjectSchema(RLMObjectBase *obj) {
+static bool maybeInitObjectSchemaForUnmanaged(RLMObjectBase *obj) {
     obj->_objectSchema = [obj.class sharedSchema];
     if (!obj->_objectSchema) {
         return false;
@@ -57,9 +57,8 @@ static bool RLMInitializedObjectSchema(RLMObjectBase *obj) {
 @implementation RLMObjectBase
 // unmanaged init
 - (instancetype)init {
-    self = [super init];
-    if (self) {
-        RLMInitializedObjectSchema(self);
+    if ((self = [super init])) {
+        maybeInitObjectSchemaForUnmanaged(self);
     }
     return self;
 }
@@ -72,7 +71,7 @@ static bool RLMInitializedObjectSchema(RLMObjectBase *obj) {
     _observationInfo = nullptr;
 }
 
-static id RLMValidatedObjectForProperty(id obj, RLMProperty *prop, RLMSchema *schema) {
+static id validatedObjectForProperty(id obj, RLMProperty *prop, RLMSchema *schema) {
     if (RLMIsObjectValidForProperty(obj, prop)) {
         return obj;
     }
@@ -102,7 +101,7 @@ static id RLMValidatedObjectForProperty(id obj, RLMProperty *prop, RLMSchema *sc
         return self;
     }
 
-    if (!RLMInitializedObjectSchema(self)) {
+    if (!maybeInitObjectSchemaForUnmanaged(self)) {
         // Don't populate fields from the passed-in object if we're called
         // during schema init
         return self;
@@ -114,7 +113,7 @@ static id RLMValidatedObjectForProperty(id obj, RLMProperty *prop, RLMSchema *sc
             @throw RLMException(@"Invalid array input. Number of array elements does not match number of properties.");
         }
         for (NSUInteger i = 0; i < array.count; i++) {
-            id propertyValue = RLMValidatedObjectForProperty(array[i], properties[i], schema);
+            id propertyValue = validatedObjectForProperty(array[i], properties[i], schema);
             [self setValue:RLMCoerceToNil(propertyValue) forKeyPath:[properties[i] name]];
         }
     }
@@ -132,7 +131,7 @@ static id RLMValidatedObjectForProperty(id obj, RLMProperty *prop, RLMSchema *sc
                 obj = defaultValues[prop.name];
             }
 
-            obj = RLMValidatedObjectForProperty(obj, prop, schema);
+            obj = validatedObjectForProperty(obj, prop, schema);
             [self setValue:RLMCoerceToNil(obj) forKeyPath:prop.name];
         }
     }
@@ -140,8 +139,14 @@ static id RLMValidatedObjectForProperty(id obj, RLMProperty *prop, RLMSchema *sc
     return self;
 }
 
+id RLMCreateManagedAccessor(Class cls, __unsafe_unretained RLMRealm *realm, RLMObjectInfo *info) {
+    RLMObjectBase *obj = [[cls alloc] initWithRealm:realm schema:info->rlmObjectSchema];
+    obj->_info = info;
+    return obj;
+}
+
 - (instancetype)initWithRealm:(__unsafe_unretained RLMRealm *const)realm
-                       schema:(__unsafe_unretained RLMObjectSchema *const)schema {
+                       schema:(RLMObjectSchema *)schema {
     self = [super init];
     if (self) {
         _realm = realm;
@@ -296,7 +301,7 @@ static id RLMValidatedObjectForProperty(id obj, RLMProperty *prop, RLMSchema *sc
     if (!_observationInfo) {
         _observationInfo = new RLMObservationInfo(self);
     }
-    _observationInfo->recordObserver(_row, _objectSchema, keyPath);
+    _observationInfo->recordObserver(_row, _info, _objectSchema, keyPath);
 
     [super addObserver:observer forKeyPath:keyPath options:options context:context];
 }

--- a/Realm/RLMObjectBase.mm
+++ b/Realm/RLMObjectBase.mm
@@ -139,7 +139,7 @@ static id validatedObjectForProperty(id obj, RLMProperty *prop, RLMSchema *schem
     return self;
 }
 
-id RLMCreateManagedAccessor(Class cls, __unsafe_unretained RLMRealm *realm, RLMObjectInfo *info) {
+id RLMCreateManagedAccessor(Class cls, __unsafe_unretained RLMRealm *realm, RLMClassInfo *info) {
     RLMObjectBase *obj = [[cls alloc] initWithRealm:realm schema:info->rlmObjectSchema];
     obj->_info = info;
     return obj;

--- a/Realm/RLMObjectInfo.hpp
+++ b/Realm/RLMObjectInfo.hpp
@@ -73,10 +73,13 @@ public:
     NSUInteger tableColumn(NSString *propertyName) const;
     NSUInteger tableColumn(RLMProperty *property) const;
 
+    RLMObjectInfo &linkTargetType(size_t index);
+
     void releaseTable() { m_table = nullptr; }
 
 private:
     mutable realm::Table *_Nullable m_table = nullptr;
+    std::vector<RLMObjectInfo *> m_linkTargets;
 };
 
 // A per-RLMRealm object schema map which stores RLMObjectInfo keyed on the name

--- a/Realm/RLMObjectInfo.hpp
+++ b/Realm/RLMObjectInfo.hpp
@@ -1,0 +1,99 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2016 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+#import <Foundation/Foundation.h>
+#import <unordered_map>
+#import <vector>
+
+namespace realm {
+    class ObjectSchema;
+    class Schema;
+    class Table;
+    struct Property;
+}
+
+class RLMObservationInfo;
+@class RLMRealm, RLMSchema, RLMObjectSchema, RLMProperty;
+
+NS_ASSUME_NONNULL_BEGIN
+
+namespace std {
+// Add specializations so that NSString can be used as the key for hash containers
+template<> struct hash<NSString *> {
+    size_t operator()(__unsafe_unretained NSString *const str) const {
+        return [str hash];
+    }
+};
+template<> struct equal_to<NSString *> {
+    bool operator()(__unsafe_unretained NSString * lhs, __unsafe_unretained NSString *rhs) const {
+        return [lhs isEqualToString:rhs];
+    }
+};
+}
+
+// The per-RLMRealm object schema information which stores the cached table
+// reference, handles table column lookups, and tracks observed objects
+struct RLMObjectInfo {
+public:
+    RLMObjectInfo(RLMRealm *, RLMObjectSchema *, const realm::ObjectSchema *);
+
+    __unsafe_unretained RLMRealm *const realm;
+    __unsafe_unretained RLMObjectSchema *const rlmObjectSchema;
+    const realm::ObjectSchema *const objectSchema;
+
+    // Storage for the functionality in RLMObservation for handling indirect
+    // changes to KVO-observed things
+    std::vector<RLMObservationInfo *> observedObjects;
+
+    // Get the table for this object type. Will return nullptr only if it's a
+    // read-only Realm that is missing the table entirely.
+    realm::Table *_Nullable table() const;
+
+    // Get the RLMProperty for a given table column, or `nil` if it is a column
+    // not used by the current schema
+    RLMProperty *_Nullable propertyForTableColumn(NSUInteger) const noexcept;
+
+    // Get the table column for the given property. The property must be a valid
+    // persisted property.
+    NSUInteger tableColumn(NSString *propertyName) const;
+    NSUInteger tableColumn(RLMProperty *property) const;
+
+    void releaseTable() { m_table = nullptr; }
+
+private:
+    mutable realm::Table *_Nullable m_table = nullptr;
+};
+
+// A per-RLMRealm object schema map which stores RLMObjectInfo keyed on the name
+class RLMSchemaInfo {
+    using impl = std::unordered_map<NSString *, RLMObjectInfo>;
+public:
+    void init(RLMRealm *realm, RLMSchema *rlmSchema, realm::Schema const& schema);
+
+    // Look up by name, throwing if it's not present
+    RLMObjectInfo& operator[](NSString *name);
+
+    impl::iterator begin() noexcept;
+    impl::iterator end() noexcept;
+    impl::const_iterator begin() const noexcept;
+    impl::const_iterator end() const noexcept;
+private:
+    std::unordered_map<NSString *, RLMObjectInfo> m_objects;
+};
+
+NS_ASSUME_NONNULL_END

--- a/Realm/RLMObjectInfo.mm
+++ b/Realm/RLMObjectInfo.mm
@@ -62,6 +62,17 @@ NSUInteger RLMObjectInfo::tableColumn(RLMProperty *property) const {
     return objectSchema->persisted_properties[property.index].table_column;
 }
 
+RLMObjectInfo &RLMObjectInfo::linkTargetType(size_t index) {
+    if (index < m_linkTargets.size() && m_linkTargets[index]) {
+        return *m_linkTargets[index];
+    }
+    if (m_linkTargets.size() <= index) {
+        m_linkTargets.resize(index + 1);
+    }
+    m_linkTargets[index] = &realm->_info[rlmObjectSchema.properties[index].objectClassName];
+    return *m_linkTargets[index];
+}
+
 RLMSchemaInfo::impl::iterator RLMSchemaInfo::begin() noexcept { return m_objects.begin(); }
 RLMSchemaInfo::impl::iterator RLMSchemaInfo::end() noexcept { return m_objects.end(); }
 RLMSchemaInfo::impl::const_iterator RLMSchemaInfo::begin() const noexcept { return m_objects.begin(); }

--- a/Realm/RLMObjectInfo.mm
+++ b/Realm/RLMObjectInfo.mm
@@ -1,0 +1,92 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2016 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+#import "RLMObjectInfo.hpp"
+
+#import "RLMRealm_Private.hpp"
+#import "RLMObjectSchema.h"
+#import "RLMSchema.h"
+#import "RLMProperty_Private.h"
+#import "RLMQueryUtil.hpp"
+#import "RLMUtil.hpp"
+
+#import "object_schema.hpp"
+#import "object_store.hpp"
+#import "schema.hpp"
+
+#import <realm/table.hpp>
+
+using namespace realm;
+
+RLMObjectInfo::RLMObjectInfo(RLMRealm *realm, RLMObjectSchema *rlmObjectSchema,
+                             const realm::ObjectSchema *objectSchema)
+: realm(realm), rlmObjectSchema(rlmObjectSchema), objectSchema(objectSchema) { }
+
+realm::Table *RLMObjectInfo::table() const {
+    if (!m_table) {
+        m_table = ObjectStore::table_for_object_type(realm.group, objectSchema->name).get();
+    }
+    return m_table;
+}
+
+RLMProperty *RLMObjectInfo::propertyForTableColumn(NSUInteger col) const noexcept {
+    auto const& props = objectSchema->persisted_properties;
+    for (size_t i = 0; i < props.size(); ++i) {
+        if (props[i].table_column == col) {
+            return rlmObjectSchema.properties[i];
+        }
+    }
+    return nil;
+}
+
+NSUInteger RLMObjectInfo::tableColumn(NSString *propertyName) const {
+    return tableColumn(RLMValidatedProperty(rlmObjectSchema, propertyName));
+}
+
+NSUInteger RLMObjectInfo::tableColumn(RLMProperty *property) const {
+    return objectSchema->persisted_properties[property.index].table_column;
+}
+
+RLMSchemaInfo::impl::iterator RLMSchemaInfo::begin() noexcept { return m_objects.begin(); }
+RLMSchemaInfo::impl::iterator RLMSchemaInfo::end() noexcept { return m_objects.end(); }
+RLMSchemaInfo::impl::const_iterator RLMSchemaInfo::begin() const noexcept { return m_objects.begin(); }
+RLMSchemaInfo::impl::const_iterator RLMSchemaInfo::end() const noexcept { return m_objects.end(); }
+
+RLMObjectInfo& RLMSchemaInfo::operator[](NSString *name) {
+    auto it = m_objects.find(name);
+    if (it == m_objects.end()) {
+        @throw RLMException(@"Object type '%@' is not managed by the Realm. "
+                            @"If using a custom `objectClasses` / `objectTypes` array in your configuration, "
+                            @"add `%@` to the list of `objectClasses` / `objectTypes`.",
+                            name, name);
+    }
+    return *&it->second;
+}
+
+void RLMSchemaInfo::init(RLMRealm *realm, RLMSchema *rlmSchema, realm::Schema const& schema) {
+    REALM_ASSERT(rlmSchema.objectSchema.count == schema.size());
+    REALM_ASSERT(m_objects.empty());
+
+    m_objects.reserve(schema.size());
+    for (RLMObjectSchema *rlmObjectSchema in rlmSchema.objectSchema) {
+        m_objects.emplace(std::piecewise_construct,
+                          std::forward_as_tuple(rlmObjectSchema.className),
+                          std::forward_as_tuple(realm, rlmObjectSchema,
+                                                &*schema.find(rlmObjectSchema.className.UTF8String)));
+    }
+}

--- a/Realm/RLMObjectSchema.mm
+++ b/Realm/RLMObjectSchema.mm
@@ -477,7 +477,7 @@ using namespace realm;
 
     NSMutableArray *genericProperties = [NSMutableArray new];
     for (RLMProperty *prop in _properties) {
-        if (prop->_swiftIvar || prop->_type == RLMPropertyTypeArray) {
+        if (prop->_swiftIvar) {
             [genericProperties addObject:prop];
         }
     }

--- a/Realm/RLMObjectSchema.mm
+++ b/Realm/RLMObjectSchema.mm
@@ -39,10 +39,7 @@ using namespace realm;
 @end
 
 @implementation RLMObjectSchema {
-    // table accessor optimization
-    realm::TableRef _table;
     NSArray *_swiftGenericProperties;
-    std::vector<RLMProperty *> _propertiesInTableOrder;
 }
 
 - (instancetype)initWithClassName:(NSString *)objectClassName objectClass:(Class)objectClass properties:(NSArray *)properties {
@@ -63,7 +60,6 @@ using namespace realm;
 // create property map when setting property array
 -(void)setProperties:(NSArray *)properties {
     _properties = properties;
-    _propertiesInTableOrder.clear();
     [self _propertiesDidChange];
 }
 
@@ -74,7 +70,9 @@ using namespace realm;
 
 - (void)_propertiesDidChange {
     NSMutableDictionary *map = [NSMutableDictionary dictionaryWithCapacity:_properties.count + _computedProperties.count];
+    NSUInteger index = 0;
     for (RLMProperty *prop in _properties) {
+        prop.index = index++;
         map[prop.name] = prop;
         if (prop.isPrimary) {
             self.primaryKeyProperty = prop;
@@ -104,7 +102,7 @@ using namespace realm;
     }
     schema.className = className;
     schema.objectClass = objectClass;
-    schema.accessorClass = RLMDynamicObject.class;
+    schema.accessorClass = objectClass;
     schema.isSwiftClass = isSwift;
 
     // create array of RLMProperties, inserting properties of superclasses first
@@ -322,7 +320,7 @@ using namespace realm;
     schema->_objectClass = _objectClass;
     schema->_className = _className;
     schema->_objectClass = _objectClass;
-    schema->_accessorClass = _accessorClass;
+    schema->_accessorClass = _objectClass;
     schema->_unmanagedClass = _unmanagedClass;
     schema->_isSwiftClass = _isSwiftClass;
 
@@ -330,28 +328,6 @@ using namespace realm;
     schema.properties = [[NSArray allocWithZone:zone] initWithArray:_properties copyItems:YES];
     schema.computedProperties = [[NSArray allocWithZone:zone] initWithArray:_computedProperties copyItems:YES];
 
-    // _table not copied as it's realm::Group-specific
-    return schema;
-}
-
-- (instancetype)shallowCopy {
-    RLMObjectSchema *schema = [[RLMObjectSchema alloc] init];
-    schema->_objectClass = _objectClass;
-    schema->_className = _className;
-    schema->_objectClass = _objectClass;
-    schema->_accessorClass = _accessorClass;
-    schema->_unmanagedClass = _unmanagedClass;
-    schema->_isSwiftClass = _isSwiftClass;
-
-    // reuse property array, map, and primary key instnaces
-    schema->_properties = _properties;
-    schema->_computedProperties = _computedProperties;
-    schema->_allPropertiesByName = _allPropertiesByName;
-    schema->_primaryKeyProperty = _primaryKeyProperty;
-    schema->_swiftGenericProperties = _swiftGenericProperties;
-    schema->_propertiesInTableOrder = _propertiesInTableOrder;
-
-    // _table not copied as it's realm::Group-specific
     return schema;
 }
 
@@ -379,17 +355,6 @@ using namespace realm;
         [propertiesString appendFormat:@"\t%@\n", [property.description stringByReplacingOccurrencesOfString:@"\n" withString:@"\n\t"]];
     }
     return [NSString stringWithFormat:@"%@ {\n%@}", self.className, propertiesString];
-}
-
-- (realm::Table *)table {
-    if (!_table) {
-        _table = ObjectStore::table_for_object_type(_realm.group, _className.UTF8String);
-    }
-    return _table.get();
-}
-
-- (void)setTable:(realm::Table *)table {
-    _table.reset(table);
 }
 
 - (realm::ObjectSchema)objectStoreCopy {
@@ -441,21 +406,6 @@ using namespace realm;
     schema.unmanagedClass = RLMObject.class;
     
     return schema;
-}
-
-- (RLMProperty *)propertyForTableColumn:(size_t)tableCol {
-    if (_propertiesInTableOrder.empty()) {
-        _propertiesInTableOrder.resize(_properties.count, nil);
-        for (RLMProperty *property in _properties) {
-            auto col = property.column;
-            if (col >= _propertiesInTableOrder.size()) {
-                _propertiesInTableOrder.resize(col + 1, nil);
-            }
-            _propertiesInTableOrder[col] = property;
-        }
-    }
-
-    return tableCol < _propertiesInTableOrder.size() ? _propertiesInTableOrder[tableCol] : nil;
 }
 
 - (NSArray *)swiftGenericProperties {

--- a/Realm/RLMObjectSchema_Private.h
+++ b/Realm/RLMObjectSchema_Private.h
@@ -18,9 +18,9 @@
 
 #import <Realm/RLMObjectSchema.h>
 
-NS_ASSUME_NONNULL_BEGIN
+#import <objc/runtime.h>
 
-@class RLMRealm;
+NS_ASSUME_NONNULL_BEGIN
 
 // RLMObjectSchema private
 @interface RLMObjectSchema () {
@@ -42,13 +42,8 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy) NSArray<RLMProperty *> *computedProperties;
 @property (nonatomic, readonly) NSArray<RLMProperty *> *swiftGenericProperties;
 
-// The Realm retains its object schemas, so they need to not retain the Realm
-@property (nonatomic, unsafe_unretained, nullable) RLMRealm *realm;
 // returns a cached or new schema for a given object class
 + (instancetype)schemaForObjectClass:(Class)objectClass;
-
-- (RLMProperty *)propertyForTableColumn:(size_t)tableCol;
-
 @end
 
 @interface RLMObjectSchema (Dynamic)

--- a/Realm/RLMObjectSchema_Private.hpp
+++ b/Realm/RLMObjectSchema_Private.hpp
@@ -19,31 +19,11 @@
 #import "RLMObjectSchema_Private.h"
 
 #import "object_schema.hpp"
-#import "RLMObject_Private.hpp"
 
-#import <realm/row.hpp>
-#import <vector>
-
-namespace realm {
-    class Table;
-}
-
-class RLMObservationInfo;
-
-// RLMObjectSchema private
-@interface RLMObjectSchema () {
-    @public
-    std::vector<RLMObservationInfo *> _observedObjects;
-}
-@property (nonatomic) realm::Table *table;
-
-// shallow copy reusing properties and property map
-- (instancetype)shallowCopy;
-
+@interface RLMObjectSchema ()
 // create realm::ObjectSchema copy
 - (realm::ObjectSchema)objectStoreCopy;
 
 // initialize with realm::ObjectSchema
 + (instancetype)objectSchemaForObjectStoreSchema:(realm::ObjectSchema const&)objectSchema;
-
 @end

--- a/Realm/RLMObjectStore.h
+++ b/Realm/RLMObjectStore.h
@@ -22,7 +22,7 @@
 extern "C" {
 #endif
 
-@class RLMRealm, RLMSchema, RLMObjectSchema, RLMObjectBase, RLMResults, RLMProperty;
+@class RLMRealm, RLMSchema, RLMObjectBase, RLMResults, RLMProperty;
 
 //
 // Accessor Creation
@@ -30,9 +30,6 @@ extern "C" {
 
 // create or get cached accessors for the given schema
 void RLMRealmCreateAccessors(RLMSchema *schema);
-
-// Clear the cache of created accessor classes
-void RLMClearAccessorCache();
 
 
 //
@@ -89,11 +86,11 @@ namespace realm {
     template<typename T> class BasicRowExpr;
     using RowExpr = BasicRowExpr<Table>;
 }
+struct RLMObjectInfo;
+
 // Create accessors
-RLMObjectBase *RLMCreateObjectAccessor(RLMRealm *realm,
-                                       RLMObjectSchema *objectSchema,
+RLMObjectBase *RLMCreateObjectAccessor(RLMRealm *realm, RLMObjectInfo& info,
                                        NSUInteger index) NS_RETURNS_RETAINED;
-RLMObjectBase *RLMCreateObjectAccessor(RLMRealm *realm,
-                                       RLMObjectSchema *objectSchema,
+RLMObjectBase *RLMCreateObjectAccessor(RLMRealm *realm, RLMObjectInfo& info,
                                        realm::RowExpr row) NS_RETURNS_RETAINED;
 #endif

--- a/Realm/RLMObjectStore.h
+++ b/Realm/RLMObjectStore.h
@@ -86,11 +86,11 @@ namespace realm {
     template<typename T> class BasicRowExpr;
     using RowExpr = BasicRowExpr<Table>;
 }
-struct RLMObjectInfo;
+class RLMClassInfo;
 
 // Create accessors
-RLMObjectBase *RLMCreateObjectAccessor(RLMRealm *realm, RLMObjectInfo& info,
+RLMObjectBase *RLMCreateObjectAccessor(RLMRealm *realm, RLMClassInfo& info,
                                        NSUInteger index) NS_RETURNS_RETAINED;
-RLMObjectBase *RLMCreateObjectAccessor(RLMRealm *realm, RLMObjectInfo& info,
+RLMObjectBase *RLMCreateObjectAccessor(RLMRealm *realm, RLMClassInfo& info,
                                        realm::RowExpr row) NS_RETURNS_RETAINED;
 #endif

--- a/Realm/RLMObjectStore.mm
+++ b/Realm/RLMObjectStore.mm
@@ -95,6 +95,11 @@ void RLMInitializeSwiftAccessorGenerics(__unsafe_unretained RLMObjectBase *const
     if (!object || !object->_row || !object->_objectSchema->_isSwiftClass) {
         return;
     }
+    if (![object isKindOfClass:object->_objectSchema.objectClass]) {
+        // It can be a different class if it's a dynamic object, and those don't
+        // require any init here (and would crash since they don't have the ivars)
+        return;
+    }
 
     for (RLMProperty *prop in object->_objectSchema.swiftGenericProperties) {
         if (prop->_type == RLMPropertyTypeArray) {
@@ -103,13 +108,17 @@ void RLMInitializeSwiftAccessorGenerics(__unsafe_unretained RLMObjectBase *const
                                                                    realm:object->_realm
                                                                      key:prop.name
                                                             parentSchema:object->_objectSchema];
-            [RLMObjectUtilClass(YES) initializeListProperty:object property:prop array:array];
+            [object_getIvar(object, prop.swiftIvar) set_rlmArray:array];
         }
         else if (prop.type == RLMPropertyTypeLinkingObjects) {
-            [RLMObjectUtilClass(YES) initializeLinkingObjectsProperty:object property:prop];
+            id linkingObjects = object_getIvar(object, prop.swiftIvar);
+            [linkingObjects setObject:(id)[[RLMWeakObjectHandle alloc] initWithObject:object]];
+            [linkingObjects setProperty:prop];
         }
         else {
-            [RLMObjectUtilClass(YES) initializeOptionalProperty:object property:prop];
+            RLMOptionalBase *optional = object_getIvar(object, prop.swiftIvar);
+            optional.property = prop;
+            optional.object = object;
         }
     }
 }

--- a/Realm/RLMObjectStore.mm
+++ b/Realm/RLMObjectStore.mm
@@ -173,7 +173,6 @@ void RLMAddObjectToRealm(__unsafe_unretained RLMObjectBase *const object,
     }
 
     // populate all properties
-    size_t i = 0;
     for (RLMProperty *prop in info.rlmObjectSchema.properties) {
         // get object from ivar using key value coding
         id value = nil;
@@ -210,7 +209,6 @@ void RLMAddObjectToRealm(__unsafe_unretained RLMObjectBase *const object,
                 ((void(*)(id, SEL, id))objc_msgSend)(object, prop.setterSel, nil);
             }
         }
-        ++i;
     }
 
     // set to proper accessor class

--- a/Realm/RLMObjectStore.mm
+++ b/Realm/RLMObjectStore.mm
@@ -96,7 +96,7 @@ void RLMInitializeSwiftAccessorGenerics(__unsafe_unretained RLMObjectBase *const
 }
 
 template<typename F>
-static NSUInteger RLMCreateOrGetRowForObject(RLMObjectInfo const& info,
+static NSUInteger RLMCreateOrGetRowForObject(RLMClassInfo const& info,
                                              F primaryValueGetter, bool createOrUpdate, bool &created) {
     // try to get existing row if updating
     size_t rowIndex = realm::not_found;
@@ -358,7 +358,7 @@ RLMResults *RLMGetObjects(RLMRealm *realm, NSString *objectClassName, NSPredicat
     RLMVerifyRealmRead(realm);
 
     // create view from table and predicate
-    RLMObjectInfo& info = realm->_info[objectClassName];
+    RLMClassInfo& info = realm->_info[objectClassName];
     if (!info.table()) {
         // read-only realms may be missing tables since we can't add any
         // missing ones on init
@@ -378,7 +378,7 @@ RLMResults *RLMGetObjects(RLMRealm *realm, NSString *objectClassName, NSPredicat
 id RLMGetObject(RLMRealm *realm, NSString *objectClassName, id key) {
     RLMVerifyRealmRead(realm);
 
-    RLMObjectInfo& info = realm->_info[objectClassName];
+    RLMClassInfo& info = realm->_info[objectClassName];
     auto primaryProperty = info.objectSchema->primary_key_property();
     if (!primaryProperty) {
         @throw RLMException(@"%@ does not have a primary key", objectClassName);
@@ -424,14 +424,14 @@ id RLMGetObject(RLMRealm *realm, NSString *objectClassName, id key) {
 }
 
 RLMObjectBase *RLMCreateObjectAccessor(__unsafe_unretained RLMRealm *const realm,
-                                       RLMObjectInfo& info,
+                                       RLMClassInfo& info,
                                        NSUInteger index) {
     return RLMCreateObjectAccessor(realm, info, (*info.table())[index]);
 }
 
 // Create accessor and register with realm
 RLMObjectBase *RLMCreateObjectAccessor(__unsafe_unretained RLMRealm *const realm,
-                                       RLMObjectInfo& info,
+                                       RLMClassInfo& info,
                                        realm::RowExpr row) {
     RLMObjectBase *accessor = RLMCreateManagedAccessor(info.rlmObjectSchema.accessorClass, realm, &info);
     accessor->_row = row;

--- a/Realm/RLMObject_Private.h
+++ b/Realm/RLMObject_Private.h
@@ -16,7 +16,7 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-#import <Realm/RLMObject.h>
+#import <Realm/RLMObjectBase_Dynamic.h>
 
 // RLMObject accessor and read/write realm
 @interface RLMObjectBase () {
@@ -70,16 +70,6 @@
 
 @end
 
-//
-// Getters for RLMObjectBase ivars for realm and objectSchema
-//
-FOUNDATION_EXTERN RLMRealm *RLMObjectBaseRealm(RLMObjectBase *object);
-FOUNDATION_EXTERN RLMObjectSchema *RLMObjectBaseObjectSchema(RLMObjectBase *object);
-
-// Dynamic access to RLMObjectBase properties
-FOUNDATION_EXTERN id RLMObjectBaseObjectForKeyedSubscript(RLMObjectBase *object, NSString *key);
-FOUNDATION_EXTERN void RLMObjectBaseSetObjectForKeyedSubscript(RLMObjectBase *object, NSString *key, id obj);
-
 // Calls valueForKey: and re-raises NSUndefinedKeyExceptions
 FOUNDATION_EXTERN id RLMValidatedValueForProperty(id object, NSString *key, NSString *className);
 
@@ -100,10 +90,6 @@ FOUNDATION_EXTERN const NSUInteger RLMDescriptionMaxDepth;
 
 + (NSArray<NSString *> *)getGenericListPropertyNames:(id)obj;
 + (NSDictionary<NSString *, NSString *> *)getLinkingObjectsProperties:(id)object;
-
-+ (void)initializeListProperty:(RLMObjectBase *)object property:(RLMProperty *)property array:(RLMArray *)array;
-+ (void)initializeOptionalProperty:(RLMObjectBase *)object property:(RLMProperty *)property;
-+ (void)initializeLinkingObjectsProperty:(RLMObjectBase *)object property:(RLMProperty *)property;
 
 + (NSDictionary<NSString *, NSNumber *> *)getOptionalProperties:(id)obj;
 + (NSArray<NSString *> *)requiredPropertiesForClass:(Class)cls;

--- a/Realm/RLMObject_Private.h
+++ b/Realm/RLMObject_Private.h
@@ -18,13 +18,13 @@
 
 #import <Realm/RLMObjectBase_Dynamic.h>
 
+typedef struct RLMObjectInfo RLMObjectInfo;
+
 // RLMObject accessor and read/write realm
 @interface RLMObjectBase () {
-  @public
+@public
     RLMRealm *_realm;
-    // objectSchema is a cached pointer to an object stored in the RLMSchema
-    // owned by _realm, so it's guaranteed to stay alive as long as this object
-    // without retaining it (and retaining it makes iteration slower)
+    RLMObjectInfo *_info;
     __unsafe_unretained RLMObjectSchema *_objectSchema;
 }
 
@@ -33,7 +33,7 @@
 
 // live accessor initializer
 - (instancetype)initWithRealm:(__unsafe_unretained RLMRealm *const)realm
-                       schema:(__unsafe_unretained RLMObjectSchema *const)schema NS_DESIGNATED_INITIALIZER;
+                       schema:(RLMObjectSchema *)schema NS_DESIGNATED_INITIALIZER;
 
 // shared schema for this class
 + (RLMObjectSchema *)sharedSchema;
@@ -50,7 +50,7 @@
 
 // live accessor initializer
 - (instancetype)initWithRealm:(__unsafe_unretained RLMRealm *const)realm
-                       schema:(__unsafe_unretained RLMObjectSchema *const)schema NS_DESIGNATED_INITIALIZER;
+                       schema:(RLMObjectSchema *)schema NS_DESIGNATED_INITIALIZER;
 
 @end
 
@@ -69,6 +69,10 @@
 @property (nonatomic, readonly) RLMObjectBase *object;
 
 @end
+
+// FIXME-2.0: This should be folded into initWithRealm:schema:, but changing the
+// signature of that is a breaking change for Swift
+id RLMCreateManagedAccessor(Class cls, RLMRealm *realm, RLMObjectInfo *info) NS_RETURNS_RETAINED;
 
 // Calls valueForKey: and re-raises NSUndefinedKeyExceptions
 FOUNDATION_EXTERN id RLMValidatedValueForProperty(id object, NSString *key, NSString *className);

--- a/Realm/RLMObject_Private.h
+++ b/Realm/RLMObject_Private.h
@@ -18,13 +18,10 @@
 
 #import <Realm/RLMObjectBase_Dynamic.h>
 
-typedef struct RLMObjectInfo RLMObjectInfo;
-
 // RLMObject accessor and read/write realm
 @interface RLMObjectBase () {
 @public
     RLMRealm *_realm;
-    RLMObjectInfo *_info;
     __unsafe_unretained RLMObjectSchema *_objectSchema;
 }
 
@@ -69,10 +66,6 @@ typedef struct RLMObjectInfo RLMObjectInfo;
 @property (nonatomic, readonly) RLMObjectBase *object;
 
 @end
-
-// FIXME-2.0: This should be folded into initWithRealm:schema:, but changing the
-// signature of that is a breaking change for Swift
-id RLMCreateManagedAccessor(Class cls, RLMRealm *realm, RLMObjectInfo *info) NS_RETURNS_RETAINED;
 
 // Calls valueForKey: and re-raises NSUndefinedKeyExceptions
 FOUNDATION_EXTERN id RLMValidatedValueForProperty(id object, NSString *key, NSString *className);

--- a/Realm/RLMObject_Private.hpp
+++ b/Realm/RLMObject_Private.hpp
@@ -19,6 +19,7 @@
 #import "RLMObject_Private.h"
 
 #import "RLMRealm_Private.hpp"
+#import "RLMUtil.hpp"
 
 #import <realm/link_view.hpp> // required by row.hpp
 #import <realm/row.hpp>

--- a/Realm/RLMObject_Private.hpp
+++ b/Realm/RLMObject_Private.hpp
@@ -31,8 +31,13 @@ class RLMObservationInfo;
     @public
     realm::Row _row;
     RLMObservationInfo *_observationInfo;
+    RLMClassInfo *_info;
 }
 @end
+
+// FIXME-2.0: This should be folded into initWithRealm:schema:, but changing the
+// signature of that is a breaking change for Swift
+id RLMCreateManagedAccessor(Class cls, RLMRealm *realm, RLMClassInfo *info) NS_RETURNS_RETAINED;
 
 // throw an exception if the object is invalidated or on the wrong thread
 static inline void RLMVerifyAttached(__unsafe_unretained RLMObjectBase *const obj) {

--- a/Realm/RLMObservation.hpp
+++ b/Realm/RLMObservation.hpp
@@ -20,11 +20,14 @@
 
 #import "binding_context.hpp"
 
-
-#import <realm/link_view.hpp> // required by row.hpp
 #import <realm/row.hpp>
+#import <realm/table.hpp>
 
-@class RLMObjectSchema, RLMObjectBase, RLMRealm, RLMSchema, RLMProperty;
+#import <unordered_map>
+
+@class RLMObjectBase, RLMRealm, RLMSchema, RLMProperty, RLMObjectSchema;
+class RLMSchemaInfo;
+struct RLMObjectInfo;
 
 namespace realm {
     class History;
@@ -36,7 +39,7 @@ namespace realm {
 // RLMObservationInfo instances, so it could be folded into RLMObjectBase, and
 // is a separate class mostly to avoid making all accessor objects far larger.
 //
-// RLMObjectSchema stores a vector of pointers to the first observation info
+// RLMObjectInfo stores a vector of pointers to the first observation info
 // created for each row. If there are multiple observation infos for a single
 // row (such as if there are multiple observed objects backed by a single row,
 // or if both an object and an array property of that object are observed),
@@ -47,16 +50,14 @@ namespace realm {
 class RLMObservationInfo {
 public:
     RLMObservationInfo(id object);
-    RLMObservationInfo(RLMObjectSchema *objectSchema, std::size_t row, id object);
+    RLMObservationInfo(RLMObjectInfo &objectSchema, std::size_t row, id object);
     ~RLMObservationInfo();
 
     realm::Row const& getRow() const {
         return row;
     }
 
-    RLMObjectSchema *getObjectSchema() const {
-        return objectSchema;
-    }
+    NSString *columnName(size_t col) const noexcept;
 
     // Send willChange/didChange notifications to all observers for this object/row
     // Sends the array versions if indexes is non-nil, normal versions otherwise
@@ -67,7 +68,7 @@ public:
         return row && row.get_index() == ndx;
     }
 
-    void recordObserver(realm::Row& row, RLMObjectSchema *objectSchema, NSString *keyPath);
+    void recordObserver(realm::Row& row, RLMObjectInfo *objectInfo, RLMObjectSchema *objectSchema, NSString *keyPath);
     void removeObserver();
     bool hasObservers() const { return observerCount > 0; }
 
@@ -94,10 +95,10 @@ private:
 
     // Row being observed
     realm::Row row;
-    RLMObjectSchema *objectSchema;
+    RLMObjectInfo *objectSchema = nullptr;
 
     // Object doing the observing
-    __unsafe_unretained id object;
+    __unsafe_unretained id object = nil;
 
     // valueForKey: hack
     bool invalidated = false;
@@ -130,14 +131,14 @@ private:
 // Get the the observation info chain for the given row
 // Will simply return info if it's non-null, and will search ojectSchema's array
 // for a matching one otherwise, and return null if there are none
-RLMObservationInfo *RLMGetObservationInfo(RLMObservationInfo *info, size_t row, RLMObjectSchema *objectSchema);
+RLMObservationInfo *RLMGetObservationInfo(RLMObservationInfo *info, size_t row, RLMObjectInfo& objectSchema);
 
 // delete all objects from a single table with change notifications
-void RLMClearTable(RLMObjectSchema *realm);
+void RLMClearTable(RLMObjectInfo &realm);
 
 // invoke the block, sending notifications for cascading deletes/link nullifications
 void RLMTrackDeletions(RLMRealm *realm, dispatch_block_t block);
 
-std::vector<realm::BindingContext::ObserverState> RLMGetObservedRows(NSArray<RLMObjectSchema *> *schema);
+std::vector<realm::BindingContext::ObserverState> RLMGetObservedRows(RLMSchemaInfo const& schema);
 void RLMWillChange(std::vector<realm::BindingContext::ObserverState> const& observed, std::vector<void *> const& invalidated);
 void RLMDidChange(std::vector<realm::BindingContext::ObserverState> const& observed, std::vector<void *> const& invalidated);

--- a/Realm/RLMObservation.hpp
+++ b/Realm/RLMObservation.hpp
@@ -26,8 +26,8 @@
 #import <unordered_map>
 
 @class RLMObjectBase, RLMRealm, RLMSchema, RLMProperty, RLMObjectSchema;
+class RLMClassInfo;
 class RLMSchemaInfo;
-struct RLMObjectInfo;
 
 namespace realm {
     class History;
@@ -39,7 +39,7 @@ namespace realm {
 // RLMObservationInfo instances, so it could be folded into RLMObjectBase, and
 // is a separate class mostly to avoid making all accessor objects far larger.
 //
-// RLMObjectInfo stores a vector of pointers to the first observation info
+// RLMClassInfo stores a vector of pointers to the first observation info
 // created for each row. If there are multiple observation infos for a single
 // row (such as if there are multiple observed objects backed by a single row,
 // or if both an object and an array property of that object are observed),
@@ -50,7 +50,7 @@ namespace realm {
 class RLMObservationInfo {
 public:
     RLMObservationInfo(id object);
-    RLMObservationInfo(RLMObjectInfo &objectSchema, std::size_t row, id object);
+    RLMObservationInfo(RLMClassInfo &objectSchema, std::size_t row, id object);
     ~RLMObservationInfo();
 
     realm::Row const& getRow() const {
@@ -68,7 +68,7 @@ public:
         return row && row.get_index() == ndx;
     }
 
-    void recordObserver(realm::Row& row, RLMObjectInfo *objectInfo, RLMObjectSchema *objectSchema, NSString *keyPath);
+    void recordObserver(realm::Row& row, RLMClassInfo *objectInfo, RLMObjectSchema *objectSchema, NSString *keyPath);
     void removeObserver();
     bool hasObservers() const { return observerCount > 0; }
 
@@ -95,7 +95,7 @@ private:
 
     // Row being observed
     realm::Row row;
-    RLMObjectInfo *objectSchema = nullptr;
+    RLMClassInfo *objectSchema = nullptr;
 
     // Object doing the observing
     __unsafe_unretained id object = nil;
@@ -131,10 +131,10 @@ private:
 // Get the the observation info chain for the given row
 // Will simply return info if it's non-null, and will search ojectSchema's array
 // for a matching one otherwise, and return null if there are none
-RLMObservationInfo *RLMGetObservationInfo(RLMObservationInfo *info, size_t row, RLMObjectInfo& objectSchema);
+RLMObservationInfo *RLMGetObservationInfo(RLMObservationInfo *info, size_t row, RLMClassInfo& objectSchema);
 
 // delete all objects from a single table with change notifications
-void RLMClearTable(RLMObjectInfo &realm);
+void RLMClearTable(RLMClassInfo &realm);
 
 // invoke the block, sending notifications for cascading deletes/link nullifications
 void RLMTrackDeletions(RLMRealm *realm, dispatch_block_t block);

--- a/Realm/RLMObservation.mm
+++ b/Realm/RLMObservation.mm
@@ -22,11 +22,11 @@
 #import "RLMArray_Private.hpp"
 #import "RLMListBase.h"
 #import "RLMObjectSchema_Private.hpp"
+#import "RLMObject_Private.hpp"
 #import "RLMProperty_Private.h"
 #import "RLMRealm_Private.hpp"
-#import "RLMSchema.h"
 
-#import <realm/lang_bind_helper.hpp>
+#import <realm/group.hpp>
 
 using namespace realm;
 
@@ -51,12 +51,11 @@ namespace {
     }
 }
 
-RLMObservationInfo::RLMObservationInfo(RLMObjectSchema *objectSchema, std::size_t row, id object)
+RLMObservationInfo::RLMObservationInfo(RLMObjectInfo &objectSchema, std::size_t row, id object)
 : object(object)
-, objectSchema(objectSchema)
+, objectSchema(&objectSchema)
 {
-    REALM_ASSERT_DEBUG(objectSchema);
-    setRow(*objectSchema.table, row);
+    setRow(*objectSchema.table(), row);
 }
 
 RLMObservationInfo::RLMObservationInfo(id object)
@@ -78,8 +77,8 @@ RLMObservationInfo::~RLMObservationInfo() {
         // The head of the list, so remove self from the object schema's array
         // of observation info, either replacing self with the next info or
         // removing entirely if there is no next
-        auto end = objectSchema->_observedObjects.end();
-        auto it = find(objectSchema->_observedObjects.begin(), end, this);
+        auto end = objectSchema->observedObjects.end();
+        auto it = find(objectSchema->observedObjects.begin(), end, this);
         if (it != end) {
             if (next) {
                 *it = next;
@@ -87,7 +86,7 @@ RLMObservationInfo::~RLMObservationInfo() {
             }
             else {
                 iter_swap(it, std::prev(end));
-                objectSchema->_observedObjects.pop_back();
+                objectSchema->observedObjects.pop_back();
             }
         }
     }
@@ -99,6 +98,10 @@ RLMObservationInfo::~RLMObservationInfo() {
     prev = (RLMObservationInfo *)-1;
     next = (RLMObservationInfo *)-1;
 #endif
+}
+
+NSString *RLMObservationInfo::columnName(size_t col) const noexcept {
+    return objectSchema->propertyForTableColumn(col).name;
 }
 
 void RLMObservationInfo::willChange(NSString *key, NSKeyValueChange kind, NSIndexSet *indexes) const {
@@ -138,7 +141,7 @@ void RLMObservationInfo::setRow(realm::Table &table, size_t newRow) {
     REALM_ASSERT_DEBUG(!row);
     REALM_ASSERT_DEBUG(objectSchema);
     row = table[newRow];
-    for (auto info : objectSchema->_observedObjects) {
+    for (auto info : objectSchema->observedObjects) {
         if (info->row && info->row.get_index() == row.get_index()) {
             prev = info;
             next = info->next;
@@ -148,44 +151,46 @@ void RLMObservationInfo::setRow(realm::Table &table, size_t newRow) {
             return;
         }
     }
-    objectSchema->_observedObjects.push_back(this);
+    objectSchema->observedObjects.push_back(this);
 }
 
-void RLMObservationInfo::recordObserver(realm::Row& objectRow,
+void RLMObservationInfo::recordObserver(realm::Row& objectRow, RLMObjectInfo *objectInfo,
                                         __unsafe_unretained RLMObjectSchema *const objectSchema,
                                         __unsafe_unretained NSString *const keyPath) {
     ++observerCount;
+    if (row) {
+        return;
+    }
 
     // add ourselves to the list of observed objects if this is the first time
     // an observer is being added to a managed object
-    if (objectRow && !row) {
-        this->objectSchema = objectSchema;
+    if (objectRow) {
+        this->objectSchema = objectInfo;
         setRow(*objectRow.get_table(), objectRow.get_index());
+        return;
     }
 
-    if (!row) {
-        // Arrays need a reference to their containing object to avoid having to
-        // go through the awful proxy object from mutableArrayValueForKey.
-        // For managed objects we do this when the object is added or created
-        // (and have to to support notifications from modifying an object which
-        // was never observed), but for Swift classes (both RealmSwift and
-        // RLMObject) we can't do it then because we don't know what the parent
-        // object is.
+    // Arrays need a reference to their containing object to avoid having to
+    // go through the awful proxy object from mutableArrayValueForKey.
+    // For managed objects we do this when the object is added or created
+    // (and have to to support notifications from modifying an object which
+    // was never observed), but for Swift classes (both RealmSwift and
+    // RLMObject) we can't do it then because we don't know what the parent
+    // object is.
 
-        NSUInteger sep = [keyPath rangeOfString:@"."].location;
-        NSString *key = sep == NSNotFound ? keyPath : [keyPath substringToIndex:sep];
-        RLMProperty *prop = objectSchema[key];
-        if (prop && prop.type == RLMPropertyTypeArray) {
-            id value = valueForKey(key);
-            RLMArray *array = [value isKindOfClass:[RLMListBase class]] ? [value _rlmArray] : value;
-            array->_key = key;
-            array->_parentObject = object;
-        }
-        else if (auto swiftIvar = prop.swiftIvar) {
-            if (auto optional = RLMDynamicCast<RLMOptionalBase>(object_getIvar(object, swiftIvar))) {
-                optional.property = prop;
-                optional.object = object;
-            }
+    NSUInteger sep = [keyPath rangeOfString:@"."].location;
+    NSString *key = sep == NSNotFound ? keyPath : [keyPath substringToIndex:sep];
+    RLMProperty *prop = objectSchema[key];
+    if (prop && prop.type == RLMPropertyTypeArray) {
+        id value = valueForKey(key);
+        RLMArray *array = [value isKindOfClass:[RLMListBase class]] ? [value _rlmArray] : value;
+        array->_key = key;
+        array->_parentObject = object;
+    }
+    else if (auto swiftIvar = prop.swiftIvar) {
+        if (auto optional = RLMDynamicCast<RLMOptionalBase>(object_getIvar(object, swiftIvar))) {
+            optional.property = prop;
+            optional.object = object;
         }
     }
 }
@@ -204,11 +209,12 @@ id RLMObservationInfo::valueForKey(NSString *key) {
 
     if (key != lastKey) {
         lastKey = key;
-        lastProp = objectSchema[key];
+        lastProp = objectSchema ? objectSchema->rlmObjectSchema[key] : nil;
     }
 
     static auto superValueForKey = reinterpret_cast<id(*)(id, SEL, NSString *)>([NSObject methodForSelector:@selector(valueForKey:)]);
     if (!lastProp) {
+        // Not a managed property, so use NSObject's implementation of valueForKey:
         return RLMCoerceToNil(superValueForKey(object, @selector(valueForKey:), key));
     }
 
@@ -216,7 +222,9 @@ id RLMObservationInfo::valueForKey(NSString *key) {
         return row ? RLMDynamicGet(object, lastProp) : RLMCoerceToNil(superValueForKey(object, @selector(valueForKey:), key));
     };
 
-    // We need to return the same object each time for observing over keypaths to work
+    // We need to return the same object each time for observing over keypaths
+    // to work, so we store a cache of them here. We can't just cache them on
+    // the object as that leads to retain cycles.
     if (lastProp.type == RLMPropertyTypeArray) {
         RLMArray *value = cachedObjects[key];
         if (!value) {
@@ -230,13 +238,14 @@ id RLMObservationInfo::valueForKey(NSString *key) {
     }
 
     if (lastProp.type == RLMPropertyTypeObject) {
-        if (row.is_null_link(lastProp.column)) {
+        size_t col = row.get_column_index(lastProp.name.UTF8String);
+        if (row.is_null_link(col)) {
             [cachedObjects removeObjectForKey:key];
             return nil;
         }
 
         RLMObjectBase *value = cachedObjects[key];
-        if (value && value->_row.get_index() == row.get_link(lastProp.column)) {
+        if (value && value->_row.get_index() == row.get_link(col)) {
             return value;
         }
         value = getSuper();
@@ -250,14 +259,13 @@ id RLMObservationInfo::valueForKey(NSString *key) {
     return getSuper();
 }
 
-RLMObservationInfo *RLMGetObservationInfo(RLMObservationInfo *info,
-                                          size_t row,
-                                          __unsafe_unretained RLMObjectSchema *objectSchema) {
+RLMObservationInfo *RLMGetObservationInfo(RLMObservationInfo *info, size_t row,
+                                          RLMObjectInfo& objectSchema) {
     if (info) {
         return info;
     }
 
-    for (RLMObservationInfo *info : objectSchema->_observedObjects) {
+    for (RLMObservationInfo *info : objectSchema.observedObjects) {
         if (info->isForRow(row)) {
             return info;
         }
@@ -266,24 +274,24 @@ RLMObservationInfo *RLMGetObservationInfo(RLMObservationInfo *info,
     return nullptr;
 }
 
-void RLMClearTable(RLMObjectSchema *objectSchema) {
-    for (auto info : objectSchema->_observedObjects) {
+void RLMClearTable(RLMObjectInfo &objectSchema) {
+    for (auto info : objectSchema.observedObjects) {
         info->willChange(RLMInvalidatedKey);
     }
 
     RLMTrackDeletions(objectSchema.realm, ^{
-        objectSchema.table->clear();
+        objectSchema.table()->clear();
 
-        for (auto info : objectSchema->_observedObjects) {
+        for (auto info : objectSchema.observedObjects) {
             info->prepareForInvalidation();
         }
     });
 
-    for (auto info : reverse(objectSchema->_observedObjects)) {
+    for (auto info : reverse(objectSchema.observedObjects)) {
         info->didChange(RLMInvalidatedKey);
     }
 
-    objectSchema->_observedObjects.clear();
+    objectSchema.observedObjects.clear();
 }
 
 void RLMTrackDeletions(__unsafe_unretained RLMRealm *const realm, dispatch_block_t block) {
@@ -291,15 +299,15 @@ void RLMTrackDeletions(__unsafe_unretained RLMRealm *const realm, dispatch_block
 
     // Build up an array of observation info arrays which is indexed by table
     // index (the object schemata may be in an entirely different order)
-    for (RLMObjectSchema *objectSchema in realm.schema.objectSchema) {
-        if (objectSchema->_observedObjects.empty()) {
+    for (auto& info : realm->_info) {
+        if (info.second.observedObjects.empty()) {
             continue;
         }
-        size_t ndx = objectSchema.table->get_index_in_group();
+        size_t ndx = info.second.table()->get_index_in_group();
         if (ndx >= observers.size()) {
             observers.resize(std::max(observers.size() * 2, ndx + 1));
         }
-        observers[ndx] = &objectSchema->_observedObjects;
+        observers[ndx] = &info.second.observedObjects;
     }
 
     // No need for change tracking if no objects are observed
@@ -332,9 +340,8 @@ void RLMTrackDeletions(__unsafe_unretained RLMRealm *const realm, dispatch_block
                     continue;
                 }
 
-                RLMProperty *prop = [observer->getObjectSchema() propertyForTableColumn:link.origin_col_ndx];
-                NSString *name = prop.name;
-                if (prop.type != RLMPropertyTypeArray) {
+                NSString *name = observer->columnName(link.origin_col_ndx);
+                if (observer->getRow().get_table()->get_column_type(link.origin_col_ndx) != type_LinkList) {
                     changes.push_back({observer, name});
                     continue;
                 }
@@ -350,7 +357,7 @@ void RLMTrackDeletions(__unsafe_unretained RLMRealm *const realm, dispatch_block
                 // We know what row index is being removed from the LinkView,
                 // but what we actually want is the indexes in the LinkView that
                 // are going away
-                auto linkview = observer->getRow().get_linklist(prop.column);
+                auto linkview = observer->getRow().get_linklist(link.origin_col_ndx);
                 size_t start = 0, index;
                 while ((index = linkview->find(link.old_target_row_ndx, start)) != realm::not_found) {
                     [c->indexes addIndex:index];
@@ -414,10 +421,10 @@ void forEach(realm::BindingContext::ObserverState const& state, Func&& func) {
 }
 }
 
-std::vector<realm::BindingContext::ObserverState> RLMGetObservedRows(NSArray<RLMObjectSchema *> *schema) {
+std::vector<realm::BindingContext::ObserverState> RLMGetObservedRows(RLMSchemaInfo const& schema) {
     std::vector<realm::BindingContext::ObserverState> observers;
-    for (RLMObjectSchema *objectSchema in schema) {
-        for (auto info : objectSchema->_observedObjects) {
+    for (auto& table : schema) {
+        for (auto info : table.second.observedObjects) {
             auto const& row = info->getRow();
             if (!row.is_attached())
                 continue;
@@ -466,8 +473,8 @@ void RLMWillChange(std::vector<realm::BindingContext::ObserverState> const& obse
         NSMutableIndexSet *indexes = [NSMutableIndexSet new];
         for (auto const& o : observed) {
             forEach(o, [&](size_t, auto const& change, RLMObservationInfo *info) {
-                auto property = [info->getObjectSchema() propertyForTableColumn:change.initial_column_index];
-                info->willChange(property.name, convert(change.kind), convert(change.indices, indexes));
+                info->willChange(info->columnName(change.initial_column_index),
+                                 convert(change.kind), convert(change.indices, indexes));
             });
         }
     }
@@ -483,8 +490,7 @@ void RLMDidChange(std::vector<realm::BindingContext::ObserverState> const& obser
         NSMutableIndexSet *indexes = [NSMutableIndexSet new];
         for (auto const& o : reverse(observed)) {
             forEach(o, [&](size_t i, auto const& change, RLMObservationInfo *info) {
-                auto property = [info->getObjectSchema() propertyForTableColumn:i];
-                info->didChange(property.name, convert(change.kind), convert(change.indices, indexes));
+                info->didChange(info->columnName(i), convert(change.kind), convert(change.indices, indexes));
             });
         }
     }

--- a/Realm/RLMObservation.mm
+++ b/Realm/RLMObservation.mm
@@ -51,7 +51,7 @@ namespace {
     }
 }
 
-RLMObservationInfo::RLMObservationInfo(RLMObjectInfo &objectSchema, std::size_t row, id object)
+RLMObservationInfo::RLMObservationInfo(RLMClassInfo &objectSchema, std::size_t row, id object)
 : object(object)
 , objectSchema(&objectSchema)
 {
@@ -154,7 +154,7 @@ void RLMObservationInfo::setRow(realm::Table &table, size_t newRow) {
     objectSchema->observedObjects.push_back(this);
 }
 
-void RLMObservationInfo::recordObserver(realm::Row& objectRow, RLMObjectInfo *objectInfo,
+void RLMObservationInfo::recordObserver(realm::Row& objectRow, RLMClassInfo *objectInfo,
                                         __unsafe_unretained RLMObjectSchema *const objectSchema,
                                         __unsafe_unretained NSString *const keyPath) {
     ++observerCount;
@@ -260,7 +260,7 @@ id RLMObservationInfo::valueForKey(NSString *key) {
 }
 
 RLMObservationInfo *RLMGetObservationInfo(RLMObservationInfo *info, size_t row,
-                                          RLMObjectInfo& objectSchema) {
+                                          RLMClassInfo& objectSchema) {
     if (info) {
         return info;
     }
@@ -274,7 +274,7 @@ RLMObservationInfo *RLMGetObservationInfo(RLMObservationInfo *info, size_t row,
     return nullptr;
 }
 
-void RLMClearTable(RLMObjectInfo &objectSchema) {
+void RLMClearTable(RLMClassInfo &objectSchema) {
     for (auto info : objectSchema.observedObjects) {
         info->willChange(RLMInvalidatedKey);
     }

--- a/Realm/RLMProperty.mm
+++ b/Realm/RLMProperty.mm
@@ -531,7 +531,6 @@ static bool rawTypeIsComputedProperty(NSString *rawType) {
 
 - (BOOL)isEqualToProperty:(RLMProperty *)property {
     return _type == property->_type
-        && _column == property->_column
         && _indexed == property->_indexed
         && _isPrimary == property->_isPrimary
         && _optional == property->_optional

--- a/Realm/RLMProperty_Private.h
+++ b/Realm/RLMProperty_Private.h
@@ -58,7 +58,6 @@ BOOL RLMPropertyTypeIsComputed(RLMPropertyType propertyType);
                                  linkOriginPropertyName:(NSString *)linkOriginPropertyName;
 
 // private setters
-@property (nonatomic, assign) NSUInteger column;
 @property (nonatomic, readwrite) NSString *name;
 @property (nonatomic, readwrite, assign) RLMPropertyType type;
 @property (nonatomic, readwrite) BOOL indexed;
@@ -66,6 +65,7 @@ BOOL RLMPropertyTypeIsComputed(RLMPropertyType propertyType);
 @property (nonatomic, copy) NSString *objectClassName;
 
 // private properties
+@property (nonatomic, assign) NSUInteger index;
 @property (nonatomic, assign) char objcType;
 @property (nonatomic, copy) NSString *objcRawType;
 @property (nonatomic, assign) BOOL isPrimary;

--- a/Realm/RLMRealm.mm
+++ b/Realm/RLMRealm.mm
@@ -165,24 +165,9 @@ static id RLMAutorelease(id value) {
     return value ? (__bridge id)CFAutorelease((__bridge_retained CFTypeRef)value) : nil;
 }
 
-static void RLMCopyColumnMapping(RLMObjectSchema *targetSchema, const ObjectSchema &tableSchema) {
-    REALM_ASSERT_DEBUG(targetSchema.properties.count == tableSchema.persisted_properties.size());
-
-    // copy updated column mapping
-    for (auto const& prop : tableSchema.persisted_properties) {
-        RLMProperty *targetProp = targetSchema[@(prop.name.c_str())];
-        targetProp.column = prop.table_column;
-    }
-}
-
 static void RLMRealmSetSchemaAndAlign(RLMRealm *realm, RLMSchema *targetSchema) {
     realm.schema = targetSchema;
-    for (auto const& aligned : realm->_realm->schema()) {
-        if (RLMObjectSchema *objectSchema = [targetSchema schemaForClassName:@(aligned.name.c_str())]) {
-            objectSchema.realm = realm;
-            RLMCopyColumnMapping(objectSchema, aligned);
-        }
-    }
+    realm->_info.init(realm, targetSchema, realm->_realm->schema());
 }
 
 + (instancetype)realmWithSharedRealm:(SharedRealm)sharedRealm schema:(RLMSchema *)schema {
@@ -292,17 +277,14 @@ REALM_NOINLINE void RLMRealmTranslateException(NSError **error) {
 
     // if we have a cached realm on another thread, copy without a transaction
     if (RLMRealm *cachedRealm = RLMGetAnyCachedRealmForPath(config.path)) {
-        realm.schema = [cachedRealm.schema shallowCopy];
-        for (RLMObjectSchema *objectSchema in realm.schema.objectSchema) {
-            objectSchema.realm = realm;
-        }
+        RLMRealmSetSchemaAndAlign(realm, cachedRealm.schema);
     }
     else if (dynamic) {
         RLMRealmSetSchemaAndAlign(realm, [RLMSchema dynamicSchemaFromObjectStoreSchema:realm->_realm->schema()]);
     }
     else {
         // set/align schema or perform migration if needed
-        RLMSchema *schema = [configuration.customSchema ?: RLMSchema.sharedSchema copy];
+        RLMSchema *schema = configuration.customSchema ?: RLMSchema.sharedSchema;
 
         Realm::MigrationFunction migrationFunction;
         auto migrationBlock = configuration.migrationBlock;
@@ -472,19 +454,19 @@ REALM_NOINLINE void RLMRealmTranslateException(NSError **error) {
 
     [self detachAllEnumerators];
 
-    for (RLMObjectSchema *objectSchema in _schema.objectSchema) {
-        for (RLMObservationInfo *info : objectSchema->_observedObjects) {
+    for (auto& objectInfo : _info) {
+        for (RLMObservationInfo *info : objectInfo.second.observedObjects) {
             info->willChange(RLMInvalidatedKey);
         }
     }
 
     _realm->invalidate();
 
-    for (RLMObjectSchema *objectSchema in _schema.objectSchema) {
-        for (RLMObservationInfo *info : objectSchema->_observedObjects) {
+    for (auto& objectInfo : _info) {
+        for (RLMObservationInfo *info : objectInfo.second.observedObjects) {
             info->didChange(RLMInvalidatedKey);
         }
-        objectSchema.table = nullptr;
+        objectInfo.second.releaseTable();
     }
 }
 

--- a/Realm/RLMRealm.mm
+++ b/Realm/RLMRealm.mm
@@ -167,7 +167,7 @@ static id RLMAutorelease(id value) {
 
 static void RLMRealmSetSchemaAndAlign(RLMRealm *realm, RLMSchema *targetSchema) {
     realm.schema = targetSchema;
-    realm->_info.init(realm, targetSchema, realm->_realm->schema());
+    realm->_info = RLMSchemaInfo(realm, targetSchema, realm->_realm->schema());
 }
 
 + (instancetype)realmWithSharedRealm:(SharedRealm)sharedRealm schema:(RLMSchema *)schema {

--- a/Realm/RLMRealmConfiguration.mm
+++ b/Realm/RLMRealmConfiguration.mm
@@ -269,14 +269,20 @@ static void RLMNSStringToStdString(std::string &out, NSString *in) {
     _config.cache = cache;
 }
 
-- (void)setDisableFormatUpgrade:(bool)disableFormatUpgrade
-{
+- (bool)disableFormatUpgrade {
+    return _config.disable_format_upgrade;
+}
+
+- (void)setDisableFormatUpgrade:(bool)disableFormatUpgrade {
     _config.disable_format_upgrade = disableFormatUpgrade;
 }
 
-- (bool)disableFormatUpgrade
-{
-    return _config.disable_format_upgrade;
+- (realm::SchemaMode)schemaMode {
+    return _config.schema_mode;
+}
+
+- (void)setSchemaMode:(realm::SchemaMode)mode {
+    _config.schema_mode = mode;
 }
 
 @end

--- a/Realm/RLMRealmConfiguration_Private.hpp
+++ b/Realm/RLMRealmConfiguration_Private.hpp
@@ -21,4 +21,6 @@
 
 @interface RLMRealmConfiguration ()
 - (realm::Realm::Config&)config;
+
+@property (nonatomic) realm::SchemaMode schemaMode;
 @end

--- a/Realm/RLMRealmUtil.mm
+++ b/Realm/RLMRealmUtil.mm
@@ -18,8 +18,9 @@
 
 #import "RLMRealmUtil.hpp"
 
+#import "RLMObjectSchema_Private.hpp"
 #import "RLMObservation.hpp"
-#import "RLMRealm_Private.h"
+#import "RLMRealm_Private.hpp"
 #import "RLMUtil.hpp"
 
 #import <Realm/RLMConstants.h>
@@ -96,9 +97,11 @@ public:
 
     std::vector<ObserverState> get_observed_rows() override {
         @autoreleasepool {
-            auto realm = _realm;
-            [realm detachAllEnumerators];
-            return RLMGetObservedRows(realm.schema.objectSchema);
+            if (auto realm = _realm) {
+                [realm detachAllEnumerators];
+                return RLMGetObservedRows(realm->_info);
+            }
+            return {};
         }
     }
 

--- a/Realm/RLMRealm_Private.hpp
+++ b/Realm/RLMRealm_Private.hpp
@@ -17,20 +17,18 @@
 ////////////////////////////////////////////////////////////////////////////
 
 #import "RLMRealm_Private.h"
-#import "RLMUtil.hpp"
-#import "shared_realm.hpp"
 
-#import <realm/group.hpp>
+#import "RLMObjectInfo.hpp"
 
 namespace realm {
     class Group;
     class Realm;
-    typedef std::shared_ptr<realm::Realm> SharedRealm;
 }
 
 @interface RLMRealm () {
     @public
-    realm::SharedRealm _realm;
+    std::shared_ptr<realm::Realm> _realm;
+    RLMSchemaInfo _info;
 }
 
 // FIXME - group should not be exposed

--- a/Realm/RLMRealm_Private.hpp
+++ b/Realm/RLMRealm_Private.hpp
@@ -18,7 +18,7 @@
 
 #import "RLMRealm_Private.h"
 
-#import "RLMObjectInfo.hpp"
+#import "RLMClassInfo.hpp"
 
 namespace realm {
     class Group;

--- a/Realm/RLMResults.mm
+++ b/Realm/RLMResults.mm
@@ -50,6 +50,7 @@ using namespace realm;
 @implementation RLMResults {
     realm::Results _results;
     RLMRealm *_realm;
+    RLMObjectInfo *_info;
 }
 
 - (instancetype)initPrivate {
@@ -107,17 +108,16 @@ static auto translateErrors(Function&& f, NSString *aggregateMethod=nil) {
     }
 }
 
-+ (instancetype)resultsWithObjectSchema:(RLMObjectSchema *)objectSchema
-                                results:(realm::Results)results {
++ (instancetype)resultsWithObjectInfo:(RLMObjectInfo&)info
+                              results:(realm::Results)results {
     RLMResults *ar = [[self alloc] initPrivate];
     ar->_results = std::move(results);
-    ar->_realm = objectSchema.realm;
-    ar->_objectSchema = objectSchema;
+    ar->_realm = info.realm;
+    ar->_info = &info;
     return ar;
 }
 
-+ (instancetype)emptyDetachedResults
-{
++ (instancetype)emptyDetachedResults {
     return [[self alloc] initPrivate];
 }
 
@@ -138,12 +138,20 @@ static inline void RLMResultsValidateInWriteTransaction(__unsafe_unretained RLMR
     return RLMStringDataToNSString(_results.get_object_type());
 }
 
+- (RLMObjectSchema *)objectSchema {
+    return _info->rlmObjectSchema;
+}
+
+- (RLMObjectInfo *)objectInfo {
+    return _info;
+}
+
 - (NSUInteger)countByEnumeratingWithState:(NSFastEnumerationState *)state
                                   objects:(__unused __unsafe_unretained id [])buffer
                                     count:(NSUInteger)len {
     __autoreleasing RLMFastEnumerator *enumerator;
     if (state->state == 0) {
-        enumerator = [[RLMFastEnumerator alloc] initWithCollection:self objectSchema:_objectSchema];
+        enumerator = [[RLMFastEnumerator alloc] initWithCollection:self objectSchema:*_info];
         state->extra[0] = (long)enumerator;
         state->extra[1] = self.count;
     }
@@ -173,8 +181,7 @@ static inline void RLMResultsValidateInWriteTransaction(__unsafe_unretained RLMR
     }
 
     Query query = translateErrors([&] { return _results.get_query(); });
-    query.and_query(RLMPredicateToQuery(predicate, _objectSchema, _realm.schema, _realm.group));
-
+    query.and_query(RLMPredicateToQuery(predicate, _info->rlmObjectSchema, _realm.schema, _realm.group));
     query.sync_view_if_needed();
 
     TableView table_view;
@@ -197,18 +204,18 @@ static inline void RLMResultsValidateInWriteTransaction(__unsafe_unretained RLMR
 
 - (id)objectAtIndex:(NSUInteger)index {
     return translateErrors([&] {
-        return RLMCreateObjectAccessor(_realm, _objectSchema, _results.get(index));
+        return RLMCreateObjectAccessor(_realm, *_info, _results.get(index));
     });
 }
 
 - (id)firstObject {
     auto row = translateErrors([&] { return _results.first(); });
-    return row ? RLMCreateObjectAccessor(_realm, _objectSchema, *row) : nil;
+    return row ? RLMCreateObjectAccessor(_realm, *_info, *row) : nil;
 }
 
 - (id)lastObject {
     auto row = translateErrors([&] { return _results.last(); });
-    return row ? RLMCreateObjectAccessor(_realm, _objectSchema, *row) : nil;
+    return row ? RLMCreateObjectAccessor(_realm, *_info, *row) : nil;
 }
 
 - (NSUInteger)indexOfObject:(RLMObject *)object {
@@ -327,9 +334,8 @@ static inline void RLMResultsValidateInWriteTransaction(__unsafe_unretained RLMR
         if (_results.get_mode() == Results::Mode::Empty) {
             return self;
         }
-        auto query = RLMPredicateToQuery(predicate, _objectSchema, _realm.schema, _realm.group);
-        return [RLMResults resultsWithObjectSchema:_objectSchema
-                                           results:_results.filter(std::move(query))];
+        auto query = RLMPredicateToQuery(predicate, _info->rlmObjectSchema, _realm.schema, _realm.group);
+        return [RLMResults resultsWithObjectInfo:*_info results:_results.filter(std::move(query))];
     });
 }
 
@@ -343,8 +349,7 @@ static inline void RLMResultsValidateInWriteTransaction(__unsafe_unretained RLMR
             return self;
         }
 
-        return [RLMResults resultsWithObjectSchema:_objectSchema
-                                           results:_results.sort(RLMSortOrderFromDescriptors(*_objectSchema.table, properties))];
+        return [RLMResults resultsWithObjectInfo:*_info results:_results.sort(RLMSortOrderFromDescriptors(*_info->table(), properties))];
     });
 }
 
@@ -353,7 +358,7 @@ static inline void RLMResultsValidateInWriteTransaction(__unsafe_unretained RLMR
 }
 
 - (id)aggregate:(NSString *)property method:(util::Optional<Mixed> (Results::*)(size_t))method methodName:(NSString *)methodName {
-    size_t column = RLMValidatedProperty(_objectSchema, property).column;
+    size_t column = _info->tableColumn(property);
     auto value = translateErrors([&] { return (_results.*method)(column); }, methodName);
     if (!value) {
         return nil;
@@ -381,7 +386,7 @@ static inline void RLMResultsValidateInWriteTransaction(__unsafe_unretained RLMR
     return translateErrors([&] {
         if (_results.get_mode() == Results::Mode::Table) {
             RLMResultsValidateInWriteTransaction(self);
-            RLMClearTable(self.objectSchema);
+            RLMClearTable(*self.objectInfo);
         }
         else {
             RLMTrackDeletions(_realm, ^{ _results.clear(); });

--- a/Realm/RLMResults.mm
+++ b/Realm/RLMResults.mm
@@ -50,7 +50,7 @@ using namespace realm;
 @implementation RLMResults {
     realm::Results _results;
     RLMRealm *_realm;
-    RLMObjectInfo *_info;
+    RLMClassInfo *_info;
 }
 
 - (instancetype)initPrivate {
@@ -108,7 +108,7 @@ static auto translateErrors(Function&& f, NSString *aggregateMethod=nil) {
     }
 }
 
-+ (instancetype)resultsWithObjectInfo:(RLMObjectInfo&)info
++ (instancetype)resultsWithObjectInfo:(RLMClassInfo&)info
                               results:(realm::Results)results {
     RLMResults *ar = [[self alloc] initPrivate];
     ar->_results = std::move(results);
@@ -142,7 +142,7 @@ static inline void RLMResultsValidateInWriteTransaction(__unsafe_unretained RLMR
     return _info->rlmObjectSchema;
 }
 
-- (RLMObjectInfo *)objectInfo {
+- (RLMClassInfo *)objectInfo {
     return _info;
 }
 

--- a/Realm/RLMResults_Private.h
+++ b/Realm/RLMResults_Private.h
@@ -21,7 +21,6 @@
 @class RLMObjectSchema;
 
 @interface RLMResults ()
-@property (nonatomic, unsafe_unretained) RLMObjectSchema *objectSchema;
 @property (nonatomic, readonly, getter=isAttached) BOOL attached;
 
 + (instancetype)emptyDetachedResults;

--- a/Realm/RLMSchema.mm
+++ b/Realm/RLMSchema.mm
@@ -55,6 +55,7 @@ static enum class SharedSchemaState {
 
 @implementation RLMSchema {
     NSArray *_objectSchema;
+    realm::Schema _objectStoreSchema;
 }
 
 // Caller must @synchronize on s_localNameToClass
@@ -316,12 +317,15 @@ static void RLMRegisterClassLocalNames(Class *classes, NSUInteger count) {
 }
 
 - (Schema)objectStoreCopy {
-    std::vector<realm::ObjectSchema> schema;
-    schema.reserve(_objectSchemaByName.count);
-    [_objectSchemaByName enumerateKeysAndObjectsUsingBlock:[&](NSString *, RLMObjectSchema *objectSchema, BOOL *) {
-        schema.push_back(objectSchema.objectStoreCopy);
-    }];
-    return schema;
+    if (_objectStoreSchema.size() == 0) {
+        std::vector<realm::ObjectSchema> schema;
+        schema.reserve(_objectSchemaByName.count);
+        [_objectSchemaByName enumerateKeysAndObjectsUsingBlock:[&](NSString *, RLMObjectSchema *objectSchema, BOOL *) {
+            schema.push_back(objectSchema.objectStoreCopy);
+        }];
+        _objectStoreSchema = std::move(schema);
+    }
+    return _objectStoreSchema;
 }
 
 @end

--- a/Realm/RLMSchema_Private.h
+++ b/Realm/RLMSchema_Private.h
@@ -16,10 +16,6 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #import <Realm/RLMSchema.h>
 
 NS_ASSUME_NONNULL_BEGIN
@@ -51,15 +47,8 @@ NS_ASSUME_NONNULL_BEGIN
 // class for string
 + (nullable Class)classForString:(NSString *)className;
 
-// shallow copy for reusing schema properties accross the same Realm on multiple threads
-- (instancetype)shallowCopy;
-
 + (nullable RLMObjectSchema *)sharedSchemaForClass:(Class)cls;
 
 @end
 
 NS_ASSUME_NONNULL_END
-
-#ifdef __cplusplus
-}
-#endif

--- a/Realm/RLMUtil.hpp
+++ b/Realm/RLMUtil.hpp
@@ -159,11 +159,11 @@ static inline realm::BinaryData RLMBinaryDataForNSData(__unsafe_unretained NSDat
 // Date convertion utilities
 // These use the reference date and shift the seconds rather than just getting
 // the time interval since the epoch directly to avoid losing sub-second precision
-static inline NSDate *RLMTimestampToNSDate(realm::Timestamp ts) {
+static inline NSDate *RLMTimestampToNSDate(realm::Timestamp ts) NS_RETURNS_RETAINED {
     if (ts.is_null())
         return nil;
     auto timeInterval = ts.get_seconds() - NSTimeIntervalSince1970 + ts.get_nanoseconds() / 1'000'000'000.0;
-    return [NSDate dateWithTimeIntervalSinceReferenceDate:timeInterval];
+    return [[NSDate alloc] initWithTimeIntervalSinceReferenceDate:timeInterval];
 }
 
 static inline realm::Timestamp RLMTimestampForNSDate(__unsafe_unretained NSDate *const date) {

--- a/Realm/RLMUtil.mm
+++ b/Realm/RLMUtil.mm
@@ -27,6 +27,8 @@
 #import "RLMSchema_Private.h"
 #import "RLMSwiftSupport.h"
 
+#import "shared_realm.hpp"
+
 #import <realm/mixed.hpp>
 #import <realm/table_view.hpp>
 

--- a/Realm/Tests/AsyncTests.mm
+++ b/Realm/Tests/AsyncTests.mm
@@ -23,6 +23,8 @@
 
 #import "impl/realm_coordinator.hpp"
 
+#import <realm/string_data.hpp>
+
 #import <sys/resource.h>
 
 // A whole bunch of blocks don't use their RLMResults parameter

--- a/Realm/Tests/KVOTests.mm
+++ b/Realm/Tests/KVOTests.mm
@@ -21,10 +21,13 @@
 #import "RLMObjectSchema_Private.hpp"
 #import "RLMObjectStore.h"
 #import "RLMObject_Private.hpp"
-#import "RLMRealmConfiguration_Private.h"
+#import "RLMRealmConfiguration_Private.hpp"
 #import "RLMRealm_Private.hpp"
 #import "RLMSchema_Private.h"
 
+#import "shared_realm.hpp"
+
+#import <realm/descriptor.hpp>
 #import <realm/group.hpp>
 
 #import <atomic>
@@ -1107,6 +1110,7 @@ public:
 - (RLMRealm *)getRealm {
     RLMRealmConfiguration *configuration = [[RLMRealmConfiguration alloc] init];
     configuration.inMemoryIdentifier = @"test";
+    configuration.schemaMode = realm::SchemaMode::Additive;
     return [RLMRealm realmWithConfiguration:configuration error:nil];
 }
 
@@ -1319,7 +1323,7 @@ public:
 @implementation KVOMultipleAccessorsTests
 - (id)observableForObject:(id)value {
     if (RLMObject *obj = RLMDynamicCast<RLMObject>(value)) {
-        RLMObject *copy = [[obj.objectSchema.accessorClass alloc] initWithRealm:obj.realm schema:obj.objectSchema];
+        RLMObject *copy = RLMCreateManagedAccessor(obj.objectSchema.accessorClass, obj.realm, obj->_info);
         copy->_row = obj->_row;
         return copy;
     }
@@ -1573,9 +1577,9 @@ public:
     [self.secondaryRealm refresh];
 
     if (RLMObject *obj = RLMDynamicCast<RLMObject>(value)) {
-        RLMObject *copy = [[obj.objectSchema.accessorClass alloc] initWithRealm:self.secondaryRealm
-                                                                         schema:self.secondaryRealm.schema[obj.objectSchema.className]];
-        copy->_row = (*copy.objectSchema.table)[obj->_row.get_index()];
+        RLMObject *copy = RLMCreateManagedAccessor(obj.objectSchema.accessorClass, self.secondaryRealm,
+                                                   &self.secondaryRealm->_info[obj.objectSchema.className]);
+        copy->_row = (*copy->_info->table())[obj->_row.get_index()];
         return copy;
     }
     else if (RLMArray *array = RLMDynamicCast<RLMArray>(value)) {
@@ -1688,19 +1692,78 @@ public:
 - (void)testInsertNewTables {
     KVOObject *obj = [self createObject];
 
-    {
-        KVORecorder r(self, obj, @"boolCol");
+    KVORecorder r1(self, obj, @"boolCol");
+    KVORecorder r2(self, obj, @"int32Col");
 
-        // Add tables before the observed one so that the observed one's index changes
-        realm::Group &group = self.realm->_realm->read_group();
-        realm::TableRef table1 = group.insert_table(5, "new table");
-        realm::TableRef table2 = group.insert_table(0, "new table 2");
-        table1->add_column(realm::type_Int, "col");
-        table2->add_column(realm::type_Int, "col");
+    obj.boolCol = YES;
 
-        obj.boolCol = YES;
-        AssertChanged(r, @NO, @YES);
-    }
+    // Add tables before the observed one so that the observed one's index changes
+    realm::Group &group = self.realm->_realm->read_group();
+    realm::TableRef table1 = group.insert_table(5, "new table");
+    realm::TableRef table2 = group.insert_table(0, "new table 2");
+    table1->add_column(realm::type_Int, "col");
+    table2->add_column(realm::type_Int, "col");
+
+    obj.int32Col = 3;
+    AssertChanged(r1, @NO, @YES);
+    AssertChanged(r2, @2, @3);
+}
+
+- (void)testInsertNewColumns {
+    KVOObject *obj = [self createObject];
+
+    KVORecorder r1(self, obj, @"boolCol");
+    KVORecorder r2(self, obj, @"int32Col");
+    auto ndx = obj->_info->tableColumn(@"int32Col");
+
+    // Add a column before the observed one so that the observed one's index changes
+    obj.boolCol = YES;
+    auto& table = *obj->_info->table();
+    table.insert_column(0, realm::type_Binary, "new col");
+    obj->_row.set_int(ndx + 1, 3); // can't use the accessor after a local schema change
+
+    AssertChanged(r1, @NO, @YES);
+    AssertChanged(r2, @2, @3);
+}
+
+- (void)testMoveObservedColumnBeforeChange {
+    KVOObject *obj = [self createObject];
+    auto ndx = obj->_info->tableColumn(@"boolCol");
+
+    KVORecorder r(self, obj, @"boolCol");
+    auto& table = *obj->_info->table();
+    realm::_impl::TableFriend::move_column(*table.get_descriptor(), ndx, 0);
+    obj->_row.set_bool(0, true); // can't use the accessor after a local schema change
+    AssertChanged(r, @NO, @YES);
+}
+
+- (void)testMoveObservedColumnAfterChange {
+    KVOObject *obj = [self createObject];
+    auto ndx = obj->_info->tableColumn(@"boolCol");
+
+    KVORecorder r(self, obj, @"boolCol");
+    obj.boolCol = YES;
+    realm::_impl::TableFriend::move_column(*obj->_info->table()->get_descriptor(), ndx, 0);
+    AssertChanged(r, @NO, @YES);
+}
+
+- (void)testShiftObservedColumnBeforeChange {
+    KVOObject *obj = [self createObject];
+    auto ndx = obj->_info->tableColumn(@"boolCol");
+
+    KVORecorder r(self, obj, @"boolCol");
+    obj->_info->table()->insert_column(0, realm::type_Binary, "new col");
+    obj->_row.set_bool(ndx + 1, true); // can't use the accessor after a local schema change
+    AssertChanged(r, @NO, @YES);
+}
+
+- (void)testShiftObservedColumnAfterChange {
+    KVOObject *obj = [self createObject];
+
+    KVORecorder r(self, obj, @"boolCol");
+    obj.boolCol = YES;
+    obj->_info->table()->insert_column(0, realm::type_Binary, "new col");
+    AssertChanged(r, @NO, @YES);
 }
 @end
 

--- a/Realm/Tests/MigrationTests.mm
+++ b/Realm/Tests/MigrationTests.mm
@@ -32,6 +32,7 @@
 #import "object_store.hpp"
 #import "shared_realm.hpp"
 
+#import <realm/table.hpp>
 #import <realm/version.hpp>
 #import <objc/runtime.h>
 
@@ -39,10 +40,12 @@ using namespace realm;
 
 static void RLMAssertRealmSchemaMatchesTable(id self, RLMRealm *realm) {
     for (RLMObjectSchema *objectSchema in realm.schema.objectSchema) {
-        Table *table = objectSchema.table;
+        auto& info = realm->_info[objectSchema.className];
+        TableRef table = ObjectStore::table_for_object_type(realm.group, objectSchema.className.UTF8String);
         for (RLMProperty *property in objectSchema.properties) {
-            XCTAssertEqual(property.column, table->get_column_index(RLMStringDataWithNSString(property.name)));
-            XCTAssertEqual(property.indexed || property.isPrimary, table->has_search_index(property.column));
+            auto column = info.tableColumn(property);
+            XCTAssertEqual(column, table->get_column_index(RLMStringDataWithNSString(property.name)));
+            XCTAssertEqual(property.indexed || property.isPrimary, table->has_search_index(column));
         }
     }
 }
@@ -572,7 +575,7 @@ RLM_ARRAY_TYPE(MigrationObject);
     config.readOnly = true;
     RLMRealm *realm = [RLMRealm realmWithConfiguration:config error:nil];
     objectSchema = realm.schema[@"StringObject"];
-    XCTAssertTrue(objectSchema.table->has_search_index([objectSchema.properties[0] column]));
+//    XCTAssertTrue(objectSchema.table->has_search_index([objectSchema.properties[0] column]));
 }
 
 - (void)testRearrangeProperties {
@@ -610,16 +613,6 @@ RLM_ARRAY_TYPE(MigrationObject);
 
     RLMAssertRealmSchemaMatchesTable(self, realm);
 
-    // verify schema for both objects
-    NSArray<RLMProperty *> *properties = defaultObj.objectSchema.properties;
-    for (NSUInteger i = 0; i < properties.count; i++) {
-        XCTAssertEqual(properties[i].column, i);
-    }
-    properties = obj.objectSchema.properties;
-    for (NSUInteger i = 0; i < properties.count; i++) {
-        XCTAssertEqual(properties[i].column, i);
-    }
-
     // re-check that things still work for the realm with the swapped order
     XCTAssertEqualObjects(obj.data, @"new data");
 
@@ -628,44 +621,6 @@ RLM_ARRAY_TYPE(MigrationObject);
     RLMAssertThrowsWithReasonMatching(([realm createObject:CircleObject.className withValue:@[@"data", NSNull.null]]),
                                       @"Invalid value 'data' to initialize object of type 'CircleObject'");
     [realm commitWriteTransaction];
-}
-
-- (void)testAccessorCreationForReadOnlyRealms {
-    RLMClearAccessorCache();
-
-    // Create a realm file with only a single table
-    [self createTestRealmWithSchema:@[[RLMObjectSchema schemaForObjectClass:IntObject.class]] block:^(RLMRealm *realm) {
-        [realm createObject:IntObject.className withValue:@[@1]];
-    }];
-
-    Class intObjectAccessorClass;
-    @autoreleasepool {
-        RLMRealm *realm = [self readOnlyRealmWithURL:RLMTestRealmURL() error:nil];
-
-        intObjectAccessorClass = realm.schema[IntObject.className].accessorClass;
-
-        // StringObject table doesn't exist, so it should not have an accessor
-        // class despite being in the object schema
-        RLMObjectSchema *missingTableSchema = realm.schema[StringObject.className];
-        XCTAssertNotNil(missingTableSchema);
-        XCTAssertEqual(missingTableSchema.accessorClass, RLMDynamicObject.class);
-    }
-
-    @autoreleasepool {
-        RLMRealm *realm = [self realmWithTestPath];
-
-        // read-write realm should have a different IntObject accessor class due
-        // to that we check for RLMSchema compatibility and not for each RLMObjectSchema
-        XCTAssertNotEqual(intObjectAccessorClass, realm.schema[IntObject.className].accessorClass);
-
-        // StringObject should now have an accessor class
-        RLMObjectSchema *missingTableSchema = realm.schema[StringObject.className];
-        XCTAssertNotNil(missingTableSchema);
-        XCTAssertNotNil(missingTableSchema.accessorClass);
-        XCTAssertNotEqual(missingTableSchema.accessorClass, RLMObject.class);
-    }
-
-    RLMClearAccessorCache();
 }
 
 #pragma mark - Migration block invocatios
@@ -797,7 +752,6 @@ RLM_ARRAY_TYPE(MigrationObject);
     // create schema with an extra column
     RLMObjectSchema *objectSchema = [RLMObjectSchema schemaForObjectClass:MigrationObject.class];
     RLMProperty *thirdProperty = [[RLMProperty alloc] initWithName:@"deletedCol" type:RLMPropertyTypeBool objectClassName:nil linkOriginPropertyName:nil indexed:NO optional:NO];
-    thirdProperty.column = 2;
     objectSchema.properties = [objectSchema.properties arrayByAddingObject:thirdProperty];
 
     // create realm with old schema and populate
@@ -1381,7 +1335,7 @@ RLM_ARRAY_TYPE(MigrationObject);
             [migration enumerateObjects:StringObject.className block:^(RLMObject *oldObject, RLMObject *newObject) {
                 oldValue = oldObject[@"stringCol0"];
                 XCTAssertNotNil(oldValue);
-                XCTAssertEqualObjects(newObject[@"stringCol1"], oldValue);
+//                XCTAssertEqualObjects(newObject[@"stringCol1"], oldValue);
                 RLMAssertThrowsWithReasonMatching(newObject[@"stringCol0"], @"Invalid property name");
             }];
         }

--- a/Realm/Tests/MigrationTests.mm
+++ b/Realm/Tests/MigrationTests.mm
@@ -574,8 +574,8 @@ RLM_ARRAY_TYPE(MigrationObject);
     RLMRealmConfiguration *config = [self config];
     config.readOnly = true;
     RLMRealm *realm = [RLMRealm realmWithConfiguration:config error:nil];
-    objectSchema = realm.schema[@"StringObject"];
-//    XCTAssertTrue(objectSchema.table->has_search_index([objectSchema.properties[0] column]));
+    auto& info = realm->_info[@"StringObject"];
+    XCTAssertTrue(info.table()->has_search_index(info.tableColumn(objectSchema.properties[0].name)));
 }
 
 - (void)testRearrangeProperties {
@@ -1335,8 +1335,8 @@ RLM_ARRAY_TYPE(MigrationObject);
             [migration enumerateObjects:StringObject.className block:^(RLMObject *oldObject, RLMObject *newObject) {
                 oldValue = oldObject[@"stringCol0"];
                 XCTAssertNotNil(oldValue);
-//                XCTAssertEqualObjects(newObject[@"stringCol1"], oldValue);
                 RLMAssertThrowsWithReasonMatching(newObject[@"stringCol0"], @"Invalid property name");
+                RLMAssertThrowsWithReasonMatching(newObject[@"stringCol1"], @"Invalid property name");
             }];
         }
         if (oldVersion < 2) {

--- a/Realm/Tests/PropertyTypeTest.mm
+++ b/Realm/Tests/PropertyTypeTest.mm
@@ -104,8 +104,6 @@
 
     obj[@"int16"] = @(v16);
     XCTAssertEqual([obj[@"int16"] shortValue], v16);
-    obj[@"int16"] = @(v32);
-    XCTAssertNotEqual([obj[@"int16"] intValue], v32, @"should truncate");
 
     obj.int16 = 0;
     obj.int16 = v16;
@@ -113,8 +111,6 @@
 
     obj[@"int32"] = @(v32);
     XCTAssertEqual([obj[@"int32"] intValue], v32);
-    obj[@"int32"] = @(v64);
-    XCTAssertNotEqual([obj[@"int32"] longLongValue], v64, @"should truncate");
 
     obj.int32 = 0;
     obj.int32 = v32;

--- a/Realm/module.modulemap
+++ b/Realm/module.modulemap
@@ -8,6 +8,7 @@ framework module Realm {
         header "RLMAccessor.h"
         header "RLMArray_Private.h"
         header "RLMListBase.h"
+        header "RLMObjectBase_Dynamic.h"
         header "RLMObjectSchema_Private.h"
         header "RLMObjectStore.h"
         header "RLMObject_Private.h"

--- a/RealmSwift/LinkingObjects.swift
+++ b/RealmSwift/LinkingObjects.swift
@@ -28,14 +28,8 @@ public class LinkingObjectsBase: NSObject, NSFastEnumeration {
     internal let propertyName: String
 
     private var cachedRLMResults: RLMResults<RLMObject>?
-    private var object: RLMWeakObjectHandle?
-    private var property: RLMProperty?
-
-    internal func attachTo(object: RLMObjectBase, property: RLMProperty) {
-        self.object = RLMWeakObjectHandle(object: object)
-        self.property = property
-        self.cachedRLMResults = nil
-    }
+    @objc private var object: RLMWeakObjectHandle?
+    @objc private var property: RLMProperty?
 
     internal var rlmResults: RLMResults<RLMObject> {
         if cachedRLMResults == nil {
@@ -476,14 +470,8 @@ public class LinkingObjectsBase: NSObject, NSFastEnumeration {
     internal let propertyName: String
 
     private var cachedRLMResults: RLMResults?
-    private var object: RLMWeakObjectHandle?
-    private var property: RLMProperty?
-
-    internal func attachTo(object object: RLMObjectBase, property: RLMProperty) {
-        self.object = RLMWeakObjectHandle(object: object)
-        self.property = property
-        self.cachedRLMResults = nil
-    }
+    @objc private var object: RLMWeakObjectHandle?
+    @objc private var property: RLMProperty?
 
     internal var rlmResults: RLMResults {
         if cachedRLMResults == nil {

--- a/RealmSwift/List.swift
+++ b/RealmSwift/List.swift
@@ -626,6 +626,10 @@ public final class List<T: Object>: ListBase {
         super.init(array: RLMArray(objectClassName: (T.self as Object.Type).className()))
     }
 
+    internal init(rlmArray: RLMArray) {
+        super.init(array: rlmArray)
+    }
+
     // MARK: Index Retrieval
 
     /**

--- a/RealmSwift/Object.swift
+++ b/RealmSwift/Object.swift
@@ -177,13 +177,7 @@ public class Object: RLMObjectBase {
             if realm == nil {
                 return value(forKey: key)
             }
-            let property = RLMValidatedGetProperty(self, key)
-            if property.type == .array {
-                return listForProperty(prop: property)
-            }
-            // No special logic is needed for optional numbers here because the NSNumber returned by RLMDynamicGet
-            // is better for callers than the RealmOptional that optionalForProperty would give us.
-            return RLMDynamicGet(self, property)
+            return RLMDynamicGetByName(self, key, true)
         }
         set(value) {
             if realm == nil {
@@ -212,7 +206,8 @@ public class Object: RLMObjectBase {
     :nodoc:
     */
     public func dynamicList(_ propertyName: String) -> List<DynamicObject> {
-        return unsafeBitCast(listForProperty(prop: RLMValidatedGetProperty(self, propertyName)), to: List<DynamicObject>.self)
+        return unsafeBitCast(RLMDynamicGetByName(self, propertyName, true),
+                             to: List<DynamicObject>.self)
     }
 
     // MARK: Equatable
@@ -248,21 +243,6 @@ public class Object: RLMObjectBase {
     public override required init(value: AnyObject, schema: RLMSchema) {
         super.init(value: value, schema: schema)
     }
-
-    // Helper for getting the list object for a property
-    internal func listForProperty(prop: RLMProperty) -> RLMListBase {
-        return object_getIvar(self, prop.swiftIvar) as! RLMListBase
-    }
-
-    // Helper for getting the optional object for a property
-    internal func optionalForProperty(prop: RLMProperty) -> RLMOptionalBase {
-        return object_getIvar(self, prop.swiftIvar) as! RLMOptionalBase
-    }
-
-    // Helper for getting the linking objects object for a property
-    internal func linkingObjectsForProperty(prop: RLMProperty) -> LinkingObjectsBase? {
-        return object_getIvar(self, prop.swiftIvar) as? LinkingObjectsBase
-    }
 }
 
 
@@ -270,33 +250,17 @@ public class Object: RLMObjectBase {
 /// Object interface which allows untyped getters and setters for Objects.
 /// :nodoc:
 public final class DynamicObject: Object {
-    private var listProperties = [String: List<DynamicObject>]()
-    private var optionalProperties = [String: RLMOptionalBase]()
-
-    // Override to create List<DynamicObject> on access
-    internal override func listForProperty(prop: RLMProperty) -> RLMListBase {
-        if let list = listProperties[prop.name] {
-            return list
+    public override subscript(key: String) -> AnyObject? {
+        get {
+            let value = RLMDynamicGetByName(self, key)
+            if let array = value as? RLMArray {
+                return List<DynamicObject>(rlmArray: array)
+            }
+            return value
         }
-        let list = List<DynamicObject>()
-        listProperties[prop.name] = list
-        return list
-    }
-
-    // Override to create RealmOptional on access
-    internal override func optionalForProperty(prop: RLMProperty) -> RLMOptionalBase {
-        if let optional = optionalProperties[prop.name] {
-            return optional
+        set(value) {
+            RLMDynamicValidatedSet(self, key, value)
         }
-        let optional = RLMOptionalBase()
-        optional?.property = prop
-        optionalProperties[prop.name] = optional
-        return optional!
-    }
-
-    // Dynamic objects never have linking objects properties
-    internal override func linkingObjectsForProperty(prop: RLMProperty) -> LinkingObjectsBase? {
-        return nil
     }
 
     /// :nodoc:
@@ -349,16 +313,6 @@ public class ObjectUtil: NSObject {
         }.flatMap { (prop: Mirror.Child) in
             return prop.label
         } as NSArray
-    }
-
-    @objc private class func initializeListProperty(_ object: RLMObjectBase, property: RLMProperty, array: RLMArray<RLMObject>) {
-        (object as! Object).listForProperty(prop: property)._rlmArray = array
-    }
-
-    @objc private class func initializeOptionalProperty(_ object: RLMObjectBase, property: RLMProperty) {
-        let optional = (object as! Object).optionalForProperty(prop: property)
-        optional.property = property
-        optional.object = object
     }
 
     // swiftlint:disable:next cyclomatic_complexity
@@ -415,11 +369,6 @@ public class ObjectUtil: NSObject {
             d[name] = ["class": results.objectClassName, "property": results.propertyName]
             return d
         } as NSDictionary
-    }
-
-    @objc private class func initializeLinkingObjectsProperty(_ object: RLMObjectBase, property: RLMProperty) {
-        guard let linkingObjects = (object as! Object).linkingObjectsForProperty(prop: property) else { return }
-        linkingObjects.attachTo(object: object, property: property)
     }
 }
 
@@ -586,13 +535,7 @@ public class Object: RLMObjectBase {
             if realm == nil {
                 return valueForKey(key)
             }
-            let property = RLMValidatedGetProperty(self, key)
-            if property.type == .Array {
-                return listForProperty(property)
-            }
-            // No special logic is needed for optional numbers here because the NSNumber returned by RLMDynamicGet
-            // is better for callers than the RealmOptional that optionalForProperty would give us.
-            return RLMDynamicGet(self, property)
+            return RLMDynamicGetByName(self, key, true)
         }
         set(value) {
             if realm == nil {
@@ -619,7 +562,8 @@ public class Object: RLMObjectBase {
     :nodoc:
     */
     public func dynamicList(propertyName: String) -> List<DynamicObject> {
-        return unsafeBitCast(listForProperty(RLMValidatedGetProperty(self, propertyName)), List<DynamicObject>.self)
+        return unsafeBitCast(RLMDynamicGetByName(self, propertyName, true),
+                             List<DynamicObject>.self)
     }
 
     // MARK: Equatable
@@ -655,21 +599,6 @@ public class Object: RLMObjectBase {
     public override required init(value: AnyObject, schema: RLMSchema) {
         super.init(value: value, schema: schema)
     }
-
-    // Helper for getting the list object for a property
-    internal func listForProperty(prop: RLMProperty) -> RLMListBase {
-        return object_getIvar(self, prop.swiftIvar) as! RLMListBase
-    }
-
-    // Helper for getting the optional object for a property
-    internal func optionalForProperty(prop: RLMProperty) -> RLMOptionalBase {
-        return object_getIvar(self, prop.swiftIvar) as! RLMOptionalBase
-    }
-
-    // Helper for getting the linking objects object for a property
-    internal func linkingObjectsForProperty(prop: RLMProperty) -> LinkingObjectsBase? {
-        return object_getIvar(self, prop.swiftIvar) as? LinkingObjectsBase
-    }
 }
 
 
@@ -677,33 +606,17 @@ public class Object: RLMObjectBase {
 /// Object interface which allows untyped getters and setters for Objects.
 /// :nodoc:
 public final class DynamicObject: Object {
-    private var listProperties = [String: List<DynamicObject>]()
-    private var optionalProperties = [String: RLMOptionalBase]()
-
-    // Override to create List<DynamicObject> on access
-    internal override func listForProperty(prop: RLMProperty) -> RLMListBase {
-        if let list = listProperties[prop.name] {
-            return list
+    public override subscript(key: String) -> AnyObject? {
+        get {
+            let value = RLMDynamicGetByName(self, key, false)
+            if let array = value as? RLMArray {
+                return List<DynamicObject>(rlmArray: array)
+            }
+            return value
         }
-        let list = List<DynamicObject>()
-        listProperties[prop.name] = list
-        return list
-    }
-
-    // Override to create RealmOptional on access
-    internal override func optionalForProperty(prop: RLMProperty) -> RLMOptionalBase {
-        if let optional = optionalProperties[prop.name] {
-            return optional
+        set(value) {
+            RLMDynamicValidatedSet(self, key, value)
         }
-        let optional = RLMOptionalBase()
-        optional.property = prop
-        optionalProperties[prop.name] = optional
-        return optional
-    }
-
-    // Dynamic objects never have linking objects properties
-    internal override func linkingObjectsForProperty(prop: RLMProperty) -> LinkingObjectsBase? {
-        return nil
     }
 
     /// :nodoc:
@@ -756,16 +669,6 @@ public class ObjectUtil: NSObject {
         }.flatMap { (prop: Mirror.Child) in
             return prop.label
         }
-    }
-
-    @objc private class func initializeListProperty(object: RLMObjectBase, property: RLMProperty, array: RLMArray) {
-        (object as! Object).listForProperty(property)._rlmArray = array
-    }
-
-    @objc private class func initializeOptionalProperty(object: RLMObjectBase, property: RLMProperty) {
-        let optional = (object as! Object).optionalForProperty(property)
-        optional.property = property
-        optional.object = object
     }
 
     // swiftlint:disable:next cyclomatic_complexity
@@ -822,11 +725,6 @@ public class ObjectUtil: NSObject {
             d[name] = ["class": results.objectClassName, "property": results.propertyName]
             return d
         }
-    }
-
-    @objc private class func initializeLinkingObjectsProperty(object: RLMObjectBase, property: RLMProperty) {
-        guard let linkingObjects = (object as! Object).linkingObjectsForProperty(property) else { return }
-        linkingObjects.attachTo(object: object, property: property)
     }
 }
 


### PR DESCRIPTION
No user-visible changes here as none of the functionality is surfaced in the API yet.

The new high-level design is:

 * RLMSchema and its children no longer contains any Realm-instance specific data (no table columns, no cached table accessors, no KVO tracking), and so we no longer need to make a shallow copy of it per RLMRealm. It does still store the accessor classes, and as a result the separate accessor cache is no longer needed.
 * All of the per-RLMRealm data that we need in addition to what the ObjectStore Schema stores is tracked in a new RLMObjectInfo class, which stores the table accessors, KVO info, and provides an efficient lookup of table columns from property indexes.
 * Everything that previously stored a table column now stores a property index and looks up the table column on each use. This has a small (~1-2%) negative impact on accessor performance.

@bdash @jpsim 