### PR TITLE
Use `Date` and `Data`

### DIFF
--- a/Realm/Tests/Swift/SwiftArrayTests.swift
+++ b/Realm/Tests/Swift/SwiftArrayTests.swift
@@ -31,7 +31,7 @@ class SwiftArrayTests: RLMTestCase {
 
         realm.beginWriteTransaction()
 
-        let dateMinInput = NSDate()
+        let dateMinInput = Date()
         let dateMaxInput = dateMinInput.addingTimeInterval(1000)
 
         _ = SwiftAggregateObject.create(in: realm, withValue: [10, 1.2 as Float, 0 as Double, true, dateMinInput])
@@ -69,7 +69,7 @@ class SwiftArrayTests: RLMTestCase {
 
         realm.beginWriteTransaction()
 
-        let dateMinInput = NSDate()
+        let dateMinInput = Date()
         let dateMaxInput = dateMinInput.addingTimeInterval(1000)
 
         _ = SwiftAggregateObject.create(in: realm, withValue: [0, 1.2 as Float, 0 as Double, true, dateMinInput])
@@ -134,9 +134,9 @@ class SwiftArrayTests: RLMTestCase {
         XCTAssertEqualWithAccuracy(min.doubleValue, Double(0), accuracy: 0.1, "Minimum should be 0.0")
 
         // Test date min
-        var dateMinOutput = noArray.min(ofProperty: "dateCol") as! NSDate
+        var dateMinOutput = noArray.min(ofProperty: "dateCol") as! Date
         XCTAssertEqual(dateMinOutput, dateMaxInput, "Minimum should be dateMaxInput")
-        dateMinOutput = yesArray.min(ofProperty: "dateCol") as! NSDate
+        dateMinOutput = yesArray.min(ofProperty: "dateCol") as! Date
         XCTAssertEqual(dateMinOutput, dateMinInput, "Minimum should be dateMinInput")
 
         // MAX ::::::::::::::::::::::::::::::::::::::::::::::
@@ -159,9 +159,9 @@ class SwiftArrayTests: RLMTestCase {
         XCTAssertEqualWithAccuracy(max.doubleValue, Double(0), accuracy: 0.1, "Maximum should be 0.0")
 
         // Test date max
-        var dateMaxOutput = noArray.max(ofProperty: "dateCol") as! NSDate
+        var dateMaxOutput = noArray.max(ofProperty: "dateCol") as! Date
         XCTAssertEqual(dateMaxOutput, dateMaxInput, "Maximum should be dateMaxInput")
-        dateMaxOutput = yesArray.max(ofProperty: "dateCol") as! NSDate
+        dateMaxOutput = yesArray.max(ofProperty: "dateCol") as! Date
         XCTAssertEqual(dateMaxOutput, dateMinInput, "Maximum should be dateMinInput")
     }
 
@@ -261,7 +261,7 @@ class SwiftArrayTests: RLMTestCase {
 
         realm.beginWriteTransaction()
 
-        let dateMinInput = NSDate()
+        let dateMinInput = Date()
         let dateMaxInput = dateMinInput.addingTimeInterval(1000)
 
         _ = AggregateObject.create(in: realm, withValue: [10, 1.2 as Float, 0 as Double, true, dateMinInput])
@@ -299,7 +299,7 @@ class SwiftArrayTests: RLMTestCase {
 
         realm.beginWriteTransaction()
 
-        let dateMinInput = NSDate()
+        let dateMinInput = Date()
         let dateMaxInput = dateMinInput.addingTimeInterval(1000)
 
         _ = AggregateObject.create(in: realm, withValue: [0, 1.2 as Float, 0 as Double, true, dateMinInput])
@@ -364,9 +364,9 @@ class SwiftArrayTests: RLMTestCase {
         XCTAssertEqualWithAccuracy(min.doubleValue, Double(0), accuracy: 0.1, "Minimum should be 0.0")
 
         // Test date min
-        var dateMinOutput = noArray.min(ofProperty: "dateCol") as! NSDate
+        var dateMinOutput = noArray.min(ofProperty: "dateCol") as! Date
         XCTAssertEqual(dateMinOutput, dateMaxInput, "Minimum should be dateMaxInput")
-        dateMinOutput = yesArray.min(ofProperty: "dateCol") as! NSDate
+        dateMinOutput = yesArray.min(ofProperty: "dateCol") as! Date
         XCTAssertEqual(dateMinOutput, dateMinInput, "Minimum should be dateMinInput")
 
         // MAX ::::::::::::::::::::::::::::::::::::::::::::::
@@ -389,9 +389,9 @@ class SwiftArrayTests: RLMTestCase {
         XCTAssertEqualWithAccuracy(max.doubleValue, Double(0), accuracy: 0.1, "Maximum should be 0.0")
 
         // Test date max
-        var dateMaxOutput = noArray.max(ofProperty: "dateCol") as! NSDate
+        var dateMaxOutput = noArray.max(ofProperty: "dateCol") as! Date
         XCTAssertEqual(dateMaxOutput, dateMaxInput, "Maximum should be dateMaxInput")
-        dateMaxOutput = yesArray.max(ofProperty: "dateCol") as! NSDate
+        dateMaxOutput = yesArray.max(ofProperty: "dateCol") as! Date
         XCTAssertEqual(dateMaxOutput, dateMinInput, "Maximum should be dateMinInput")
     }
 

--- a/Realm/Tests/Swift/SwiftDynamicTests.swift
+++ b/Realm/Tests/Swift/SwiftDynamicTests.swift
@@ -118,7 +118,7 @@ class SwiftDynamicTests: RLMTestCase {
     }
 
     func testDynamicTypes_objc() {
-        let date = NSDate(timeIntervalSince1970: 100000)
+        let date = Date(timeIntervalSince1970: 100000)
         let data = "a".data(using: String.Encoding.utf8)!
         let obj1: [Any] = [true, 1, 1.1 as Float, 1.11, "string",
             data, date, true, 11, NSNull()]

--- a/Realm/Tests/Swift/SwiftObjectInterfaceTests.swift
+++ b/Realm/Tests/Swift/SwiftObjectInterfaceTests.swift
@@ -70,7 +70,7 @@ class SwiftObjectInterfaceTests: RLMTestCase {
         obj.doubleCol = 2.2
         obj.stringCol = "abcd"
         obj.binaryCol = "abcd".data(using: String.Encoding.utf8)
-        obj.dateCol = NSDate(timeIntervalSince1970: 123)
+        obj.dateCol = Date(timeIntervalSince1970: 123)
         obj.objectCol = SwiftBoolObject()
         obj.objectCol.boolCol = true
         obj.arrayCol.add(obj.objectCol)
@@ -85,7 +85,7 @@ class SwiftObjectInterfaceTests: RLMTestCase {
         XCTAssertEqual(firstObj.doubleCol, 2.2, "should be 2.2")
         XCTAssertEqual(firstObj.stringCol, "abcd", "should be abcd")
         XCTAssertEqual(firstObj.binaryCol!, data!)
-        XCTAssertEqual(firstObj.dateCol, NSDate(timeIntervalSince1970: 123), "should be epoch + 123")
+        XCTAssertEqual(firstObj.dateCol, Date(timeIntervalSince1970: 123), "should be epoch + 123")
         XCTAssertEqual(firstObj.objectCol.boolCol, true, "should be true")
         XCTAssertEqual(obj.arrayCol.count, UInt(1), "array count should be 1")
         XCTAssertEqual((obj.arrayCol.firstObject() as? SwiftBoolObject)!.boolCol, true, "should be true")
@@ -106,7 +106,7 @@ class SwiftObjectInterfaceTests: RLMTestCase {
         XCTAssertEqual(firstObj.doubleCol, 12.3, "should be 12.3")
         XCTAssertEqual(firstObj.stringCol, "a", "should be a")
         XCTAssertEqual(firstObj.binaryCol!, data!)
-        XCTAssertEqual(firstObj.dateCol, NSDate(timeIntervalSince1970: 1), "should be epoch + 1")
+        XCTAssertEqual(firstObj.dateCol, Date(timeIntervalSince1970: 1), "should be epoch + 1")
         XCTAssertEqual(firstObj.objectCol.boolCol, false, "should be false")
         XCTAssertEqual(firstObj.arrayCol.count, UInt(0), "array count should be zero")
     }
@@ -199,14 +199,14 @@ class SwiftObjectInterfaceTests: RLMTestCase {
 
             firstObj.optStringCol = "Hi!"
             firstObj.optNSStringCol = "Hi!"
-            firstObj.optBinaryCol = NSData(bytes: "hi", length: 2)
-            firstObj.optDateCol = NSDate(timeIntervalSinceReferenceDate: 10)
+            firstObj.optBinaryCol = Data(bytes: "hi", count: 2)
+            firstObj.optDateCol = Date(timeIntervalSinceReferenceDate: 10)
         }
         XCTAssertTrue(firstObj.optObjectCol!.boolCol)
         XCTAssertEqual(firstObj.optStringCol!, "Hi!")
         XCTAssertEqual(firstObj.optNSStringCol!, "Hi!")
-        XCTAssertEqual(firstObj.optBinaryCol!, NSData(bytes: "hi", length: 2))
-        XCTAssertEqual(firstObj.optDateCol!,  NSDate(timeIntervalSinceReferenceDate: 10))
+        XCTAssertEqual(firstObj.optBinaryCol!, Data(bytes: "hi", count: 2))
+        XCTAssertEqual(firstObj.optDateCol!,  Date(timeIntervalSinceReferenceDate: 10))
 
         try! realm.transaction {
             firstObj.optObjectCol = nil

--- a/Realm/Tests/Swift/SwiftPropertyTypeTest.swift
+++ b/Realm/Tests/Swift/SwiftPropertyTypeTest.swift
@@ -121,6 +121,25 @@ class SwiftPropertyTypeTest: RLMTestCase {
         }
         XCTAssertNotNil(succeeded, "Writing an object with an ignored lazy property should work.")
     }
+
+    func testObjectiveCTypeProperties() {
+        let realm = realmWithTestPath()
+        var object: SwiftObjectiveCTypesObject!
+        let now = NSDate()
+        let data = "fizzbuzz".data(using: .utf8)! as Data as NSData
+        try! realm.transaction {
+            object = SwiftObjectiveCTypesObject()
+            realm.add(object)
+            object.stringCol = "Hello world!"
+            object.dateCol = now
+            object.dataCol = data
+            object.numCol = 42
+        }
+        XCTAssertEqual("Hello world!", object.stringCol)
+        XCTAssertEqual(now, object.dateCol)
+        XCTAssertEqual(data, object.dataCol)
+        XCTAssertEqual(42, object.numCol)
+    }
 }
 
 #else

--- a/Realm/Tests/Swift/SwiftTestObjects.swift
+++ b/Realm/Tests/Swift/SwiftTestObjects.swift
@@ -43,7 +43,7 @@ class SwiftObject: RLMObject {
     dynamic var doubleCol = 12.3
     dynamic var stringCol = "a"
     dynamic var binaryCol = "a".data(using: String.Encoding.utf8)
-    dynamic var dateCol = NSDate(timeIntervalSince1970: 1)
+    dynamic var dateCol = Date(timeIntervalSince1970: 1)
     dynamic var objectCol = SwiftBoolObject()
     dynamic var arrayCol = RLMArray(objectClassName: SwiftBoolObject.className())
 }
@@ -56,8 +56,8 @@ class SwiftOptionalObject: RLMObject {
 //    dynamic var optDoubleCol: Double?
     dynamic var optStringCol: String?
     dynamic var optNSStringCol: NSString?
-    dynamic var optBinaryCol: NSData?
-    dynamic var optDateCol: NSDate?
+    dynamic var optBinaryCol: Data?
+    dynamic var optDateCol: Date?
     dynamic var optObjectCol: SwiftBoolObject?
 }
 
@@ -75,7 +75,7 @@ class SwiftAggregateObject: RLMObject {
     dynamic var floatCol = 0 as Float
     dynamic var doubleCol = 0.0
     dynamic var boolCol = false
-    dynamic var dateCol = NSDate()
+    dynamic var dateCol = Date()
 }
 
 class SwiftAllIntSizesObject: RLMObject {
@@ -152,6 +152,13 @@ class SwiftIgnoredLazyVarObject : RLMObject {
     dynamic var id = 0
     dynamic lazy var ignoredVar : String = "hello world"
     override class func ignoredProperties() -> [String] { return ["ignoredVar"] }
+}
+
+class SwiftObjectiveCTypesObject: RLMObject {
+    dynamic var stringCol: NSString?
+    dynamic var dateCol: NSDate?
+    dynamic var dataCol: NSData?
+    dynamic var numCol: NSNumber? = 0
 }
 
 #else

--- a/RealmSwift/Object.swift
+++ b/RealmSwift/Object.swift
@@ -42,14 +42,14 @@ class Dog: Object {
 - `Float`
 - `Double`
 - `Bool`
-- `NSDate`
-- `NSData`
+- `Date`, `NSDate`
+- `Data`, `NSData`
 - `RealmOptional<T>` for optional numeric properties
 - `Object` subclasses for to-one relationships
 - `List<T: Object>` for to-many relationships
 
-`String`, `NSString`, `NSDate`, `NSData` and `Object` subclass properties can be
-optional. `Int`, `Int8`, Int16`, Int32`, `Int64`, `Float`, `Double`, `Bool`
+`String`, `NSString`, `Date`, `NSDate`, `Data`, `NSData` and `Object` subclass properties
+can be optional. `Int`, `Int8`, Int16`, Int32`, `Int64`, `Float`, `Double`, `Bool`
 and `List` properties cannot. To store an optional number, instead use
 `RealmOptional<Int>`, `RealmOptional<Float>`, `RealmOptional<Double>`, or
 `RealmOptional<Bool>` instead, which wraps an optional value of the generic type.
@@ -162,7 +162,7 @@ open class Object: RLMObjectBase {
 
     /**
     Return an array of property names for properties which should be indexed.
-    Only supported for string, integer, boolean and NSDate properties.
+    Only supported for string, integer, boolean and date properties.
 
     - returns: `Array` of property names to index.
     */
@@ -325,9 +325,9 @@ public class ObjectUtil: NSObject {
             var properties = properties
             if type is Optional<String>.Type || type is Optional<NSString>.Type {
                 properties[name] = NSNumber(value: PropertyType.string.rawValue)
-            } else if type is Optional<NSDate>.Type {
+            } else if type is Optional<Date>.Type {
                 properties[name] = NSNumber(value: PropertyType.date.rawValue)
-            } else if type is Optional<NSData>.Type {
+            } else if type is Optional<Data>.Type {
                 properties[name] = NSNumber(value: PropertyType.data.rawValue)
             } else if type is Optional<Object>.Type {
                 properties[name] = NSNumber(value: PropertyType.object.rawValue)

--- a/RealmSwift/Realm.swift
+++ b/RealmSwift/Realm.swift
@@ -672,7 +672,7 @@ extension Realm {
     public var autorefresh : Bool { get { fatalError() } set { fatalError() } }
 
     @available(*, unavailable, renamed:"writeCopy(toFileURL:encryptionKey:)")
-    public func writeCopyToURL(_ fileURL: NSURL, encryptionKey: NSData? = nil) throws { fatalError() }
+    public func writeCopyToURL(_ fileURL: NSURL, encryptionKey: Data? = nil) throws { fatalError() }
 }
 
 #else

--- a/RealmSwift/Results.swift
+++ b/RealmSwift/Results.swift
@@ -36,6 +36,7 @@ extension Int32: MinMaxType {}
 extension Int64: MinMaxType {}
 extension Date: MinMaxType {}
 extension NSDate: MinMaxType {}
+
 extension MinMaxType {
     internal static func bridging(objCValue: Any) -> Self {
         return (Self.self as! ObjectiveCBridgeable.Type).bridging(objCValue: objCValue) as! Self

--- a/RealmSwift/Tests/KVOTests.swift
+++ b/RealmSwift/Tests/KVOTests.swift
@@ -40,8 +40,8 @@ class KVOObject: Object {
     dynamic var floatCol: Float = 5
     dynamic var doubleCol: Double = 6
     dynamic var stringCol: String = ""
-    dynamic var binaryCol: NSData = NSData()
-    dynamic var dateCol: NSDate = NSDate(timeIntervalSince1970: 0)
+    dynamic var binaryCol: Data = Data()
+    dynamic var dateCol: Date = Date(timeIntervalSince1970: 0)
     dynamic var objectCol: KVOObject?
     let arrayCol = List<KVOObject>()
     let optIntCol = RealmOptional<Int>()
@@ -49,8 +49,8 @@ class KVOObject: Object {
     let optDoubleCol = RealmOptional<Double>()
     let optBoolCol = RealmOptional<Bool>()
     dynamic var optStringCol: String?
-    dynamic var optBinaryCol: NSData?
-    dynamic var optDateCol: NSDate?
+    dynamic var optBinaryCol: Data?
+    dynamic var optDateCol: Date?
 
     override class func primaryKey() -> String { return "pk" }
     override class func ignoredProperties() -> [String] { return ["ignored"] }
@@ -142,11 +142,11 @@ class KVOTests: TestCase {
         observeChange(obj, "stringCol", "", "abc") { obj.stringCol = "abc" }
         observeChange(obj, "objectCol", nil, obj) { obj.objectCol = obj }
 
-        let data = "abc".data(using: String.Encoding.utf8, allowLossyConversion: false)! as Data as NSData
-        observeChange(obj, "binaryCol", NSData(), data) { obj.binaryCol = data as NSData }
+        let data = "abc".data(using: String.Encoding.utf8, allowLossyConversion: false)!
+        observeChange(obj, "binaryCol", Data(), data) { obj.binaryCol = data }
 
-        let date = NSDate(timeIntervalSince1970: 1)
-        observeChange(obj, "dateCol", NSDate(timeIntervalSince1970: 0), date) { obj.dateCol = date }
+        let date = Date(timeIntervalSince1970: 1)
+        observeChange(obj, "dateCol", Date(timeIntervalSince1970: 0), date) { obj.dateCol = date }
 
         observeListChange(obj, "arrayCol", .insertion, NSIndexSet(index: 0)) {
             obj.arrayCol.append(obj)
@@ -160,7 +160,7 @@ class KVOTests: TestCase {
         observeChange(obj, "optDoubleCol", nil, 10) { obj.optDoubleCol.value = 10 }
         observeChange(obj, "optBoolCol", nil, true) { obj.optBoolCol.value = true }
         observeChange(obj, "optStringCol", nil, "abc") { obj.optStringCol = "abc" }
-        observeChange(obj, "optBinaryCol", nil, data) { obj.optBinaryCol = data as NSData }
+        observeChange(obj, "optBinaryCol", nil, data) { obj.optBinaryCol = data }
         observeChange(obj, "optDateCol", nil, date) { obj.optDateCol = date }
 
         observeChange(obj, "optIntCol", 10, nil) { obj.optIntCol.value = nil }
@@ -186,11 +186,11 @@ class KVOTests: TestCase {
         observeChange(obj, "stringCol", "", "abc") { obj.stringCol = "abc" }
         observeChange(obj, "objectCol", nil, obj) { obj.objectCol = obj }
 
-        let data = "abc".data(using: String.Encoding.utf8, allowLossyConversion: false)! as Data as NSData
-        observeChange(obj, "binaryCol", NSData(), data) { obj.binaryCol = data as NSData }
+        let data = "abc".data(using: String.Encoding.utf8, allowLossyConversion: false)!
+        observeChange(obj, "binaryCol", Data(), data) { obj.binaryCol = data }
 
-        let date = NSDate(timeIntervalSince1970: 1)
-        observeChange(obj, "dateCol", NSDate(timeIntervalSince1970: 0), date) { obj.dateCol = date }
+        let date = Date(timeIntervalSince1970: 1)
+        observeChange(obj, "dateCol", Date(timeIntervalSince1970: 0), date) { obj.dateCol = date }
 
         observeListChange(obj, "arrayCol", .insertion, NSIndexSet(index: 0)) {
             obj.arrayCol.append(obj)
@@ -204,7 +204,7 @@ class KVOTests: TestCase {
         observeChange(obj, "optDoubleCol", nil, 10) { obj.optDoubleCol.value = 10 }
         observeChange(obj, "optBoolCol", nil, true) { obj.optBoolCol.value = true }
         observeChange(obj, "optStringCol", nil, "abc") { obj.optStringCol = "abc" }
-        observeChange(obj, "optBinaryCol", nil, data) { obj.optBinaryCol = data as NSData }
+        observeChange(obj, "optBinaryCol", nil, data) { obj.optBinaryCol = data }
         observeChange(obj, "optDateCol", nil, date) { obj.optDateCol = date }
 
         observeChange(obj, "optIntCol", 10, nil) { obj.optIntCol.value = nil }
@@ -241,11 +241,11 @@ class KVOTests: TestCase {
         observeChange(obs, "stringCol", "", "abc") { obj.stringCol = "abc" }
         observeChange(obs, "objectCol", nil, obj) { obj.objectCol = obj }
 
-        let data = "abc".data(using: String.Encoding.utf8, allowLossyConversion: false)! as Data as NSData
-        observeChange(obs, "binaryCol", NSData(), data) { obj.binaryCol = data as NSData }
+        let data = "abc".data(using: String.Encoding.utf8, allowLossyConversion: false)!
+        observeChange(obs, "binaryCol", Data(), data) { obj.binaryCol = data }
 
-        let date = NSDate(timeIntervalSince1970: 1)
-        observeChange(obs, "dateCol", NSDate(timeIntervalSince1970: 0), date) { obj.dateCol = date }
+        let date = Date(timeIntervalSince1970: 1)
+        observeChange(obs, "dateCol", Date(timeIntervalSince1970: 0), date) { obj.dateCol = date }
 
         observeListChange(obs, "arrayCol", .insertion, NSIndexSet(index: 0)) {
             obj.arrayCol.append(obj)
@@ -259,7 +259,7 @@ class KVOTests: TestCase {
         observeChange(obs, "optDoubleCol", nil, 10) { obj.optDoubleCol.value = 10 }
         observeChange(obs, "optBoolCol", nil, true) { obj.optBoolCol.value = true }
         observeChange(obs, "optStringCol", nil, "abc") { obj.optStringCol = "abc" }
-        observeChange(obs, "optBinaryCol", nil, data) { obj.optBinaryCol = data as NSData }
+        observeChange(obs, "optBinaryCol", nil, data) { obj.optBinaryCol = data }
         observeChange(obs, "optDateCol", nil, date) { obj.optDateCol = date }
 
         observeChange(obs, "optIntCol", 10, nil) { obj.optIntCol.value = nil }

--- a/RealmSwift/Tests/MigrationTests.swift
+++ b/RealmSwift/Tests/MigrationTests.swift
@@ -209,8 +209,8 @@ class MigrationTests: TestCase {
                 let soo = SwiftOptionalObject()
                 soo.optNSStringCol = "NSString"
                 soo.optStringCol = "String"
-                soo.optBinaryCol = NSData()
-                soo.optDateCol = NSDate()
+                soo.optBinaryCol = Data()
+                soo.optDateCol = Date()
                 soo.optIntCol.value = 1
                 soo.optInt8Col.value = 2
                 soo.optInt16Col.value = 3
@@ -231,10 +231,10 @@ class MigrationTests: TestCase {
                 XCTAssertTrue(newObject!["optNSStringCol"]! is NSString)
                 XCTAssertTrue(oldObject!["optStringCol"]! is String)
                 XCTAssertTrue(newObject!["optStringCol"]! is String)
-                XCTAssertTrue(oldObject!["optBinaryCol"]! is NSData)
-                XCTAssertTrue(newObject!["optBinaryCol"]! is NSData)
-                XCTAssertTrue(oldObject!["optDateCol"]! is NSDate)
-                XCTAssertTrue(newObject!["optDateCol"]! is NSDate)
+                XCTAssertTrue(oldObject!["optBinaryCol"]! is Data)
+                XCTAssertTrue(newObject!["optBinaryCol"]! is Data)
+                XCTAssertTrue(oldObject!["optDateCol"]! is Date)
+                XCTAssertTrue(newObject!["optDateCol"]! is Date)
                 XCTAssertTrue(oldObject!["optIntCol"]! is Int)
                 XCTAssertTrue(newObject!["optIntCol"]! is Int)
                 XCTAssertTrue(oldObject!["optInt8Col"]! is Int)
@@ -375,12 +375,12 @@ class MigrationTests: TestCase {
                 XCTAssertEqual((newObj!["doubleCol"] as! Double), 12.3 as Double)
 
                 let binaryCol = "a".data(using: String.Encoding.utf8)!
-                XCTAssertEqual((oldObj!["binaryCol"] as! NSData), binaryCol as NSData)
-                XCTAssertEqual((newObj!["binaryCol"] as! NSData), binaryCol as NSData)
+                XCTAssertEqual((oldObj!["binaryCol"] as! Data), binaryCol)
+                XCTAssertEqual((newObj!["binaryCol"] as! Data), binaryCol)
 
-                let dateCol = NSDate(timeIntervalSince1970: 1)
-                XCTAssertEqual((oldObj!["dateCol"] as! NSDate), dateCol)
-                XCTAssertEqual((newObj!["dateCol"] as! NSDate), dateCol)
+                let dateCol = Date(timeIntervalSince1970: 1)
+                XCTAssertEqual((oldObj!["dateCol"] as! Date), dateCol)
+                XCTAssertEqual((newObj!["dateCol"] as! Date), dateCol)
 
                 // FIXME - test that casting to SwiftBoolObject throws
                 XCTAssertEqual(((oldObj!["objectCol"] as! MigrationObject)["boolCol"] as! Bool), true)
@@ -396,8 +396,8 @@ class MigrationTests: TestCase {
                 newObj!["intCol"] = 1
                 newObj!["floatCol"] = 1.0
                 newObj!["doubleCol"] = 10.0
-                newObj!["binaryCol"] = NSData(bytes: "b", length: 1)
-                newObj!["dateCol"] = NSDate(timeIntervalSince1970: 2)
+                newObj!["binaryCol"] = Data(bytes: "b", count: 1)
+                newObj!["dateCol"] = Date(timeIntervalSince1970: 2)
 
                 let falseObj = SwiftBoolObject(value: [false])
                 newObj!["objectCol"] = falseObj
@@ -436,8 +436,8 @@ class MigrationTests: TestCase {
         XCTAssertEqual(object.intCol, 1)
         XCTAssertEqual(object.floatCol, 1.0 as Float)
         XCTAssertEqual(object.doubleCol, 10.0)
-        XCTAssertEqual(object.binaryCol, NSData(bytes: "b", length: 1))
-        XCTAssertEqual(object.dateCol, NSDate(timeIntervalSince1970: 2))
+        XCTAssertEqual(object.binaryCol, Data(bytes: "b", count: 1))
+        XCTAssertEqual(object.dateCol, Date(timeIntervalSince1970: 2))
         XCTAssertEqual(object.objectCol!.boolCol, false)
         XCTAssertEqual(object.arrayCol.count, 2)
         XCTAssertEqual(object.arrayCol[0].boolCol, false)

--- a/RealmSwift/Tests/ObjectAccessorTests.swift
+++ b/RealmSwift/Tests/ObjectAccessorTests.swift
@@ -56,11 +56,11 @@ class ObjectAccessorTests: TestCase {
         object.stringCol = utf8TestString
         XCTAssertEqual(object.stringCol, utf8TestString)
 
-        let data = "b".data(using: String.Encoding.utf8, allowLossyConversion: false)! as Data as NSData
+        let data = "b".data(using: String.Encoding.utf8, allowLossyConversion: false)!
         object.binaryCol = data
         XCTAssertEqual(object.binaryCol, data)
 
-        let date = NSDate(timeIntervalSinceReferenceDate: 2)
+        let date = Date(timeIntervalSinceReferenceDate: 2)
         object.dateCol = date
         XCTAssertEqual(object.dateCol, date)
 
@@ -244,13 +244,13 @@ class ObjectAccessorTests: TestCase {
         object.optStringCol = nil
         XCTAssertNil(object.optStringCol)
 
-        let data = "b".data(using: String.Encoding.utf8, allowLossyConversion: false)! as Data as NSData
+        let data = "b".data(using: String.Encoding.utf8, allowLossyConversion: false)!
         object.optBinaryCol = data
         XCTAssertEqual(object.optBinaryCol!, data)
         object.optBinaryCol = nil
         XCTAssertNil(object.optBinaryCol)
 
-        let date = NSDate(timeIntervalSinceReferenceDate: 2)
+        let date = Date(timeIntervalSinceReferenceDate: 2)
         object.optDateCol = date
         XCTAssertEqual(object.optDateCol!, date)
         object.optDateCol = nil

--- a/RealmSwift/Tests/ObjectCreationTests.swift
+++ b/RealmSwift/Tests/ObjectCreationTests.swift
@@ -68,7 +68,7 @@ class ObjectCreationTests: TestCase {
             "doubleCol": 11.1,
             "stringCol": "b",
             "binaryCol": "b".data(using: String.Encoding.utf8)!,
-            "dateCol": NSDate(timeIntervalSince1970: 2),
+            "dateCol": Date(timeIntervalSince1970: 2),
             "objectCol": SwiftBoolObject(value: [true]),
             "arrayCol": [SwiftBoolObject(value: [true]), SwiftBoolObject()]
            ]
@@ -108,7 +108,7 @@ class ObjectCreationTests: TestCase {
     func testInitWithArray() {
         // array with all values specified
         let baselineValues: [Any] = [true, 1, 1.1 as Float, 11.1, "b", "b".data(using: String.Encoding.utf8)!,
-            NSDate(timeIntervalSince1970: 2), ["boolCol": true], [[true], [false]]]
+            Date(timeIntervalSince1970: 2), ["boolCol": true], [[true], [false]]]
 
         // test with valid dictionary literals
         let props = try! Realm().schema["SwiftObject"]!.properties
@@ -214,7 +214,7 @@ class ObjectCreationTests: TestCase {
             "doubleCol": 11.1,
             "stringCol": "b",
             "binaryCol": "b".data(using: String.Encoding.utf8)!,
-            "dateCol": NSDate(timeIntervalSince1970: 2),
+            "dateCol": Date(timeIntervalSince1970: 2),
             "objectCol": SwiftBoolObject(value: [true]),
             "arrayCol": [SwiftBoolObject(value: [true]), SwiftBoolObject()]
         ]
@@ -264,7 +264,7 @@ class ObjectCreationTests: TestCase {
     func testCreateWithArray() {
         // array with all values specified
         let baselineValues: [Any] = [true, 1, 1.1 as Float, 11.1, "b", "b".data(using: String.Encoding.utf8)!,
-            NSDate(timeIntervalSince1970: 2), ["boolCol": true], [[true], [false]]]
+            Date(timeIntervalSince1970: 2), ["boolCol": true], [[true], [false]]]
 
         // test with valid dictionary literals
         let props = try! Realm().schema["SwiftObject"]!.properties
@@ -360,7 +360,7 @@ class ObjectCreationTests: TestCase {
             "doubleCol": 11.1,
             "stringCol": "b",
             "binaryCol": "b".data(using: String.Encoding.utf8)!,
-            "dateCol": NSDate(timeIntervalSince1970: 2),
+            "dateCol": Date(timeIntervalSince1970: 2),
             "objectCol": SwiftBoolObject(value: [true]),
             "arrayCol": [SwiftBoolObject(value: [true]), SwiftBoolObject()],
         ]
@@ -386,7 +386,7 @@ class ObjectCreationTests: TestCase {
             "doubleCol": 11.1,
             "stringCol": "b",
             "binaryCol": "b".data(using: String.Encoding.utf8)!,
-            "dateCol": NSDate(timeIntervalSince1970: 2),
+            "dateCol": Date(timeIntervalSince1970: 2),
             "objectCol": SwiftBoolObject(value: [true]),
             "arrayCol": [SwiftBoolObject(value: [true]), SwiftBoolObject()],
         ]
@@ -437,7 +437,7 @@ class ObjectCreationTests: TestCase {
             "doubleCol": 11.1,
             "stringCol": "b",
             "binaryCol": "b".data(using: String.Encoding.utf8)!,
-            "dateCol": NSDate(timeIntervalSince1970: 2),
+            "dateCol": Date(timeIntervalSince1970: 2),
             "objectCol": NSNull(),
             "arrayCol": NSNull(),
         ]
@@ -492,8 +492,8 @@ class ObjectCreationTests: TestCase {
         XCTAssertEqual(object.floatCol, (array[2] as! Float))
         XCTAssertEqual(object.doubleCol, (array[3] as! Double))
         XCTAssertEqual(object.stringCol, (array[4] as! String))
-        XCTAssertEqual(object.binaryCol, (array[5] as! NSData))
-        XCTAssertEqual(object.dateCol, (array[6] as! NSDate))
+        XCTAssertEqual(object.binaryCol, (array[5] as! Data))
+        XCTAssertEqual(object.dateCol, (array[6] as! Date))
         XCTAssertEqual(object.objectCol!.boolCol, boolObjectValue)
         XCTAssertEqual(object.arrayCol.count, boolObjectListValues.count)
         for i in 0..<boolObjectListValues.count {
@@ -508,8 +508,8 @@ class ObjectCreationTests: TestCase {
         XCTAssertEqual(object.floatCol, (dictionary["floatCol"] as! Float))
         XCTAssertEqual(object.doubleCol, (dictionary["doubleCol"] as! Double))
         XCTAssertEqual(object.stringCol, (dictionary["stringCol"] as! String))
-        XCTAssertEqual(object.binaryCol, (dictionary["binaryCol"] as! NSData))
-        XCTAssertEqual(object.dateCol, (dictionary["dateCol"] as! NSDate))
+        XCTAssertEqual(object.binaryCol, (dictionary["binaryCol"] as! Data))
+        XCTAssertEqual(object.dateCol, (dictionary["dateCol"] as! Date))
         XCTAssertEqual(object.objectCol!.boolCol, boolObjectValue)
         XCTAssertEqual(object.arrayCol.count, boolObjectListValues.count)
         for i in 0..<boolObjectListValues.count {
@@ -533,8 +533,8 @@ class ObjectCreationTests: TestCase {
         XCTAssertEqual(object.optDoubleCol.value, (dictionary["optDoubleCol"] as! Double?))
         XCTAssertEqual(object.optStringCol, (dictionary["optStringCol"] as! String?))
         XCTAssertEqual(object.optNSStringCol, (dictionary["optNSStringCol"] as! NSString))
-        XCTAssertEqual(object.optBinaryCol, (dictionary["optBinaryCol"] as! NSData?))
-        XCTAssertEqual(object.optDateCol, (dictionary["optDateCol"] as! NSDate?))
+        XCTAssertEqual(object.optBinaryCol, (dictionary["optBinaryCol"] as! Data?))
+        XCTAssertEqual(object.optDateCol, (dictionary["optDateCol"] as! Date?))
         XCTAssertEqual(object.optObjectCol?.boolCol, boolObjectValue)
     }
 
@@ -558,8 +558,8 @@ class ObjectCreationTests: TestCase {
             case .float:    return [NSNumber(value: 1 as Int), NSNumber(value: 1.1 as Float), NSNumber(value: 11.1 as Double)]
             case .double:   return [NSNumber(value: 1 as Int), NSNumber(value: 1.1 as Float), NSNumber(value: 11.1 as Double)]
             case .string:   return ["b"]
-            case .data:     return ["b".data(using: String.Encoding.utf8, allowLossyConversion: false)! as Data as NSData]
-            case .date:     return [NSDate(timeIntervalSince1970: 2)]
+            case .data:     return ["b".data(using: String.Encoding.utf8, allowLossyConversion: false)!]
+            case .date:     return [Date(timeIntervalSince1970: 2)]
             case .object:   return [[true], ["boolCol": true], SwiftBoolObject(value: [true]), persistedObject]
             case .array:    return [
                 [[true], [false]],

--- a/RealmSwift/Tests/ObjectSchemaInitializationTests.swift
+++ b/RealmSwift/Tests/ObjectSchemaInitializationTests.swift
@@ -243,7 +243,7 @@ class SwiftObjectWithStruct: SwiftFakeObject {
 }
 
 class SwiftObjectWithDatePrimaryKey: SwiftFakeObject {
-    dynamic var date = NSDate()
+    dynamic var date = Date()
 
     dynamic override class func primaryKey() -> String? {
         return "date"
@@ -259,7 +259,7 @@ class SwiftObjectWithOptionalNSNumber: SwiftFakeObject {
 }
 
 class SwiftFakeObjectSubclass: SwiftFakeObject {
-    dynamic var dateCol = NSDate()
+    dynamic var dateCol = Date()
 }
 
 class SwiftObjectWithUnindexibleProperties: SwiftFakeObject {
@@ -268,7 +268,7 @@ class SwiftObjectWithUnindexibleProperties: SwiftFakeObject {
     dynamic var floatCol = 1.23 as Float
     dynamic var doubleCol = 12.3
     dynamic var binaryCol = "a".data(using: String.Encoding.utf8)!
-    dynamic var dateCol = NSDate(timeIntervalSince1970: 1)
+    dynamic var dateCol = Date(timeIntervalSince1970: 1)
     dynamic var objectCol: SwiftBoolObject? = SwiftBoolObject()
     let arrayCol = List<SwiftBoolObject>()
 
@@ -279,7 +279,7 @@ class SwiftObjectWithUnindexibleProperties: SwiftFakeObject {
 
 // swiftlint:disable:next type_name
 class SwiftObjectWithNonNullableOptionalProperties: SwiftFakeObject {
-    dynamic var optDateCol: NSDate?
+    dynamic var optDateCol: Date?
 }
 
 class SwiftObjectWithNonOptionalLinkProperty: SwiftFakeObject {

--- a/RealmSwift/Tests/ObjectTests.swift
+++ b/RealmSwift/Tests/ObjectTests.swift
@@ -165,11 +165,11 @@ class ObjectTests: TestCase {
             XCTAssertEqual(object.value(forKey: "doubleCol") as! Double!, 12.3)
             XCTAssertEqual(object.value(forKey: "stringCol") as! String!, "a")
 
-            let expected = (object.value(forKey: "binaryCol") as! NSData) as Data
+            let expected = object.value(forKey: "binaryCol") as! Data
             let actual = "a".data(using: String.Encoding.utf8)!
             XCTAssertTrue(expected == actual)
 
-            XCTAssertEqual(object.value(forKey: "dateCol") as! NSDate!, NSDate(timeIntervalSince1970: 1))
+            XCTAssertEqual(object.value(forKey: "dateCol") as! Date!, Date(timeIntervalSince1970: 1))
             XCTAssertEqual((object.value(forKey: "objectCol")! as! SwiftBoolObject).boolCol, false)
             XCTAssert(object.value(forKey: "arrayCol")! is List<SwiftBoolObject>)
         }
@@ -198,12 +198,12 @@ class ObjectTests: TestCase {
         setter(object, "z", "stringCol")
         XCTAssertEqual(getter(object, "stringCol") as! String!, "z")
 
-        setter(object, "z".data(using: String.Encoding.utf8)! as Data as NSData, "binaryCol")
-        let gotData = (getter(object, "binaryCol") as! NSData) as Data
+        setter(object, "z".data(using: String.Encoding.utf8)! as Data, "binaryCol")
+        let gotData = getter(object, "binaryCol") as! Data
         XCTAssertTrue(gotData == "z".data(using: String.Encoding.utf8)!)
 
-        setter(object, NSDate(timeIntervalSince1970: 333), "dateCol")
-        XCTAssertEqual(getter(object, "dateCol") as! NSDate!, NSDate(timeIntervalSince1970: 333))
+        setter(object, Date(timeIntervalSince1970: 333), "dateCol")
+        XCTAssertEqual(getter(object, "dateCol") as! Date!, Date(timeIntervalSince1970: 333))
 
         let boolObject = SwiftBoolObject(value: [true])
         setter(object, boolObject, "objectCol")
@@ -243,12 +243,12 @@ class ObjectTests: TestCase {
         setter(object, "z", "stringCol")
         XCTAssertEqual((getter(object, "stringCol") as! String), "z")
 
-        setter(object, "z".data(using: String.Encoding.utf8)! as Data as NSData, "binaryCol")
-        let gotData = (getter(object, "binaryCol") as! NSData) as Data
+        setter(object, "z".data(using: String.Encoding.utf8)! as Data, "binaryCol")
+        let gotData = getter(object, "binaryCol") as! Data
         XCTAssertTrue(gotData == "z".data(using: String.Encoding.utf8)!)
 
-        setter(object, NSDate(timeIntervalSince1970: 333), "dateCol")
-        XCTAssertEqual((getter(object, "dateCol") as! NSDate), NSDate(timeIntervalSince1970: 333))
+        setter(object, Date(timeIntervalSince1970: 333), "dateCol")
+        XCTAssertEqual((getter(object, "dateCol") as! Date), Date(timeIntervalSince1970: 333))
 
         setter(object, boolObject, "objectCol")
         XCTAssertEqual((getter(object, "objectCol") as! DynamicObject), boolObject)

--- a/RealmSwift/Tests/ObjectTests.swift
+++ b/RealmSwift/Tests/ObjectTests.swift
@@ -349,6 +349,25 @@ class ObjectTests: TestCase {
         XCTAssertEqual(arrayObject.dynamicList("intArray").count, 0)
         assertThrows(arrayObject.dynamicList("noSuchList"))
     }
+
+    func testObjectiveCTypeProperties() {
+        let realm = try! Realm()
+        var object: SwiftObjectiveCTypesObject!
+        let now = NSDate()
+        let data = "fizzbuzz".data(using: .utf8)! as Data as NSData
+        try! realm.write {
+            object = SwiftObjectiveCTypesObject()
+            realm.add(object)
+            object.stringCol = "Hello world!"
+            object.dateCol = now
+            object.dataCol = data
+            object.numCol = 42
+        }
+        XCTAssertEqual("Hello world!", object.stringCol)
+        XCTAssertEqual(now, object.dateCol)
+        XCTAssertEqual(data, object.dataCol)
+        XCTAssertEqual(42, object.numCol)
+    }
 }
 
 #else

--- a/RealmSwift/Tests/PerformanceTests.swift
+++ b/RealmSwift/Tests/PerformanceTests.swift
@@ -476,7 +476,7 @@ class SwiftPerformanceTests: TestCase {
             self.startMeasuring()
             try! realm.write { object.intCol += 1 }
             while object.intCol < stopValue {
-                RunLoop.current.run(mode: RunLoopMode.defaultRunLoopMode, before: NSDate.distantFuture)
+                RunLoop.current.run(mode: RunLoopMode.defaultRunLoopMode, before: Date.distantFuture)
             }
             queue.sync() {}
             self.stopMeasuring()

--- a/RealmSwift/Tests/RealmCollectionTypeTests.swift
+++ b/RealmSwift/Tests/RealmCollectionTypeTests.swift
@@ -30,7 +30,7 @@ class CTTAggregateObject: Object {
     dynamic var floatCol = 0 as Float
     dynamic var doubleCol = 0.0
     dynamic var boolCol = false
-    dynamic var dateCol = NSDate()
+    dynamic var dateCol = Date()
     dynamic var trueCol = true
     let stringListCol = List<CTTStringObjectWithLink>()
     dynamic var linkCol: CTTLinkTarget?
@@ -77,7 +77,7 @@ class RealmCollectionTypeTests: TestCase {
         obj1.int64Col = 1
         obj1.floatCol = 1.1
         obj1.doubleCol = 1.11
-        obj1.dateCol = NSDate(timeIntervalSince1970: 1)
+        obj1.dateCol = Date(timeIntervalSince1970: 1)
         obj1.boolCol = false
 
         let obj2 = CTTAggregateObject()
@@ -88,7 +88,7 @@ class RealmCollectionTypeTests: TestCase {
         obj2.int64Col = 2
         obj2.floatCol = 2.2
         obj2.doubleCol = 2.22
-        obj2.dateCol = NSDate(timeIntervalSince1970: 2)
+        obj2.dateCol = Date(timeIntervalSince1970: 2)
         obj2.boolCol = false
 
         let obj3 = CTTAggregateObject()
@@ -99,7 +99,7 @@ class RealmCollectionTypeTests: TestCase {
         obj3.int64Col = 3
         obj3.floatCol = 2.2
         obj3.doubleCol = 2.22
-        obj3.dateCol = NSDate(timeIntervalSince1970: 2)
+        obj3.dateCol = Date(timeIntervalSince1970: 2)
         obj3.boolCol = false
 
         realmWithTestPath().add([obj1, obj2, obj3])
@@ -881,8 +881,8 @@ class ListStandaloneRealmCollectionTypeTests: ListRealmCollectionTypeTests {
         assertThrows(collection.minimumValue(ofProperty: "floatCol") as Float!)
         assertThrows(collection.minimumValue(ofProperty: "doubleCol") as NSNumber!)
         assertThrows(collection.minimumValue(ofProperty: "doubleCol") as Double!)
-        assertThrows(collection.minimumValue(ofProperty: "dateCol") as Date!)
         assertThrows(collection.minimumValue(ofProperty: "dateCol") as NSDate!)
+        assertThrows(collection.minimumValue(ofProperty: "dateCol") as Date!)
     }
 
     override func testMax() {
@@ -903,8 +903,8 @@ class ListStandaloneRealmCollectionTypeTests: ListRealmCollectionTypeTests {
         assertThrows(collection.maximumValue(ofProperty: "floatCol") as Float!)
         assertThrows(collection.maximumValue(ofProperty: "doubleCol") as NSNumber!)
         assertThrows(collection.maximumValue(ofProperty: "doubleCol") as Double!)
-        assertThrows(collection.maximumValue(ofProperty: "dateCol") as Date!)
         assertThrows(collection.maximumValue(ofProperty: "dateCol") as NSDate!)
+        assertThrows(collection.maximumValue(ofProperty: "dateCol") as Date!)
     }
 
     override func testSum() {

--- a/RealmSwift/Tests/RealmTests.swift
+++ b/RealmSwift/Tests/RealmTests.swift
@@ -471,7 +471,7 @@ class RealmTests: TestCase {
         XCTAssertEqual(object["doubleCol"] as? NSNumber, dictionary["doubleCol"] as! NSNumber?)
         XCTAssertEqual(object["stringCol"] as! String?, dictionary["stringCol"] as! String?)
         XCTAssertEqual(object["binaryCol"] as! NSData?, dictionary["binaryCol"] as! NSData?)
-        XCTAssertEqual(object["dateCol"] as! NSDate?, dictionary["dateCol"] as! NSDate?)
+        XCTAssertEqual(object["dateCol"] as! Date?, dictionary["dateCol"] as! Date?)
         XCTAssertEqual((object["objectCol"] as? SwiftBoolObject)?.boolCol, false)
     }
 
@@ -493,7 +493,7 @@ class RealmTests: TestCase {
         XCTAssertEqual(object["optStringCol"] as! String?, dictionary["optStringCol"] as! String?)
         XCTAssertEqual(object["optNSStringCol"] as! String?, dictionary["optNSStringCol"] as! String?)
         XCTAssertEqual(object["optBinaryCol"] as! NSData?, dictionary["optBinaryCol"] as! NSData?)
-        XCTAssertEqual(object["optDateCol"] as! NSDate?, dictionary["optDateCol"] as! NSDate?)
+        XCTAssertEqual(object["optDateCol"] as! Date?, dictionary["optDateCol"] as! Date?)
         XCTAssertEqual((object["optObjectCol"] as? SwiftBoolObject)?.boolCol, true)
     }
 

--- a/RealmSwift/Tests/SwiftTestObjects.swift
+++ b/RealmSwift/Tests/SwiftTestObjects.swift
@@ -44,8 +44,8 @@ class SwiftObject: Object {
     dynamic var floatCol = 1.23 as Float
     dynamic var doubleCol = 12.3
     dynamic var stringCol = "a"
-    dynamic var binaryCol = "a".data(using: String.Encoding.utf8)! as Data as NSData
-    dynamic var dateCol = NSDate(timeIntervalSince1970: 1)
+    dynamic var binaryCol = "a".data(using: String.Encoding.utf8)!
+    dynamic var dateCol = Date(timeIntervalSince1970: 1)
     dynamic var objectCol: SwiftBoolObject? = SwiftBoolObject()
     let arrayCol = List<SwiftBoolObject>()
 
@@ -57,7 +57,7 @@ class SwiftObject: Object {
             "doubleCol": 12.3,
             "stringCol": "a",
             "binaryCol":  "a".data(using: String.Encoding.utf8)!,
-            "dateCol": NSDate(timeIntervalSince1970: 1),
+            "dateCol": Date(timeIntervalSince1970: 1),
             "objectCol": [false],
             "arrayCol": []
         ]
@@ -67,8 +67,8 @@ class SwiftObject: Object {
 class SwiftOptionalObject: Object {
     dynamic var optNSStringCol: NSString?
     dynamic var optStringCol: String?
-    dynamic var optBinaryCol: NSData?
-    dynamic var optDateCol: NSDate?
+    dynamic var optBinaryCol: Data?
+    dynamic var optDateCol: Date?
     let optIntCol = RealmOptional<Int>()
     let optInt8Col = RealmOptional<Int8>()
     let optInt16Col = RealmOptional<Int16>()
@@ -83,16 +83,16 @@ class SwiftOptionalObject: Object {
 class SwiftImplicitlyUnwrappedOptionalObject: Object {
     dynamic var optNSStringCol: NSString!
     dynamic var optStringCol: String!
-    dynamic var optBinaryCol: NSData!
-    dynamic var optDateCol: NSDate!
+    dynamic var optBinaryCol: Data!
+    dynamic var optDateCol: Date!
     dynamic var optObjectCol: SwiftBoolObject!
 }
 
 class SwiftOptionalDefaultValuesObject: Object {
     dynamic var optNSStringCol: NSString? = "A"
     dynamic var optStringCol: String? = "B"
-    dynamic var optBinaryCol: NSData? = "C".data(using: String.Encoding.utf8)! as Data as NSData
-    dynamic var optDateCol: NSDate? = NSDate(timeIntervalSince1970: 10)
+    dynamic var optBinaryCol: Data? = "C".data(using: String.Encoding.utf8)! as Data
+    dynamic var optDateCol: Date? = Date(timeIntervalSince1970: 10)
     let optIntCol = RealmOptional<Int>(1)
     let optInt8Col = RealmOptional<Int8>(1)
     let optInt16Col = RealmOptional<Int16>(1)
@@ -109,7 +109,7 @@ class SwiftOptionalDefaultValuesObject: Object {
             "optNSStringCol" : "A",
             "optStringCol" : "B",
             "optBinaryCol" : "C".data(using: String.Encoding.utf8)!,
-            "optDateCol" : NSDate(timeIntervalSince1970: 10),
+            "optDateCol" : Date(timeIntervalSince1970: 10),
             "optIntCol" : 1,
             "optInt8Col" : 1,
             "optInt16Col" : 1,
@@ -127,8 +127,8 @@ class SwiftOptionalIgnoredPropertiesObject: Object {
 
     dynamic var optNSStringCol: NSString? = "A"
     dynamic var optStringCol: String? = "B"
-    dynamic var optBinaryCol: NSData? = "C".data(using: String.Encoding.utf8)! as Data as NSData
-    dynamic var optDateCol: NSDate? = NSDate(timeIntervalSince1970: 10)
+    dynamic var optBinaryCol: Data? = "C".data(using: String.Encoding.utf8)! as Data
+    dynamic var optDateCol: Date? = Date(timeIntervalSince1970: 10)
     dynamic var optObjectCol: SwiftBoolObject? = SwiftBoolObject(value: [true])
 
     override class func ignoredProperties() -> [String] {
@@ -159,7 +159,7 @@ class SwiftAggregateObject: Object {
     dynamic var floatCol = 0 as Float
     dynamic var doubleCol = 0.0
     dynamic var boolCol = false
-    dynamic var dateCol = NSDate()
+    dynamic var dateCol = Date()
     dynamic var trueCol = true
     let stringListCol = List<SwiftStringObject>()
 }
@@ -347,11 +347,11 @@ class SwiftIndexedPropertiesObject: Object {
     dynamic var int32Col: Int32 = 0
     dynamic var int64Col: Int64 = 0
     dynamic var boolCol = false
-    dynamic var dateCol = NSDate()
+    dynamic var dateCol = Date()
 
     dynamic var floatCol: Float = 0.0
     dynamic var doubleCol: Double = 0.0
-    dynamic var dataCol = NSData()
+    dynamic var dataCol = Data()
 
     override class func indexedProperties() -> [String] {
         return ["stringCol", "intCol", "int8Col", "int16Col", "int32Col", "int64Col", "boolCol", "dateCol"]
@@ -366,11 +366,11 @@ class SwiftIndexedOptionalPropertiesObject: Object {
     let optionalInt32Col = RealmOptional<Int32>()
     let optionalInt64Col = RealmOptional<Int64>()
     let optionalBoolCol = RealmOptional<Bool>()
-    dynamic var optionalDateCol: NSDate? = NSDate()
+    dynamic var optionalDateCol: Date? = Date()
 
     let optionalFloatCol = RealmOptional<Float>()
     let optionalDoubleCol = RealmOptional<Double>()
-    dynamic var optionalDataCol: NSData? = NSData()
+    dynamic var optionalDataCol: Data? = Data()
 
     override class func indexedProperties() -> [String] {
         return ["optionalStringCol", "optionalIntCol", "optionalInt8Col", "optionalInt16Col",

--- a/RealmSwift/Tests/SwiftTestObjects.swift
+++ b/RealmSwift/Tests/SwiftTestObjects.swift
@@ -411,6 +411,13 @@ class SwiftConvenienceInitializerObject: Object {
     }
 }
 
+class SwiftObjectiveCTypesObject: Object {
+    dynamic var stringCol: NSString?
+    dynamic var dateCol: NSDate?
+    dynamic var dataCol: NSData?
+    dynamic var numCol: NSNumber? = 0
+}
+
 #else
 
 class SwiftStringObject: Object {


### PR DESCRIPTION
Well, https://github.com/realm/realm-cocoa/issues/3968 was much easier than expected. Literally no changes were required, so I just updated our tests to use `Date` and `Data` and updated doc comments.