### PR TITLE
RM-1: Reworked flow of adding object a bit, added wrappers around primitives

### DIFF
--- a/Realm.xcodeproj/project.pbxproj
+++ b/Realm.xcodeproj/project.pbxproj
@@ -413,6 +413,8 @@
 		5DD755CA1BE056DE002800DA /* schema.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 3FE556431B9A43E5002A1129 /* schema.hpp */; };
 		5DD755CB1BE056DE002800DA /* shared_realm.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 3FAE25541B8CEBBE00D01405 /* shared_realm.hpp */; };
 		5DD755E21BE05DAF002800DA /* Realm.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5DD755CF1BE056DE002800DA /* Realm.framework */; };
+		5F3E8AB91DB20F0700B525CB /* Primitive.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F3E8AB81DB20F0700B525CB /* Primitive.swift */; };
+		5F8BB3EA1DB3A76C006FAADD /* SwiftObjectAddingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F8BB3E81DB3A76C006FAADD /* SwiftObjectAddingTests.swift */; };
 		C042A48D1B7522A900771ED2 /* RealmConfigurationTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = C042A48C1B7522A900771ED2 /* RealmConfigurationTests.mm */; };
 		C042A48E1B7522A900771ED2 /* RealmConfigurationTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = C042A48C1B7522A900771ED2 /* RealmConfigurationTests.mm */; };
 		C0CDC0821B38DABA00C5716D /* UtilTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 021A88311AAFB5BE00EEAC84 /* UtilTests.mm */; };
@@ -794,6 +796,8 @@
 		5DD755CF1BE056DE002800DA /* Realm.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework.static; includeInIndex = 0; path = Realm.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		5DD755E01BE05C19002800DA /* Tests.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Tests.xcconfig; sourceTree = "<group>"; };
 		5DD755E31BE05EA1002800DA /* Tests iOS static.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = "Tests iOS static.xcconfig"; sourceTree = "<group>"; };
+		5F3E8AB81DB20F0700B525CB /* Primitive.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Primitive.swift; sourceTree = "<group>"; };
+		5F8BB3E81DB3A76C006FAADD /* SwiftObjectAddingTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwiftObjectAddingTests.swift; sourceTree = "<group>"; };
 		A05FA61E1B62C3900000C9B2 /* RLMObjectBase_Dynamic.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RLMObjectBase_Dynamic.h; sourceTree = "<group>"; };
 		C0004BEB1B8E4FCF00304BF3 /* RLMOptionalBase.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RLMOptionalBase.h; sourceTree = "<group>"; };
 		C0004BEC1B8E4FCF00304BF3 /* RLMOptionalBase.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = RLMOptionalBase.mm; sourceTree = "<group>"; };
@@ -1135,6 +1139,7 @@
 				5D660FE61BE98D670021E04F /* Object.swift */,
 				5D660FE71BE98D670021E04F /* ObjectSchema.swift */,
 				5D660FE81BE98D670021E04F /* Optional.swift */,
+				5F3E8AB81DB20F0700B525CB /* Primitive.swift */,
 				5D660FE91BE98D670021E04F /* Property.swift */,
 				5D660FEA1BE98D670021E04F /* Realm.swift */,
 				1AB605D21D495927007F53DE /* RealmCollection.swift */,
@@ -1163,6 +1168,7 @@
 				5D6610061BE98D880021E04F /* ObjectTests.swift */,
 				5D6610071BE98D880021E04F /* PerformanceTests.swift */,
 				5D6610081BE98D880021E04F /* PropertyTests.swift */,
+				5F8BB3E81DB3A76C006FAADD /* SwiftObjectAddingTests.swift */,
 				5D6610091BE98D880021E04F /* RealmCollectionTypeTests.swift */,
 				5D66100A1BE98D880021E04F /* RealmConfigurationTests.swift */,
 				5D66100C1BE98D880021E04F /* RealmTests.swift */,
@@ -2168,6 +2174,7 @@
 				5D660FF81BE98D670021E04F /* Realm.swift in Sources */,
 				1AB605D31D495927007F53DE /* RealmCollection.swift in Sources */,
 				5D660FFA1BE98D670021E04F /* RealmConfiguration.swift in Sources */,
+				5F3E8AB91DB20F0700B525CB /* Primitive.swift in Sources */,
 				5D660FFB1BE98D670021E04F /* Results.swift in Sources */,
 				5D660FFC1BE98D670021E04F /* Schema.swift in Sources */,
 				5D660FFD1BE98D670021E04F /* SortDescriptor.swift in Sources */,
