### PR TITLE
Improve object server test suite

### DIFF
--- a/RLMSyncManager+ObjectServerTests.h
+++ b/RLMSyncManager+ObjectServerTests.h
@@ -16,20 +16,10 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-#import <Foundation/Foundation.h>
+#import "RLMSyncManager.h"
 
-@class RLMSyncUser;
+@interface RLMSyncManager (ObjectServerTests)
 
-@interface RLMSyncFileManager : NSObject
-
-NS_ASSUME_NONNULL_BEGIN
-
-- (instancetype)initWithRootDirectory:(NSURL *)rootDirectory;
-
-- (NSURL *)fileURLForRawRealmURL:(NSURL *)url user:(RLMSyncUser *)user;
-- (NSURL *)fileURLForMetadata;
-- (BOOL)removeFilesForUserIdentity:(NSString *)identity error:(NSError * _Nullable* _Nullable)error;
-
-NS_ASSUME_NONNULL_END
+- (void)prepareForDestruction;
 
 @end

--- a/RLMSyncManager+ObjectServerTests.m
+++ b/RLMSyncManager+ObjectServerTests.m
@@ -1,0 +1,76 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2016 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+#import "RLMSyncManager+ObjectServerTests.h"
+#import "RLMSyncTestCase.h"
+#import "RLMSyncFileManager.h"
+
+#import <objc/runtime.h>
+
+@interface RLMSyncManager ()
+- (NSMutableDictionary<NSString *, RLMSyncUser *> *)activeUsers;
+- (RLMSyncFileManager *)fileManager;
+@end
+
+@implementation RLMSyncManager (ObjectServerTests)
+
++ (void)load {
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        Class class = object_getClass((id)self);
+        SEL originalSelector = @selector(sharedManager);
+        SEL swizzledSelector = @selector(ost_sharedManager);
+        Method originalMethod = class_getClassMethod(class, originalSelector);
+        Method swizzledMethod = class_getClassMethod(class, swizzledSelector);
+
+        if (class_addMethod(class,
+                            originalSelector,
+                            method_getImplementation(swizzledMethod),
+                            method_getTypeEncoding(swizzledMethod))) {
+            class_replaceMethod(class,
+                                swizzledSelector,
+                                method_getImplementation(originalMethod),
+                                method_getTypeEncoding(originalMethod));
+        } else {
+            method_exchangeImplementations(originalMethod, swizzledMethod);
+        }
+    });
+}
+
++ (instancetype)ost_sharedManager {
+    return [RLMSyncTestCase managerForCurrentTest];
+}
+
+- (void)prepareForDestruction {
+    // Log out all the logged-in users. This will immediately kill any open sessions.
+    NSMutableArray<RLMSyncUser *> *buffer = [NSMutableArray array];
+    for (id key in [self activeUsers]) {
+        [buffer addObject:[self activeUsers][key]];
+    }
+    [[[self activeUsers] allValues] makeObjectsPerformSelector:@selector(logOut)];
+    NSURL *metadataURL = [self.fileManager fileURLForMetadata];
+
+    // Destroy the metadata Realm.
+    // FIXME: replace this with the appropriate call to `[RLMSyncFileManager deleteRealmAtPath:]` once that code is in.
+    NSFileManager *manager = [NSFileManager defaultManager];
+    [manager removeItemAtURL:metadataURL error:nil];
+    [manager removeItemAtURL:[metadataURL URLByAppendingPathExtension:@"lock"] error:nil];
+    [manager removeItemAtURL:[metadataURL URLByAppendingPathExtension:@"management"] error:nil];
+}
+
+@end

--- a/Realm.xcodeproj/project.pbxproj
+++ b/Realm.xcodeproj/project.pbxproj
@@ -109,6 +109,8 @@
 		1A8B51971D74B9BB00AE7923 /* sync_metadata.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 1A8B51951D74B9BB00AE7923 /* sync_metadata.hpp */; };
 		1A90FCBB1D3D37F50086A57F /* RLMSyncManager.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1AF7EA951D340AF70001A9B5 /* RLMSyncManager.mm */; };
 		1A90FCBC1D3D37F70086A57F /* RLMNetworkClient.m in Sources */ = {isa = PBXBuildFile; fileRef = 1AF7EA9A1D340E700001A9B5 /* RLMNetworkClient.m */; };
+		1A9428DC1D9C8BE900A74ED2 /* RLMSyncManager+ObjectServerTests.h in Headers */ = {isa = PBXBuildFile; fileRef = 1A9428DA1D9C8BE900A74ED2 /* RLMSyncManager+ObjectServerTests.h */; };
+		1A9428DE1D9C8BF800A74ED2 /* RLMSyncManager+ObjectServerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 1A9428DB1D9C8BE900A74ED2 /* RLMSyncManager+ObjectServerTests.m */; };
 		1AA5AE981D989BE400ED8C27 /* SwiftSyncTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AA5AE961D989BE000ED8C27 /* SwiftSyncTestCase.swift */; };
 		1AA5AE9C1D98A68E00ED8C27 /* RLMSyncTestCase.m in Sources */ = {isa = PBXBuildFile; fileRef = 1AA5AE9B1D98A68E00ED8C27 /* RLMSyncTestCase.m */; };
 		1AA5AEA11D98C99800ED8C27 /* SwiftObjectServerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AA5AE9F1D98C99500ED8C27 /* SwiftObjectServerTests.swift */; };
@@ -654,6 +656,8 @@
 		1A8413351D4C0B5B00C5326F /* RLMSyncUser_Private.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = RLMSyncUser_Private.hpp; sourceTree = "<group>"; };
 		1A8B51941D74B9BB00AE7923 /* sync_metadata.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = sync_metadata.cpp; sourceTree = "<group>"; };
 		1A8B51951D74B9BB00AE7923 /* sync_metadata.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = sync_metadata.hpp; sourceTree = "<group>"; };
+		1A9428DA1D9C8BE900A74ED2 /* RLMSyncManager+ObjectServerTests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "RLMSyncManager+ObjectServerTests.h"; sourceTree = "<group>"; };
+		1A9428DB1D9C8BE900A74ED2 /* RLMSyncManager+ObjectServerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "RLMSyncManager+ObjectServerTests.m"; sourceTree = "<group>"; };
 		1AA5AE961D989BE000ED8C27 /* SwiftSyncTestCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; name = SwiftSyncTestCase.swift; path = Realm/ObjectServerTests/SwiftSyncTestCase.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		1AA5AE9A1D98A1B000ED8C27 /* Object-Server-Tests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "Object-Server-Tests-Bridging-Header.h"; path = "Realm/ObjectServerTests/Object-Server-Tests-Bridging-Header.h"; sourceTree = "<group>"; };
 		1AA5AE9B1D98A68E00ED8C27 /* RLMSyncTestCase.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RLMSyncTestCase.m; path = Realm/ObjectServerTests/RLMSyncTestCase.m; sourceTree = "<group>"; };
@@ -1008,6 +1012,8 @@
 				1AA5AE9A1D98A1B000ED8C27 /* Object-Server-Tests-Bridging-Header.h */,
 				1AF2F7A41D95E44F0063A138 /* RLMSyncUser+ObjectServerTests.h */,
 				1AF2F7A51D95E44F0063A138 /* RLMSyncUser+ObjectServerTests.mm */,
+				1A9428DA1D9C8BE900A74ED2 /* RLMSyncManager+ObjectServerTests.h */,
+				1A9428DB1D9C8BE900A74ED2 /* RLMSyncManager+ObjectServerTests.m */,
 			);
 			name = Utility;
 			sourceTree = "<group>";
@@ -1498,6 +1504,7 @@
 				3F9863BD1D36876B00641C98 /* RLMClassInfo.hpp in Headers */,
 				5D659EAB1BE04556006515A0 /* RLMCollection.h in Headers */,
 				3FBEF67A1C63D66100F6935B /* RLMCollection_Private.hpp in Headers */,
+				1A9428DC1D9C8BE900A74ED2 /* RLMSyncManager+ObjectServerTests.h in Headers */,
 				5D659EAC1BE04556006515A0 /* RLMConstants.h in Headers */,
 				5D659EAE1BE04556006515A0 /* RLMListBase.h in Headers */,
 				1AF6EA471D36B1850014EB85 /* RLMAuthResponseModel.h in Headers */,
