### PR TITLE
Throw when `deleteRealmIfMigrationNeeded` and `readOnly` are both set

### DIFF
--- a/Realm/RLMRealmConfiguration.mm
+++ b/Realm/RLMRealmConfiguration.mm
@@ -217,9 +217,12 @@ static void RLMNSStringToStdString(std::string &out, NSString *in) {
 
 - (void)setReadOnly:(BOOL)readOnly {
     if (readOnly) {
+        if (self.deleteRealmIfMigrationNeeded) {
+            @throw RLMException(@"Cannot set `readOnly` when `deleteRealmIfMigrationNeeded` is set.");
+        }
         _config.schema_mode = realm::SchemaMode::ReadOnly;
     }
-    else if (_config.schema_mode == realm::SchemaMode::ReadOnly) {
+    else if (self.readOnly) {
         _config.schema_mode = realm::SchemaMode::Automatic;
     }
 }
@@ -241,9 +244,12 @@ static void RLMNSStringToStdString(std::string &out, NSString *in) {
 
 - (void)setDeleteRealmIfMigrationNeeded:(BOOL)deleteRealmIfMigrationNeeded {
     if (deleteRealmIfMigrationNeeded) {
+        if (self.readOnly) {
+            @throw RLMException(@"Cannot set `deleteRealmIfMigrationNeeded` when `readOnly` is set.");
+        }
         _config.schema_mode = realm::SchemaMode::ResetFile;
     }
-    else if (_config.schema_mode == realm::SchemaMode::ResetFile) {
+    else if (self.deleteRealmIfMigrationNeeded) {
         _config.schema_mode = realm::SchemaMode::Automatic;
     }
 }

--- a/Realm/Tests/RealmConfigurationTests.mm
+++ b/Realm/Tests/RealmConfigurationTests.mm
@@ -79,6 +79,17 @@
     XCTAssertNoThrow(configuration.objectClasses = (@[CompanyObject.class, EmployeeObject.class]));
 }
 
+- (void)testCannotSetMutuallyExclusiveProperties {
+    RLMRealmConfiguration *configuration = [[RLMRealmConfiguration alloc] init];
+    XCTAssertNoThrow(configuration.readOnly = YES);
+    XCTAssertNoThrow(configuration.deleteRealmIfMigrationNeeded = NO);
+    XCTAssertThrows(configuration.deleteRealmIfMigrationNeeded = YES);
+    XCTAssertNoThrow(configuration.readOnly = NO);
+    XCTAssertNoThrow(configuration.deleteRealmIfMigrationNeeded = YES);
+    XCTAssertNoThrow(configuration.readOnly = NO);
+    XCTAssertThrows(configuration.readOnly = YES);
+}
+
 #pragma mark - Default Configuration
 
 - (void)testDefaultConfiguration {

--- a/RealmSwift/Tests/RealmConfigurationTests.swift
+++ b/RealmSwift/Tests/RealmConfigurationTests.swift
@@ -41,6 +41,14 @@ class RealmConfigurationTests: TestCase {
         XCTAssertEqual(Realm.Configuration.defaultConfiguration.fileURL, URL(fileURLWithPath: "/dev/null"))
         Realm.Configuration.defaultConfiguration.fileURL = fileURL
     }
+
+    func testCannotSetMutuallyExclusiveProperties() {
+        var configuration = Realm.Configuration()
+        configuration.readOnly = true
+        configuration.deleteRealmIfMigrationNeeded = true
+        assertThrows(try! Realm(configuration: configuration),
+                     reason: "Cannot set `deleteRealmIfMigrationNeeded` when `readOnly` is set.")
+    }
 }
 
 #else
@@ -63,6 +71,14 @@ class RealmConfigurationTests: TestCase {
         Realm.Configuration.defaultConfiguration = configuration
         XCTAssertEqual(Realm.Configuration.defaultConfiguration.fileURL, NSURL(fileURLWithPath: "/dev/null"))
         Realm.Configuration.defaultConfiguration.fileURL = fileURL
+    }
+
+    func testCannotSetMutuallyExclusiveProperties() {
+        var configuration = Realm.Configuration()
+        configuration.readOnly = true
+        configuration.deleteRealmIfMigrationNeeded = true
+        assertThrows(try! Realm(configuration: configuration),
+                     reason: "Cannot set `deleteRealmIfMigrationNeeded` when `readOnly` is set.")
     }
 }
 


### PR DESCRIPTION
Fixes https://github.com/realm/realm-cocoa/issues/3940.

Note that this doesn't yet any changes to Swift's configuration, but a similar exception will be thrown when a `Realm.Configuration` is converted internally to an `RLMRealmConfiguration`. It does seem weird to throw exceptions on property set in Objective-C but when creating a `Realm` in Swift. I would appreciate feedback on how to make this more consistent (which way is better). @bdash 