### PR TITLE
Allow explicitly specifying `NSNumber` property types in Swift

### DIFF
--- a/Realm.podspec
+++ b/Realm.podspec
@@ -20,6 +20,7 @@ Pod::Spec.new do |s|
                               'include/**/RLMCollection.h',
                               'include/**/RLMConstants.h',
                               'include/**/RLMListBase.h',
+                              'include/**/RLMNumericNull.h’,
                               'include/**/RLMMigration.h',
                               'include/**/RLMObject.h',
                               'include/**/RLMObjectBase.h',

--- a/Realm.xcodeproj/project.pbxproj
+++ b/Realm.xcodeproj/project.pbxproj
@@ -355,6 +355,10 @@
 		C042A48E1B7522A900771ED2 /* RealmConfigurationTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = C042A48C1B7522A900771ED2 /* RealmConfigurationTests.mm */; };
 		C0CDC0821B38DABA00C5716D /* UtilTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 021A88311AAFB5BE00EEAC84 /* UtilTests.mm */; };
 		C0CDC0831B38DABB00C5716D /* UtilTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 021A88311AAFB5BE00EEAC84 /* UtilTests.mm */; };
+		D43E91D81D760BF90008C04C /* RLMNumericNull.mm in Sources */ = {isa = PBXBuildFile; fileRef = D43E91D51D760BF90008C04C /* RLMNumericNull.mm */; };
+		D43E91D91D760BF90008C04C /* RLMNumericNull.mm in Sources */ = {isa = PBXBuildFile; fileRef = D43E91D51D760BF90008C04C /* RLMNumericNull.mm */; };
+		D43E91DE1D760D6F0008C04C /* RLMNumericNull.h in Headers */ = {isa = PBXBuildFile; fileRef = D43E91DD1D760D6F0008C04C /* RLMNumericNull.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D43E91DF1D760D6F0008C04C /* RLMNumericNull.h in Headers */ = {isa = PBXBuildFile; fileRef = D43E91DD1D760D6F0008C04C /* RLMNumericNull.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		E81A1FD51955FE0100FDED82 /* ArrayPropertyTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E81A1FB81955FE0100FDED82 /* ArrayPropertyTests.m */; settings = {COMPILER_FLAGS = "-fobjc-arc-exceptions"; }; };
 		E81A1FDB1955FE0100FDED82 /* EnumeratorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E81A1FBB1955FE0100FDED82 /* EnumeratorTests.m */; settings = {COMPILER_FLAGS = "-fobjc-arc-exceptions"; }; };
 		E81A1FDD1955FE0100FDED82 /* LinkTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E81A1FBC1955FE0100FDED82 /* LinkTests.m */; settings = {COMPILER_FLAGS = "-fobjc-arc-exceptions"; }; };
@@ -651,6 +655,8 @@
 		C0D2DD061B6BDEA1004E8919 /* RLMRealmConfiguration.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = RLMRealmConfiguration.mm; sourceTree = "<group>"; };
 		C0D2DD0F1B6BE0DD004E8919 /* RLMRealmConfiguration_Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RLMRealmConfiguration_Private.h; sourceTree = "<group>"; };
 		C0D6E4101AFBFAF7001F3027 /* RLMAssertions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RLMAssertions.h; sourceTree = "<group>"; };
+		D43E91D51D760BF90008C04C /* RLMNumericNull.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = RLMNumericNull.mm; sourceTree = "<group>"; };
+		D43E91DD1D760D6F0008C04C /* RLMNumericNull.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RLMNumericNull.h; sourceTree = "<group>"; };
 		E81A1F621955FC9300FDED82 /* Realm-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "Realm-Info.plist"; sourceTree = "<group>"; };
 		E81A1F631955FC9300FDED82 /* RLMAccessor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RLMAccessor.h; sourceTree = "<group>"; };
 		E81A1F641955FC9300FDED82 /* RLMAccessor.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = RLMAccessor.mm; sourceTree = "<group>"; };
@@ -1079,6 +1085,8 @@
 				0207AB7D195DF9FB007EFB12 /* RLMMigration.h */,
 				0207AB7E195DF9FB007EFB12 /* RLMMigration.mm */,
 				0207AB7C195DF9FB007EFB12 /* RLMMigration_Private.h */,
