### PR TITLE
Use protocol for primary key specification

### DIFF
--- a/Realm/RLMObjectSchema.mm
+++ b/Realm/RLMObjectSchema.mm
@@ -138,20 +138,24 @@ using namespace realm;
         }
     }
 
-    if (NSString *primaryKey = [objectClass primaryKey]) {
-        for (RLMProperty *prop in schema.properties) {
-            if ([primaryKey isEqualToString:prop.name]) {
-                prop.indexed = YES;
-                schema.primaryKeyProperty = prop;
-                break;
+    // Swift classes without primary keys don't respond
+    if ([objectClass respondsToSelector:@selector(primaryKey)]) {
+        // Objective-C classes without primary keys return nil
+        if (NSString *primaryKey = [objectClass primaryKey]) {
+            for (RLMProperty *prop in schema.properties) {
+                if ([primaryKey isEqualToString:prop.name]) {
+                    prop.indexed = YES;
+                    schema.primaryKeyProperty = prop;
+                    break;
+                }
             }
-        }
 
-        if (!schema.primaryKeyProperty) {
-            @throw RLMException(@"Primary key property '%@' does not exist on object '%@'", primaryKey, className);
-        }
-        if (schema.primaryKeyProperty.type != RLMPropertyTypeInt && schema.primaryKeyProperty.type != RLMPropertyTypeString) {
-            @throw RLMException(@"Only 'string' and 'int' properties can be designated the primary key");
+            if (!schema.primaryKeyProperty) {
+                @throw RLMException(@"Primary key property '%@' does not exist on object '%@'", primaryKey, className);
+            }
+            if (schema.primaryKeyProperty.type != RLMPropertyTypeInt && schema.primaryKeyProperty.type != RLMPropertyTypeString) {
+                @throw RLMException(@"Only 'string' and 'int' properties can be designated the primary key");
+            }
         }
     }
 

--- a/RealmSwift/Object.swift
+++ b/RealmSwift/Object.swift
@@ -22,6 +22,21 @@ import Realm.Private
 
 #if swift(>=3.0)
 
+/* sealed */ public protocol PrimaryKeyType { }
+extension String: PrimaryKeyType { }
+extension Int: PrimaryKeyType { }
+extension Int8: PrimaryKeyType { }
+extension Int16: PrimaryKeyType { }
+extension Int32: PrimaryKeyType { }
+extension Int64: PrimaryKeyType { }
+// FIXME: Conditionally conform to `PrimaryKey` once Swift supports conditional conformances.
+extension Optional: PrimaryKeyType /* where Wrapped: PrimaryKey */ { }
+
+public protocol PrimaryKeyed {
+    associatedtype PrimaryKey: PrimaryKeyType
+    static var primaryKey: String { get }
+}
+    
 /**
 In Realm you define your model classes by subclassing `Object` and adding properties to be persisted.
 You then instantiate and use your custom subclasses instead of using the Object class directly.
@@ -141,16 +156,6 @@ open class Object: RLMObjectBase {
 
 
     // MARK: Object Customization
-
-    /**
-    Override to designate a property as the primary key for an `Object` subclass. Only properties of
-    type String and Int can be designated as the primary key. Primary key
-    properties enforce uniqueness for each value whenever the property is set which incurs some overhead.
-    Indexes are created automatically for primary key properties.
-
-    - returns: Name of the property designated as the primary key, or `nil` if the model has no primary key.
-    */
-    open class func primaryKey() -> String? { return nil }
 
     /**
     Override to return an array of property names to ignore. These properties will not be persisted

--- a/RealmSwift/Realm.swift
+++ b/RealmSwift/Realm.swift
@@ -406,16 +406,16 @@ public final class Realm {
 
     Returns `nil` if no object exists with the given primary key.
 
-    This method requires that `primaryKey()` be overridden on the given subclass.
+    This method requires that `primaryKey` be overridden on the given subclass.
 
-    - see: Object.primaryKey()
+    - see: Object.primaryKey
 
     - parameter type: The type of the objects to be returned.
     - parameter key:  The primary key of the desired object.
 
     - returns: An object of type `type` or `nil` if an object with the given primary key does not exist.
     */
-    public func object<T: Object, K>(ofType type: T.Type, forPrimaryKey key: K) -> T? {
+    public func object<T: Object>(ofType type: T.Type, forPrimaryKey key: T.PrimaryKey) -> T? where T: PrimaryKeyed {
         return unsafeBitCast(RLMGetObject(rlmRealm, (type as Object.Type).className(),
                                           dynamicBridgeCast(fromSwift: key)) as! RLMObjectBase?,
                              to: Optional<T>.self)
@@ -430,9 +430,9 @@ public final class Realm {
 
     Returns `nil` if no object exists with the given class name and primary key.
 
-    This method requires that `primaryKey()` be overridden on the given subclass.
+    This method requires that `primaryKey` be overridden on the given subclass.
 
-    - see: Object.primaryKey()
+    - see: Object.primaryKey
 
     - warning: This method is useful only in specialized circumstances.
 

--- a/RealmSwift/Tests/KVOTests.swift
+++ b/RealmSwift/Tests/KVOTests.swift
@@ -27,7 +27,7 @@ func nextPrimaryKey() -> Int {
     return pkCounter
 }
 
-class KVOObject: Object {
+class KVOObject: Object, PrimaryKeyed {
     // swiftlint:disable:next variable_name
     dynamic var pk = nextPrimaryKey() // primary key for equality
     dynamic var ignored: Int = 0
@@ -52,7 +52,9 @@ class KVOObject: Object {
     dynamic var optBinaryCol: Data?
     dynamic var optDateCol: Date?
 
-    override class func primaryKey() -> String { return "pk" }
+    typealias PrimaryKey = Int
+    static let primaryKey = "pk"
+
     override class func ignoredProperties() -> [String] { return ["ignored"] }
 }
 

--- a/RealmSwift/Tests/ObjectTests.swift
+++ b/RealmSwift/Tests/ObjectTests.swift
@@ -108,10 +108,8 @@ class ObjectTests: TestCase {
     }
 
     func testSchemaHasPrimaryKey() {
-        XCTAssertNil(Object.primaryKey(), "primary key should default to nil")
-        XCTAssertNil(SwiftStringObject.primaryKey())
         XCTAssertNil(SwiftStringObject().objectSchema.primaryKeyProperty)
-        XCTAssertEqual(SwiftPrimaryStringObject.primaryKey()!, "stringCol")
+        XCTAssertEqual(SwiftPrimaryStringObject.primaryKey, "stringCol")
         XCTAssertEqual(SwiftPrimaryStringObject().objectSchema.primaryKeyProperty!.name, "stringCol")
     }
 

--- a/RealmSwift/Tests/RealmTests.swift
+++ b/RealmSwift/Tests/RealmTests.swift
@@ -499,7 +499,7 @@ class RealmTests: TestCase {
 
     func testIntPrimaryKey() {
         func testIntPrimaryKey<O: Object>(for type: O.Type)
-            where O: SwiftPrimaryKeyObjectType, O.PrimaryKey: ExpressibleByIntegerLiteral {
+            where O: PrimaryKeyed, O.PrimaryKey: ExpressibleByIntegerLiteral {
 
                 let realm = try! Realm()
                 try! realm.write {
@@ -523,21 +523,20 @@ class RealmTests: TestCase {
 
     func testOptionalIntPrimaryKey() {
         func testOptionalIntPrimaryKey<O: Object, Wrapped: RealmOptionalType>(for type: O.Type)
-            where O: SwiftPrimaryKeyObjectType, O.PrimaryKey == RealmOptional<Wrapped>,
-                  Wrapped: ExpressibleByIntegerLiteral {
+            where O: PrimaryKeyed, O.PrimaryKey == Wrapped?, Wrapped: ExpressibleByIntegerLiteral {
                 let realm = try! Realm()
                 try! realm.write {
                     realm.createObject(ofType: type, populatedWith: ["a", NSNull()])
                     realm.createObject(ofType: type, populatedWith: ["b", 2])
                 }
 
-                let object1 = realm.object(ofType: type, forPrimaryKey: NSNull())
+                let object1 = realm.object(ofType: type, forPrimaryKey: nil)
                 XCTAssertNotNil(object1)
 
-                let object2 = realm.object(ofType: type, forPrimaryKey: 2 as Wrapped)
+                let object2 = realm.object(ofType: type, forPrimaryKey: 2)
                 XCTAssertNotNil(object2)
 
-                let missingObject = realm.object(ofType: type, forPrimaryKey: 0 as Wrapped)
+                let missingObject = realm.object(ofType: type, forPrimaryKey: 0)
                 XCTAssertNil(missingObject)
         }
 
@@ -574,7 +573,7 @@ class RealmTests: TestCase {
             realm.createObject(ofType: SwiftPrimaryOptionalStringObject.self, populatedWith: ["b", 2])
         }
 
-        let object1 = realm.object(ofType: SwiftPrimaryOptionalStringObject.self, forPrimaryKey: NSNull())
+        let object1 = realm.object(ofType: SwiftPrimaryOptionalStringObject.self, forPrimaryKey: nil)
         XCTAssertNotNil(object1)
 
         let object2 = realm.object(ofType: SwiftPrimaryOptionalStringObject.self, forPrimaryKey: "b")

--- a/RealmSwift/Tests/SwiftTestObjects.swift
+++ b/RealmSwift/Tests/SwiftTestObjects.swift
@@ -199,15 +199,14 @@ class SwiftArrayPropertySubclassObject: SwiftArrayPropertyObject {
     let boolArray = List<SwiftBoolObject>()
 }
 
-class SwiftLinkToPrimaryStringObject: Object {
+class SwiftLinkToPrimaryStringObject: Object, PrimaryKeyed {
     // swiftlint:disable:next variable_name
     dynamic var pk = ""
     dynamic var object: SwiftPrimaryStringObject?
     let objects = List<SwiftPrimaryStringObject>()
 
-    override class func primaryKey() -> String? {
-        return "pk"
-    }
+    typealias PrimaryKey = String
+    static let primaryKey = "pk"
 }
 
 class SwiftUTF8Object: Object {
@@ -231,129 +230,100 @@ class SwiftRecursiveObject: Object {
     let objects = List<SwiftRecursiveObject>()
 }
 
-protocol SwiftPrimaryKeyObjectType {
-    associatedtype PrimaryKey
-    static func primaryKey() -> String?
-}
-
-class SwiftPrimaryStringObject: Object, SwiftPrimaryKeyObjectType {
+class SwiftPrimaryStringObject: Object, PrimaryKeyed {
     dynamic var stringCol = ""
     dynamic var intCol = 0
 
     typealias PrimaryKey = String
-    override class func primaryKey() -> String? {
-        return "stringCol"
-    }
+    static let primaryKey = "stringCol"
 }
 
-class SwiftPrimaryOptionalStringObject: Object, SwiftPrimaryKeyObjectType {
+class SwiftPrimaryOptionalStringObject: Object, PrimaryKeyed {
     dynamic var stringCol: String? = ""
     dynamic var intCol = 0
 
     typealias PrimaryKey = String?
-    override class func primaryKey() -> String? {
-        return "stringCol"
-    }
+    static let primaryKey = "stringCol"
 }
 
-class SwiftPrimaryIntObject: Object, SwiftPrimaryKeyObjectType {
+class SwiftPrimaryIntObject: Object, PrimaryKeyed {
     dynamic var stringCol = ""
     dynamic var intCol = 0
 
     typealias PrimaryKey = Int
-    override class func primaryKey() -> String? {
-        return "intCol"
-    }
+    static let primaryKey = "intCol"
 }
 
-class SwiftPrimaryOptionalIntObject: Object, SwiftPrimaryKeyObjectType {
+class SwiftPrimaryOptionalIntObject: Object, PrimaryKeyed {
     dynamic var stringCol = ""
     let intCol = RealmOptional<Int>()
 
-    typealias PrimaryKey = RealmOptional<Int>
-    override class func primaryKey() -> String? {
-        return "intCol"
-    }
+    typealias PrimaryKey = Int?
+    static let primaryKey = "intCol"
 }
 
-class SwiftPrimaryInt8Object: Object, SwiftPrimaryKeyObjectType {
+class SwiftPrimaryInt8Object: Object, PrimaryKeyed {
     dynamic var stringCol = ""
     dynamic var int8Col: Int8 = 0
 
     typealias PrimaryKey = Int8
-    override class func primaryKey() -> String? {
-        return "int8Col"
-    }
+    static let primaryKey = "int8Col"
 }
 
-class SwiftPrimaryOptionalInt8Object: Object, SwiftPrimaryKeyObjectType {
+class SwiftPrimaryOptionalInt8Object: Object, PrimaryKeyed {
     dynamic var stringCol = ""
     let int8Col = RealmOptional<Int8>()
 
-    typealias PrimaryKey = RealmOptional<Int8>
-    override class func primaryKey() -> String? {
-        return "int8Col"
-    }
+    typealias PrimaryKey = Int8?
+    static let primaryKey = "int8Col"
 }
 
-class SwiftPrimaryInt16Object: Object, SwiftPrimaryKeyObjectType {
+class SwiftPrimaryInt16Object: Object, PrimaryKeyed {
     dynamic var stringCol = ""
     dynamic var int16Col: Int16 = 0
 
     typealias PrimaryKey = Int16
-    override class func primaryKey() -> String? {
-        return "int16Col"
-    }
+    static let primaryKey = "int16Col"
 }
 
-class SwiftPrimaryOptionalInt16Object: Object, SwiftPrimaryKeyObjectType {
+class SwiftPrimaryOptionalInt16Object: Object, PrimaryKeyed {
     dynamic var stringCol = ""
     let int16Col = RealmOptional<Int16>()
 
-    typealias PrimaryKey = RealmOptional<Int16>
-    override class func primaryKey() -> String? {
-        return "int16Col"
-    }
+    typealias PrimaryKey = Int16?
+    static let primaryKey = "int16Col"
 }
 
-class SwiftPrimaryInt32Object: Object, SwiftPrimaryKeyObjectType {
+class SwiftPrimaryInt32Object: Object, PrimaryKeyed {
     dynamic var stringCol = ""
     dynamic var int32Col: Int32 = 0
 
     typealias PrimaryKey = Int32
-    override class func primaryKey() -> String? {
-        return "int32Col"
-    }
+    static let primaryKey = "int32Col"
 }
 
-class SwiftPrimaryOptionalInt32Object: Object, SwiftPrimaryKeyObjectType {
+class SwiftPrimaryOptionalInt32Object: Object, PrimaryKeyed {
     dynamic var stringCol = ""
     let int32Col = RealmOptional<Int32>()
 
-    typealias PrimaryKey = RealmOptional<Int32>
-    override class func primaryKey() -> String? {
-        return "int32Col"
-    }
+    typealias PrimaryKey = Int32?
+    static let primaryKey = "int32Col"
 }
 
-class SwiftPrimaryInt64Object: Object, SwiftPrimaryKeyObjectType {
+class SwiftPrimaryInt64Object: Object, PrimaryKeyed {
     dynamic var stringCol = ""
     dynamic var int64Col: Int64 = 0
 
     typealias PrimaryKey = Int64
-    override class func primaryKey() -> String? {
-        return "int64Col"
-    }
+    static let primaryKey = "int64Col"
 }
 
-class SwiftPrimaryOptionalInt64Object: Object, SwiftPrimaryKeyObjectType {
+class SwiftPrimaryOptionalInt64Object: Object, PrimaryKeyed {
     dynamic var stringCol = ""
     let int64Col = RealmOptional<Int64>()
 
-    typealias PrimaryKey = RealmOptional<Int64>
-    override class func primaryKey() -> String? {
-        return "int64Col"
-    }
+    typealias PrimaryKey = Int64?
+    static let primaryKey = "int64Col"
 }
 
 class SwiftIndexedPropertiesObject: Object {


### PR DESCRIPTION
This is an idea for an API breaking change we might want to make for Swift eventually. We introduce a protocol for models with a primary key that includes an associated type for the primary key. This allows us to provide type-safety in functions like `object(ofType:forPrimaryKey:)` and also allows us to, at compile-time, reduce the change they're using an invalid primary key type.

``` swift
class Person: Object, PrimaryKeyed {
  dynamic var id = 0
  dynamic var name = ""

  typealias PrimaryKey = Int
  static let primaryKey = "id"
}
```
