### PR TITLE
Replace Swift sync configuration tuple with a struct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ x.x.x Release notes (yyyy-MM-dd)
   * `SyncUser.allUsers()` in Swift 2.
   * `SyncUser.all` in Swift 3.
 * Rename `SyncManager.sharedManager()` to `SyncManager.shared` in Swift 3.
+* Change `Realm.Configuration.syncConfiguration` to take a `SyncConfiguration`
+  struct rather than a named tuple.
 
 ### Enhancements
 

--- a/Realm/ObjectServerTests/SwiftSyncTestCase.swift
+++ b/Realm/ObjectServerTests/SwiftSyncTestCase.swift
@@ -50,7 +50,7 @@ class SwiftSyncTestCase: RLMSyncTestCase {
             semaphore.signal()
         }
         SyncManager.shared.setSessionCompletionNotifier(basicBlock)
-        let config = Realm.Configuration(syncConfiguration: (user, url))
+        let config = Realm.Configuration(syncConfiguration: SyncConfiguration(user: user, realmURL: url))
         let realm = try Realm(configuration: config)
         // FIXME: Perhaps we should have a reasonable timeout here, instead of allowing bad code to stall forever.
         _ = semaphore.wait(timeout: .distantFuture)
@@ -58,7 +58,7 @@ class SwiftSyncTestCase: RLMSyncTestCase {
     }
 
     func immediatelyOpenRealm(url: URL, user: SyncUser) throws -> Realm {
-        return try Realm(configuration: Realm.Configuration(syncConfiguration: (user, url)))
+        return try Realm(configuration: Realm.Configuration(syncConfiguration: SyncConfiguration(user: user, realmURL: url)))
     }
 
     func synchronouslyLogInUser(for credential: Credential,
@@ -124,7 +124,7 @@ class SwiftSyncTestCase: RLMSyncTestCase {
             dispatch_semaphore_signal(semaphore)
         }
         SyncManager.sharedManager().setSessionCompletionNotifier(basicBlock)
-        let config = Realm.Configuration(syncConfiguration: (user, url))
+        let config = Realm.Configuration(syncConfiguration: SyncConfiguration(user: user, realmURL: url))
         let realm = try Realm(configuration: config)
         // FIXME: Perhaps we should have a reasonable timeout here, instead of allowing bad code to stall forever.
         dispatch_semaphore_wait(semaphore, DISPATCH_TIME_FOREVER)
@@ -132,7 +132,7 @@ class SwiftSyncTestCase: RLMSyncTestCase {
     }
 
     func immediatelyOpenRealm(url: NSURL, user: SyncUser) throws -> Realm {
-        return try Realm(configuration: Realm.Configuration(syncConfiguration: (user, url)))
+        return try Realm(configuration: Realm.Configuration(syncConfiguration: SyncConfiguration(user: user, realmURL: url)))
     }
 
     func synchronouslyLogInUser(for credential: Credential, server url: NSURL) throws -> SyncUser {

--- a/RealmSwift/RealmConfiguration.swift
+++ b/RealmSwift/RealmConfiguration.swift
@@ -55,11 +55,12 @@ extension Realm {
         /**
          Creates a `Configuration` which can be used to create new `Realm` instances.
 
+         - note: The `fileURL`, `inMemoryIdentifier`, and `syncConfiguration` parameters are mutually exclusive. Only
+                 set one of them, or none if you wish to use the default file URL.
+
          - parameter fileURL:            The local URL to the Realm file.
          - parameter inMemoryIdentifier: A string used to identify a particular in-memory Realm.
-         - parameter syncConfiguration:  A `SyncUser` and URL that, together, identify a remote Realm. Note that the
-                                         URL must be absolute (e.g. `realm://example.com/~/foo`), and cannot end with
-                                         `.realm`, `.realm.lock` or `.realm.management`.
+         - parameter syncConfiguration:  For Realms intended to sync with the Realm Object Server, a sync configuration.
          - parameter encryptionKey:      An optional 64-byte key to use to encrypt the data.
          - parameter readOnly:           Whether the Realm is read-only (must be true for read-only files).
          - parameter schemaVersion:      The current schema version.
@@ -70,7 +71,7 @@ extension Realm {
         */
         public init(fileURL: URL? = URL(fileURLWithPath: RLMRealmPathForFile("default.realm"), isDirectory: false),
             inMemoryIdentifier: String? = nil,
-            syncConfiguration: (user: SyncUser, realmURL: URL)? = nil,
+            syncConfiguration: SyncConfiguration? = nil,
             encryptionKey: Data? = nil,
             readOnly: Bool = false,
             schemaVersion: UInt64 = 0,
@@ -95,12 +96,10 @@ extension Realm {
         // MARK: Configuration Properties
 
         /**
-         A tuple used to configure a Realm for synchronization with the Realm Object Server. Mutually exclusive with
-         `inMemoryIdentifier` and `fileURL`.
-
-         - warning: The URL cannot end with `.realm`, `.realm.lock` or `.realm.management`.
+         A configuration value used to configure a Realm for synchronization with the Realm Object Server. Mutually
+         exclusive with `inMemoryIdentifier` and `fileURL`.
          */
-        public var syncConfiguration: (user: SyncUser, realmURL: URL)? {
+        public var syncConfiguration: SyncConfiguration? {
             set {
                 _path = nil
                 _inMemoryIdentifier = nil
@@ -111,7 +110,7 @@ extension Realm {
             }
         }
 
-        private var _syncConfiguration: (user: SyncUser, realmURL: URL)?
+        private var _syncConfiguration: SyncConfiguration?
 
         /// The local URL of the Realm file. Mutually exclusive with `inMemoryIdentifier` and `syncConfiguration`.
         public var fileURL: URL? {
@@ -197,8 +196,7 @@ extension Realm {
             } else if let inMemoryIdentifier = inMemoryIdentifier {
                 configuration.inMemoryIdentifier = inMemoryIdentifier
             } else if let syncConfiguration = syncConfiguration {
-                configuration.syncConfiguration = RLMSyncConfiguration(user: syncConfiguration.0,
-                                                                       realmURL: syncConfiguration.1)
+                configuration.syncConfiguration = syncConfiguration.asConfig()
             } else {
                 fatalError("A Realm Configuration must specify a path or an in-memory identifier.")
             }
@@ -217,7 +215,7 @@ extension Realm {
             configuration._path = rlmConfiguration.fileURL?.path
             configuration._inMemoryIdentifier = rlmConfiguration.inMemoryIdentifier
             if let objcSyncConfig = rlmConfiguration.syncConfiguration {
-                configuration._syncConfiguration = (objcSyncConfig.user, objcSyncConfig.realmURL)
+                configuration._syncConfiguration = SyncConfiguration(config: objcSyncConfig)
             } else {
                 configuration._syncConfiguration = nil
             }
@@ -284,11 +282,12 @@ extension Realm {
         /**
          Creates a `Configuration` which can be used to create new `Realm` instances.
 
+         - note: The `fileURL`, `inMemoryIdentifier`, and `syncConfiguration` parameters are mutually exclusive. Only
+                 set one of them, or none if you wish to use the default file URL.
+
          - parameter fileURL:            The local URL to the Realm file.
          - parameter inMemoryIdentifier: A string used to identify a particular in-memory Realm.
-         - parameter syncConfiguration:  A `SyncUser` and URL that, together, identify a remote Realm. Note that the
-                                         URL must be absolute (e.g. `realm://example.com/~/foo`), and cannot end with
-                                         `.realm`, `.realm.lock` or `.realm.management`.
+         - parameter syncConfiguration:  For Realms intended to sync with the Realm Object Server, a sync configuration.
          - parameter encryptionKey:      An optional 64-byte key to use to encrypt the data.
          - parameter readOnly:           Whether the Realm is read-only (must be true for read-only files).
          - parameter schemaVersion:      The current schema version.
@@ -299,7 +298,7 @@ extension Realm {
          */
         public init(fileURL: NSURL? = NSURL(fileURLWithPath: RLMRealmPathForFile("default.realm"), isDirectory: false),
             inMemoryIdentifier: String? = nil,
-            syncConfiguration: (user: SyncUser, realmURL: NSURL)? = nil,
+            syncConfiguration: SyncConfiguration? = nil,
             encryptionKey: NSData? = nil,
             readOnly: Bool = false,
             schemaVersion: UInt64 = 0,
@@ -324,12 +323,10 @@ extension Realm {
         // MARK: Configuration Properties
 
         /**
-         A tuple used to configure a Realm for synchronization with the Realm Object Server. Mutually exclusive with
-         `inMemoryIdentifier` and `fileURL`.
-
-         - warning: The URL cannot end with `.realm`, `.realm.lock` or `.realm.management`.
+         A configuration value used to configure a Realm for synchronization with the Realm Object Server. Mutually
+         exclusive with `inMemoryIdentifier` and `fileURL`.
          */
-        public var syncConfiguration: (user: SyncUser, realmURL: NSURL)? {
+        public var syncConfiguration: SyncConfiguration? {
             set {
                 _path = nil
                 _inMemoryIdentifier = nil
@@ -340,7 +337,7 @@ extension Realm {
             }
         }
 
-        private var _syncConfiguration: (user: SyncUser, realmURL: NSURL)?
+        private var _syncConfiguration: SyncConfiguration?
 
         /// The local URL of the Realm file. Mutually exclusive with `inMemoryIdentifier` and `syncConfiguration`.
         public var fileURL: NSURL? {
@@ -427,8 +424,7 @@ extension Realm {
             } else if inMemoryIdentifier != nil {
                 configuration.inMemoryIdentifier = self.inMemoryIdentifier
             } else if let syncConfiguration = syncConfiguration {
-                configuration.syncConfiguration = RLMSyncConfiguration(user: syncConfiguration.0,
-                                                                       realmURL: syncConfiguration.1)
+                configuration.syncConfiguration = syncConfiguration.asConfig()
             } else {
                 fatalError("A Realm Configuration must specify a path or an in-memory identifier.")
             }
@@ -447,7 +443,7 @@ extension Realm {
             configuration._path = rlmConfiguration.fileURL?.path
             configuration._inMemoryIdentifier = rlmConfiguration.inMemoryIdentifier
             if let objcSyncConfig = rlmConfiguration.syncConfiguration {
-                configuration._syncConfiguration = (objcSyncConfig.user, objcSyncConfig.realmURL)
+                configuration._syncConfiguration = SyncConfiguration(config: objcSyncConfig)
             } else {
                 configuration._syncConfiguration = nil
             }

--- a/RealmSwift/Sync.swift
+++ b/RealmSwift/Sync.swift
@@ -92,13 +92,55 @@ public typealias SyncLogLevel = RLMSyncLogLevel
  */
 public typealias Provider = RLMIdentityProvider
 
+/// A `SyncConfiguration` represents configuration parameters for Realms intended to sync with a Realm Object Server.
+public struct SyncConfiguration {
+    /// The `SyncUser` who owns the Realm that this configuration should open.
+    public let user: SyncUser
+
+    /**
+     The URL of the Realm on the Realm Object Server that this configuration should open.
+
+     - warning: The URL must be absolute (e.g. `realms://example.com/~/foo`), and cannot end with
+                `.realm`, `.realm.lock` or `.realm.management`.
+     */
+    public let realmURL: URL
+
+    /// A policy that determines what should happen when all references to Realms opened by this configuration
+    /// go out of scope.
+    internal let stopPolicy: RLMSyncStopPolicy
+
+    internal init(config: RLMSyncConfiguration) {
+        self.user = config.user
+        self.realmURL = config.realmURL
+        self.stopPolicy = config.stopPolicy
+    }
+
+    func asConfig() -> RLMSyncConfiguration {
+        let config = RLMSyncConfiguration(user: user, realmURL: realmURL)
+        config.stopPolicy = stopPolicy
+        return config
+    }
+
+    /**
+     Initialize a sync configuration with a user and a Realm URL.
+
+     - warning: The URL must be absolute (e.g. `realms://example.com/~/foo`), and cannot end with
+                `.realm`, `.realm.lock` or `.realm.management`.
+     */
+    public init(user: SyncUser, realmURL: URL) {
+        self.user = user
+        self.realmURL = realmURL
+        self.stopPolicy = .afterChangesUploaded
+    }
+}
+
 /// A `Credential` represents data that uniquely identifies a Realm Object Server user.
 public struct Credential {
     public typealias Token = String
 
-    var token: Token
-    var provider: Provider
-    var userInfo: [String: Any]
+    internal var token: Token
+    internal var provider: Provider
+    internal var userInfo: [String: Any]
 
     /// Initialize a new credential using a custom token, authentication provider, and user information dictionary. In
     /// most cases, the convenience initializers should be used instead.
@@ -176,13 +218,55 @@ extension SyncUser {
  */
 public typealias Provider = String // `RLMIdentityProvider` imports as `NSString`
 
+/// A `SyncConfiguration` represents configuration parameters for Realms intended to sync with a Realm Object Server.
+public struct SyncConfiguration {
+    /// The `SyncUser` who owns the Realm that this configuration should open.
+    public let user: SyncUser
+
+    /**
+     The URL of the Realm on the Realm Object Server that this configuration should open.
+
+     - warning: The URL must be absolute (e.g. `realms://example.com/~/foo`), and cannot end with
+                `.realm`, `.realm.lock` or `.realm.management`.
+     */
+    public let realmURL: NSURL
+
+    /// A policy that determines what should happen when all references to Realms opened by this configuration
+    /// go out of scope.
+    internal let stopPolicy: RLMSyncStopPolicy
+
+    internal init(config: RLMSyncConfiguration) {
+        self.user = config.user
+        self.realmURL = config.realmURL
+        self.stopPolicy = config.stopPolicy
+    }
+
+    func asConfig() -> RLMSyncConfiguration {
+        let config = RLMSyncConfiguration(user: user, realmURL: realmURL)
+        config.stopPolicy = stopPolicy
+        return config
+    }
+
+    /**
+     Initialize a sync configuration with a user and a Realm URL.
+
+     - warning: The URL must be absolute (e.g. `realms://example.com/~/foo`), and cannot end with
+                `.realm`, `.realm.lock` or `.realm.management`.
+     */
+    public init(user: SyncUser, realmURL: NSURL) {
+        self.user = user
+        self.realmURL = realmURL
+        self.stopPolicy = .AfterChangesUploaded
+    }
+}
+
 /// A `Credential` represents data that uniquely identifies a Realm Object Server user.
 public struct Credential {
     public typealias Token = String
 
-    var token: Token
-    var provider: Provider
-    var userInfo: [String: AnyObject]
+    internal var token: Token
+    internal var provider: Provider
+    internal var userInfo: [String: AnyObject]
 
     // swiftlint:disable valid_docs
 


### PR DESCRIPTION
@jpsim @bdash @tgoyne 

Fixes #4198 

We have Swift sync server tests, but they're disabled right now. I'll fix them in a separate PR.
