### PR TITLE
Fix inconsistencies between subscripting managed and unmanaged objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ x.x.x Release notes (yyyy-MM-dd)
 * Fix a crash when `initWithValue:` is used to create a nested object for a class
   with an uninitialized schema.
 * Enforce uniqueness for `RealmOptional` primary keys when using the `value` setter.
+* Fix incorrect behavior where subscripting an unmanaged object can also set properties
+  that are not managed, inconsitent with subscripting a managed object.
 
 1.0.2 Release notes (2016-07-13)
 =============================================================

--- a/Realm/RLMObjectBase.mm
+++ b/Realm/RLMObjectBase.mm
@@ -334,6 +334,15 @@ RLMObjectSchema *RLMObjectBaseObjectSchema(__unsafe_unretained RLMObjectBase *ob
     return object ? object->_objectSchema : nil;
 }
 
+static RLMProperty *getPropertyWithName(__unsafe_unretained RLMObjectBase *object, __unsafe_unretained NSString *name) {
+    if (RLMProperty *property = object->_objectSchema[name]) {
+        return property;
+    } else {
+        @throw RLMException(@"Invalid property name '%@' for class '%@'.",
+                            name, object->_objectSchema.className);
+    }
+}
+
 id RLMObjectBaseObjectForKeyedSubscript(RLMObjectBase *object, NSString *key) {
     if (!object) {
         return nil;
@@ -343,7 +352,7 @@ id RLMObjectBaseObjectForKeyedSubscript(RLMObjectBase *object, NSString *key) {
         return RLMDynamicGetByName(object, key, false);
     }
     else {
-        return [object valueForKey:key];
+        return [object valueForKey:getPropertyWithName(object, key).name];
     }
 }
 
@@ -356,7 +365,7 @@ void RLMObjectBaseSetObjectForKeyedSubscript(RLMObjectBase *object, NSString *ke
         RLMDynamicValidatedSet(object, key, obj);
     }
     else {
-        [object setValue:obj forKey:key];
+        [object setValue:obj forKey:getPropertyWithName(object, key).name];
     }
 }
 

