### PR TITLE
update ObjC model template comment to use ObjC generics

### DIFF
--- a/plugin/Templates/file_templates/Realm Model Object.xctemplate/Objective-C/___FILEBASENAME___.h
+++ b/plugin/Templates/file_templates/Realm Model Object.xctemplate/Objective-C/___FILEBASENAME___.h
@@ -13,5 +13,5 @@
 @end
 
 // This protocol enables typed collections. i.e.:
-// RLMArray<___FILEBASENAMEASIDENTIFIER___>
+// RLMArray<___FILEBASENAMEASIDENTIFIER___ *><___FILEBASENAMEASIDENTIFIER___>
 RLM_ARRAY_TYPE(___FILEBASENAMEASIDENTIFIER___)


### PR DESCRIPTION
Since we no longer support Xcode 6, might as well encourage the use of ObjC generics.