### PR TITLE
Skip unspecified, undefaulted values in `initWithValue:`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ x.x.x Release notes (yyyy-MM-dd)
 * Fix compilation with Swift 2.3 using Xcode 8 beta 2.
 * Further reduce the download size of the prebuilt static libraries.
 * Improve sort performance, especially on non-nullable columns.
+* Allow partial initialization of object by `initWithValue:`, deferring
+  required property checks until object is added to Realm.
 
 ### Bugfixes
 

--- a/Realm/RLMObjectBase.mm
+++ b/Realm/RLMObjectBase.mm
@@ -117,7 +117,7 @@ static id validatedObjectForProperty(id obj, RLMProperty *prop, RLMSchema *schem
             [self setValue:RLMCoerceToNil(propertyValue) forKeyPath:[properties[i] name]];
         }
     }
-    else {
+    else if (value) {
         // assume our object is an NSDictionary or an object with kvc properties
         NSDictionary *defaultValues = nil;
         for (RLMProperty *prop in properties) {
@@ -131,9 +131,16 @@ static id validatedObjectForProperty(id obj, RLMProperty *prop, RLMSchema *schem
                 obj = defaultValues[prop.name];
             }
 
+            // don't set unspecified properties
+            if (!obj) {
+                continue;
+            }
+
             obj = validatedObjectForProperty(obj, prop, schema);
             [self setValue:RLMCoerceToNil(obj) forKeyPath:prop.name];
         }
+    } else {
+        @throw RLMException(@"Must provide a non-nil value.");
     }
 
     return self;

--- a/Realm/Tests/ObjectTests.m
+++ b/Realm/Tests/ObjectTests.m
@@ -390,7 +390,7 @@ RLM_ARRAY_TYPE(PrimaryEmployeeObject);
     XCTAssertEqual(fromRealm.age, 25, @"Age should be equal");
     XCTAssertEqual(fromRealm.hired, YES, @"Hired should be equal");
     
-    XCTAssertThrows([[EmployeeObject alloc] initWithValue:@{}], @"Initialization with missing values should throw");
+    XCTAssertNoThrow([[EmployeeObject alloc] initWithValue:@{}], @"Initialization with missing values should not throw");
     XCTAssertNoThrow([[DefaultObject alloc] initWithValue:@{@"intCol": @1}],
                      "Overriding some default values at initialization should not throw");
 
@@ -445,7 +445,6 @@ RLM_ARRAY_TYPE(PrimaryEmployeeObject);
 
 - (void)testInitFromDictionaryMissingPropertyKey {
     CompanyObject *co = nil;
-    XCTAssertThrows([[DogExtraObject alloc] initWithValue:@{}]);
     XCTAssertNoThrow(co = [[CompanyObject alloc] initWithValue:@{@"name": @"a"}]);
     XCTAssertEqualObjects(co.name, @"a");
     XCTAssertEqual(co.employees.count, 0U);


### PR DESCRIPTION
Fixes https://github.com/realm/realm-cocoa/issues/2377. @jpsim 