### PR TITLE
Revert "Make the 'Object Server Tests' scheme buildable directly"

### DIFF
--- a/Realm.xcodeproj/xcshareddata/xcschemes/Object Server Tests.xcscheme
+++ b/Realm.xcodeproj/xcshareddata/xcschemes/Object Server Tests.xcscheme
@@ -1,40 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "0800"
-   version = "1.8">
+   version = "1.3">
    <BuildAction
-      parallelizeBuildables = "NO"
+      parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
-      <BuildActionEntries>
-         <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "5D659E7D1BE04556006515A0"
-               BuildableName = "Realm.framework"
-               BlueprintName = "Realm"
-               ReferencedContainer = "container:Realm.xcodeproj">
-            </BuildableReference>
-         </BuildActionEntry>
-         <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "NO"
-            buildForProfiling = "NO"
-            buildForArchiving = "NO"
-            buildForAnalyzing = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "E856D1DE195614A400FB2FCF"
-               BuildableName = "iOS static tests.xctest"
-               BlueprintName = "iOS static tests"
-               ReferencedContainer = "container:Realm.xcodeproj">
-            </BuildableReference>
-         </BuildActionEntry>
-      </BuildActionEntries>
    </BuildAction>
    <TestAction
       buildConfiguration = "Debug"
@@ -53,15 +23,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "5D659E7D1BE04556006515A0"
-            BuildableName = "Realm.framework"
-            BlueprintName = "Realm"
-            ReferencedContainer = "container:Realm.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
       <AdditionalOptions>
       </AdditionalOptions>
    </TestAction>
@@ -75,15 +36,6 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "5D659E7D1BE04556006515A0"
-            BuildableName = "Realm.framework"
-            BlueprintName = "Realm"
-            ReferencedContainer = "container:Realm.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
       <AdditionalOptions>
       </AdditionalOptions>
    </LaunchAction>
@@ -93,17 +45,6 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "5D659E7D1BE04556006515A0"
-            BuildableName = "Realm.framework"
-            BlueprintName = "Realm"
-            ReferencedContainer = "container:Realm.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">


### PR DESCRIPTION
This reverts commit 0b7efa72137cb761312b444cb188e352edc5cdbc.

By reverting this commit, Xcode will no longer guess that the "Object Server Tests" scheme is a framework, and therefore Carthage will no longer attempt to build it as if it was a framework.

Fixes #4343.

This has the unfortunate effect of 1) not doing something sensible when hitting ⌘+B in Xcode and 2) not being able to run the unit tests with Instruments.app.

See [rdar://29407087](http://www.openradar.me/29407087) for details.

/cc @tgoyne 