### PR TITLE
Enable sync metadata reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ x.x.x Release notes (yyyy-MM-dd)
 
 ### Bugfixes
 
-* None.
+* Reset sync metadata Realm in case of decryption error.
 
 2.1.0 Release notes (2016-11-18)
 =============================================================

--- a/Realm/RLMSyncManager.mm
+++ b/Realm/RLMSyncManager.mm
@@ -112,7 +112,7 @@ static dispatch_once_t s_onceToken;
         bool should_encrypt = !getenv("REALM_DISABLE_METADATA_ENCRYPTION");
         auto mode = should_encrypt ? SyncManager::MetadataMode::Encryption : SyncManager::MetadataMode::NoEncryption;
         rootDirectory = rootDirectory ?: [NSURL fileURLWithPath:RLMDefaultDirectoryForBundleIdentifier(nil)];
-        SyncManager::shared().configure_file_system(rootDirectory.path.UTF8String, mode);
+        SyncManager::shared().configure_file_system(rootDirectory.path.UTF8String, mode, none, true);
         return self;
     }
     return nil;


### PR DESCRIPTION
Enables metadata reset implemented in https://github.com/realm/realm-object-store/pull/213, fixes https://github.com/realm/realm-cocoa/issues/4264.

/cc @austinzheng, @jpsim 