@@ -2188,6 +2195,7 @@
 				5D6610191BE98D880021E04F /* ObjectCreationTests.swift in Sources */,
 				5D66101A1BE98D880021E04F /* ObjectSchemaInitializationTests.swift in Sources */,
 				5D66101B1BE98D880021E04F /* ObjectSchemaTests.swift in Sources */,
+				5F8BB3EA1DB3A76C006FAADD /* SwiftObjectAddingTests.swift in Sources */,
 				5D66101C1BE98D880021E04F /* ObjectTests.swift in Sources */,
 				5D66101D1BE98D880021E04F /* PerformanceTests.swift in Sources */,
 				5D66101E1BE98D880021E04F /* PropertyTests.swift in Sources */,

--- a/Realm/RLMAccessor.mm
+++ b/Realm/RLMAccessor.mm
@@ -166,7 +166,7 @@ static inline RLMObjectBase *RLMGetLinkedObjectForValue(__unsafe_unretained RLMR
 
     if (creationOptions & RLMCreationOptionsPromoteUnmanaged) {
         if (!link->_realm) {
-            RLMAddObjectToRealm(link, realm, creationOptions & RLMCreationOptionsCreateOrUpdate);
+            RLMAddOrUpdateObjectToRealm(link, realm, creationOptions & RLMCreationOptionsCreateOrUpdate);
             return link;
         }
         @throw RLMException(@"Can not add objects from a different Realm");

--- a/Realm/RLMObjectStore.h
+++ b/Realm/RLMObjectStore.h
@@ -56,7 +56,10 @@ typedef NS_OPTIONS(NSUInteger, RLMCreationOptions) {
 //
 
 // add an object to the given realm
-void RLMAddObjectToRealm(RLMObjectBase *object, RLMRealm *realm, bool createOrUpdate);
+void RLMAddObjectToRealm(RLMObjectBase *object, RLMRealm *realm);
+    
+// adds or updates an object to the given realm
+void RLMAddOrUpdateObjectToRealm(RLMObjectBase *object, RLMRealm *realm, bool createOrUpdate);
 
 // delete an object from its realm
 void RLMDeleteObjectFromRealm(RLMObjectBase *object, RLMRealm *realm);

--- a/Realm/RLMRealm.mm
+++ b/Realm/RLMRealm.mm
@@ -524,7 +524,7 @@ REALM_NOINLINE void RLMRealmTranslateException(NSError **error) {
 }
 
 - (void)addObject:(__unsafe_unretained RLMObject *const)object {
-    RLMAddObjectToRealm(object, self, false);
+    RLMAddObjectToRealm(object, self);
 }
 
 - (void)addObjects:(id<NSFastEnumeration>)array {
@@ -543,7 +543,7 @@ REALM_NOINLINE void RLMRealmTranslateException(NSError **error) {
         @throw RLMException(@"'%@' does not have a primary key and can not be updated", object.objectSchema.className);
     }
 
-    RLMAddObjectToRealm(object, self, true);
+    RLMAddOrUpdateObjectToRealm(object, self, true);
 }
 
 - (void)addOrUpdateObjectsFromArray:(id)array {

--- a/RealmSwift/Primitive.swift
+++ b/RealmSwift/Primitive.swift
@@ -1,0 +1,100 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2015 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+import Realm
+
+public class RealmInt: Object, ExpressibleByIntegerLiteral {
+    public typealias IntegerLiteralType = Int
+    
+    public dynamic var value: Int = 0
+    
+    public required init(integerLiteral value: Int) {
+        super.init()
+        self.value = value
+    }
+    
+    public required init() {
+        super.init()
+    }
+    
+    public required init(realm: RLMRealm, schema: RLMObjectSchema) {
+        super.init(realm: realm, schema: schema)
+    }
+    
+    public required init(value: Any, schema: RLMSchema) {
+        super.init(value: value, schema: schema)
+    }
+}
+
+public class RealmDouble: Object, ExpressibleByFloatLiteral {
+    public typealias FloatLiteralType = Double
+    
+    public dynamic var value: Double = 0.0
+    
+    public required init(floatLiteral value: Double) {
+        super.init()
+        self.value = value
+    }
+    
+    public required init() {
+        super.init()
+    }
+    
+    public required init(realm: RLMRealm, schema: RLMObjectSchema) {
+        super.init(realm: realm, schema: schema)
+    }
+    
+    public required init(value: Any, schema: RLMSchema) {
+        super.init(value: value, schema: schema)
+    }
+}
+
+public class RealmString: Object, ExpressibleByStringLiteral {
+    public typealias StringLiteralType = String
+    public typealias UnicodeScalarLiteralType = String
+    public typealias ExtendedGraphemeClusterLiteralType = String
+    
+    public dynamic var value: String = ""
+    
+    public required init(stringLiteral value: String) {
+        super.init()
+        self.value = value
+    }
+    
+    public required init(extendedGraphemeClusterLiteral value: String) {
+        super.init()
+        self.value = value
+    }
+    
+    public required init(unicodeScalarLiteral value: String) {
+        super.init()
+        self.value = value
+    }
+    
+    public required init() {
+        super.init()
+    }
+    
+    public required init(realm: RLMRealm, schema: RLMObjectSchema) {
+        super.init(realm: realm, schema: schema)
+    }
+    
+    public required init(value: Any, schema: RLMSchema) {
+        super.init(value: value, schema: schema)
+    }
+}

--- a/RealmSwift/Realm.swift
+++ b/RealmSwift/Realm.swift
@@ -199,12 +199,28 @@ public final class Realm {
     }
 
     // MARK: Adding and Creating objects
+    /**
+     Adds object into the Realm.
+     
+     When added, all child relationships referenced by this object will also be added to the Realm if they are not
+     already in it. If the object or any related objects are already being managed by a different Realm an error will be
+     thrown. Instead, use one of the `create` functions to insert a copy of a managed object into a different Realm.
+     
+     The object to be added must be valid and cannot have been previously deleted from a Realm (i.e. `isInvalidated`
+     must be `false`).
+     
+     - parameter object: The object to be added to this Realm.
+     */
+    public func add(_ object: Object) {
+        RLMAddObjectToRealm(object, rlmRealm)
+    }
 
     /**
      Adds or updates an existing object into the Realm.
 
      Only pass `true` to `update` if the object has a primary key. If no objects exist in the Realm with the same
-     primary key value, the object is inserted. Otherwise, the existing object is updated with any changed values.
+     primary key value, the object is inserted. Otherwise, the existing object is updated with any changed values. 
+     If object with such ID already exists and `update` is set to `false` - the object will be skiped with no changes.
 
      When added, all child relationships referenced by this object will also be added to the Realm if they are not
      already in it. If the object or any related objects are already being managed by a different Realm an error will be
@@ -221,7 +237,8 @@ public final class Realm {
         if update && object.objectSchema.primaryKeyProperty == nil {
             throwRealmException("'\(object.objectSchema.className)' does not have a primary key and can not be updated")
         }
-        RLMAddObjectToRealm(object, rlmRealm, update)
+        
+        RLMAddOrUpdateObjectToRealm(object, rlmRealm, update)
     }
 
     /**

--- a/RealmSwift/Tests/SwiftObjectAddingTests.swift
+++ b/RealmSwift/Tests/SwiftObjectAddingTests.swift
@@ -1,0 +1,190 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2015 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+import XCTest
+#if DEBUG
+    @testable import RealmSwift
+#else
+    import RealmSwift
+#endif
+import Foundation
+
+class TestClass: Object {
+    dynamic var id: Int = 0
+    
+    let intArray = List<RealmInt>()
+    let doubleArray = List<RealmDouble>()
+    let stringArray = List<RealmString>()
+    
+    override static func primaryKey() -> String? {
+        return "id"
+    }
+}
+
+class SwiftObjectAddingTests: TestCase {
+    
+    func testShouldAddObjectWithExpressibleInts() {
+        let realm = try! Realm(fileURL: testRealmURL())
+        try! realm.write {
+            let object = TestClass()
+            
+            object.intArray.append(0)
+            object.intArray.append(1)
+            
+            realm.add(object)
+        }
+        
+        if let object = realm.object(ofType: TestClass.self, forPrimaryKey: 0) {
+            XCTAssertEqual(object.intArray.count, 2)
+            XCTAssertEqual(object.stringArray.count, 0)
+            XCTAssertEqual(object.doubleArray.count, 0)
+            
+            XCTAssertEqual(object.intArray[0].value, 0)
+            XCTAssertEqual(object.intArray[1].value, 1)
+        } else {
+            XCTFail()
+        }
+    }
+    
+    func testShouldAddObjectWithExpressibleDoubles() {
+        let realm = try! Realm(fileURL: testRealmURL())
+        try! realm.write {
+            let object = TestClass()
+            
+            object.doubleArray.append(0.0)
+            object.doubleArray.append(1.5)
+            
+            realm.add(object)
+        }
+        
+        if let object = realm.object(ofType: TestClass.self, forPrimaryKey: 0) {
+            XCTAssertEqual(object.intArray.count, 0)
+            XCTAssertEqual(object.doubleArray.count, 2)
+            XCTAssertEqual(object.stringArray.count, 0)
+            
+            XCTAssertEqual(object.doubleArray[0].value, 0.0)
+            XCTAssertEqual(object.doubleArray[1].value, 1.5)
+        } else {
+            XCTFail()
+        }
+    }
+    
+    func testShouldAddObjectWithExpressibleStrings() {
+        let realm = try! Realm(fileURL: testRealmURL())
+        try! realm.write {
+            let object = TestClass()
+            
+            object.stringArray.append("abba")
+            object.stringArray.append("kappacino")
+            
+            realm.add(object)
+        }
+        
+        if let object = realm.object(ofType: TestClass.self, forPrimaryKey: 0) {
+            XCTAssertEqual(object.intArray.count, 0)
+            XCTAssertEqual(object.doubleArray.count, 0)
+            XCTAssertEqual(object.stringArray.count, 2)
+            
+            XCTAssertEqual(object.stringArray[0].value, "abba")
+            XCTAssertEqual(object.stringArray[1].value, "kappacino")
+        } else {
+            XCTFail()
+        }
+    }
+    
+    func testShouldThrowOnAddingObjectWithExistingId() {
+        let realm = try! Realm(fileURL: testRealmURL())
+        
+        try! realm.write {
+            let object = TestClass()
+            realm.add(object)
+        }
+        
+        try! realm.write {
+            let object = TestClass()
+            assertThrows(realm.add(object))
+        }
+    }
+    
+    func testShouldUpdateObjectWithExisitingId() {
+        let realm = try! Realm(fileURL: testRealmURL())
+
+        try! realm.write {
+            let object = TestClass()
+            realm.add(object)
+        }
+        
+        assertTestObjectEmpty(realm: realm)
+        
+        try! realm.write {
+            let object = TestClass()
+            
+            object.intArray.append(0)
+            object.intArray.append(1)
+            
+            realm.add(object, update: true)
+        }
+        
+        if let object = realm.object(ofType: TestClass.self, forPrimaryKey: 0) {
+            XCTAssertEqual(object.intArray.count, 2)
+            XCTAssertEqual(object.stringArray.count, 0)
+            XCTAssertEqual(object.doubleArray.count, 0)
+            
+            XCTAssertEqual(object.intArray[0].value, 0)
+            XCTAssertEqual(object.intArray[1].value, 1)
+        } else {
+            XCTFail()
+        }
+    }
+
+    func testShouldNotUpdateObjectWithExisitingId() {
+        let realm = try! Realm(fileURL: testRealmURL())
+        
+        try! realm.write {
+            realm.deleteAll()
+        }
+        
+        try! realm.write {
+            let object = TestClass()
+            realm.add(object)
+        }
+        
+        assertTestObjectEmpty(realm: realm)
+        
+        try! realm.write {
+            let object = TestClass()
+            
+            object.intArray.append(0)
+            object.intArray.append(1)
+            
+            realm.add(object, update: false)
+        }
+        
+        assertTestObjectEmpty(realm: realm)
+    }
+    
+    private func assertTestObjectEmpty(realm: Realm) {
+        if let object = realm.object(ofType: TestClass.self, forPrimaryKey: 0) {
+            XCTAssertEqual(object.intArray.count, 0)
+            XCTAssertEqual(object.stringArray.count, 0)
+            XCTAssertEqual(object.doubleArray.count, 0)
+        } else {
+            XCTFail()
+        }
+    }
+}


### PR DESCRIPTION
In my recent project in which my team is using Realm, I've meet few things that seems to be unintuitive for me. I tried my best to make it more clean and intuitive and hope that my idea will pass into project at some point :)
First of all, I believe way in which function `realm.add(object, update: false)` is a bit misleading. When I saw this function for first time, I thought that it's actually skipping object, if exists, without any changes, while `realm.add(object, update: true)` is updating existing object. Later I realised that `realm.add(object, update: false)` is actually throwing exception if object with such primary key already exists, what was a bit frustrating for me. The first change that I want to provide is to make `realm.add(object, update: false)` just skip object instead of throwing error if exists. It's quite critical for my project, since user of application can fire multiple requests at time and objects in result can already exists in database, but we don't want to update them, since it could overwrite local changes. 
Second thing: wrappers around primitive types (Int, Double and String for now) for List<T> to provide builtin possibility of saving list of primitive types  in Realm. Yes, it's not a big deal to write such thing for particular project, but I feel that it would be nice to have such possibility out of the box :)
I hope that I correctly read down the code and documentation and didn't duplicate features that already exists somewhere in Realm :)