### PR TITLE
Fix object server test file settings

### DIFF
--- a/RLMSyncManager+ObjectServerTests.h
+++ b/RLMSyncManager+ObjectServerTests.h
@@ -16,20 +16,10 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-#import <Foundation/Foundation.h>
+#import "RLMSyncManager.h"
 
-@class RLMSyncUser;
+@interface RLMSyncManager (ObjectServerTests)
 
-@interface RLMSyncFileManager : NSObject
-
-NS_ASSUME_NONNULL_BEGIN
-
-- (instancetype)initWithRootDirectory:(NSURL *)rootDirectory;
-
-- (NSURL *)fileURLForRawRealmURL:(NSURL *)url user:(RLMSyncUser *)user;
-- (NSURL *)fileURLForMetadata;
-- (BOOL)removeFilesForUserIdentity:(NSString *)identity error:(NSError * _Nullable* _Nullable)error;
-
-NS_ASSUME_NONNULL_END
+- (void)prepareForDestruction;
 
 @end

--- a/RLMSyncManager+ObjectServerTests.m
+++ b/RLMSyncManager+ObjectServerTests.m
@@ -1,0 +1,76 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2016 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+#import "RLMSyncManager+ObjectServerTests.h"
+#import "RLMSyncTestCase.h"
+#import "RLMSyncFileManager.h"
+
+#import <objc/runtime.h>
+
+@interface RLMSyncManager ()
+- (NSMutableDictionary<NSString *, RLMSyncUser *> *)activeUsers;
+- (RLMSyncFileManager *)fileManager;
+@end
+
+@implementation RLMSyncManager (ObjectServerTests)
+
++ (void)load {
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        Class class = object_getClass((id)self);
+        SEL originalSelector = @selector(sharedManager);
+        SEL swizzledSelector = @selector(ost_sharedManager);
+        Method originalMethod = class_getClassMethod(class, originalSelector);
+        Method swizzledMethod = class_getClassMethod(class, swizzledSelector);
+
+        if (class_addMethod(class,
+                            originalSelector,
+                            method_getImplementation(swizzledMethod),
+                            method_getTypeEncoding(swizzledMethod))) {
+            class_replaceMethod(class,
+                                swizzledSelector,
+                                method_getImplementation(originalMethod),
+                                method_getTypeEncoding(originalMethod));
+        } else {
+            method_exchangeImplementations(originalMethod, swizzledMethod);
+        }
+    });
+}
+
++ (instancetype)ost_sharedManager {
+    return [RLMSyncTestCase managerForCurrentTest];
+}
+
+- (void)prepareForDestruction {
+    // Log out all the logged-in users. This will immediately kill any open sessions.
+    NSMutableArray<RLMSyncUser *> *buffer = [NSMutableArray array];
+    for (id key in [self activeUsers]) {
+        [buffer addObject:[self activeUsers][key]];
+    }
+    [[[self activeUsers] allValues] makeObjectsPerformSelector:@selector(logOut)];
+    NSURL *metadataURL = [self.fileManager fileURLForMetadata];
+
+    // Destroy the metadata Realm.
+    // FIXME: replace this with the appropriate call to `[RLMSyncFileManager deleteRealmAtPath:]` once that code is in.
+    NSFileManager *manager = [NSFileManager defaultManager];
+    [manager removeItemAtURL:metadataURL error:nil];
+    [manager removeItemAtURL:[metadataURL URLByAppendingPathExtension:@"lock"] error:nil];
+    [manager removeItemAtURL:[metadataURL URLByAppendingPathExtension:@"management"] error:nil];
+}
+
+@end

--- a/Realm.xcodeproj/project.pbxproj
+++ b/Realm.xcodeproj/project.pbxproj
@@ -109,6 +109,8 @@
 		1A8B51971D74B9BB00AE7923 /* sync_metadata.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 1A8B51951D74B9BB00AE7923 /* sync_metadata.hpp */; };
 		1A90FCBB1D3D37F50086A57F /* RLMSyncManager.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1AF7EA951D340AF70001A9B5 /* RLMSyncManager.mm */; };
 		1A90FCBC1D3D37F70086A57F /* RLMNetworkClient.m in Sources */ = {isa = PBXBuildFile; fileRef = 1AF7EA9A1D340E700001A9B5 /* RLMNetworkClient.m */; };