+				D43E91DD1D760D6F0008C04C /* RLMNumericNull.h */,
+				D43E91D51D760BF90008C04C /* RLMNumericNull.mm */,
 				E81A1F6E1955FC9300FDED82 /* RLMObject.h */,
 				E81A1F6F1955FC9300FDED82 /* RLMObject.mm */,
 				E81A1F6D1955FC9300FDED82 /* RLMObject_Private.h */,
@@ -1183,6 +1191,7 @@
 				3F9801A01C8E4F55000A8B07 /* collection_notifier.hpp in Headers */,
 				5D5AF7FD1D3D8F9C003036AB /* compiler.hpp in Headers */,
 				5D659EA01BE04556006515A0 /* external_commit_helper.hpp in Headers */,
+				D43E91DE1D760D6F0008C04C /* RLMNumericNull.h in Headers */,
 				3F0543F81C56F78300AA5322 /* external_commit_helper.hpp in Headers */,
 				5DB591AB1D063DF8001D8F93 /* format.hpp in Headers */,
 				3F6864E81D5B825E000024C3 /* handover.hpp in Headers */,
@@ -1296,6 +1305,7 @@
 				5DD755C11BE056DE002800DA /* RLMRealmConfiguration_Private.h in Headers */,
 				E86900E31CC04F5B0008A8B6 /* RLMRealmConfiguration_Private.hpp in Headers */,
 				5DD755C21BE056DE002800DA /* RLMRealmUtil.hpp in Headers */,
+				D43E91DF1D760D6F0008C04C /* RLMNumericNull.h in Headers */,
 				5DD755C31BE056DE002800DA /* RLMResults.h in Headers */,
 				5DD755C41BE056DE002800DA /* RLMResults_Private.h in Headers */,
 				5DD755C51BE056DE002800DA /* RLMSchema.h in Headers */,
@@ -1765,6 +1775,7 @@
 				3F9801AB1C8E4F6B000A8B07 /* collection_notifications.cpp in Sources */,
 				3F9801A41C8E4F55000A8B07 /* collection_notifier.cpp in Sources */,
 				5D659E811BE04556006515A0 /* external_commit_helper.cpp in Sources */,
+				D43E91D81D760BF90008C04C /* RLMNumericNull.mm in Sources */,
 				5DB591AA1D063DF8001D8F93 /* format.cpp in Sources */,
 				3F6864E71D5B825E000024C3 /* handover.cpp in Sources */,
 				5D659E821BE04556006515A0 /* index_set.cpp in Sources */,
@@ -1868,6 +1879,7 @@
 				3F9801AC1C8E4F6F000A8B07 /* collection_notifications.cpp in Sources */,
 				3F9801A61C8E4F5A000A8B07 /* collection_notifier.cpp in Sources */,
 				5DD7557F1BE056DE002800DA /* external_commit_helper.cpp in Sources */,
+				D43E91D91D760BF90008C04C /* RLMNumericNull.mm in Sources */,
 				5DB591AC1D0775D2001D8F93 /* format.cpp in Sources */,
 				3F6864E91D5B8262000024C3 /* handover.cpp in Sources */,
 				5DD755801BE056DE002800DA /* index_set.cpp in Sources */,

--- a/Realm/RLMNumericNull.h
+++ b/Realm/RLMNumericNull.h
@@ -1,0 +1,29 @@
+//
+//  RLMNumberDefault.h
+//  Realm
+//
+//  Created by Realm on 8/30/16.
+//  Copyright © 2016 Realm. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface RLMNumericNull : NSNumber
+
+- (instancetype)initWithObjCType:(const char *)objCType;
+
++ (instancetype)nullChar             NS_SWIFT_NAME(nullInt8());
++ (instancetype)nullUnsignedChar     NS_SWIFT_NAME(nullUInt8());
++ (instancetype)nullShort            NS_SWIFT_NAME(nullInt16());
++ (instancetype)nullUnsignedShort    NS_SWIFT_NAME(nullUInt16());
++ (instancetype)nullInt              NS_SWIFT_NAME(nullInt32());
++ (instancetype)nullUnsignedInt      NS_SWIFT_NAME(nullUInt32());
++ (instancetype)nullLong             NS_SWIFT_NAME(nullInt());
++ (instancetype)nullUnsignedLong     NS_SWIFT_NAME(nullUInt());
++ (instancetype)nullLongLong         NS_SWIFT_NAME(nullInt64());
++ (instancetype)nullUnsignedLongLong NS_SWIFT_NAME(nullUInt64());
++ (instancetype)nullFloat;
++ (instancetype)nullDouble;
++ (instancetype)nullBool;
+
+@end

