### PR TITLE
Fix nullability annotations in Swift 3 Realm Objective-C tests

### DIFF
--- a/Realm/Tests/Swift/SwiftDynamicTests.swift
+++ b/Realm/Tests/Swift/SwiftDynamicTests.swift
@@ -66,7 +66,7 @@ class SwiftDynamicTests: RLMTestCase {
 
         // verify properties
         let dyrealm = realm(withTestPathAndSchema: nil)
-        let array = dyrealm.allObjects("SwiftDynamicObject")!
+        let array = dyrealm.allObjects("SwiftDynamicObject")
 
         XCTAssertTrue(array[0]["intCol"] as! NSNumber == 1)
         XCTAssertTrue(array[1]["stringCol"] as! String == "column2")
@@ -111,7 +111,7 @@ class SwiftDynamicTests: RLMTestCase {
 
         // verify properties
         let dyrealm = realm(withTestPathAndSchema: nil)
-        let array = dyrealm.allObjects("DynamicObject")!
+        let array = dyrealm.allObjects("DynamicObject")
 
         XCTAssertTrue(array[0]["intCol"] as! NSNumber == 1)
         XCTAssertTrue(array[1]["stringCol"] as! String == "column2")
@@ -141,7 +141,7 @@ class SwiftDynamicTests: RLMTestCase {
 
         // verify properties
         let dyrealm = realm(withTestPathAndSchema: nil)
-        let results = dyrealm.allObjects(AllTypesObject.className())!
+        let results = dyrealm.allObjects(AllTypesObject.className())
         XCTAssertEqual(results.count, UInt(2))
         let robj1 = results[0]
         let robj2 = results[1]


### PR DESCRIPTION
Broken by incomplete testing of #4032.

I accidentally introduced build errors into master.