+		1A9428DC1D9C8BE900A74ED2 /* RLMSyncManager+ObjectServerTests.h in Headers */ = {isa = PBXBuildFile; fileRef = 1A9428DA1D9C8BE900A74ED2 /* RLMSyncManager+ObjectServerTests.h */; };
+		1A9428DE1D9C8BF800A74ED2 /* RLMSyncManager+ObjectServerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 1A9428DB1D9C8BE900A74ED2 /* RLMSyncManager+ObjectServerTests.m */; };
 		1AA5AE981D989BE400ED8C27 /* SwiftSyncTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AA5AE961D989BE000ED8C27 /* SwiftSyncTestCase.swift */; };
 		1AA5AE9C1D98A68E00ED8C27 /* RLMSyncTestCase.m in Sources */ = {isa = PBXBuildFile; fileRef = 1AA5AE9B1D98A68E00ED8C27 /* RLMSyncTestCase.m */; };
 		1AA5AEA11D98C99800ED8C27 /* SwiftObjectServerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AA5AE9F1D98C99500ED8C27 /* SwiftObjectServerTests.swift */; };
@@ -654,6 +656,8 @@
 		1A8413351D4C0B5B00C5326F /* RLMSyncUser_Private.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = RLMSyncUser_Private.hpp; sourceTree = "<group>"; };
 		1A8B51941D74B9BB00AE7923 /* sync_metadata.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = sync_metadata.cpp; sourceTree = "<group>"; };
 		1A8B51951D74B9BB00AE7923 /* sync_metadata.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = sync_metadata.hpp; sourceTree = "<group>"; };
+		1A9428DA1D9C8BE900A74ED2 /* RLMSyncManager+ObjectServerTests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "RLMSyncManager+ObjectServerTests.h"; sourceTree = "<group>"; };
+		1A9428DB1D9C8BE900A74ED2 /* RLMSyncManager+ObjectServerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "RLMSyncManager+ObjectServerTests.m"; sourceTree = "<group>"; };
 		1AA5AE961D989BE000ED8C27 /* SwiftSyncTestCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; name = SwiftSyncTestCase.swift; path = Realm/ObjectServerTests/SwiftSyncTestCase.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		1AA5AE9A1D98A1B000ED8C27 /* Object-Server-Tests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "Object-Server-Tests-Bridging-Header.h"; path = "Realm/ObjectServerTests/Object-Server-Tests-Bridging-Header.h"; sourceTree = "<group>"; };
 		1AA5AE9B1D98A68E00ED8C27 /* RLMSyncTestCase.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RLMSyncTestCase.m; path = Realm/ObjectServerTests/RLMSyncTestCase.m; sourceTree = "<group>"; };
@@ -1008,6 +1012,8 @@
 				1AA5AE9A1D98A1B000ED8C27 /* Object-Server-Tests-Bridging-Header.h */,
 				1AF2F7A41D95E44F0063A138 /* RLMSyncUser+ObjectServerTests.h */,
 				1AF2F7A51D95E44F0063A138 /* RLMSyncUser+ObjectServerTests.mm */,
+				1A9428DA1D9C8BE900A74ED2 /* RLMSyncManager+ObjectServerTests.h */,
+				1A9428DB1D9C8BE900A74ED2 /* RLMSyncManager+ObjectServerTests.m */,
 			);
 			name = Utility;
 			sourceTree = "<group>";
@@ -1498,6 +1504,7 @@
 				3F9863BD1D36876B00641C98 /* RLMClassInfo.hpp in Headers */,
 				5D659EAB1BE04556006515A0 /* RLMCollection.h in Headers */,
 				3FBEF67A1C63D66100F6935B /* RLMCollection_Private.hpp in Headers */,
+				1A9428DC1D9C8BE900A74ED2 /* RLMSyncManager+ObjectServerTests.h in Headers */,
 				5D659EAC1BE04556006515A0 /* RLMConstants.h in Headers */,
 				5D659EAE1BE04556006515A0 /* RLMListBase.h in Headers */,
 				1AF6EA471D36B1850014EB85 /* RLMAuthResponseModel.h in Headers */,
@@ -2327,6 +2334,7 @@
 				1AA5AEA11D98C99800ED8C27 /* SwiftObjectServerTests.swift in Sources */,
 				1AF2F7A81D95E47B0063A138 /* RLMSyncUser+ObjectServerTests.mm in Sources */,
 				1AA5AE981D989BE400ED8C27 /* SwiftSyncTestCase.swift in Sources */,
+				1A9428DE1D9C8BF800A74ED2 /* RLMSyncManager+ObjectServerTests.m in Sources */,
 				1AF2F7A31D95DBC70063A138 /* RLMMultiProcessTestCase.m in Sources */,
 				E86E61241D91E4E200DC2419 /* RLMTestCase.m in Sources */,
 				1AA5AE9C1D98A68E00ED8C27 /* RLMSyncTestCase.m in Sources */,

--- a/Realm/ObjectServerTests/RLMSyncTestCase.h
+++ b/Realm/ObjectServerTests/RLMSyncTestCase.h
@@ -32,6 +32,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface RLMSyncTestCase : RLMMultiProcessTestCase
 