@@ -2327,6 +2334,7 @@
 				1AA5AEA11D98C99800ED8C27 /* SwiftObjectServerTests.swift in Sources */,
 				1AF2F7A81D95E47B0063A138 /* RLMSyncUser+ObjectServerTests.mm in Sources */,
 				1AA5AE981D989BE400ED8C27 /* SwiftSyncTestCase.swift in Sources */,
+				1A9428DE1D9C8BF800A74ED2 /* RLMSyncManager+ObjectServerTests.m in Sources */,
 				1AF2F7A31D95DBC70063A138 /* RLMMultiProcessTestCase.m in Sources */,
 				E86E61241D91E4E200DC2419 /* RLMTestCase.m in Sources */,
 				1AA5AE9C1D98A68E00ED8C27 /* RLMSyncTestCase.m in Sources */,

--- a/Realm/ObjectServerTests/RLMObjectServerTests.m
+++ b/Realm/ObjectServerTests/RLMObjectServerTests.m
@@ -50,6 +50,8 @@ static NSURL *makeRealmURL(const char *function, NSString *identifier) {
                                                     server:[RLMSyncTestCase authServerURL]];
     // Logging in with equivalent credentials should return the same user object instance.
     XCTAssertEqual(firstUser, secondUser);
+    // Authentication server property should be properly set.
+    XCTAssertEqualObjects(firstUser.authenticationServer, [RLMSyncTestCase authServerURL]);
 
     // Trying to "create" a username/password account that already exists should cause an error.
     XCTestExpectation *expectation = [self expectationWithDescription:@""];
@@ -89,7 +91,7 @@ static NSURL *makeRealmURL(const char *function, NSString *identifier) {
     XCTAssertTrue([[RLMSyncUser all] containsObject:user]);
 }
 
