### PR TITLE
Fix some crashes when working with a RLMLinkingObjects property of an unmanaged object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ x.x.x Release notes (yyyy-MM-dd)
 * Fix an assertion failure when a write transaction is in progress at the point
   of process termination.
 
+* Fix a crash that could occur when working with a `RLMLinkingObject` property
+  of an unmanaged object.
+
 2.0.2 Release notes (2016-10-05)
 =============================================================
 

--- a/Realm/RLMResults.mm
+++ b/Realm/RLMResults.mm
@@ -279,25 +279,26 @@ static inline void RLMResultsValidateInWriteTransaction(__unsafe_unretained RLMR
     RLMCollectionSetValueForKey(self, key, value);
 }
 
-- (NSNumber *)_aggregateForKeyPath:(NSString *)keyPath method:(util::Optional<Mixed> (Results::*)(size_t))method methodName:(NSString *)methodName {
+- (NSNumber *)_aggregateForKeyPath:(NSString *)keyPath method:(util::Optional<Mixed> (Results::*)(size_t))method
+                        methodName:(NSString *)methodName returnNilForEmpty:(BOOL)returnNilForEmpty {
     assertKeyPathIsNotNested(keyPath);
-    return [self aggregate:keyPath method:method methodName:methodName];
+    return [self aggregate:keyPath method:method methodName:methodName returnNilForEmpty:returnNilForEmpty];
 }
 
 - (NSNumber *)_minForKeyPath:(NSString *)keyPath {
-    return [self _aggregateForKeyPath:keyPath method:&Results::min methodName:@"@min"];
+    return [self _aggregateForKeyPath:keyPath method:&Results::min methodName:@"@min" returnNilForEmpty:YES];
 }
 
 - (NSNumber *)_maxForKeyPath:(NSString *)keyPath {
-    return [self _aggregateForKeyPath:keyPath method:&Results::max methodName:@"@max"];
+    return [self _aggregateForKeyPath:keyPath method:&Results::max methodName:@"@max" returnNilForEmpty:YES];
 }
 
 - (NSNumber *)_sumForKeyPath:(NSString *)keyPath {
-    return [self _aggregateForKeyPath:keyPath method:&Results::sum methodName:@"@sum"];
+    return [self _aggregateForKeyPath:keyPath method:&Results::sum methodName:@"@sum" returnNilForEmpty:NO];
 }
 
 - (NSNumber *)_avgForKeyPath:(NSString *)keyPath {
-    return [self _aggregateForKeyPath:keyPath method:&Results::average methodName:@"@avg"];
+    return [self _aggregateForKeyPath:keyPath method:&Results::average methodName:@"@avg" returnNilForEmpty:YES];
 }
 
 - (NSArray *)_unionOfObjectsForKeyPath:(NSString *)keyPath {
@@ -375,9 +376,10 @@ static inline void RLMResultsValidateInWriteTransaction(__unsafe_unretained RLMR
     return [self objectAtIndex:index];
 }
 
-- (id)aggregate:(NSString *)property method:(util::Optional<Mixed> (Results::*)(size_t))method methodName:(NSString *)methodName {
+- (id)aggregate:(NSString *)property method:(util::Optional<Mixed> (Results::*)(size_t))method
+     methodName:(NSString *)methodName returnNilForEmpty:(BOOL)returnNilForEmpty {
     if (_results.get_mode() == Results::Mode::Empty) {
-        return nil;
+        return returnNilForEmpty ? nil : @0;
     }
     size_t column = _info->tableColumn(property);
     auto value = translateErrors([&] { return (_results.*method)(column); }, methodName);
@@ -388,19 +390,19 @@ static inline void RLMResultsValidateInWriteTransaction(__unsafe_unretained RLMR
 }
 
 - (id)minOfProperty:(NSString *)property {
-    return [self aggregate:property method:&Results::min methodName:@"minOfProperty"];
+    return [self aggregate:property method:&Results::min methodName:@"minOfProperty" returnNilForEmpty:YES];
 }
 
 - (id)maxOfProperty:(NSString *)property {
-    return [self aggregate:property method:&Results::max methodName:@"maxOfProperty"];
+    return [self aggregate:property method:&Results::max methodName:@"maxOfProperty" returnNilForEmpty:YES];
 }
 
 - (id)sumOfProperty:(NSString *)property {
-    return [self aggregate:property method:&Results::sum methodName:@"sumOfProperty"];
+    return [self aggregate:property method:&Results::sum methodName:@"sumOfProperty" returnNilForEmpty:NO];
 }
 
 - (id)averageOfProperty:(NSString *)property {
-    return [self aggregate:property method:&Results::average methodName:@"averageOfProperty"];
+    return [self aggregate:property method:&Results::average methodName:@"averageOfProperty" returnNilForEmpty:YES];
 }
 
 - (void)deleteObjectsFromRealm {

--- a/Realm/Tests/LinkingObjectsTests.mm
+++ b/Realm/Tests/LinkingObjectsTests.mm
@@ -57,10 +57,11 @@
     PersonObject *don = [[PersonObject alloc] initWithValue:@[ @"Don", @60, @[] ]];
 
     XCTAssertEqual(0u, don.parents.count);
+    XCTAssertNil(don.parents.firstObject);
+    XCTAssertNil(don.parents.lastObject);
 
-    for (PersonObject *parent in don.parents) {
-        (void)parent;
-        XCTFail();
+    for (__unused id parent in don.parents) {
+        XCTFail(@"Got an item in empty linking objects");
     }
 
     XCTAssertEqual(0u, [don.parents sortedResultsUsingProperty:@"age" ascending:YES].count);
@@ -68,18 +69,17 @@
 
     XCTAssertNil([don.parents minOfProperty:@"age"]);
     XCTAssertNil([don.parents maxOfProperty:@"age"]);
-    XCTAssertNil([don.parents sumOfProperty:@"age"]);
+    XCTAssertEqualObjects(@0, [don.parents sumOfProperty:@"age"]);
     XCTAssertNil([don.parents averageOfProperty:@"age"]);
 
     XCTAssertEqualObjects(@[], [don.parents valueForKey:@"age"]);
     XCTAssertEqualObjects(@0, [don.parents valueForKeyPath:@"@count"]);
     XCTAssertNil([don.parents valueForKeyPath:@"@min.age"]);
     XCTAssertNil([don.parents valueForKeyPath:@"@max.age"]);
-    XCTAssertNil([don.parents valueForKeyPath:@"@sum.age"]);
+    XCTAssertEqualObjects(@0, [don.parents valueForKeyPath:@"@sum.age"]);
     XCTAssertNil([don.parents valueForKeyPath:@"@avg.age"]);
 
     PersonObject *mark = [[PersonObject alloc] initWithValue:@[ @"Mark", @30, @[] ]];
-
     XCTAssertEqual(NSNotFound, [don.parents indexOfObject:mark]);
     XCTAssertEqual(NSNotFound, [don.parents indexOfObjectWhere:@"TRUEPREDICATE"]);
 }

--- a/Realm/Tests/LinkingObjectsTests.mm
+++ b/Realm/Tests/LinkingObjectsTests.mm
@@ -53,6 +53,37 @@
     XCTAssertEqualObjects(asArray(hannahsParents), (@[ ]));
 }
 
+- (void)testLinkingObjectsOnUnmanagedObject {
+    PersonObject *don = [[PersonObject alloc] initWithValue:@[ @"Don", @60, @[] ]];
+
+    XCTAssertEqual(0u, don.parents.count);
+
+    for (PersonObject *parent in don.parents) {
+        (void)parent;
+        XCTFail();
+    }
+
+    XCTAssertEqual(0u, [don.parents sortedResultsUsingProperty:@"age" ascending:YES].count);
+    XCTAssertEqual(0u, [don.parents objectsWhere:@"TRUEPREDICATE"].count);
+
+    XCTAssertNil([don.parents minOfProperty:@"age"]);
+    XCTAssertNil([don.parents maxOfProperty:@"age"]);
+    XCTAssertNil([don.parents sumOfProperty:@"age"]);
+    XCTAssertNil([don.parents averageOfProperty:@"age"]);
+
+    XCTAssertEqualObjects(@[], [don.parents valueForKey:@"age"]);
+    XCTAssertEqualObjects(@0, [don.parents valueForKeyPath:@"@count"]);
+    XCTAssertNil([don.parents valueForKeyPath:@"@min.age"]);
+    XCTAssertNil([don.parents valueForKeyPath:@"@max.age"]);
+    XCTAssertNil([don.parents valueForKeyPath:@"@sum.age"]);
+    XCTAssertNil([don.parents valueForKeyPath:@"@avg.age"]);
+
+    PersonObject *mark = [[PersonObject alloc] initWithValue:@[ @"Mark", @30, @[] ]];
+
+    XCTAssertEqual(NSNotFound, [don.parents indexOfObject:mark]);
+    XCTAssertEqual(NSNotFound, [don.parents indexOfObjectWhere:@"TRUEPREDICATE"]);
+}
+
 - (void)testFilteredLinkingObjects {
     NSArray *(^asArray)(id) = ^(id arrayLike) {
         return [arrayLike valueForKeyPath:@"self"];

--- a/Realm/Tests/RealmTests.mm
+++ b/Realm/Tests/RealmTests.mm
@@ -1339,7 +1339,7 @@
     XCTAssertNil([results maxOfProperty:@"intCol"]);
     XCTAssertNil([results minOfProperty:@"intCol"]);
     XCTAssertNil([results averageOfProperty:@"intCol"]);
-    XCTAssertNil([results sumOfProperty:@"intCol"]);
+    XCTAssertEqualObjects(@0, [results sumOfProperty:@"intCol"]);
     XCTAssertNil([results firstObject]);
     XCTAssertNil([results lastObject]);
     for (__unused id obj in results) {


### PR DESCRIPTION
A `RLMLinkingObjects` property of an unmanaged object is the only case in which a `RLMResults` instance has a null `_info` pointer. We were not adequately ensuring that the `_info` pointer is not accessed in such cases.

Fixes #4195.

/cc @jpsim @tgoyne @austinzheng 
