### PR TITLE
Fix Realm headers to be compatible with pre-C++11 dialects of Objective-C++

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+x.x.x Release notes (yyyy-MM-dd)
+=============================================================
+
+### API breaking changes
+
+* None.
+
+### Enhancements
+
+* None.
+
+### Bugfixes
+
+* Fix Realm headers to be compatible with pre-C++11 dialects of Objective-C++.
+
 2.0.1 Release notes (2016-09-29)
 =============================================================
 

--- a/Realm/RLMConstants.h
+++ b/Realm/RLMConstants.h
@@ -29,7 +29,7 @@ NS_ASSUME_NONNULL_BEGIN
 #define RLM_EXTENSIBLE_STRING_ENUM_CASE_SWIFT_NAME(fully_qualified, _) NS_SWIFT_NAME(fully_qualified)
 #endif
 
-#if __has_attribute(ns_error_domain)
+#if __has_attribute(ns_error_domain) && (!__cplusplus || __cplusplus >= 201103L)
 #define RLM_ERROR_ENUM(type, name, domain) \
     _Pragma("clang diagnostic push") \
     _Pragma("clang diagnostic ignored \"-Wignored-attributes\"") \


### PR DESCRIPTION
Our abuse of `NS_ENUM` to define `RLM_ERROR_ENUM` was incompatible with the expansion of `NS_ENUM` with pre-C++11 dialects. Fall back to the simple definition for older versions of C++. The more advanced definition is only used at this point by the Swift importer.

/cc @jpsim @tgoyne 

Fixes #4164.