### PR TITLE
Update binding to use latest object store

### DIFF
--- a/Realm/RLMSyncConfiguration.mm
+++ b/Realm/RLMSyncConfiguration.mm
@@ -19,6 +19,7 @@
 #import "RLMSyncConfiguration_Private.hpp"
 
 #import "RLMSyncManager_Private.h"
+#import "RLMSyncSession_Private.hpp"
 #import "RLMSyncUser_Private.hpp"
 #import "RLMSyncUtil_Private.hpp"
 #import "RLMUtil.hpp"
@@ -122,8 +123,11 @@ static BOOL isValidRealmURL(NSURL *url) {
                           isStandalone:NO];
         };
         if (!errorHandler) {
-            errorHandler = [=](int error_code, std::string message, realm::SyncSessionError error_type) {
-                RLMSyncSession *session = [user sessionForURL:url];
+            errorHandler = [=](std::shared_ptr<SyncSession> errored_session,
+                               int error_code,
+                               std::string message,
+                               realm::SyncSessionError error_type) {
+                RLMSyncSession *session = [[RLMSyncSession alloc] initWithSyncSession:errored_session];
                 [[RLMSyncManager sharedManager] _fireErrorWithCode:error_code
                                                            message:@(message.c_str())
                                                            session:session


### PR DESCRIPTION
@jpsim @TimOliver 

Changes:
- Session error callback no longer looks up its session, it gets the session directly (see https://github.com/realm/realm-object-store/pull/265)