### PR TITLE
Fix crash when looking up by non-bridged primary key

### DIFF
--- a/RealmSwift/LinkingObjects.swift
+++ b/RealmSwift/LinkingObjects.swift
@@ -301,7 +301,7 @@ public final class LinkingObjects<T: Object>: LinkingObjectsBase {
      - returns: The sum of the given property over all objects in the collection.
      */
     public func sum<U: AddableType>(ofProperty property: String) -> U {
-        return dynamicBridgeCast(fromObjCValue: rlmResults.sum(ofProperty: property))
+        return dynamicBridgeCast(fromObjectiveC: rlmResults.sum(ofProperty: property))
     }
 
     /**
@@ -735,7 +735,7 @@ public final class LinkingObjects<T: Object>: LinkingObjectsBase {
      - returns: The sum of the given property.
      */
     public func sum<U: AddableType>(property: String) -> U {
-        return dynamicBridgeCast(rlmResults.sumOfProperty(property))
+        return dynamicBridgeCast(fromObjectiveC: rlmResults.sumOfProperty(property))
     }
 
     /**

--- a/RealmSwift/Realm.swift
+++ b/RealmSwift/Realm.swift
@@ -415,8 +415,9 @@ public final class Realm {
 
     - returns: An object of type `type` or `nil` if an object with the given primary key does not exist.
     */
-    public func object<T: Object>(ofType type: T.Type, forPrimaryKey key: Any) -> T? {
-        return unsafeBitCast(RLMGetObject(rlmRealm, (type as Object.Type).className(), key) as! RLMObjectBase?,
+    public func object<T: Object, K>(ofType type: T.Type, forPrimaryKey key: K) -> T? {
+        return unsafeBitCast(RLMGetObject(rlmRealm, (type as Object.Type).className(),
+                                          dynamicBridgeCast(fromSwift: key)) as! RLMObjectBase?,
                              to: Optional<T>.self)
     }
 

--- a/RealmSwift/Results.swift
+++ b/RealmSwift/Results.swift
@@ -298,7 +298,7 @@ public final class Results<T: Object>: NSObject, NSFastEnumeration {
     - returns: The sum of the given property over all objects in the Results.
     */
     public func sum<U: AddableType>(ofProperty property: String) -> U {
-        return dynamicBridgeCast(fromObjCValue: rlmResults.sum(ofProperty: property))
+        return dynamicBridgeCast(fromObjectiveC: rlmResults.sum(ofProperty: property))
     }
 
     /**
@@ -745,7 +745,7 @@ public final class Results<T: Object>: ResultsBase {
      - returns: The sum of the given property.
      */
     public func sum<U: AddableType>(property: String) -> U {
-        return dynamicBridgeCast(rlmResults.sumOfProperty(property))
+        return dynamicBridgeCast(fromObjectiveC: rlmResults.sumOfProperty(property))
     }
 
     /**

--- a/RealmSwift/Tests/RealmTests.swift
+++ b/RealmSwift/Tests/RealmTests.swift
@@ -1239,18 +1239,71 @@ class RealmTests: TestCase {
         XCTAssertEqual(object["optObjectCol"]?.boolCol, true)
     }
 
-    func testObjectForPrimaryKey() {
-        let intTypes: [Object.Type] = [SwiftPrimaryIntObject.self,
-                                       SwiftPrimaryInt8Object.self,
-                                       SwiftPrimaryInt16Object.self,
-                                       SwiftPrimaryInt32Object.self,
-                                       SwiftPrimaryInt64Object.self]
-        let optionalIntTypes: [Object.Type] = [SwiftPrimaryOptionalIntObject.self,
-                                               SwiftPrimaryOptionalInt8Object.self,
-                                               SwiftPrimaryOptionalInt16Object.self,
-                                               SwiftPrimaryOptionalInt32Object.self,
-                                               SwiftPrimaryOptionalInt64Object.self]
+    func testIntPrimaryKey() {
+        func testIntPrimaryKey<O: Object>(for type: O.Type) {
 
+            let realm = try! Realm()
+            try! realm.write {
+                realm.create(type, value: ["a", 1])
+                realm.create(type, value: ["b", 2])
+            }
+
+            let object = realm.objectForPrimaryKey(type, key: 1)
+            XCTAssertNotNil(object)
+
+            let missingObject = realm.objectForPrimaryKey(type, key: 0)
+            XCTAssertNil(missingObject)
+        }
+
+        testIntPrimaryKey(for: SwiftPrimaryIntObject.self)
+        testIntPrimaryKey(for: SwiftPrimaryInt8Object.self)
+        testIntPrimaryKey(for: SwiftPrimaryInt16Object.self)
+        testIntPrimaryKey(for: SwiftPrimaryInt32Object.self)
+        testIntPrimaryKey(for: SwiftPrimaryInt64Object.self)
+    }
+
+    func testOptionalIntPrimaryKey() {
+        func testOptionalIntPrimaryKey<O: Object>(for type: O.Type) {
+            let realm = try! Realm()
+            try! realm.write {
+                realm.create(type, value: ["a", NSNull()])
+                realm.create(type, value: ["b", 2])
+            }
+
+            let object1 = realm.objectForPrimaryKey(type, key: NSNull())
+            XCTAssertNotNil(object1)
+
+            let object2 = realm.objectForPrimaryKey(type, key: 2)
+            XCTAssertNotNil(object2)
+
+            let missingObject = realm.objectForPrimaryKey(type, key: 0)
+            XCTAssertNil(missingObject)
+        }
+
+        testOptionalIntPrimaryKey(for: SwiftPrimaryOptionalIntObject.self)
+        testOptionalIntPrimaryKey(for: SwiftPrimaryOptionalInt8Object.self)
+        testOptionalIntPrimaryKey(for: SwiftPrimaryOptionalInt16Object.self)
+        testOptionalIntPrimaryKey(for: SwiftPrimaryOptionalInt32Object.self)
+        testOptionalIntPrimaryKey(for: SwiftPrimaryOptionalInt64Object.self)
+    }
+
+    func testStringPrimaryKey() {
+        let realm = try! Realm()
+        try! realm.write {
+            realm.create(SwiftPrimaryStringObject.self, value: ["a", 1])
+            realm.create(SwiftPrimaryStringObject.self, value: ["b", 2])
+        }
+
+        // When this is directly inside the XCTAssertNotNil, it doesn't work
+        let object = realm.objectForPrimaryKey(SwiftPrimaryStringObject.self, key: "a")
+        XCTAssertNotNil(object)
+
+        // When this is directly inside the XCTAssertNil, it fails for some reason
+        let missingObject = realm.objectForPrimaryKey(SwiftPrimaryStringObject.self, key: "z")
+        XCTAssertNil(missingObject)
+    }
+
+    func testOptionalStringPrimaryKey() {
         let realm = try! Realm()
         try! realm.write {
             realm.create(SwiftPrimaryStringObject.self, value: ["a", 1])
@@ -1258,79 +1311,16 @@ class RealmTests: TestCase {
 
             realm.create(SwiftPrimaryOptionalStringObject.self, value: [NSNull(), 1])
             realm.create(SwiftPrimaryOptionalStringObject.self, value: ["b", 2])
-
-            func createIntObject(objectType: Object.Type) {
-                realm.create(objectType, value: ["a", 1])
-                realm.create(objectType, value: ["b", 2])
-            }
-
-            func createOptionalIntObject(objectType: Object.Type) {
-                realm.create(objectType, value: ["a", NSNull()])
-                realm.create(objectType, value: ["b", 2])
-            }
-
-            for type in intTypes {
-                createIntObject(type)
-            }
-
-            for type in optionalIntTypes {
-                createOptionalIntObject(type)
-            }
         }
 
-        do {
-            // When this is directly inside the XCTAssertNotNil, it doesn't work
-            let object = realm.objectForPrimaryKey(SwiftPrimaryStringObject.self, key: "a")
-            XCTAssertNotNil(object)
+        let object1 = realm.objectForPrimaryKey(SwiftPrimaryOptionalStringObject.self, key: NSNull())
+        XCTAssertNotNil(object1)
 
-            // When this is directly inside the XCTAssertNil, it fails for some reason
-            let missingObject = realm.objectForPrimaryKey(SwiftPrimaryStringObject.self, key: "z")
-            XCTAssertNil(missingObject)
-        }
+        let object2 = realm.objectForPrimaryKey(SwiftPrimaryOptionalStringObject.self, key: "b")
+        XCTAssertNotNil(object2)
 
-        do {
-            let object1 = realm.objectForPrimaryKey(SwiftPrimaryOptionalStringObject.self, key: NSNull())
-            XCTAssertNotNil(object1)
-
-            let object2 = realm.objectForPrimaryKey(SwiftPrimaryOptionalStringObject.self, key: nil)
-            XCTAssertEqual(object1, object2)
-
-            let object3 = realm.objectForPrimaryKey(SwiftPrimaryOptionalStringObject.self, key: "b")
-            XCTAssertNotNil(object3)
-
-            let missingObject = realm.objectForPrimaryKey(SwiftPrimaryOptionalStringObject.self, key: "z")
-            XCTAssertNil(missingObject)
-        }
-
-        func assertIntObject(objectType: Object.Type) {
-            let object = realm.objectForPrimaryKey(objectType, key: 1)
-            XCTAssertNotNil(object)
-
-            let missingObject = realm.objectForPrimaryKey(objectType, key: 0)
-            XCTAssertNil(missingObject)
-        }
-
-        func assertOptionalIntObject(objectType: Object.Type) {
-            let object1 = realm.objectForPrimaryKey(objectType, key: NSNull())
-            XCTAssertNotNil(object1)
-
-            let object2 = realm.objectForPrimaryKey(objectType, key: nil)
-            XCTAssertEqual(object1, object2)
-
-            let object3 = realm.objectForPrimaryKey(objectType, key: 2)
-            XCTAssertNotNil(object3)
-
-            let missingObject = realm.objectForPrimaryKey(objectType, key: 0)
-            XCTAssertNil(missingObject)
-        }
-
-        for type in intTypes {
-            assertIntObject(type)
-        }
-
-        for type in optionalIntTypes {
-            assertOptionalIntObject(type)
-        }
+        let missingObject = realm.objectForPrimaryKey(SwiftPrimaryOptionalStringObject.self, key: "z")
+        XCTAssertNil(missingObject)
     }
 
     func testDynamicObjectForPrimaryKey() {

--- a/RealmSwift/Tests/SwiftTestObjects.swift
+++ b/RealmSwift/Tests/SwiftTestObjects.swift
@@ -646,109 +646,126 @@ class SwiftRecursiveObject: Object {
     let objects = List<SwiftRecursiveObject>()
 }
 
-class SwiftPrimaryStringObject: Object {
+protocol SwiftPrimaryKeyObjectType {
+    associatedtype PrimaryKey
+    static func primaryKey() -> String?
+}
+
+class SwiftPrimaryStringObject: Object, SwiftPrimaryKeyObjectType {
     dynamic var stringCol = ""
     dynamic var intCol = 0
 
+    typealias PrimaryKey = String
     override class func primaryKey() -> String? {
         return "stringCol"
     }
 }
 
-class SwiftPrimaryOptionalStringObject: Object {
+class SwiftPrimaryOptionalStringObject: Object, SwiftPrimaryKeyObjectType {
     dynamic var stringCol: String? = ""
     dynamic var intCol = 0
 
+    typealias PrimaryKey = String?
     override class func primaryKey() -> String? {
         return "stringCol"
     }
 }
 
-class SwiftPrimaryIntObject: Object {
+class SwiftPrimaryIntObject: Object, SwiftPrimaryKeyObjectType {
     dynamic var stringCol = ""
     dynamic var intCol = 0
 
+    typealias PrimaryKey = Int
     override class func primaryKey() -> String? {
         return "intCol"
     }
 }
 
-class SwiftPrimaryOptionalIntObject: Object {
+class SwiftPrimaryOptionalIntObject: Object, SwiftPrimaryKeyObjectType {
     dynamic var stringCol = ""
     let intCol = RealmOptional<Int>()
 
+    typealias PrimaryKey = RealmOptional<Int>
     override class func primaryKey() -> String? {
         return "intCol"
     }
 }
 
-class SwiftPrimaryInt8Object: Object {
+class SwiftPrimaryInt8Object: Object, SwiftPrimaryKeyObjectType {
     dynamic var stringCol = ""
     dynamic var int8Col: Int8 = 0
 
+    typealias PrimaryKey = Int8
     override class func primaryKey() -> String? {
         return "int8Col"
     }
 }
 
-class SwiftPrimaryOptionalInt8Object: Object {
+class SwiftPrimaryOptionalInt8Object: Object, SwiftPrimaryKeyObjectType {
     dynamic var stringCol = ""
     let int8Col = RealmOptional<Int8>()
 
+    typealias PrimaryKey = RealmOptional<Int8>
     override class func primaryKey() -> String? {
         return "int8Col"
     }
 }
 
-class SwiftPrimaryInt16Object: Object {
+class SwiftPrimaryInt16Object: Object, SwiftPrimaryKeyObjectType {
     dynamic var stringCol = ""
     dynamic var int16Col: Int16 = 0
 
+    typealias PrimaryKey = Int16
     override class func primaryKey() -> String? {
         return "int16Col"
     }
 }
 
-class SwiftPrimaryOptionalInt16Object: Object {
+class SwiftPrimaryOptionalInt16Object: Object, SwiftPrimaryKeyObjectType {
     dynamic var stringCol = ""
     let int16Col = RealmOptional<Int16>()
 
+    typealias PrimaryKey = RealmOptional<Int16>
     override class func primaryKey() -> String? {
         return "int16Col"
     }
 }
 
-class SwiftPrimaryInt32Object: Object {
+class SwiftPrimaryInt32Object: Object, SwiftPrimaryKeyObjectType {
     dynamic var stringCol = ""
     dynamic var int32Col: Int32 = 0
 
+    typealias PrimaryKey = Int32
     override class func primaryKey() -> String? {
         return "int32Col"
     }
 }
 
-class SwiftPrimaryOptionalInt32Object: Object {
+class SwiftPrimaryOptionalInt32Object: Object, SwiftPrimaryKeyObjectType {
     dynamic var stringCol = ""
     let int32Col = RealmOptional<Int32>()
 
+    typealias PrimaryKey = RealmOptional<Int32>
     override class func primaryKey() -> String? {
         return "int32Col"
     }
 }
 
-class SwiftPrimaryInt64Object: Object {
+class SwiftPrimaryInt64Object: Object, SwiftPrimaryKeyObjectType {
     dynamic var stringCol = ""
     dynamic var int64Col: Int64 = 0
 
+    typealias PrimaryKey = Int64
     override class func primaryKey() -> String? {
         return "int64Col"
     }
 }
 
-class SwiftPrimaryOptionalInt64Object: Object {
+class SwiftPrimaryOptionalInt64Object: Object, SwiftPrimaryKeyObjectType {
     dynamic var stringCol = ""
     let int64Col = RealmOptional<Int64>()
 
+    typealias PrimaryKey = RealmOptional<Int64>
     override class func primaryKey() -> String? {
         return "int64Col"
     }

--- a/RealmSwift/Tests/SwiftTestObjects.swift
+++ b/RealmSwift/Tests/SwiftTestObjects.swift
@@ -231,109 +231,126 @@ class SwiftRecursiveObject: Object {
     let objects = List<SwiftRecursiveObject>()
 }
 
-class SwiftPrimaryStringObject: Object {
+protocol SwiftPrimaryKeyObjectType {
+    associatedtype PrimaryKey
+    static func primaryKey() -> String?
+}
+
+class SwiftPrimaryStringObject: Object, SwiftPrimaryKeyObjectType {
     dynamic var stringCol = ""
     dynamic var intCol = 0
 
+    typealias PrimaryKey = String
     override class func primaryKey() -> String? {
         return "stringCol"
     }
 }
 
-class SwiftPrimaryOptionalStringObject: Object {
+class SwiftPrimaryOptionalStringObject: Object, SwiftPrimaryKeyObjectType {
     dynamic var stringCol: String? = ""
     dynamic var intCol = 0
 
+    typealias PrimaryKey = String?
     override class func primaryKey() -> String? {
         return "stringCol"
     }
 }
 
-class SwiftPrimaryIntObject: Object {
+class SwiftPrimaryIntObject: Object, SwiftPrimaryKeyObjectType {
     dynamic var stringCol = ""
     dynamic var intCol = 0
 
+    typealias PrimaryKey = Int
     override class func primaryKey() -> String? {
         return "intCol"
     }
 }
 
-class SwiftPrimaryOptionalIntObject: Object {
+class SwiftPrimaryOptionalIntObject: Object, SwiftPrimaryKeyObjectType {
     dynamic var stringCol = ""
     let intCol = RealmOptional<Int>()
 
+    typealias PrimaryKey = RealmOptional<Int>
     override class func primaryKey() -> String? {
         return "intCol"
     }
 }
 
-class SwiftPrimaryInt8Object: Object {
+class SwiftPrimaryInt8Object: Object, SwiftPrimaryKeyObjectType {
     dynamic var stringCol = ""
     dynamic var int8Col: Int8 = 0
 
+    typealias PrimaryKey = Int8
     override class func primaryKey() -> String? {
         return "int8Col"
     }
 }
 
-class SwiftPrimaryOptionalInt8Object: Object {
+class SwiftPrimaryOptionalInt8Object: Object, SwiftPrimaryKeyObjectType {
     dynamic var stringCol = ""
     let int8Col = RealmOptional<Int8>()
 
+    typealias PrimaryKey = RealmOptional<Int8>
     override class func primaryKey() -> String? {
         return "int8Col"
     }
 }
 
-class SwiftPrimaryInt16Object: Object {
+class SwiftPrimaryInt16Object: Object, SwiftPrimaryKeyObjectType {
     dynamic var stringCol = ""
     dynamic var int16Col: Int16 = 0
 
+    typealias PrimaryKey = Int16
     override class func primaryKey() -> String? {
         return "int16Col"
     }
 }
 
-class SwiftPrimaryOptionalInt16Object: Object {
+class SwiftPrimaryOptionalInt16Object: Object, SwiftPrimaryKeyObjectType {
     dynamic var stringCol = ""
     let int16Col = RealmOptional<Int16>()
 
+    typealias PrimaryKey = RealmOptional<Int16>
     override class func primaryKey() -> String? {
         return "int16Col"
     }
 }
 
-class SwiftPrimaryInt32Object: Object {
+class SwiftPrimaryInt32Object: Object, SwiftPrimaryKeyObjectType {
     dynamic var stringCol = ""
     dynamic var int32Col: Int32 = 0
 
+    typealias PrimaryKey = Int32
     override class func primaryKey() -> String? {
         return "int32Col"
     }
 }
 
-class SwiftPrimaryOptionalInt32Object: Object {
+class SwiftPrimaryOptionalInt32Object: Object, SwiftPrimaryKeyObjectType {
     dynamic var stringCol = ""
     let int32Col = RealmOptional<Int32>()
 
+    typealias PrimaryKey = RealmOptional<Int32>
     override class func primaryKey() -> String? {
         return "int32Col"
     }
 }
 
-class SwiftPrimaryInt64Object: Object {
+class SwiftPrimaryInt64Object: Object, SwiftPrimaryKeyObjectType {
     dynamic var stringCol = ""
     dynamic var int64Col: Int64 = 0
 
+    typealias PrimaryKey = Int64
     override class func primaryKey() -> String? {
         return "int64Col"
     }
 }
 
-class SwiftPrimaryOptionalInt64Object: Object {
+class SwiftPrimaryOptionalInt64Object: Object, SwiftPrimaryKeyObjectType {
     dynamic var stringCol = ""
     let int64Col = RealmOptional<Int64>()
 
+    typealias PrimaryKey = RealmOptional<Int64>
     override class func primaryKey() -> String? {
         return "int64Col"
     }

--- a/RealmSwift/Util.swift
+++ b/RealmSwift/Util.swift
@@ -49,7 +49,7 @@ internal func gsub(pattern: String, template: String, string: String, error: NSE
 
 // MARK: CustomObjectiveCBridgeable
 
-internal func dynamicBridgeCast<T>(_ x: Any) -> T {
+internal func dynamicBridgeCast<T>(fromObjectiveC x: Any) -> T {
     if let BridgeableType = T.self as? CustomObjectiveCBridgeable.Type {
         return BridgeableType.bridging(objCValue: x) as! T
     } else {
@@ -57,7 +57,7 @@ internal func dynamicBridgeCast<T>(_ x: Any) -> T {
     }
 }
 
-internal func dynamicBridgeCast<T>(_ x: T) -> Any {
+internal func dynamicBridgeCast<T>(fromSwift x: T) -> Any {
     if let x = x as? CustomObjectiveCBridgeable {
         return x.objCValue
     } else {
@@ -127,7 +127,7 @@ internal func gsub(pattern: String, template: String, string: String, error: NSE
 
 // MARK: CustomObjectiveCBridgeable
 
-internal func dynamicBridgeCast<T>(x: AnyObject) -> T {
+internal func dynamicBridgeCast<T>(fromObjectiveC x: AnyObject) -> T {
     if let BridgeableType = T.self as? CustomObjectiveCBridgeable.Type {
         return BridgeableType.bridging(objCValue: x) as! T
     } else {
@@ -135,7 +135,7 @@ internal func dynamicBridgeCast<T>(x: AnyObject) -> T {
     }
 }
 
-internal func dynamicBridgeCast<T>(x: T) -> AnyObject {
+internal func dynamicBridgeCast<T>(fromSwift x: T) -> AnyObject {
     if let x = x as? CustomObjectiveCBridgeable {
         return x.objCValue
     } else {


### PR DESCRIPTION
Calls `dynamicBridgeCast` before passing primary key value into Objective-C to support `Int8`/`Int16`/`Int32`/`Int64` lookups. Note that most of the changes here are improvements of the test structure designed to make it possible to test lookups with the same type as the primary key type (rather than always using `Int`). https://github.com/realm/realm-cocoa/issues/4007