### PR TITLE
add "Sync Breaking Changes" section to changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
 x.x.x Release notes (yyyy-MM-dd)
 =============================================================
 
-### API breaking changes
+### Sync Breaking Changes (In Beta)
+
+* None.
+
+### API Breaking Changes
 
 * None.
 
@@ -15,6 +19,10 @@ x.x.x Release notes (yyyy-MM-dd)
 
 2.1.0 Release notes (2016-11-18)
 =============================================================
+
+### Sync Breaking Changes (In Beta)
+
+* None.
 
 ### API breaking changes
 
@@ -38,7 +46,7 @@ x.x.x Release notes (yyyy-MM-dd)
 2.0.4 Release notes (2016-11-14)
 =============================================================
 
-### API breaking changes
+### Sync Breaking Changes (In Beta)
 
 * Remove `RLMAuthenticationActions` and replace
   `+[RLMSyncCredential credentialWithUsername:password:actions:]` with
@@ -58,6 +66,10 @@ x.x.x Release notes (yyyy-MM-dd)
   struct rather than a named tuple.
 * `+[RLMSyncUser logInWithCredentials:]` now invokes its callback block on a
   background queue.
+
+### API breaking changes
+
+* None.
 
 ### Enhancements
 

--- a/build.sh
+++ b/build.sh
@@ -1373,7 +1373,11 @@ EOF
 x.x.x Release notes (yyyy-MM-dd)
 =============================================================
 
-### API breaking changes
+### Sync Breaking Changes (In Beta)
+
+* None.
+
+### API Breaking Changes
 
 * None.
 


### PR DESCRIPTION
This follows what [`realm/realm-java/CHANGELOG.md`](https://github.com/realm/realm-java/blob/master/CHANGELOG.md) does to distinguish between breaking changes to the sync APIs ([which are in beta](https://realm.io/news/realm-objc-swift-2.0/#platform-extensions-are-in-beta)) and the rest of our APIs, which follow semver.

I've opted to refer to "Sync" rather than "Platform Extensions" or "Object Server" because "Sync" is the term we use all over our API naming (e.g. `RLMSyncUser`, `RLMSyncConfiguration`, etc.) and I've opted not to limit this to "API" breaking changes but breaking changes in general in case the transmit protocol version is bumped, or file format, or schema, etc.

/cc @bmunkholm @austinzheng 