### PR TITLE
Introduce `unsafeCastToRLMObject` method on `Object`

### DIFF
--- a/RealmSwift/LinkingObjects.swift
+++ b/RealmSwift/LinkingObjects.swift
@@ -122,7 +122,7 @@ public final class LinkingObjects<T: Object>: LinkingObjectsBase {
      - returns: The index of the given object, or `nil` if the object is not present.
      */
     public func index(of object: T) -> Int? {
-        return notFoundToNil(index: rlmResults.index(of: unsafeBitCast(object, to: RLMObject.self)))
+        return notFoundToNil(index: rlmResults.index(of: object.unsafeAsObjectiveCAccessor()))
     }
 
     /**
@@ -563,7 +563,7 @@ public final class LinkingObjects<T: Object>: LinkingObjectsBase {
      - parameter object: The object whose index is being queried.
      */
     public func indexOf(object: T) -> Int? {
-        return notFoundToNil(rlmResults.indexOfObject(unsafeBitCast(object, RLMObject.self)))
+        return notFoundToNil(rlmResults.indexOfObject(object.unsafeAsObjectiveCAccessor()))
     }
 
     /**

--- a/RealmSwift/LinkingObjects.swift
+++ b/RealmSwift/LinkingObjects.swift
@@ -122,7 +122,7 @@ public final class LinkingObjects<T: Object>: LinkingObjectsBase {
      - returns: The index of the given object, or `nil` if the object is not present.
      */
     public func index(of object: T) -> Int? {
-        return notFoundToNil(index: rlmResults.index(of: object.unsafeAsObjectiveCAccessor()))
+        return notFoundToNil(index: rlmResults.index(of: object.unsafeCastToRLMObject()))
     }
 
     /**
@@ -563,7 +563,7 @@ public final class LinkingObjects<T: Object>: LinkingObjectsBase {
      - parameter object: The object whose index is being queried.
      */
     public func indexOf(object: T) -> Int? {
-        return notFoundToNil(rlmResults.indexOfObject(object.unsafeAsObjectiveCAccessor()))
+        return notFoundToNil(rlmResults.indexOfObject(object.unsafeCastToRLMObject()))
     }
 
     /**

--- a/RealmSwift/List.swift
+++ b/RealmSwift/List.swift
@@ -88,7 +88,7 @@ public final class List<T: Object>: ListBase {
     - returns: The index of the given object, or `nil` if the object is not in the List.
     */
     public func index(of object: T) -> Int? {
-        return notFoundToNil(index: _rlmArray.index(of: object.unsafeAsObjectiveCAccessor()))
+        return notFoundToNil(index: _rlmArray.index(of: object.unsafeCastToRLMObject()))
     }
 
     /**
@@ -135,7 +135,7 @@ public final class List<T: Object>: ListBase {
         }
         set {
             throwForNegativeIndex(position)
-            _rlmArray.replaceObject(at: UInt(position), with: newValue.unsafeAsObjectiveCAccessor())
+            _rlmArray.replaceObject(at: UInt(position), with: newValue.unsafeCastToRLMObject())
         }
     }
 
@@ -297,7 +297,7 @@ public final class List<T: Object>: ListBase {
     - parameter object: An object.
     */
     public func append(_ object: T) {
-        _rlmArray.add(object.unsafeAsObjectiveCAccessor())
+        _rlmArray.add(object.unsafeCastToRLMObject())
     }
 
     /**
@@ -309,7 +309,7 @@ public final class List<T: Object>: ListBase {
     */
     public func append<S: Sequence>(objectsIn objects: S) where S.Iterator.Element == T {
         for obj in objects {
-            _rlmArray.add(obj.unsafeAsObjectiveCAccessor())
+            _rlmArray.add(obj.unsafeCastToRLMObject())
         }
     }
 
@@ -325,7 +325,7 @@ public final class List<T: Object>: ListBase {
     */
     public func insert(_ object: T, at index: Int) {
         throwForNegativeIndex(index)
-        _rlmArray.insert(object.unsafeAsObjectiveCAccessor(), at: UInt(index))
+        _rlmArray.insert(object.unsafeCastToRLMObject(), at: UInt(index))
     }
 
     /**
@@ -372,7 +372,7 @@ public final class List<T: Object>: ListBase {
     */
     public func replace(index: Int, object: T) {
         throwForNegativeIndex(index)
-        _rlmArray.replaceObject(at: UInt(index), with: object.unsafeAsObjectiveCAccessor())
+        _rlmArray.replaceObject(at: UInt(index), with: object.unsafeCastToRLMObject())
     }
 
     /**
@@ -642,7 +642,7 @@ public final class List<T: Object>: ListBase {
      - parameter object: An object to find.
      */
     public func indexOf(object: T) -> Int? {
-        return notFoundToNil(_rlmArray.indexOfObject(object.unsafeAsObjectiveCAccessor()))
+        return notFoundToNil(_rlmArray.indexOfObject(object.unsafeCastToRLMObject()))
     }
 
     /**
@@ -681,7 +681,7 @@ public final class List<T: Object>: ListBase {
         }
         set {
             throwForNegativeIndex(index)
-            return _rlmArray[UInt(index)] = newValue.unsafeAsObjectiveCAccessor()
+            return _rlmArray[UInt(index)] = newValue.unsafeCastToRLMObject()
         }
     }
 
@@ -844,7 +844,7 @@ public final class List<T: Object>: ListBase {
      - parameter object: An object.
      */
     public func append(object: T) {
-        _rlmArray.addObject(object.unsafeAsObjectiveCAccessor())
+        _rlmArray.addObject(object.unsafeCastToRLMObject())
     }
 
     /**
@@ -856,7 +856,7 @@ public final class List<T: Object>: ListBase {
     */
     public func appendContentsOf<S: SequenceType where S.Generator.Element == T>(objects: S) {
         for obj in objects {
-            _rlmArray.addObject(obj.unsafeAsObjectiveCAccessor())
+            _rlmArray.addObject(obj.unsafeCastToRLMObject())
         }
     }
 
@@ -872,7 +872,7 @@ public final class List<T: Object>: ListBase {
      */
     public func insert(object: T, atIndex index: Int) {
         throwForNegativeIndex(index)
-        _rlmArray.insertObject(object.unsafeAsObjectiveCAccessor(), atIndex: UInt(index))
+        _rlmArray.insertObject(object.unsafeCastToRLMObject(), atIndex: UInt(index))
     }
 
     /**
@@ -919,7 +919,7 @@ public final class List<T: Object>: ListBase {
      */
     public func replace(index: Int, object: T) {
         throwForNegativeIndex(index)
-        _rlmArray.replaceObjectAtIndex(UInt(index), withObject: object.unsafeAsObjectiveCAccessor())
+        _rlmArray.replaceObjectAtIndex(UInt(index), withObject: object.unsafeCastToRLMObject())
     }
 
     /**

--- a/RealmSwift/List.swift
+++ b/RealmSwift/List.swift
@@ -88,7 +88,7 @@ public final class List<T: Object>: ListBase {
     - returns: The index of the given object, or `nil` if the object is not in the List.
     */
     public func index(of object: T) -> Int? {
-        return notFoundToNil(index: _rlmArray.index(of: unsafeBitCast(object, to: RLMObject.self)))
+        return notFoundToNil(index: _rlmArray.index(of: object.unsafeAsObjectiveCAccessor()))
     }
 
     /**
@@ -135,7 +135,7 @@ public final class List<T: Object>: ListBase {
         }
         set {
             throwForNegativeIndex(position)
-            _rlmArray.replaceObject(at: UInt(position), with: unsafeBitCast(newValue, to: RLMObject.self))
+            _rlmArray.replaceObject(at: UInt(position), with: newValue.unsafeAsObjectiveCAccessor())
         }
     }
 
@@ -297,7 +297,7 @@ public final class List<T: Object>: ListBase {
     - parameter object: An object.
     */
     public func append(_ object: T) {
-        _rlmArray.add(unsafeBitCast(object, to: RLMObject.self))
+        _rlmArray.add(object.unsafeAsObjectiveCAccessor())
     }
 
     /**
@@ -309,7 +309,7 @@ public final class List<T: Object>: ListBase {
     */
     public func append<S: Sequence>(objectsIn objects: S) where S.Iterator.Element == T {
         for obj in objects {
-            _rlmArray.add(unsafeBitCast(obj, to: RLMObject.self))
+            _rlmArray.add(obj.unsafeAsObjectiveCAccessor())
         }
     }
 
@@ -325,7 +325,7 @@ public final class List<T: Object>: ListBase {
     */
     public func insert(_ object: T, at index: Int) {
         throwForNegativeIndex(index)
-        _rlmArray.insert(unsafeBitCast(object, to: RLMObject.self), at: UInt(index))
+        _rlmArray.insert(object.unsafeAsObjectiveCAccessor(), at: UInt(index))
     }
 
     /**
@@ -372,7 +372,7 @@ public final class List<T: Object>: ListBase {
     */
     public func replace(index: Int, object: T) {
         throwForNegativeIndex(index)
-        _rlmArray.replaceObject(at: UInt(index), with: unsafeBitCast(object, to: RLMObject.self))
+        _rlmArray.replaceObject(at: UInt(index), with: object.unsafeAsObjectiveCAccessor())
     }
 
     /**
@@ -642,7 +642,7 @@ public final class List<T: Object>: ListBase {
      - parameter object: An object to find.
      */
     public func indexOf(object: T) -> Int? {
-        return notFoundToNil(_rlmArray.indexOfObject(unsafeBitCast(object, RLMObject.self)))
+        return notFoundToNil(_rlmArray.indexOfObject(object.unsafeAsObjectiveCAccessor()))
     }
 
     /**
@@ -681,7 +681,7 @@ public final class List<T: Object>: ListBase {
         }
         set {
             throwForNegativeIndex(index)
-            return _rlmArray[UInt(index)] = unsafeBitCast(newValue, RLMObject.self)
+            return _rlmArray[UInt(index)] = newValue.unsafeAsObjectiveCAccessor()
         }
     }
 
@@ -844,7 +844,7 @@ public final class List<T: Object>: ListBase {
      - parameter object: An object.
      */
     public func append(object: T) {
-        _rlmArray.addObject(unsafeBitCast(object, RLMObject.self))
+        _rlmArray.addObject(object.unsafeAsObjectiveCAccessor())
     }
 
     /**
@@ -856,7 +856,7 @@ public final class List<T: Object>: ListBase {
     */
     public func appendContentsOf<S: SequenceType where S.Generator.Element == T>(objects: S) {
         for obj in objects {
-            _rlmArray.addObject(unsafeBitCast(obj, RLMObject.self))
+            _rlmArray.addObject(obj.unsafeAsObjectiveCAccessor())
         }
     }
 
@@ -872,7 +872,7 @@ public final class List<T: Object>: ListBase {
      */
     public func insert(object: T, atIndex index: Int) {
         throwForNegativeIndex(index)
-        _rlmArray.insertObject(unsafeBitCast(object, RLMObject.self), atIndex: UInt(index))
+        _rlmArray.insertObject(object.unsafeAsObjectiveCAccessor(), atIndex: UInt(index))
     }
 
     /**
@@ -919,7 +919,7 @@ public final class List<T: Object>: ListBase {
      */
     public func replace(index: Int, object: T) {
         throwForNegativeIndex(index)
-        _rlmArray.replaceObjectAtIndex(UInt(index), withObject: unsafeBitCast(object, RLMObject.self))
+        _rlmArray.replaceObjectAtIndex(UInt(index), withObject: object.unsafeAsObjectiveCAccessor())
     }
 
     /**

--- a/RealmSwift/Results.swift
+++ b/RealmSwift/Results.swift
@@ -125,7 +125,7 @@ public final class Results<T: Object>: NSObject, NSFastEnumeration {
     - returns: The index of the given object, or `nil` if the object is not in the results.
     */
     public func index(of object: T) -> Int? {
-        return notFoundToNil(index: rlmResults.index(of: unsafeBitCast(object, to: RLMObject.self)))
+        return notFoundToNil(index: rlmResults.index(of: object.unsafeAsObjectiveCAccessor()))
     }
 
     /**
@@ -577,7 +577,7 @@ public final class Results<T: Object>: ResultsBase {
      - parameter object: An object.
      */
     public func indexOf(object: T) -> Int? {
-        return notFoundToNil(rlmResults.indexOfObject(unsafeBitCast(object, RLMObject.self)))
+        return notFoundToNil(rlmResults.indexOfObject(object.unsafeAsObjectiveCAccessor()))
     }
 
     /**

--- a/RealmSwift/Results.swift
+++ b/RealmSwift/Results.swift
@@ -125,7 +125,7 @@ public final class Results<T: Object>: NSObject, NSFastEnumeration {
     - returns: The index of the given object, or `nil` if the object is not in the results.
     */
     public func index(of object: T) -> Int? {
-        return notFoundToNil(index: rlmResults.index(of: object.unsafeAsObjectiveCAccessor()))
+        return notFoundToNil(index: rlmResults.index(of: object.unsafeCastToRLMObject()))
     }
 
     /**
@@ -577,7 +577,7 @@ public final class Results<T: Object>: ResultsBase {
      - parameter object: An object.
      */
     public func indexOf(object: T) -> Int? {
-        return notFoundToNil(rlmResults.indexOfObject(object.unsafeAsObjectiveCAccessor()))
+        return notFoundToNil(rlmResults.indexOfObject(object.unsafeCastToRLMObject()))
     }
 
     /**

--- a/RealmSwift/Util.swift
+++ b/RealmSwift/Util.swift
@@ -47,6 +47,14 @@ internal func gsub(pattern: String, template: String, string: String, error: NSE
                                            withTemplate: template)
 }
 
+extension Object {
+    // Must *only* be used to call Realm Objective-C APIs that are exposed on `RLMObject`
+    // but actually operator on `RLMObjectBase`. Do not expose casted value to user.
+    internal func unsafeAsObjectiveCAccessor() -> RLMObject {
+        return unsafeBitCast(self, to: RLMObject.self)
+    }
+}
+
 // MARK: CustomObjectiveCBridgeable
 
 internal func dynamicBridgeCast<T>(fromObjectiveC x: Any) -> T {
@@ -123,6 +131,14 @@ internal func gsub(pattern: String, template: String, string: String, error: NSE
     return regex?.stringByReplacingMatchesInString(string, options: [],
                                                    range: NSRange(location: 0, length: string.utf16.count),
                                                    withTemplate: template)
+}
+
+extension Object {
+    // Must *only* be used to call Realm Objective-C APIs that are exposed on `RLMObject`
+    // but actually operator on `RLMObjectBase`. Do not expose casted value to user.
+    internal func unsafeAsObjectiveCAccessor() -> RLMObject {
+        return unsafeBitCast(self, RLMObject.self)
+    }
 }
 
 // MARK: CustomObjectiveCBridgeable

--- a/RealmSwift/Util.swift
+++ b/RealmSwift/Util.swift
@@ -50,7 +50,7 @@ internal func gsub(pattern: String, template: String, string: String, error: NSE
 extension Object {
     // Must *only* be used to call Realm Objective-C APIs that are exposed on `RLMObject`
     // but actually operate on `RLMObjectBase`. Do not expose cast value to user.
-    internal func unsafeAsObjectiveCAccessor() -> RLMObject {
+    internal func unsafeCastToRLMObject() -> RLMObject {
         return unsafeBitCast(self, to: RLMObject.self)
     }
 }
@@ -136,7 +136,7 @@ internal func gsub(pattern: String, template: String, string: String, error: NSE
 extension Object {
     // Must *only* be used to call Realm Objective-C APIs that are exposed on `RLMObject`
     // but actually operate on `RLMObjectBase`. Do not expose cast value to user.
-    internal func unsafeAsObjectiveCAccessor() -> RLMObject {
+    internal func unsafeCastToRLMObject() -> RLMObject {
         return unsafeBitCast(self, RLMObject.self)
     }
 }

--- a/RealmSwift/Util.swift
+++ b/RealmSwift/Util.swift
@@ -49,7 +49,7 @@ internal func gsub(pattern: String, template: String, string: String, error: NSE
 
 extension Object {
     // Must *only* be used to call Realm Objective-C APIs that are exposed on `RLMObject`
-    // but actually operator on `RLMObjectBase`. Do not expose casted value to user.
+    // but actually operate on `RLMObjectBase`. Do not expose cast value to user.
     internal func unsafeAsObjectiveCAccessor() -> RLMObject {
         return unsafeBitCast(self, to: RLMObject.self)
     }
@@ -135,7 +135,7 @@ internal func gsub(pattern: String, template: String, string: String, error: NSE
 
 extension Object {
     // Must *only* be used to call Realm Objective-C APIs that are exposed on `RLMObject`
-    // but actually operator on `RLMObjectBase`. Do not expose casted value to user.
+    // but actually operate on `RLMObjectBase`. Do not expose cast value to user.
     internal func unsafeAsObjectiveCAccessor() -> RLMObject {
         return unsafeBitCast(self, RLMObject.self)
     }


### PR DESCRIPTION
We expose the Realm Objective-C API operating on `RLMObject`, but many of the methods can operate on any subclass of `RLMObjectBase`. As such, we currently bitcast `Object` to `RLMObject` to call these methods. This commit introduces an `unsafeAsObjectiveCAccessor` function on `Object` to clarify the intent of the cast, to prevent mistakes (such as bitcasting `Any` to `RLMObject` without first force casting to `Object`), and to discourage raw usage of `unsafeBitCast` in our codebase.

Closes https://github.com/realm/realm-cocoa/issues/3970.