### PR TITLE
Migrate to Swift 3 Beta 6

### DIFF
--- a/Realm/RLMObjectSchema.h
+++ b/Realm/RLMObjectSchema.h
@@ -60,7 +60,7 @@ NS_ASSUME_NONNULL_BEGIN
  
  @return An `RLMProperty` object, or `nil` if there is no property with the given name.
  */
-- (nullable RLMProperty *)objectForKeyedSubscript:(id <NSCopying>)propertyName;
+- (nullable RLMProperty *)objectForKeyedSubscript:(NSString *)propertyName;
 
 /**
   Returns a Boolean value that indicates whether two `RLMObjectSchema` instances are equal.

--- a/Realm/RLMObjectSchema.mm
+++ b/Realm/RLMObjectSchema.mm
@@ -53,7 +53,7 @@ using namespace realm;
 }
 
 // return properties by name
--(RLMProperty *)objectForKeyedSubscript:(id <NSCopying>)key {
+-(RLMProperty *)objectForKeyedSubscript:(__unsafe_unretained NSString *const)key {
     return _allPropertiesByName[key];
 }
 

--- a/Realm/RLMOptionalBase.h
+++ b/Realm/RLMOptionalBase.h
@@ -19,6 +19,8 @@
 #import <Foundation/Foundation.h>
 #import <Realm/RLMConstants.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @class RLMObjectBase, RLMProperty;
 
 @interface RLMOptionalBase : NSProxy
@@ -29,6 +31,8 @@
 
 @property (nonatomic, unsafe_unretained) RLMProperty *property;
 
-@property (nonatomic, strong) id underlyingValue;
+@property (nonatomic, strong, nullable) id underlyingValue;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Realm/RLMSchema.h
+++ b/Realm/RLMSchema.h
@@ -65,7 +65,7 @@ NS_ASSUME_NONNULL_BEGIN
 
  @see               `RLMObjectSchema`
  */
-- (RLMObjectSchema *)objectForKeyedSubscript:(id <NSCopying>)className;
+- (RLMObjectSchema *)objectForKeyedSubscript:(NSString *)className;
 
 /**
  Returns a Boolean value that indicates whether two `RLMSchema` instances are equivalent.

--- a/Realm/RLMSchema.mm
+++ b/Realm/RLMSchema.mm
@@ -143,7 +143,7 @@ static void RLMRegisterClassLocalNames(Class *classes, NSUInteger count) {
     return _objectSchemaByName[className];
 }
 
-- (RLMObjectSchema *)objectForKeyedSubscript:(__unsafe_unretained id<NSCopying> const)className {
+- (RLMObjectSchema *)objectForKeyedSubscript:(__unsafe_unretained NSString *const)className {
     RLMObjectSchema *schema = _objectSchemaByName[className];
     if (!schema) {
         @throw RLMException(@"Object type '%@' not managed by the Realm", className);

--- a/Realm/Swift/RLMSupport.swift
+++ b/Realm/Swift/RLMSupport.swift
@@ -20,14 +20,15 @@ import Realm
 
 #if swift(>=3.0)
     extension RLMRealm {
-        public class func schemaVersion(at url: URL, usingEncryptionKey key: Data? = nil) throws -> UInt64 {
-            var error: NSError?
-            let version = __schemaVersion(at: url, encryptionKey: key, error: &error)
-            guard version != RLMNotVersioned else {
-                throw error!
-            }
-            return version
-        }
+        // TODO: Figure out why this causes the Swift 3 compiler to segfault.
+//        public class func schemaVersion(at url: URL, usingEncryptionKey key: Data? = nil) throws -> UInt64 {
+//            var error: NSError?
+//            let version = __schemaVersion(at: url, encryptionKey: key, error: &error)
+//            guard version != RLMNotVersioned else {
+//                throw error!
+//            }
+//            return version
+//        }
     }
 
     extension RLMObject {
@@ -55,7 +56,7 @@ import Realm
         }
     }
 
-    // TODO: Figure out why this causes the Swift 3 compiler to segfault.
+    // SR-2348: A bug in Objective-C generics currently make this impossible w/o an error or compiler crash.
 //    extension RLMArray: Sequence  {
 //        // Support Sequence-style enumeration
 //        public func makeIterator() -> RLMIterator {

--- a/Realm/Tests/Swift/RLMTestCaseUtils.swift
+++ b/Realm/Tests/Swift/RLMTestCaseUtils.swift
@@ -19,7 +19,7 @@
 #if swift(>=3.0)
 
 extension RLMTestCase {
-    func assertThrowsWithReasonMatching<T>(_ block: @autoclosure(escaping) () -> T, _ regexString: String,
+    func assertThrowsWithReasonMatching<T>(_ block: @autoclosure @escaping () -> T, _ regexString: String,
         _ message: String? = nil, fileName: String = #file, lineNumber: UInt = #line) {
             RLMAssertThrowsWithReasonMatchingSwift(self, { _ = block() }, regexString, message, fileName, lineNumber)
     }

--- a/Realm/Tests/Swift/SwiftArrayPropertyTests.swift
+++ b/Realm/Tests/Swift/SwiftArrayPropertyTests.swift
@@ -110,7 +110,7 @@ class SwiftArrayPropertyTests: RLMTestCase {
         let child1 = SwiftStringObject.create(in: realm, withValue: ["a"])
         let child2 = SwiftStringObject()
         child2.stringCol = "b"
-        obj.array.addObjects([child2, child1])
+        obj.array.addObjects([child2, child1] as NSArray)
         try! realm.commitWriteTransaction()
 
         let children = SwiftStringObject.allObjects(in: realm)
@@ -221,7 +221,7 @@ class SwiftArrayPropertyTests: RLMTestCase {
         let child1 = StringObject.create(in: realm, withValue: ["a"])
         let child2 = StringObject()
         child2.stringCol = "b"
-        obj.array.addObjects([child2, child1])
+        obj.array.addObjects([child2, child1] as NSArray)
         try! realm.commitWriteTransaction()
 
         let children = StringObject.allObjects(in: realm)

--- a/Realm/Tests/Swift/SwiftDynamicTests.swift
+++ b/Realm/Tests/Swift/SwiftDynamicTests.swift
@@ -167,8 +167,8 @@ class SwiftDynamicTests: RLMTestCase {
         let schema = dyrealm.schema[AllTypesObject.className()]
         for idx in 0..<obj1.count - 1 {
             let prop = schema.properties[idx]
-            XCTAssertTrue(obj1[idx].isEqual(robj1[prop.name]))
-            XCTAssertTrue(obj2[idx].isEqual(robj2[prop.name]))
+            XCTAssertTrue((obj1[idx] as AnyObject).isEqual(robj1[prop.name]))
+            XCTAssertTrue((obj2[idx] as AnyObject).isEqual(robj2[prop.name]))
         }
 
         // check sub object type

--- a/Realm/Tests/Swift/SwiftDynamicTests.swift
+++ b/Realm/Tests/Swift/SwiftDynamicTests.swift
@@ -117,36 +117,18 @@ class SwiftDynamicTests: RLMTestCase {
         XCTAssertTrue(array[1]["stringCol"] as! String == "column2")
     }
 
-    // these helper functions make the below test not take five minutes to compile
-    // I suspect a type inference bug
-    func Ni(_ x: Int) -> AnyObject {
-        return NSNumber(value: x)
-    }
-
-    func Nb(_ x: Bool) -> AnyObject {
-        return NSNumber(value: x)
-    }
-
-    func Nd(_ x: Double) -> AnyObject {
-        return NSNumber(value: x)
-    }
-
-    func Nf(_ x: Float) -> AnyObject {
-        return NSNumber(value: x)
-    }
-
     func testDynamicTypes_objc() {
         let date = NSDate(timeIntervalSince1970: 100000)
         let data = "a".data(using: String.Encoding.utf8)!
-        let obj1 = [Nb(true), Ni(1), Nf(1.1), Nd(1.11), "string" as NSString,
-            data as AnyObject, date, Nb(true), Ni(11), NSNull()] as NSArray
+        let obj1: [Any] = [true, 1, 1.1 as Float, 1.11, "string",
+            data, date, true, 11, NSNull()]
 
         let obj = StringObject()
         obj.stringCol = "string"
 
         let data2 = "b".data(using: String.Encoding.utf8)!
-        let obj2 = [Nb(false), Ni(2), Nf(2.2), Nd(2.22), "string2" as NSString,
-            data2 as AnyObject, date, Nb(false), Ni(22), obj] as NSArray
+        let obj2: [Any] = [false, 2, 2.2 as Float, 2.22, "string2",
+            data2, date, false, 22, obj]
 
         autoreleasepool {
             // open realm in autoreleasepool to create tables and then dispose

--- a/Realm/Tests/Swift/SwiftObjectInterfaceTests.swift
+++ b/Realm/Tests/Swift/SwiftObjectInterfaceTests.swift
@@ -48,8 +48,8 @@ class SwiftDefaultObject: RLMObject {
 
 class SwiftOptionalNumberObject: RLMObject {
     dynamic var intCol: NSNumber? = 1
-    dynamic var floatCol: NSNumber? = 2.2 as Float
-    dynamic var doubleCol: NSNumber? = 3.3 as Double
+    dynamic var floatCol: NSNumber? = 2.2 as Float as NSNumber
+    dynamic var doubleCol: NSNumber? = 3.3
     dynamic var boolCol: NSNumber? = true
 }
 
@@ -152,7 +152,7 @@ class SwiftObjectInterfaceTests: RLMTestCase {
         XCTAssertEqual([.int, .float, .double, .bool], no.objectSchema.properties.map { $0.type })
 
         XCTAssertEqual(1, no.intCol!)
-        XCTAssertEqual(2.2 as Float, no.floatCol!)
+        XCTAssertEqual(2.2 as Float as NSNumber, no.floatCol!)
         XCTAssertEqual(3.3, no.doubleCol!)
         XCTAssertEqual(true, no.boolCol!)
 
@@ -171,13 +171,13 @@ class SwiftObjectInterfaceTests: RLMTestCase {
 
         try! realm.transaction {
             no.intCol = 1.1
-            no.floatCol = 2.2 as Float
+            no.floatCol = 2.2 as Float as NSNumber
             no.doubleCol = 3.3
             no.boolCol = false
         }
 
         XCTAssertEqual(1, no.intCol!)
-        XCTAssertEqual(2.2 as Float, no.floatCol!)
+        XCTAssertEqual(2.2 as Float as NSNumber, no.floatCol!)
         XCTAssertEqual(3.3, no.doubleCol!)
         XCTAssertEqual(false, no.boolCol!)
     }

--- a/Realm/Tests/Swift/SwiftObjectInterfaceTests.swift
+++ b/Realm/Tests/Swift/SwiftObjectInterfaceTests.swift
@@ -41,7 +41,7 @@ class SwiftDefaultObject: RLMObject {
     dynamic var intCol = 1
     dynamic var boolCol = true
 
-    override class func defaultPropertyValues() -> [NSObject : AnyObject]? {
+    override class func defaultPropertyValues() -> [AnyHashable : Any]? {
         return ["intCol": 2]
     }
 }

--- a/RealmSwift/LinkingObjects.swift
+++ b/RealmSwift/LinkingObjects.swift
@@ -378,7 +378,7 @@ public final class LinkingObjects<T: Object>: LinkingObjectsBase {
      - parameter block: The block to be called with the evaluated linking objects and change information.
      - returns: A token which must be held for as long as you want updates to be delivered.
      */
