### PR TITLE
Fix getting versions from dependencies.list when running build.sh from out-of-root

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -13,12 +13,14 @@
 set -o pipefail
 set -e
 
+source_root="$(dirname "$0")"
+
 # You can override the version of the core library
-: ${REALM_CORE_VERSION:=$(sed -n 's/^REALM_CORE_VERSION=\(.*\)$/\1/p' dependencies.list)} # set to "current" to always use the current build
+: ${REALM_CORE_VERSION:=$(sed -n 's/^REALM_CORE_VERSION=\(.*\)$/\1/p' ${source_root}/dependencies.list)} # set to "current" to always use the current build
 
-: ${REALM_SYNC_VERSION:=$(sed -n 's/^REALM_SYNC_VERSION=\(.*\)$/\1/p' dependencies.list)}
+: ${REALM_SYNC_VERSION:=$(sed -n 's/^REALM_SYNC_VERSION=\(.*\)$/\1/p' ${source_root}/dependencies.list)}
 
-: ${REALM_OBJECT_SERVER_VERSION:=$(sed -n 's/^REALM_OBJECT_SERVER_VERSION=\(.*\)$/\1/p' dependencies.list)}
+: ${REALM_OBJECT_SERVER_VERSION:=$(sed -n 's/^REALM_OBJECT_SERVER_VERSION=\(.*\)$/\1/p' ${source_root}/dependencies.list)}
 
 # You can override the xcmode used
 : ${XCMODE:=xcodebuild} # must be one of: xcodebuild (default), xcpretty, xctool
@@ -371,7 +373,7 @@ case "$COMMAND" in
 esac
 export CONFIGURATION
 
-source "$(dirname "$0")/scripts/swift-version.sh"
+source "${source_root}/scripts/swift-version.sh"
 
 case "$COMMAND" in
 
@@ -401,7 +403,7 @@ case "$COMMAND" in
         ;;
 
     "reset-object-server")
-        package="$( cd "$( dirname "${BASH_SOURCE[0]}" )/sync" && pwd )"
+        package="${source_root}/sync"
         for file in "$package"/realm-object-server-*; do
             if [ -d "$file" ]; then
                 package="$file"
@@ -486,7 +488,7 @@ case "$COMMAND" in
         ;;
 
     "prelaunch-simulator")
-        sh $(dirname $0)/scripts/reset-simulators.sh
+        sh ${source_root}/scripts/reset-simulators.sh
         ;;
 
     ######################################
@@ -1075,7 +1077,7 @@ EOM
         unzip ${OBJC}.zip
 
         cp $0 ${OBJC}
-        cp -r $(dirname $0)/scripts ${OBJC}
+        cp -r ${source_root}/scripts ${OBJC}
         cd ${OBJC}
         sh build.sh examples-ios
         sh build.sh examples-tvos
@@ -1086,7 +1088,7 @@ EOM
         unzip ${SWIFT}.zip
 
         cp $0 ${SWIFT}
-        cp -r $(dirname $0)/scripts ${SWIFT}
+        cp -r ${source_root}/scripts ${SWIFT}
         cd ${SWIFT}
         sh build.sh examples-ios-swift
         sh build.sh examples-tvos-swift


### PR DESCRIPTION
Fixes a bunch of `sed: dependencies.list: No such file or directory` errors when running some CI jobs.