### PR TITLE
Allow throws within Realm.write(_:) block in Swift 3

### DIFF
--- a/RealmSwift/Realm.swift
+++ b/RealmSwift/Realm.swift
@@ -116,8 +116,15 @@ public final class Realm {
      - throws: An `NSError` if the transaction could not be completed successfully.
                If `block` throws, the function throws the propagated `ErrorType` instead.
      */
-    public func write(_ block: () -> Void) throws {
-        try rlmRealm.transaction(block)
+    public func write(_ block: (() throws -> Void)) throws {
+        beginWrite()
+        do {
+            try block()
+        } catch let error {
+            if isInWriteTransaction { cancelWrite() }
+            throw error
+        }
+        if isInWriteTransaction { try commitWrite() }
     }
 
     /**

--- a/RealmSwift/Tests/RealmTests.swift
+++ b/RealmSwift/Tests/RealmTests.swift
@@ -27,6 +27,10 @@ import Foundation
 #if swift(>=3.0)
 
 class RealmTests: TestCase {
+    enum TestError: Swift.Error {
+        case intentional
+    }
+
     func testFileURL() {
         XCTAssertEqual(try! Realm(fileURL: testRealmURL()).configuration.fileURL,
                        testRealmURL())
@@ -256,6 +260,20 @@ class RealmTests: TestCase {
             XCTAssertEqual(try! Realm().objects(SwiftStringObject.self).count, 0)
         }
         XCTAssertEqual(try! Realm().objects(SwiftStringObject.self).count, 0)
+    }
+
+    func testThrowsWrite() {
+        assertFails(TestError.intentional) {
+            try Realm().write {
+                throw TestError.intentional
+            }
+        }
+        assertFails(TestError.intentional) {
+            try Realm().write {
+                try! Realm().create(SwiftStringObject.self, value: ["1"])
+                throw TestError.intentional
+            }
+        }
     }
 
     func testInWriteTransaction() {

--- a/RealmSwift/Tests/TestCase.swift
+++ b/RealmSwift/Tests/TestCase.swift
@@ -152,6 +152,21 @@ class TestCase: XCTestCase {
         }
     }
 
+    func assertFails<T>(_ expectedError: Swift.Error, _ message: String? = nil,
+                     fileName: StaticString = #file, lineNumber: UInt = #line,
+                     block: () throws -> T) {
+        do {
+            _ = try block()
+            XCTFail("Expected to catch <\(expectedError)>, but no error was thrown.",
+                file: fileName, line: lineNumber)
+        } catch let e where e._code == expectedError._code {
+            // Success!
+        } catch {
+            XCTFail("Expected to catch <\(expectedError)>, but instead caught <\(error)>.",
+                file: fileName, line: lineNumber)
+        }
+    }
+
     func assertNil<T>(block: @autoclosure() -> T?, _ message: String? = nil,
                       fileName: StaticString = #file, lineNumber: UInt = #line) {
         XCTAssert(block() == nil, message ?? "", file: fileName, line: lineNumber)


### PR DESCRIPTION
Fixes #4120 /cc @austinzheng 