-    public func addNotificationBlock(block: ((RealmCollectionChange<LinkingObjects>) -> Void)) -> NotificationToken {
+    public func addNotificationBlock(block: @escaping (RealmCollectionChange<LinkingObjects>) -> Void) -> NotificationToken {
         return rlmResults.addNotificationBlock { results, change, error in
             block(RealmCollectionChange.fromObjc(value: self, change: change, error: error))
         }
@@ -413,7 +413,7 @@ extension LinkingObjects : RealmCollection {
     }
 
     /// :nodoc:
-    public func _addNotificationBlock(block: (RealmCollectionChange<AnyRealmCollection<T>>) -> Void) ->
+    public func _addNotificationBlock(block: @escaping (RealmCollectionChange<AnyRealmCollection<T>>) -> Void) ->
         NotificationToken {
             let anyCollection = AnyRealmCollection(self)
             return rlmResults.addNotificationBlock { _, change, error in

--- a/RealmSwift/LinkingObjects.swift
+++ b/RealmSwift/LinkingObjects.swift
@@ -145,7 +145,7 @@ public final class LinkingObjects<T: Object>: LinkingObjectsBase {
 
      - returns: The index of the first matching object, or `nil` if no objects match.
      */
-    public func indexOfObject(for predicateFormat: String, _ args: AnyObject...) -> Int? {
+    public func indexOfObject(for predicateFormat: String, _ args: Any...) -> Int? {
         return notFoundToNil(index: rlmResults.indexOfObject(with: NSPredicate(format: predicateFormat,
                                                                                argumentArray: args)))
     }
@@ -183,7 +183,7 @@ public final class LinkingObjects<T: Object>: LinkingObjectsBase {
      - returns: Array containing the results of invoking `valueForKey(_:)` using key on each of the
        collection's objects.
      */
-    public override func value(forKey key: String) -> AnyObject? {
+    public override func value(forKey key: String) -> Any? {
         return value(forKeyPath: key)
     }
 
@@ -196,7 +196,7 @@ public final class LinkingObjects<T: Object>: LinkingObjectsBase {
      - returns: Array containing the results of invoking `valueForKeyPath(_:)` using keyPath on each of the
        collection's objects.
      */
-    public override func value(forKeyPath keyPath: String) -> AnyObject? {
+    public override func value(forKeyPath keyPath: String) -> Any? {
         return rlmResults.value(forKeyPath: keyPath)
     }
 
@@ -208,7 +208,7 @@ public final class LinkingObjects<T: Object>: LinkingObjectsBase {
      - parameter value: The object value.
      - parameter key:   The name of the property.
      */
-    public override func setValue(_ value: AnyObject?, forKey key: String) {
+    public override func setValue(_ value: Any?, forKey key: String) {
         return rlmResults.setValue(value, forKeyPath: key)
     }
 
@@ -221,7 +221,7 @@ public final class LinkingObjects<T: Object>: LinkingObjectsBase {
 
      - returns: Results containing objects that match the given predicate.
      */
-    public func filter(using predicateFormat: String, _ args: AnyObject...) -> Results<T> {
+    public func filter(using predicateFormat: String, _ args: Any...) -> Results<T> {
         return Results<T>(rlmResults.objects(with: NSPredicate(format: predicateFormat, argumentArray: args)))
     }
 

--- a/RealmSwift/LinkingObjects.swift
+++ b/RealmSwift/LinkingObjects.swift
@@ -432,13 +432,13 @@ extension LinkingObjects {
     public func index(of predicate: NSPredicate) -> Int? { fatalError() }
 
     @available(*, unavailable, renamed:"indexOfObject(for:_:)")
-    public func index(of predicateFormat: String, _ args: AnyObject...) -> Int? { fatalError() }
+    public func index(of predicateFormat: String, _ args: Any...) -> Int? { fatalError() }
 
     @available(*, unavailable, renamed:"filter(using:)")
     public func filter(_ predicate: NSPredicate) -> Results<T> { fatalError() }
 
     @available(*, unavailable, renamed:"filter(using:_:)")
-    public func filter(_ predicateFormat: String, _ args: AnyObject...) -> Results<T> { fatalError() }
+    public func filter(_ predicateFormat: String, _ args: Any...) -> Results<T> { fatalError() }
 
     @available(*, unavailable, renamed:"sorted(onProperty:ascending:)")
     public func sorted(_ property: String, ascending: Bool = true) -> Results<T> { fatalError() }

--- a/RealmSwift/LinkingObjects.swift
+++ b/RealmSwift/LinkingObjects.swift
@@ -257,7 +257,7 @@ public final class LinkingObjects<T: Object>: LinkingObjectsBase {
 
      - returns: `Results` with elements sorted by the given sort descriptors.
      */
-    public func sorted<S: Sequence where S.Iterator.Element == SortDescriptor>(with sortDescriptors: S) -> Results<T> {
+    public func sorted<S: Sequence>(with sortDescriptors: S) -> Results<T> where S.Iterator.Element == SortDescriptor {
         return Results<T>(rlmResults.sortedResults(using: sortDescriptors.map { $0.rlmSortDescriptorValue }))
     }
 
@@ -444,7 +444,7 @@ extension LinkingObjects {
     public func sorted(_ property: String, ascending: Bool = true) -> Results<T> { fatalError() }
 
     @available(*, unavailable, renamed:"sorted(with:)")
-    public func sorted<S: Sequence where S.Iterator.Element == SortDescriptor>(_ sortDescriptors: S) -> Results<T> {
+    public func sorted<S: Sequence>(_ sortDescriptors: S) -> Results<T> where S.Iterator.Element == SortDescriptor {
         fatalError()
     }
 

--- a/RealmSwift/List.swift
+++ b/RealmSwift/List.swift
@@ -468,7 +468,7 @@ public final class List<T: Object>: ListBase {
     - parameter block: The block to be called each time the list changes.
     - returns: A token which must be held for as long as you want notifications to be delivered.
     */
-    public func addNotificationBlock(block: (RealmCollectionChange<List>) -> ()) -> NotificationToken {
+    public func addNotificationBlock(block: @escaping (RealmCollectionChange<List>) -> ()) -> NotificationToken {
         return _rlmArray.addNotificationBlock { list, change, error in
             block(RealmCollectionChange.fromObjc(value: self, change: change, error: error))
         }
@@ -514,7 +514,7 @@ extension List : RealmCollection, RangeReplaceableCollection {
     public func index(before i: Int) -> Int { return i - 1 }
 
     /// :nodoc:
-    public func _addNotificationBlock(block: (RealmCollectionChange<AnyRealmCollection<T>>) -> Void) ->
+    public func _addNotificationBlock(block: @escaping (RealmCollectionChange<AnyRealmCollection<T>>) -> Void) ->
         NotificationToken {
         let anyCollection = AnyRealmCollection(self)
         return _rlmArray.addNotificationBlock { _, change, error in

--- a/RealmSwift/List.swift
+++ b/RealmSwift/List.swift
@@ -112,7 +112,7 @@ public final class List<T: Object>: ListBase {
 
     - returns: The index of the first matching object, or `nil` if no objects match.
     */
-    public func indexOfObject(for predicateFormat: String, _ args: AnyObject...) -> Int? {
+    public func indexOfObject(for predicateFormat: String, _ args: Any...) -> Int? {
         return indexOfObject(for: NSPredicate(format: predicateFormat, argumentArray: args))
     }
 
@@ -154,7 +154,7 @@ public final class List<T: Object>: ListBase {
 
     - returns: Array containing the results of invoking `valueForKey(_:)` using key on each of the collection's objects.
     */
-    public override func value(forKey key: String) -> AnyObject? {
+    public override func value(forKey key: String) -> Any? {
         return value(forKeyPath: key)
     }
 
@@ -167,7 +167,7 @@ public final class List<T: Object>: ListBase {
      - returns: Array containing the results of invoking `valueForKeyPath(_:)` using keyPath on each of the
      collection's objects.
      */
-    public override func value(forKeyPath keyPath: String) -> AnyObject? {
+    public override func value(forKeyPath keyPath: String) -> Any? {
         return _rlmArray.value(forKeyPath: keyPath)
     }
 
@@ -179,7 +179,7 @@ public final class List<T: Object>: ListBase {
     - parameter value: The object value.
     - parameter key:   The name of the property.
     */
-    public override func setValue(_ value: AnyObject?, forKey key: String) {
+    public override func setValue(_ value: Any?, forKey key: String) {
         return _rlmArray.setValue(value, forKeyPath: key)
     }
 
@@ -192,7 +192,7 @@ public final class List<T: Object>: ListBase {
 
     - returns: `Results` containing elements that match the given predicate.
     */
-    public func filter(using predicateFormat: String, _ args: AnyObject...) -> Results<T> {
+    public func filter(using predicateFormat: String, _ args: Any...) -> Results<T> {
         return Results<T>(_rlmArray.objects(with: NSPredicate(format: predicateFormat, argumentArray: args)))
     }
 

--- a/RealmSwift/List.swift
+++ b/RealmSwift/List.swift
@@ -491,8 +491,8 @@ extension List : RealmCollection, RangeReplaceableCollection {
     - parameter subRange:    The range of elements to be replaced.
     - parameter newElements: The new elements to be inserted into the List.
     */
-    public func replaceSubrange<C : Collection>(_ subrange: Range<Int>,
-                                with newElements: C) where C.Iterator.Element == T {
+    public func replaceSubrange<C : Collection>(_ subrange: Range<Int>, with newElements: C)
+        where C.Iterator.Element == T {
         for _ in subrange.lowerBound..<subrange.upperBound {
             remove(objectAtIndex: subrange.lowerBound)
         }

--- a/RealmSwift/List.swift
+++ b/RealmSwift/List.swift
@@ -228,7 +228,7 @@ public final class List<T: Object>: ListBase {
 
     - returns: `Results` with elements sorted by the given sort descriptors.
     */
-    public func sorted<S: Sequence where S.Iterator.Element == SortDescriptor>(with sortDescriptors: S) -> Results<T> {
+    public func sorted<S: Sequence>(with sortDescriptors: S) -> Results<T> where S.Iterator.Element == SortDescriptor {
         return Results<T>(_rlmArray.sortedResults(using: sortDescriptors.map { $0.rlmSortDescriptorValue }))
     }
 
@@ -307,7 +307,7 @@ public final class List<T: Object>: ListBase {
 
     - parameter objects: A sequence of objects.
     */
-    public func append<S: Sequence where S.Iterator.Element == T>(objectsIn objects: S) {
+    public func append<S: Sequence>(objectsIn objects: S) where S.Iterator.Element == T {
         for obj in objects {
             _rlmArray.add(unsafeBitCast(obj, to: RLMObject.self))
         }
@@ -491,8 +491,8 @@ extension List : RealmCollection, RangeReplaceableCollection {
     - parameter subRange:    The range of elements to be replaced.
     - parameter newElements: The new elements to be inserted into the List.
     */
-    public func replaceSubrange<C : Collection where C.Iterator.Element == T>(_ subrange: Range<Int>,
-                                                                              with newElements: C) {
+    public func replaceSubrange<C : Collection>(_ subrange: Range<Int>,
+                                with newElements: C) where C.Iterator.Element == T {
         for _ in subrange.lowerBound..<subrange.upperBound {
             remove(objectAtIndex: subrange.lowerBound)
         }
@@ -527,7 +527,7 @@ extension List : RealmCollection, RangeReplaceableCollection {
 
 extension List {
     @available(*, unavailable, renamed:"append(objectsIn:)")
-    public func appendContentsOf<S: Sequence where S.Iterator.Element == T>(_ objects: S) { fatalError() }
+    public func appendContentsOf<S: Sequence>(_ objects: S) where S.Iterator.Element == T { fatalError() }
 
     @available(*, unavailable, renamed:"removeAllObjects()")
     public func removeAll() { }
@@ -557,7 +557,7 @@ extension List {
     public func sorted(_ property: String, ascending: Bool = true) -> Results<T> { fatalError() }
 
     @available(*, unavailable, renamed:"sorted(with:)")
-    public func sorted<S: Sequence where S.Iterator.Element == SortDescriptor>(_ sortDescriptors: S) -> Results<T> {
+    public func sorted<S: Sequence>(_ sortDescriptors: S) -> Results<T> where S.Iterator.Element == SortDescriptor {
         fatalError()
     }
 

--- a/RealmSwift/List.swift
+++ b/RealmSwift/List.swift
@@ -545,13 +545,13 @@ extension List {
     public func index(of predicate: NSPredicate) -> Int? { fatalError() }
 
     @available(*, unavailable, renamed:"indexOfObject(for:_:)")
-    public func index(of predicateFormat: String, _ args: AnyObject...) -> Int? { fatalError() }
+    public func index(of predicateFormat: String, _ args: Any...) -> Int? { fatalError() }
 
     @available(*, unavailable, renamed:"filter(using:)")
     public func filter(_ predicate: NSPredicate) -> Results<T> { fatalError() }
 
     @available(*, unavailable, renamed:"filter(using:_:)")
-    public func filter(_ predicateFormat: String, _ args: AnyObject...) -> Results<T> { fatalError() }
+    public func filter(_ predicateFormat: String, _ args: Any...) -> Results<T> { fatalError() }
 
     @available(*, unavailable, renamed:"sorted(onProperty:ascending:)")
     public func sorted(_ property: String, ascending: Bool = true) -> Results<T> { fatalError() }

--- a/RealmSwift/Migration.swift
+++ b/RealmSwift/Migration.swift
@@ -127,7 +127,7 @@ public final class Migration {
     - returns: The created object.
     */
     @discardableResult
-    public func createObject(ofType typeName: String, populatedWith value: AnyObject = [:]) -> MigrationObject {
+    public func createObject(ofType typeName: String, populatedWith value: Any = [:]) -> MigrationObject {
         return unsafeBitCast(rlmMigration.createObject(typeName, withValue: value), to: MigrationObject.self)
     }
 
@@ -204,7 +204,7 @@ extension Migration {
     public func enumerate(_ objectClassName: String, _ block: MigrationObjectEnumerateBlock) { }
 
     @available(*, unavailable, renamed:"createObject(ofType:populatedWith:)")
-    public func create(_ className: String, value: AnyObject = [:]) -> MigrationObject {
+    public func create(_ className: String, value: AnyObject = [:] as NSDictionary) -> MigrationObject {
         fatalError()
     }
 

--- a/RealmSwift/Migration.swift
+++ b/RealmSwift/Migration.swift
@@ -169,7 +169,7 @@ public final class Migration {
         rlmMigration.renameProperty(forClass: typeName, oldName: oldName, newName: newName)
     }
 
-    private init(_ rlmMigration: RLMMigration) {
+    fileprivate init(_ rlmMigration: RLMMigration) {
         self.rlmMigration = rlmMigration
     }
 }

--- a/RealmSwift/Migration.swift
+++ b/RealmSwift/Migration.swift
@@ -30,7 +30,7 @@ Migration block used to migrate a Realm.
                        existing objects which require migration.
 - parameter oldSchemaVersion: The schema version of the `Realm` being migrated.
 */
-public typealias MigrationBlock = (migration: Migration, oldSchemaVersion: UInt64) -> Void
+public typealias MigrationBlock = (_ migration: Migration, _ oldSchemaVersion: UInt64) -> Void
 
 /// Object class used during migrations.
 public typealias MigrationObject = DynamicObject
@@ -42,7 +42,7 @@ accessed using subscripting.
 - parameter oldObject: Object in original `Realm` (read-only).
 - parameter newObject: Object in migrated `Realm` (read-write).
 */
-public typealias MigrationObjectEnumerateBlock = (oldObject: MigrationObject?, newObject: MigrationObject?) -> Void
+public typealias MigrationObjectEnumerateBlock = (_ oldObject: MigrationObject?, _ newObject: MigrationObject?) -> Void
 
 /**
 Get the schema version for a Realm at a given local URL.
@@ -109,8 +109,8 @@ public final class Migration {
     */
     public func enumerateObjects(ofType typeName: String, _ block: MigrationObjectEnumerateBlock) {
         rlmMigration.enumerateObjects(typeName) {
-            block(oldObject: unsafeBitCast($0, to: MigrationObject.self),
-                  newObject: unsafeBitCast($1, to: MigrationObject.self))
+            block(/* oldObject: */ unsafeBitCast($0, to: MigrationObject.self),
+                  /* newObject: */ unsafeBitCast($1, to: MigrationObject.self))
         }
     }
 
@@ -177,7 +177,8 @@ public final class Migration {
 
 // MARK: Private Helpers
 
-internal func accessorMigrationBlock(_ migrationBlock: MigrationBlock) -> RLMMigrationBlock {
+internal func accessorMigrationBlock(_ migrationBlock: MigrationBlock)
+    -> RLMMigrationBlock {
     return { migration, oldVersion in
         // set all accessor classes to MigrationObject
         for objectSchema in migration.oldSchema.objectSchema {
@@ -192,7 +193,7 @@ internal func accessorMigrationBlock(_ migrationBlock: MigrationBlock) -> RLMMig
         }
 
         // run migration
-        migrationBlock(migration: Migration(migration), oldSchemaVersion: oldVersion)
+        migrationBlock(/* migration: */ Migration(migration), /* oldSchemaVersion: */ oldVersion)
     }
 }
 

--- a/RealmSwift/Migration.swift
+++ b/RealmSwift/Migration.swift
@@ -193,7 +193,7 @@ internal func accessorMigrationBlock(_ migrationBlock: MigrationBlock)
         }
 
         // run migration
-        migrationBlock(/* migration: */ Migration(migration), /* oldSchemaVersion: */ oldVersion)
+        migrationBlock(Migration(migration), oldVersion)
     }
 }
 

--- a/RealmSwift/Migration.swift
+++ b/RealmSwift/Migration.swift
@@ -204,7 +204,7 @@ extension Migration {
     public func enumerate(_ objectClassName: String, _ block: MigrationObjectEnumerateBlock) { }
 
     @available(*, unavailable, renamed:"createObject(ofType:populatedWith:)")
-    public func create(_ className: String, value: AnyObject = [:] as NSDictionary) -> MigrationObject {
+    public func create(_ className: String, value: Any = [:]) -> MigrationObject {
         fatalError()
     }
 

--- a/RealmSwift/Migration.swift
+++ b/RealmSwift/Migration.swift
@@ -108,9 +108,9 @@ public final class Migration {
     - parameter block:           The block providing both the old and new versions of an object in this Realm.
     */
     public func enumerateObjects(ofType typeName: String, _ block: MigrationObjectEnumerateBlock) {
-        rlmMigration.enumerateObjects(typeName) {
-            block(/* oldObject: */ unsafeBitCast($0, to: MigrationObject.self),
-                  /* newObject: */ unsafeBitCast($1, to: MigrationObject.self))
+        rlmMigration.enumerateObjects(typeName) { oldObject, newObject in
+            block(unsafeBitCast(oldObject, to: MigrationObject.self),
+                  unsafeBitCast(newObject, to: MigrationObject.self))
         }
     }
 

--- a/RealmSwift/Object.swift
+++ b/RealmSwift/Object.swift
@@ -206,7 +206,7 @@ open class Object: RLMObjectBase {
     :nodoc:
     */
     public func dynamicList(_ propertyName: String) -> List<DynamicObject> {
-        return unsafeBitCast(RLMDynamicGetByName(self, propertyName, true),
+        return unsafeBitCast(RLMDynamicGetByName(self, propertyName, true) as! RLMListBase,
                              to: List<DynamicObject>.self)
     }
 

--- a/RealmSwift/Object.swift
+++ b/RealmSwift/Object.swift
@@ -68,7 +68,7 @@ method on `Realm`.
 See our [Cocoa guide](http://realm.io/docs/cocoa) for more details.
 */
 @objc(RealmSwiftObject)
-public class Object: RLMObjectBase {
+open class Object: RLMObjectBase {
 
     // MARK: Initializers
 
@@ -118,10 +118,10 @@ public class Object: RLMObjectBase {
     ///
     /// An object can no longer be accessed if the object has been deleted from the containing
     /// `realm` or if `invalidate` is called on the containing `realm`.
-    public override var isInvalidated: Bool { return super.isInvalidated }
+    open override var isInvalidated: Bool { return super.isInvalidated }
 
     /// Returns a human-readable description of this object.
-    public override var description: String { return super.description }
+    open override var description: String { return super.description }
 
     #if os(OSX)
     /// Helper to return the class name for an Object subclass.
@@ -135,7 +135,7 @@ public class Object: RLMObjectBase {
     WARNING: This is an internal helper method not intended for public use.
     :nodoc:
     */
-    public override class func objectUtilClass(_ isSwift: Bool) -> AnyClass {
+    open override class func objectUtilClass(_ isSwift: Bool) -> AnyClass {
         return ObjectUtil.self
     }
 
@@ -150,7 +150,7 @@ public class Object: RLMObjectBase {
 
     - returns: Name of the property designated as the primary key, or `nil` if the model has no primary key.
     */
-    public class func primaryKey() -> String? { return nil }
+    open class func primaryKey() -> String? { return nil }
 
     /**
     Override to return an array of property names to ignore. These properties will not be persisted
@@ -158,7 +158,7 @@ public class Object: RLMObjectBase {
 
     - returns: `Array` of property names to ignore.
     */
-    public class func ignoredProperties() -> [String] { return [] }
+    open class func ignoredProperties() -> [String] { return [] }
 
     /**
     Return an array of property names for properties which should be indexed.
@@ -166,13 +166,13 @@ public class Object: RLMObjectBase {
 
     - returns: `Array` of property names to index.
     */
-    public class func indexedProperties() -> [String] { return [] }
+    open class func indexedProperties() -> [String] { return [] }
 
 
     // MARK: Key-Value Coding & Subscripting
 
     /// Returns or sets the value of the property with the given name.
-    public subscript(key: String) -> Any? {
+    open subscript(key: String) -> Any? {
         get {
             if realm == nil {
                 return value(forKey: key)
@@ -220,7 +220,7 @@ public class Object: RLMObjectBase {
 
     - parameter object: Object to compare for equality.
     */
-    public override func isEqual(_ object: Any?) -> Bool {
+    open override func isEqual(_ object: Any?) -> Bool {
         return RLMObjectBaseAreEqual(self as RLMObjectBase?, object as? RLMObjectBase)
     }
 

--- a/RealmSwift/Object.swift
+++ b/RealmSwift/Object.swift
@@ -450,7 +450,7 @@ public class Object: RLMObjectBase {
      - parameter value:  The value used to populate the object.
     */
     public init(value: AnyObject) {
-    self.dynamicType.sharedSchema() // ensure this class' objectSchema is loaded in the partialSharedSchema
+        self.dynamicType.sharedSchema() // ensure this class' objectSchema is loaded in the partialSharedSchema
         super.init(value: value, schema: RLMSchema.partialSharedSchema())
     }
 

--- a/RealmSwift/Object.swift
+++ b/RealmSwift/Object.swift
@@ -93,7 +93,7 @@ public class Object: RLMObjectBase {
                        thrown if any required properties are not present and no default is set.
     */
     public init(value: AnyObject) {
-        self.dynamicType.sharedSchema() // ensure this class' objectSchema is loaded in the partialSharedSchema
+        type(of: self).sharedSchema() // ensure this class' objectSchema is loaded in the partialSharedSchema
         super.init(value: value, schema: RLMSchema.partialShared())
     }
 
@@ -309,7 +309,7 @@ public class ObjectUtil: NSObject {
     // Get the names of all properties in the object which are of type List<>.
     @objc private class func getGenericListPropertyNames(_ object: AnyObject) -> NSArray {
         return Mirror(reflecting: object).children.filter { (prop: Mirror.Child) in
-            return prop.value.dynamicType is RLMListBase.Type
+            return type(of: prop.value) is RLMListBase.Type
         }.flatMap { (prop: Mirror.Child) in
             return prop.label
         } as NSArray
@@ -450,7 +450,7 @@ public class Object: RLMObjectBase {
      - parameter value:  The value used to populate the object.
     */
     public init(value: AnyObject) {
-        self.dynamicType.sharedSchema() // ensure this class' objectSchema is loaded in the partialSharedSchema
+    self.dynamicType.sharedSchema() // ensure this class' objectSchema is loaded in the partialSharedSchema
         super.init(value: value, schema: RLMSchema.partialSharedSchema())
     }
 

--- a/RealmSwift/ObjectSchema.swift
+++ b/RealmSwift/ObjectSchema.swift
@@ -64,7 +64,7 @@ public final class ObjectSchema: CustomStringConvertible {
 
     /// Returns the property with the given name, if it exists.
     public subscript(propertyName: String) -> Property? {
-        if let rlmProperty = rlmObjectSchema[propertyName as NSString] {
+        if let rlmProperty = rlmObjectSchema[propertyName] {
             return Property(rlmProperty)
         }
         return nil

--- a/RealmSwift/Optional.swift
+++ b/RealmSwift/Optional.swift
@@ -32,7 +32,7 @@ extension Double: RealmOptionalType {}
 extension Bool: RealmOptionalType {}
 
 private func realmOptionalToAny<T: RealmOptionalType>(_ value: T) -> Any {
-    // FIXME: Use common protocol that defines bridging instead of special-case check with no exaustiveness guarentees.
+    // FIXME: Use common protocol that defines bridging instead of special-case check with no exhaustiveness guarentees.
     if let int8Value = value as? Int8 {
         return NSNumber(value: int8Value)
     } else if let int16Value = value as? Int16 {
@@ -47,7 +47,7 @@ private func realmOptionalToAny<T: RealmOptionalType>(_ value: T) -> Any {
 }
 
 private func anyToRealmOptional<T: RealmOptionalType>(_ value: Any) -> T {
-    // FIXME: Use common protocol that defines bridging instead of special-case check with no exaustiveness guarentees.
+    // FIXME: Use common protocol that defines bridging instead of special-case check with no exhaustiveness guarentees.
     if T.self is Int8.Type {
         return (value as! NSNumber).int8Value as! T
     } else if T.self is Int16.Type {

--- a/RealmSwift/Realm.swift
+++ b/RealmSwift/Realm.swift
@@ -416,7 +416,8 @@ public final class Realm {
     - returns: An object of type `type` or `nil` if an object with the given primary key does not exist.
     */
     public func object<T: Object>(ofType type: T.Type, forPrimaryKey key: Any) -> T? {
-        return unsafeBitCast(RLMGetObject(rlmRealm, (type as Object.Type).className(), key), to: Optional<T>.self)
+        return unsafeBitCast(RLMGetObject(rlmRealm, (type as Object.Type).className(), key) as! RLMObjectBase?,
+                             to: Optional<T>.self)
     }
 
     /**
@@ -442,7 +443,7 @@ public final class Realm {
     :nodoc:
     */
     public func dynamicObject(ofType typeName: String, forPrimaryKey key: Any) -> DynamicObject? {
-        return unsafeBitCast(RLMGetObject(rlmRealm, typeName, key), to: Optional<DynamicObject>.self)
+        return unsafeBitCast(RLMGetObject(rlmRealm, typeName, key) as! RLMObjectBase?, to: Optional<DynamicObject>.self)
     }
 
     // MARK: Notifications

--- a/RealmSwift/Realm.swift
+++ b/RealmSwift/Realm.swift
@@ -113,7 +113,7 @@ public final class Realm {
 
     - throws: An NSError if the transaction could not be written.
     */
-    public func write(block: @noescape () -> Void) throws {
+    public func write(block: () -> Void) throws {
         try rlmRealm.transaction(block)
     }
 
@@ -628,7 +628,7 @@ public enum Notification: String {
 }
 
 /// Closure to run when the data in a Realm was modified.
-public typealias NotificationBlock = (_ notification: Notification, _ realm: Realm) -> Void
+public typealias NotificationBlock = @escaping (_ notification: Notification, _ realm: Realm) -> Void
 
 
 // MARK: Unavailable

--- a/RealmSwift/Realm.swift
+++ b/RealmSwift/Realm.swift
@@ -263,7 +263,7 @@ public final class Realm {
     - returns: The created object.
     */
     @discardableResult
-    public func createObject<T: Object>(ofType type: T.Type, populatedWith value: AnyObject = [:], update: Bool = false) -> T {
+    public func createObject<T: Object>(ofType type: T.Type, populatedWith value: Any = [:], update: Bool = false) -> T {
         let typeName = (type as Object.Type).className()
         if update && schema[typeName]?.primaryKeyProperty == nil {
             throwRealmException("'\(typeName)' does not have a primary key and can not be updated")
@@ -300,7 +300,7 @@ public final class Realm {
     :nodoc:
     */
     @discardableResult
-    public func createDynamicObject(ofType typeName: String, populatedWith value: AnyObject = [:], update: Bool = false) -> DynamicObject {
+    public func createDynamicObject(ofType typeName: String, populatedWith value: Any = [:], update: Bool = false) -> DynamicObject {
         if update && schema[typeName]?.primaryKeyProperty == nil {
             throwRealmException("'\(typeName)' does not have a primary key and can not be updated")
         }
@@ -415,7 +415,7 @@ public final class Realm {
 
     - returns: An object of type `type` or `nil` if an object with the given primary key does not exist.
     */
-    public func object<T: Object>(ofType type: T.Type, forPrimaryKey key: AnyObject) -> T? {
+    public func object<T: Object>(ofType type: T.Type, forPrimaryKey key: Any) -> T? {
         return unsafeBitCast(RLMGetObject(rlmRealm, (type as Object.Type).className(), key), to: Optional<T>.self)
     }
 
@@ -441,7 +441,7 @@ public final class Realm {
 
     :nodoc:
     */
-    public func dynamicObject(ofType typeName: String, forPrimaryKey key: AnyObject) -> DynamicObject? {
+    public func dynamicObject(ofType typeName: String, forPrimaryKey key: Any) -> DynamicObject? {
         return unsafeBitCast(RLMGetObject(rlmRealm, typeName, key), to: Optional<DynamicObject>.self)
     }
 
@@ -639,10 +639,10 @@ extension Realm {
     public var inWriteTransaction : Bool { fatalError() }
 
     @available(*, unavailable, renamed:"createObject(ofType:populatedWith:update:)")
-    public func create<T: Object>(_ type: T.Type, value: AnyObject = [:], update: Bool = false) -> T { fatalError() }
+    public func create<T: Object>(_ type: T.Type, value: AnyObject = [:] as NSDictionary, update: Bool = false) -> T { fatalError() }
 
     @available(*, unavailable, renamed:"createDynamicObject(ofType:populatedWith:update:)")
-    public func dynamicCreate(_ className: String, value: AnyObject = [:], update: Bool = false) -> DynamicObject {
+    public func dynamicCreate(_ className: String, value: AnyObject = [:] as NSDictionary, update: Bool = false) -> DynamicObject {
         fatalError()
     }
 

--- a/RealmSwift/Realm.swift
+++ b/RealmSwift/Realm.swift
@@ -477,9 +477,9 @@ public final class Realm {
         return rlmRealm.addNotificationBlock { rlmNotification, _ in
             switch rlmNotification {
             case RLMNotification.DidChange:
-                block(notification: .DidChange, realm: self)
+                block(/* notification: */ .DidChange, /* realm: */ self)
             case RLMNotification.RefreshRequired:
-                block(notification: .RefreshRequired, realm: self)
+                block(/* notification: */ .RefreshRequired, /* realm: */ self)
             default:
                 fatalError("Unhandled notification type: \(rlmNotification)")
             }
@@ -628,7 +628,7 @@ public enum Notification: String {
 }
 
 /// Closure to run when the data in a Realm was modified.
-public typealias NotificationBlock = (notification: Notification, realm: Realm) -> Void
+public typealias NotificationBlock = (_ notification: Notification, _ realm: Realm) -> Void
 
 
 // MARK: Unavailable

--- a/RealmSwift/Realm.swift
+++ b/RealmSwift/Realm.swift
@@ -478,9 +478,9 @@ public final class Realm {
         return rlmRealm.addNotificationBlock { rlmNotification, _ in
             switch rlmNotification {
             case RLMNotification.DidChange:
-                block(/* notification: */ .DidChange, /* realm: */ self)
+                block(.DidChange, self)
             case RLMNotification.RefreshRequired:
-                block(/* notification: */ .RefreshRequired, /* realm: */ self)
+                block(.RefreshRequired, self)
             default:
                 fatalError("Unhandled notification type: \(rlmNotification)")
             }

--- a/RealmSwift/Realm.swift
+++ b/RealmSwift/Realm.swift
@@ -233,7 +233,7 @@ public final class Realm {
     - parameter objects: A sequence which contains objects to be added to this Realm.
     - parameter update: If true will try to update existing objects with the same primary key.
     */
-    public func add<S: Sequence where S.Iterator.Element: Object>(_ objects: S, update: Bool = false) {
+    public func add<S: Sequence>(_ objects: S, update: Bool = false) where S.Iterator.Element: Object {
         for obj in objects {
             add(obj, update: update)
         }
@@ -328,7 +328,7 @@ public final class Realm {
     - parameter objects: The objects to be deleted. This can be a `List<Object>`, `Results<Object>`,
                          or any other enumerable SequenceType which generates Object.
     */
-    public func delete<S: Sequence where S.Iterator.Element: Object>(_ objects: S) {
+    public func delete<S: Sequence>(_ objects: S) where S.Iterator.Element: Object {
         for obj in objects {
             delete(obj)
         }

--- a/RealmSwift/RealmCollectionType.swift
+++ b/RealmSwift/RealmCollectionType.swift
@@ -174,7 +174,7 @@ public protocol RealmCollection: RandomAccessCollection, LazyCollectionProtocol,
 
     - returns: The index of the first matching object, or `nil` if no objects match.
     */
-    func indexOfObject(for predicateFormat: String, _ args: AnyObject...) -> Int?
+    func indexOfObject(for predicateFormat: String, _ args: Any...) -> Int?
 
 
     // MARK: Filtering
@@ -186,7 +186,7 @@ public protocol RealmCollection: RandomAccessCollection, LazyCollectionProtocol,
 
     - returns: `Results` containing collection elements that match the given predicate.
     */
-    func filter(using predicateFormat: String, _ args: AnyObject...) -> Results<Element>
+    func filter(using predicateFormat: String, _ args: Any...) -> Results<Element>
 
     /**
     Returns `Results` containing collection elements that match the given predicate.
@@ -279,7 +279,7 @@ public protocol RealmCollection: RandomAccessCollection, LazyCollectionProtocol,
 
     - returns: Array containing the results of invoking `valueForKey(_:)` using key on each of the collection's objects.
     */
-    func value(forKey key: String) -> AnyObject?
+    func value(forKey key: String) -> Any?
 
     /**
      Returns an Array containing the results of invoking `valueForKeyPath(_:)` using keyPath on each of the
@@ -290,7 +290,7 @@ public protocol RealmCollection: RandomAccessCollection, LazyCollectionProtocol,
      - returns: Array containing the results of invoking `valueForKeyPath(_:)` using keyPath on each of the
      collection's objects.
      */
-    func value(forKeyPath keyPath: String) -> AnyObject?
+    func value(forKeyPath keyPath: String) -> Any?
 
     /**
     Invokes `setValue(_:forKey:)` on each of the collection's objects using the specified value and key.
@@ -300,7 +300,7 @@ public protocol RealmCollection: RandomAccessCollection, LazyCollectionProtocol,
     - parameter value: The object value.
     - parameter key:   The name of the property.
     */
-    func setValue(_ value: AnyObject?, forKey key: String)
+    func setValue(_ value: Any?, forKey key: String)
 
     // MARK: Notifications
 
@@ -372,8 +372,8 @@ private class _AnyRealmCollectionBase<T: Object> {
     var description: String { fatalError() }
     func index(of object: Element) -> Int? { fatalError() }
     func indexOfObject(for predicate: NSPredicate) -> Int? { fatalError() }
-    func indexOfObject(for predicateFormat: String, _ args: AnyObject...) -> Int? { fatalError() }
-    func filter(using predicateFormat: String, _ args: AnyObject...) -> Results<Element> { fatalError() }
+    func indexOfObject(for predicateFormat: String, _ args: Any...) -> Int? { fatalError() }
+    func filter(using predicateFormat: String, _ args: Any...) -> Results<Element> { fatalError() }
     func filter(using predicate: NSPredicate) -> Results<Element> { fatalError() }
     func sorted(onProperty property: String, ascending: Bool) -> Results<Element> { fatalError() }
     func sorted<S: Sequence>(with sortDescriptors: S) -> Results<Element> where S.Iterator.Element == SortDescriptor {
@@ -387,9 +387,9 @@ private class _AnyRealmCollectionBase<T: Object> {
     func makeIterator() -> RLMIterator<T> { fatalError() }
     var startIndex: Int { fatalError() }
     var endIndex: Int { fatalError() }
-    func value(forKey key: String) -> AnyObject? { fatalError() }
-    func value(forKeyPath keyPath: String) -> AnyObject? { fatalError() }
-    func setValue(_ value: AnyObject?, forKey key: String) { fatalError() }
+    func value(forKey key: String) -> Any? { fatalError() }
+    func value(forKeyPath keyPath: String) -> Any? { fatalError() }
+    func setValue(_ value: Any?, forKey key: String) { fatalError() }
     func _addNotificationBlock(block: (RealmCollectionChange<Wrapper>) -> Void)
         -> NotificationToken { fatalError() }
 }
@@ -449,7 +449,7 @@ private final class _AnyRealmCollection<C: RealmCollection>: _AnyRealmCollection
 
     - returns: The index of the first matching object, or `nil` if no objects match.
     */
-    override func indexOfObject(for predicateFormat: String, _ args: AnyObject...) -> Int? {
+    override func indexOfObject(for predicateFormat: String, _ args: Any...) -> Int? {
         return base.indexOfObject(for: NSPredicate(format: predicateFormat, argumentArray: args))
     }
 
@@ -462,7 +462,7 @@ private final class _AnyRealmCollection<C: RealmCollection>: _AnyRealmCollection
 
     - returns: `Results` containing collection elements that match the given predicate.
     */
-    override func filter(using predicateFormat: String, _ args: AnyObject...) -> Results<C.Element> {
+    override func filter(using predicateFormat: String, _ args: Any...) -> Results<C.Element> {
         return base.filter(using: NSPredicate(format: predicateFormat, argumentArray: args))
     }
 
@@ -609,7 +609,7 @@ private final class _AnyRealmCollection<C: RealmCollection>: _AnyRealmCollection
 
     - returns: Array containing the results of invoking `valueForKey(_:)` using key on each of the collection's objects.
     */
-    override func value(forKey key: String) -> AnyObject? { return base.value(forKey: key) }
+    override func value(forKey key: String) -> Any? { return base.value(forKey: key) }
 
     /**
      Returns an Array containing the results of invoking `valueForKeyPath(_:)` using keyPath on each of the
@@ -620,7 +620,7 @@ private final class _AnyRealmCollection<C: RealmCollection>: _AnyRealmCollection
      - returns: Array containing the results of invoking `valueForKeyPath(_:)` using keyPath on each of the
        collection's objects.
      */
-    override func value(forKeyPath keyPath: String) -> AnyObject? { return base.value(forKeyPath: keyPath) }
+    override func value(forKeyPath keyPath: String) -> Any? { return base.value(forKeyPath: keyPath) }
 
     /**
     Invokes `setValue(_:forKey:)` on each of the collection's objects using the specified value and key.
@@ -630,7 +630,7 @@ private final class _AnyRealmCollection<C: RealmCollection>: _AnyRealmCollection
     - parameter value: The object value.
     - parameter key:   The name of the property.
     */
-    override func setValue(_ value: AnyObject?, forKey key: String) { base.setValue(value, forKey: key) }
+    override func setValue(_ value: Any?, forKey key: String) { base.setValue(value, forKey: key) }
 
     // MARK: Notifications
 
@@ -708,7 +708,7 @@ public final class AnyRealmCollection<T: Object>: RealmCollection {
 
     - returns: The index of the first matching object, or `nil` if no objects match.
     */
-    public func indexOfObject(for predicateFormat: String, _ args: AnyObject...) -> Int? {
+    public func indexOfObject(for predicateFormat: String, _ args: Any...) -> Int? {
         return base.indexOfObject(for: NSPredicate(format: predicateFormat, argumentArray: args))
     }
 
@@ -721,7 +721,7 @@ public final class AnyRealmCollection<T: Object>: RealmCollection {
 
     - returns: `Results` containing collection elements that match the given predicate.
     */
-    public func filter(using predicateFormat: String, _ args: AnyObject...) -> Results<Element> {
+    public func filter(using predicateFormat: String, _ args: Any...) -> Results<Element> {
         return base.filter(using: NSPredicate(format: predicateFormat, argumentArray: args))
     }
 
@@ -852,7 +852,7 @@ public final class AnyRealmCollection<T: Object>: RealmCollection {
 
     - returns: Array containing the results of invoking `valueForKey(_:)` using key on each of the collection's objects.
     */
-    public func value(forKey key: String) -> AnyObject? { return base.value(forKey: key) }
+    public func value(forKey key: String) -> Any? { return base.value(forKey: key) }
 
     /**
      Returns an Array containing the results of invoking `valueForKeyPath(_:)` using keyPath on each of the
@@ -863,7 +863,7 @@ public final class AnyRealmCollection<T: Object>: RealmCollection {
      - returns: Array containing the results of invoking `valueForKeyPath(_:)` using keyPath on each of the
      collection's objects.
      */
-    public func value(forKeyPath keyPath: String) -> AnyObject? { return base.value(forKeyPath: keyPath) }
+    public func value(forKeyPath keyPath: String) -> Any? { return base.value(forKeyPath: keyPath) }
 
     /**
     Invokes `setValue(_:forKey:)` on each of the collection's objects using the specified value and key.
@@ -873,7 +873,7 @@ public final class AnyRealmCollection<T: Object>: RealmCollection {
     - parameter value: The object value.
     - parameter key:   The name of the property.
     */
-    public func setValue(_ value: AnyObject?, forKey key: String) { base.setValue(value, forKey: key) }
+    public func setValue(_ value: Any?, forKey key: String) { base.setValue(value, forKey: key) }
 
     // MARK: Notifications
 

--- a/RealmSwift/RealmCollectionType.swift
+++ b/RealmSwift/RealmCollectionType.swift
@@ -99,9 +99,9 @@ public enum RealmCollectionChange<T> {
     /// .Error result and an NSError with details. Currently the only thing
     /// that can fail is opening the Realm on a background worker thread to
     /// calculate the change set.
-    case Error(NSError)
+    case Error(Swift.Error)
 
-    static func fromObjc(value: T, change: RLMCollectionChange?, error: NSError?) -> RealmCollectionChange {
+    static func fromObjc(value: T, change: RLMCollectionChange?, error: Swift.Error?) -> RealmCollectionChange {
         if let error = error {
             return .Error(error)
         }

--- a/RealmSwift/RealmCollectionType.swift
+++ b/RealmSwift/RealmCollectionType.swift
@@ -107,9 +107,9 @@ public enum RealmCollectionChange<T> {
         }
         if let change = change {
             return .Update(value,
-                deletions: change.deletions as! [Int],
-                insertions: change.insertions as! [Int],
-                modifications: change.modifications as! [Int])
+                deletions: change.deletions as [Int],
+                insertions: change.insertions as [Int],
+                modifications: change.modifications as [Int])
         }
         return .Initial(value)
     }

--- a/RealmSwift/RealmCollectionType.swift
+++ b/RealmSwift/RealmCollectionType.swift
@@ -357,10 +357,10 @@ public protocol RealmCollection: RandomAccessCollection, LazyCollectionProtocol,
      - parameter block: The block to be called with the evaluated collection and change information.
      - returns: A token which must be held for as long as you want updates to be delivered.
      */
-    func addNotificationBlock(block: (RealmCollectionChange<Self>) -> Void) -> NotificationToken
+    func addNotificationBlock(block: @escaping (RealmCollectionChange<Self>) -> Void) -> NotificationToken
 
     /// :nodoc:
-    func _addNotificationBlock(block: (RealmCollectionChange<AnyRealmCollection<Element>>) -> Void) -> NotificationToken
+    func _addNotificationBlock(block: @escaping (RealmCollectionChange<AnyRealmCollection<Element>>) -> Void) -> NotificationToken
 }
 
 private class _AnyRealmCollectionBase<T: Object> {
@@ -390,7 +390,7 @@ private class _AnyRealmCollectionBase<T: Object> {
     func value(forKey key: String) -> Any? { fatalError() }
     func value(forKeyPath keyPath: String) -> Any? { fatalError() }
     func setValue(_ value: Any?, forKey key: String) { fatalError() }
-    func _addNotificationBlock(block: (RealmCollectionChange<Wrapper>) -> Void)
+    func _addNotificationBlock(block: @escaping (RealmCollectionChange<Wrapper>) -> Void)
         -> NotificationToken { fatalError() }
 }
 
@@ -635,7 +635,7 @@ private final class _AnyRealmCollection<C: RealmCollection>: _AnyRealmCollection
     // MARK: Notifications
 
     /// :nodoc:
-    override func _addNotificationBlock(block: (RealmCollectionChange<Wrapper>) -> Void)
+    override func _addNotificationBlock(block: @escaping (RealmCollectionChange<Wrapper>) -> Void)
         -> NotificationToken { return base._addNotificationBlock(block: block) }
 }
 
@@ -930,11 +930,11 @@ public final class AnyRealmCollection<T: Object>: RealmCollection {
      - parameter block: The block to be called with the evaluated collection and change information.
      - returns: A token which must be held for as long as you want updates to be delivered.
      */
-    public func addNotificationBlock(block: (RealmCollectionChange<AnyRealmCollection>) -> ())
+    public func addNotificationBlock(block: @escaping (RealmCollectionChange<AnyRealmCollection>) -> ())
         -> NotificationToken { return base._addNotificationBlock(block: block) }
 
     /// :nodoc:
-    public func _addNotificationBlock(block: (RealmCollectionChange<AnyRealmCollection>) -> ())
+    public func _addNotificationBlock(block: @escaping (RealmCollectionChange<AnyRealmCollection>) -> ())
         -> NotificationToken { return base._addNotificationBlock(block: block) }
 }
 

--- a/RealmSwift/RealmCollectionType.swift
+++ b/RealmSwift/RealmCollectionType.swift
@@ -756,8 +756,8 @@ public final class AnyRealmCollection<T: Object>: RealmCollection {
 
     - returns: `Results` with elements sorted by the given sort descriptors.
     */
-    public func sorted<S: Sequence>
-        (with sortDescriptors: S) -> Results<Element> where S.Iterator.Element == SortDescriptor {
+    public func sorted<S: Sequence>(with sortDescriptors: S) -> Results<Element>
+        where S.Iterator.Element == SortDescriptor {
         return base.sorted(with: sortDescriptors)
     }
 

--- a/RealmSwift/RealmCollectionType.swift
+++ b/RealmSwift/RealmCollectionType.swift
@@ -217,7 +217,7 @@ public protocol RealmCollection: RandomAccessCollection, LazyCollectionProtocol,
 
     - returns: `Results` with elements sorted by the given sort descriptors.
     */
-    func sorted<S: Sequence where S.Iterator.Element == SortDescriptor>(with sortDescriptors: S) -> Results<Element>
+    func sorted<S: Sequence>(with sortDescriptors: S) -> Results<Element> where S.Iterator.Element == SortDescriptor
 
 
     // MARK: Aggregate Operations
@@ -376,7 +376,7 @@ private class _AnyRealmCollectionBase<T: Object> {
     func filter(using predicateFormat: String, _ args: AnyObject...) -> Results<Element> { fatalError() }
     func filter(using predicate: NSPredicate) -> Results<Element> { fatalError() }
     func sorted(onProperty property: String, ascending: Bool) -> Results<Element> { fatalError() }
-    func sorted<S: Sequence where S.Iterator.Element == SortDescriptor>(with sortDescriptors: S) -> Results<Element> {
+    func sorted<S: Sequence>(with sortDescriptors: S) -> Results<Element> where S.Iterator.Element == SortDescriptor {
         fatalError()
     }
     func minimumValue<U: MinMaxType>(ofProperty property: String) -> U? { fatalError() }
@@ -497,8 +497,8 @@ private final class _AnyRealmCollection<C: RealmCollection>: _AnyRealmCollection
 
     - returns: `Results` with elements sorted by the given sort descriptors.
     */
-    override func sorted<S: Sequence where S.Iterator.Element == SortDescriptor>
-                        (with sortDescriptors: S) -> Results<C.Element> {
+    override func sorted<S: Sequence>
+        (with sortDescriptors: S) -> Results<C.Element> where S.Iterator.Element == SortDescriptor {
         return base.sorted(with: sortDescriptors)
     }
 
@@ -655,7 +655,7 @@ public final class AnyRealmCollection<T: Object>: RealmCollection {
     private let base: _AnyRealmCollectionBase<T>
 
     /// Creates an AnyRealmCollection wrapping `base`.
-    public init<C: RealmCollection where C.Element == T>(_ base: C) {
+    public init<C: RealmCollection>(_ base: C) where C.Element == T {
         self.base = _AnyRealmCollection(base: base)
     }
 
@@ -756,8 +756,8 @@ public final class AnyRealmCollection<T: Object>: RealmCollection {
 
     - returns: `Results` with elements sorted by the given sort descriptors.
     */
-    public func sorted<S: Sequence where S.Iterator.Element == SortDescriptor>
-                      (with sortDescriptors: S) -> Results<Element> {
+    public func sorted<S: Sequence>
+        (with sortDescriptors: S) -> Results<Element> where S.Iterator.Element == SortDescriptor {
         return base.sorted(with: sortDescriptors)
     }
 
@@ -961,7 +961,7 @@ extension AnyRealmCollection {
     public func sorted(_ property: String, ascending: Bool = true) -> Results<T> { fatalError() }
 
     @available(*, unavailable, renamed:"sorted(with:)")
-    public func sorted<S: Sequence where S.Iterator.Element == SortDescriptor>(_ sortDescriptors: S) -> Results<T> {
+    public func sorted<S: Sequence>(_ sortDescriptors: S) -> Results<T> where S.Iterator.Element == SortDescriptor {
         fatalError()
     }
 

--- a/RealmSwift/Results.swift
+++ b/RealmSwift/Results.swift
@@ -432,7 +432,7 @@ public final class Results<T: Object>: NSObject, NSFastEnumeration {
      - parameter block: The block to be called with the evaluated results and change information.
      - returns: A token which must be held for as long as you want query results to be delivered.
      */
-    public func addNotificationBlock(block: ((RealmCollectionChange<Results>) -> Void)) -> NotificationToken {
+    public func addNotificationBlock(block: @escaping (RealmCollectionChange<Results>) -> Void) -> NotificationToken {
         return rlmResults.addNotificationBlock { results, change, error in
             block(RealmCollectionChange.fromObjc(value: self, change: change, error: error))
         }
@@ -462,7 +462,7 @@ extension Results: RealmCollection {
     public func index(before i: Int) -> Int { return i - 1 }
 
     /// :nodoc:
-    public func _addNotificationBlock(block: (RealmCollectionChange<AnyRealmCollection<T>>) -> Void) ->
+    public func _addNotificationBlock(block: @escaping (RealmCollectionChange<AnyRealmCollection<T>>) -> Void) ->
         NotificationToken {
         let anyCollection = AnyRealmCollection(self)
         return rlmResults.addNotificationBlock { _, change, error in

--- a/RealmSwift/Results.swift
+++ b/RealmSwift/Results.swift
@@ -24,45 +24,45 @@ import Realm
 // MARK: Bridgable
 
 // Used for conversion from Objective-C types to Swift types
-private protocol Bridgable  { static func bridging(_ value: AnyObject) -> Self }
+private protocol Bridgable  { static func bridging(_ value: Any) -> Self }
 
 extension Double: Bridgable {
-    static func bridging(_ value: AnyObject) -> Double {
+    static func bridging(_ value: Any) -> Double {
         return (value as! NSNumber).doubleValue
     }
 }
 extension Float: Bridgable {
-    static func bridging(_ value: AnyObject) -> Float {
+    static func bridging(_ value: Any) -> Float {
         return (value as! NSNumber).floatValue
     }
 }
 extension Int: Bridgable {
-    static func bridging(_ value: AnyObject) -> Int {
+    static func bridging(_ value: Any) -> Int {
         return (value as! NSNumber).intValue
     }
 }
 extension Int8: Bridgable {
-    static func bridging(_ value: AnyObject) -> Int8 {
+    static func bridging(_ value: Any) -> Int8 {
         return (value as! NSNumber).int8Value
     }
 }
 extension Int16: Bridgable {
-    static func bridging(_ value: AnyObject) -> Int16 {
+    static func bridging(_ value: Any) -> Int16 {
         return (value as! NSNumber).int16Value
     }
 }
 extension Int32: Bridgable {
-    static func bridging(_ value: AnyObject) -> Int32 {
+    static func bridging(_ value: Any) -> Int32 {
         return (value as! NSNumber).int32Value
     }
 }
 extension Int64: Bridgable {
-    static func bridging(_ value: AnyObject) -> Int64 {
+    static func bridging(_ value: Any) -> Int64 {
         return (value as! NSNumber).int64Value
     }
 }
 extension NSDate: Bridgable {
-    static func bridging(_ value: AnyObject) -> Self   {
+    static func bridging(_ value: Any) -> Self   {
         func forceCastTrampoline<T, U>(_ x: T) -> U {
             return x as! U
         }
@@ -83,7 +83,7 @@ extension Int32: MinMaxType {}
 extension Int64: MinMaxType {}
 extension NSDate: MinMaxType {}
 extension MinMaxType {
-    internal static func bridging(_ value: AnyObject) -> Self {
+    internal static func bridging(_ value: Any) -> Self {
         return (Self.self as! Bridgable.Type).bridging(value) as! Self
     }
 }
@@ -100,7 +100,7 @@ extension Int16: AddableType {}
 extension Int32: AddableType {}
 extension Int64: AddableType {}
 extension AddableType {
-    internal static func bridging(_ value: AnyObject) -> Self {
+    internal static func bridging(_ value: Any) -> Self {
         return (Self.self as! Bridgable.Type).bridging(value) as! Self
     }
 }
@@ -205,7 +205,7 @@ public final class Results<T: Object>: NSObject, NSFastEnumeration {
 
     - returns: The index of the first matching object, or `nil` if no objects match.
     */
-    public func indexOfObject(for predicateFormat: String, _ args: AnyObject...) -> Int? {
+    public func indexOfObject(for predicateFormat: String, _ args: Any...) -> Int? {
         return notFoundToNil(index: rlmResults.indexOfObject(with: NSPredicate(format: predicateFormat,
                                                                                argumentArray: args)))
     }
@@ -239,7 +239,7 @@ public final class Results<T: Object>: NSObject, NSFastEnumeration {
 
     - returns: Array containing the results of invoking `valueForKey(_:)` using key on each of the collection's objects.
     */
-    public override func value(forKey key: String) -> AnyObject? {
+    public override func value(forKey key: String) -> Any? {
         return value(forKeyPath: key)
     }
 
@@ -252,7 +252,7 @@ public final class Results<T: Object>: NSObject, NSFastEnumeration {
      - returns: Array containing the results of invoking `valueForKeyPath(_:)` using keyPath on each of the
      collection's objects.
      */
-    public override func value(forKeyPath keyPath: String) -> AnyObject? {
+    public override func value(forKeyPath keyPath: String) -> Any? {
         return rlmResults.value(forKeyPath: keyPath)
     }
 
@@ -264,7 +264,7 @@ public final class Results<T: Object>: NSObject, NSFastEnumeration {
     - parameter value: The object value.
     - parameter key:   The name of the property.
     */
-    public override func setValue(_ value: AnyObject?, forKey key: String) {
+    public override func setValue(_ value: Any?, forKey key: String) {
         return rlmResults.setValue(value, forKeyPath: key)
     }
 
@@ -277,7 +277,7 @@ public final class Results<T: Object>: NSObject, NSFastEnumeration {
 
     - returns: Results containing objects that match the given predicate.
     */
-    public func filter(using predicateFormat: String, _ args: AnyObject...) -> Results<T> {
+    public func filter(using predicateFormat: String, _ args: Any...) -> Results<T> {
         return Results<T>(rlmResults.objects(with: NSPredicate(format: predicateFormat, argumentArray: args)))
     }
 

--- a/RealmSwift/Results.swift
+++ b/RealmSwift/Results.swift
@@ -313,7 +313,7 @@ public final class Results<T: Object>: NSObject, NSFastEnumeration {
 
     - returns: `Results` with elements sorted by the given sort descriptors.
     */
-    public func sorted<S: Sequence where S.Iterator.Element == SortDescriptor>(with sortDescriptors: S) -> Results<T> {
+    public func sorted<S: Sequence>(with sortDescriptors: S) -> Results<T> where S.Iterator.Element == SortDescriptor {
         return Results<T>(rlmResults.sortedResults(using: sortDescriptors.map { $0.rlmSortDescriptorValue }))
     }
 
@@ -493,7 +493,7 @@ extension Results {
     public func sorted(_ property: String, ascending: Bool = true) -> Results<T> { fatalError() }
 
     @available(*, unavailable, renamed:"sorted(with:)")
-    public func sorted<S: Sequence where S.Iterator.Element == SortDescriptor>(_ sortDescriptors: S) -> Results<T> {
+    public func sorted<S: Sequence>(_ sortDescriptors: S) -> Results<T> where S.Iterator.Element == SortDescriptor {
         fatalError()
     }
 

--- a/RealmSwift/Tests/KVOTests.swift
+++ b/RealmSwift/Tests/KVOTests.swift
@@ -142,8 +142,8 @@ class KVOTests: TestCase {
         observeChange(obj, "stringCol", "", "abc") { obj.stringCol = "abc" }
         observeChange(obj, "objectCol", nil, obj) { obj.objectCol = obj }
 
-        let data = "abc".data(using: String.Encoding.utf8, allowLossyConversion: false)!
-        observeChange(obj, "binaryCol", NSData(), data) { obj.binaryCol = data }
+        let data = "abc".data(using: String.Encoding.utf8, allowLossyConversion: false)! as Data as NSData
+        observeChange(obj, "binaryCol", NSData(), data) { obj.binaryCol = data as NSData }
 
         let date = NSDate(timeIntervalSince1970: 1)
         observeChange(obj, "dateCol", NSDate(timeIntervalSince1970: 0), date) { obj.dateCol = date }
@@ -160,7 +160,7 @@ class KVOTests: TestCase {
         observeChange(obj, "optDoubleCol", nil, 10) { obj.optDoubleCol.value = 10 }
         observeChange(obj, "optBoolCol", nil, true) { obj.optBoolCol.value = true }
         observeChange(obj, "optStringCol", nil, "abc") { obj.optStringCol = "abc" }
-        observeChange(obj, "optBinaryCol", nil, data) { obj.optBinaryCol = data }
+        observeChange(obj, "optBinaryCol", nil, data) { obj.optBinaryCol = data as NSData }
         observeChange(obj, "optDateCol", nil, date) { obj.optDateCol = date }
 
         observeChange(obj, "optIntCol", 10, nil) { obj.optIntCol.value = nil }
@@ -186,8 +186,8 @@ class KVOTests: TestCase {
         observeChange(obj, "stringCol", "", "abc") { obj.stringCol = "abc" }
         observeChange(obj, "objectCol", nil, obj) { obj.objectCol = obj }
 
-        let data = "abc".data(using: String.Encoding.utf8, allowLossyConversion: false)!
-        observeChange(obj, "binaryCol", NSData(), data) { obj.binaryCol = data }
+        let data = "abc".data(using: String.Encoding.utf8, allowLossyConversion: false)! as Data as NSData
+        observeChange(obj, "binaryCol", NSData(), data) { obj.binaryCol = data as NSData }
 
         let date = NSDate(timeIntervalSince1970: 1)
         observeChange(obj, "dateCol", NSDate(timeIntervalSince1970: 0), date) { obj.dateCol = date }
@@ -204,7 +204,7 @@ class KVOTests: TestCase {
         observeChange(obj, "optDoubleCol", nil, 10) { obj.optDoubleCol.value = 10 }
         observeChange(obj, "optBoolCol", nil, true) { obj.optBoolCol.value = true }
         observeChange(obj, "optStringCol", nil, "abc") { obj.optStringCol = "abc" }
-        observeChange(obj, "optBinaryCol", nil, data) { obj.optBinaryCol = data }
+        observeChange(obj, "optBinaryCol", nil, data) { obj.optBinaryCol = data as NSData }
         observeChange(obj, "optDateCol", nil, date) { obj.optDateCol = date }
 
         observeChange(obj, "optIntCol", 10, nil) { obj.optIntCol.value = nil }
@@ -241,8 +241,8 @@ class KVOTests: TestCase {
         observeChange(obs, "stringCol", "", "abc") { obj.stringCol = "abc" }
         observeChange(obs, "objectCol", nil, obj) { obj.objectCol = obj }
 
-        let data = "abc".data(using: String.Encoding.utf8, allowLossyConversion: false)!
-        observeChange(obs, "binaryCol", NSData(), data) { obj.binaryCol = data }
+        let data = "abc".data(using: String.Encoding.utf8, allowLossyConversion: false)! as Data as NSData
+        observeChange(obs, "binaryCol", NSData(), data) { obj.binaryCol = data as NSData }
 
         let date = NSDate(timeIntervalSince1970: 1)
         observeChange(obs, "dateCol", NSDate(timeIntervalSince1970: 0), date) { obj.dateCol = date }
@@ -259,7 +259,7 @@ class KVOTests: TestCase {
         observeChange(obs, "optDoubleCol", nil, 10) { obj.optDoubleCol.value = 10 }
         observeChange(obs, "optBoolCol", nil, true) { obj.optBoolCol.value = true }
         observeChange(obs, "optStringCol", nil, "abc") { obj.optStringCol = "abc" }
-        observeChange(obs, "optBinaryCol", nil, data) { obj.optBinaryCol = data }
+        observeChange(obs, "optBinaryCol", nil, data) { obj.optBinaryCol = data as NSData }
         observeChange(obs, "optDateCol", nil, date) { obj.optDateCol = date }
 
         observeChange(obs, "optIntCol", 10, nil) { obj.optIntCol.value = nil }

--- a/RealmSwift/Tests/KVOTests.swift
+++ b/RealmSwift/Tests/KVOTests.swift
@@ -73,32 +73,36 @@ class KVOTests: TestCase {
         super.tearDown()
     }
 
-    var changeDictionary: [NSKeyValueChangeKey: AnyObject]?
+    var changeDictionary: [NSKeyValueChangeKey: Any]?
 
-
-
-    override func observeValue(forKeyPath keyPath: String?, of object: AnyObject?,
-                               change: [NSKeyValueChangeKey : AnyObject]?, context: UnsafeMutablePointer<Void>?) {
+    override func observeValue(forKeyPath keyPath: String?, of object: Any?,
+                               change: [NSKeyValueChangeKey : Any]?, context: UnsafeMutableRawPointer?) {
         changeDictionary = change
     }
 
-    func observeChange(_ obj: NSObject, _ key: String, _ old: AnyObject, _ new: AnyObject,
+    func observeChange<T: Equatable>(_ obj: NSObject, _ key: String, _ old: T?, _ new: T?,
                        fileName: StaticString = #file, lineNumber: UInt = #line, _ block: () -> Void) {
         obj.addObserver(self, forKeyPath: key, options: [.old, .new], context: nil)
         block()
         obj.removeObserver(self, forKeyPath: key)
 
         XCTAssert(changeDictionary != nil, "Did not get a notification", file: fileName, line: lineNumber)
-        if changeDictionary == nil {
-            return
-        }
+        guard changeDictionary != nil else { return }
 
-        let actualOld: AnyObject = (changeDictionary?[NSKeyValueChangeKey.oldKey]!)!
-        let actualNew: AnyObject = (changeDictionary?[NSKeyValueChangeKey.newKey]!)!
-        XCTAssert(actualOld.isEqual(old), "Old value: expected \(old), got \(actualOld)", file: fileName,
-            line: lineNumber)
-        XCTAssert(actualNew.isEqual(new), "New value: expected \(new), got \(actualNew)", file: fileName,
-            line: lineNumber)
+        func forceCoerce(_ value: Any) -> T? {
+            // FIXME: Remove once Swift fixes `value as! T?` for `value: Any`.
+            func forceCast<T, U>(_ value: T, to type: U.Type) -> U { return value as! U }
+
+            if value is NSNull { return nil }
+            else { return forceCast(value, to: Optional<T>.self) }
+        }
+        let actualOld = forceCoerce(changeDictionary![NSKeyValueChangeKey.oldKey]!)
+        let actualNew = forceCoerce(changeDictionary![NSKeyValueChangeKey.newKey]!)
+
+        XCTAssert(old == actualOld, "Old value: expected \(old), got \(actualOld)",
+                  file: fileName, line: lineNumber)
+        XCTAssert(new == actualNew, "New value: expected \(new), got \(actualNew)",
+                  file: fileName, line: lineNumber)
 
         changeDictionary = nil
     }
@@ -136,7 +140,7 @@ class KVOTests: TestCase {
         observeChange(obj, "floatCol", 5, 10) { obj.floatCol = 10 }
         observeChange(obj, "doubleCol", 6, 10) { obj.doubleCol = 10 }
         observeChange(obj, "stringCol", "", "abc") { obj.stringCol = "abc" }
-        observeChange(obj, "objectCol", NSNull(), obj) { obj.objectCol = obj }
+        observeChange(obj, "objectCol", nil, obj) { obj.objectCol = obj }
 
         let data = "abc".data(using: String.Encoding.utf8, allowLossyConversion: false)!
         observeChange(obj, "binaryCol", NSData(), data) { obj.binaryCol = data }
@@ -151,21 +155,21 @@ class KVOTests: TestCase {
             obj.arrayCol.removeAllObjects()
         }
 
-        observeChange(obj, "optIntCol", NSNull(), 10) { obj.optIntCol.value = 10 }
-        observeChange(obj, "optFloatCol", NSNull(), 10) { obj.optFloatCol.value = 10 }
-        observeChange(obj, "optDoubleCol", NSNull(), 10) { obj.optDoubleCol.value = 10 }
-        observeChange(obj, "optBoolCol", NSNull(), true) { obj.optBoolCol.value = true }
-        observeChange(obj, "optStringCol", NSNull(), "abc") { obj.optStringCol = "abc" }
-        observeChange(obj, "optBinaryCol", NSNull(), data) { obj.optBinaryCol = data }
-        observeChange(obj, "optDateCol", NSNull(), date) { obj.optDateCol = date }
+        observeChange(obj, "optIntCol", nil, 10) { obj.optIntCol.value = 10 }
+        observeChange(obj, "optFloatCol", nil, 10) { obj.optFloatCol.value = 10 }
+        observeChange(obj, "optDoubleCol", nil, 10) { obj.optDoubleCol.value = 10 }
+        observeChange(obj, "optBoolCol", nil, true) { obj.optBoolCol.value = true }
+        observeChange(obj, "optStringCol", nil, "abc") { obj.optStringCol = "abc" }
+        observeChange(obj, "optBinaryCol", nil, data) { obj.optBinaryCol = data }
+        observeChange(obj, "optDateCol", nil, date) { obj.optDateCol = date }
 
-        observeChange(obj, "optIntCol", 10, NSNull()) { obj.optIntCol.value = nil }
-        observeChange(obj, "optFloatCol", 10, NSNull()) { obj.optFloatCol.value = nil }
-        observeChange(obj, "optDoubleCol", 10, NSNull()) { obj.optDoubleCol.value = nil }
-        observeChange(obj, "optBoolCol", true, NSNull()) { obj.optBoolCol.value = nil }
-        observeChange(obj, "optStringCol", "abc", NSNull()) { obj.optStringCol = nil }
-        observeChange(obj, "optBinaryCol", data, NSNull()) { obj.optBinaryCol = nil }
-        observeChange(obj, "optDateCol", date, NSNull()) { obj.optDateCol = nil }
+        observeChange(obj, "optIntCol", 10, nil) { obj.optIntCol.value = nil }
+        observeChange(obj, "optFloatCol", 10, nil) { obj.optFloatCol.value = nil }
+        observeChange(obj, "optDoubleCol", 10, nil) { obj.optDoubleCol.value = nil }
+        observeChange(obj, "optBoolCol", true, nil) { obj.optBoolCol.value = nil }
+        observeChange(obj, "optStringCol", "abc", nil) { obj.optStringCol = nil }
+        observeChange(obj, "optBinaryCol", data, nil) { obj.optBinaryCol = nil }
+        observeChange(obj, "optDateCol", date, nil) { obj.optDateCol = nil }
     }
 
     func testAllPropertyTypesPersisted() {
@@ -180,7 +184,7 @@ class KVOTests: TestCase {
         observeChange(obj, "floatCol", 5, 10) { obj.floatCol = 10 }
         observeChange(obj, "doubleCol", 6, 10) { obj.doubleCol = 10 }
         observeChange(obj, "stringCol", "", "abc") { obj.stringCol = "abc" }
-        observeChange(obj, "objectCol", NSNull(), obj) { obj.objectCol = obj }
+        observeChange(obj, "objectCol", nil, obj) { obj.objectCol = obj }
 
         let data = "abc".data(using: String.Encoding.utf8, allowLossyConversion: false)!
         observeChange(obj, "binaryCol", NSData(), data) { obj.binaryCol = data }
@@ -195,21 +199,21 @@ class KVOTests: TestCase {
             obj.arrayCol.removeAllObjects()
         }
 
-        observeChange(obj, "optIntCol", NSNull(), 10) { obj.optIntCol.value = 10 }
-        observeChange(obj, "optFloatCol", NSNull(), 10) { obj.optFloatCol.value = 10 }
-        observeChange(obj, "optDoubleCol", NSNull(), 10) { obj.optDoubleCol.value = 10 }
-        observeChange(obj, "optBoolCol", NSNull(), true) { obj.optBoolCol.value = true }
-        observeChange(obj, "optStringCol", NSNull(), "abc") { obj.optStringCol = "abc" }
-        observeChange(obj, "optBinaryCol", NSNull(), data) { obj.optBinaryCol = data }
-        observeChange(obj, "optDateCol", NSNull(), date) { obj.optDateCol = date }
+        observeChange(obj, "optIntCol", nil, 10) { obj.optIntCol.value = 10 }
+        observeChange(obj, "optFloatCol", nil, 10) { obj.optFloatCol.value = 10 }
+        observeChange(obj, "optDoubleCol", nil, 10) { obj.optDoubleCol.value = 10 }
+        observeChange(obj, "optBoolCol", nil, true) { obj.optBoolCol.value = true }
+        observeChange(obj, "optStringCol", nil, "abc") { obj.optStringCol = "abc" }
+        observeChange(obj, "optBinaryCol", nil, data) { obj.optBinaryCol = data }
+        observeChange(obj, "optDateCol", nil, date) { obj.optDateCol = date }
 
-        observeChange(obj, "optIntCol", 10, NSNull()) { obj.optIntCol.value = nil }
-        observeChange(obj, "optFloatCol", 10, NSNull()) { obj.optFloatCol.value = nil }
-        observeChange(obj, "optDoubleCol", 10, NSNull()) { obj.optDoubleCol.value = nil }
-        observeChange(obj, "optBoolCol", true, NSNull()) { obj.optBoolCol.value = nil }
-        observeChange(obj, "optStringCol", "abc", NSNull()) { obj.optStringCol = nil }
-        observeChange(obj, "optBinaryCol", data, NSNull()) { obj.optBinaryCol = nil }
-        observeChange(obj, "optDateCol", date, NSNull()) { obj.optDateCol = nil }
+        observeChange(obj, "optIntCol", 10, nil) { obj.optIntCol.value = nil }
+        observeChange(obj, "optFloatCol", 10, nil) { obj.optFloatCol.value = nil }
+        observeChange(obj, "optDoubleCol", 10, nil) { obj.optDoubleCol.value = nil }
+        observeChange(obj, "optBoolCol", true, nil) { obj.optBoolCol.value = nil }
+        observeChange(obj, "optStringCol", "abc", nil) { obj.optStringCol = nil }
+        observeChange(obj, "optBinaryCol", data, nil) { obj.optBinaryCol = nil }
+        observeChange(obj, "optDateCol", date, nil) { obj.optDateCol = nil }
 
         observeChange(obj, "invalidated", false, true) {
             self.realm.delete(obj)
@@ -235,7 +239,7 @@ class KVOTests: TestCase {
         observeChange(obs, "floatCol", 5, 10) { obj.floatCol = 10 }
         observeChange(obs, "doubleCol", 6, 10) { obj.doubleCol = 10 }
         observeChange(obs, "stringCol", "", "abc") { obj.stringCol = "abc" }
-        observeChange(obs, "objectCol", NSNull(), obj) { obj.objectCol = obj }
+        observeChange(obs, "objectCol", nil, obj) { obj.objectCol = obj }
 
         let data = "abc".data(using: String.Encoding.utf8, allowLossyConversion: false)!
         observeChange(obs, "binaryCol", NSData(), data) { obj.binaryCol = data }
@@ -250,21 +254,21 @@ class KVOTests: TestCase {
             obj.arrayCol.removeAllObjects()
         }
 
-        observeChange(obs, "optIntCol", NSNull(), 10) { obj.optIntCol.value = 10 }
-        observeChange(obs, "optFloatCol", NSNull(), 10) { obj.optFloatCol.value = 10 }
-        observeChange(obs, "optDoubleCol", NSNull(), 10) { obj.optDoubleCol.value = 10 }
-        observeChange(obs, "optBoolCol", NSNull(), true) { obj.optBoolCol.value = true }
-        observeChange(obs, "optStringCol", NSNull(), "abc") { obj.optStringCol = "abc" }
-        observeChange(obs, "optBinaryCol", NSNull(), data) { obj.optBinaryCol = data }
-        observeChange(obs, "optDateCol", NSNull(), date) { obj.optDateCol = date }
+        observeChange(obs, "optIntCol", nil, 10) { obj.optIntCol.value = 10 }
+        observeChange(obs, "optFloatCol", nil, 10) { obj.optFloatCol.value = 10 }
+        observeChange(obs, "optDoubleCol", nil, 10) { obj.optDoubleCol.value = 10 }
+        observeChange(obs, "optBoolCol", nil, true) { obj.optBoolCol.value = true }
+        observeChange(obs, "optStringCol", nil, "abc") { obj.optStringCol = "abc" }
+        observeChange(obs, "optBinaryCol", nil, data) { obj.optBinaryCol = data }
+        observeChange(obs, "optDateCol", nil, date) { obj.optDateCol = date }
 
-        observeChange(obs, "optIntCol", 10, NSNull()) { obj.optIntCol.value = nil }
-        observeChange(obs, "optFloatCol", 10, NSNull()) { obj.optFloatCol.value = nil }
-        observeChange(obs, "optDoubleCol", 10, NSNull()) { obj.optDoubleCol.value = nil }
-        observeChange(obs, "optBoolCol", true, NSNull()) { obj.optBoolCol.value = nil }
-        observeChange(obs, "optStringCol", "abc", NSNull()) { obj.optStringCol = nil }
-        observeChange(obs, "optBinaryCol", data, NSNull()) { obj.optBinaryCol = nil }
-        observeChange(obs, "optDateCol", date, NSNull()) { obj.optDateCol = nil }
+        observeChange(obs, "optIntCol", 10, nil) { obj.optIntCol.value = nil }
+        observeChange(obs, "optFloatCol", 10, nil) { obj.optFloatCol.value = nil }
+        observeChange(obs, "optDoubleCol", 10, nil) { obj.optDoubleCol.value = nil }
+        observeChange(obs, "optBoolCol", true, nil) { obj.optBoolCol.value = nil }
+        observeChange(obs, "optStringCol", "abc", nil) { obj.optStringCol = nil }
+        observeChange(obs, "optBinaryCol", data, nil) { obj.optBinaryCol = nil }
+        observeChange(obs, "optDateCol", date, nil) { obj.optDateCol = nil }
 
         observeChange(obs, "invalidated", false, true) {
             self.realm.delete(obj)

--- a/RealmSwift/Tests/KVOTests.swift
+++ b/RealmSwift/Tests/KVOTests.swift
@@ -281,7 +281,7 @@ class KVOTests: TestCase {
     func testReadSharedSchemaFromObservedObject() {
         let obj = KVOObject()
         obj.addObserver(self, forKeyPath: "boolCol", options: [.old, .new], context: nil)
-        XCTAssertEqual(obj.dynamicType.sharedSchema(), KVOObject.sharedSchema())
+        XCTAssertEqual(type(of: obj).sharedSchema(), KVOObject.sharedSchema())
         obj.removeObserver(self, forKeyPath: "boolCol")
     }
 }

--- a/RealmSwift/Tests/KVOTests.swift
+++ b/RealmSwift/Tests/KVOTests.swift
@@ -229,7 +229,7 @@ class KVOTests: TestCase {
     func testAllPropertyTypesMultipleAccessors() {
         let obj = KVOObject()
         realm.add(obj)
-        let obs = realm.object(ofType: KVOObject.self, forPrimaryKey: obj.pk as AnyObject)!
+        let obs = realm.object(ofType: KVOObject.self, forPrimaryKey: obj.pk)!
 
         observeChange(obs, "boolCol", false, true) { obj.boolCol = true }
         observeChange(obs, "int8Col", 1, 10) { obj.int8Col = 10 }
@@ -276,7 +276,7 @@ class KVOTests: TestCase {
 
         let obj2 = KVOObject()
         realm.add(obj2)
-        let obs2 = realm.object(ofType: KVOObject.self, forPrimaryKey: obj2.pk as AnyObject)!
+        let obs2 = realm.object(ofType: KVOObject.self, forPrimaryKey: obj2.pk)!
         observeChange(obs2, "arrayCol.invalidated", false, true) {
             self.realm.delete(obj2)
         }

--- a/RealmSwift/Tests/MigrationTests.swift
+++ b/RealmSwift/Tests/MigrationTests.swift
@@ -375,8 +375,8 @@ class MigrationTests: TestCase {
                 XCTAssertEqual((newObj!["doubleCol"] as! Double), 12.3 as Double)
 
                 let binaryCol = "a".data(using: String.Encoding.utf8)!
-                XCTAssertEqual((oldObj!["binaryCol"] as! NSData), binaryCol)
-                XCTAssertEqual((newObj!["binaryCol"] as! NSData), binaryCol)
+                XCTAssertEqual((oldObj!["binaryCol"] as! NSData), binaryCol as NSData)
+                XCTAssertEqual((newObj!["binaryCol"] as! NSData), binaryCol as NSData)
 
                 let dateCol = NSDate(timeIntervalSince1970: 1)
                 XCTAssertEqual((oldObj!["dateCol"] as! NSDate), dateCol)

--- a/RealmSwift/Tests/MigrationTests.swift
+++ b/RealmSwift/Tests/MigrationTests.swift
@@ -63,7 +63,7 @@ class MigrationTests: TestCase {
         let config = Realm.Configuration(fileURL: fileURL, schemaVersion: schemaVersion,
             migrationBlock: { migration, oldSchemaVersion in
                 if let block = block {
-                    block(migration: migration, oldSchemaVersion: oldSchemaVersion)
+                    block(/* migration: */ migration, /* oldSchemaVersion: */ oldSchemaVersion)
                 }
                 didRun = true
                 return

--- a/RealmSwift/Tests/MigrationTests.swift
+++ b/RealmSwift/Tests/MigrationTests.swift
@@ -63,7 +63,7 @@ class MigrationTests: TestCase {
         let config = Realm.Configuration(fileURL: fileURL, schemaVersion: schemaVersion,
             migrationBlock: { migration, oldSchemaVersion in
                 if let block = block {
-                    block(/* migration: */ migration, /* oldSchemaVersion: */ oldSchemaVersion)
+                    block(migration, oldSchemaVersion)
                 }
                 didRun = true
                 return

--- a/RealmSwift/Tests/ObjectAccessorTests.swift
+++ b/RealmSwift/Tests/ObjectAccessorTests.swift
@@ -56,7 +56,7 @@ class ObjectAccessorTests: TestCase {
         object.stringCol = utf8TestString
         XCTAssertEqual(object.stringCol, utf8TestString)
 
-        let data = "b".data(using: String.Encoding.utf8, allowLossyConversion: false)!
+        let data = "b".data(using: String.Encoding.utf8, allowLossyConversion: false)! as Data as NSData
         object.binaryCol = data
         XCTAssertEqual(object.binaryCol, data)
 
@@ -244,7 +244,7 @@ class ObjectAccessorTests: TestCase {
         object.optStringCol = nil
         XCTAssertNil(object.optStringCol)
 
-        let data = "b".data(using: String.Encoding.utf8, allowLossyConversion: false)!
+        let data = "b".data(using: String.Encoding.utf8, allowLossyConversion: false)! as Data as NSData
         object.optBinaryCol = data
         XCTAssertEqual(object.optBinaryCol!, data)
         object.optBinaryCol = nil

--- a/RealmSwift/Tests/ObjectAccessorTests.swift
+++ b/RealmSwift/Tests/ObjectAccessorTests.swift
@@ -60,7 +60,7 @@ class ObjectAccessorTests: TestCase {
         object.binaryCol = data
         XCTAssertEqual(object.binaryCol, data)
 
-        let date = NSDate(timeIntervalSinceReferenceDate: 2) as NSDate
+        let date = NSDate(timeIntervalSinceReferenceDate: 2)
         object.dateCol = date
         XCTAssertEqual(object.dateCol, date)
 
@@ -250,7 +250,7 @@ class ObjectAccessorTests: TestCase {
         object.optBinaryCol = nil
         XCTAssertNil(object.optBinaryCol)
 
-        let date = NSDate(timeIntervalSinceReferenceDate: 2) as NSDate
+        let date = NSDate(timeIntervalSinceReferenceDate: 2)
         object.optDateCol = date
         XCTAssertEqual(object.optDateCol!, date)
         object.optDateCol = nil
@@ -373,7 +373,7 @@ class ObjectAccessorTests: TestCase {
         object.binaryCol = data
         XCTAssertEqual(object.binaryCol, data)
 
-        let date = NSDate(timeIntervalSinceReferenceDate: 2) as NSDate
+        let date = NSDate(timeIntervalSinceReferenceDate: 2)
         object.dateCol = date
         XCTAssertEqual(object.dateCol, date)
 
@@ -563,7 +563,7 @@ class ObjectAccessorTests: TestCase {
         object.optBinaryCol = nil
         XCTAssertNil(object.optBinaryCol)
 
-        let date = NSDate(timeIntervalSinceReferenceDate: 2) as NSDate
+        let date = NSDate(timeIntervalSinceReferenceDate: 2)
         object.optDateCol = date
         XCTAssertEqual(object.optDateCol!, date)
         object.optDateCol = nil

--- a/RealmSwift/Tests/ObjectCreationTests.swift
+++ b/RealmSwift/Tests/ObjectCreationTests.swift
@@ -107,7 +107,7 @@ class ObjectCreationTests: TestCase {
 
     func testInitWithArray() {
         // array with all values specified
-        let baselineValues: [Any] = [true, 1, 1.1, 11.1, "b", "b".data(using: String.Encoding.utf8)!,
+        let baselineValues: [Any] = [true, 1, 1.1 as Float, 11.1, "b", "b".data(using: String.Encoding.utf8)!,
             NSDate(timeIntervalSince1970: 2) as NSDate, ["boolCol": true], [[true], [false]]]
 
         // test with valid dictionary literals
@@ -210,7 +210,7 @@ class ObjectCreationTests: TestCase {
         let baselineValues: [String: Any] = [
             "boolCol": true,
             "intCol": 1,
-            "floatCol": 1.1,
+            "floatCol": 1.1 as Float,
             "doubleCol": 11.1,
             "stringCol": "b",
             "binaryCol": "b".data(using: String.Encoding.utf8)!,
@@ -263,7 +263,7 @@ class ObjectCreationTests: TestCase {
 
     func testCreateWithArray() {
         // array with all values specified
-        let baselineValues: [Any] = [true, 1, 1.1, 11.1, "b", "b".data(using: String.Encoding.utf8)!,
+        let baselineValues: [Any] = [true, 1, 1.1 as Float, 11.1, "b", "b".data(using: String.Encoding.utf8)!,
             NSDate(timeIntervalSince1970: 2) as NSDate, ["boolCol": true], [[true], [false]]]
 
         // test with valid dictionary literals

--- a/RealmSwift/Tests/ObjectCreationTests.swift
+++ b/RealmSwift/Tests/ObjectCreationTests.swift
@@ -61,7 +61,7 @@ class ObjectCreationTests: TestCase {
 
     func testInitWithDictionary() {
         // dictionary with all values specified
-        let baselineValues =
+        let baselineValues: [String: Any] =
            ["boolCol": true as NSNumber,
             "intCol": 1 as NSNumber,
             "floatCol": 1.1 as NSNumber,
@@ -107,8 +107,8 @@ class ObjectCreationTests: TestCase {
 
     func testInitWithArray() {
         // array with all values specified
-        let baselineValues = [true, 1, 1.1, 11.1, "b", "b".data(using: String.Encoding.utf8)!,
-            NSDate(timeIntervalSince1970: 2) as NSDate, ["boolCol": true], [[true], [false]]] as [AnyObject]
+        let baselineValues: [Any] = [true, 1, 1.1, 11.1, "b", "b".data(using: String.Encoding.utf8)!,
+            NSDate(timeIntervalSince1970: 2) as NSDate, ["boolCol": true], [[true], [false]]]
 
         // test with valid dictionary literals
         let props = try! Realm().schema["SwiftObject"]!.properties
@@ -207,7 +207,7 @@ class ObjectCreationTests: TestCase {
 
     func testCreateWithDictionary() {
         // dictionary with all values specified
-        let baselineValues: [String: AnyObject] = [
+        let baselineValues: [String: Any] = [
             "boolCol": true,
             "intCol": 1,
             "floatCol": 1.1,
@@ -263,8 +263,8 @@ class ObjectCreationTests: TestCase {
 
     func testCreateWithArray() {
         // array with all values specified
-        let baselineValues = [true, 1, 1.1, 11.1, "b", "b".data(using: String.Encoding.utf8)!,
-            NSDate(timeIntervalSince1970: 2) as NSDate, ["boolCol": true], [[true], [false]]] as [AnyObject]
+        let baselineValues: [Any] = [true, 1, 1.1, 11.1, "b", "b".data(using: String.Encoding.utf8)!,
+            NSDate(timeIntervalSince1970: 2) as NSDate, ["boolCol": true], [[true], [false]]]
 
         // test with valid dictionary literals
         let props = try! Realm().schema["SwiftObject"]!.properties
@@ -353,7 +353,7 @@ class ObjectCreationTests: TestCase {
     }
 
     func testCreateWithObjectsFromAnotherRealm() {
-        let values = [
+        let values: [String: Any] = [
             "boolCol": true as NSNumber,
             "intCol": 1 as NSNumber,
             "floatCol": 1.1 as NSNumber,
@@ -379,7 +379,7 @@ class ObjectCreationTests: TestCase {
     }
 
     func testCreateWithDeeplyNestedObjectsFromAnotherRealm() {
-        let values = [
+        let values: [String: Any] = [
             "boolCol": true as NSNumber,
             "intCol": 1 as NSNumber,
             "floatCol": 1.1 as NSNumber,
@@ -430,7 +430,7 @@ class ObjectCreationTests: TestCase {
     }
 
     func testCreateWithNSNullLinks() {
-        let values = [
+        let values: [String: Any] = [
             "boolCol": true as NSNumber,
             "intCol": 1 as NSNumber,
             "floatCol": 1.1 as NSNumber,

--- a/RealmSwift/Tests/ObjectCreationTests.swift
+++ b/RealmSwift/Tests/ObjectCreationTests.swift
@@ -485,7 +485,7 @@ class ObjectCreationTests: TestCase {
     }
 
     // MARK: Private utilities
-    private func verifySwiftObjectWithArrayLiteral(_ object: SwiftObject, array: [AnyObject], boolObjectValue: Bool,
+    private func verifySwiftObjectWithArrayLiteral(_ object: SwiftObject, array: [Any], boolObjectValue: Bool,
                                                    boolObjectListValues: [Bool]) {
         XCTAssertEqual(object.boolCol, (array[0] as! Bool))
         XCTAssertEqual(object.intCol, (array[1] as! Int))
@@ -501,7 +501,7 @@ class ObjectCreationTests: TestCase {
         }
     }
 
-    private func verifySwiftObjectWithDictionaryLiteral(_ object: SwiftObject, dictionary: [String:AnyObject],
+    private func verifySwiftObjectWithDictionaryLiteral(_ object: SwiftObject, dictionary: [String: Any],
                                                         boolObjectValue: Bool, boolObjectListValues: [Bool]) {
         XCTAssertEqual(object.boolCol, (dictionary["boolCol"] as! Bool))
         XCTAssertEqual(object.intCol, (dictionary["intCol"] as! Int))
@@ -518,7 +518,7 @@ class ObjectCreationTests: TestCase {
     }
 
     private func verifySwiftOptionalObjectWithDictionaryLiteral(_ object: SwiftOptionalDefaultValuesObject,
-                                                                dictionary: [String:AnyObject],
+                                                                dictionary: [String: Any],
                                                                 boolObjectValue: Bool?) {
         XCTAssertEqual(object.optBoolCol.value, (dictionary["optBoolCol"] as! Bool?))
         XCTAssertEqual(object.optIntCol.value, (dictionary["optIntCol"] as! Int?))
@@ -538,7 +538,7 @@ class ObjectCreationTests: TestCase {
         XCTAssertEqual(object.optObjectCol?.boolCol, boolObjectValue)
     }
 
-    private func defaultSwiftObjectValuesWithReplacements(_ replace: [String: AnyObject]) -> [String: AnyObject] {
+    private func defaultSwiftObjectValuesWithReplacements(_ replace: [String: Any]) -> [String: Any] {
         var valueDict = SwiftObject.defaultValues()
         for (key, value) in replace {
             valueDict[key] = value
@@ -548,7 +548,7 @@ class ObjectCreationTests: TestCase {
 
     // return an array of valid values that can be used to initialize each type
     // swiftlint:disable:next cyclomatic_complexity
-    private func validValuesForSwiftObjectType(_ type: PropertyType) -> [AnyObject] {
+    private func validValuesForSwiftObjectType(_ type: PropertyType) -> [Any] {
         try! Realm().beginWrite()
         let persistedObject = try! Realm().createObject(ofType: SwiftBoolObject.self, populatedWith: [true])
         try! Realm().commitWrite()
@@ -574,7 +574,7 @@ class ObjectCreationTests: TestCase {
     }
 
     // swiftlint:disable:next cyclomatic_complexity
-    private func invalidValuesForSwiftObjectType(_ type: PropertyType) -> [AnyObject] {
+    private func invalidValuesForSwiftObjectType(_ type: PropertyType) -> [Any] {
         try! Realm().beginWrite()
         let persistedObject = try! Realm().createObject(ofType: SwiftIntObject.self)
         try! Realm().commitWrite()

--- a/RealmSwift/Tests/ObjectCreationTests.swift
+++ b/RealmSwift/Tests/ObjectCreationTests.swift
@@ -558,7 +558,7 @@ class ObjectCreationTests: TestCase {
             case .float:    return [NSNumber(value: 1 as Int), NSNumber(value: 1.1 as Float), NSNumber(value: 11.1 as Double)]
             case .double:   return [NSNumber(value: 1 as Int), NSNumber(value: 1.1 as Float), NSNumber(value: 11.1 as Double)]
             case .string:   return ["b"]
-            case .data:     return ["b".data(using: String.Encoding.utf8, allowLossyConversion: false)!]
+            case .data:     return ["b".data(using: String.Encoding.utf8, allowLossyConversion: false)! as Data as NSData]
             case .date:     return [NSDate(timeIntervalSince1970: 2) as AnyObject]
             case .object:   return [[true], ["boolCol": true], SwiftBoolObject(value: [true]), persistedObject]
             case .array:    return [

--- a/RealmSwift/Tests/ObjectCreationTests.swift
+++ b/RealmSwift/Tests/ObjectCreationTests.swift
@@ -62,15 +62,15 @@ class ObjectCreationTests: TestCase {
     func testInitWithDictionary() {
         // dictionary with all values specified
         let baselineValues: [String: Any] =
-           ["boolCol": true as NSNumber,
-            "intCol": 1 as NSNumber,
-            "floatCol": 1.1 as NSNumber,
-            "doubleCol": 11.1 as NSNumber,
-            "stringCol": "b" as NSString,
+           ["boolCol": true,
+            "intCol": 1,
+            "floatCol": 1.1 as Float,
+            "doubleCol": 11.1,
+            "stringCol": "b",
             "binaryCol": "b".data(using: String.Encoding.utf8)!,
-            "dateCol": NSDate(timeIntervalSince1970: 2) as NSDate,
-            "objectCol": SwiftBoolObject(value: [true]) as AnyObject,
-            "arrayCol": [SwiftBoolObject(value: [true]), SwiftBoolObject()]  as AnyObject
+            "dateCol": NSDate(timeIntervalSince1970: 2),
+            "objectCol": SwiftBoolObject(value: [true]),
+            "arrayCol": [SwiftBoolObject(value: [true]), SwiftBoolObject()]
            ]
 
         // test with valid dictionary literals
@@ -80,7 +80,7 @@ class ObjectCreationTests: TestCase {
                 // update dict with valid value and init
                 var values = baselineValues
                 values[props[propNum].name] = validValue
-                let object = SwiftObject(value: values as AnyObject)
+                let object = SwiftObject(value: values)
                 verifySwiftObjectWithDictionaryLiteral(object, dictionary: values, boolObjectValue: true,
                     boolObjectListValues: [true, false])
             }
@@ -92,7 +92,7 @@ class ObjectCreationTests: TestCase {
                 // update dict with invalid value and init
                 var values = baselineValues
                 values[props[propNum].name] = invalidValue
-                assertThrows(SwiftObject(value: values as AnyObject), "Invalid property value")
+                assertThrows(SwiftObject(value: values), "Invalid property value")
             }
         }
     }
@@ -108,7 +108,7 @@ class ObjectCreationTests: TestCase {
     func testInitWithArray() {
         // array with all values specified
         let baselineValues: [Any] = [true, 1, 1.1 as Float, 11.1, "b", "b".data(using: String.Encoding.utf8)!,
-            NSDate(timeIntervalSince1970: 2) as NSDate, ["boolCol": true], [[true], [false]]]
+            NSDate(timeIntervalSince1970: 2), ["boolCol": true], [[true], [false]]]
 
         // test with valid dictionary literals
         let props = try! Realm().schema["SwiftObject"]!.properties
@@ -117,7 +117,7 @@ class ObjectCreationTests: TestCase {
                 // update dict with valid value and init
                 var values = baselineValues
                 values[propNum] = validValue
-                let object = SwiftObject(value: values as AnyObject)
+                let object = SwiftObject(value: values)
                 verifySwiftObjectWithArrayLiteral(object, array: values, boolObjectValue: true,
                     boolObjectListValues: [true, false])
             }
@@ -129,7 +129,7 @@ class ObjectCreationTests: TestCase {
                 // update dict with invalid value and init
                 var values = baselineValues
                 values[propNum] = invalidValue
-                assertThrows(SwiftObject(value: values as AnyObject), "Invalid property value")
+                assertThrows(SwiftObject(value: values), "Invalid property value")
             }
         }
     }
@@ -227,7 +227,7 @@ class ObjectCreationTests: TestCase {
                 var values = baselineValues
                 values[props[propNum].name] = validValue
                 try! Realm().beginWrite()
-                let object = try! Realm().createObject(ofType: SwiftObject.self, populatedWith: values as AnyObject)
+                let object = try! Realm().createObject(ofType: SwiftObject.self, populatedWith: values)
                 verifySwiftObjectWithDictionaryLiteral(object, dictionary: values, boolObjectValue: true,
                     boolObjectListValues: [true, false])
                 try! Realm().commitWrite()
@@ -243,7 +243,7 @@ class ObjectCreationTests: TestCase {
                 var values = baselineValues
                 values[props[propNum].name] = invalidValue
                 try! Realm().beginWrite()
-                assertThrows(try! Realm().createObject(ofType: SwiftObject.self, populatedWith: values as AnyObject), "Invalid property value")
+                assertThrows(try! Realm().createObject(ofType: SwiftObject.self, populatedWith: values), "Invalid property value")
                 try! Realm().cancelWrite()
             }
         }
@@ -264,7 +264,7 @@ class ObjectCreationTests: TestCase {
     func testCreateWithArray() {
         // array with all values specified
         let baselineValues: [Any] = [true, 1, 1.1 as Float, 11.1, "b", "b".data(using: String.Encoding.utf8)!,
-            NSDate(timeIntervalSince1970: 2) as NSDate, ["boolCol": true], [[true], [false]]]
+            NSDate(timeIntervalSince1970: 2), ["boolCol": true], [[true], [false]]]
 
         // test with valid dictionary literals
         let props = try! Realm().schema["SwiftObject"]!.properties
@@ -274,7 +274,7 @@ class ObjectCreationTests: TestCase {
                 var values = baselineValues
                 values[propNum] = validValue
                 try! Realm().beginWrite()
-                let object = try! Realm().createObject(ofType: SwiftObject.self, populatedWith: values as AnyObject)
+                let object = try! Realm().createObject(ofType: SwiftObject.self, populatedWith: values)
                 verifySwiftObjectWithArrayLiteral(object, array: values, boolObjectValue: true,
                     boolObjectListValues: [true, false])
                 try! Realm().commitWrite()
@@ -291,7 +291,7 @@ class ObjectCreationTests: TestCase {
                 values[propNum] = invalidValue
 
                 try! Realm().beginWrite()
-                assertThrows(try! Realm().createObject(ofType: SwiftObject.self, populatedWith: values as AnyObject),
+                assertThrows(try! Realm().createObject(ofType: SwiftObject.self, populatedWith: values),
                     "Invalid property value '\(invalidValue)' for property number \(propNum)")
                 try! Realm().cancelWrite()
             }
@@ -354,19 +354,19 @@ class ObjectCreationTests: TestCase {
 
     func testCreateWithObjectsFromAnotherRealm() {
         let values: [String: Any] = [
-            "boolCol": true as NSNumber,
-            "intCol": 1 as NSNumber,
-            "floatCol": 1.1 as NSNumber,
-            "doubleCol": 11.1 as NSNumber,
-            "stringCol": "b" as NSString,
+            "boolCol": true,
+            "intCol": 1,
+            "floatCol": 1.1 as Float,
+            "doubleCol": 11.1,
+            "stringCol": "b",
             "binaryCol": "b".data(using: String.Encoding.utf8)!,
-            "dateCol": NSDate(timeIntervalSince1970: 2) as NSDate,
-            "objectCol": SwiftBoolObject(value: [true]) as AnyObject,
-            "arrayCol": [SwiftBoolObject(value: [true]), SwiftBoolObject()] as AnyObject,
+            "dateCol": NSDate(timeIntervalSince1970: 2),
+            "objectCol": SwiftBoolObject(value: [true]),
+            "arrayCol": [SwiftBoolObject(value: [true]), SwiftBoolObject()],
         ]
 
         realmWithTestPath().beginWrite()
-        let otherRealmObject = realmWithTestPath().createObject(ofType: SwiftObject.self, populatedWith: values as AnyObject)
+        let otherRealmObject = realmWithTestPath().createObject(ofType: SwiftObject.self, populatedWith: values)
         try! realmWithTestPath().commitWrite()
 
         try! Realm().beginWrite()
@@ -380,15 +380,15 @@ class ObjectCreationTests: TestCase {
 
     func testCreateWithDeeplyNestedObjectsFromAnotherRealm() {
         let values: [String: Any] = [
-            "boolCol": true as NSNumber,
-            "intCol": 1 as NSNumber,
-            "floatCol": 1.1 as NSNumber,
-            "doubleCol": 11.1 as NSNumber,
-            "stringCol": "b" as NSString,
+            "boolCol": true,
+            "intCol": 1,
+            "floatCol": 1.1 as Float,
+            "doubleCol": 11.1,
+            "stringCol": "b",
             "binaryCol": "b".data(using: String.Encoding.utf8)!,
-            "dateCol": NSDate(timeIntervalSince1970: 2) as NSDate,
-            "objectCol": SwiftBoolObject(value: [true]) as AnyObject,
-            "arrayCol": [SwiftBoolObject(value: [true]), SwiftBoolObject()] as AnyObject,
+            "dateCol": NSDate(timeIntervalSince1970: 2),
+            "objectCol": SwiftBoolObject(value: [true]),
+            "arrayCol": [SwiftBoolObject(value: [true]), SwiftBoolObject()],
         ]
 
         let realmA = realmWithTestPath()
@@ -396,8 +396,8 @@ class ObjectCreationTests: TestCase {
 
         var realmAObject: SwiftListOfSwiftObject!
         try! realmA.write {
-            let array = [SwiftObject(value: values as AnyObject), SwiftObject(value: values as AnyObject)]
-            realmAObject = realmA.createObject(ofType: SwiftListOfSwiftObject.self, populatedWith: ["array": array as AnyObject])
+            let array = [SwiftObject(value: values), SwiftObject(value: values)]
+            realmAObject = realmA.createObject(ofType: SwiftListOfSwiftObject.self, populatedWith: ["array": array])
         }
 
         var realmBObject: SwiftListOfSwiftObject!
@@ -431,19 +431,19 @@ class ObjectCreationTests: TestCase {
 
     func testCreateWithNSNullLinks() {
         let values: [String: Any] = [
-            "boolCol": true as NSNumber,
-            "intCol": 1 as NSNumber,
-            "floatCol": 1.1 as NSNumber,
-            "doubleCol": 11.1 as NSNumber,
-            "stringCol": "b" as NSString,
+            "boolCol": true,
+            "intCol": 1,
+            "floatCol": 1.1,
+            "doubleCol": 11.1,
+            "stringCol": "b",
             "binaryCol": "b".data(using: String.Encoding.utf8)!,
-            "dateCol": NSDate(timeIntervalSince1970: 2) as NSDate,
+            "dateCol": NSDate(timeIntervalSince1970: 2),
             "objectCol": NSNull(),
             "arrayCol": NSNull(),
         ]
 
         realmWithTestPath().beginWrite()
-        let object = realmWithTestPath().createObject(ofType: SwiftObject.self, populatedWith: values as AnyObject)
+        let object = realmWithTestPath().createObject(ofType: SwiftObject.self, populatedWith: values)
         try! realmWithTestPath().commitWrite()
 
         XCTAssert(object.objectCol == nil) // XCTAssertNil caused a NULL deref inside _swift_getClass
@@ -559,7 +559,7 @@ class ObjectCreationTests: TestCase {
             case .double:   return [NSNumber(value: 1 as Int), NSNumber(value: 1.1 as Float), NSNumber(value: 11.1 as Double)]
             case .string:   return ["b"]
             case .data:     return ["b".data(using: String.Encoding.utf8, allowLossyConversion: false)! as Data as NSData]
-            case .date:     return [NSDate(timeIntervalSince1970: 2) as AnyObject]
+            case .date:     return [NSDate(timeIntervalSince1970: 2)]
             case .object:   return [[true], ["boolCol": true], SwiftBoolObject(value: [true]), persistedObject]
             case .array:    return [
                 [[true], [false]],

--- a/RealmSwift/Tests/ObjectSchemaInitializationTests.swift
+++ b/RealmSwift/Tests/ObjectSchemaInitializationTests.swift
@@ -176,7 +176,7 @@ class ObjectSchemaInitializationTests: TestCase {
 
         let unindexibleSchema = RLMObjectSchema(forObjectClass: SwiftObjectWithUnindexibleProperties.self)
         for propName in SwiftObjectWithUnindexibleProperties.indexedProperties() {
-            XCTAssertFalse(unindexibleSchema[propName as NSString]!.indexed,
+            XCTAssertFalse(unindexibleSchema[propName]!.indexed,
                 "Shouldn't mark unindexible property '\(propName)' as indexed")
         }
     }

--- a/RealmSwift/Tests/ObjectTests.swift
+++ b/RealmSwift/Tests/ObjectTests.swift
@@ -198,7 +198,7 @@ class ObjectTests: TestCase {
         setter(object, "z", "stringCol")
         XCTAssertEqual(getter(object, "stringCol") as! String!, "z")
 
-        setter(object, "z".data(using: String.Encoding.utf8), "binaryCol")
+        setter(object, "z".data(using: String.Encoding.utf8)! as Data as NSData, "binaryCol")
         let gotData = (getter(object, "binaryCol") as! NSData) as Data
         XCTAssertTrue(gotData == "z".data(using: String.Encoding.utf8)!)
 
@@ -243,7 +243,7 @@ class ObjectTests: TestCase {
         setter(object, "z", "stringCol")
         XCTAssertEqual((getter(object, "stringCol") as! String), "z")
 
-        setter(object, "z".data(using: String.Encoding.utf8), "binaryCol")
+        setter(object, "z".data(using: String.Encoding.utf8)! as Data as NSData, "binaryCol")
         let gotData = (getter(object, "binaryCol") as! NSData) as Data
         XCTAssertTrue(gotData == "z".data(using: String.Encoding.utf8)!)
 

--- a/RealmSwift/Tests/ObjectTests.swift
+++ b/RealmSwift/Tests/ObjectTests.swift
@@ -181,8 +181,8 @@ class ObjectTests: TestCase {
         }
     }
 
-    func setAndTestAllTypes(_ setter: (SwiftObject, AnyObject?, String) -> (),
-                            getter: (SwiftObject, String) -> (AnyObject?), object: SwiftObject) {
+    func setAndTestAllTypes(_ setter: (SwiftObject, Any?, String) -> (),
+                            getter: (SwiftObject, String) -> (Any?), object: SwiftObject) {
         setter(object, true, "boolCol")
         XCTAssertEqual(getter(object, "boolCol") as! Bool!, true)
 
@@ -225,8 +225,8 @@ class ObjectTests: TestCase {
         XCTAssertEqual((getter(object, "arrayCol") as! List<SwiftBoolObject>).first!, boolObject)
     }
 
-    func dynamicSetAndTestAllTypes(_ setter: (DynamicObject, AnyObject?, String) -> (),
-                                   getter: (DynamicObject, String) -> (AnyObject?), object: DynamicObject,
+    func dynamicSetAndTestAllTypes(_ setter: (DynamicObject, Any?, String) -> (),
+                                   getter: (DynamicObject, String) -> (Any?), object: DynamicObject,
                                    boolObject: DynamicObject) {
         setter(object, true, "boolCol")
         XCTAssertEqual((getter(object, "boolCol") as! Bool), true)
@@ -292,11 +292,11 @@ class ObjectTests: TestCase {
     }
 
     func testSetValueForKey() {
-        let setter: (Object, AnyObject?, String) -> () = { object, value, key in
+        let setter: (Object, Any?, String) -> () = { object, value, key in
             object.setValue(value, forKey: key)
             return
         }
-        let getter: (Object, String) -> (AnyObject?) = { object, key in
+        let getter: (Object, String) -> (Any?) = { object, key in
             object.value(forKey: key)
         }
 
@@ -313,11 +313,11 @@ class ObjectTests: TestCase {
     }
 
     func testSubscript() {
-        let setter: (Object, AnyObject?, String) -> () = { object, value, key in
+        let setter: (Object, Any?, String) -> () = { object, value, key in
             object[key] = value
             return
         }
-        let getter: (Object, String) -> (AnyObject?) = { object, key in
+        let getter: (Object, String) -> (Any?) = { object, key in
             object[key]
         }
 

--- a/RealmSwift/Tests/ObjectTests.swift
+++ b/RealmSwift/Tests/ObjectTests.swift
@@ -252,7 +252,7 @@ class ObjectTests: TestCase {
 
         setter(object, boolObject, "objectCol")
         XCTAssertEqual((getter(object, "objectCol") as! DynamicObject), boolObject)
-        XCTAssertEqual(((getter(object, "objectCol") as! DynamicObject)["boolCol"] as! NSNumber), true as NSNumber)
+        XCTAssertEqual(((getter(object, "objectCol") as! DynamicObject)["boolCol"] as! Bool), true)
 
         setter(object, [boolObject], "arrayCol")
         XCTAssertEqual((getter(object, "arrayCol") as! List<DynamicObject>).count, 1)

--- a/RealmSwift/Tests/ObjectTests.swift
+++ b/RealmSwift/Tests/ObjectTests.swift
@@ -71,12 +71,12 @@ class ObjectTests: TestCase {
 
     func testSharedSchemaUnmanaged() {
         let object = SwiftObject()
-        XCTAssertEqual(object.dynamicType.sharedSchema(), SwiftObject.sharedSchema())
+        XCTAssertEqual(type(of: object).sharedSchema(), SwiftObject.sharedSchema())
     }
 
     func testSharedSchemaManaged() {
         let object = SwiftObject()
-        XCTAssertEqual(object.dynamicType.sharedSchema(), SwiftObject.sharedSchema())
+        XCTAssertEqual(type(of: object).sharedSchema(), SwiftObject.sharedSchema())
     }
 
     func testInvalidated() {

--- a/RealmSwift/Tests/PerformanceTests.swift
+++ b/RealmSwift/Tests/PerformanceTests.swift
@@ -76,7 +76,7 @@ class SwiftPerformanceTests: TestCase {
         }
     }
 
-    override func measureMetrics(_ metrics: [String], automaticallyStartMeasuring: Bool, for block: () -> Void) {
+    override func measureMetrics(_ metrics: [String], automaticallyStartMeasuring: Bool, for block: @escaping () -> Void) {
         super.measureMetrics(metrics, automaticallyStartMeasuring: automaticallyStartMeasuring) {
             autoreleasepool {
                 block()
@@ -84,7 +84,7 @@ class SwiftPerformanceTests: TestCase {
         }
     }
 
-    func inMeasureBlock(block: () -> ()) {
+    func inMeasureBlock(block: @escaping () -> ()) {
         measureMetrics(type(of: self).defaultPerformanceMetrics(), automaticallyStartMeasuring: false) {
             _ = block()
         }

--- a/RealmSwift/Tests/PerformanceTests.swift
+++ b/RealmSwift/Tests/PerformanceTests.swift
@@ -285,12 +285,12 @@ class SwiftPerformanceTests: TestCase {
         let realm = realmWithTestPath()
         try! realm.write {
             for i in 0..<1000 {
-                realm.createObject(ofType: SwiftStringObject.self, populatedWith: [i.description] as AnyObject)
+                realm.createObject(ofType: SwiftStringObject.self, populatedWith: [i.description])
             }
         }
         measure {
             for i in 0..<1000 {
-                _ = realm.allObjects(ofType: SwiftStringObject.self).filter(using: "stringCol = %@", i.description as AnyObject).first
+                _ = realm.allObjects(ofType: SwiftStringObject.self).filter(using: "stringCol = %@", i.description).first
             }
         }
     }
@@ -299,12 +299,12 @@ class SwiftPerformanceTests: TestCase {
         let realm = realmWithTestPath()
         try! realm.write {
             for i in 0..<1000 {
-                realm.createObject(ofType: SwiftIndexedPropertiesObject.self, populatedWith: [i.description as AnyObject, i as AnyObject])
+                realm.createObject(ofType: SwiftIndexedPropertiesObject.self, populatedWith: [i.description, i])
             }
         }
         measure {
             for i in 0..<1000 {
-                _ = realm.allObjects(ofType: SwiftIndexedPropertiesObject.self).filter(using: "stringCol = %@", i.description as AnyObject).first
+                _ = realm.allObjects(ofType: SwiftIndexedPropertiesObject.self).filter(using: "stringCol = %@", i.description).first
             }
         }
     }
@@ -314,14 +314,14 @@ class SwiftPerformanceTests: TestCase {
         realm.beginWrite()
         var ids = [Int]()
         for i in 0..<10000 {
-            realm.createObject(ofType: SwiftIntObject.self, populatedWith: [i as AnyObject])
+            realm.createObject(ofType: SwiftIntObject.self, populatedWith: [i])
             if i % 2 != 0 {
                 ids.append(i)
             }
         }
         try! realm.commitWrite()
         measure {
-            _ = realm.allObjects(ofType: SwiftIntObject.self).filter(using: "intCol IN %@", ids as AnyObject).first
+            _ = realm.allObjects(ofType: SwiftIntObject.self).filter(using: "intCol IN %@", ids).first
         }
     }
 
@@ -330,7 +330,7 @@ class SwiftPerformanceTests: TestCase {
         try! realm.write {
             for _ in 0..<8000 {
                 let randomNumber = Int(arc4random_uniform(UInt32(INT_MAX)))
-                realm.createObject(ofType: SwiftIntObject.self, populatedWith: [randomNumber as AnyObject])
+                realm.createObject(ofType: SwiftIntObject.self, populatedWith: [randomNumber])
             }
         }
         measure {

--- a/RealmSwift/Tests/PerformanceTests.swift
+++ b/RealmSwift/Tests/PerformanceTests.swift
@@ -85,7 +85,7 @@ class SwiftPerformanceTests: TestCase {
     }
 
     func inMeasureBlock(block: () -> ()) {
-        measureMetrics(self.dynamicType.defaultPerformanceMetrics(), automaticallyStartMeasuring: false) {
+        measureMetrics(type(of: self).defaultPerformanceMetrics(), automaticallyStartMeasuring: false) {
             _ = block()
         }
     }

--- a/RealmSwift/Tests/RealmCollectionTypeTests.swift
+++ b/RealmSwift/Tests/RealmCollectionTypeTests.swift
@@ -577,8 +577,8 @@ class ResultsTests: RealmCollectionTypeTests {
                 XCTAssertEqual(insertions, [2])
                 XCTAssertEqual(modifications, [])
                 break
-            case .Error(let err):
-                XCTFail(err.description)
+            case .Error(let error):
+                XCTFail(String(describing: error))
                 break
             }
 

--- a/RealmSwift/Tests/RealmCollectionTypeTests.swift
+++ b/RealmSwift/Tests/RealmCollectionTypeTests.swift
@@ -739,7 +739,7 @@ class ListStandaloneRealmCollectionTypeTests: ListRealmCollectionTypeTests {
     }
 
     override func getAggregateableCollection() -> AnyRealmCollection<CTTAggregateObject> {
-        return AnyRealmCollection(CTTAggregateObjectList(value: [makeAggregateableObjects() as AnyObject]).list)
+        return AnyRealmCollection(CTTAggregateObjectList(value: [makeAggregateableObjects()]).list)
     }
 
     override func testRealm() {
@@ -897,7 +897,7 @@ class ListNewlyAddedRealmCollectionTypeTests: ListRealmCollectionTypeTests {
         guard let str1 = str1, let str2 = str2 else {
             fatalError("Test precondition failure - a property was unexpectedly nil")
         }
-        let array = CTTStringList(value: [[str1, str2] as AnyObject])
+        let array = CTTStringList(value: [[str1, str2]])
         realmWithTestPath().add(array)
         return array.array
     }
@@ -905,7 +905,7 @@ class ListNewlyAddedRealmCollectionTypeTests: ListRealmCollectionTypeTests {
     override func getAggregateableCollection() -> AnyRealmCollection<CTTAggregateObject> {
         var list: CTTAggregateObjectList?
         try! realmWithTestPath().write {
-            list = CTTAggregateObjectList(value: [makeAggregateableObjectsInWriteTransaction() as AnyObject])
+            list = CTTAggregateObjectList(value: [makeAggregateableObjectsInWriteTransaction()])
             realmWithTestPath().add(list!)
         }
         return AnyRealmCollection(list!.list)
@@ -917,7 +917,7 @@ class ListNewlyCreatedRealmCollectionTypeTests: ListRealmCollectionTypeTests {
         guard let str1 = str1, let str2 = str2 else {
             fatalError("Test precondition failure - a property was unexpectedly nil")
         }
-        let array = realmWithTestPath().createObject(ofType: CTTStringList.self, populatedWith: [[str1, str2] as AnyObject])
+        let array = realmWithTestPath().createObject(ofType: CTTStringList.self, populatedWith: [[str1, str2]])
         return array.array
     }
 
@@ -936,7 +936,7 @@ class ListRetrievedRealmCollectionTypeTests: ListRealmCollectionTypeTests {
         guard let str1 = str1, let str2 = str2 else {
             fatalError("Test precondition failure - a property was unexpectedly nil")
         }
-        _ = realmWithTestPath().createObject(ofType: CTTStringList.self, populatedWith: [[str1, str2] as AnyObject])
+        _ = realmWithTestPath().createObject(ofType: CTTStringList.self, populatedWith: [[str1, str2]])
         let array = realmWithTestPath().allObjects(ofType: CTTStringList.self).first!
         return array.array
     }

--- a/RealmSwift/Tests/RealmConfigurationTests.swift
+++ b/RealmSwift/Tests/RealmConfigurationTests.swift
@@ -38,7 +38,7 @@ class RealmConfigurationTests: TestCase {
         let fileURL = Realm.Configuration.defaultConfiguration.fileURL
         let configuration = Realm.Configuration(fileURL: URL(fileURLWithPath: "/dev/null"))
         Realm.Configuration.defaultConfiguration = configuration
-        XCTAssertEqual(Realm.Configuration.defaultConfiguration.fileURL, NSURL(fileURLWithPath: "/dev/null"))
+        XCTAssertEqual(Realm.Configuration.defaultConfiguration.fileURL, URL(fileURLWithPath: "/dev/null"))
         Realm.Configuration.defaultConfiguration.fileURL = fileURL
     }
 }

--- a/RealmSwift/Tests/SwiftTestObjects.swift
+++ b/RealmSwift/Tests/SwiftTestObjects.swift
@@ -49,7 +49,7 @@ class SwiftObject: Object {
     dynamic var objectCol: SwiftBoolObject? = SwiftBoolObject()
     let arrayCol = List<SwiftBoolObject>()
 
-    class func defaultValues() -> [String: AnyObject] {
+    class func defaultValues() -> [String: Any] {
         return  ["boolCol": false as AnyObject,
             "intCol": 123 as AnyObject,
             "floatCol": 1.23 as AnyObject,
@@ -102,7 +102,7 @@ class SwiftOptionalDefaultValuesObject: Object {
     dynamic var optObjectCol: SwiftBoolObject? = SwiftBoolObject(value: [true])
     //    let arrayCol = List<SwiftBoolObject?>()
 
-    class func defaultValues() -> [String: AnyObject] {
+    class func defaultValues() -> [String: Any] {
         return [
             "optNSStringCol" : "A",
             "optStringCol" : "B",
@@ -394,7 +394,7 @@ class SwiftCustomInitializerObject: Object {
         super.init(realm: realm, schema: schema)
     }
 
-    required init(value: AnyObject, schema: RLMSchema) {
+    required init(value: Any, schema: RLMSchema) {
         stringCol = ""
         super.init(value: value, schema: schema)
     }

--- a/RealmSwift/Tests/SwiftTestObjects.swift
+++ b/RealmSwift/Tests/SwiftTestObjects.swift
@@ -44,7 +44,7 @@ class SwiftObject: Object {
     dynamic var floatCol = 1.23 as Float
     dynamic var doubleCol = 12.3
     dynamic var stringCol = "a"
-    dynamic var binaryCol = "a".data(using: String.Encoding.utf8)!
+    dynamic var binaryCol = "a".data(using: String.Encoding.utf8)! as Data as NSData
     dynamic var dateCol = NSDate(timeIntervalSince1970: 1)
     dynamic var objectCol: SwiftBoolObject? = SwiftBoolObject()
     let arrayCol = List<SwiftBoolObject>()
@@ -55,7 +55,7 @@ class SwiftObject: Object {
             "floatCol": 1.23 as AnyObject,
             "doubleCol": 12.3 as AnyObject,
             "stringCol": "a" as AnyObject,
-            "binaryCol":  "a".data(using: String.Encoding.utf8)!,
+            "binaryCol":  "a".data(using: String.Encoding.utf8)! as Data as NSData,
             "dateCol": NSDate(timeIntervalSince1970: 1),
             "objectCol": [false],
             "arrayCol": [] as NSArray]
@@ -89,7 +89,7 @@ class SwiftImplicitlyUnwrappedOptionalObject: Object {
 class SwiftOptionalDefaultValuesObject: Object {
     dynamic var optNSStringCol: NSString? = "A"
     dynamic var optStringCol: String? = "B"
-    dynamic var optBinaryCol: NSData? = "C".data(using: String.Encoding.utf8)
+    dynamic var optBinaryCol: NSData? = "C".data(using: String.Encoding.utf8)! as Data as NSData
     dynamic var optDateCol: NSDate? = NSDate(timeIntervalSince1970: 10)
     let optIntCol = RealmOptional<Int>(1)
     let optInt8Col = RealmOptional<Int8>(1)
@@ -125,7 +125,7 @@ class SwiftOptionalIgnoredPropertiesObject: Object {
 
     dynamic var optNSStringCol: NSString? = "A"
     dynamic var optStringCol: String? = "B"
-    dynamic var optBinaryCol: NSData? = "C".data(using: String.Encoding.utf8)
+    dynamic var optBinaryCol: NSData? = "C".data(using: String.Encoding.utf8)! as Data as NSData
     dynamic var optDateCol: NSDate? = NSDate(timeIntervalSince1970: 10)
     dynamic var optObjectCol: SwiftBoolObject? = SwiftBoolObject(value: [true])
 

--- a/RealmSwift/Tests/SwiftTestObjects.swift
+++ b/RealmSwift/Tests/SwiftTestObjects.swift
@@ -115,7 +115,7 @@ class SwiftOptionalDefaultValuesObject: Object {
             "optInt16Col" : 1,
             "optInt32Col" : 1,
             "optInt64Col" : 1,
-            "optFloatCol" : NSNumber(value: 2.2 as Float),
+            "optFloatCol" : 2.2 as Float,
             "optDoubleCol" : 3.3,
             "optBoolCol" : true,
         ]

--- a/RealmSwift/Tests/SwiftTestObjects.swift
+++ b/RealmSwift/Tests/SwiftTestObjects.swift
@@ -50,15 +50,17 @@ class SwiftObject: Object {
     let arrayCol = List<SwiftBoolObject>()
 
     class func defaultValues() -> [String: Any] {
-        return  ["boolCol": false as AnyObject,
-            "intCol": 123 as AnyObject,
-            "floatCol": 1.23 as AnyObject,
-            "doubleCol": 12.3 as AnyObject,
-            "stringCol": "a" as AnyObject,
-            "binaryCol":  "a".data(using: String.Encoding.utf8)! as Data as NSData,
+        return  [
+            "boolCol": false,
+            "intCol": 123,
+            "floatCol": 1.23 as Float,
+            "doubleCol": 12.3,
+            "stringCol": "a",
+            "binaryCol":  "a".data(using: String.Encoding.utf8)!,
             "dateCol": NSDate(timeIntervalSince1970: 1),
             "objectCol": [false],
-            "arrayCol": [] as NSArray]
+            "arrayCol": []
+        ]
     }
 }
 

--- a/RealmSwift/Tests/SwiftUnicodeTests.swift
+++ b/RealmSwift/Tests/SwiftUnicodeTests.swift
@@ -28,24 +28,24 @@ class SwiftUnicodeTests: TestCase {
         let realm = realmWithTestPath()
 
         try! realm.write {
-            realm.createObject(ofType: SwiftStringObject.self, populatedWith: [utf8TestString] as AnyObject)
+            realm.createObject(ofType: SwiftStringObject.self, populatedWith: [utf8TestString])
             return
         }
 
         let obj1 = realm.allObjects(ofType: SwiftStringObject.self).first!
         XCTAssertEqual(obj1.stringCol, utf8TestString)
 
-        let obj2 = realm.allObjects(ofType: SwiftStringObject.self).filter(using: "stringCol == %@", utf8TestString as AnyObject).first!
+        let obj2 = realm.allObjects(ofType: SwiftStringObject.self).filter(using: "stringCol == %@", utf8TestString).first!
         XCTAssertEqual(obj1, obj2)
         XCTAssertEqual(obj2.stringCol, utf8TestString)
 
-        XCTAssertEqual(Int(0), realm.allObjects(ofType: SwiftStringObject.self).filter(using: "stringCol != %@", utf8TestString as AnyObject).count)
+        XCTAssertEqual(Int(0), realm.allObjects(ofType: SwiftStringObject.self).filter(using: "stringCol != %@", utf8TestString).count)
     }
 
     func testUTF8PropertyWithUTF8StringContents() {
         let realm = realmWithTestPath()
         try! realm.write {
-            realm.createObject(ofType: SwiftUTF8Object.self, populatedWith: [utf8TestString] as AnyObject)
+            realm.createObject(ofType: SwiftUTF8Object.self, populatedWith: [utf8TestString])
             return
         }
 
@@ -53,7 +53,7 @@ class SwiftUnicodeTests: TestCase {
         XCTAssertEqual(obj1.柱колоéнǢкƱаم👍, utf8TestString,
             "Storing and retrieving a string with UTF8 content should work")
 
-        let obj2 = realm.allObjects(ofType: SwiftUTF8Object.self).filter(using: "%K == %@", "柱колоéнǢкƱаم👍", utf8TestString as AnyObject).first!
+        let obj2 = realm.allObjects(ofType: SwiftUTF8Object.self).filter(using: "%K == %@", "柱колоéнǢкƱаم👍", utf8TestString).first!
         XCTAssertEqual(obj1, obj2, "Querying a realm searching for a string with UTF8 content should work")
     }
 }

--- a/RealmSwift/Tests/TestCase.swift
+++ b/RealmSwift/Tests/TestCase.swift
@@ -96,6 +96,7 @@ class TestCase: XCTestCase {
         // Verify that there are no remaining realm files after the test
         let parentDir = (testDir as NSString).deletingLastPathComponent
         for url in FileManager().enumerator(atPath: parentDir)! {
+            let url = url as! URL
             XCTAssertNotEqual(url.pathExtension, "realm", "Lingering realm file at \(parentDir)/\(url)")
             assert(url.pathExtension != "realm")
         }

--- a/RealmSwift/Tests/TestCase.swift
+++ b/RealmSwift/Tests/TestCase.swift
@@ -105,7 +105,7 @@ class TestCase: XCTestCase {
         RLMRealm.resetRealmState()
     }
 
-    func dispatchSyncNewThread(block: () -> Void) {
+    func dispatchSyncNewThread(block: @escaping () -> Void) {
         queue.async {
             autoreleasepool {
                 block()
@@ -114,19 +114,19 @@ class TestCase: XCTestCase {
         queue.sync { }
     }
 
-    func assertThrows<T>(_ block: @autoclosure(escaping)() -> T, named: String? = RLMExceptionName,
+    func assertThrows<T>(_ block: @autoclosure @escaping() -> T, named: String? = RLMExceptionName,
                          _ message: String? = nil, fileName: String = #file, lineNumber: UInt = #line) {
         exceptionThrown = true
         RLMAssertThrowsWithName(self, { _ = block() }, named, message, fileName, lineNumber)
     }
 
-    func assertThrows<T>(_ block: @autoclosure(escaping) () -> T, reason regexString: String,
+    func assertThrows<T>(_ block: @autoclosure @escaping () -> T, reason regexString: String,
                          _ message: String? = nil, fileName: String = #file, lineNumber: UInt = #line) {
         RLMAssertThrowsWithReasonMatching(self, { _ = block() }, regexString, message, fileName, lineNumber)
     }
 
     func assertSucceeds(message: String? = nil, fileName: StaticString = #file,
-                        lineNumber: UInt = #line, block: @noescape () throws -> ()) {
+                        lineNumber: UInt = #line, block: () throws -> ()) {
         do {
             try block()
         } catch {
@@ -137,7 +137,7 @@ class TestCase: XCTestCase {
 
     func assertFails<T>(_ expectedError: RealmSwift.Error.Code, _ message: String? = nil,
                         fileName: StaticString = #file, lineNumber: UInt = #line,
-                        block: @noescape () throws -> T) {
+                        block: () throws -> T) {
         do {
             _ = try block()
             XCTFail("Expected to catch <\(expectedError)>, but no error was thrown.",

--- a/RealmSwift/Util.swift
+++ b/RealmSwift/Util.swift
@@ -30,7 +30,7 @@ internal func notFoundToNil(index: UInt) -> Int? {
 
 #if swift(>=3.0)
 
-internal func throwRealmException(_ message: String, userInfo: [String:AnyObject] = [:]) {
+internal func throwRealmException(_ message: String, userInfo: [AnyHashable: Any]? = nil) {
     NSException(name: NSExceptionName(rawValue: RLMExceptionName), reason: message, userInfo: userInfo).raise()
 }
 


### PR DESCRIPTION
This fixes the Swift compilation issues in Realm Swift and Realm Objective-C. Note this PR makes the smallest possible changes to get the current codebase to compile. After this is merged, we should also improve the API by considering the following:
- Support Swift native `Date` and `Data` types (https://github.com/realm/realm-cocoa/issues/3968)
- Improve type-safety of Swift 3 API (https://github.com/realm/realm-cocoa/issues/3969)
- Find better way to specify `NSNumber` type from Swift when using Realm Objective-C (https://github.com/realm/realm-cocoa/issues/3971)
- Use `Optional`s instead of `NSNull` in Swift API (https://github.com/realm/realm-cocoa/issues/3972)
- Create protocol for types that can be stored as `Realm` object properties (https://github.com/realm/realm-cocoa/issues/3973)
- Vet Realm Swift API `open` members (https://github.com/realm/realm-cocoa/issues/3974)
- Fix segfaulting Swift functions in Realm Objective-C (https://github.com/realm/realm-cocoa/issues/3975)
- Introduce `addObjects` Swift helper function in Realm Objective-C (https://github.com/realm/realm-cocoa/issues/3976)