### PR TITLE
Delete the CoreSimulator log before running CI tests

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1031,6 +1031,7 @@ EOM
             export CONFIGURATION=$configuration
             export REALM_EXTRA_BUILD_ARGUMENTS='GCC_GENERATE_DEBUGGING_SYMBOLS=NO REALM_PREFIX_HEADER=Realm/RLMPrefix.h'
             sh build.sh prelaunch-simulator
+            rm ~/Library/Logs/CoreSimulator/CoreSimulator.log
             # Verify that no Realm files still exist
             ! find ~/Library/Developer/CoreSimulator/Devices/ -name '*.realm' | grep -q .
 


### PR DESCRIPTION
Discarding the old logs makes the report when a job fails much less noisy.