--- a/Realm/Tests/ObjectTests.m
+++ b/Realm/Tests/ObjectTests.m
@@ -502,26 +502,30 @@ RLM_ARRAY_TYPE(PrimaryEmployeeObject);
 {
     // unmanaged
     EmployeeObject *objs = [[EmployeeObject alloc] initWithValue:@{@"name" : @"Test0", @"age" : @23, @"hired": @NO}];
-    XCTAssertEqualObjects(objs[@"name"], @"Test0",  @"Name should be Test0");
-    XCTAssertEqualObjects(objs[@"age"], @23,  @"age should be 23");
-    XCTAssertEqualObjects(objs[@"hired"], @NO,  @"hired should be NO");
+    XCTAssertEqualObjects(objs[@"name"], @"Test0");
+    XCTAssertEqualObjects(objs[@"age"], @23);
+    XCTAssertEqualObjects(objs[@"hired"], @NO);
     objs[@"name"] = @"Test1";
-    XCTAssertEqualObjects(objs.name, @"Test1",  @"Name should be Test1");
+    XCTAssertEqualObjects(objs.name, @"Test1");
+    RLMAssertThrowsWithReasonMatching(objs[@"invalidName"], @"Invalid property name");
+    RLMAssertThrowsWithReasonMatching(objs[@"invalidName"] = @0, @"Invalid property name");
 
     RLMRealm *realm = [RLMRealm defaultRealm];
     [realm beginWriteTransaction];
     EmployeeObject *obj0 = [EmployeeObject createInRealm:realm withValue:@{@"name" : @"Test1", @"age" : @24, @"hired": @NO}];
     EmployeeObject *obj1 = [EmployeeObject createInRealm:realm withValue:@{@"name" : @"Test2", @"age" : @25, @"hired": @YES}];
     [realm commitWriteTransaction];
-    
-    XCTAssertEqualObjects(obj0[@"name"], @"Test1",  @"Name should be Test1");
-    XCTAssertEqualObjects(obj1[@"name"], @"Test2", @"Name should be Test1");
+
+    RLMAssertThrowsWithReasonMatching(obj0[@"invalidName"], @"Invalid property name");
+    RLMAssertThrowsWithReasonMatching(objs[@"invalidName"] = @0, @"Invalid property name");
+    XCTAssertEqualObjects(obj0[@"name"], @"Test1");
+    XCTAssertEqualObjects(obj1[@"name"], @"Test2");
     
     [realm beginWriteTransaction];
     obj0[@"name"] = @"newName";
     [realm commitWriteTransaction];
     
-    XCTAssertEqualObjects(obj0[@"name"], @"newName",  @"Name should be newName");
+    XCTAssertEqualObjects(obj0[@"name"], @"newName");
 
     [realm beginWriteTransaction];
     obj0[@"name"] = nil;

--- a/RealmSwift/Object.swift
+++ b/RealmSwift/Object.swift
@@ -174,17 +174,15 @@ open class Object: RLMObjectBase {
     /// Returns or sets the value of the property with the given name.
     open subscript(key: String) -> Any? {
         get {
-            if realm == nil {
-                return value(forKey: key)
-            }
-            return RLMDynamicGetByName(self, key, true)
-        }
-        set(value) {
-            if realm == nil {
-                setValue(value, forKey: key)
+            let value = RLMObjectBaseObjectForKeyedSubscript(self, key)
+            if let array = value as? RLMArray {
+                return List<DynamicObject>(rlmArray: array)
             } else {
-                RLMDynamicValidatedSet(self, key, value)
+                return value
             }
+        }
+        set {
+            RLMObjectBaseSetObjectForKeyedSubscript(self, key, newValue)
         }
     }
 

--- a/RealmSwift/Tests/ObjectTests.swift
+++ b/RealmSwift/Tests/ObjectTests.swift
@@ -218,11 +218,16 @@ class ObjectTests: TestCase {
         }
     }
 
-    func setAndTestAllTypes(_ setter: (SwiftObject, Any?, String) -> (),
-                            getter: (SwiftObject, String) -> (Any?), object: SwiftObject) {
-        assertThrows(setter(object, 0, "fakeCol"), reason: "Invalid property name")
-        assertThrows(getter(object, "fakeCol"), reason: "Invalid property name")
 
+    func setAndTestFakeColumn(setter: (SwiftObject, Any?, String) -> (),
+                              getter: (SwiftObject, String) -> (Any?), object: SwiftObject,
+                              failureReason reason: String) {
+        assertThrows(setter(object, 0, "fakeCol"), reason: reason)
+        assertThrows(getter(object, "fakeCol"), reason: reason)
+    }
+
+    func setAndTestAllTypes(setter: (SwiftObject, Any?, String) -> (),
+                            getter: (SwiftObject, String) -> (Any?), object: SwiftObject) {
         setter(object, true, "boolCol")
         XCTAssertEqual(getter(object, "boolCol") as! Bool!, true)
 
@@ -345,10 +350,14 @@ class ObjectTests: TestCase {
             self.dynamicSetAndTestAllTypes(setter, getter: getter, object: migrationObject, boolObject: boolObject)
         }
 
-        setAndTestAllTypes(setter, getter: getter, object: SwiftObject())
+        setAndTestAllTypes(setter: setter, getter: getter, object: SwiftObject())
+        setAndTestFakeColumn(setter: setter, getter: getter, object: SwiftObject(),
+                             failureReason: "not key value coding-compliant for the key")
         try! Realm().write {
             let persistedObject = try! Realm().createObject(ofType: SwiftObject.self, populatedWith: [:])
-            self.setAndTestAllTypes(setter, getter: getter, object: persistedObject)
+            setAndTestAllTypes(setter: setter, getter: getter, object: persistedObject)
+            setAndTestFakeColumn(setter: setter, getter: getter, object: SwiftObject(),
+                                 failureReason: "not key value coding-compliant for the key")
         }
     }
 
@@ -366,10 +375,14 @@ class ObjectTests: TestCase {
             self.dynamicSetAndTestAllTypes(setter, getter: getter, object: migrationObject, boolObject: boolObject)
         }
 
-        setAndTestAllTypes(setter, getter: getter, object: SwiftObject())
+        setAndTestAllTypes(setter: setter, getter: getter, object: SwiftObject())
+        setAndTestFakeColumn(setter: setter, getter: getter, object: SwiftObject(),
+                             failureReason: "Invalid property name")
         try! Realm().write {
             let persistedObject = try! Realm().createObject(ofType: SwiftObject.self, populatedWith: [:])
-            self.setAndTestAllTypes(setter, getter: getter, object: persistedObject)
+            setAndTestAllTypes(setter: setter, getter: getter, object: persistedObject)
+            setAndTestFakeColumn(setter: setter, getter: getter, object: SwiftObject(),
+                                 failureReason: "Invalid property name")
         }
     }
 

--- a/RealmSwift/Tests/ObjectTests.swift
+++ b/RealmSwift/Tests/ObjectTests.swift
@@ -220,6 +220,9 @@ class ObjectTests: TestCase {
 
     func setAndTestAllTypes(_ setter: (SwiftObject, Any?, String) -> (),
                             getter: (SwiftObject, String) -> (Any?), object: SwiftObject) {
+        assertThrows(setter(object, 0, "fakeCol"), reason: "Invalid property name")
+        assertThrows(getter(object, "fakeCol"), reason: "Invalid property name")
+
         setter(object, true, "boolCol")
         XCTAssertEqual(getter(object, "boolCol") as! Bool!, true)
 

--- a/RealmSwift/Tests/TestCase.swift
+++ b/RealmSwift/Tests/TestCase.swift
@@ -115,13 +115,13 @@ class TestCase: XCTestCase {
         queue.sync { }
     }
 
-    func assertThrows<T>(_ block: @autoclosure @escaping() -> T, named: String? = RLMExceptionName,
+    func assertThrows<T>(_ block: @autoclosure () -> T, named: String? = RLMExceptionName,
                          _ message: String? = nil, fileName: String = #file, lineNumber: UInt = #line) {
         exceptionThrown = true
         RLMAssertThrowsWithName(self, { _ = block() }, named, message, fileName, lineNumber)
     }
 
-    func assertThrows<T>(_ block: @autoclosure @escaping () -> T, reason regexString: String,
+    func assertThrows<T>(_ block: @autoclosure () -> T, reason regexString: String,
                          _ message: String? = nil, fileName: String = #file, lineNumber: UInt = #line) {
         exceptionThrown = true
         RLMAssertThrowsWithReasonMatching(self, { _ = block() }, regexString, message, fileName, lineNumber)


### PR DESCRIPTION
Currently, subscripting a managed object looks up the managed properties value while subscripting an unmanaged object uses `valueForKey:` (meaning it also works with unmanaged properties). This PR ensures that the key corresponds to a property in the schema before calling `valueForKey:`.

@bdash @jpsim 
