### PR TITLE
remove unused REALM_SKIP_DEBUGGER_CHECKS env var

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -35,8 +35,6 @@ if ! [ -z "${JENKINS_HOME}" ]; then
     CODESIGN_PARAMS="CODE_SIGN_IDENTITY= CODE_SIGNING_REQUIRED=NO"
 fi
 
-export REALM_SKIP_DEBUGGER_CHECKS=YES
-
 usage() {
 cat <<EOF
 Usage: sh $0 command [argument]


### PR DESCRIPTION
This dates back to times when lldb didn't work with encrypted Realms, but that constraint has long been lifted. /cc @tgoyne 