### PR TITLE
Retry building installation examples if they hit an xcodebuild internal error

### DIFF
--- a/examples/installation/build.sh
+++ b/examples/installation/build.sh
@@ -84,17 +84,18 @@ xctest() {
     if [[ $PLATFORM == ios ]]; then
         DESTINATION="-destination id=$(xcrun simctl list devices | grep -v unavailable | grep -m 1 -o '[0-9A-F\-]\{36\}')"
     fi
-    CMD="-project $PROJECT"
+    PROJECT="-project $PROJECT"
     if [ -d $WORKSPACE ]; then
-        CMD="-workspace $WORKSPACE"
+        PROJECT="-workspace $WORKSPACE"
     fi
-    ACTION=""
+    ACTION="build test"
     if [[ $PLATFORM == watchos ]]; then
         ACTION="build"
-    else
-        ACTION="build test"
     fi
-    xcodebuild $CMD -scheme $NAME clean $ACTION $DESTINATION CODE_SIGN_IDENTITY= CODE_SIGNING_REQUIRED=NO
+    CMD="$PROJECT -scheme $NAME clean $ACTION $DESTINATION CODE_SIGN_IDENTITY= CODE_SIGNING_REQUIRED=NO"
+    if ! xcodebuild $CMD | tee build.log && grep 'operation never finished bootstrapping' build.log; then
+        xcodebuild $CMD
+    fi
 }
 
 source "$(dirname "$0")/../../scripts/swift-version.sh"


### PR DESCRIPTION
Attempts to work around failures such as [this one](https://ci.realm.io/job/Cocoa%20Installation%20Examples/433/binding=objc,method=static,platform=ios/console) where it never actually starts to build the example.