--- a/Realm/RLMNumericNull.mm
+++ b/Realm/RLMNumericNull.mm
@@ -1,0 +1,123 @@
+//
+//  RLMNumberDefault.m
+//  Realm
+//
+//  Created by Realm on 8/30/16.
+//  Copyright © 2016 Realm. All rights reserved.
+//
+
+#import "RLMNumericNull.h"
+#import "RLMUtil.hpp"
+
+@implementation RLMNumericNull
+
+@synthesize objCType = _objCType;
+
+- (instancetype)initWithObjCType:(const char *)objCType {
+    if (self = [super init]) {
+        _objCType = objCType;
+    }
+    return self;
+}
+
++ (instancetype)nullChar {
+    return [[self alloc] initWithObjCType:@encode(char)];
+}
++ (instancetype)nullUnsignedChar {
+    return [[self alloc] initWithObjCType:@encode(unsigned char)];
+}
++ (instancetype)nullShort {
+    return [[self alloc] initWithObjCType:@encode(short)];
+}
++ (instancetype)nullUnsignedShort {
+    return [[self alloc] initWithObjCType:@encode(unsigned short)];
+}
++ (instancetype)nullInt {
+    return [[self alloc] initWithObjCType:@encode(int)];
+}
++ (instancetype)nullUnsignedInt {
+    return [[self alloc] initWithObjCType:@encode(unsigned int)];
+}
++ (instancetype)nullLong {
+    return [[self alloc] initWithObjCType:@encode(long)];
+}
++ (instancetype)nullUnsignedLong {
+    return [[self alloc] initWithObjCType:@encode(unsigned long)];
+}
++ (instancetype)nullLongLong {
+    return [[self alloc] initWithObjCType:@encode(long long)];
+}
++ (instancetype)nullUnsignedLongLong {
+    return [[self alloc] initWithObjCType:@encode(unsigned long long)];
+}
++ (instancetype)nullFloat {
+    return [[self alloc] initWithObjCType:@encode(float)];
+}
++ (instancetype)nullDouble {
+    return [[self alloc] initWithObjCType:@encode(double)];
+}
++ (instancetype)nullBool {
+    return [[self alloc] initWithObjCType:@encode(bool)];
+}
++ (instancetype)nullInteger {
+    return [[self alloc] initWithObjCType:@encode(NSInteger)];
+}
++ (instancetype)nullUnsignedInteger {
+    return [[self alloc] initWithObjCType:@encode(NSUInteger)];
+}
+
+- (char)charValue {
+    @throw RLMException(@"Unexpected call to accessor method on `RLMNumericNull`.");
+}
+- (unsigned char)unsignedCharValue {
+    @throw RLMException(@"Unexpected call to accessor method on `RLMNumericNull`.");
+}
+- (short)shortValue {
+    @throw RLMException(@"Unexpected call to accessor method on `RLMNumericNull`.");
+}
+- (unsigned short)unsignedShortValue {
+    @throw RLMException(@"Unexpected call to accessor method on `RLMNumericNull`.");
+}
+- (int)intValue {
+    @throw RLMException(@"Unexpected call to accessor method on `RLMNumericNull`.");
+}
+- (unsigned int)unsignedIntValue {
+    @throw RLMException(@"Unexpected call to accessor method on `RLMNumericNull`.");
+}
+- (long)longValue {
+    @throw RLMException(@"Unexpected call to accessor method on `RLMNumericNull`.");
+}
+- (unsigned long)unsignedLongValue {
+    @throw RLMException(@"Unexpected call to accessor method on `RLMNumericNull`.");
+}
+- (long long)longLongValue {
+    @throw RLMException(@"Unexpected call to accessor method on `RLMNumericNull`.");
+}
+- (unsigned long long)unsignedLongLongValue {
+    @throw RLMException(@"Unexpected call to accessor method on `RLMNumericNull`.");
+}
+- (float)floatValue {
+    @throw RLMException(@"Unexpected call to accessor method on `RLMNumericNull`.");
+}
+- (double)doubleValue {
+    @throw RLMException(@"Unexpected call to accessor method on `RLMNumericNull`.");
+}
+- (BOOL)boolValue {
+    @throw RLMException(@"Unexpected call to accessor method on `RLMNumericNull`.");
+}
+- (NSInteger)integerValue {
+    @throw RLMException(@"Unexpected call to accessor method on `RLMNumericNull`.");
+}
+- (NSUInteger)unsignedIntegerValue {
+    @throw RLMException(@"Unexpected call to accessor method on `RLMNumericNull`.");
+}
+
+- (NSString *)stringValue {
+    return @"<null>";
+}
+
+-(NSString *)description {
+    return self.stringValue;
+}
+
+@end

