### PR TITLE
Enforce uniqueness for `RealmOptional` primary keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ x.x.x Release notes (yyyy-MM-dd)
   within the observation.
 * Fix a crash when `initWithValue:` is used to create a nested object for a class
   with an uninitialized schema.
+* Enforce uniqueness for `RealmOptional` primary keys when using the `value` setter.
 
 1.0.2 Release notes (2016-07-13)
 =============================================================

--- a/Realm/RLMOptionalBase.mm
+++ b/Realm/RLMOptionalBase.mm
@@ -20,7 +20,7 @@
 #import "RLMOptionalBase.h"
 #import "RLMObject_Private.h"
 #import "RLMObjectStore.h"
-#import "RLMProperty.h"
+#import "RLMProperty_Private.h"
 #import "RLMUtil.hpp"
 
 #import <objc/runtime.h>
@@ -46,6 +46,9 @@
 
 - (void)setUnderlyingValue:(id)underlyingValue {
     if ((_object && _object->_realm) || _object.isInvalidated) {
+        if (_property.isPrimary) {
+            @throw RLMException(@"Primary key can't be changed after an object is inserted.");
+        }
         RLMDynamicSet(_object, _property, underlyingValue, RLMCreationOptionsNone);
     }
     else {

--- a/RealmSwift/Tests/ObjectTests.swift
+++ b/RealmSwift/Tests/ObjectTests.swift
@@ -107,12 +107,49 @@ class ObjectTests: TestCase {
         // swiftlint:enable line_length
     }
 
-    func testPrimaryKey() {
+    func testSchemaHasPrimaryKey() {
         XCTAssertNil(Object.primaryKey(), "primary key should default to nil")
         XCTAssertNil(SwiftStringObject.primaryKey())
         XCTAssertNil(SwiftStringObject().objectSchema.primaryKeyProperty)
         XCTAssertEqual(SwiftPrimaryStringObject.primaryKey()!, "stringCol")
         XCTAssertEqual(SwiftPrimaryStringObject().objectSchema.primaryKeyProperty!.name, "stringCol")
+    }
+
+    func testCannotUpdatePrimaryKey() {
+        let realm = self.realmWithTestPath()
+        let primaryKeyReason = "Primary key can't be changed .*after an object is inserted."
+
+        let intObj = SwiftPrimaryIntObject()
+        intObj.intCol = 1
+        intObj.intCol = 0; // can change primary key unattached
+        XCTAssertEqual(0, intObj.intCol)
+
+        let optionalIntObj = SwiftPrimaryOptionalIntObject()
+        optionalIntObj.intCol.value = 1
+        optionalIntObj.intCol.value = 0; // can change primary key unattached
+        XCTAssertEqual(0, optionalIntObj.intCol.value)
+
+        let stringObj = SwiftPrimaryStringObject()
+        stringObj.stringCol = "a"
+        stringObj.stringCol = "b" // can change primary key unattached
+        XCTAssertEqual("b", stringObj.stringCol)
+
+        try! realm.write {
+            realm.add(intObj)
+            assertThrows(intObj.intCol = 2, reason: primaryKeyReason)
+            assertThrows(intObj["intCol"] = 2, reason: primaryKeyReason)
+            assertThrows(intObj.setValue(2, forKey: "intCol"), reason: primaryKeyReason)
+
+            realm.add(optionalIntObj)
+            assertThrows(optionalIntObj.intCol.value = 2, reason: primaryKeyReason)
+            assertThrows(optionalIntObj["intCol"] = 2, reason: primaryKeyReason)
+            assertThrows(optionalIntObj.setValue(2, forKey: "intCol"), reason: primaryKeyReason)
+
+            realm.add(stringObj)
+            assertThrows(stringObj.stringCol = "c", reason: primaryKeyReason)
+            assertThrows(stringObj["stringCol"] = "c", reason: primaryKeyReason)
+            assertThrows(stringObj.setValue("c", forKey: "stringCol"), reason: primaryKeyReason)
+        }
     }
 
     func testIgnoredProperties() {
@@ -457,12 +494,49 @@ class ObjectTests: TestCase {
         // swiftlint:enable line_length
     }
 
-    func testPrimaryKey() {
+    func testSchemaHasPrimaryKey() {
         XCTAssertNil(Object.primaryKey(), "primary key should default to nil")
         XCTAssertNil(SwiftStringObject.primaryKey())
         XCTAssertNil(SwiftStringObject().objectSchema.primaryKeyProperty)
         XCTAssertEqual(SwiftPrimaryStringObject.primaryKey()!, "stringCol")
         XCTAssertEqual(SwiftPrimaryStringObject().objectSchema.primaryKeyProperty!.name, "stringCol")
+    }
+
+    func testCannotUpdatePrimaryKey() {
+        let realm = self.realmWithTestPath()
+        let primaryKeyReason = "Primary key can't be changed .*after an object is inserted."
+
+        let intObj = SwiftPrimaryIntObject()
+        intObj.intCol = 1
+        intObj.intCol = 0; // can change primary key unattached
+        XCTAssertEqual(0, intObj.intCol)
+
+        let optionalIntObj = SwiftPrimaryOptionalIntObject()
+        optionalIntObj.intCol.value = 1
+        optionalIntObj.intCol.value = 0; // can change primary key unattached
+        XCTAssertEqual(0, optionalIntObj.intCol.value)
+
+        let stringObj = SwiftPrimaryStringObject()
+        stringObj.stringCol = "a"
+        stringObj.stringCol = "b" // can change primary key unattached
+        XCTAssertEqual("b", stringObj.stringCol)
+
+        try! realm.write {
+            realm.add(intObj)
+            assertThrows(intObj.intCol = 2, reason: primaryKeyReason)
+            assertThrows(intObj["intCol"] = 2, reason: primaryKeyReason)
+            assertThrows(intObj.setValue(2, forKey: "intCol"), reason: primaryKeyReason)
+
+            realm.add(optionalIntObj)
+            assertThrows(optionalIntObj.intCol.value = 2, reason: primaryKeyReason)
+            assertThrows(optionalIntObj["intCol"] = 2, reason: primaryKeyReason)
+            assertThrows(optionalIntObj.setValue(2, forKey: "intCol"), reason: primaryKeyReason)
+
+            realm.add(stringObj)
+            assertThrows(stringObj.stringCol = "c", reason: primaryKeyReason)
+            assertThrows(stringObj["stringCol"] = "c", reason: primaryKeyReason)
+            assertThrows(stringObj.setValue("c", forKey: "stringCol"), reason: primaryKeyReason)
+        }
     }
 
     func testIgnoredProperties() {

--- a/RealmSwift/Tests/TestCase.swift
+++ b/RealmSwift/Tests/TestCase.swift
@@ -123,6 +123,7 @@ class TestCase: XCTestCase {
 
     func assertThrows<T>(_ block: @autoclosure @escaping () -> T, reason regexString: String,
                          _ message: String? = nil, fileName: String = #file, lineNumber: UInt = #line) {
+        exceptionThrown = true
         RLMAssertThrowsWithReasonMatching(self, { _ = block() }, regexString, message, fileName, lineNumber)
     }
 
@@ -271,6 +272,7 @@ class TestCase: XCTestCase {
 
     func assertThrows<T>(@autoclosure(escaping) block: () -> T, reason regexString: String,
                          _ message: String? = nil, fileName: String = #file, lineNumber: UInt = #line) {
+        exceptionThrown = true
         RLMAssertThrowsWithReasonMatching(self, { _ = block() } as dispatch_block_t, regexString, message, fileName, lineNumber)
     }
 


### PR DESCRIPTION
Fixes https://github.com/realm/realm-cocoa/issues/4022

@jpsim 