### PR TITLE
Only conform types in need of custom bridging to `CustomObjectiveCBridgeable`

### DIFF
--- a/RealmSwift/LinkingObjects.swift
+++ b/RealmSwift/LinkingObjects.swift
@@ -274,7 +274,7 @@ public final class LinkingObjects<T: Object>: LinkingObjectsBase {
        is empty.
      */
     public func minimumValue<U: MinMaxType>(ofProperty property: String) -> U? {
-        return rlmResults.min(ofProperty: property).map(forceSwiftBridgeCast)
+        return rlmResults.min(ofProperty: property).map(dynamicBridgeCast)
     }
 
     /**
@@ -288,7 +288,7 @@ public final class LinkingObjects<T: Object>: LinkingObjectsBase {
        is empty.
      */
     public func maximumValue<U: MinMaxType>(ofProperty property: String) -> U? {
-        return rlmResults.max(ofProperty: property).map(forceSwiftBridgeCast)
+        return rlmResults.max(ofProperty: property).map(dynamicBridgeCast)
     }
 
     /**
@@ -301,7 +301,7 @@ public final class LinkingObjects<T: Object>: LinkingObjectsBase {
      - returns: The sum of the given property over all objects in the collection.
      */
     public func sum<U: AddableType>(ofProperty property: String) -> U {
-        return forceSwiftBridgeCast(fromObjCValue: rlmResults.sum(ofProperty: property))
+        return dynamicBridgeCast(fromObjCValue: rlmResults.sum(ofProperty: property))
     }
 
     /**
@@ -315,7 +315,7 @@ public final class LinkingObjects<T: Object>: LinkingObjectsBase {
        is empty.
      */
     public func average<U: AddableType>(ofProperty property: String) -> U? {
-        return rlmResults.average(ofProperty: property).map(forceSwiftBridgeCast)
+        return rlmResults.average(ofProperty: property).map(dynamicBridgeCast)
     }
 
     // MARK: Notifications
@@ -707,7 +707,7 @@ public final class LinkingObjects<T: Object>: LinkingObjectsBase {
      - returns: The minimum value of the property, or `nil` if the collection is empty.
      */
     public func min<U: MinMaxType>(property: String) -> U? {
-        return rlmResults.minOfProperty(property).map(forceSwiftBridgeCast)
+        return rlmResults.minOfProperty(property).map(dynamicBridgeCast)
     }
 
     /**
@@ -721,7 +721,7 @@ public final class LinkingObjects<T: Object>: LinkingObjectsBase {
      - returns: The maximum value of the property, or `nil` if the collection is empty.
      */
     public func max<U: MinMaxType>(property: String) -> U? {
-        return rlmResults.maxOfProperty(property).map(forceSwiftBridgeCast)
+        return rlmResults.maxOfProperty(property).map(dynamicBridgeCast)
     }
 
     /**
@@ -735,7 +735,7 @@ public final class LinkingObjects<T: Object>: LinkingObjectsBase {
      - returns: The sum of the given property.
      */
     public func sum<U: AddableType>(property: String) -> U {
-        return forceSwiftBridgeCast(fromObjCValue: rlmResults.sumOfProperty(property))
+        return dynamicBridgeCast(rlmResults.sumOfProperty(property))
     }
 
     /**
@@ -748,7 +748,7 @@ public final class LinkingObjects<T: Object>: LinkingObjectsBase {
      - returns: The average value of the given property, or `nil` if the collection is empty.
      */
     public func average<U: AddableType>(property: String) -> U? {
-        return rlmResults.averageOfProperty(property).map(forceSwiftBridgeCast)
+        return rlmResults.averageOfProperty(property).map(dynamicBridgeCast)
     }
 
     // MARK: Notifications

--- a/RealmSwift/LinkingObjects.swift
+++ b/RealmSwift/LinkingObjects.swift
@@ -274,7 +274,7 @@ public final class LinkingObjects<T: Object>: LinkingObjectsBase {
        is empty.
      */
     public func minimumValue<U: MinMaxType>(ofProperty property: String) -> U? {
-        return rlmResults.min(ofProperty: property).map(U.bridging)
+        return rlmResults.min(ofProperty: property).map(forceSwiftBridgeCast)
     }
 
     /**
@@ -288,7 +288,7 @@ public final class LinkingObjects<T: Object>: LinkingObjectsBase {
        is empty.
      */
     public func maximumValue<U: MinMaxType>(ofProperty property: String) -> U? {
-        return rlmResults.max(ofProperty: property).map(U.bridging)
+        return rlmResults.max(ofProperty: property).map(forceSwiftBridgeCast)
     }
 
     /**
@@ -301,7 +301,7 @@ public final class LinkingObjects<T: Object>: LinkingObjectsBase {
      - returns: The sum of the given property over all objects in the collection.
      */
     public func sum<U: AddableType>(ofProperty property: String) -> U {
-        return U.bridging(objCValue: rlmResults.sum(ofProperty: property))
+        return forceSwiftBridgeCast(fromObjCValue: rlmResults.sum(ofProperty: property))
     }
 
     /**
@@ -315,7 +315,7 @@ public final class LinkingObjects<T: Object>: LinkingObjectsBase {
        is empty.
      */
     public func average<U: AddableType>(ofProperty property: String) -> U? {
-        return rlmResults.average(ofProperty: property).map(U.bridging)
+        return rlmResults.average(ofProperty: property).map(forceSwiftBridgeCast)
     }
 
     // MARK: Notifications
@@ -707,7 +707,7 @@ public final class LinkingObjects<T: Object>: LinkingObjectsBase {
      - returns: The minimum value of the property, or `nil` if the collection is empty.
      */
     public func min<U: MinMaxType>(property: String) -> U? {
-        return rlmResults.minOfProperty(property).map(U.bridging)
+        return rlmResults.minOfProperty(property).map(forceSwiftBridgeCast)
     }
 
     /**
@@ -721,7 +721,7 @@ public final class LinkingObjects<T: Object>: LinkingObjectsBase {
      - returns: The maximum value of the property, or `nil` if the collection is empty.
      */
     public func max<U: MinMaxType>(property: String) -> U? {
-        return rlmResults.maxOfProperty(property).map(U.bridging)
+        return rlmResults.maxOfProperty(property).map(forceSwiftBridgeCast)
     }
 
     /**
@@ -735,7 +735,7 @@ public final class LinkingObjects<T: Object>: LinkingObjectsBase {
      - returns: The sum of the given property.
      */
     public func sum<U: AddableType>(property: String) -> U {
-        return U.bridging(rlmResults.sumOfProperty(property))
+        return forceSwiftBridgeCast(fromObjCValue: rlmResults.sumOfProperty(property))
     }
 
     /**
@@ -748,7 +748,7 @@ public final class LinkingObjects<T: Object>: LinkingObjectsBase {
      - returns: The average value of the given property, or `nil` if the collection is empty.
      */
     public func average<U: AddableType>(property: String) -> U? {
-        return rlmResults.averageOfProperty(property).map(U.bridging)
+        return rlmResults.averageOfProperty(property).map(forceSwiftBridgeCast)
     }
 
     // MARK: Notifications

--- a/RealmSwift/Optional.swift
+++ b/RealmSwift/Optional.swift
@@ -22,7 +22,7 @@ import Realm
 
 /// Types that can be represented in a `RealmOptional`.
 public protocol RealmOptionalType {
-    // Must conform to ObjectiveCBridgeable
+    // Must conform to CustomObjectiveCBridgeable
 }
 extension Int: RealmOptionalType {}
 extension Int8: RealmOptionalType {}
@@ -34,10 +34,10 @@ extension Double: RealmOptionalType {}
 extension Bool: RealmOptionalType {}
 extension RealmOptionalType {
     internal static func bridging(objCValue value: Any) -> Self {
-        return (Self.self as! ObjectiveCBridgeable.Type).bridging(objCValue: value) as! Self
+        return (Self.self as! CustomObjectiveCBridgeable.Type).bridging(objCValue: value) as! Self
     }
     var objCValue: Any {
-        return (self as! ObjectiveCBridgeable).objCValue
+        return (self as! CustomObjectiveCBridgeable).objCValue
     }
 }
 
@@ -74,7 +74,7 @@ public final class RealmOptional<T: RealmOptionalType>: RLMOptionalBase {
 
 /// A protocol describing types that can parameterize a `RealmOptional`.
 public protocol RealmOptionalType {
-    // Must conform to ObjectiveCBridgeable
+    // Must conform to CustomObjectiveCBridgeable
 }
 extension Int: RealmOptionalType {}
 extension Int8: RealmOptionalType {}
@@ -86,10 +86,10 @@ extension Double: RealmOptionalType {}
 extension Bool: RealmOptionalType {}
 extension RealmOptionalType {
     internal static func bridging(objCValue objCValue: AnyObject) -> Self {
-        return (Self.self as! ObjectiveCBridgeable.Type).bridging(objCValue: objCValue) as! Self
+        return (Self.self as! CustomObjectiveCBridgeable.Type).bridging(objCValue: objCValue) as! Self
     }
     var objCValue: AnyObject {
-        return (self as! ObjectiveCBridgeable).objCValue
+        return (self as! CustomObjectiveCBridgeable).objCValue
     }
 }
 

--- a/RealmSwift/Optional.swift
+++ b/RealmSwift/Optional.swift
@@ -42,10 +42,10 @@ public final class RealmOptional<T: RealmOptionalType>: RLMOptionalBase {
     /// The value this optional represents.
     public var value: T? {
         get {
-            return underlyingValue.map(forceSwiftBridgeCast)
+            return underlyingValue.map(dynamicBridgeCast)
         }
         set {
-            underlyingValue = newValue.map(objCBridgeCast)
+            underlyingValue = newValue.map(dynamicBridgeCast)
         }
     }
 
@@ -83,10 +83,10 @@ public final class RealmOptional<T: RealmOptionalType>: RLMOptionalBase {
     /// The value this optional represents.
     public var value: T? {
         get {
-            return underlyingValue.map(forceSwiftBridgeCast)
+            return underlyingValue.map(dynamicBridgeCast)
         }
         set {
-            underlyingValue = newValue.map(forceObjCBridgeCast)
+            underlyingValue = newValue.map(dynamicBridgeCast)
         }
     }
 

--- a/RealmSwift/Optional.swift
+++ b/RealmSwift/Optional.swift
@@ -21,9 +21,7 @@ import Realm
 #if swift(>=3.0)
 
 /// Types that can be represented in a `RealmOptional`.
-public protocol RealmOptionalType {
-    // Must conform to CustomObjectiveCBridgeable
-}
+public protocol RealmOptionalType {}
 extension Int: RealmOptionalType {}
 extension Int8: RealmOptionalType {}
 extension Int16: RealmOptionalType {}
@@ -32,14 +30,6 @@ extension Int64: RealmOptionalType {}
 extension Float: RealmOptionalType {}
 extension Double: RealmOptionalType {}
 extension Bool: RealmOptionalType {}
-extension RealmOptionalType {
-    internal static func bridging(objCValue value: Any) -> Self {
-        return (Self.self as! CustomObjectiveCBridgeable.Type).bridging(objCValue: value) as! Self
-    }
-    var objCValue: Any {
-        return (self as! CustomObjectiveCBridgeable).objCValue
-    }
-}
 
 /**
 A `RealmOptional` represents a optional value for types that can't be directly
@@ -52,10 +42,10 @@ public final class RealmOptional<T: RealmOptionalType>: RLMOptionalBase {
     /// The value this optional represents.
     public var value: T? {
         get {
-            return underlyingValue.map(T.bridging)
+            return underlyingValue.map(forceSwiftBridgeCast)
         }
         set {
-            underlyingValue = newValue.map({ $0.objCValue })
+            underlyingValue = newValue.map(objCBridgeCast)
         }
     }
 
@@ -73,9 +63,7 @@ public final class RealmOptional<T: RealmOptionalType>: RLMOptionalBase {
 #else
 
 /// A protocol describing types that can parameterize a `RealmOptional`.
-public protocol RealmOptionalType {
-    // Must conform to CustomObjectiveCBridgeable
-}
+public protocol RealmOptionalType {}
 extension Int: RealmOptionalType {}
 extension Int8: RealmOptionalType {}
 extension Int16: RealmOptionalType {}
@@ -84,14 +72,6 @@ extension Int64: RealmOptionalType {}
 extension Float: RealmOptionalType {}
 extension Double: RealmOptionalType {}
 extension Bool: RealmOptionalType {}
-extension RealmOptionalType {
-    internal static func bridging(objCValue objCValue: AnyObject) -> Self {
-        return (Self.self as! CustomObjectiveCBridgeable.Type).bridging(objCValue: objCValue) as! Self
-    }
-    var objCValue: AnyObject {
-        return (self as! CustomObjectiveCBridgeable).objCValue
-    }
-}
 
 /**
  A `RealmOptional` instance represents a optional value for types that can't be directly declared as `dynamic` in Swift,
@@ -103,10 +83,10 @@ public final class RealmOptional<T: RealmOptionalType>: RLMOptionalBase {
     /// The value this optional represents.
     public var value: T? {
         get {
-            return underlyingValue.map(T.bridging)
+            return underlyingValue.map(forceSwiftBridgeCast)
         }
         set {
-            underlyingValue = newValue.map({ $0.objCValue })
+            underlyingValue = newValue.map(forceObjCBridgeCast)
         }
     }
 

--- a/RealmSwift/Results.swift
+++ b/RealmSwift/Results.swift
@@ -23,9 +23,7 @@ import Realm
 // MARK: MinMaxType
 
 /// Types which can be used for min()/max().
-public protocol MinMaxType {
-    // Must conform to `CustomObjectiveCBridgeable`
-}
+public protocol MinMaxType {}
 extension NSNumber: MinMaxType {}
 extension Double: MinMaxType {}
 extension Float: MinMaxType {}
@@ -37,18 +35,10 @@ extension Int64: MinMaxType {}
 extension Date: MinMaxType {}
 extension NSDate: MinMaxType {}
 
-extension MinMaxType {
-    internal static func bridging(objCValue: Any) -> Self {
-        return (Self.self as! CustomObjectiveCBridgeable.Type).bridging(objCValue: objCValue) as! Self
-    }
-}
-    
 // MARK: AddableType
 
 /// Types which can be used for average()/sum().
-public protocol AddableType {
-    // Must conform to `CustomObjectiveCBridgeable`
-}
+public protocol AddableType {}
 extension NSNumber: AddableType {}
 extension Double: AddableType {}
 extension Float: AddableType {}
@@ -57,11 +47,6 @@ extension Int8: AddableType {}
 extension Int16: AddableType {}
 extension Int32: AddableType {}
 extension Int64: AddableType {}
-extension AddableType {
-    internal static func bridging(objCValue: Any) -> Self {
-        return (Self.self as! CustomObjectiveCBridgeable.Type).bridging(objCValue: objCValue) as! Self
-    }
-}
 
 /**
 Results is an auto-updating container type in Realm returned from object queries.
@@ -287,7 +272,7 @@ public final class Results<T: Object>: NSObject, NSFastEnumeration {
     - returns: The minimum value for the property amongst objects in the Results, or `nil` if the Results is empty.
     */
     public func minimumValue<U: MinMaxType>(ofProperty property: String) -> U? {
-        return rlmResults.min(ofProperty: property).map(U.bridging)
+        return rlmResults.min(ofProperty: property).map(forceSwiftBridgeCast)
     }
 
     /**
@@ -300,7 +285,7 @@ public final class Results<T: Object>: NSObject, NSFastEnumeration {
     - returns: The maximum value for the property amongst objects in the Results, or `nil` if the Results is empty.
     */
     public func maximumValue<U: MinMaxType>(ofProperty property: String) -> U? {
-        return rlmResults.max(ofProperty: property).map(U.bridging)
+        return rlmResults.max(ofProperty: property).map(forceSwiftBridgeCast)
     }
 
     /**
@@ -313,7 +298,7 @@ public final class Results<T: Object>: NSObject, NSFastEnumeration {
     - returns: The sum of the given property over all objects in the Results.
     */
     public func sum<U: AddableType>(ofProperty property: String) -> U {
-        return U.bridging(objCValue: rlmResults.sum(ofProperty: property))
+        return forceSwiftBridgeCast(fromObjCValue: rlmResults.sum(ofProperty: property))
     }
 
     /**
@@ -326,7 +311,7 @@ public final class Results<T: Object>: NSObject, NSFastEnumeration {
     - returns: The average of the given property over all objects in the Results, or `nil` if the Results is empty.
     */
     public func average<U: AddableType>(ofProperty property: String) -> U? {
-        return rlmResults.average(ofProperty: property).map(U.bridging)
+        return rlmResults.average(ofProperty: property).map(forceSwiftBridgeCast)
     }
 
     // MARK: Notifications
@@ -477,9 +462,7 @@ extension Results {
 
  - see: `min(_:)`, `max(_:)`
  */
-public protocol MinMaxType {
-    // Must conform to `CustomObjectiveCBridgeable`
-}
+public protocol MinMaxType {}
 extension NSNumber: MinMaxType {}
 extension Double: MinMaxType {}
 extension Float: MinMaxType {}
@@ -489,11 +472,6 @@ extension Int16: MinMaxType {}
 extension Int32: MinMaxType {}
 extension Int64: MinMaxType {}
 extension NSDate: MinMaxType {}
-extension MinMaxType {
-    internal static func bridging(objCValue objCValue: AnyObject) -> Self {
-        return (Self.self as! CustomObjectiveCBridgeable.Type).bridging(objCValue: objCValue) as! Self
-    }
-}
 
 // MARK: AddableType
 
@@ -502,9 +480,7 @@ extension MinMaxType {
 
  - see: `sum(_:)`, `average(_:)`
  */
-public protocol AddableType {
-    // Must conform to `CustomObjectiveCBridgeable`
-}
+public protocol AddableType {}
 extension NSNumber: AddableType {}
 extension Double: AddableType {}
 extension Float: AddableType {}
@@ -513,11 +489,6 @@ extension Int8: AddableType {}
 extension Int16: AddableType {}
 extension Int32: AddableType {}
 extension Int64: AddableType {}
-extension AddableType {
-    internal static func bridging(objCValue: AnyObject) -> Self {
-        return (Self.self as! CustomObjectiveCBridgeable.Type).bridging(objCValue: objCValue) as! Self
-    }
-}
 
 /// :nodoc:
 /// Internal class. Do not use directly.
@@ -748,7 +719,7 @@ public final class Results<T: Object>: ResultsBase {
      - returns: The minimum value of the property, or `nil` if the collection is empty.
      */
     public func min<U: MinMaxType>(property: String) -> U? {
-        return rlmResults.minOfProperty(property).map(U.bridging)
+        return rlmResults.minOfProperty(property).map(forceSwiftBridgeCast)
     }
 
     /**
@@ -761,7 +732,7 @@ public final class Results<T: Object>: ResultsBase {
      - returns: The maximum value of the property, or `nil` if the collection is empty.
      */
     public func max<U: MinMaxType>(property: String) -> U? {
-        return rlmResults.maxOfProperty(property).map(U.bridging)
+        return rlmResults.maxOfProperty(property).map(forceSwiftBridgeCast)
     }
 
     /**
@@ -774,7 +745,7 @@ public final class Results<T: Object>: ResultsBase {
      - returns: The sum of the given property.
      */
     public func sum<U: AddableType>(property: String) -> U {
-        return U.bridging(rlmResults.sumOfProperty(property))
+        return forceSwiftBridgeCast(fromObjCValue: rlmResults.sumOfProperty(property))
     }
 
     /**
@@ -787,7 +758,7 @@ public final class Results<T: Object>: ResultsBase {
      - returns: The average value of the given property, or `nil` if the collection is empty.
      */
     public func average<U: AddableType>(property: String) -> U? {
-        return rlmResults.averageOfProperty(property).map(U.bridging)
+        return rlmResults.averageOfProperty(property).map(forceSwiftBridgeCast)
     }
 
     // MARK: Notifications

--- a/RealmSwift/Results.swift
+++ b/RealmSwift/Results.swift
@@ -272,7 +272,7 @@ public final class Results<T: Object>: NSObject, NSFastEnumeration {
     - returns: The minimum value for the property amongst objects in the Results, or `nil` if the Results is empty.
     */
     public func minimumValue<U: MinMaxType>(ofProperty property: String) -> U? {
-        return rlmResults.min(ofProperty: property).map(forceSwiftBridgeCast)
+        return rlmResults.min(ofProperty: property).map(dynamicBridgeCast)
     }
 
     /**
@@ -285,7 +285,7 @@ public final class Results<T: Object>: NSObject, NSFastEnumeration {
     - returns: The maximum value for the property amongst objects in the Results, or `nil` if the Results is empty.
     */
     public func maximumValue<U: MinMaxType>(ofProperty property: String) -> U? {
-        return rlmResults.max(ofProperty: property).map(forceSwiftBridgeCast)
+        return rlmResults.max(ofProperty: property).map(dynamicBridgeCast)
     }
 
     /**
@@ -298,7 +298,7 @@ public final class Results<T: Object>: NSObject, NSFastEnumeration {
     - returns: The sum of the given property over all objects in the Results.
     */
     public func sum<U: AddableType>(ofProperty property: String) -> U {
-        return forceSwiftBridgeCast(fromObjCValue: rlmResults.sum(ofProperty: property))
+        return dynamicBridgeCast(fromObjCValue: rlmResults.sum(ofProperty: property))
     }
 
     /**
@@ -311,7 +311,7 @@ public final class Results<T: Object>: NSObject, NSFastEnumeration {
     - returns: The average of the given property over all objects in the Results, or `nil` if the Results is empty.
     */
     public func average<U: AddableType>(ofProperty property: String) -> U? {
-        return rlmResults.average(ofProperty: property).map(forceSwiftBridgeCast)
+        return rlmResults.average(ofProperty: property).map(dynamicBridgeCast)
     }
 
     // MARK: Notifications
@@ -719,7 +719,7 @@ public final class Results<T: Object>: ResultsBase {
      - returns: The minimum value of the property, or `nil` if the collection is empty.
      */
     public func min<U: MinMaxType>(property: String) -> U? {
-        return rlmResults.minOfProperty(property).map(forceSwiftBridgeCast)
+        return rlmResults.minOfProperty(property).map(dynamicBridgeCast)
     }
 
     /**
@@ -732,7 +732,7 @@ public final class Results<T: Object>: ResultsBase {
      - returns: The maximum value of the property, or `nil` if the collection is empty.
      */
     public func max<U: MinMaxType>(property: String) -> U? {
-        return rlmResults.maxOfProperty(property).map(forceSwiftBridgeCast)
+        return rlmResults.maxOfProperty(property).map(dynamicBridgeCast)
     }
 
     /**
@@ -745,7 +745,7 @@ public final class Results<T: Object>: ResultsBase {
      - returns: The sum of the given property.
      */
     public func sum<U: AddableType>(property: String) -> U {
-        return forceSwiftBridgeCast(fromObjCValue: rlmResults.sumOfProperty(property))
+        return dynamicBridgeCast(rlmResults.sumOfProperty(property))
     }
 
     /**
@@ -758,7 +758,7 @@ public final class Results<T: Object>: ResultsBase {
      - returns: The average value of the given property, or `nil` if the collection is empty.
      */
     public func average<U: AddableType>(property: String) -> U? {
-        return rlmResults.averageOfProperty(property).map(forceSwiftBridgeCast)
+        return rlmResults.averageOfProperty(property).map(dynamicBridgeCast)
     }
 
     // MARK: Notifications

--- a/RealmSwift/Results.swift
+++ b/RealmSwift/Results.swift
@@ -24,7 +24,7 @@ import Realm
 
 /// Types which can be used for min()/max().
 public protocol MinMaxType {
-    // Must conform to `ObjectiveCBridgeable`
+    // Must conform to `CustomObjectiveCBridgeable`
 }
 extension NSNumber: MinMaxType {}
 extension Double: MinMaxType {}
@@ -39,7 +39,7 @@ extension NSDate: MinMaxType {}
 
 extension MinMaxType {
     internal static func bridging(objCValue: Any) -> Self {
-        return (Self.self as! ObjectiveCBridgeable.Type).bridging(objCValue: objCValue) as! Self
+        return (Self.self as! CustomObjectiveCBridgeable.Type).bridging(objCValue: objCValue) as! Self
     }
 }
     
@@ -47,7 +47,7 @@ extension MinMaxType {
 
 /// Types which can be used for average()/sum().
 public protocol AddableType {
-    // Must conform to `ObjectiveCBridgeable`
+    // Must conform to `CustomObjectiveCBridgeable`
 }
 extension NSNumber: AddableType {}
 extension Double: AddableType {}
@@ -59,7 +59,7 @@ extension Int32: AddableType {}
 extension Int64: AddableType {}
 extension AddableType {
     internal static func bridging(objCValue: Any) -> Self {
-        return (Self.self as! ObjectiveCBridgeable.Type).bridging(objCValue: objCValue) as! Self
+        return (Self.self as! CustomObjectiveCBridgeable.Type).bridging(objCValue: objCValue) as! Self
     }
 }
 
@@ -478,7 +478,7 @@ extension Results {
  - see: `min(_:)`, `max(_:)`
  */
 public protocol MinMaxType {
-    // Must conform to `ObjectiveCBridgeable`
+    // Must conform to `CustomObjectiveCBridgeable`
 }
 extension NSNumber: MinMaxType {}
 extension Double: MinMaxType {}
@@ -491,7 +491,7 @@ extension Int64: MinMaxType {}
 extension NSDate: MinMaxType {}
 extension MinMaxType {
     internal static func bridging(objCValue objCValue: AnyObject) -> Self {
-        return (Self.self as! ObjectiveCBridgeable.Type).bridging(objCValue: objCValue) as! Self
+        return (Self.self as! CustomObjectiveCBridgeable.Type).bridging(objCValue: objCValue) as! Self
     }
 }
 
@@ -503,7 +503,7 @@ extension MinMaxType {
  - see: `sum(_:)`, `average(_:)`
  */
 public protocol AddableType {
-    // Must conform to `ObjectiveCBridgeable`
+    // Must conform to `CustomObjectiveCBridgeable`
 }
 extension NSNumber: AddableType {}
 extension Double: AddableType {}
@@ -515,7 +515,7 @@ extension Int32: AddableType {}
 extension Int64: AddableType {}
 extension AddableType {
     internal static func bridging(objCValue: AnyObject) -> Self {
-        return (Self.self as! ObjectiveCBridgeable.Type).bridging(objCValue: objCValue) as! Self
+        return (Self.self as! CustomObjectiveCBridgeable.Type).bridging(objCValue: objCValue) as! Self
     }
 }
 

--- a/RealmSwift/Util.swift
+++ b/RealmSwift/Util.swift
@@ -49,51 +49,30 @@ internal func gsub(pattern: String, template: String, string: String, error: NSE
 
 // MARK: CustomObjectiveCBridgeable
 
+internal func forceSwiftBridgeCast<T>(fromObjCValue value: Any) -> T {
+    if let BridgeableType = T.self as? CustomObjectiveCBridgeable.Type {
+        return BridgeableType.bridging(objCValue: value) as! T
+    } else {
+        return value as! T
+    }
+}
+
+internal func objCBridgeCast<T>(fromSwiftValue value: T) -> Any {
+    if let value = value as? CustomObjectiveCBridgeable {
+        return value.objCValue
+    } else {
+        return value
+    }
+}
+
 // Used for conversion from Objective-C types to Swift types
 internal protocol CustomObjectiveCBridgeable  {
     /* FIXME: Remove protocol once SR-2393 bridges all integer types to `NSNumber`
-     *        Instead, use `as AnyObject` and `as! [SwiftType]` to cast between. */
+     *        At this point, use `as! [SwiftType]` to cast between. */
     static func bridging(objCValue: Any) -> Self
     var objCValue: Any { get }
 }
 
-// FIXME: Remove once Swift supports `as! Self` casts
-private func forceCastToInferred<T, U>(_ x: T) -> U {
-    return x as! U
-}
-
-extension NSNumber: CustomObjectiveCBridgeable {
-    static func bridging(objCValue: Any) -> Self {
-        return forceCastToInferred(objCValue)
-    }
-    var objCValue: Any {
-        return self
-    }
-}
-extension Double: CustomObjectiveCBridgeable {
-    static func bridging(objCValue: Any) -> Double {
-        return (objCValue as! NSNumber).doubleValue
-    }
-    var objCValue: Any {
-        return NSNumber(value: self)
-    }
-}
-extension Float: CustomObjectiveCBridgeable {
-    static func bridging(objCValue: Any) -> Float {
-        return (objCValue as! NSNumber).floatValue
-    }
-    var objCValue: Any {
-        return NSNumber(value: self)
-    }
-}
-extension Int: CustomObjectiveCBridgeable {
-    static func bridging(objCValue: Any) -> Int {
-        return (objCValue as! NSNumber).intValue
-    }
-    var objCValue: Any {
-        return NSNumber(value: self)
-    }
-}
 extension Int8: CustomObjectiveCBridgeable {
     static func bridging(objCValue: Any) -> Int8 {
         return (objCValue as! NSNumber).int8Value
@@ -126,30 +105,6 @@ extension Int64: CustomObjectiveCBridgeable {
         return NSNumber(value: self)
     }
 }
-extension Bool: CustomObjectiveCBridgeable {
-    static func bridging(objCValue: Any) -> Bool {
-        return (objCValue as! NSNumber).boolValue
-    }
-    var objCValue: Any {
-        return NSNumber(value: self)
-    }
-}
-extension Date: CustomObjectiveCBridgeable {
-    static func bridging(objCValue: Any) -> Date   {
-        return objCValue as! Date
-    }
-    var objCValue: Any {
-        return self
-    }
-}
-extension NSDate: CustomObjectiveCBridgeable {
-    static func bridging(objCValue: Any) -> Self   {
-        return forceCastToInferred(objCValue)
-    }
-    var objCValue: Any {
-        return self
-    }
-}
 
 #else
 
@@ -172,51 +127,30 @@ internal func gsub(pattern: String, template: String, string: String, error: NSE
 
 // MARK: CustomObjectiveCBridgeable
 
+internal func forceSwiftBridgeCast<T>(fromObjCValue value: AnyObject) -> T {
+    if let BridgeableType = T.self as? CustomObjectiveCBridgeable.Type {
+        return BridgeableType.bridging(objCValue: value) as! T
+    } else {
+        return value as! T
+    }
+}
+
+internal func forceObjCBridgeCast<T>(fromSwiftValue value: T) -> AnyObject {
+    if let value = value as? CustomObjectiveCBridgeable {
+        return value.objCValue
+    } else {
+        return value as! AnyObject
+    }
+}
+
 // Used for conversion from Objective-C types to Swift types
 internal protocol CustomObjectiveCBridgeable  {
     /* FIXME: Remove protocol once SR-2393 bridges all integer types to `NSNumber`
-     *        Instead, use `as AnyObject` and `as! [SwiftType]` to cast between. */
+     *        At this point, use `as! [SwiftType]` to cast between. */
     static func bridging(objCValue objCValue: AnyObject) -> Self
     var objCValue: AnyObject { get }
 }
 
-// FIXME: Remove once Swift supports `as! Self` casts
-private func forceCastToInferred<T, U>(x: T) -> U {
-    return x as! U
-}
-
-extension NSNumber: CustomObjectiveCBridgeable {
-    static func bridging(objCValue objCValue: AnyObject) -> Self {
-        return forceCastToInferred(objCValue)
-    }
-    var objCValue: AnyObject {
-        return self
-    }
-}
-extension Double: CustomObjectiveCBridgeable {
-    static func bridging(objCValue objCValue: AnyObject) -> Double {
-        return (objCValue as! NSNumber).doubleValue
-    }
-    var objCValue: AnyObject {
-        return NSNumber(double: self)
-    }
-}
-extension Float: CustomObjectiveCBridgeable {
-    static func bridging(objCValue objCValue: AnyObject) -> Float {
-        return (objCValue as! NSNumber).floatValue
-    }
-    var objCValue: AnyObject {
-        return NSNumber(float: self)
-    }
-}
-extension Int: CustomObjectiveCBridgeable {
-    static func bridging(objCValue objCValue: AnyObject) -> Int {
-        return (objCValue as! NSNumber).integerValue
-    }
-    var objCValue: AnyObject {
-        return NSNumber(integer: self)
-    }
-}
 extension Int8: CustomObjectiveCBridgeable {
     static func bridging(objCValue objCValue: AnyObject) -> Int8 {
         return (objCValue as! NSNumber).charValue
@@ -247,25 +181,6 @@ extension Int64: CustomObjectiveCBridgeable {
     }
     var objCValue: AnyObject {
         return NSNumber(longLong: self)
-    }
-}
-extension Bool: CustomObjectiveCBridgeable {
-    static func bridging(objCValue objCValue: AnyObject) -> Bool {
-        return (objCValue as! NSNumber).boolValue
-    }
-    var objCValue: AnyObject {
-        return NSNumber(bool: self)
-    }
-}
-extension NSDate: CustomObjectiveCBridgeable {
-    static func bridging(objCValue objCValue: AnyObject) -> Self   {
-        func forceCastTrampoline<T, U>(x: T) -> U {
-            return x as! U
-        }
-        return forceCastTrampoline(objCValue)
-    }
-    var objCValue: AnyObject {
-        return self
     }
 }
 

--- a/RealmSwift/Util.swift
+++ b/RealmSwift/Util.swift
@@ -47,10 +47,10 @@ internal func gsub(pattern: String, template: String, string: String, error: NSE
                                            withTemplate: template)
 }
 
-// MARK: ObjectiveCBridgeable
+// MARK: CustomObjectiveCBridgeable
 
 // Used for conversion from Objective-C types to Swift types
-internal protocol ObjectiveCBridgeable  {
+internal protocol CustomObjectiveCBridgeable  {
     /* FIXME: Remove protocol once SR-2393 bridges all integer types to `NSNumber`
      *        Instead, use `as AnyObject` and `as! [SwiftType]` to cast between. */
     static func bridging(objCValue: Any) -> Self
@@ -62,7 +62,7 @@ private func forceCastToInferred<T, U>(_ x: T) -> U {
     return x as! U
 }
 
-extension NSNumber: ObjectiveCBridgeable {
+extension NSNumber: CustomObjectiveCBridgeable {
     static func bridging(objCValue: Any) -> Self {
         return forceCastToInferred(objCValue)
     }
@@ -70,7 +70,7 @@ extension NSNumber: ObjectiveCBridgeable {
         return self
     }
 }
-extension Double: ObjectiveCBridgeable {
+extension Double: CustomObjectiveCBridgeable {
     static func bridging(objCValue: Any) -> Double {
         return (objCValue as! NSNumber).doubleValue
     }
@@ -78,7 +78,7 @@ extension Double: ObjectiveCBridgeable {
         return NSNumber(value: self)
     }
 }
-extension Float: ObjectiveCBridgeable {
+extension Float: CustomObjectiveCBridgeable {
     static func bridging(objCValue: Any) -> Float {
         return (objCValue as! NSNumber).floatValue
     }
@@ -86,7 +86,7 @@ extension Float: ObjectiveCBridgeable {
         return NSNumber(value: self)
     }
 }
-extension Int: ObjectiveCBridgeable {
+extension Int: CustomObjectiveCBridgeable {
     static func bridging(objCValue: Any) -> Int {
         return (objCValue as! NSNumber).intValue
     }
@@ -94,7 +94,7 @@ extension Int: ObjectiveCBridgeable {
         return NSNumber(value: self)
     }
 }
-extension Int8: ObjectiveCBridgeable {
+extension Int8: CustomObjectiveCBridgeable {
     static func bridging(objCValue: Any) -> Int8 {
         return (objCValue as! NSNumber).int8Value
     }
@@ -102,7 +102,7 @@ extension Int8: ObjectiveCBridgeable {
         return NSNumber(value: self)
     }
 }
-extension Int16: ObjectiveCBridgeable {
+extension Int16: CustomObjectiveCBridgeable {
     static func bridging(objCValue: Any) -> Int16 {
         return (objCValue as! NSNumber).int16Value
     }
@@ -110,7 +110,7 @@ extension Int16: ObjectiveCBridgeable {
         return NSNumber(value: self)
     }
 }
-extension Int32: ObjectiveCBridgeable {
+extension Int32: CustomObjectiveCBridgeable {
     static func bridging(objCValue: Any) -> Int32 {
         return (objCValue as! NSNumber).int32Value
     }
@@ -118,7 +118,7 @@ extension Int32: ObjectiveCBridgeable {
         return NSNumber(value: self)
     }
 }
-extension Int64: ObjectiveCBridgeable {
+extension Int64: CustomObjectiveCBridgeable {
     static func bridging(objCValue: Any) -> Int64 {
         return (objCValue as! NSNumber).int64Value
     }
@@ -126,7 +126,7 @@ extension Int64: ObjectiveCBridgeable {
         return NSNumber(value: self)
     }
 }
-extension Bool: ObjectiveCBridgeable {
+extension Bool: CustomObjectiveCBridgeable {
     static func bridging(objCValue: Any) -> Bool {
         return (objCValue as! NSNumber).boolValue
     }
@@ -134,7 +134,7 @@ extension Bool: ObjectiveCBridgeable {
         return NSNumber(value: self)
     }
 }
-extension Date: ObjectiveCBridgeable {
+extension Date: CustomObjectiveCBridgeable {
     static func bridging(objCValue: Any) -> Date   {
         return objCValue as! Date
     }
@@ -142,7 +142,7 @@ extension Date: ObjectiveCBridgeable {
         return self
     }
 }
-extension NSDate: ObjectiveCBridgeable {
+extension NSDate: CustomObjectiveCBridgeable {
     static func bridging(objCValue: Any) -> Self   {
         return forceCastToInferred(objCValue)
     }
@@ -170,10 +170,10 @@ internal func gsub(pattern: String, template: String, string: String, error: NSE
                                                    withTemplate: template)
 }
 
-// MARK: ObjectiveCBridgeable
+// MARK: CustomObjectiveCBridgeable
 
 // Used for conversion from Objective-C types to Swift types
-internal protocol ObjectiveCBridgeable  {
+internal protocol CustomObjectiveCBridgeable  {
     /* FIXME: Remove protocol once SR-2393 bridges all integer types to `NSNumber`
      *        Instead, use `as AnyObject` and `as! [SwiftType]` to cast between. */
     static func bridging(objCValue objCValue: AnyObject) -> Self
@@ -185,7 +185,7 @@ private func forceCastToInferred<T, U>(x: T) -> U {
     return x as! U
 }
 
-extension NSNumber: ObjectiveCBridgeable {
+extension NSNumber: CustomObjectiveCBridgeable {
     static func bridging(objCValue objCValue: AnyObject) -> Self {
         return forceCastToInferred(objCValue)
     }
@@ -193,7 +193,7 @@ extension NSNumber: ObjectiveCBridgeable {
         return self
     }
 }
-extension Double: ObjectiveCBridgeable {
+extension Double: CustomObjectiveCBridgeable {
     static func bridging(objCValue objCValue: AnyObject) -> Double {
         return (objCValue as! NSNumber).doubleValue
     }
@@ -201,7 +201,7 @@ extension Double: ObjectiveCBridgeable {
         return NSNumber(double: self)
     }
 }
-extension Float: ObjectiveCBridgeable {
+extension Float: CustomObjectiveCBridgeable {
     static func bridging(objCValue objCValue: AnyObject) -> Float {
         return (objCValue as! NSNumber).floatValue
     }
@@ -209,7 +209,7 @@ extension Float: ObjectiveCBridgeable {
         return NSNumber(float: self)
     }
 }
-extension Int: ObjectiveCBridgeable {
+extension Int: CustomObjectiveCBridgeable {
     static func bridging(objCValue objCValue: AnyObject) -> Int {
         return (objCValue as! NSNumber).integerValue
     }
@@ -217,7 +217,7 @@ extension Int: ObjectiveCBridgeable {
         return NSNumber(integer: self)
     }
 }
-extension Int8: ObjectiveCBridgeable {
+extension Int8: CustomObjectiveCBridgeable {
     static func bridging(objCValue objCValue: AnyObject) -> Int8 {
         return (objCValue as! NSNumber).charValue
     }
@@ -225,7 +225,7 @@ extension Int8: ObjectiveCBridgeable {
         return NSNumber(char: self)
     }
 }
-extension Int16: ObjectiveCBridgeable {
+extension Int16: CustomObjectiveCBridgeable {
     static func bridging(objCValue objCValue: AnyObject) -> Int16 {
         return (objCValue as! NSNumber).shortValue
     }
@@ -233,7 +233,7 @@ extension Int16: ObjectiveCBridgeable {
         return NSNumber(short: self)
     }
 }
-extension Int32: ObjectiveCBridgeable {
+extension Int32: CustomObjectiveCBridgeable {
     static func bridging(objCValue objCValue: AnyObject) -> Int32 {
         return (objCValue as! NSNumber).intValue
     }
@@ -241,7 +241,7 @@ extension Int32: ObjectiveCBridgeable {
         return NSNumber(int: self)
     }
 }
-extension Int64: ObjectiveCBridgeable {
+extension Int64: CustomObjectiveCBridgeable {
     static func bridging(objCValue objCValue: AnyObject) -> Int64 {
         return (objCValue as! NSNumber).longLongValue
     }
@@ -249,7 +249,7 @@ extension Int64: ObjectiveCBridgeable {
         return NSNumber(longLong: self)
     }
 }
-extension Bool: ObjectiveCBridgeable {
+extension Bool: CustomObjectiveCBridgeable {
     static func bridging(objCValue objCValue: AnyObject) -> Bool {
         return (objCValue as! NSNumber).boolValue
     }
@@ -257,7 +257,7 @@ extension Bool: ObjectiveCBridgeable {
         return NSNumber(bool: self)
     }
 }
-extension NSDate: ObjectiveCBridgeable {
+extension NSDate: CustomObjectiveCBridgeable {
     static func bridging(objCValue objCValue: AnyObject) -> Self   {
         func forceCastTrampoline<T, U>(x: T) -> U {
             return x as! U

--- a/RealmSwift/Util.swift
+++ b/RealmSwift/Util.swift
@@ -49,19 +49,19 @@ internal func gsub(pattern: String, template: String, string: String, error: NSE
 
 // MARK: CustomObjectiveCBridgeable
 
-internal func forceSwiftBridgeCast<T>(fromObjCValue value: Any) -> T {
+internal func dynamicBridgeCast<T>(_ x: Any) -> T {
     if let BridgeableType = T.self as? CustomObjectiveCBridgeable.Type {
-        return BridgeableType.bridging(objCValue: value) as! T
+        return BridgeableType.bridging(objCValue: x) as! T
     } else {
-        return value as! T
+        return x as! T
     }
 }
 
-internal func objCBridgeCast<T>(fromSwiftValue value: T) -> Any {
-    if let value = value as? CustomObjectiveCBridgeable {
-        return value.objCValue
+internal func dynamicBridgeCast<T>(_ x: T) -> Any {
+    if let x = x as? CustomObjectiveCBridgeable {
+        return x.objCValue
     } else {
-        return value
+        return x
     }
 }
 
@@ -127,19 +127,19 @@ internal func gsub(pattern: String, template: String, string: String, error: NSE
 
 // MARK: CustomObjectiveCBridgeable
 
-internal func forceSwiftBridgeCast<T>(fromObjCValue value: AnyObject) -> T {
+internal func dynamicBridgeCast<T>(x: AnyObject) -> T {
     if let BridgeableType = T.self as? CustomObjectiveCBridgeable.Type {
-        return BridgeableType.bridging(objCValue: value) as! T
+        return BridgeableType.bridging(objCValue: x) as! T
     } else {
-        return value as! T
+        return x as! T
     }
 }
 
-internal func forceObjCBridgeCast<T>(fromSwiftValue value: T) -> AnyObject {
-    if let value = value as? CustomObjectiveCBridgeable {
-        return value.objCValue
+internal func dynamicBridgeCast<T>(x: T) -> AnyObject {
+    if let x = x as? CustomObjectiveCBridgeable {
+        return x.objCValue
     } else {
-        return value as! AnyObject
+        return x as! AnyObject
     }
 }
 


### PR DESCRIPTION
It doesn't make sense to keep adding no-op conformances to the type when we want to use it in different contexts. For example, fixing `filter` to support bridging (https://github.com/realm/realm-cocoa/issues/4007) would have required conforming *all* other types that should *not* be bridged to the protocol. Instead, this PR introduces a `dynamicBridgeCast` function that will bridge if a conformance exists and no-op otherwise.