### PR TITLE
Use `ObjectiveCBridgeable ` for `RealmOptional` conversions

### DIFF
--- a/RealmSwift/LinkingObjects.swift
+++ b/RealmSwift/LinkingObjects.swift
@@ -301,7 +301,7 @@ public final class LinkingObjects<T: Object>: LinkingObjectsBase {
      - returns: The sum of the given property over all objects in the collection.
      */
     public func sum<U: AddableType>(ofProperty property: String) -> U {
-        return U.bridging(rlmResults.sum(ofProperty: property))
+        return U.bridging(objCValue: rlmResults.sum(ofProperty: property))
     }
 
     /**

--- a/RealmSwift/Optional.swift
+++ b/RealmSwift/Optional.swift
@@ -21,7 +21,9 @@ import Realm
 #if swift(>=3.0)
 
 /// Types that can be represented in a `RealmOptional`.
-public protocol RealmOptionalType {}
+public protocol RealmOptionalType {
+    // Must conform to Bridgable
+}
 extension Int: RealmOptionalType {}
 extension Int8: RealmOptionalType {}
 extension Int16: RealmOptionalType {}
@@ -30,34 +32,13 @@ extension Int64: RealmOptionalType {}
 extension Float: RealmOptionalType {}
 extension Double: RealmOptionalType {}
 extension Bool: RealmOptionalType {}
-
-private func realmOptionalToAny<T: RealmOptionalType>(_ value: T) -> Any {
-    // FIXME: Use common protocol that defines bridging instead of special-case check with no exhaustiveness guarentees.
-    if let int8Value = value as? Int8 {
-        return NSNumber(value: int8Value)
-    } else if let int16Value = value as? Int16 {
-        return NSNumber(value: int16Value)
-    } else if let int32Value = value as? Int32 {
-        return NSNumber(value: int32Value)
-    } else if let int64Value = value as? Int64 {
-        return NSNumber(value: int64Value)
-    } else {
-        return value
+extension RealmOptionalType {
+    internal static func bridging(objCValue value: Any) -> Self {
+        return (Self.self as! Bridgable.Type).bridging(objCValue: value) as! Self
     }
-}
-
-private func anyToRealmOptional<T: RealmOptionalType>(_ value: Any) -> T {
-    // FIXME: Use common protocol that defines bridging instead of special-case check with no exhaustiveness guarentees.
-    if T.self is Int8.Type {
-        return (value as! NSNumber).int8Value as! T
-    } else if T.self is Int16.Type {
-        return (value as! NSNumber).int16Value as! T
-    } else if T.self is Int32.Type {
-        return (value as! NSNumber).int32Value as! T
-    } else if T.self is Int64.Type {
-        return (value as! NSNumber).int64Value as! T
+    var objCValue: Any {
+        return (self as! Bridgable).objCValue
     }
-    return value as! T
 }
 
 /**
@@ -71,10 +52,10 @@ public final class RealmOptional<T: RealmOptionalType>: RLMOptionalBase {
     /// The value this optional represents.
     public var value: T? {
         get {
-            return underlyingValue.map(anyToRealmOptional)
+            return underlyingValue.map(T.bridging)
         }
         set {
-            underlyingValue = newValue.map(realmOptionalToAny)
+            underlyingValue = newValue.map({ $0.objCValue })
         }
     }
 
@@ -92,7 +73,9 @@ public final class RealmOptional<T: RealmOptionalType>: RLMOptionalBase {
 #else
 
 /// A protocol describing types that can parameterize a `RealmOptional`.
-public protocol RealmOptionalType {}
+public protocol RealmOptionalType {
+    // Must conform to Bridgable
+}
 extension Int: RealmOptionalType {}
 extension Int8: RealmOptionalType {}
 extension Int16: RealmOptionalType {}
@@ -101,35 +84,13 @@ extension Int64: RealmOptionalType {}
 extension Float: RealmOptionalType {}
 extension Double: RealmOptionalType {}
 extension Bool: RealmOptionalType {}
-
-// Not all RealmOptionalType's can be cast to AnyObject, so handle casting logic here.
-private func realmOptionalToAnyObject<T: RealmOptionalType>(value: T?) -> AnyObject? {
-    if let anyObjectValue: AnyObject = value as? AnyObject {
-        return anyObjectValue
-    } else if let int8Value = value as? Int8 {
-        return NSNumber(long: Int(int8Value))
-    } else if let int16Value = value as? Int16 {
-        return NSNumber(long: Int(int16Value))
-    } else if let int32Value = value as? Int32 {
-        return NSNumber(long: Int(int32Value))
-    } else if let int64Value = value as? Int64 {
-        return NSNumber(longLong: int64Value)
+extension RealmOptionalType {
+    internal static func bridging(objCValue objCValue: AnyObject) -> Self {
+        return (Self.self as! Bridgable.Type).bridging(objCValue: objCValue) as! Self
     }
-    return nil
-}
-
-// Not all RealmOptionalType's can be cast from AnyObject, so handle casting logic here.
-private func anyObjectToRealmOptional<T: RealmOptionalType>(anyObject: AnyObject?) -> T? {
-    if T.self is Int8.Type {
-        return ((anyObject as! NSNumber?)?.longValue).map { Int8($0) } as! T?
-    } else if T.self is Int16.Type {
-        return ((anyObject as! NSNumber?)?.longValue).map { Int16($0) } as! T?
-    } else if T.self is Int32.Type {
-        return ((anyObject as! NSNumber?)?.longValue).map { Int32($0) } as! T?
-    } else if T.self is Int64.Type {
-        return (anyObject as! NSNumber?)?.longLongValue as! T?
+    var objCValue: AnyObject {
+        return (self as! Bridgable).objCValue
     }
-    return anyObject as! T?
 }
 
 /**
@@ -142,10 +103,10 @@ public final class RealmOptional<T: RealmOptionalType>: RLMOptionalBase {
     /// The value this optional represents.
     public var value: T? {
         get {
-            return anyObjectToRealmOptional(underlyingValue)
+            return underlyingValue.map(T.bridging)
         }
         set {
-            underlyingValue = realmOptionalToAnyObject(newValue)
+            underlyingValue = newValue.map({ $0.objCValue })
         }
     }
 

--- a/RealmSwift/Optional.swift
+++ b/RealmSwift/Optional.swift
@@ -22,7 +22,7 @@ import Realm
 
 /// Types that can be represented in a `RealmOptional`.
 public protocol RealmOptionalType {
-    // Must conform to Bridgable
+    // Must conform to ObjectiveCBridgeable
 }
 extension Int: RealmOptionalType {}
 extension Int8: RealmOptionalType {}
@@ -34,10 +34,10 @@ extension Double: RealmOptionalType {}
 extension Bool: RealmOptionalType {}
 extension RealmOptionalType {
     internal static func bridging(objCValue value: Any) -> Self {
-        return (Self.self as! Bridgable.Type).bridging(objCValue: value) as! Self
+        return (Self.self as! ObjectiveCBridgeable.Type).bridging(objCValue: value) as! Self
     }
     var objCValue: Any {
-        return (self as! Bridgable).objCValue
+        return (self as! ObjectiveCBridgeable).objCValue
     }
 }
 
@@ -74,7 +74,7 @@ public final class RealmOptional<T: RealmOptionalType>: RLMOptionalBase {
 
 /// A protocol describing types that can parameterize a `RealmOptional`.
 public protocol RealmOptionalType {
-    // Must conform to Bridgable
+    // Must conform to ObjectiveCBridgeable
 }
 extension Int: RealmOptionalType {}
 extension Int8: RealmOptionalType {}
@@ -86,10 +86,10 @@ extension Double: RealmOptionalType {}
 extension Bool: RealmOptionalType {}
 extension RealmOptionalType {
     internal static func bridging(objCValue objCValue: AnyObject) -> Self {
-        return (Self.self as! Bridgable.Type).bridging(objCValue: objCValue) as! Self
+        return (Self.self as! ObjectiveCBridgeable.Type).bridging(objCValue: objCValue) as! Self
     }
     var objCValue: AnyObject {
-        return (self as! Bridgable).objCValue
+        return (self as! ObjectiveCBridgeable).objCValue
     }
 }
 

--- a/RealmSwift/Results.swift
+++ b/RealmSwift/Results.swift
@@ -20,70 +20,6 @@ import Foundation
 import Realm
 
 #if swift(>=3.0)
-
-// MARK: Bridgable
-
-// Used for conversion from Objective-C types to Swift types
-private protocol Bridgable  { static func bridging(_ value: Any) -> Self }
-
-// FIXME: Remove once Swift supports `as! Self` casts
-private func forceCastToInferred<T, U>(_ x: T) -> U {
-    return x as! U
-}
-
-extension NSNumber: Bridgable {
-    static func bridging(_ value: Any) -> Self {
-        // Unsafe if `Self` is a concrete subclass of `NSNumber`
-        return forceCastToInferred(value)
-    }
-}
-extension Double: Bridgable {
-    static func bridging(_ value: Any) -> Double {
-        return (value as! NSNumber).doubleValue
-    }
-}
-extension Float: Bridgable {
-    static func bridging(_ value: Any) -> Float {
-        return (value as! NSNumber).floatValue
-    }
-}
-extension Int: Bridgable {
-    static func bridging(_ value: Any) -> Int {
-        return (value as! NSNumber).intValue
-    }
-}
-extension Int8: Bridgable {
-    static func bridging(_ value: Any) -> Int8 {
-        return (value as! NSNumber).int8Value
-    }
-}
-extension Int16: Bridgable {
-    static func bridging(_ value: Any) -> Int16 {
-        return (value as! NSNumber).int16Value
-    }
-}
-extension Int32: Bridgable {
-    static func bridging(_ value: Any) -> Int32 {
-        return (value as! NSNumber).int32Value
-    }
-}
-extension Int64: Bridgable {
-    static func bridging(_ value: Any) -> Int64 {
-        return (value as! NSNumber).int64Value
-    }
-}
-extension Date: Bridgable {
-    static func bridging(_ value: Any) -> Date   {
-        return value as! Date
-    }
-}
-extension NSDate: Bridgable {
-    static func bridging(_ value: Any) -> Self   {
-        // Unsafe if `Self` is a concrete subclass of `NSDate`
-        return forceCastToInferred(value)
-    }
-}
-
 // MARK: MinMaxType
 
 /// Types which can be used for min()/max().
@@ -101,8 +37,8 @@ extension Int64: MinMaxType {}
 extension Date: MinMaxType {}
 extension NSDate: MinMaxType {}
 extension MinMaxType {
-    internal static func bridging(_ value: Any) -> Self {
-        return (Self.self as! Bridgable.Type).bridging(value) as! Self
+    internal static func bridging(objCValue: Any) -> Self {
+        return (Self.self as! Bridgable.Type).bridging(objCValue: objCValue) as! Self
     }
 }
     
@@ -121,8 +57,8 @@ extension Int16: AddableType {}
 extension Int32: AddableType {}
 extension Int64: AddableType {}
 extension AddableType {
-    internal static func bridging(_ value: Any) -> Self {
-        return (Self.self as! Bridgable.Type).bridging(value) as! Self
+    internal static func bridging(objCValue: Any) -> Self {
+        return (Self.self as! Bridgable.Type).bridging(objCValue: objCValue) as! Self
     }
 }
 
@@ -376,7 +312,7 @@ public final class Results<T: Object>: NSObject, NSFastEnumeration {
     - returns: The sum of the given property over all objects in the Results.
     */
     public func sum<U: AddableType>(ofProperty property: String) -> U {
-        return U.bridging(rlmResults.sum(ofProperty: property))
+        return U.bridging(objCValue: rlmResults.sum(ofProperty: property))
     }
 
     /**
@@ -533,64 +469,6 @@ extension Results {
 
 #else
 
-// MARK: Bridgable
-
-// Used for conversion from Objective-C types to Swift types
-private protocol Bridgable  { static func bridging(value: AnyObject) -> Self }
-
-// FIXME: Remove once Swift supports `as! Self` casts
-private func forceCastToInferred<T, U>(x: T) -> U {
-    return x as! U
-}
-
-extension NSNumber: Bridgable {
-    static func bridging(value: AnyObject) -> Self {
-        // Unsafe if `Self` is a concrete subclass of `NSNumber`
-        return forceCastToInferred(value)
-    }
-}
-extension Double: Bridgable {
-    static func bridging(value: AnyObject) -> Double {
-        return (value as! NSNumber).doubleValue
-    }
-}
-extension Float: Bridgable {
-    static func bridging(value: AnyObject) -> Float {
-        return (value as! NSNumber).floatValue
-    }
-}
-extension Int: Bridgable {
-    static func bridging(value: AnyObject) -> Int {
-        return (value as! NSNumber).integerValue
-    }
-}
-extension Int8: Bridgable {
-    static func bridging(value: AnyObject) -> Int8 {
-        return (value as! NSNumber).charValue
-    }
-}
-extension Int16: Bridgable {
-    static func bridging(value: AnyObject) -> Int16 {
-        return (value as! NSNumber).shortValue
-    }
-}
-extension Int32: Bridgable {
-    static func bridging(value: AnyObject) -> Int32 {
-        return (value as! NSNumber).intValue
-    }
-}
-extension Int64: Bridgable {
-    static func bridging(value: AnyObject) -> Int64 {
-        return (value as! NSNumber).longLongValue
-    }
-}
-extension NSDate: Bridgable {
-    static func bridging(value: AnyObject) -> Self   {
-        // Unsafe if `Self` is a concrete subclass of `NSDate`
-        return forceCastToInferred(value)
-    }
-}
-
 // MARK: MinMaxType
 
 /**
@@ -611,8 +489,8 @@ extension Int32: MinMaxType {}
 extension Int64: MinMaxType {}
 extension NSDate: MinMaxType {}
 extension MinMaxType {
-    internal static func bridging(value: AnyObject) -> Self {
-        return (Self.self as! Bridgable.Type).bridging(value) as! Self
+    internal static func bridging(objCValue objCValue: AnyObject) -> Self {
+        return (Self.self as! Bridgable.Type).bridging(objCValue: objCValue) as! Self
     }
 }
 
@@ -635,8 +513,8 @@ extension Int16: AddableType {}
 extension Int32: AddableType {}
 extension Int64: AddableType {}
 extension AddableType {
-    internal static func bridging(value: AnyObject) -> Self {
-        return (Self.self as! Bridgable.Type).bridging(value) as! Self
+    internal static func bridging(objCValue: AnyObject) -> Self {
+        return (Self.self as! Bridgable.Type).bridging(objCValue: objCValue) as! Self
     }
 }
 

--- a/RealmSwift/Results.swift
+++ b/RealmSwift/Results.swift
@@ -24,7 +24,7 @@ import Realm
 
 /// Types which can be used for min()/max().
 public protocol MinMaxType {
-    // Must conform to `Bridgable`
+    // Must conform to `ObjectiveCBridgeable`
 }
 extension NSNumber: MinMaxType {}
 extension Double: MinMaxType {}
@@ -38,7 +38,7 @@ extension Date: MinMaxType {}
 extension NSDate: MinMaxType {}
 extension MinMaxType {
     internal static func bridging(objCValue: Any) -> Self {
-        return (Self.self as! Bridgable.Type).bridging(objCValue: objCValue) as! Self
+        return (Self.self as! ObjectiveCBridgeable.Type).bridging(objCValue: objCValue) as! Self
     }
 }
     
@@ -46,7 +46,7 @@ extension MinMaxType {
 
 /// Types which can be used for average()/sum().
 public protocol AddableType {
-    // Must conform to `Bridgable`
+    // Must conform to `ObjectiveCBridgeable`
 }
 extension NSNumber: AddableType {}
 extension Double: AddableType {}
@@ -58,7 +58,7 @@ extension Int32: AddableType {}
 extension Int64: AddableType {}
 extension AddableType {
     internal static func bridging(objCValue: Any) -> Self {
-        return (Self.self as! Bridgable.Type).bridging(objCValue: objCValue) as! Self
+        return (Self.self as! ObjectiveCBridgeable.Type).bridging(objCValue: objCValue) as! Self
     }
 }
 
@@ -477,7 +477,7 @@ extension Results {
  - see: `min(_:)`, `max(_:)`
  */
 public protocol MinMaxType {
-    // Must conform to `Bridgable`
+    // Must conform to `ObjectiveCBridgeable`
 }
 extension NSNumber: MinMaxType {}
 extension Double: MinMaxType {}
@@ -490,7 +490,7 @@ extension Int64: MinMaxType {}
 extension NSDate: MinMaxType {}
 extension MinMaxType {
     internal static func bridging(objCValue objCValue: AnyObject) -> Self {
-        return (Self.self as! Bridgable.Type).bridging(objCValue: objCValue) as! Self
+        return (Self.self as! ObjectiveCBridgeable.Type).bridging(objCValue: objCValue) as! Self
     }
 }
 
@@ -502,7 +502,7 @@ extension MinMaxType {
  - see: `sum(_:)`, `average(_:)`
  */
 public protocol AddableType {
-    // Must conform to `Bridgable`
+    // Must conform to `ObjectiveCBridgeable`
 }
 extension NSNumber: AddableType {}
 extension Double: AddableType {}
@@ -514,7 +514,7 @@ extension Int32: AddableType {}
 extension Int64: AddableType {}
 extension AddableType {
     internal static func bridging(objCValue: AnyObject) -> Self {
-        return (Self.self as! Bridgable.Type).bridging(objCValue: objCValue) as! Self
+        return (Self.self as! ObjectiveCBridgeable.Type).bridging(objCValue: objCValue) as! Self
     }
 }
 

--- a/RealmSwift/Util.swift
+++ b/RealmSwift/Util.swift
@@ -47,6 +47,110 @@ internal func gsub(pattern: String, template: String, string: String, error: NSE
                                            withTemplate: template)
 }
 
+// MARK: Bridgable
+
+// Used for conversion from Objective-C types to Swift types
+internal protocol Bridgable  {
+    /* FIXME: Remove protocol once SR-2393 bridges all integer types to `NSNumber`
+     *        Instead, use `as AnyObject` and `as! [SwiftType]` to cast between. */
+    static func bridging(objCValue: Any) -> Self
+    var objCValue: Any { get }
+}
+
+// FIXME: Remove once Swift supports `as! Self` casts
+private func forceCastToInferred<T, U>(_ x: T) -> U {
+    return x as! U
+}
+
+extension NSNumber: Bridgable {
+    static func bridging(objCValue: Any) -> Self {
+        return forceCastToInferred(objCValue)
+    }
+    var objCValue: Any {
+        return self
+    }
+}
+extension Double: Bridgable {
+    static func bridging(objCValue: Any) -> Double {
+        return (objCValue as! NSNumber).doubleValue
+    }
+    var objCValue: Any {
+        return NSNumber(value: self)
+    }
+}
+extension Float: Bridgable {
+    static func bridging(objCValue: Any) -> Float {
+        return (objCValue as! NSNumber).floatValue
+    }
+    var objCValue: Any {
+        return NSNumber(value: self)
+    }
+}
+extension Int: Bridgable {
+    static func bridging(objCValue: Any) -> Int {
+        return (objCValue as! NSNumber).intValue
+    }
+    var objCValue: Any {
+        return NSNumber(value: self)
+    }
+}
+extension Int8: Bridgable {
+    static func bridging(objCValue: Any) -> Int8 {
+        return (objCValue as! NSNumber).int8Value
+    }
+    var objCValue: Any {
+        return NSNumber(value: self)
+    }
+}
+extension Int16: Bridgable {
+    static func bridging(objCValue: Any) -> Int16 {
+        return (objCValue as! NSNumber).int16Value
+    }
+    var objCValue: Any {
+        return NSNumber(value: self)
+    }
+}
+extension Int32: Bridgable {
+    static func bridging(objCValue: Any) -> Int32 {
+        return (objCValue as! NSNumber).int32Value
+    }
+    var objCValue: Any {
+        return NSNumber(value: self)
+    }
+}
+extension Int64: Bridgable {
+    static func bridging(objCValue: Any) -> Int64 {
+        return (objCValue as! NSNumber).int64Value
+    }
+    var objCValue: Any {
+        return NSNumber(value: self)
+    }
+}
+extension Bool: Bridgable {
+    static func bridging(objCValue: Any) -> Bool {
+        return (objCValue as! NSNumber).boolValue
+    }
+    var objCValue: Any {
+        return NSNumber(value: self)
+    }
+}
+extension Date: Bridgable {
+    static func bridging(objCValue: Any) -> Date   {
+        return objCValue as! Date
+    }
+    var objCValue: Any {
+        return self
+    }
+}
+extension NSDate: Bridgable {
+    static func bridging(objCValue: Any) -> Self   {
+        return forceCastToInferred(objCValue)
+    }
+    var objCValue: Any {
+        return self
+    }
+}
+
 #else
 
 internal func throwRealmException(message: String, userInfo: [String:AnyObject] = [:]) {
@@ -64,6 +168,105 @@ internal func gsub(pattern: String, template: String, string: String, error: NSE
     return regex?.stringByReplacingMatchesInString(string, options: [],
                                                    range: NSRange(location: 0, length: string.utf16.count),
                                                    withTemplate: template)
+}
+
+// MARK: Bridgable
+
+// Used for conversion from Objective-C types to Swift types
+internal protocol Bridgable  {
+    /* FIXME: Remove protocol once SR-2393 bridges all integer types to `NSNumber`
+     *        Instead, use `as AnyObject` and `as! [SwiftType]` to cast between. */
+    static func bridging(objCValue objCValue: AnyObject) -> Self
+    var objCValue: AnyObject { get }
+}
+
+// FIXME: Remove once Swift supports `as! Self` casts
+private func forceCastToInferred<T, U>(x: T) -> U {
+    return x as! U
+}
+
+extension NSNumber: Bridgable {
+    static func bridging(objCValue objCValue: AnyObject) -> Self {
+        return forceCastToInferred(objCValue)
+    }
+    var objCValue: AnyObject {
+        return self
+    }
+}
+extension Double: Bridgable {
+    static func bridging(objCValue objCValue: AnyObject) -> Double {
+        return (objCValue as! NSNumber).doubleValue
+    }
+    var objCValue: AnyObject {
+        return NSNumber(double: self)
+    }
+}
+extension Float: Bridgable {
+    static func bridging(objCValue objCValue: AnyObject) -> Float {
+        return (objCValue as! NSNumber).floatValue
+    }
+    var objCValue: AnyObject {
+        return NSNumber(float: self)
+    }
+}
+extension Int: Bridgable {
+    static func bridging(objCValue objCValue: AnyObject) -> Int {
+        return (objCValue as! NSNumber).integerValue
+    }
+    var objCValue: AnyObject {
+        return NSNumber(integer: self)
+    }
+}
+extension Int8: Bridgable {
+    static func bridging(objCValue objCValue: AnyObject) -> Int8 {
+        return (objCValue as! NSNumber).charValue
+    }
+    var objCValue: AnyObject {
+        return NSNumber(char: self)
+    }
+}
+extension Int16: Bridgable {
+    static func bridging(objCValue objCValue: AnyObject) -> Int16 {
+        return (objCValue as! NSNumber).shortValue
+    }
+    var objCValue: AnyObject {
+        return NSNumber(short: self)
+    }
+}
+extension Int32: Bridgable {
+    static func bridging(objCValue objCValue: AnyObject) -> Int32 {
+        return (objCValue as! NSNumber).intValue
+    }
+    var objCValue: AnyObject {
+        return NSNumber(int: self)
+    }
+}
+extension Int64: Bridgable {
+    static func bridging(objCValue objCValue: AnyObject) -> Int64 {
+        return (objCValue as! NSNumber).longLongValue
+    }
+    var objCValue: AnyObject {
+        return NSNumber(longLong: self)
+    }
+}
+extension Bool: Bridgable {
+    static func bridging(objCValue objCValue: AnyObject) -> Bool {
+        return (objCValue as! NSNumber).boolValue
+    }
+    var objCValue: AnyObject {
+        return NSNumber(bool: self)
+    }
+}
+extension NSDate: Bridgable {
+    static func bridging(objCValue objCValue: AnyObject) -> Self   {
+        func forceCastTrampoline<T, U>(x: T) -> U {
+            return x as! U
+        }
+        return forceCastTrampoline(objCValue)
+    }
+    var objCValue: AnyObject {
+        return self
+    }
 }
 
 #endif

--- a/RealmSwift/Util.swift
+++ b/RealmSwift/Util.swift
@@ -47,10 +47,10 @@ internal func gsub(pattern: String, template: String, string: String, error: NSE
                                            withTemplate: template)
 }
 
-// MARK: Bridgable
+// MARK: ObjectiveCBridgeable
 
 // Used for conversion from Objective-C types to Swift types
-internal protocol Bridgable  {
+internal protocol ObjectiveCBridgeable  {
     /* FIXME: Remove protocol once SR-2393 bridges all integer types to `NSNumber`
      *        Instead, use `as AnyObject` and `as! [SwiftType]` to cast between. */
     static func bridging(objCValue: Any) -> Self
@@ -62,7 +62,7 @@ private func forceCastToInferred<T, U>(_ x: T) -> U {
     return x as! U
 }
 
-extension NSNumber: Bridgable {
+extension NSNumber: ObjectiveCBridgeable {
     static func bridging(objCValue: Any) -> Self {
         return forceCastToInferred(objCValue)
     }
@@ -70,7 +70,7 @@ extension NSNumber: Bridgable {
         return self
     }
 }
-extension Double: Bridgable {
+extension Double: ObjectiveCBridgeable {
     static func bridging(objCValue: Any) -> Double {
         return (objCValue as! NSNumber).doubleValue
     }
@@ -78,7 +78,7 @@ extension Double: Bridgable {
         return NSNumber(value: self)
     }
 }
-extension Float: Bridgable {
+extension Float: ObjectiveCBridgeable {
     static func bridging(objCValue: Any) -> Float {
         return (objCValue as! NSNumber).floatValue
     }
@@ -86,7 +86,7 @@ extension Float: Bridgable {
         return NSNumber(value: self)
     }
 }
-extension Int: Bridgable {
+extension Int: ObjectiveCBridgeable {
     static func bridging(objCValue: Any) -> Int {
         return (objCValue as! NSNumber).intValue
     }
@@ -94,7 +94,7 @@ extension Int: Bridgable {
         return NSNumber(value: self)
     }
 }
-extension Int8: Bridgable {
+extension Int8: ObjectiveCBridgeable {
     static func bridging(objCValue: Any) -> Int8 {
         return (objCValue as! NSNumber).int8Value
     }
@@ -102,7 +102,7 @@ extension Int8: Bridgable {
         return NSNumber(value: self)
     }
 }
-extension Int16: Bridgable {
+extension Int16: ObjectiveCBridgeable {
     static func bridging(objCValue: Any) -> Int16 {
         return (objCValue as! NSNumber).int16Value
     }
@@ -110,7 +110,7 @@ extension Int16: Bridgable {
         return NSNumber(value: self)
     }
 }
-extension Int32: Bridgable {
+extension Int32: ObjectiveCBridgeable {
     static func bridging(objCValue: Any) -> Int32 {
         return (objCValue as! NSNumber).int32Value
     }
@@ -118,7 +118,7 @@ extension Int32: Bridgable {
         return NSNumber(value: self)
     }
 }
-extension Int64: Bridgable {
+extension Int64: ObjectiveCBridgeable {
     static func bridging(objCValue: Any) -> Int64 {
         return (objCValue as! NSNumber).int64Value
     }
@@ -126,7 +126,7 @@ extension Int64: Bridgable {
         return NSNumber(value: self)
     }
 }
-extension Bool: Bridgable {
+extension Bool: ObjectiveCBridgeable {
     static func bridging(objCValue: Any) -> Bool {
         return (objCValue as! NSNumber).boolValue
     }
@@ -134,7 +134,7 @@ extension Bool: Bridgable {
         return NSNumber(value: self)
     }
 }
-extension Date: Bridgable {
+extension Date: ObjectiveCBridgeable {
     static func bridging(objCValue: Any) -> Date   {
         return objCValue as! Date
     }
@@ -142,7 +142,7 @@ extension Date: Bridgable {
         return self
     }
 }
-extension NSDate: Bridgable {
+extension NSDate: ObjectiveCBridgeable {
     static func bridging(objCValue: Any) -> Self   {
         return forceCastToInferred(objCValue)
     }
@@ -170,10 +170,10 @@ internal func gsub(pattern: String, template: String, string: String, error: NSE
                                                    withTemplate: template)
 }
 
-// MARK: Bridgable
+// MARK: ObjectiveCBridgeable
 
 // Used for conversion from Objective-C types to Swift types
-internal protocol Bridgable  {
+internal protocol ObjectiveCBridgeable  {
     /* FIXME: Remove protocol once SR-2393 bridges all integer types to `NSNumber`
      *        Instead, use `as AnyObject` and `as! [SwiftType]` to cast between. */
     static func bridging(objCValue objCValue: AnyObject) -> Self
@@ -185,7 +185,7 @@ private func forceCastToInferred<T, U>(x: T) -> U {
     return x as! U
 }
 
-extension NSNumber: Bridgable {
+extension NSNumber: ObjectiveCBridgeable {
     static func bridging(objCValue objCValue: AnyObject) -> Self {
         return forceCastToInferred(objCValue)
     }
@@ -193,7 +193,7 @@ extension NSNumber: Bridgable {
         return self
     }
 }
-extension Double: Bridgable {
+extension Double: ObjectiveCBridgeable {
     static func bridging(objCValue objCValue: AnyObject) -> Double {
         return (objCValue as! NSNumber).doubleValue
     }
@@ -201,7 +201,7 @@ extension Double: Bridgable {
         return NSNumber(double: self)
     }
 }
-extension Float: Bridgable {
+extension Float: ObjectiveCBridgeable {
     static func bridging(objCValue objCValue: AnyObject) -> Float {
         return (objCValue as! NSNumber).floatValue
     }
@@ -209,7 +209,7 @@ extension Float: Bridgable {
         return NSNumber(float: self)
     }
 }
-extension Int: Bridgable {
+extension Int: ObjectiveCBridgeable {
     static func bridging(objCValue objCValue: AnyObject) -> Int {
         return (objCValue as! NSNumber).integerValue
     }
@@ -217,7 +217,7 @@ extension Int: Bridgable {
         return NSNumber(integer: self)
     }
 }
-extension Int8: Bridgable {
+extension Int8: ObjectiveCBridgeable {
     static func bridging(objCValue objCValue: AnyObject) -> Int8 {
         return (objCValue as! NSNumber).charValue
     }
@@ -225,7 +225,7 @@ extension Int8: Bridgable {
         return NSNumber(char: self)
     }
 }
-extension Int16: Bridgable {
+extension Int16: ObjectiveCBridgeable {
     static func bridging(objCValue objCValue: AnyObject) -> Int16 {
         return (objCValue as! NSNumber).shortValue
     }
@@ -233,7 +233,7 @@ extension Int16: Bridgable {
         return NSNumber(short: self)
     }
 }
-extension Int32: Bridgable {
+extension Int32: ObjectiveCBridgeable {
     static func bridging(objCValue objCValue: AnyObject) -> Int32 {
         return (objCValue as! NSNumber).intValue
     }
@@ -241,7 +241,7 @@ extension Int32: Bridgable {
         return NSNumber(int: self)
     }
 }
-extension Int64: Bridgable {
+extension Int64: ObjectiveCBridgeable {
     static func bridging(objCValue objCValue: AnyObject) -> Int64 {
         return (objCValue as! NSNumber).longLongValue
     }
@@ -249,7 +249,7 @@ extension Int64: Bridgable {
         return NSNumber(longLong: self)
     }
 }
-extension Bool: Bridgable {
+extension Bool: ObjectiveCBridgeable {
     static func bridging(objCValue objCValue: AnyObject) -> Bool {
         return (objCValue as! NSNumber).boolValue
     }
@@ -257,7 +257,7 @@ extension Bool: Bridgable {
         return NSNumber(bool: self)
     }
 }
-extension NSDate: Bridgable {
+extension NSDate: ObjectiveCBridgeable {
     static func bridging(objCValue objCValue: AnyObject) -> Self   {
         func forceCastTrampoline<T, U>(x: T) -> U {
             return x as! U


### PR DESCRIPTION
Moves `ObjectiveCBridgeable` protocol to `Util.swift` and uses the protocol for `RealmOptional` versions. Additionally, adds "FIXME" message that explains when the `ObjectiveCBridgeable ` protocol will no longer be necessary.