### PR TITLE
Reenable some disabled object server tests

### DIFF
--- a/Realm/ObjectServerTests/RLMObjectServerTests.m
+++ b/Realm/ObjectServerTests/RLMObjectServerTests.m
@@ -185,7 +185,7 @@
 
 // FIXME: get these tests working reliably on CI
 /// A client should be able to open multiple Realms and add objects to each of them.
-- (void)DISABLED_testMultipleRealmsAddObjects {
+- (void)testMultipleRealmsAddObjects {
     NSURL *urlA = CUSTOM_REALM_URL(@"a");
     NSURL *urlB = CUSTOM_REALM_URL(@"b");
     NSURL *urlC = CUSTOM_REALM_URL(@"c");
@@ -225,7 +225,7 @@
 }
 
 /// A client should be able to open multiple Realms and delete objects from each of them.
-- (void)DISABLED_testMultipleRealmsDeleteObjects {
+- (void)testMultipleRealmsDeleteObjects {
     NSURL *urlA = CUSTOM_REALM_URL(@"a");
     NSURL *urlB = CUSTOM_REALM_URL(@"b");
     NSURL *urlC = CUSTOM_REALM_URL(@"c");
@@ -287,7 +287,7 @@
 
 // FIXME: figure out how to get this test to reliably pass.
 /// When a session opened by a Realm goes out of scope, it should stay alive long enough to finish any waiting uploads.
-- (void)DISABLED_testUploadChangesWhenRealmOutOfScope {
+- (void)testUploadChangesWhenRealmOutOfScope {
     const NSInteger OBJECT_COUNT = 10000;
     NSURL *url = REALM_URL();
     // Log in the user.

--- a/Realm/ObjectServerTests/SwiftObjectServerTests.swift
+++ b/Realm/ObjectServerTests/SwiftObjectServerTests.swift
@@ -22,7 +22,7 @@ import RealmSwift
 #if swift(>=3.0)
 class SwiftObjectServerTests: SwiftSyncTestCase {
     /// It should be possible to successfully open a Realm configured for sync.
-    func DISABLED_testBasicSwiftSync() {
+    func testBasicSwiftSync() {
         let url = URL(string: "realm://localhost:9080/~/testBasicSync")!
         do {
             let user = try synchronouslyLogInUser(for: basicCredential(create: true), server: authURL)
@@ -34,7 +34,7 @@ class SwiftObjectServerTests: SwiftSyncTestCase {
     }
 
     /// If client B adds objects to a Realm, client A should see those new objects.
-    func DISABLED_testSwiftRemoteAddObjects() {
+    func testSwiftAddObjects() {
         do {
             let user = try synchronouslyLogInUser(for: basicCredential(create: isParent), server: authURL)
             let realm = try synchronouslyOpenRealm(url: realmURL, user: user)
@@ -60,7 +60,7 @@ class SwiftObjectServerTests: SwiftSyncTestCase {
     }
 
     /// If client B removes objects from a Realm, client A should see those changes.
-    func DISABLED_testSwiftRemoteDeleteObjects() {
+    func testSwiftDeleteObjects() {
         do {
             let user = try synchronouslyLogInUser(for: basicCredential(create: isParent), server: authURL)
             let realm = try synchronouslyOpenRealm(url: realmURL, user: user)
@@ -102,7 +102,7 @@ class SwiftObjectServerTests: SwiftSyncTestCase {
     }
 
     /// If client B adds objects to a Realm, client A should see those new objects.
-    func testSwiftRemoteAddObjects() {
+    func testSwiftAddObjects() {
         do {
             let user = try synchronouslyLogInUser(for: basicCredential(create: isParent), server: authURL)
             let realm = try synchronouslyOpenRealm(url: realmURL, user: user)
@@ -128,7 +128,7 @@ class SwiftObjectServerTests: SwiftSyncTestCase {
     }
 
     /// If client B removes objects from a Realm, client A should see those changes.
-    func testSwiftRemoteDeleteObjects() {
+    func testSwiftDeleteObjects() {
         do {
             let user = try synchronouslyLogInUser(for: basicCredential(create: isParent), server: authURL)
             let realm = try synchronouslyOpenRealm(url: realmURL, user: user)

--- a/Realm/ObjectServerTests/SwiftSyncTestCase.swift
+++ b/Realm/ObjectServerTests/SwiftSyncTestCase.swift
@@ -36,9 +36,9 @@ class SwiftSyncTestCase: RLMSyncTestCase {
         XCTAssert(0 == runChildAndWait(), "Tests in child process failed", file: file, line: line)
     }
 
-    func basicCredential(create: Bool) -> Credential {
+    func basicCredential(create: Bool, file: StaticString = #file, line: UInt = #line) -> Credential {
         let actions: AuthenticationActions = create ? .createAccount : .useExistingAccount
-        return Credential.usernamePassword(username: "a", password: "a", actions: actions)
+        return Credential.usernamePassword(username: "\(file)\(line)", password: "a", actions: actions)
     }
 
     func synchronouslyOpenRealm(url: URL, user: SyncUser, file: StaticString = #file, line: UInt = #line) throws -> Realm {
@@ -110,9 +110,9 @@ class SwiftSyncTestCase: RLMSyncTestCase {
         XCTAssert(0 == runChildAndWait(), "Tests in child process failed")
     }
 
-    func basicCredential(create create: Bool) -> Credential {
+    func basicCredential(create create: Bool, file: StaticString = #file, line: UInt = #line) -> Credential {
         let actions: AuthenticationActions = create ? .CreateAccount : .UseExistingAccount
-        return Credential.usernamePassword("a", password: "a", actions: actions)
+        return Credential.usernamePassword("\(file)\(line)", password: "a", actions: actions)
     }
 
     func synchronouslyOpenRealm(url url: NSURL,

--- a/build.sh
+++ b/build.sh
@@ -415,6 +415,8 @@ case "$COMMAND" in
 
     "reset-object-server")
         kill_object_server
+        # Add a short delay, so file system doesn't complain about files in use
+        sleep 1
         package="${source_root}/sync"
         for file in "$package"/realm-object-server-*; do
             if [ -d "$file" ]; then
@@ -826,6 +828,7 @@ case "$COMMAND" in
     "verify-osx-object-server")
         sh build.sh download-object-server
         sh build.sh test-osx-object-server
+        sh build.sh reset-object-server
         exit 0
         ;;
 


### PR DESCRIPTION
@jpsim 

Kicking this off to see what CI thinks...

Changes:
- Re-enabled Swift tests
- Re-enabled some disabled Objective-C tests
- Base test case class no longer terminates server process upon tearDown