### PR TITLE
Fix `@escaping` compilation errors introduced in GM

### DIFF
--- a/Realm/RLMMigration.h
+++ b/Realm/RLMMigration.h
@@ -71,7 +71,7 @@ typedef void (^RLMObjectMigrationBlock)(RLMObject * __nullable oldObject, RLMObj
             to `className`. Instead, treat them as `RLMObject`s and use keyed subscripting to access
             properties.
  */
-- (void)enumerateObjects:(NSString *)className block:(RLMObjectMigrationBlock)block;
+- (void)enumerateObjects:(NSString *)className block:(__attribute__((noescape)) RLMObjectMigrationBlock)block;
 
 /**
  Creates and returns an `RLMObject` instance of type `className` in the Realm being migrated.

--- a/RealmSwift/Migration.swift
+++ b/RealmSwift/Migration.swift
@@ -177,8 +177,7 @@ public final class Migration {
 
 // MARK: Private Helpers
 
-internal func accessorMigrationBlock(_ migrationBlock: MigrationBlock)
-    -> RLMMigrationBlock {
+internal func accessorMigrationBlock(_ migrationBlock: @escaping MigrationBlock) -> RLMMigrationBlock {
     return { migration, oldVersion in
         // set all accessor classes to MigrationObject
         for objectSchema in migration.oldSchema.objectSchema {

--- a/RealmSwift/Realm.swift
+++ b/RealmSwift/Realm.swift
@@ -475,7 +475,7 @@ public final class Realm {
 
     - returns: A token which must be held for as long as you want notifications to be delivered.
     */
-    public func addNotificationBlock(block: NotificationBlock) -> NotificationToken {
+    public func addNotificationBlock(block: @escaping NotificationBlock) -> NotificationToken {
         return rlmRealm.addNotificationBlock { rlmNotification, _ in
             switch rlmNotification {
             case RLMNotification.DidChange:
@@ -630,7 +630,7 @@ public enum Notification: String {
 }
 
 /// Closure to run when the data in a Realm was modified.
-public typealias NotificationBlock = @escaping (_ notification: Notification, _ realm: Realm) -> Void
+public typealias NotificationBlock = (_ notification: Notification, _ realm: Realm) -> Void
 
 
 // MARK: Unavailable

--- a/RealmSwift/Tests/MigrationTests.swift
+++ b/RealmSwift/Tests/MigrationTests.swift
@@ -80,7 +80,7 @@ class MigrationTests: TestCase {
         XCTAssertEqual(didRun, shouldRun)
     }
 
-    private func migrateAndTestDefaultRealm(_ schemaVersion: UInt64 = 1, block: MigrationBlock) {
+    private func migrateAndTestDefaultRealm(_ schemaVersion: UInt64 = 1, block: @escaping MigrationBlock) {
         migrateAndTestRealm(defaultRealmURL(), schemaVersion: schemaVersion, block: block)
         let config = Realm.Configuration(fileURL: defaultRealmURL(),
                                          schemaVersion: schemaVersion)

--- a/RealmSwift/Tests/ObjectTests.swift
+++ b/RealmSwift/Tests/ObjectTests.swift
@@ -306,7 +306,7 @@ class ObjectTests: TestCase {
     }
 
     // Yields a read-write migration `SwiftObject` to the given block
-    private func withMigrationObject(block: ((MigrationObject, Migration) -> ())) {
+    private func withMigrationObject(block: @escaping ((MigrationObject, Migration) -> ())) {
         autoreleasepool {
             let realm = self.realmWithTestPath()
             try! realm.write {

--- a/RealmSwift/Tests/PerformanceTests.swift
+++ b/RealmSwift/Tests/PerformanceTests.swift
@@ -68,7 +68,7 @@ class SwiftPerformanceTests: TestCase {
         // Do nothing, as we need to keep our in-memory realms around between tests
     }
 
-    override func measure(_ block: (() -> Void)) {
+    override func measure(_ block: @escaping (() -> Void)) {
         super.measure {
             autoreleasepool {
                 block()


### PR DESCRIPTION
Swift 3 GM changed where `@escaping` can be placed (now only in argument positions, not typealiases) and fixed bugs related to its enforcement.

@jpsim @austinzheng @bdash