### PR TITLE
Use default property value for primary key if none was provided when creating objects

### DIFF
--- a/Realm/RLMObjectStore.mm
+++ b/Realm/RLMObjectStore.mm
@@ -387,7 +387,7 @@ RLMObjectBase *RLMCreateObjectInRealmWithValue(RLMRealm *realm, NSString *classN
         }
     }
     else {
-        __block bool foundExisting;
+        __block bool foundExisting = false;
         __block NSDictionary *defaultValues = nil;
         auto getValue = ^(RLMProperty *prop) {
             id propValue = RLMValidatedValueForProperty(value, prop.name, info.rlmObjectSchema.className);

--- a/Realm/RLMObjectStore.mm
+++ b/Realm/RLMObjectStore.mm
@@ -387,21 +387,10 @@ RLMObjectBase *RLMCreateObjectInRealmWithValue(RLMRealm *realm, NSString *classN
         }
     }
     else {
-        // get or create our accessor
-        bool foundExisting;
-        auto primaryGetter = [=](RLMProperty *p) { return [value valueForKey:p.name]; };
-        object->_row = (*info.table())[createOrGetRowForObject(info, primaryGetter, createOrUpdate, &foundExisting)];
-
-        // populate
-        NSDictionary *defaultValues = nil;
-        for (RLMProperty *prop in info.rlmObjectSchema.properties) {
-
-            // skip primary key when updating since it doesn't change
-            if (prop.isPrimary)
-                continue;
-
+        __block bool foundExisting;
+        __block NSDictionary *defaultValues = nil;
+        auto getValue = ^(RLMProperty *prop) {
             id propValue = RLMValidatedValueForProperty(value, prop.name, info.rlmObjectSchema.className);
-
             if (!propValue && !foundExisting) {
                 if (!defaultValues) {
                     defaultValues = RLMDefaultValuesForObjectSchema(info.rlmObjectSchema);
@@ -411,8 +400,18 @@ RLMObjectBase *RLMCreateObjectInRealmWithValue(RLMRealm *realm, NSString *classN
                     propValue = NSNull.null;
                 }
             }
+            return propValue;
+        };
+        // get or create our accessor
+        object->_row = (*info.table())[createOrGetRowForObject(info, getValue, createOrUpdate, &foundExisting)];
 
-            if (propValue) {
+        // populate
+        for (RLMProperty *prop in info.rlmObjectSchema.properties) {
+            // skip primary key when updating since it doesn't change
+            if (prop.isPrimary)
+                continue;
+
+            if (id propValue = getValue(prop)) {
                 validateValueForProperty(propValue, prop);
                 RLMDynamicSet(object, prop, RLMCoerceToNil(propValue), creationOptions);
             }

--- a/Realm/Tests/ObjectTests.m
+++ b/Realm/Tests/ObjectTests.m
@@ -73,6 +73,9 @@
              @"stringCol" : [[NSUUID UUID] UUIDString],
              @"binaryCol" : [[[NSUUID UUID] UUIDString] dataUsingEncoding:NSUTF8StringEncoding]};
 }
++ (NSString *)primaryKey {
+    return @"intCol";
+}
 @end
 
 

--- a/Realm/Tests/ObjectTests.m
+++ b/Realm/Tests/ObjectTests.m
@@ -66,6 +66,9 @@ NSInteger dynamicDefaultSeed = 0;
 @end
 
 @implementation DynamicDefaultObject
++ (BOOL)shouldIncludeInDefaultSchema {
+    return NO;
+}
 + (NSDictionary *)defaultPropertyValues {
     dynamicDefaultSeed++;
     return @{@"intCol" : @(dynamicDefaultSeed),
@@ -1279,7 +1282,9 @@ static void testDatesInRange(NSTimeInterval from, NSTimeInterval to, void (^chec
         XCTAssertNotEqualObjects(obj1.binaryCol, obj2.binaryCol);
     };
     assertDifferentPropertyValues([[DynamicDefaultObject alloc] init], [[DynamicDefaultObject alloc] init]);
-    RLMRealm *realm = [RLMRealm defaultRealm];
+    RLMRealmConfiguration *configuration = [RLMRealmConfiguration defaultConfiguration];
+    configuration.objectClasses = @[[DynamicDefaultObject class]];
+    RLMRealm *realm = [RLMRealm realmWithConfiguration:configuration error:nil];
     [realm beginWriteTransaction];
     assertDifferentPropertyValues([DynamicDefaultObject createInRealm:realm withValue:@{}], [DynamicDefaultObject createInRealm:realm withValue:@{}]);
     [realm cancelWriteTransaction];

--- a/Realm/Tests/ObjectTests.m
+++ b/Realm/Tests/ObjectTests.m
@@ -55,7 +55,8 @@
 @end
 
 
-@interface RandomDefaultObject : RLMObject
+NSInteger dynamicDefaultSeed = 0;
+@interface DynamicDefaultObject : RLMObject
 @property int       intCol;
 @property float     floatCol;
 @property double    doubleCol;
@@ -64,12 +65,13 @@
 @property NSData   *binaryCol;
 @end
 
-@implementation RandomDefaultObject
+@implementation DynamicDefaultObject
 + (NSDictionary *)defaultPropertyValues {
-    return @{@"intCol" : @(arc4random()),
-             @"floatCol" : @(arc4random() / 1000.0f),
-             @"doubleCol" : @(arc4random() / 1000.0),
-             @"dateCol" : [NSDate dateWithTimeIntervalSince1970:arc4random()],
+    dynamicDefaultSeed++;
+    return @{@"intCol" : @(dynamicDefaultSeed),
+             @"floatCol" : @((float)dynamicDefaultSeed),
+             @"doubleCol" : @((double)dynamicDefaultSeed),
+             @"dateCol" : [NSDate dateWithTimeIntervalSince1970:dynamicDefaultSeed],
              @"stringCol" : [[NSUUID UUID] UUIDString],
              @"binaryCol" : [[[NSUUID UUID] UUIDString] dataUsingEncoding:NSUTF8StringEncoding]};
 }
@@ -1267,8 +1269,8 @@ static void testDatesInRange(NSTimeInterval from, NSTimeInterval to, void (^chec
     [realm cancelWriteTransaction];
 }
 
-- (void)testRandomDefaultPropertyValues {
-    void (^assertDifferentPropertyValues)(RandomDefaultObject *, RandomDefaultObject *) = ^(RandomDefaultObject *obj1, RandomDefaultObject *obj2) {
+- (void)testDynamicDefaultPropertyValues {
+    void (^assertDifferentPropertyValues)(DynamicDefaultObject *, DynamicDefaultObject *) = ^(DynamicDefaultObject *obj1, DynamicDefaultObject *obj2) {
         XCTAssertNotEqual(obj1.intCol, obj2.intCol);
         XCTAssertNotEqual(obj1.floatCol, obj2.floatCol);
         XCTAssertNotEqual(obj1.doubleCol, obj2.doubleCol);
@@ -1276,10 +1278,10 @@ static void testDatesInRange(NSTimeInterval from, NSTimeInterval to, void (^chec
         XCTAssertNotEqualObjects(obj1.stringCol, obj2.stringCol);
         XCTAssertNotEqualObjects(obj1.binaryCol, obj2.binaryCol);
     };
-    assertDifferentPropertyValues([[RandomDefaultObject alloc] init], [[RandomDefaultObject alloc] init]);
+    assertDifferentPropertyValues([[DynamicDefaultObject alloc] init], [[DynamicDefaultObject alloc] init]);
     RLMRealm *realm = [RLMRealm defaultRealm];
     [realm beginWriteTransaction];
-    assertDifferentPropertyValues([RandomDefaultObject createInRealm:realm withValue:@{}], [RandomDefaultObject createInRealm:realm withValue:@{}]);
+    assertDifferentPropertyValues([DynamicDefaultObject createInRealm:realm withValue:@{}], [DynamicDefaultObject createInRealm:realm withValue:@{}]);
     [realm cancelWriteTransaction];
 }
 

--- a/RealmSwift/Tests/ObjectTests.swift
+++ b/RealmSwift/Tests/ObjectTests.swift
@@ -22,6 +22,15 @@ import Foundation
 
 #if swift(>=3.0)
 
+class RandomDefaultObject: Object {
+    dynamic var intCol = Int(arc4random())
+    dynamic var floatCol = Float(arc4random()) / 1000
+    dynamic var doubleCol = Double(arc4random()) / 1000
+    dynamic var dateCol = Date(timeIntervalSinceReferenceDate: TimeInterval(arc4random()))
+    dynamic var stringCol = UUID().uuidString
+    dynamic var binaryCol = UUID().uuidString.data(using: .utf8)
+}
+
 class ObjectTests: TestCase {
 
     // init() Tests are in ObjectCreationTests.swift
@@ -192,6 +201,22 @@ class ObjectTests: TestCase {
         XCTAssertFalse(SwiftIndexedOptionalPropertiesObject().objectSchema["optionalDataCol"]!.isIndexed)
         XCTAssertFalse(SwiftIndexedOptionalPropertiesObject().objectSchema["optionalFloatCol"]!.isIndexed)
         XCTAssertFalse(SwiftIndexedOptionalPropertiesObject().objectSchema["optionalDoubleCol"]!.isIndexed)
+    }
+
+    func testRandomDefaultPropertyValues() {
+        func assertDifferentPropertyValues(_ obj1: RandomDefaultObject, _ obj2: RandomDefaultObject) {
+            XCTAssertNotEqual(obj1.intCol, obj2.intCol)
+            XCTAssertNotEqual(obj1.floatCol, obj2.floatCol)
+            XCTAssertNotEqual(obj1.doubleCol, obj2.doubleCol)
+            XCTAssertNotEqualWithAccuracy(obj1.dateCol.timeIntervalSinceReferenceDate, obj2.dateCol.timeIntervalSinceReferenceDate, 0.01)
+            XCTAssertNotEqual(obj1.stringCol, obj2.stringCol)
+            XCTAssertNotEqual(obj1.binaryCol, obj2.binaryCol)
+        }
+        assertDifferentPropertyValues(RandomDefaultObject(), RandomDefaultObject())
+        let realm = try! Realm()
+        try! realm.write {
+            assertDifferentPropertyValues(realm.create(RandomDefaultObject.self), realm.create(RandomDefaultObject.self))
+        }
     }
 
     func testValueForKey() {
@@ -409,6 +434,15 @@ class ObjectTests: TestCase {
 
 #else
 
+class RandomDefaultObject: Object {
+    dynamic var intCol = Int(arc4random())
+    dynamic var floatCol = Float(arc4random()) / 1000
+    dynamic var doubleCol = Double(arc4random()) / 1000
+    dynamic var dateCol = NSDate(timeIntervalSinceReferenceDate: NSTimeInterval(arc4random()))
+    dynamic var stringCol = NSUUID().UUIDString
+    dynamic var binaryCol = NSUUID().UUIDString.dataUsingEncoding(NSUTF8StringEncoding)
+}
+
 class ObjectTests: TestCase {
 
     // init() Tests are in ObjectCreationTests.swift
@@ -579,6 +613,22 @@ class ObjectTests: TestCase {
         XCTAssertFalse(SwiftIndexedOptionalPropertiesObject().objectSchema["optionalDataCol"]!.indexed)
         XCTAssertFalse(SwiftIndexedOptionalPropertiesObject().objectSchema["optionalFloatCol"]!.indexed)
         XCTAssertFalse(SwiftIndexedOptionalPropertiesObject().objectSchema["optionalDoubleCol"]!.indexed)
+    }
+
+    func testRandomDefaultPropertyValues() {
+        func assertDifferentPropertyValues(obj1: RandomDefaultObject, _ obj2: RandomDefaultObject) {
+            XCTAssertNotEqual(obj1.intCol, obj2.intCol)
+            XCTAssertNotEqual(obj1.floatCol, obj2.floatCol)
+            XCTAssertNotEqual(obj1.doubleCol, obj2.doubleCol)
+            XCTAssertNotEqualWithAccuracy(obj1.dateCol.timeIntervalSinceReferenceDate, obj2.dateCol.timeIntervalSinceReferenceDate, 0.01)
+            XCTAssertNotEqual(obj1.stringCol, obj2.stringCol)
+            XCTAssertNotEqual(obj1.binaryCol, obj2.binaryCol)
+        }
+        assertDifferentPropertyValues(RandomDefaultObject(), RandomDefaultObject())
+        let realm = try! Realm()
+        try! realm.write {
+            assertDifferentPropertyValues(realm.create(RandomDefaultObject.self), realm.create(RandomDefaultObject.self))
+        }
     }
 
     func testValueForKey() {

--- a/RealmSwift/Tests/ObjectTests.swift
+++ b/RealmSwift/Tests/ObjectTests.swift
@@ -22,11 +22,16 @@ import Foundation
 
 #if swift(>=3.0)
 
-class RandomDefaultObject: Object {
-    dynamic var intCol = Int(arc4random())
-    dynamic var floatCol = Float(arc4random()) / 1000
-    dynamic var doubleCol = Double(arc4random()) / 1000
-    dynamic var dateCol = Date(timeIntervalSinceReferenceDate: TimeInterval(arc4random()))
+private var dynamicDefaultSeed = 0
+private func nextDynamicDefaultSeed() -> Int {
+    dynamicDefaultSeed += 1
+    return dynamicDefaultSeed
+}
+class DynamicDefaultObject: Object {
+    dynamic var intCol = nextDynamicDefaultSeed()
+    dynamic var floatCol = Float(nextDynamicDefaultSeed())
+    dynamic var doubleCol = Double(nextDynamicDefaultSeed())
+    dynamic var dateCol = Date(timeIntervalSinceReferenceDate: TimeInterval(nextDynamicDefaultSeed()))
     dynamic var stringCol = UUID().uuidString
     dynamic var binaryCol = UUID().uuidString.data(using: .utf8)
 
@@ -207,8 +212,8 @@ class ObjectTests: TestCase {
         XCTAssertFalse(SwiftIndexedOptionalPropertiesObject().objectSchema["optionalDoubleCol"]!.isIndexed)
     }
 
-    func testRandomDefaultPropertyValues() {
-        func assertDifferentPropertyValues(_ obj1: RandomDefaultObject, _ obj2: RandomDefaultObject) {
+    func testDynamicDefaultPropertyValues() {
+        func assertDifferentPropertyValues(_ obj1: DynamicDefaultObject, _ obj2: DynamicDefaultObject) {
             XCTAssertNotEqual(obj1.intCol, obj2.intCol)
             XCTAssertNotEqual(obj1.floatCol, obj2.floatCol)
             XCTAssertNotEqual(obj1.doubleCol, obj2.doubleCol)
@@ -216,10 +221,10 @@ class ObjectTests: TestCase {
             XCTAssertNotEqual(obj1.stringCol, obj2.stringCol)
             XCTAssertNotEqual(obj1.binaryCol, obj2.binaryCol)
         }
-        assertDifferentPropertyValues(RandomDefaultObject(), RandomDefaultObject())
+        assertDifferentPropertyValues(DynamicDefaultObject(), DynamicDefaultObject())
         let realm = try! Realm()
         try! realm.write {
-            assertDifferentPropertyValues(realm.create(RandomDefaultObject.self), realm.create(RandomDefaultObject.self))
+            assertDifferentPropertyValues(realm.create(DynamicDefaultObject.self), realm.create(DynamicDefaultObject.self))
         }
     }
 
@@ -438,11 +443,16 @@ class ObjectTests: TestCase {
 
 #else
 
-class RandomDefaultObject: Object {
-    dynamic var intCol = Int(arc4random())
-    dynamic var floatCol = Float(arc4random()) / 1000
-    dynamic var doubleCol = Double(arc4random()) / 1000
-    dynamic var dateCol = NSDate(timeIntervalSinceReferenceDate: NSTimeInterval(arc4random()))
+private var dynamicDefaultSeed = 0
+private func nextDynamicDefaultSeed() -> Int {
+    dynamicDefaultSeed += 1
+    return dynamicDefaultSeed
+}
+class DynamicDefaultObject: Object {
+    dynamic var intCol = nextDynamicDefaultSeed()
+    dynamic var floatCol = Float(nextDynamicDefaultSeed())
+    dynamic var doubleCol = Double(nextDynamicDefaultSeed())
+    dynamic var dateCol = NSDate(timeIntervalSinceReferenceDate: NSTimeInterval(nextDynamicDefaultSeed()))
     dynamic var stringCol = NSUUID().UUIDString
     dynamic var binaryCol = NSUUID().UUIDString.dataUsingEncoding(NSUTF8StringEncoding)
 
@@ -623,8 +633,8 @@ class ObjectTests: TestCase {
         XCTAssertFalse(SwiftIndexedOptionalPropertiesObject().objectSchema["optionalDoubleCol"]!.indexed)
     }
 
-    func testRandomDefaultPropertyValues() {
-        func assertDifferentPropertyValues(obj1: RandomDefaultObject, _ obj2: RandomDefaultObject) {
+    func testDynamicDefaultPropertyValues() {
+        func assertDifferentPropertyValues(obj1: DynamicDefaultObject, _ obj2: DynamicDefaultObject) {
             XCTAssertNotEqual(obj1.intCol, obj2.intCol)
             XCTAssertNotEqual(obj1.floatCol, obj2.floatCol)
             XCTAssertNotEqual(obj1.doubleCol, obj2.doubleCol)
@@ -632,10 +642,10 @@ class ObjectTests: TestCase {
             XCTAssertNotEqual(obj1.stringCol, obj2.stringCol)
             XCTAssertNotEqual(obj1.binaryCol, obj2.binaryCol)
         }
-        assertDifferentPropertyValues(RandomDefaultObject(), RandomDefaultObject())
+        assertDifferentPropertyValues(DynamicDefaultObject(), DynamicDefaultObject())
         let realm = try! Realm()
         try! realm.write {
-            assertDifferentPropertyValues(realm.create(RandomDefaultObject.self), realm.create(RandomDefaultObject.self))
+            assertDifferentPropertyValues(realm.create(DynamicDefaultObject.self), realm.create(DynamicDefaultObject.self))
         }
     }
 

--- a/RealmSwift/Tests/ObjectTests.swift
+++ b/RealmSwift/Tests/ObjectTests.swift
@@ -29,6 +29,10 @@ class RandomDefaultObject: Object {
     dynamic var dateCol = Date(timeIntervalSinceReferenceDate: TimeInterval(arc4random()))
     dynamic var stringCol = UUID().uuidString
     dynamic var binaryCol = UUID().uuidString.data(using: .utf8)
+
+    override static func primaryKey() -> String? {
+        return "intCol"
+    }
 }
 
 class ObjectTests: TestCase {
@@ -441,6 +445,10 @@ class RandomDefaultObject: Object {
     dynamic var dateCol = NSDate(timeIntervalSinceReferenceDate: NSTimeInterval(arc4random()))
     dynamic var stringCol = NSUUID().UUIDString
     dynamic var binaryCol = NSUUID().UUIDString.dataUsingEncoding(NSUTF8StringEncoding)
+
+    override static func primaryKey() -> String? {
+        return "intCol"
+    }
 }
 
 class ObjectTests: TestCase {


### PR DESCRIPTION
fixes #4079 /cc @tgoyne. No changelog entry because we never shipped this regression.