### PR TITLE
Annotate nullability in all private Objective-C only headers

### DIFF
--- a/Realm/RLMArray_Private.h
+++ b/Realm/RLMArray_Private.h
@@ -18,7 +18,11 @@
 
 #import <Realm/RLMArray.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface RLMArray ()
 - (instancetype)initWithObjectClassName:(NSString *)objectClassName;
 - (NSString *)descriptionWithMaxDepth:(NSUInteger)depth;
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Realm/RLMConstants.h
+++ b/Realm/RLMConstants.h
@@ -18,6 +18,8 @@
 
 #import <Foundation/Foundation.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 // For compatibility with Xcode 7, before extensible string enums were introduced,
 #ifdef NS_EXTENSIBLE_STRING_ENUM
 #define RLM_EXTENSIBLE_STRING_ENUM NS_EXTENSIBLE_STRING_ENUM
@@ -198,3 +200,5 @@ extern NSString * const RLMRealmCoreVersionKey;
 
 /** The corresponding key is the Realm invalidated property name. */
 extern NSString * const RLMInvalidatedKey;
+
+NS_ASSUME_NONNULL_END

--- a/Realm/RLMListBase.h
+++ b/Realm/RLMListBase.h
@@ -20,6 +20,8 @@
 
 @class RLMArray;
 
+NS_ASSUME_NONNULL_BEGIN
+
 // A base class for Swift generic Lists to make it possible to interact with
 // them from obj-c
 @interface RLMListBase : NSObject <NSFastEnumeration>
@@ -27,3 +29,5 @@
 
 - (instancetype)initWithArray:(RLMArray *)array;
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Realm/RLMMigration_Private.h
+++ b/Realm/RLMMigration_Private.h
@@ -24,6 +24,8 @@ namespace realm {
     class Schema;
 }
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface RLMMigration ()
 
 @property (nonatomic, strong) RLMRealm *oldRealm;