++ (RLMSyncManager *)managerForCurrentTest;
+
 + (NSURL *)rootRealmCocoaURL;
 
 + (NSURL *)authServerURL;

--- a/Realm/RLMRealm.mm
+++ b/Realm/RLMRealm.mm
@@ -336,7 +336,6 @@ REALM_NOINLINE void RLMRealmTranslateException(NSError **error) {
 }
 
 + (void)resetRealmState {
-    [RLMSyncManager _resetStateForTesting];
     RLMClearRealmCache();
     realm::_impl::RealmCoordinator::clear_cache();
     [RLMRealmConfiguration resetRealmConfigurationState];

--- a/Realm/RLMRealmConfiguration+Sync.mm
+++ b/Realm/RLMRealmConfiguration+Sync.mm
@@ -20,8 +20,8 @@
 
 #import "RLMRealmConfiguration_Private.hpp"
 #import "RLMSyncConfiguration_Private.hpp"
-#import "RLMSyncUser_Private.hpp"
 #import "RLMSyncFileManager.h"
+#import "RLMSyncUser_Private.hpp"
 #import "RLMSyncManager_Private.hpp"
 #import "RLMSyncUtil_Private.hpp"
 #import "RLMUtil.hpp"
@@ -43,7 +43,7 @@
     // Ensure sync manager is initialized, if it hasn't already been.
     [RLMSyncManager sharedManager];
     NSAssert(user.identity, @"Cannot call this method on a user that doesn't have an identity.");
-    NSURL *localFileURL = [RLMSyncFileManager fileURLForRawRealmURL:realmURL user:user];
+    NSURL *localFileURL = [[[RLMSyncManager sharedManager] fileManager] fileURLForRawRealmURL:realmURL user:user];
     if (syncConfiguration.customFileURL) {
         localFileURL = syncConfiguration.customFileURL;
     }

--- a/Realm/RLMSyncManager.mm
+++ b/Realm/RLMSyncManager.mm
@@ -66,9 +66,13 @@ struct CocoaSyncLoggerFactory : public realm::SyncLoggerFactory {
 
 } // anonymous namespace
 
-@interface RLMSyncManager ()
+@interface RLMSyncManager () {
+    std::unique_ptr<realm::SyncMetadataManager> _metadata_manager;
+}
 
-- (instancetype)initPrivate NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithCustomRootDirectory:(nullable NSURL *)rootDirectory NS_DESIGNATED_INITIALIZER;
+
+@property (nonnull, nonatomic) RLMSyncFileManager *fileManager;
 
 @property (nonnull, nonatomic) NSMutableDictionary<NSString *, RLMSyncUser *> *activeUsers;
 @property (nonnull, nonatomic) NSMutableDictionary<NSString *, RLMSyncUser *> *loggedOutUsers;
@@ -82,20 +86,20 @@ static dispatch_once_t s_onceToken;
 
 + (instancetype)sharedManager {
     dispatch_once(&s_onceToken, ^{
-        s_sharedManager = [[RLMSyncManager alloc] initPrivate];
+        s_sharedManager = [[RLMSyncManager alloc] initWithCustomRootDirectory:nil];
     });
     return s_sharedManager;
 }
 
 - (RLMSyncSession *)sessionForSyncConfiguration:(RLMSyncConfiguration *)config {
-    NSURL *fileURL = [RLMSyncFileManager fileURLForRawRealmURL:config.realmURL user:config.user];
+    NSURL *fileURL = [self.fileManager fileURLForRawRealmURL:config.realmURL user:config.user];
     return [config.user _registerSessionForBindingWithFileURL:fileURL
                                                    syncConfig:config
                                             standaloneSession:YES
                                                  onCompletion:nil];
 }
 
-- (instancetype)initPrivate {
+- (instancetype)initWithCustomRootDirectory:(NSURL *)rootDirectory {
     if (self = [super init]) {
         // Create the global error handler.
         auto errorLambda = [=](int error_code, std::string message) {
@@ -122,10 +126,13 @@ static dispatch_once_t s_onceToken;
         self.activeUsers = [NSMutableDictionary dictionary];
         self.loggedOutUsers = [NSMutableDictionary dictionary];
 
+        rootDirectory = rootDirectory ?: [NSURL fileURLWithPath:RLMDefaultDirectoryForBundleIdentifier(nil)];
+        self.fileManager = [[RLMSyncFileManager alloc] initWithRootDirectory:rootDirectory];
+
         // Initialize the sync engine.
         SyncManager::shared().set_error_handler(errorLambda);
         SyncManager::shared().set_login_function(loginLambda);
-        NSString *metadataDirectory = [[RLMSyncFileManager fileURLForMetadata] path];
+        NSString *metadataDirectory = [[self.fileManager fileURLForMetadata] path];
         bool should_encrypt = !getenv("REALM_DISABLE_METADATA_ENCRYPTION");
         _metadata_manager = std::make_unique<SyncMetadataManager>([metadataDirectory UTF8String], should_encrypt);
         [self _cleanUpMarkedUsers];
@@ -154,29 +161,6 @@ static dispatch_once_t s_onceToken;
 
 
 #pragma mark - Private API
-
-+ (void)_resetStateForTesting {
-    // Log out all the logged-in users. This will immediately kill any open sessions.
-    NSMutableArray<RLMSyncUser *> *buffer = [NSMutableArray array];
-    if (s_sharedManager) {
-        for (id key in s_sharedManager.activeUsers) {
-            [buffer addObject:s_sharedManager.activeUsers[key]];
-        }
-    }
-    [[s_sharedManager.activeUsers allValues] makeObjectsPerformSelector:@selector(logOut)];
-
-    // Reset the singleton.
-    s_onceToken = 0;
-    s_sharedManager = nil;
-
-    // Destroy the metadata Realm.
-    NSURL *metadataURL = [RLMSyncFileManager fileURLForMetadata];
-    // FIXME: replace this with the appropriate call to `[RLMSyncFileManager deleteRealmAtPath:]` once that code is in.
-    NSFileManager *manager = [NSFileManager defaultManager];
-    [manager removeItemAtURL:metadataURL error:nil];
-    [manager removeItemAtURL:[metadataURL URLByAppendingPathExtension:@"lock"] error:nil];
-    [manager removeItemAtURL:[metadataURL URLByAppendingPathExtension:@"management"] error:nil];
-}
 
 - (void)_fireError:(NSError *)error {
     dispatch_async(dispatch_get_main_queue(), ^{
@@ -251,7 +235,7 @@ static dispatch_once_t s_onceToken;
             auto user = users_to_remove.get(i);
             // FIXME: delete user data in a different way? (This deletes a logged-out user's data as soon as the app
             // launches again, which might not be how some apps want to treat their data.)
-            [RLMSyncFileManager removeFilesForUserIdentity:@(user.identity().c_str()) error:nil];
+            [self.fileManager removeFilesForUserIdentity:@(user.identity().c_str()) error:nil];
             dead_users.emplace_back(std::move(user));
         }
         for (auto user : dead_users) {

--- a/Realm/RLMSyncManager_Private.hpp
+++ b/Realm/RLMSyncManager_Private.hpp
@@ -20,19 +20,19 @@
 
 #import "RLMSyncUtil_Private.h"
 
-#import "sync_config.hpp"
-#import "sync_metadata.hpp"
+namespace realm {
+enum class SyncSessionError;
+class SyncMetadataManager;
+}
 
-@class RLMSyncUser;
+@class RLMSyncUser, RLMSyncFileManager;
 
 // All private API methods are threadsafe and synchronized, unless denoted otherwise. Since they are expected to be
 // called very infrequently, this should pose no issues.
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface RLMSyncManager () {
-    std::unique_ptr<realm::SyncMetadataManager> _metadata_manager;
-}
+@interface RLMSyncManager ()
 
 @property (nullable, nonatomic, copy) RLMSyncBasicErrorReportingBlock sessionCompletionNotifier;
 
@@ -43,9 +43,6 @@ NS_ASSUME_NONNULL_BEGIN
  (by using the same configuration) will return `nil`.
  */
 - (nullable RLMSyncSession *)sessionForSyncConfiguration:(RLMSyncConfiguration *)config NS_UNAVAILABLE;
-
-/// Reset the singleton instance, and any saved state. Only for use with Realm Object Store tests.
-+ (void)_resetStateForTesting;
 
 - (void)_fireError:(NSError *)error;
 
@@ -58,6 +55,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (realm::SyncMetadataManager&)_metadataManager;
 
 - (NSArray<RLMSyncUser *> *)_allUsers;
+
+- (RLMSyncFileManager *)fileManager;
 
 /**
  Register a user. If an equivalent user has already been registered, the argument is not added to the store, and the

--- a/build.sh
+++ b/build.sh
@@ -410,6 +410,8 @@ case "$COMMAND" in
                 break
             fi
         done
+        rm -rf "~/Library/Application Support/xctest"
+        rm -rf "~/Library/Application Support/xctest-child"
         rm -rf "$package/object-server/root_dir/"
         rm -rf "$package/object-server/temp_dir/"
         exit 0


### PR DESCRIPTION
@jpsim 

Changes:
- Object store multiprocess tests shouldn't share local Realm files anymore, meaning that they can actually test sync

This should fix the issue where the metadata Realm couldn't be opened by the child test processes, causing the tests to hang/fail.