### PR TITLE
Update Cocoa binding to reflect object store changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ x.x.x Release notes (yyyy-MM-dd)
 * Fix a `LogicError: Bad version number` exception when using `RLMResults` with
   no notification blocks and explicitly called `-[RLMRealm refresh]` from that
   thread.
+* Logged-out users are no longer returned from `+[RLMSyncUser currentUser]` or
+  `+[RLMSyncUser allUsers]`.
 
 2.1.0 Release notes (2016-11-18)
 =============================================================

--- a/Realm/ObjectServerTests/RLMObjectServerTests.m
+++ b/Realm/ObjectServerTests/RLMObjectServerTests.m
@@ -72,7 +72,7 @@
     [self logInUserForCredentials:credentials server:[RLMObjectServerTests authServerURL]];
 }
 
-#pragma mark - User Persistence
+#pragma mark - Users
 
 /// `[RLMSyncUser all]` should be updated once a user is logged in.
 - (void)testBasicUserPersistence {
@@ -93,6 +93,18 @@
     NSDictionary *dict2 = @{user.identity: user, user2.identity: user2};
     XCTAssertEqualObjects([RLMSyncUser allUsers], dict2);
     RLMAssertThrowsWithReasonMatching([RLMSyncUser currentUser], @"currentUser cannot be called if more that one valid, logged-in user exists");
+}
+
+/// `[RLMSyncUser currentUser]` should become nil if the user is logged out.
+- (void)testCurrentUserLogout {
+    XCTAssertNil([RLMSyncUser currentUser]);
+    RLMSyncUser *user = [self logInUserForCredentials:[RLMObjectServerTests basicCredentialsWithName:ACCOUNT_NAME()
+                                                                                            register:YES]
+                                               server:[RLMObjectServerTests authServerURL]];
+    XCTAssertNotNil(user);
+    XCTAssertEqualObjects([RLMSyncUser currentUser], user);
+    [user logOut];
+    XCTAssertNil([RLMSyncUser currentUser]);
 }
 
 #pragma mark - Basic Sync

--- a/Realm/RLMSyncManager.mm
+++ b/Realm/RLMSyncManager.mm
@@ -192,7 +192,7 @@ static dispatch_once_t s_onceToken;
 
 - (NSArray<RLMSyncUser *> *)_allUsers {
     NSMutableArray<RLMSyncUser *> *buffer = [NSMutableArray array];
-    for (auto user : SyncManager::shared().all_users()) {
+    for (auto user : SyncManager::shared().all_logged_in_users()) {
         [buffer addObject:[[RLMSyncUser alloc] initWithSyncUser:std::move(user)]];
     }
     return buffer;


### PR DESCRIPTION
@jpsim 
cc. @dhmspector 

Requires https://github.com/realm/realm-object-store/pull/261
Fixes https://github.com/realm/realm-object-store/issues/231

TODO: update submodule pointer once the object store PR is merged

Changes:
- Cocoa binding uses the new `all_logged_in_users` API on the object store’s `SyncManager`
- Added a unit test