@@ -34,3 +36,5 @@ namespace realm {
 - (void)execute:(RLMMigrationBlock)block;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Realm/RLMObjectBase_Dynamic.h
+++ b/Realm/RLMObjectBase_Dynamic.h
@@ -20,6 +20,8 @@
 
 @class RLMObjectSchema, RLMRealm;
 
+NS_ASSUME_NONNULL_BEGIN
+
 /**
  Returns the Realm that manages the object, if one exists.
  
@@ -31,7 +33,7 @@
  
  @return The Realm which manages this object. Returns `nil `for unmanaged objects.
  */
-FOUNDATION_EXTERN RLMRealm *RLMObjectBaseRealm(RLMObjectBase *object);
+FOUNDATION_EXTERN RLMRealm * _Nullable RLMObjectBaseRealm(RLMObjectBase * _Nullable object);
 
 /**
  Returns an `RLMObjectSchema` which describes the managed properties of the object.
@@ -44,7 +46,7 @@ FOUNDATION_EXTERN RLMRealm *RLMObjectBaseRealm(RLMObjectBase *object);
  
  @return The object schema which lists the managed properties for the object.
  */
-FOUNDATION_EXTERN RLMObjectSchema *RLMObjectBaseObjectSchema(RLMObjectBase *object);
+FOUNDATION_EXTERN RLMObjectSchema * _Nullable RLMObjectBaseObjectSchema(RLMObjectBase * _Nullable object);
 
 /**
  Returns the object corresponding to a key value.
@@ -60,7 +62,7 @@ FOUNDATION_EXTERN RLMObjectSchema *RLMObjectBaseObjectSchema(RLMObjectBase *obje
  
  @return The object for the property requested.
  */
-FOUNDATION_EXTERN id RLMObjectBaseObjectForKeyedSubscript(RLMObjectBase *object, NSString *key);
+FOUNDATION_EXTERN id _Nullable RLMObjectBaseObjectForKeyedSubscript(RLMObjectBase * _Nullable object, NSString *key);
 
 /**
  Sets a value for a key on the object.
@@ -75,5 +77,6 @@ FOUNDATION_EXTERN id RLMObjectBaseObjectForKeyedSubscript(RLMObjectBase *object,
  @param key		The name of the property.
  @param obj		The object to set as the value of the key.
  */
-FOUNDATION_EXTERN void RLMObjectBaseSetObjectForKeyedSubscript(RLMObjectBase *object, NSString *key, id obj);
+FOUNDATION_EXTERN void RLMObjectBaseSetObjectForKeyedSubscript(RLMObjectBase * _Nullable object, NSString *key, id _Nullable obj);
 
+NS_ASSUME_NONNULL_END

--- a/Realm/RLMObjectStore.h
+++ b/Realm/RLMObjectStore.h
@@ -24,6 +24,8 @@ extern "C" {
 
 @class RLMRealm, RLMSchema, RLMObjectBase, RLMResults, RLMProperty;
 
+NS_ASSUME_NONNULL_BEGIN
+
 //
 // Accessor Creation
 //
@@ -61,13 +63,15 @@ void RLMDeleteObjectFromRealm(RLMObjectBase *object, RLMRealm *realm);
 void RLMDeleteAllObjectsFromRealm(RLMRealm *realm);
 
 // get objects of a given class
-RLMResults *RLMGetObjects(RLMRealm *realm, NSString *objectClassName, NSPredicate *predicate) NS_RETURNS_RETAINED;
+RLMResults *RLMGetObjects(RLMRealm *realm, NSString *objectClassName, NSPredicate * _Nullable predicate)
+NS_RETURNS_RETAINED;
 
 // get an object with the given primary key
-id RLMGetObject(RLMRealm *realm, NSString *objectClassName, id key) NS_RETURNS_RETAINED;
+id _Nullable RLMGetObject(RLMRealm *realm, NSString *objectClassName, id _Nullable key) NS_RETURNS_RETAINED;
 
 // create object from array or dictionary
-RLMObjectBase *RLMCreateObjectInRealmWithValue(RLMRealm *realm, NSString *className, id value, bool createOrUpdate) NS_RETURNS_RETAINED;
+RLMObjectBase *RLMCreateObjectInRealmWithValue(RLMRealm *realm, NSString *className, id _Nullable value, bool createOrUpdate)
+NS_RETURNS_RETAINED;
     
 
 //
@@ -94,3 +98,5 @@ RLMObjectBase *RLMCreateObjectAccessor(RLMRealm *realm, RLMClassInfo& info,
 RLMObjectBase *RLMCreateObjectAccessor(RLMRealm *realm, RLMClassInfo& info,
                                        realm::RowExpr row) NS_RETURNS_RETAINED;
 #endif
+
+NS_ASSUME_NONNULL_END

--- a/Realm/RLMObject_Private.h
+++ b/Realm/RLMObject_Private.h
@@ -18,6 +18,8 @@
 
 #import <Realm/RLMObjectBase_Dynamic.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 // RLMObject accessor and read/write realm
 @interface RLMObjectBase () {
 @public
@@ -33,7 +35,7 @@
                        schema:(RLMObjectSchema *)schema NS_DESIGNATED_INITIALIZER;
 
 // shared schema for this class
-+ (RLMObjectSchema *)sharedSchema;
++ (nullable RLMObjectSchema *)sharedSchema;
 
 // provide injection point for alternative Swift object util class
 + (Class)objectUtilClass:(BOOL)isSwift;
@@ -68,10 +70,10 @@
 @end
 
 // Calls valueForKey: and re-raises NSUndefinedKeyExceptions
-FOUNDATION_EXTERN id RLMValidatedValueForProperty(id object, NSString *key, NSString *className);
+FOUNDATION_EXTERN id _Nullable RLMValidatedValueForProperty(id object, NSString *key, NSString *className);
 
 // Compare two RLObjectBases
-FOUNDATION_EXTERN BOOL RLMObjectBaseAreEqual(RLMObjectBase *o1, RLMObjectBase *o2);
+FOUNDATION_EXTERN BOOL RLMObjectBaseAreEqual(RLMObjectBase * _Nullable o1, RLMObjectBase * _Nullable o2);
 
 // Get ObjectUil class for objc or swift
 FOUNDATION_EXTERN Class RLMObjectUtilClass(BOOL isSwift);
@@ -81,14 +83,16 @@ FOUNDATION_EXTERN const NSUInteger RLMDescriptionMaxDepth;
 @class RLMProperty, RLMArray;
 @interface RLMObjectUtil : NSObject
 
-+ (NSArray<NSString *> *)ignoredPropertiesForClass:(Class)cls;
-+ (NSArray<NSString *> *)indexedPropertiesForClass:(Class)cls;
-+ (NSDictionary<NSString *, NSDictionary<NSString *, NSString *> *> *)linkingObjectsPropertiesForClass:(Class)cls;
++ (nullable NSArray<NSString *> *)ignoredPropertiesForClass:(Class)cls;
++ (nullable NSArray<NSString *> *)indexedPropertiesForClass:(Class)cls;
++ (nullable NSDictionary<NSString *, NSDictionary<NSString *, NSString *> *> *)linkingObjectsPropertiesForClass:(Class)cls;
 
-+ (NSArray<NSString *> *)getGenericListPropertyNames:(id)obj;
-+ (NSDictionary<NSString *, NSString *> *)getLinkingObjectsProperties:(id)object;
++ (nullable NSArray<NSString *> *)getGenericListPropertyNames:(id)obj;
++ (nullable NSDictionary<NSString *, NSString *> *)getLinkingObjectsProperties:(id)object;
 
-+ (NSDictionary<NSString *, NSNumber *> *)getOptionalProperties:(id)obj;
-+ (NSArray<NSString *> *)requiredPropertiesForClass:(Class)cls;
++ (nullable NSDictionary<NSString *, NSNumber *> *)getOptionalProperties:(id)obj;
++ (nullable NSArray<NSString *> *)requiredPropertiesForClass:(Class)cls;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Realm/RLMProperty_Private.h
+++ b/Realm/RLMProperty_Private.h
@@ -22,6 +22,8 @@
 
 @class RLMObjectBase;
 
+NS_ASSUME_NONNULL_BEGIN
+
 BOOL RLMPropertyTypeIsNullable(RLMPropertyType propertyType);
 BOOL RLMPropertyTypeIsComputed(RLMPropertyType propertyType);
 
@@ -34,18 +36,18 @@ BOOL RLMPropertyTypeIsComputed(RLMPropertyType propertyType);
 
 - (instancetype)initWithName:(NSString *)name
                      indexed:(BOOL)indexed
-      linkPropertyDescriptor:(RLMPropertyDescriptor *)linkPropertyDescriptor
+      linkPropertyDescriptor:(nullable RLMPropertyDescriptor *)linkPropertyDescriptor
                     property:(objc_property_t)property;
 
 - (instancetype)initSwiftPropertyWithName:(NSString *)name
                                   indexed:(BOOL)indexed
-                   linkPropertyDescriptor:(RLMPropertyDescriptor *)linkPropertyDescriptor
+                   linkPropertyDescriptor:(nullable RLMPropertyDescriptor *)linkPropertyDescriptor
                                  property:(objc_property_t)property
                                  instance:(RLMObjectBase *)objectInstance;
 
 - (instancetype)initSwiftListPropertyWithName:(NSString *)name
                                          ivar:(Ivar)ivar
-                              objectClassName:(NSString *)objectClassName;
+                              objectClassName:(nullable NSString *)objectClassName;
 
 - (instancetype)initSwiftOptionalPropertyWithName:(NSString *)name
                                           indexed:(BOOL)indexed
@@ -54,15 +56,15 @@ BOOL RLMPropertyTypeIsComputed(RLMPropertyType propertyType);
 
 - (instancetype)initSwiftLinkingObjectsPropertyWithName:(NSString *)name
                                                    ivar:(Ivar)ivar
-                                        objectClassName:(NSString *)objectClassName
-                                 linkOriginPropertyName:(NSString *)linkOriginPropertyName;
+                                        objectClassName:(nullable NSString *)objectClassName
+                                 linkOriginPropertyName:(nullable NSString *)linkOriginPropertyName;
 
 // private setters
 @property (nonatomic, readwrite) NSString *name;
 @property (nonatomic, readwrite, assign) RLMPropertyType type;
 @property (nonatomic, readwrite) BOOL indexed;
 @property (nonatomic, readwrite) BOOL optional;
-@property (nonatomic, copy) NSString *objectClassName;
+@property (nonatomic, copy, nullable) NSString *objectClassName;
 
 // private properties
 @property (nonatomic, assign) NSUInteger index;
@@ -100,9 +102,10 @@ BOOL RLMPropertyTypeIsComputed(RLMPropertyType propertyType);
  */
 - (instancetype)initWithName:(NSString *)name
                         type:(RLMPropertyType)type
-             objectClassName:(NSString *)objectClassName
-      linkOriginPropertyName:(NSString *)linkOriginPropertyName
+             objectClassName:(nullable NSString *)objectClassName
+      linkOriginPropertyName:(nullable NSString *)linkOriginPropertyName
                      indexed:(BOOL)indexed
                     optional:(BOOL)optional;
 @end
 
+NS_ASSUME_NONNULL_END

--- a/Realm/RLMRealm.h
+++ b/Realm/RLMRealm.h
@@ -93,7 +93,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  The `RLMSchema` used by the Realm.
  */
-@property (nonatomic, readonly, null_unspecified) RLMSchema *schema;
+@property (nonatomic, readonly) RLMSchema *schema;
 
 /**
  Indicates if the Realm is currently engaged in a write transaction.

--- a/Realm/RLMRealmConfiguration_Private.h
+++ b/Realm/RLMRealmConfiguration_Private.h
@@ -20,12 +20,14 @@
 
 @class RLMSchema;
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface RLMRealmConfiguration ()
 
 @property (nonatomic, readwrite) bool cache;
 @property (nonatomic, readwrite) bool dynamic;
 @property (nonatomic, readwrite) bool disableFormatUpgrade;
-@property (nonatomic, copy) RLMSchema *customSchema;
+@property (nonatomic, copy, nullable) RLMSchema *customSchema;
 
 // Get the default confiugration without copying it
 + (RLMRealmConfiguration *)rawDefaultConfiguration;
@@ -36,3 +38,5 @@
 // Get a path in the platform-appropriate documents directory with the given filename
 FOUNDATION_EXTERN NSString *RLMRealmPathForFile(NSString *fileName);
 FOUNDATION_EXTERN NSString *RLMRealmPathForFileAndBundleIdentifier(NSString *fileName, NSString *mainBundleIdentifier);
+
+NS_ASSUME_NONNULL_END

--- a/Realm/RLMRealm_Dynamic.h
+++ b/Realm/RLMRealm_Dynamic.h
@@ -23,6 +23,8 @@
 
 @class RLMResults;
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface RLMRealm (Dynamic)
 
 #pragma mark - Getting Objects from a Realm
@@ -88,7 +90,7 @@
  
  @see       `+[RLMObject objectForPrimaryKey:]`
  */
-- (RLMObject *)objectWithClassName:(NSString *)className forPrimaryKey:(id)primaryKey;
+- (nullable RLMObject *)objectWithClassName:(NSString *)className forPrimaryKey:(id)primaryKey;
 
 /**
  Creates an `RLMObject` instance of type `className` in the Realm, and populates it using a given object.
@@ -112,3 +114,5 @@
 -(RLMObject *)createObject:(NSString *)className withValue:(id)value;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Realm/RLMRealm_Private.h
+++ b/Realm/RLMRealm_Private.h
@@ -20,10 +20,12 @@
 
 @class RLMFastEnumerator;
 
+NS_ASSUME_NONNULL_BEGIN
+
 // Disable syncing files to disk. Cannot be re-enabled. Use only for tests.
 FOUNDATION_EXTERN void RLMDisableSyncToDisk();
 
-FOUNDATION_EXTERN NSData *RLMRealmValidatedEncryptionKey(NSData *key);
+FOUNDATION_EXTERN NSData * _Nullable RLMRealmValidatedEncryptionKey(NSData *key);
 
 // Translate an in-flight exception resulting from opening a SharedGroup to
 // an NSError or NSException (if error is nil)
@@ -33,7 +35,7 @@ void RLMRealmTranslateException(NSError **error);
 @interface RLMRealm ()
 
 @property (nonatomic, readonly) BOOL dynamic;
-@property (nonatomic, readwrite) RLMSchema *schema;
+@property (nonatomic, readwrite, null_unspecified) RLMSchema *schema;
 
 + (void)resetRealmState;
 
@@ -48,3 +50,5 @@ void RLMRealmTranslateException(NSError **error);
 + (NSString *)writeableTemporaryPathForFile:(NSString *)fileName;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Realm/RLMRealm_Private.h
+++ b/Realm/RLMRealm_Private.h
@@ -35,7 +35,7 @@ void RLMRealmTranslateException(NSError **error);
 @interface RLMRealm ()
 
 @property (nonatomic, readonly) BOOL dynamic;
-@property (nonatomic, readwrite, null_unspecified) RLMSchema *schema;
+@property (nonatomic, readwrite) RLMSchema *schema;
 
 + (void)resetRealmState;
 

--- a/Realm/RLMResults_Private.h
+++ b/Realm/RLMResults_Private.h
@@ -20,9 +20,13 @@
 
 @class RLMObjectSchema;
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface RLMResults ()
 @property (nonatomic, readonly, getter=isAttached) BOOL attached;
 
 + (instancetype)emptyDetachedResults;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Realm/RLMSwiftSupport.h
+++ b/Realm/RLMSwiftSupport.h
@@ -18,9 +18,13 @@
 
 #import <Foundation/Foundation.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface RLMSwiftSupport : NSObject
 
 + (BOOL)isSwiftClassName:(NSString *)className;
 + (NSString *)demangleClassName:(NSString *)className;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Realm/Tests/QueryTests.m
+++ b/Realm/Tests/QueryTests.m
@@ -137,8 +137,11 @@
     XCTAssertThrows([[realm objects:@"" where:@"age > 25"] sortedResultsUsingProperty:@"age" ascending:YES], @"missing class name");
 
     // nil class name
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wnonnull"
     XCTAssertThrows([realm objects:nil where:@"age > 25"], @"nil class name");
     XCTAssertThrows([[realm objects:nil where:@"age > 25"] sortedResultsUsingProperty:@"age" ascending:YES], @"nil class name");
+#pragma clang diagnostic pop
 }
 
 - (void)testPredicateValidUse

--- a/RealmSwift/Migration.swift
+++ b/RealmSwift/Migration.swift
@@ -138,7 +138,7 @@ public final class Migration {
     - parameter object: Object to be deleted from the Realm being migrated.
     */
     public func delete(_ object: MigrationObject) {
-        RLMDeleteObjectFromRealm(object, RLMObjectBaseRealm(object))
+        RLMDeleteObjectFromRealm(object, RLMObjectBaseRealm(object)!)
     }
 
     /**
@@ -363,7 +363,7 @@ public final class Migration {
      - parameter object: An object to be deleted from the Realm being migrated.
      */
     public func delete(object: MigrationObject) {
-        RLMDeleteObjectFromRealm(object, RLMObjectBaseRealm(object))
+        RLMDeleteObjectFromRealm(object, RLMObjectBaseRealm(object)!)
     }
 
     /**

--- a/RealmSwift/Object.swift
+++ b/RealmSwift/Object.swift
@@ -111,7 +111,7 @@ open class Object: RLMObjectBase {
 
     /// The `ObjectSchema` which lists the persisted properties for this object.
     public var objectSchema: ObjectSchema {
-        return ObjectSchema(RLMObjectBaseObjectSchema(self))
+        return ObjectSchema(RLMObjectBaseObjectSchema(self)!)
     }
 
     /// Indicates if an object can no longer be accessed.
@@ -467,7 +467,7 @@ public class Object: RLMObjectBase {
 
     /// The object schema which lists the managed properties for the object.
     public var objectSchema: ObjectSchema {
-        return ObjectSchema(RLMObjectBaseObjectSchema(self))
+        return ObjectSchema(RLMObjectBaseObjectSchema(self)!)
     }
 
     /// Indicates if the object can no longer be accessed because it is now invalid.

--- a/RealmSwift/Tests/MigrationTests.swift
+++ b/RealmSwift/Tests/MigrationTests.swift
@@ -141,7 +141,7 @@ class MigrationTests: TestCase {
         let prop = RLMProperty(name: "stringCol", type: RLMPropertyType.int, objectClassName: nil,
                                linkOriginPropertyName: nil, indexed: false, optional: false)
         _ = autoreleasepool {
-            realmWithSingleClassProperties(defaultRealmURL(), className: "SwiftStringObject", properties: [prop!])
+            realmWithSingleClassProperties(defaultRealmURL(), className: "SwiftStringObject", properties: [prop])
         }
 
         migrateAndTestDefaultRealm() { migration, oldSchemaVersion in
@@ -303,7 +303,7 @@ class MigrationTests: TestCase {
             let prop = RLMProperty(name: "id", type: .int, objectClassName: nil,
                                    linkOriginPropertyName: nil, indexed: false, optional: false)
             let realm = realmWithSingleClassProperties(defaultRealmURL(),
-                className: "DeletedClass", properties: [prop!])
+                className: "DeletedClass", properties: [prop])
             try! realm.transaction {
                 realm.createObject("DeletedClass", withValue: [0])
             }
@@ -330,7 +330,7 @@ class MigrationTests: TestCase {
                 linkOriginPropertyName: nil, indexed: false, optional: false)
             autoreleasepool {
                 let realm = realmWithSingleClassProperties(defaultRealmURL(), className: "SwiftStringObject",
-                    properties: [prop!])
+                    properties: [prop])
                 try! realm.transaction {
                     realm.createObject("SwiftStringObject", withValue: ["a"])
                 }
@@ -451,7 +451,7 @@ class MigrationTests: TestCase {
         let prop = RLMProperty(name: "name", type: RLMPropertyType.string, objectClassName: nil,
                                linkOriginPropertyName: nil, indexed: false, optional: false)
         _ = autoreleasepool {
-            realmWithSingleClassProperties(defaultRealmURL(), className: "SwiftEmployeeObject", properties: [prop!])
+            realmWithSingleClassProperties(defaultRealmURL(), className: "SwiftEmployeeObject", properties: [prop])
         }
 
         let config = Realm.Configuration(fileURL: defaultRealmURL(), objectTypes: [SwiftEmployeeObject.self])
@@ -466,7 +466,7 @@ class MigrationTests: TestCase {
         let prop = RLMProperty(name: "name", type: RLMPropertyType.string, objectClassName: nil,
                                linkOriginPropertyName: nil, indexed: false, optional: false)
         _ = autoreleasepool {
-            realmWithSingleClassProperties(defaultRealmURL(), className: "SwiftEmployeeObject", properties: [prop!])
+            realmWithSingleClassProperties(defaultRealmURL(), className: "SwiftEmployeeObject", properties: [prop])
         }
 
         var config = Realm.Configuration(fileURL: defaultRealmURL(), objectTypes: [SwiftEmployeeObject.self])
@@ -797,7 +797,7 @@ class MigrationTests: TestCase {
             let prop = RLMProperty(name: "id", type: .Int, objectClassName: nil,
                 linkOriginPropertyName: nil, indexed: false, optional: false)
             let realm = realmWithSingleClassProperties(defaultRealmURL(),
-                className: "DeletedClass", properties: [prop!])
+                className: "DeletedClass", properties: [prop])
             try! realm.transactionWithBlock {
                 realm.createObject("DeletedClass", withValue: [])
             }


### PR DESCRIPTION
I audited our private `.h` files for nullability.

@jpsim 