### PR TITLE
Fix force cast to incorrect type `URL` instead of `NSString`

### DIFF
--- a/RealmSwift/Tests/TestCase.swift
+++ b/RealmSwift/Tests/TestCase.swift
@@ -96,7 +96,7 @@ class TestCase: XCTestCase {
         // Verify that there are no remaining realm files after the test
         let parentDir = (testDir as NSString).deletingLastPathComponent
         for url in FileManager().enumerator(atPath: parentDir)! {
-            let url = url as! URL
+            let url = url as! NSString
             XCTAssertNotEqual(url.pathExtension, "realm", "Lingering realm file at \(parentDir)/\(url)")
             assert(url.pathExtension != "realm")
         }

--- a/RealmSwift/Tests/TestCase.swift
+++ b/RealmSwift/Tests/TestCase.swift
@@ -95,7 +95,7 @@ class TestCase: XCTestCase {
 
         // Verify that there are no remaining realm files after the test
         let parentDir = (testDir as NSString).deletingLastPathComponent
-        for url in FileManager().enumerator(atPath: parentDir)! {
+        for url in FileManager.default.enumerator(atPath: parentDir)! {
             let url = url as! NSString
             XCTAssertNotEqual(url.pathExtension, "realm", "Lingering realm file at \(parentDir)/\(url)")
             assert(url.pathExtension != "realm")


### PR DESCRIPTION
Addresses https://github.com/realm/realm-cocoa/issues/4009, which was causing crashes when some tests fail. This used to have no cast when it was imported as `AnyObject`, but the Swift 3 changes importing it as `Any` changed this. In migrating that code, I incorrectly thought this should be cast to `URL` but the actual correct type is `NSString`. I missed that this was incorrect because this code is not called when tests pass.

@jpsim 