### PR TITLE
Speed up the object server tests

### DIFF
--- a/Configuration/object-server-config.yml
+++ b/Configuration/object-server-config.yml
@@ -1,0 +1,12 @@
+storage:
+  root_path: 'root_dir'
+auth:
+  public_key_path: 'keys/token-signature.pub'
+  private_key_path: 'keys/token-signature.key'
+  sync_hosts:
+    - 'localhost:9080'
+  providers:
+    password:
+      iterations: 1
+enterprise:
+  skip_setup: true

--- a/Realm.xcodeproj/xcshareddata/xcschemes/Object Server Tests.xcscheme
+++ b/Realm.xcodeproj/xcshareddata/xcschemes/Object Server Tests.xcscheme
@@ -1,10 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "0800"
-   version = "1.3">
+   version = "1.8">
    <BuildAction
-      parallelizeBuildables = "YES"
+      parallelizeBuildables = "NO"
       buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "5D659E7D1BE04556006515A0"
+               BuildableName = "Realm.framework"
+               BlueprintName = "Realm"
+               ReferencedContainer = "container:Realm.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "E856D1DE195614A400FB2FCF"
+               BuildableName = "iOS static tests.xctest"
+               BlueprintName = "iOS static tests"
+               ReferencedContainer = "container:Realm.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
    </BuildAction>
    <TestAction
       buildConfiguration = "Debug"
@@ -23,6 +53,15 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "5D659E7D1BE04556006515A0"
+            BuildableName = "Realm.framework"
+            BlueprintName = "Realm"
+            ReferencedContainer = "container:Realm.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <AdditionalOptions>
       </AdditionalOptions>
    </TestAction>
@@ -36,6 +75,15 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "5D659E7D1BE04556006515A0"
+            BuildableName = "Realm.framework"
+            BlueprintName = "Realm"
+            ReferencedContainer = "container:Realm.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <AdditionalOptions>
       </AdditionalOptions>
    </LaunchAction>
@@ -45,6 +93,17 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "5D659E7D1BE04556006515A0"
+            BuildableName = "Realm.framework"
+            BlueprintName = "Realm"
+            ReferencedContainer = "container:Realm.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/Realm/ObjectServerTests/RLMObjectServerTests.m
+++ b/Realm/ObjectServerTests/RLMObjectServerTests.m
@@ -355,6 +355,10 @@
                                                                                    register:NO]
                                       server:[RLMObjectServerTests authServerURL]];
         [self addSyncObjectsToRealm:realm descriptions:@[@"parent-2", @"parent-3"]];
+
+        // FIXME: calling wait_for_upload_complete() before receiving BIND does
+        // not actually wait
+        sleep(1);
         WAIT_FOR_UPLOAD(user, url);
         CHECK_COUNT(3, SyncObject, realm);
         RLMRunChildAndWait();
@@ -389,6 +393,10 @@
     } else {
         WAIT_FOR_DOWNLOAD(user, url);
         [self addSyncObjectsToRealm:realm descriptions:@[@"child-1", @"child-2"]];
+
+        // FIXME: calling wait_for_upload_complete() before receiving BIND does
+        // not actually wait
+        sleep(1);
         WAIT_FOR_UPLOAD(user, url);
         CHECK_COUNT(3, SyncObject, realm);
     }
@@ -552,6 +560,10 @@
         realm = [self immediatelyOpenRealmForURL:url user:user];
         [self addSyncObjectsToRealm:realm descriptions:@[@"child-1", @"child-2", @"child-3", @"child-4"]];
         CHECK_COUNT(5, SyncObject, realm);
+
+        // FIXME: calling wait_for_upload_complete() before receiving BIND does
+        // not actually wait
+        sleep(1);
         WAIT_FOR_UPLOAD(user, url);
         RLMRunChildAndWait();
     } else {

--- a/Realm/ObjectServerTests/RLMObjectServerTests.m
+++ b/Realm/ObjectServerTests/RLMObjectServerTests.m
@@ -772,7 +772,7 @@
 }
 
 - (void)verifyChangePermission:(RLMSyncPermissionChange *)permissionChange statusMessage:(NSString *)message owner:(RLMSyncUser *)owner {
-    RLMRealm *managementRealm = [self managementRealmForUser:owner];
+    RLMRealm *managementRealm = [owner managementRealmWithError:nil];
 
     XCTestExpectation *expectation = [self expectationWithDescription:@"A new permission will be granted by the server"];
 

--- a/Realm/ObjectServerTests/RLMSyncTestCase.h
+++ b/Realm/ObjectServerTests/RLMSyncTestCase.h
@@ -45,8 +45,6 @@ NS_ASSUME_NONNULL_BEGIN
 /// Synchronously open a synced Realm and wait until the binding process has completed or failed.
 - (RLMRealm *)openRealmForURL:(NSURL *)url user:(RLMSyncUser *)user;
 
-- (RLMRealm *)managementRealmForUser:(RLMSyncUser *)user;
-
 /// Immediately open a synced Realm.
 - (RLMRealm *)immediatelyOpenRealmForURL:(NSURL *)url user:(RLMSyncUser *)user;
 

--- a/build.sh
+++ b/build.sh
@@ -297,11 +297,7 @@ download_object_server() {
     mkdir sync
     tar xf $archive_name -C sync
     rm $archive_name
-    echo "\nenterprise:\n  skip_setup: true" >> "sync/object-server/configuration.yml"
-    sed -i '' -e "s/    listen_address: '0\.0\.0\.0'/    listen_address: '::'/" "sync/object-server/configuration.yml"
-    LF=$(printf '\\\012_')
-    LF=${LF%_}
-    sed -i '' -e "s/  sync_hosts:/  sync_hosts:$LF    - 'localhost:9080'/" "sync/object-server/configuration.yml"
+    cp Configuration/object-server-config.yml sync/object-server/configuration.yml
     touch "sync/object-server/do_not_open_browser"
 }
 


### PR DESCRIPTION
Reduce the number of iterations used to hash the password to 1, as that's where most of the run time of the tests was spent. Cuts the total run time from 1 minute to 25 seconds on my machine.

This exposes some race conditions in the tests which are currently just worked around with some `sleep()` calls until the object store bug is fixed.