### PR TITLE
add "Abort trap: 6" to build.sh Xcode error detection

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -921,7 +921,7 @@ EOM
 
             failed=0
             sh build.sh verify-$target 2>&1 | tee build/build.log | xcpretty -r junit -o build/reports/junit.xml || failed=1
-            if [ "$failed" = "1" ] && cat build/build.log | grep -E 'DTXProxyChannel|DTXChannel|out of date and needs to be rebuilt'; then
+            if [ "$failed" = "1" ] && cat build/build.log | grep -E 'DTXProxyChannel|DTXChannel|out of date and needs to be rebuilt|Abort trap: 6'; then
                 echo "Known Xcode error detected. Running job again."
                 failed=0
                 sh build.sh verify-$target | tee build/build.log | xcpretty -r junit -o build/reports/junit.xml || failed=1


### PR DESCRIPTION
This error occasionally occurs when running `xcodebuild`. For example, in [this Jenkins job](https://ci.realm.io/job/objc_pr/4070/configuration=Debug,swift_version=3.0,target=osx/consoleFull):

```
...
Test Case '-[KVOManagedObjectTests testOnlyObserversForTheCorrectPropertyAreNotified]' started.
build.sh: line 95: 15175 Abort trap: 6           xcodebuild -IDECustomDerivedDataLocation=build/DerivedData -scheme Realm -configuration Debug test GCC_GENERATE_TEST_COVERAGE_FILES=YES GCC_INSTRUMENT_PROGRAM_FLOW_ARCS=YES SWIFT_VERSION=3.0 GCC_GENERATE_DEBUGGING_SYMBOLS=NO REALM_PREFIX_HEADER=Realm/RLMPrefix.h
...
```

/cc @tgoyne 