--- a/Realm/RLMSchema.mm
+++ b/Realm/RLMSchema.mm
@@ -231,6 +231,9 @@ static void RLMRegisterClassLocalNames(Class *classes, NSUInteger count) {
             }
 
             [s_localNameToClass enumerateKeysAndObjectsUsingBlock:^(NSString *, Class cls, BOOL *) {
+                if ([NSStringFromClass(cls) isEqualToString:@"Tests.SwiftNilDefaultOptionalNumberObject"]) {
+                    ;
+                }
                 RLMRegisterClass(cls);
             }];
         }

--- a/Realm/RLMSchema.mm
+++ b/Realm/RLMSchema.mm
@@ -231,9 +231,6 @@ static void RLMRegisterClassLocalNames(Class *classes, NSUInteger count) {
             }
 
             [s_localNameToClass enumerateKeysAndObjectsUsingBlock:^(NSString *, Class cls, BOOL *) {
-                if ([NSStringFromClass(cls) isEqualToString:@"Tests.SwiftNilDefaultOptionalNumberObject"]) {
-                    ;
-                }
                 RLMRegisterClass(cls);
             }];
         }

--- a/Realm/RLMUtil.hpp
+++ b/Realm/RLMUtil.hpp
@@ -18,6 +18,7 @@
 
 #import <Realm/RLMConstants.h>
 #import <Realm/RLMOptionalBase.h>
+#import <Realm/RLMNumericNull.h>
 #import <objc/runtime.h>
 
 #import <realm/array.hpp>
@@ -82,9 +83,16 @@ static inline T *RLMDynamicCast(__unsafe_unretained id obj) {
     return nil;
 }
 
+static inline bool RLMIsNullNumber(__unsafe_unretained NSNumber *const number) {
+    return number == nil || [number isKindOfClass:RLMNumericNull.class];
+}
+
 template<typename T>
 static inline T RLMCoerceToNil(__unsafe_unretained T obj) {
     if (static_cast<id>(obj) == NSNull.null) {
+        return nil;
+    }
+    else if ([obj isKindOfClass:RLMNumericNull.class]) {
         return nil;
     }
     else if (__unsafe_unretained auto optional = RLMDynamicCast<RLMOptionalBase>(obj)) {

--- a/Realm/Realm.h
+++ b/Realm/Realm.h
@@ -20,6 +20,7 @@
 
 #import <Realm/RLMArray.h>
 #import <Realm/RLMMigration.h>
+#import <Realm/RLMNumericNull.h>
 #import <Realm/RLMObject.h>
 #import <Realm/RLMObjectSchema.h>
 #import <Realm/RLMPlatform.h>

--- a/Realm/Swift/RLMSupport.swift
+++ b/Realm/Swift/RLMSupport.swift
@@ -89,6 +89,48 @@ import Realm
         }
     }
 
