### PR TITLE
Use `set_int_unique` and `set_string_unique` for primary keys

### DIFF
--- a/Realm/RLMAccessor.mm
+++ b/Realm/RLMAccessor.mm
@@ -83,10 +83,7 @@ static inline void RLMSetValue(__unsafe_unretained RLMObjectBase *const obj, NSU
 static inline void RLMSetValueUnique(__unsafe_unretained RLMObjectBase *const obj, NSUInteger colIndex, NSString *propName, long long val) {
     RLMVerifyInWriteTransaction(obj);
     size_t row = obj->_row.get_table()->find_first_int(colIndex, val);
-    if (row == obj->_row.get_index()) {
-        return;
-    }
-    if (row != realm::not_found) {
+    if (row != obj->_row.get_index() && row != realm::not_found) {
         @throw RLMException(@"Can't set primary key property '%@' to existing value '%lld'.", propName, val);
     }
     obj->_row.set_int_unique(colIndex, val);
@@ -128,10 +125,7 @@ static inline void RLMSetValueUnique(__unsafe_unretained RLMObjectBase *const ob
     RLMVerifyInWriteTransaction(obj);
     realm::StringData str = RLMStringDataWithNSString(val);
     size_t row = obj->_row.get_table()->find_first_string(colIndex, str);
-    if (row == obj->_row.get_index()) {
-        return;
-    }
-    if (row != realm::not_found) {
+    if (row != obj->_row.get_index() && row != realm::not_found) {
         @throw RLMException(@"Can't set primary key property '%@' to existing value '%@'.", propName, val);
     }
     try {
@@ -283,10 +277,7 @@ static inline void RLMSetValueUnique(__unsafe_unretained RLMObjectBase *const ob
         row = obj->_row.get_table()->find_first_null(colIndex);
     }
 
-    if (row == obj->_row.get_index()) {
-        return;
-    }
-    if (row != realm::not_found) {
+    if (row != obj->_row.get_index() && row != realm::not_found) {
         @throw RLMException(@"Can't set primary key property '%@' to existing value '%@'.", propName, intObject);
     }
 

--- a/Realm/RLMAccessor.mm
+++ b/Realm/RLMAccessor.mm
@@ -89,7 +89,7 @@ static inline void RLMSetValueUnique(__unsafe_unretained RLMObjectBase *const ob
     if (row != realm::not_found) {
         @throw RLMException(@"Can't set primary key property '%@' to existing value '%lld'.", propName, val);
     }
-    obj->_row.set_int(colIndex, val);
+    obj->_row.set_int_unique(colIndex, val);
 }
 
 // float getter/setter
@@ -135,7 +135,7 @@ static inline void RLMSetValueUnique(__unsafe_unretained RLMObjectBase *const ob
         @throw RLMException(@"Can't set primary key property '%@' to existing value '%@'.", propName, val);
     }
     try {
-        obj->_row.set_string(colIndex, str);
+        obj->_row.set_string_unique(colIndex, str);
     }
     catch (std::exception const& e) {
         @throw RLMException(e);
@@ -291,10 +291,10 @@ static inline void RLMSetValueUnique(__unsafe_unretained RLMObjectBase *const ob
     }
 
     if (intObject) {
-        obj->_row.set_int(colIndex, longLongValue);
+        obj->_row.set_int_unique(colIndex, longLongValue);
     }
     else {
-        obj->_row.set_null(colIndex);
+        obj->_row.set_null(colIndex); // FIXME: Use `set_null_unique` once Core implements it.
     }
 }
 


### PR DESCRIPTION
Note that Core doesn't yet support `set_null_unique` which is required for continued support of null integer primary keys. https://github.com/realm/realm-cocoa/issues/3998