### PR TITLE
Fix an asssertion failure when sorting by zero properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+x.x.x Release notes (yyyy-MM-dd)
+=============================================================
+
+### API breaking changes
+
+* None.
+
+### Enhancements
+
+* None.
+
+### Bugfixes
+
+* Fix an assertion failure when sorting by zero properties.
+
 1.1.0 Release notes (2016-09-16)
 =============================================================
 

--- a/Realm/RLMArrayLinkView.mm
+++ b/Realm/RLMArrayLinkView.mm
@@ -361,6 +361,11 @@ static void RLMInsertObject(RLMArrayLinkView *ar, RLMObject *object, NSUInteger 
 }
 
 - (RLMResults *)sortedResultsUsingDescriptors:(NSArray *)properties {
+    if (properties.count == 0) {
+        auto results = translateErrors([&] { return _backingList.filter({}); });
+        return [RLMResults resultsWithObjectInfo:*_objectInfo results:std::move(results)];
+    }
+
     auto order = RLMSortDescriptorFromDescriptors(*_objectInfo->table(), properties);
     auto results = translateErrors([&] { return _backingList.sort(std::move(order)); });
     return [RLMResults resultsWithObjectInfo:*_objectInfo results:std::move(results)];

--- a/Realm/RLMResults.mm
+++ b/Realm/RLMResults.mm
@@ -359,6 +359,9 @@ static inline void RLMResultsValidateInWriteTransaction(__unsafe_unretained RLMR
 }
 
 - (RLMResults *)sortedResultsUsingDescriptors:(NSArray *)properties {
+    if (properties.count == 0) {
+        return self;
+    }
     return translateErrors([&] {
         if (_results.get_mode() == Results::Mode::Empty) {
             return self;

--- a/Realm/Tests/ArrayPropertyTests.m
+++ b/Realm/Tests/ArrayPropertyTests.m
@@ -750,6 +750,24 @@
     }];
 }
 
+- (void)testSortByNoColumns {
+    RLMRealm *realm = [RLMRealm defaultRealm];
+    [realm beginWriteTransaction];
+    DogObject *a2 = [DogObject createInDefaultRealmWithValue:@[@"a", @2]];
+    DogObject *b1 = [DogObject createInDefaultRealmWithValue:@[@"b", @1]];
+    DogObject *a1 = [DogObject createInDefaultRealmWithValue:@[@"a", @1]];
+    DogObject *b2 = [DogObject createInDefaultRealmWithValue:@[@"b", @2]];
+
+    RLMArray<DogObject *> *array = [DogArrayObject createInDefaultRealmWithValue:@[@[a2, b1, a1, b2]]].dogs;
+    [realm commitWriteTransaction];
+
+    RLMResults *notActuallySorted = [array sortedResultsUsingDescriptors:@[]];
+    XCTAssertTrue([array[0] isEqualToObject:notActuallySorted[0]]);
+    XCTAssertTrue([array[1] isEqualToObject:notActuallySorted[1]]);
+    XCTAssertTrue([array[2] isEqualToObject:notActuallySorted[2]]);
+    XCTAssertTrue([array[3] isEqualToObject:notActuallySorted[3]]);
+}
+
 - (void)testSortByMultipleColumns {
     RLMRealm *realm = [RLMRealm defaultRealm];
     [realm beginWriteTransaction];

--- a/Realm/Tests/QueryTests.m
+++ b/Realm/Tests/QueryTests.m
@@ -608,6 +608,22 @@
     XCTAssertThrows([arrayOfAll.array sortedResultsUsingProperty:@"key.path" ascending:NO]);
 }
 
+- (void)testSortByNoColumns {
+    RLMRealm *realm = [RLMRealm defaultRealm];
+    [realm beginWriteTransaction];
+    DogObject *a2 = [DogObject createInDefaultRealmWithValue:@[@"a", @2]];
+    DogObject *b1 = [DogObject createInDefaultRealmWithValue:@[@"b", @1]];
+    DogObject *a1 = [DogObject createInDefaultRealmWithValue:@[@"a", @1]];
+    DogObject *b2 = [DogObject createInDefaultRealmWithValue:@[@"b", @2]];
+    [realm commitWriteTransaction];
+
+    RLMResults *notActuallySorted = [DogObject.allObjects sortedResultsUsingDescriptors:@[]];
+    XCTAssertTrue([a2 isEqualToObject:notActuallySorted[0]]);
+    XCTAssertTrue([b1 isEqualToObject:notActuallySorted[1]]);
+    XCTAssertTrue([a1 isEqualToObject:notActuallySorted[2]]);
+    XCTAssertTrue([b2 isEqualToObject:notActuallySorted[3]]);
+}
+
 - (void)testSortByMultipleColumns {
     RLMRealm *realm = [self realm];
     [realm beginWriteTransaction];

--- a/RealmSwift/Tests/RealmCollectionTypeTests.swift
+++ b/RealmSwift/Tests/RealmCollectionTypeTests.swift
@@ -325,6 +325,10 @@ class RealmCollectionTypeTests: TestCase {
     func testSortWithDescriptor() {
         let collection = getAggregateableCollection()
 
+        let notActuallySorted = collection.sorted(by: [])
+        XCTAssertEqual(collection[0], notActuallySorted[0])
+        XCTAssertEqual(collection[1], notActuallySorted[1])
+
         var sorted = collection.sorted(by: [SortDescriptor(property: "intCol", ascending: true)])
         XCTAssertEqual(1, sorted[0].intCol)
         XCTAssertEqual(2, sorted[1].intCol)
@@ -1331,6 +1335,10 @@ class RealmCollectionTypeTests: TestCase {
 
     func testSortWithDescriptor() {
         let collection = getAggregateableCollection()
+
+        let notActuallySorted = collection.sorted([])
+        XCTAssertEqual(collection[0], notActuallySorted[0])
+        XCTAssertEqual(collection[1], notActuallySorted[1])
 
         var sorted = collection.sorted([SortDescriptor(property: "intCol", ascending: true)])
         XCTAssertEqual(1, sorted[0].intCol)


### PR DESCRIPTION
The new core-level SortDescriptor doesn't like being created with zero columns, so special-case that to avoid using the sort codepaths at all.