### PR TITLE
Fix a crash when an observed object is deallocated from within an observation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ x.x.x Release notes (yyyy-MM-dd)
 * Fix crash when an aggregate is accessed as an `Int8`, `Int16`, `Int32`, or `Int64`.
 * Fix a race condition that could lead to a crash if an RLMArray or List was
   deallocated on a different thread than it was created on.
+* Fix a crash when the last reference to an observed object is released from
+  within the observation.
 
 1.0.2 Release notes (2016-07-13)
 =============================================================


### PR DESCRIPTION
Retain the object while we're calling observers in case the user releases their last reference to it from within the observer.

Fixes #2549.