+    extension NSNumber {
+        static func float(_ value: Float?) -> NSNumber {
+            guard let value = value else { return RLMNumericNull.nullFloat() }
+            return NSNumber(value: value)
+        }
+
+        static func double(_ value: Double?) -> NSNumber {
+            guard let value = value else { return RLMNumericNull.nullDouble() }
+            return NSNumber(value: value)
+        }
+
+        static func bool(_ value: Bool?) -> NSNumber {
+            guard let value = value else { return RLMNumericNull.nullBool() }
+            return NSNumber(value: value)
+        }
+
+        static func int(_ value: Int?) -> NSNumber {
+            guard let value = value else { return RLMNumericNull.nullInt() }
+            return NSNumber(value: value)
+        }
+
+        static func int8(_ value: Int8?) -> NSNumber {
+            guard let value = value else { return RLMNumericNull.nullInt8() }
+            return NSNumber(value: value)
+        }
+
+        static func int16(_ value: Int16?) -> NSNumber {
+            guard let value = value else { return RLMNumericNull.nullInt16() }
+            return NSNumber(value: value)
+        }
+
+        static func int32(_ value: Int32?) -> NSNumber {
+            guard let value = value else { return RLMNumericNull.nullInt32() }
+            return NSNumber(value: value)
+        }
+
+        static func int64(_ value: Int64?) -> NSNumber {
+            guard let value = value else { return RLMNumericNull.nullInt64() }
+            return NSNumber(value: value)
+        }
+    }
+
 #else
     extension RLMRealm {
         @nonobjc public class func schemaVersionAtURL(url: NSURL, encryptionKey key: NSData? = nil,
@@ -152,6 +194,48 @@ import Realm
 
         public func objectsWhere(predicateFormat: String, _ args: CVarArgType...) -> RLMResults {
             return objectsWithPredicate(NSPredicate(format: predicateFormat, arguments: getVaList(args)))
+        }
+    }
+
+    extension NSNumber {
+        static func float(value: Float?) -> NSNumber {
+            guard let value = value else { return RLMNumericNull.nullFloat() }
+            return NSNumber(float: value)
+        }
+
+        static func double(value: Double?) -> NSNumber {
+            guard let value = value else { return RLMNumericNull.nullDouble() }
+            return NSNumber(double: value)
+        }
+
+        static func bool(value: Bool?) -> NSNumber {
+            guard let value = value else { return RLMNumericNull.nullBool() }
+            return NSNumber(bool: value)
+        }
+
+        static func int(value: Int?) -> NSNumber {
+            guard let value = value else { return RLMNumericNull.nullInt() }
+            return NSNumber(integer: value)
+        }
+
+        static func int8(value: Int8?) -> NSNumber {
+            guard let value = value else { return RLMNumericNull.nullInt8() }
+            return NSNumber(char: value)
+        }
+
+        static func int16(value: Int16?) -> NSNumber {
+            guard let value = value else { return RLMNumericNull.nullInt16() }
+            return NSNumber(short: value)
+        }
+
+        static func int32(value: Int32?) -> NSNumber {
+            guard let value = value else { return RLMNumericNull.nullInt32() }
+            return NSNumber(int: value)
+        }
+
+        static func int64(value: Int64?) -> NSNumber {
+            guard let value = value else { return RLMNumericNull.nullInt64() }
+            return NSNumber(longLong: value)
         }
     }
 #endif

--- a/Realm/Tests/Swift/SwiftObjectInterfaceTests.swift
+++ b/Realm/Tests/Swift/SwiftObjectInterfaceTests.swift
@@ -47,10 +47,17 @@ class SwiftDefaultObject: RLMObject {
 }
 
 class SwiftOptionalNumberObject: RLMObject {
-    dynamic var intCol: NSNumber? = 1
-    dynamic var floatCol: NSNumber? = 2.2 as Float as NSNumber
-    dynamic var doubleCol: NSNumber? = 3.3
+    dynamic var intCol: NSNumber? = .int(1)
+    dynamic var floatCol: NSNumber? = .float(2.2)
+    dynamic var doubleCol: NSNumber? = .double(3.3)
     dynamic var boolCol: NSNumber? = true
+}
+
+class SwiftNilDefaultOptionalNumberObject: RLMObject {
+    dynamic var intCol: NSNumber? = .int(nil)
+    dynamic var floatCol: NSNumber? = .float(nil)
+    dynamic var doubleCol: NSNumber? = .double(nil)
+    dynamic var boolCol: NSNumber? = .bool(nil)
 }
 
 class SwiftObjectInterfaceTests: RLMTestCase {
@@ -180,6 +187,62 @@ class SwiftObjectInterfaceTests: RLMTestCase {
         XCTAssertEqual(2.2 as Float as NSNumber, no.floatCol!)
         XCTAssertEqual(3.3, no.doubleCol!)
         XCTAssertEqual(false, no.boolCol!)
+    }
+
+    func testNilDefaultOptionalNumberObject() {
+        let realm = realmWithTestPath()
+
+        // Ensure that the static methods return NSNumbers when not passed nil
+        XCTAssertEqual(1, NSNumber.int(1))
+        XCTAssertEqual(2.2 as Float as NSNumber, NSNumber.float(2.2))
+        XCTAssertEqual(3.3, NSNumber.double(3.3))
+        XCTAssertEqual(true, NSNumber.bool(true))
+
+        // Ensure the object schema was correclty parsed
+        let objectSchema = SwiftNilDefaultOptionalNumberObject.sharedSchema()!
+        XCTAssertEqual(RLMPropertyType.int,    objectSchema["intCol"]?.type)
+        XCTAssertEqual(RLMPropertyType.float,  objectSchema["floatCol"]?.type)
+        XCTAssertEqual(RLMPropertyType.double, objectSchema["doubleCol"]?.type)
+        XCTAssertEqual(RLMPropertyType.bool,   objectSchema["boolCol"]?.type)
+
+        // Ensure the default initialized object has nil properties
+        let empty = SwiftNilDefaultOptionalNumberObject()
+        XCTAssertNil(empty.intCol)
+        XCTAssertNil(empty.floatCol)
+        XCTAssertNil(empty.doubleCol)
+        XCTAssertNil(empty.boolCol)
+
+        // Ensure the properties can be initialized to non-nil values
+        let initialized = SwiftNilDefaultOptionalNumberObject(value: [1, 2.2 as Float, 3.3, true])
+        XCTAssertEqual(.int(1),      initialized.intCol)
+        XCTAssertEqual(.float(2.2),  initialized.floatCol)
+        XCTAssertEqual(.double(3.3), initialized.doubleCol)
+        XCTAssertEqual(.bool(true),  initialized.boolCol)
+
+        // Ensure unmanaged properties can be set back to nil by setting `RLMNumericNull`
+        let unmanaged = SwiftNilDefaultOptionalNumberObject(value: [1, 2.2 as Float, 3.3, true])
+        unmanaged.intCol    = .int(nil)
+        unmanaged.floatCol  = .float(nil)
+        unmanaged.doubleCol = .double(nil)
+        unmanaged.boolCol   = .bool(nil)
+        XCTAssertNil(unmanaged.intCol)
+        XCTAssertNil(unmanaged.floatCol)
+        XCTAssertNil(unmanaged.doubleCol)
+        XCTAssertNil(unmanaged.boolCol)
+
+        // Ensure managed properties can be set back to nil by setting `RLMNumericNull`
+        let managed = SwiftNilDefaultOptionalNumberObject(value: [1, 2.2 as Float, 3.3, true])
+        try! realm.transaction {
+            realm.add(managed)
+            managed.intCol    = .int(nil)
+            managed.floatCol  = .float(nil)
+            managed.doubleCol = .double(nil)
+            managed.boolCol   = .bool(nil)
+        }
+        XCTAssertNil(managed.intCol)
+        XCTAssertNil(managed.floatCol)
+        XCTAssertNil(managed.doubleCol)
+        XCTAssertNil(managed.boolCol)
     }
 
     func testOptionalSwiftProperties() {
@@ -320,6 +383,13 @@ class SwiftOptionalNumberObject: RLMObject {
     dynamic var boolCol: NSNumber? = true
 }
 
+class SwiftNilDefaultOptionalNumberObject: RLMObject {
+    dynamic var intCol: NSNumber? = .int(nil)
+    dynamic var floatCol: NSNumber? = .float(nil)
+    dynamic var doubleCol: NSNumber? = .double(nil)
+    dynamic var boolCol: NSNumber? = .bool(nil)
+}
+
 class SwiftObjectInterfaceTests: RLMTestCase {
 
     // Swift models
@@ -447,6 +517,62 @@ class SwiftObjectInterfaceTests: RLMTestCase {
         XCTAssertEqual(2.2 as Float, no.floatCol!)
         XCTAssertEqual(3.3, no.doubleCol!)
         XCTAssertEqual(false, no.boolCol!)
+    }
+
+    func testNilDefaultOptionalNumberObject() {
+        let realm = realmWithTestPath()
+
+        // Ensure that the static methods return NSNumbers when not passed nil
+        XCTAssertEqual(1, NSNumber.int(1))
+        XCTAssertEqual(2.2 as Float as NSNumber, NSNumber.float(2.2))
+        XCTAssertEqual(3.3, NSNumber.double(3.3))
+        XCTAssertEqual(true, NSNumber.bool(true))
+
+        // Ensure the object schema was correclty parsed
+        let objectSchema = SwiftNilDefaultOptionalNumberObject.sharedSchema()!
+        XCTAssertEqual(RLMPropertyType.Int,    objectSchema["intCol"]?.type)
+        XCTAssertEqual(RLMPropertyType.Float,  objectSchema["floatCol"]?.type)
+        XCTAssertEqual(RLMPropertyType.Double, objectSchema["doubleCol"]?.type)
+        XCTAssertEqual(RLMPropertyType.Bool,   objectSchema["boolCol"]?.type)
+
+        // Ensure the default initialized object has nil properties
+        let empty = SwiftNilDefaultOptionalNumberObject()
+        XCTAssertNil(empty.intCol)
+        XCTAssertNil(empty.floatCol)
+        XCTAssertNil(empty.doubleCol)
+        XCTAssertNil(empty.boolCol)
+
+        // Ensure the properties can be initialized to non-nil values
+        let initialized = SwiftNilDefaultOptionalNumberObject(value: [1, 2.2 as Float, 3.3, true])
+        XCTAssertEqual(.int(1),      initialized.intCol)
+        XCTAssertEqual(.float(2.2),  initialized.floatCol)
+        XCTAssertEqual(.double(3.3), initialized.doubleCol)
+        XCTAssertEqual(.bool(true),  initialized.boolCol)
+
+        // Ensure unmanaged properties can be set back to nil by setting `RLMNumericNull`
+        let unmanaged = SwiftNilDefaultOptionalNumberObject(value: [1, 2.2 as Float, 3.3, true])
+        unmanaged.intCol    = .int(nil)
+        unmanaged.floatCol  = .float(nil)
+        unmanaged.doubleCol = .double(nil)
+        unmanaged.boolCol   = .bool(nil)
+        XCTAssertNil(unmanaged.intCol)
+        XCTAssertNil(unmanaged.floatCol)
+        XCTAssertNil(unmanaged.doubleCol)
+        XCTAssertNil(unmanaged.boolCol)
+
+        // Ensure managed properties can be set back to nil by setting `RLMNumericNull`
+        let managed = SwiftNilDefaultOptionalNumberObject(value: [1, 2.2 as Float, 3.3, true])
+        try! realm.transactionWithBlock {
+            realm.addObject(managed)
+            managed.intCol    = .int(nil)
+            managed.floatCol  = .float(nil)
+            managed.doubleCol = .double(nil)
+            managed.boolCol   = .bool(nil)
+        }
+        XCTAssertNil(managed.intCol)
+        XCTAssertNil(managed.floatCol)
+        XCTAssertNil(managed.doubleCol)
+        XCTAssertNil(managed.boolCol)
     }
 
     func testOptionalSwiftProperties() {


### PR DESCRIPTION
Adds static properties to `NSNumber` that allow users to explicitly specify the type of an `NSNumber` default value, including a `nil` default value fixing https://github.com/realm/realm-cocoa/issues/4026.

Also, this enhancement fixes https://github.com/realm/realm-cocoa/issues/3971, a regression due to the removal of implicit bridging that required `NSNumber<RLMFloat>` properties in Swift to be written `dynamic var floatCol: NSNumber? = 3.14 as Float as NSNumber`.

These changes live in a new public class `RLMNumericNull` and in `RLMSupport.swift`. Though Objective-C users can use `[RLMNumericNull nullFloat]` and friends as default values, there's no reason to recommend or document this due to the superior protocol approach. Swift users can use the `NSNumber` extensions define in `RLMSupport.swift`.

``` swift
class SwiftNilDefaultOptionalNumberObject: RLMObject {
    dynamic var intCol: NSNumber? = .int(nil)
    dynamic var floatCol: NSNumber? = .float(nil)
    dynamic var doubleCol: NSNumber? = .double(nil)
    dynamic var boolCol: NSNumber? = .bool(nil)
}
```

Note that these changes don't expose the extensions to Realm Swift. If we decide this is an API change we want to make, I'll copy the extension to the Realm Swift target as well.
