### PR TITLE
update build.sh docs generation for Swift 3 & Jazzy 0.7.1

### DIFF
--- a/RealmSwift/Results.swift
+++ b/RealmSwift/Results.swift
@@ -84,6 +84,7 @@ public final class Results<T: Object>: NSObject, NSFastEnumeration {
 
     // MARK: Fast Enumeration
 
+    /// :nodoc:
     public func countByEnumerating(with state: UnsafeMutablePointer<NSFastEnumerationState>,
                    objects buffer: AutoreleasingUnsafeMutablePointer<AnyObject?>!,
                    count len: Int) -> Int {


### PR DESCRIPTION
Jazzy 0.7.1 changed the format of `undocumented.json` and added support for Swift 3 ACLs.

/cc @bdash 