### PR TITLE
Fix running just the Schema tests

### DIFF
--- a/Realm/Tests/SchemaTests.mm
+++ b/Realm/Tests/SchemaTests.mm
@@ -263,8 +263,7 @@ RLM_ARRAY_TYPE(NotARealClass)
 
 @implementation SchemaTests
 
-+ (void)tearDown
-{
+- (void)tearDown {
     RLMSetTreatFakeObjectAsRLMObject(NO);
     [super tearDown];
 }


### PR DESCRIPTION
`RLMSetTreatFakeObjectAsRLMObject(NO)` needs to be called after every test, not
just after the Schema test suite is complete. It happened to work when running
all tests because an earlier test would initialize the shared schema before the
Schema tests were ever run.

@jpsim 