### PR TITLE
Fix build with Swift 2.3 in Xcode 8 beta 6

### DIFF
--- a/Realm/Tests/Swift/SwiftRealmTests.swift
+++ b/Realm/Tests/Swift/SwiftRealmTests.swift
@@ -445,9 +445,15 @@ class SwiftRealmTests: RLMTestCase {
         let notificationFired = expectationWithDescription("notification fired")
         let token = realm.addNotificationBlock { note, realm in
             XCTAssertNotNil(realm, "Realm should not be nil")
+#if swift(>=2.3)
+            if note == DidChange {
+                notificationFired.fulfill()
+            }
+#else
             if note == RLMRealmDidChangeNotification {
                 notificationFired.fulfill()
             }
+#endif
         }
 
         dispatchAsync {


### PR DESCRIPTION
The constant `RLMRealmDidChangeNotification` is now imported differently.