### PR TITLE
moving from iCloud to CloudKit

### DIFF
--- a/Realm/RLMSyncCredentials.h
+++ b/Realm/RLMSyncCredentials.h
@@ -42,8 +42,8 @@ extern RLMIdentityProvider const RLMIdentityProviderFacebook;
 /// A Google account as an identity provider.
 extern RLMIdentityProvider const RLMIdentityProviderGoogle;
 
-/// An iCloud account as an identity provider.
-extern RLMIdentityProvider const RLMIdentityProviderICloud;
+/// A CloudKit account as an identity provider.
+extern RLMIdentityProvider const RLMIdentityProviderCloudKit;
 
 /**
  Opaque credentials representing a specific Realm Object Server user.
@@ -70,9 +70,9 @@ extern RLMIdentityProvider const RLMIdentityProviderICloud;
 + (instancetype)credentialsWithGoogleToken:(RLMSyncCredentialsToken)token;
 
 /**
- Construct and return credentials from an iCloud account token.
+ Construct and return credentials from an CloudKit account token.
  */
-+ (instancetype)credentialsWithICloudToken:(RLMSyncCredentialsToken)token;
++ (instancetype)credentialsWithCloudKitToken:(RLMSyncCredentialsToken)token;
 
 /**
  Construct and return credentials from a Realm Object Server username and password.

--- a/Realm/RLMSyncCredentials.m
+++ b/Realm/RLMSyncCredentials.m
@@ -28,7 +28,7 @@ RLMIdentityProvider const RLMIdentityProviderUsernamePassword       = @"password
 RLMIdentityProvider const RLMIdentityProviderFacebook               = @"facebook";
 RLMIdentityProvider const RLMIdentityProviderTwitter                = @"twitter";
 RLMIdentityProvider const RLMIdentityProviderGoogle                 = @"google";
-RLMIdentityProvider const RLMIdentityProviderICloud                 = @"cloudkit";
+RLMIdentityProvider const RLMIdentityProviderCloudKit               = @"cloudkit";
 
 @interface RLMSyncCredentials ()
 
@@ -52,8 +52,8 @@ RLMIdentityProvider const RLMIdentityProviderICloud                 = @"cloudkit
     return [[self alloc] initWithCustomToken:token provider:RLMIdentityProviderGoogle userInfo:nil];
 }
 
-+ (instancetype)credentialsWithICloudToken:(RLMSyncCredentialsToken)token {
-    return [[self alloc] initWithCustomToken:token provider:RLMIdentityProviderICloud userInfo:nil];
++ (instancetype)credentialsWithCloudKitToken:(RLMSyncCredentialsToken)token {
+    return [[self alloc] initWithCustomToken:token provider:RLMIdentityProviderCloudKit userInfo:nil];
 }
 
 + (instancetype)credentialsWithUsername:(NSString *)username

--- a/RealmSwift/Sync.swift
+++ b/RealmSwift/Sync.swift
@@ -173,9 +173,9 @@ public struct SyncCredentials {
         return SyncCredentials(RLMSyncCredentials(googleToken: token))
     }
 
-    /// Initialize new credentials using an iCloud account token.
-    public static func iCloud(token: Token) -> SyncCredentials {
-        return SyncCredentials(RLMSyncCredentials(iCloudToken: token))
+    /// Initialize new credentials using an CloudKit account token.
+    public static func cloudKit(token: Token) -> SyncCredentials {
+        return SyncCredentials(RLMSyncCredentials(cloudKitToken: token))
     }
 
     /// Initialize new credentials using a Realm Object Server username and password.
@@ -399,9 +399,9 @@ public struct SyncCredentials {
         return SyncCredentials(RLMSyncCredentials(googleToken: token))
     }
 
-    /// Initialize new credentials using an iCloud account token.
-    public static func iCloud(token: Token) -> SyncCredentials {
-        return SyncCredentials(RLMSyncCredentials(ICloudToken: token))
+    /// Initialize new credentials using an CloudKit account token.
+    public static func cloudKit(token: Token) -> SyncCredentials {
+        return SyncCredentials(RLMSyncCredentials(cloudKitToken: token))
     }
 
     /// Initialize new credentials using a Realm Object Server username and password.

--- a/RealmSwift/Sync.swift
+++ b/RealmSwift/Sync.swift
@@ -173,7 +173,7 @@ public struct SyncCredentials {
         return SyncCredentials(RLMSyncCredentials(googleToken: token))
     }
 
-    /// Initialize new credentials using an CloudKit account token.
+    /// Initialize new credentials using a CloudKit account token.
     public static func cloudKit(token: Token) -> SyncCredentials {
         return SyncCredentials(RLMSyncCredentials(cloudKitToken: token))
     }
@@ -399,7 +399,7 @@ public struct SyncCredentials {
         return SyncCredentials(RLMSyncCredentials(googleToken: token))
     }
 
-    /// Initialize new credentials using an CloudKit account token.
+    /// Initialize new credentials using a CloudKit account token.
     public static func cloudKit(token: Token) -> SyncCredentials {
         return SyncCredentials(RLMSyncCredentials(cloudKitToken: token))
     }


### PR DESCRIPTION
addressing issues #4415

instances of iCloud renamed to CloudKit.