### PR TITLE
Fix dispatch SyncUser.logIn completion callback to the main thread

### DIFF
--- a/Realm/RLMSyncUser.mm
+++ b/Realm/RLMSyncUser.mm
@@ -312,7 +312,7 @@ using namespace realm;
                     return;
                 }
                 user->_user = sync_user;
-                completion(user, nil);
+                theBlock(user, nil);
             }
         } else {
             // Something else went wrong


### PR DESCRIPTION
Initially this issue was addressed in https://github.com/realm/realm-cocoa-private/issues/186, so I've added a test to handle this in the future.

/cc @austinzheng, @jpsim 