### PR TITLE
Disable idle timer for Draw app

### DIFF
--- a/examples/ios/objc/Draw/AppDelegate.m
+++ b/examples/ios/objc/Draw/AppDelegate.m
@@ -30,6 +30,7 @@
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
     application.applicationSupportsShakeToEdit = YES;
+    application.idleTimerDisabled = YES;
 
     self.window = [[UIWindow alloc] initWithFrame:[[UIScreen mainScreen] bounds]];
     self.window.rootViewController = [[UIViewController alloc] init];


### PR DESCRIPTION
As the RMP demo apps are often left open for extended periods, it's necessary to ensure that iOS does not try and force the app to go into an idle or backgrounded state, which necessitates a lengthy startup afterwards.

This sets a `UIApplication` level property ensuring the system doesn't go idle while the app is open.