-#pragma mark - Sync
+#pragma mark - Basic Sync
 
 /// It should be possible to successfully open a Realm configured for sync with an access token.
 - (void)testOpenRealmWithAdminToken {
@@ -102,10 +104,8 @@ static NSURL *makeRealmURL(const char *function, NSString *identifier) {
     XCTAssertNotNil(credential);
     RLMSyncUser *user = [self logInUserForCredential:credential
                                               server:[RLMObjectServerTests authServerURL]];
-    NSError *error = nil;
     NSURL *url = [NSURL URLWithString:@"realm://localhost:9080/testSyncWithAdminToken"];
-    RLMRealm *realm = [self openRealmForURL:url user:user error:&error];
-    XCTAssertNil(error);
+    RLMRealm *realm = [self openRealmForURL:url user:user];
     XCTAssertTrue(realm.isEmpty);
 }
 
@@ -113,10 +113,8 @@ static NSURL *makeRealmURL(const char *function, NSString *identifier) {
 - (void)testOpenRealmWithNormalCredential {
     RLMSyncUser *user = [self logInUserForCredential:[RLMObjectServerTests basicCredential:YES]
                                               server:[RLMObjectServerTests authServerURL]];
-    NSError *error = nil;
     NSURL *url = REALM_URL();
-    RLMRealm *realm = [self openRealmForURL:url user:user error:&error];
-    XCTAssertNil(error);
+    RLMRealm *realm = [self openRealmForURL:url user:user];
     XCTAssertTrue(realm.isEmpty);
 }
 
@@ -125,23 +123,17 @@ static NSURL *makeRealmURL(const char *function, NSString *identifier) {
     NSURL *url = REALM_URL();
     RLMSyncUser *user = [self logInUserForCredential:[RLMObjectServerTests basicCredential:self.isParent]
                                               server:[RLMObjectServerTests authServerURL]];
-    NSError *error = nil;
-    RLMRealm *r = [self openRealmForURL:url user:user error:&error];
-    XCTAssertNil(error, @"Error when opening Realm: %@", error);
+    RLMRealm *r = [self openRealmForURL:url user:user];
     if (self.isParent) {
-        [user waitForDownloadToFinish:url];
+        WAIT_FOR_DOWNLOAD(user, url);
         CHECK_COUNT(0, SyncObject, r);
         RLMRunChildAndWait();
-        [user waitForDownloadToFinish:url];
+        WAIT_FOR_DOWNLOAD(user, url);
         CHECK_COUNT(3, SyncObject, r);
     } else {
         // Add objects.
-        [r beginWriteTransaction];
-        [r addObject:[[SyncObject alloc] initWithValue:@[@"child-1"]]];
-        [r addObject:[[SyncObject alloc] initWithValue:@[@"child-2"]]];
-        [r addObject:[[SyncObject alloc] initWithValue:@[@"child-3"]]];
-        [r commitWriteTransaction];
-        [user waitForUploadToFinish:url];
+        [self addSyncObjectsToRealm:r descriptions:@[@"child-1", @"child-2", @"child-3"]];
+        WAIT_FOR_UPLOAD(user, url);
         CHECK_COUNT(3, SyncObject, r);
     }
 }
@@ -151,32 +143,148 @@ static NSURL *makeRealmURL(const char *function, NSString *identifier) {
     NSURL *url = REALM_URL();
     RLMSyncUser *user = [self logInUserForCredential:[RLMObjectServerTests basicCredential:self.isParent]
                                               server:[RLMObjectServerTests authServerURL]];
-    NSError *error = nil;
-    RLMRealm *r = [self openRealmForURL:url user:user error:&error];
-    XCTAssertNil(error, @"Error when opening Realm: %@", error);
+    RLMRealm *r = [self openRealmForURL:url user:user];
     if (self.isParent) {
-        [user waitForDownloadToFinish:url];
+        WAIT_FOR_DOWNLOAD(user, url);
         // Add objects.
-        [r beginWriteTransaction];
-        [r addObject:[[SyncObject alloc] initWithValue:@[@"parent-1"]]];
-        [r addObject:[[SyncObject alloc] initWithValue:@[@"parent-2"]]];
-        [r addObject:[[SyncObject alloc] initWithValue:@[@"parent-3"]]];
-        [r commitWriteTransaction];
-        [user waitForUploadToFinish:url];
+        [self addSyncObjectsToRealm:r descriptions:@[@"parent-1", @"parent-2", @"parent-3"]];
+        WAIT_FOR_UPLOAD(user, url);
         CHECK_COUNT(3, SyncObject, r);
         RLMRunChildAndWait();
-        [user waitForDownloadToFinish:url];
+        WAIT_FOR_DOWNLOAD(user, url);
         CHECK_COUNT(0, SyncObject, r);
     } else {
-        [user waitForDownloadToFinish:url];
+        WAIT_FOR_DOWNLOAD(user, url);
         CHECK_COUNT(3, SyncObject, r);
         [r beginWriteTransaction];
         [r deleteAllObjects];
         [r commitWriteTransaction];
-        [user waitForUploadToFinish:url];
+        WAIT_FOR_UPLOAD(user, url);
         CHECK_COUNT(0, SyncObject, r);
     }
 }
+
+#pragma mark - Multiple Realm Sync
+
+/// If a client opens multiple Realms, there should be one session object for each Realm that was opened.
+- (void)testMultipleRealmsSessions {
+    NSURL *urlA = CUSTOM_REALM_URL(@"a");
+    NSURL *urlB = CUSTOM_REALM_URL(@"b");
+    NSURL *urlC = CUSTOM_REALM_URL(@"c");
+    RLMSyncUser *user = [self logInUserForCredential:[RLMObjectServerTests basicCredential:self.isParent]
+                                              server:[RLMObjectServerTests authServerURL]];
+    // Open three Realms.
+    __unused RLMRealm *realmA = [self openRealmForURL:urlA user:user];
+    __unused RLMRealm *realmB = [self openRealmForURL:urlB user:user];
+    __unused RLMRealm *realmC = [self openRealmForURL:urlC user:user];
+    // Make sure there are three active sessions for the user.
+    XCTAssert(user.allSessions.count == 3, @"Expected 3 sessions, but didn't get 3 sessions");
+    XCTAssertNotNil([user sessionForURL:urlA], @"Expected to get a session for URL A");
+    XCTAssertNotNil([user sessionForURL:urlB], @"Expected to get a session for URL B");
+    XCTAssertNotNil([user sessionForURL:urlC], @"Expected to get a session for URL C");
+    XCTAssertTrue([user sessionForURL:urlA].state == RLMSyncSessionStateActive, @"Expected active session for URL A");
+    XCTAssertTrue([user sessionForURL:urlB].state == RLMSyncSessionStateActive, @"Expected active session for URL B");
+    XCTAssertTrue([user sessionForURL:urlC].state == RLMSyncSessionStateActive, @"Expected active session for URL C");
+}
+
+/// A client should be able to open multiple Realms and add objects to each of them.
+- (void)testMultipleRealmsAddObjects {
+    NSURL *urlA = CUSTOM_REALM_URL(@"a");
+    NSURL *urlB = CUSTOM_REALM_URL(@"b");
+    NSURL *urlC = CUSTOM_REALM_URL(@"c");
+    RLMSyncUser *user = [self logInUserForCredential:[RLMObjectServerTests basicCredential:self.isParent]
+                                              server:[RLMObjectServerTests authServerURL]];
+    RLMRealm *realmA = [self openRealmForURL:urlA user:user];
+    RLMRealm *realmB = [self openRealmForURL:urlB user:user];
+    RLMRealm *realmC = [self openRealmForURL:urlC user:user];
+    if (self.isParent) {
+        WAIT_FOR_DOWNLOAD(user, urlA);
+        WAIT_FOR_DOWNLOAD(user, urlC);
+        WAIT_FOR_DOWNLOAD(user, urlB);
+        CHECK_COUNT(0, SyncObject, realmA);
+        CHECK_COUNT(0, SyncObject, realmB);
+        CHECK_COUNT(0, SyncObject, realmC);
+        RLMRunChildAndWait();
+        [self waitForDownloadsForUser:user
+                               realms:@[realmA, realmB, realmC]
+                            realmURLs:@[urlA, urlB, urlC]
+                       expectedCounts:@[@3, @2, @5]];
+    } else {
+        // Add objects.
+        [self addSyncObjectsToRealm:realmA
+                       descriptions:@[@"child-A1", @"child-A2", @"child-A3"]];
+        [self addSyncObjectsToRealm:realmB
+                       descriptions:@[@"child-B1", @"child-B2"]];
+        [self addSyncObjectsToRealm:realmC
+                       descriptions:@[@"child-C1", @"child-C2", @"child-C3", @"child-C4", @"child-C5"]];
+        WAIT_FOR_UPLOAD(user, urlA);
+        WAIT_FOR_UPLOAD(user, urlB);
+        WAIT_FOR_UPLOAD(user, urlC);
+        CHECK_COUNT(3, SyncObject, realmA);
+        CHECK_COUNT(2, SyncObject, realmB);
+        CHECK_COUNT(5, SyncObject, realmC);
+    }
+}
+
+/// A client should be able to open multiple Realms and delete objects from each of them.
+- (void)testMultipleRealmsRemoveObjects {
+    NSURL *urlA = CUSTOM_REALM_URL(@"a");
+    NSURL *urlB = CUSTOM_REALM_URL(@"b");
+    NSURL *urlC = CUSTOM_REALM_URL(@"c");
+    RLMSyncUser *user = [self logInUserForCredential:[RLMObjectServerTests basicCredential:self.isParent]
+                                              server:[RLMObjectServerTests authServerURL]];
+    RLMRealm *realmA = [self openRealmForURL:urlA user:user];
+    RLMRealm *realmB = [self openRealmForURL:urlB user:user];
+    RLMRealm *realmC = [self openRealmForURL:urlC user:user];
+    if (self.isParent) {
+        WAIT_FOR_DOWNLOAD(user, urlA);
+        WAIT_FOR_DOWNLOAD(user, urlB);
+        WAIT_FOR_DOWNLOAD(user, urlC);
+        // Add objects.
+        [self addSyncObjectsToRealm:realmA
+                       descriptions:@[@"parent-A1", @"parent-A2", @"parent-A3", @"parent-A4"]];
+        [self addSyncObjectsToRealm:realmB
+                       descriptions:@[@"parent-B1", @"parent-B2", @"parent-B3", @"parent-B4", @"parent-B5"]];
+        [self addSyncObjectsToRealm:realmC
+                       descriptions:@[@"parent-C1", @"parent-C2"]];
+        WAIT_FOR_UPLOAD(user, urlA);
+        WAIT_FOR_UPLOAD(user, urlB);
+        WAIT_FOR_UPLOAD(user, urlC);
+        CHECK_COUNT(4, SyncObject, realmA);
+        CHECK_COUNT(5, SyncObject, realmB);
+        CHECK_COUNT(2, SyncObject, realmC);
+        RLMRunChildAndWait();
+        [self waitForDownloadsForUser:user
+                               realms:@[realmA, realmB, realmC]
+                            realmURLs:@[urlA, urlB, urlC]
+                       expectedCounts:@[@0, @0, @0]];
+    } else {
+        // Delete all the objects from the Realms.
+        WAIT_FOR_DOWNLOAD(user, urlA);
+        WAIT_FOR_DOWNLOAD(user, urlB);
+        WAIT_FOR_DOWNLOAD(user, urlC);
+        CHECK_COUNT(4, SyncObject, realmA);
+        CHECK_COUNT(5, SyncObject, realmB);
+        CHECK_COUNT(2, SyncObject, realmC);
+        [realmA beginWriteTransaction];
+        [realmA deleteAllObjects];
+        [realmA commitWriteTransaction];
+        [realmB beginWriteTransaction];
+        [realmB deleteAllObjects];
+        [realmB commitWriteTransaction];
+        [realmC beginWriteTransaction];
+        [realmC deleteAllObjects];
+        [realmC commitWriteTransaction];
+        WAIT_FOR_UPLOAD(user, urlA);
+        WAIT_FOR_UPLOAD(user, urlB);
+        WAIT_FOR_UPLOAD(user, urlC);
+        CHECK_COUNT(0, SyncObject, realmA);
+        CHECK_COUNT(0, SyncObject, realmB);
+        CHECK_COUNT(0, SyncObject, realmC);
+    }
+}
+
+#pragma mark - Session Lifetime
 
 /// When a session opened by a Realm goes out of scope, it should stay alive long enough to finish any waiting uploads.
 - (void)testUploadChangesWhenRealmOutOfScope {
@@ -185,14 +293,11 @@ static NSURL *makeRealmURL(const char *function, NSString *identifier) {
     // Log in the user.
     RLMSyncUser *user = [self logInUserForCredential:[RLMObjectServerTests basicCredential:self.isParent]
                                               server:[RLMObjectServerTests authServerURL]];
-    // Open the Realm
-    NSError *error = nil;
 
     if (self.isParent) {
         // Open the Realm in an autorelease pool so that it is destroyed as soon as possible.
         @autoreleasepool {
-            RLMRealm *r = [self openRealmForURL:url user:user error:&error];
-            XCTAssertNil(error, @"Error when opening Realm: %@", error);
+            RLMRealm *r = [self openRealmForURL:url user:user];
             [r beginWriteTransaction];
             for (NSInteger i=0; i<OBJECT_COUNT; i++) {
                 [r addObject:[[SyncObject alloc] initWithValue:@[[NSString stringWithFormat:@"parent-%@", @(i+1)]]]];
@@ -204,13 +309,39 @@ static NSURL *makeRealmURL(const char *function, NSString *identifier) {
         usleep(50000);
         RLMRunChildAndWait();
     } else {
-        RLMRealm *r = [self openRealmForURL:url user:user error:&error];
-        XCTAssertNil(error, @"Error when opening Realm: %@", error);
+        RLMRealm *r = [self openRealmForURL:url user:user];
         // Wait for download to complete.
-        [user waitForDownloadToFinish:url];
+        WAIT_FOR_DOWNLOAD(user, url);
         CHECK_COUNT(OBJECT_COUNT, SyncObject, r);
     }
 }
+
+/// If a client logs out, the session should be immediately terminated.
+- (void)testImmediateSessionTerminationWhenLoggingOut {
+    const NSInteger OBJECT_COUNT = 10000;
+    NSURL *url = [NSURL URLWithString:@"realm://localhost:9080/~/testBasicSync"];
+    // Log in the user.
+    RLMSyncUser *user = [self logInUserForCredential:[RLMObjectServerTests basicCredential:self.isParent]
+                                              server:[RLMObjectServerTests authServerURL]];
+    // Open the Realm
+    RLMRealm *r = [self openRealmForURL:url user:user];
+    if (self.isParent) {
+        [r beginWriteTransaction];
+        for (NSInteger i=0; i<OBJECT_COUNT; i++) {
+            [r addObject:[[SyncObject alloc] initWithValue:@[[NSString stringWithFormat:@"parent-%@", @(i+1)]]]];
+        }
+        [r commitWriteTransaction];
+        [user logOut];
+        CHECK_COUNT(OBJECT_COUNT, SyncObject, r);
+        usleep(50000);
+        RLMRunChildAndWait();
+    } else {
+        WAIT_FOR_DOWNLOAD(user, url);
+        CHECK_COUNT(0, SyncObject, r);
+    }
+}
+
+#pragma mark - Logging Back In
 
 /// A Realm that was opened before a user logged out should be able to resume uploading if the user logs back in.
 - (void)testLogBackInSameRealmUpload {
@@ -218,16 +349,12 @@ static NSURL *makeRealmURL(const char *function, NSString *identifier) {
     // Log in the user.
     RLMSyncUser *user = [self logInUserForCredential:[RLMObjectServerTests basicCredential:self.isParent]
                                               server:[RLMObjectServerTests authServerURL]];
-    NSError *error = nil;
-    RLMRealm *r = [self openRealmForURL:url user:user error:&error];
-    XCTAssertNil(error, @"Error when opening Realm: %@", error);
+    RLMRealm *r = [self openRealmForURL:url user:user];
 
     if (self.isParent) {
-        [r beginWriteTransaction];
-        [r addObject:[[SyncObject alloc] initWithValue:@[@"parent-1"]]];
-        [r commitWriteTransaction];
+        [self addSyncObjectsToRealm:r descriptions:@[@"parent-1"]];
         CHECK_COUNT(1, SyncObject, r);
-        [user waitForUploadToFinish:url];
+        WAIT_FOR_UPLOAD(user, url);
         // Log out the user.
         [user logOut];
         // Log the user back in.
@@ -235,16 +362,13 @@ static NSURL *makeRealmURL(const char *function, NSString *identifier) {
                                      server:[RLMObjectServerTests authServerURL]];
         // Wait for the sessions to asynchronously rebind
         // FIXME: once new token system is in this will be unnecessary
-        sleep(1);
-        [r beginWriteTransaction];
-        [r addObject:[[SyncObject alloc] initWithValue:@[@"parent-2"]]];
-        [r addObject:[[SyncObject alloc] initWithValue:@[@"parent-3"]]];
-        [r commitWriteTransaction];
-        [user waitForUploadToFinish:url];
+        usleep(200000);
+        [self addSyncObjectsToRealm:r descriptions:@[@"parent-2", @"parent-3"]];
+        WAIT_FOR_UPLOAD(user, url);
         CHECK_COUNT(3, SyncObject, r);
         RLMRunChildAndWait();
     } else {
-        [user waitForDownloadToFinish:url];
+        WAIT_FOR_DOWNLOAD(user, url);
         CHECK_COUNT(3, SyncObject, r);
     }
 }
@@ -255,16 +379,12 @@ static NSURL *makeRealmURL(const char *function, NSString *identifier) {
     // Log in the user.
     RLMSyncUser *user = [self logInUserForCredential:[RLMObjectServerTests basicCredential:self.isParent]
                                               server:[RLMObjectServerTests authServerURL]];
-    NSError *error = nil;
-    RLMRealm *r = [self openRealmForURL:url user:user error:&error];
-    XCTAssertNil(error, @"Error when opening Realm: %@", error);
+    RLMRealm *r = [self openRealmForURL:url user:user];
 
     if (self.isParent) {
-        [r beginWriteTransaction];
-        [r addObject:[[SyncObject alloc] initWithValue:@[@"parent-1"]]];
-        [r commitWriteTransaction];
+        [self addSyncObjectsToRealm:r descriptions:@[@"parent-1"]];
         CHECK_COUNT(1, SyncObject, r);
-        [user waitForUploadToFinish:url];
+        WAIT_FOR_UPLOAD(user, url);
         // Log out the user.
         [user logOut];
         // Log the user back in.
@@ -272,17 +392,14 @@ static NSURL *makeRealmURL(const char *function, NSString *identifier) {
                                      server:[RLMObjectServerTests authServerURL]];
         // Wait for the sessions to asynchronously rebind
         // FIXME: once new token system is in this will be unnecessary
-        sleep(1);
-        RLMRunChildAndWait();;
-        [user waitForDownloadToFinish:url];
+        usleep(200000);
+        RLMRunChildAndWait();
+        WAIT_FOR_DOWNLOAD(user, url);
         CHECK_COUNT(3, SyncObject, r);
     } else {
-        [user waitForDownloadToFinish:url];
-        [r beginWriteTransaction];
-        [r addObject:[[SyncObject alloc] initWithValue:@[@"child-1"]]];
-        [r addObject:[[SyncObject alloc] initWithValue:@[@"child-2"]]];
-        [r commitWriteTransaction];
-        [user waitForUploadToFinish:url];
+        WAIT_FOR_DOWNLOAD(user, url);
+        [self addSyncObjectsToRealm:r descriptions:@[@"child-1", @"child-2"]];
+        WAIT_FOR_UPLOAD(user, url);
         CHECK_COUNT(3, SyncObject, r);
     }
 }
@@ -301,26 +418,21 @@ static NSURL *makeRealmURL(const char *function, NSString *identifier) {
         // Open a Realm after the user's been logged out.
         RLMRealm *r = [RLMRealm realmWithConfiguration:config error:&error];
         XCTAssertNil(error, @"Error when opening Realm: %@", error);
-        [r beginWriteTransaction];
-        [r addObject:[[SyncObject alloc] initWithValue:@[@"parent-1"]]];
-        [r commitWriteTransaction];
+        [self addSyncObjectsToRealm:r descriptions:@[@"parent-1"]];
         CHECK_COUNT(1, SyncObject, r);
         user = [self logInUserForCredential:[RLMObjectServerTests basicCredential:NO]
                                      server:[RLMObjectServerTests authServerURL]];
         // Wait for the sessions to asynchronously rebind
         // FIXME: once new token system is in this will be unnecessary
-        usleep(500000);
-        [r beginWriteTransaction];
-        [r addObject:[[SyncObject alloc] initWithValue:@[@"parent-2"]]];
-        [r addObject:[[SyncObject alloc] initWithValue:@[@"parent-3"]]];
-        [r commitWriteTransaction];
-        [user waitForUploadToFinish:url];
+        usleep(200000);
+        [self addSyncObjectsToRealm:r descriptions:@[@"parent-2", @"parent-3"]];
+        WAIT_FOR_UPLOAD(user, url);
         CHECK_COUNT(3, SyncObject, r);
         RLMRunChildAndWait();
     } else {
-        RLMRealm *r = [self openRealmForURL:url user:user error:&error];
+        RLMRealm *r = [self openRealmForURL:url user:user];
         XCTAssertNil(error, @"Error when opening Realm: %@", error);
-        [user waitForDownloadToFinish:url];
+        WAIT_FOR_DOWNLOAD(user, url);
         CHECK_COUNT(3, SyncObject, r);
     }
 }
@@ -340,31 +452,19 @@ static NSURL *makeRealmURL(const char *function, NSString *identifier) {
         // Open a Realm after the user's been logged out.
         RLMRealm *r = [RLMRealm realmWithConfiguration:config error:&error];
         XCTAssertNil(error, @"Error when opening Realm: %@", error);
-        [r beginWriteTransaction];
-        [r addObject:[[SyncObject alloc] initWithValue:@[@"parent-1"]]];
-        [r commitWriteTransaction];
+        [self addSyncObjectsToRealm:r descriptions:@[@"parent-1"]];
         CHECK_COUNT(1, SyncObject, r);
         user = [self logInUserForCredential:[RLMObjectServerTests basicCredential:NO]
                                      server:[RLMObjectServerTests authServerURL]];
         // Wait for the sessions to asynchronously rebind
         // FIXME: once new token system is in this will be unnecessary
-        usleep(500000);
-        [user waitForDownloadToFinish:url];
-        XCTestExpectation *checkCountExpectation = [self expectationWithDescription:@""];
-        dispatch_async(dispatch_get_main_queue(), ^{
-            CHECK_COUNT(4, SyncObject, r);
-            [checkCountExpectation fulfill];
-        });
-        [self waitForExpectationsWithTimeout:2.0 handler:nil];
+        usleep(200000);
+        [self waitForDownloadsForUser:user realms:@[r] realmURLs:@[url] expectedCounts:@[@4]];
     } else {
-        RLMRealm *r = [self openRealmForURL:url user:user error:&error];
+        RLMRealm *r = [self openRealmForURL:url user:user];
         XCTAssertNil(error, @"Error when opening Realm: %@", error);
-        [r beginWriteTransaction];
-        [r addObject:[[SyncObject alloc] initWithValue:@[@"child-1"]]];
-        [r addObject:[[SyncObject alloc] initWithValue:@[@"child-2"]]];
-        [r addObject:[[SyncObject alloc] initWithValue:@[@"child-3"]]];
-        [r commitWriteTransaction];
-        [user waitForUploadToFinish:url];
+        [self addSyncObjectsToRealm:r descriptions:@[@"child-1", @"child-2", @"child-3"]];
+        WAIT_FOR_UPLOAD(user, url);
         CHECK_COUNT(3, SyncObject, r);
     }
 }
@@ -377,7 +477,6 @@ static NSURL *makeRealmURL(const char *function, NSString *identifier) {
                                               server:[RLMObjectServerTests authServerURL]];
 
     // Now run a basic multi-client test.
-    NSError *error = nil;
     if (self.isParent) {
         // Log out the user.
         [user logOut];
@@ -385,20 +484,15 @@ static NSURL *makeRealmURL(const char *function, NSString *identifier) {
         user = [self logInUserForCredential:[RLMObjectServerTests basicCredential:NO]
                                      server:[RLMObjectServerTests authServerURL]];
         // Open the Realm (for the first time).
-        RLMRealm *r = [self openRealmForURL:url user:user error:&error];
-        XCTAssertNil(error, @"Error when opening Realm: %@", error);
-        [r beginWriteTransaction];
-        [r addObject:[[SyncObject alloc] initWithValue:@[@"child-1"]]];
-        [r addObject:[[SyncObject alloc] initWithValue:@[@"child-2"]]];
-        [r commitWriteTransaction];
-        [user waitForUploadToFinish:url];
+        RLMRealm *r = [self openRealmForURL:url user:user];
+        [self addSyncObjectsToRealm:r descriptions:@[@"child-1", @"child-2"]];
+        WAIT_FOR_UPLOAD(user, url);
         CHECK_COUNT(2, SyncObject, r);
         RLMRunChildAndWait();
     } else {
-        RLMRealm *r = [self openRealmForURL:url user:user error:&error];
-        XCTAssertNil(error, @"Error when opening Realm: %@", error);
+        RLMRealm *r = [self openRealmForURL:url user:user];
         // Add objects.
-        [user waitForDownloadToFinish:url];
+        WAIT_FOR_DOWNLOAD(user, url);
         CHECK_COUNT(2, SyncObject, r);
     }
 }
@@ -411,7 +505,6 @@ static NSURL *makeRealmURL(const char *function, NSString *identifier) {
                                               server:[RLMObjectServerTests authServerURL]];
 
     // Now run a basic multi-client test.
-    NSError *error = nil;
     if (self.isParent) {
         // Log out the user.
         [user logOut];
@@ -420,24 +513,19 @@ static NSURL *makeRealmURL(const char *function, NSString *identifier) {
                                      server:[RLMObjectServerTests authServerURL]];
         // Allow for asynchronous binding work.
         // FIXME: remove this once we get the new token system
-        usleep(500000);
+        usleep(200000);
         // Open the Realm (for the first time).
-        RLMRealm *r = [self openRealmForURL:url user:user error:&error];
-        XCTAssertNil(error, @"Error when opening Realm: %@", error);
+        RLMRealm *r = [self openRealmForURL:url user:user];
         // Run the sub-test.
         RLMRunChildAndWait();
-        [user waitForDownloadToFinish:url];
+        WAIT_FOR_DOWNLOAD(user, url);
         CHECK_COUNT(2, SyncObject, r);
     } else {
-        RLMRealm *r = [self openRealmForURL:url user:user error:&error];
-        XCTAssertNil(error, @"Error when opening Realm: %@", error);
+        RLMRealm *r = [self openRealmForURL:url user:user];
         // Add objects.
-        [user waitForDownloadToFinish:url];
-        [r beginWriteTransaction];
-        [r addObject:[[SyncObject alloc] initWithValue:@[@"child-1"]]];
-        [r addObject:[[SyncObject alloc] initWithValue:@[@"child-2"]]];
-        [r commitWriteTransaction];
-        [user waitForUploadToFinish:url];
+        WAIT_FOR_DOWNLOAD(user, url);
+        [self addSyncObjectsToRealm:r descriptions:@[@"child-1", @"child-2"]];
+        WAIT_FOR_UPLOAD(user, url);
         CHECK_COUNT(2, SyncObject, r);
     }
 }
@@ -450,14 +538,10 @@ static NSURL *makeRealmURL(const char *function, NSString *identifier) {
     RLMSyncUser *user = [self logInUserForCredential:[RLMObjectServerTests basicCredential:self.isParent]
                                               server:[RLMObjectServerTests authServerURL]];
     // Open the Realm
-    NSError *error = nil;
-    RLMRealm *r = [self openRealmForURL:url user:user error:&error];
-    XCTAssertNil(error, @"Error when opening Realm: %@", error);
+    RLMRealm *r = [self openRealmForURL:url user:user];
     if (self.isParent) {
-        [r beginWriteTransaction];
-        [r addObject:[[SyncObject alloc] initWithValue:@[@"parent-1"]]];
-        [r commitWriteTransaction];
-        [user waitForUploadToFinish:url];
+        [self addSyncObjectsToRealm:r descriptions:@[@"parent-1"]];
+        WAIT_FOR_UPLOAD(user, url);
         CHECK_COUNT(1, SyncObject, r);
         // Log out the user.
         [user logOut];
@@ -465,20 +549,15 @@ static NSURL *makeRealmURL(const char *function, NSString *identifier) {
         user = [self logInUserForCredential:[RLMObjectServerTests basicCredential:NO]
                                      server:[RLMObjectServerTests authServerURL]];
         // Give the sessions time to asynchronously re-bind.
-        sleep(1);
+        usleep(200000);
         // Open the Realm again.
-        r = [self immediatelyOpenRealmForURL:url user:user error:nil];
-        [r beginWriteTransaction];
-        [r addObject:[[SyncObject alloc] initWithValue:@[@"child-1"]]];
-        [r addObject:[[SyncObject alloc] initWithValue:@[@"child-2"]]];
-        [r addObject:[[SyncObject alloc] initWithValue:@[@"child-3"]]];
-        [r addObject:[[SyncObject alloc] initWithValue:@[@"child-4"]]];
-        [r commitWriteTransaction];
+        r = [self immediatelyOpenRealmForURL:url user:user];
+        [self addSyncObjectsToRealm:r descriptions:@[@"child-1", @"child-2", @"child-3", @"child-4"]];
         CHECK_COUNT(5, SyncObject, r);
-        [user waitForUploadToFinish:url];
+        WAIT_FOR_UPLOAD(user, url);
         RLMRunChildAndWait();
     } else {
-        [user waitForDownloadToFinish:url];
+        WAIT_FOR_DOWNLOAD(user, url);
         CHECK_COUNT(5, SyncObject, r);
     }
 }
@@ -491,14 +570,10 @@ static NSURL *makeRealmURL(const char *function, NSString *identifier) {
     RLMSyncUser *user = [self logInUserForCredential:[RLMObjectServerTests basicCredential:self.isParent]
                                               server:[RLMObjectServerTests authServerURL]];
     // Open the Realm
-    NSError *error = nil;
-    RLMRealm *r = [self openRealmForURL:url user:user error:&error];
-    XCTAssertNil(error, @"Error when opening Realm: %@", error);
+    RLMRealm *r = [self openRealmForURL:url user:user];
     if (self.isParent) {
-        [r beginWriteTransaction];
-        [r addObject:[[SyncObject alloc] initWithValue:@[@"parent-1"]]];
-        [r commitWriteTransaction];
-        [user waitForUploadToFinish:url];
+        [self addSyncObjectsToRealm:r descriptions:@[@"parent-1"]];
+        WAIT_FOR_UPLOAD(user, url);
         XCTAssert([SyncObject allObjectsInRealm:r].count == 1, @"Expected 1 item");
         // Log out the user.
         [user logOut];
@@ -507,55 +582,16 @@ static NSURL *makeRealmURL(const char *function, NSString *identifier) {
                                      server:[RLMObjectServerTests authServerURL]];
         // Run the sub-test.
         RLMRunChildAndWait();
-        // Open the Realm again.
-        r = [self immediatelyOpenRealmForURL:url user:user error:nil];
-        [user waitForDownloadToFinish:url];
-        // Dispatch async since Realm notifiers depend on their runloop being able to run.
-        XCTestExpectation *checkCountExpectation = [self expectationWithDescription:@""];
-        dispatch_async(dispatch_get_main_queue(), ^{
-            CHECK_COUNT(5, SyncObject, r);
-            [checkCountExpectation fulfill];
-        });
-        [self waitForExpectationsWithTimeout:2.0 handler:nil];
+        // Open the Realm again and get the items.
+        r = [self immediatelyOpenRealmForURL:url user:user];
+        [self waitForDownloadsForUser:user realms:@[r] realmURLs:@[url] expectedCounts:@[@5]];
     } else {
         // Add objects.
-        [user waitForDownloadToFinish:url];
+        WAIT_FOR_DOWNLOAD(user, url);
         CHECK_COUNT(1, SyncObject, r);
-        [r beginWriteTransaction];
-        [r addObject:[[SyncObject alloc] initWithValue:@[@"child-1"]]];
-        [r addObject:[[SyncObject alloc] initWithValue:@[@"child-2"]]];
-        [r addObject:[[SyncObject alloc] initWithValue:@[@"child-3"]]];
-        [r addObject:[[SyncObject alloc] initWithValue:@[@"child-4"]]];
-        [r commitWriteTransaction];
-        [user waitForUploadToFinish:url];
+        [self addSyncObjectsToRealm:r descriptions:@[@"child-1", @"child-2", @"child-3", @"child-4"]];
+        WAIT_FOR_UPLOAD(user, url);
         CHECK_COUNT(5, SyncObject, r);
-    }
-}
-
-/// If a client logs out, the session should be immediately terminated.
-- (void)testImmediateSessionTerminationWhenLoggingOut {
-    const NSInteger OBJECT_COUNT = 10000;
-    NSURL *url = REALM_URL();
-    // Log in the user.
-    RLMSyncUser *user = [self logInUserForCredential:[RLMObjectServerTests basicCredential:self.isParent]
-                                              server:[RLMObjectServerTests authServerURL]];
-    // Open the Realm
-    NSError *error = nil;
-    RLMRealm *r = [self openRealmForURL:url user:user error:&error];
-    XCTAssertNil(error, @"Error when opening Realm: %@", error);
-    if (self.isParent) {
-        [r beginWriteTransaction];
-        for (NSInteger i=0; i<OBJECT_COUNT; i++) {
-            [r addObject:[[SyncObject alloc] initWithValue:@[[NSString stringWithFormat:@"parent-%@", @(i+1)]]]];
-        }
-        [r commitWriteTransaction];
-        [user logOut];
-        CHECK_COUNT(OBJECT_COUNT, SyncObject, r);
-        usleep(50000);
-        RLMRunChildAndWait();
-    } else {
-        [user waitForDownloadToFinish:url];
-        CHECK_COUNT(0, SyncObject, r);
     }
 }
 

--- a/Realm/ObjectServerTests/RLMSyncTestCase.h
+++ b/Realm/ObjectServerTests/RLMSyncTestCase.h
@@ -18,6 +18,8 @@
 
 #import "RLMMultiProcessTestCase.h"
 
+#import "RLMSyncUser+ObjectServerTests.h"
+
 typedef void(^RLMSyncBasicErrorReportingBlock)(NSError * _Nullable);
 
 NS_ASSUME_NONNULL_BEGIN
@@ -41,22 +43,37 @@ NS_ASSUME_NONNULL_BEGIN
 + (RLMSyncCredential *)basicCredential:(BOOL)createAccount;
 
 /// Synchronously open a synced Realm and wait until the binding process has completed or failed.
-- (RLMRealm *)openRealmForURL:(NSURL *)url user:(RLMSyncUser *)user error:(NSError **)error;
+- (RLMRealm *)openRealmForURL:(NSURL *)url user:(RLMSyncUser *)user;
 
 /// Immediately open a synced Realm.
-- (RLMRealm *)immediatelyOpenRealmForURL:(NSURL *)url user:(RLMSyncUser *)user error:(NSError **)error;
+- (RLMRealm *)immediatelyOpenRealmForURL:(NSURL *)url user:(RLMSyncUser *)user;
 
 /// Synchronously create, log in, and return a user.
 - (RLMSyncUser *)logInUserForCredential:(RLMSyncCredential *)credential
                                  server:(NSURL *)url;
 
+/// Add a number of objects to a Realm.
+- (void)addSyncObjectsToRealm:(RLMRealm *)realm descriptions:(NSArray<NSString *> *)descriptions;
+
+/// Synchronously wait for downloads to complete for any number of Realms, and then check their `SyncObject` counts.
+- (void)waitForDownloadsForUser:(RLMSyncUser *)user
+                         realms:(NSArray<RLMRealm *> *)realms
+                      realmURLs:(NSArray<NSURL *> *)realmURLs
+                 expectedCounts:(NSArray<NSNumber *> *)counts;
+
 @end
 
 NS_ASSUME_NONNULL_END
 
+#define WAIT_FOR_UPLOAD(macro_user, macro_url) \
+XCTAssertTrue([macro_user waitForUploadToFinish:macro_url], @"Upload timed out for URL: %@", macro_url);
+
+#define WAIT_FOR_DOWNLOAD(macro_user, macro_url) \
+XCTAssertTrue([macro_user waitForDownloadToFinish:macro_url], @"Download timed out for URL: %@", macro_url);
+
 #define CHECK_COUNT(d_count, macro_object_type, macro_realm) \
 { \
-NSInteger c = [macro_object_type allObjectsInRealm:r].count; \
+NSInteger c = [macro_object_type allObjectsInRealm:macro_realm].count; \
 NSString *w = self.isParent ? @"parent" : @"child"; \
 XCTAssert(d_count == c, @"Expected %@ items, but actually got %@ (%@)", @(d_count), @(c), w); \
 }

--- a/Realm/ObjectServerTests/RLMSyncTestCase.h
+++ b/Realm/ObjectServerTests/RLMSyncTestCase.h
@@ -32,6 +32,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface RLMSyncTestCase : RLMMultiProcessTestCase
 
++ (RLMSyncManager *)managerForCurrentTest;
+
 + (NSURL *)rootRealmCocoaURL;
 
 + (NSURL *)authServerURL;

--- a/Realm/ObjectServerTests/RLMSyncTestCase.m
+++ b/Realm/ObjectServerTests/RLMSyncTestCase.m
@@ -81,27 +81,60 @@ static NSURL *syncDirectoryForChildProcess() {
                                                       : RLMAuthenticationActionsUseExistingAccount)];
 }
 
-- (RLMRealm *)openRealmForURL:(NSURL *)url user:(RLMSyncUser *)user error:(NSError **)error {
-    dispatch_semaphore_t handshake_sema = dispatch_semaphore_create(0);;
+- (void)addSyncObjectsToRealm:(RLMRealm *)realm descriptions:(NSArray<NSString *> *)descriptions {
+    [realm beginWriteTransaction];
+    for (NSString *desc in descriptions) {
+        [realm addObject:[[SyncObject alloc] initWithValue:@[desc]]];
+    }
+    [realm commitWriteTransaction];
+}
+
+- (void)waitForDownloadsForUser:(RLMSyncUser *)user
+                         realms:(NSArray<RLMRealm *> *)realms
+                      realmURLs:(NSArray<NSURL *> *)realmURLs
+                 expectedCounts:(NSArray<NSNumber *> *)counts {
+    NSAssert(realms.count == counts.count && realms.count == realmURLs.count,
+             @"Test logic error: all array arguments must be the same size.");
+    XCTestExpectation *checkCountExpectation = [self expectationWithDescription:@"Downloads should complete"];
+    for (NSUInteger i = 0; i < realms.count; i++) {
+        WAIT_FOR_DOWNLOAD(user, realmURLs[i]);
+    }
+    dispatch_async(dispatch_get_main_queue(), ^{
+        for (NSUInteger i = 0; i < realms.count; i++) {
+            CHECK_COUNT([counts[i] integerValue], SyncObject, realms[i]);
+        }
+        [checkCountExpectation fulfill];
+    });
+    [self waitForExpectationsWithTimeout:20.0 handler:nil];
+}
+
+- (RLMRealm *)openRealmForURL:(NSURL *)url user:(RLMSyncUser *)user {
+    NSError *error = nil;
+    const NSTimeInterval timeout = 4;
+    dispatch_semaphore_t sema = dispatch_semaphore_create(0);
     RLMSyncBasicErrorReportingBlock basicBlock = ^(NSError *error) {
         if (error) {
             XCTFail(@"Received an asynchronous error: %@ (process: %@)", error, self.isParent ? @"parent" : @"child");
         }
-        dispatch_semaphore_signal(handshake_sema);
+        dispatch_semaphore_signal(sema);
     };
     [[RLMSyncManager sharedManager] setSessionCompletionNotifier:basicBlock];
     RLMRealmConfiguration *c = [[RLMRealmConfiguration defaultConfiguration] copy];
-    c.syncConfiguration = [[RLMSyncConfiguration alloc] initWithUser:user realmURL:url];;
-    RLMRealm *r = [RLMRealm realmWithConfiguration:c error:error];
+    c.syncConfiguration = [[RLMSyncConfiguration alloc] initWithUser:user realmURL:url];
+    RLMRealm *r = [RLMRealm realmWithConfiguration:c error:&error];
     // Wait for login to succeed or fail.
-    dispatch_semaphore_wait(handshake_sema, DISPATCH_TIME_FOREVER);
+    XCTAssert(dispatch_semaphore_wait(sema, dispatch_time(DISPATCH_TIME_NOW, (int64_t)(timeout * NSEC_PER_SEC))) == 0,
+              @"Timed out while trying to asynchronously open Realm for URL: %@", url);
     return r;
 }
 
-- (RLMRealm *)immediatelyOpenRealmForURL:(NSURL *)url user:(RLMSyncUser *)user error:(NSError **)error {
+- (RLMRealm *)immediatelyOpenRealmForURL:(NSURL *)url user:(RLMSyncUser *)user {
+    NSError *error = nil;
     RLMRealmConfiguration *c = [[RLMRealmConfiguration defaultConfiguration] copy];
-    c.syncConfiguration = [[RLMSyncConfiguration alloc] initWithUser:user realmURL:url];;
-    return [RLMRealm realmWithConfiguration:c error:error];
+    c.syncConfiguration = [[RLMSyncConfiguration alloc] initWithUser:user realmURL:url];
+    RLMRealm *r = [RLMRealm realmWithConfiguration:c error:&error];
+    XCTAssertNil(error, @"Experienced an error opening the Realm at %@: %@", url, error);
+    return r;
 }
 
 - (RLMSyncUser *)logInUserForCredential:(RLMSyncCredential *)credential
@@ -139,6 +172,7 @@ static NSURL *syncDirectoryForChildProcess() {
 
 - (void)setUp {
     [super setUp];
+    self.continueAfterFailure = NO;
 
     if (!self.isParent) {
         // Don't start the sync server if not the originating process.
@@ -167,7 +201,9 @@ static NSURL *syncDirectoryForChildProcess() {
         }
     }];
     [self.task launch];
-    dispatch_semaphore_wait(sema, DISPATCH_TIME_FOREVER);
+    const NSTimeInterval timeout = 60;
+    XCTAssert(dispatch_semaphore_wait(sema, dispatch_time(DISPATCH_TIME_NOW, (int64_t)(timeout * NSEC_PER_SEC))) == 0,
+              @"Object server did not launch properly, terminating test...");
 }
 
 - (void)tearDown {
@@ -182,6 +218,7 @@ static NSURL *syncDirectoryForChildProcess() {
         self.task.standardOutput = [NSPipe pipe];
         [self.task launch];
         [self.task waitUntilExit];
+        usleep(500000);
     }
     s_managerForTest = nil;
     [super tearDown];

--- a/Realm/ObjectServerTests/RLMSyncUser+ObjectServerTests.h
+++ b/Realm/ObjectServerTests/RLMSyncUser+ObjectServerTests.h
@@ -22,8 +22,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface RLMSyncUser (ObjectServerTests)
 
-- (void)waitForUploadToFinish:(NSURL *)url;
-- (void)waitForDownloadToFinish:(NSURL *)url;
+// NOTE: Don't use these from Objective-C directly. Use the XCTest macros instead.
+
+- (BOOL)waitForUploadToFinish:(NSURL *)url;
+- (BOOL)waitForDownloadToFinish:(NSURL *)url;
 
 @end
 

--- a/Realm/ObjectServerTests/RLMSyncUser+ObjectServerTests.mm
+++ b/Realm/ObjectServerTests/RLMSyncUser+ObjectServerTests.mm
@@ -27,7 +27,8 @@
 
 @implementation RLMSyncUser (ObjectServerTests)
 
-- (void)waitForUploadToFinish:(NSURL *)url {
+- (BOOL)waitForUploadToFinish:(NSURL *)url {
+    const NSTimeInterval timeout = 20;
     dispatch_semaphore_t sema = dispatch_semaphore_create(0);
     RLMSyncSession *session = [self sessionForURL:url];
     NSAssert(session, @"Cannot call with invalid URL");
@@ -35,10 +36,12 @@
                                                    callback:^{
                                                        dispatch_semaphore_signal(sema);
                                                    }];
-    dispatch_semaphore_wait(sema, DISPATCH_TIME_FOREVER);
+
+    return dispatch_semaphore_wait(sema, dispatch_time(DISPATCH_TIME_NOW, (int64_t)(timeout * NSEC_PER_SEC))) == 0;
 }
 
-- (void)waitForDownloadToFinish:(NSURL *)url {
+- (BOOL)waitForDownloadToFinish:(NSURL *)url {
+    const NSTimeInterval timeout = 20;
     dispatch_semaphore_t sema = dispatch_semaphore_create(0);
     RLMSyncSession *session = [self sessionForURL:url];
     NSAssert(session, @"Cannot call with invalid URL");
@@ -46,7 +49,7 @@
                                                      callback:^{
                                                          dispatch_semaphore_signal(sema);
                                                      }];
-    dispatch_semaphore_wait(sema, DISPATCH_TIME_FOREVER);
+    return dispatch_semaphore_wait(sema, dispatch_time(DISPATCH_TIME_NOW, (int64_t)(timeout * NSEC_PER_SEC))) == 0;
 }
 
 @end

--- a/Realm/RLMRealm.mm
+++ b/Realm/RLMRealm.mm
@@ -336,7 +336,6 @@ REALM_NOINLINE void RLMRealmTranslateException(NSError **error) {
 }
 
 + (void)resetRealmState {
-    [RLMSyncManager _resetStateForTesting];
     RLMClearRealmCache();
     realm::_impl::RealmCoordinator::clear_cache();
     [RLMRealmConfiguration resetRealmConfigurationState];

--- a/Realm/RLMRealmConfiguration+Sync.mm
+++ b/Realm/RLMRealmConfiguration+Sync.mm
@@ -20,8 +20,8 @@
 
 #import "RLMRealmConfiguration_Private.hpp"
 #import "RLMSyncConfiguration_Private.hpp"
-#import "RLMSyncUser_Private.hpp"
 #import "RLMSyncFileManager.h"
+#import "RLMSyncUser_Private.hpp"
 #import "RLMSyncManager_Private.hpp"
 #import "RLMSyncUtil_Private.hpp"
 #import "RLMUtil.hpp"
@@ -43,7 +43,7 @@
     // Ensure sync manager is initialized, if it hasn't already been.
     [RLMSyncManager sharedManager];
     NSAssert(user.identity, @"Cannot call this method on a user that doesn't have an identity.");
-    NSURL *localFileURL = [RLMSyncFileManager fileURLForRawRealmURL:realmURL user:user];
+    NSURL *localFileURL = [[[RLMSyncManager sharedManager] fileManager] fileURLForRawRealmURL:realmURL user:user];
     if (syncConfiguration.customFileURL) {
         localFileURL = syncConfiguration.customFileURL;
     }

--- a/Realm/RLMSyncManager.mm
+++ b/Realm/RLMSyncManager.mm
@@ -66,9 +66,13 @@ struct CocoaSyncLoggerFactory : public realm::SyncLoggerFactory {
 
 } // anonymous namespace
 
-@interface RLMSyncManager ()
+@interface RLMSyncManager () {
+    std::unique_ptr<realm::SyncMetadataManager> _metadata_manager;
+}
 
-- (instancetype)initPrivate NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithCustomRootDirectory:(nullable NSURL *)rootDirectory NS_DESIGNATED_INITIALIZER;
+
+@property (nonnull, nonatomic) RLMSyncFileManager *fileManager;
 
 @property (nonnull, nonatomic) NSMutableDictionary<NSString *, RLMSyncUser *> *activeUsers;
 @property (nonnull, nonatomic) NSMutableDictionary<NSString *, RLMSyncUser *> *loggedOutUsers;
@@ -82,20 +86,20 @@ static dispatch_once_t s_onceToken;
 
 + (instancetype)sharedManager {
     dispatch_once(&s_onceToken, ^{
-        s_sharedManager = [[RLMSyncManager alloc] initPrivate];
+        s_sharedManager = [[RLMSyncManager alloc] initWithCustomRootDirectory:nil];
     });
     return s_sharedManager;
 }
 
 - (RLMSyncSession *)sessionForSyncConfiguration:(RLMSyncConfiguration *)config {
-    NSURL *fileURL = [RLMSyncFileManager fileURLForRawRealmURL:config.realmURL user:config.user];
+    NSURL *fileURL = [self.fileManager fileURLForRawRealmURL:config.realmURL user:config.user];
     return [config.user _registerSessionForBindingWithFileURL:fileURL
                                                    syncConfig:config
                                             standaloneSession:YES
                                                  onCompletion:nil];
 }
 
-- (instancetype)initPrivate {
+- (instancetype)initWithCustomRootDirectory:(NSURL *)rootDirectory {
     if (self = [super init]) {
         // Create the global error handler.
         auto errorLambda = [=](int error_code, std::string message) {
@@ -122,10 +126,13 @@ static dispatch_once_t s_onceToken;
         self.activeUsers = [NSMutableDictionary dictionary];
         self.loggedOutUsers = [NSMutableDictionary dictionary];
 
+        rootDirectory = rootDirectory ?: [NSURL fileURLWithPath:RLMDefaultDirectoryForBundleIdentifier(nil)];
+        self.fileManager = [[RLMSyncFileManager alloc] initWithRootDirectory:rootDirectory];
+
         // Initialize the sync engine.
         SyncManager::shared().set_error_handler(errorLambda);
         SyncManager::shared().set_login_function(loginLambda);
-        NSString *metadataDirectory = [[RLMSyncFileManager fileURLForMetadata] path];
+        NSString *metadataDirectory = [[self.fileManager fileURLForMetadata] path];
         bool should_encrypt = !getenv("REALM_DISABLE_METADATA_ENCRYPTION");
         _metadata_manager = std::make_unique<SyncMetadataManager>([metadataDirectory UTF8String], should_encrypt);
         [self _cleanUpMarkedUsers];
@@ -154,29 +161,6 @@ static dispatch_once_t s_onceToken;
 
 
 #pragma mark - Private API
-
-+ (void)_resetStateForTesting {
-    // Log out all the logged-in users. This will immediately kill any open sessions.
-    NSMutableArray<RLMSyncUser *> *buffer = [NSMutableArray array];
-    if (s_sharedManager) {
-        for (id key in s_sharedManager.activeUsers) {
-            [buffer addObject:s_sharedManager.activeUsers[key]];
-        }
-    }
-    [[s_sharedManager.activeUsers allValues] makeObjectsPerformSelector:@selector(logOut)];
-
-    // Reset the singleton.
-    s_onceToken = 0;
-    s_sharedManager = nil;
-
-    // Destroy the metadata Realm.
-    NSURL *metadataURL = [RLMSyncFileManager fileURLForMetadata];
-    // FIXME: replace this with the appropriate call to `[RLMSyncFileManager deleteRealmAtPath:]` once that code is in.
-    NSFileManager *manager = [NSFileManager defaultManager];
-    [manager removeItemAtURL:metadataURL error:nil];
-    [manager removeItemAtURL:[metadataURL URLByAppendingPathExtension:@"lock"] error:nil];
-    [manager removeItemAtURL:[metadataURL URLByAppendingPathExtension:@"management"] error:nil];
-}
 
 - (void)_fireError:(NSError *)error {
     dispatch_async(dispatch_get_main_queue(), ^{
@@ -251,7 +235,7 @@ static dispatch_once_t s_onceToken;
             auto user = users_to_remove.get(i);
             // FIXME: delete user data in a different way? (This deletes a logged-out user's data as soon as the app
             // launches again, which might not be how some apps want to treat their data.)
-            [RLMSyncFileManager removeFilesForUserIdentity:@(user.identity().c_str()) error:nil];
+            [self.fileManager removeFilesForUserIdentity:@(user.identity().c_str()) error:nil];
             dead_users.emplace_back(std::move(user));
         }
         for (auto user : dead_users) {

--- a/Realm/RLMSyncManager_Private.hpp
+++ b/Realm/RLMSyncManager_Private.hpp
@@ -20,19 +20,19 @@
 
 #import "RLMSyncUtil_Private.h"
 
-#import "sync_config.hpp"
-#import "sync_metadata.hpp"
+namespace realm {
+enum class SyncSessionError;
+class SyncMetadataManager;
+}
 
-@class RLMSyncUser;
+@class RLMSyncUser, RLMSyncFileManager;
 
 // All private API methods are threadsafe and synchronized, unless denoted otherwise. Since they are expected to be
 // called very infrequently, this should pose no issues.
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface RLMSyncManager () {
-    std::unique_ptr<realm::SyncMetadataManager> _metadata_manager;
-}
+@interface RLMSyncManager ()
 
 @property (nullable, nonatomic, copy) RLMSyncBasicErrorReportingBlock sessionCompletionNotifier;
 
@@ -43,9 +43,6 @@ NS_ASSUME_NONNULL_BEGIN
  (by using the same configuration) will return `nil`.
  */
 - (nullable RLMSyncSession *)sessionForSyncConfiguration:(RLMSyncConfiguration *)config NS_UNAVAILABLE;
-
-/// Reset the singleton instance, and any saved state. Only for use with Realm Object Store tests.
-+ (void)_resetStateForTesting;
 
 - (void)_fireError:(NSError *)error;
 
@@ -58,6 +55,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (realm::SyncMetadataManager&)_metadataManager;
 
 - (NSArray<RLMSyncUser *> *)_allUsers;
+
+- (RLMSyncFileManager *)fileManager;
 
 /**
  Register a user. If an equivalent user has already been registered, the argument is not added to the store, and the

--- a/build.sh
+++ b/build.sh
@@ -410,6 +410,8 @@ case "$COMMAND" in
                 break
             fi
         done
+        rm -rf "~/Library/Application Support/xctest"
+        rm -rf "~/Library/Application Support/xctest-child"
         rm -rf "$package/object-server/root_dir/"
         rm -rf "$package/object-server/temp_dir/"
         exit 0


### PR DESCRIPTION
@jpsim 

Replaces https://github.com/realm/realm-cocoa-private/pull/369

Changes:
- Tests should no longer stall forever on semaphores
- 'Waiting for upload/download' API usage replaced by macros that assert on timeout
- Added tests for syncing multiple Realms
- Added more helper methods to make actual test code easier to read
- Moved responsibility for checking for errors when synchronously opening users and Realms for tests into the helper methods
- Organized and grouped new tests by purpose