### PR TITLE
fix recursive option of git submodule update command written in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ In case you don't want to use the precompiled version, you can build Realm yours
 Prerequisites:
 
 * Building Realm requires Xcode 7.3.1 or Xcode 8.x.
-* If cloning from git, submodules are required: `git submodule update --init —recursive`.
+* If cloning from git, submodules are required: `git submodule update --init --recursive`.
 * Building Realm documentation requires [jazzy](https://github.com/realm/jazzy)
 
 Once you have all the necessary prerequisites, building Realm.framework just takes a single command: `sh build.sh build`. You'll need an internet connection the first time you build Realm to download the core binary.


### PR DESCRIPTION
1, I cloned your project with execute command 
` git clone https://github.com/realm/realm-cocoa.git `

2, I read ` README.md ` and execute command written in ` README.md ` but not worked properly
 ` git submodule update --init —recursive `
(https://github.com/realm/realm-cocoa/blob/master/README.md) 

3, A hyphen written before "recursive" is NOT hyphen so it should be replaced by 2 hyphens.

-----------
ProductName:	Mac OS X
ProductVersion:	10.11.5

Xcode 7.3.1

/pod
1.0.1
(not in use here)

GNU bash, version 3.2.57(1)-release (x86_64-apple-darwin15)

(not in use here)

git version 2.7.4 (Apple Git-66)