### PR TITLE
Support Swift files with overridden @objc names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ x.x.x Release notes (yyyy-MM-dd)
 
 ### Bugfixes
 
-* None.
+* Support Realm model classes defined in Swift with overridden Objective-C
+  names (e.g. `@objc(Foo) class SwiftFoo: Object {}`).
 
 2.6.2 Release notes (2017-04-21)
 =============================================================

--- a/Realm/RLMObjectSchema.mm
+++ b/Realm/RLMObjectSchema.mm
@@ -96,10 +96,14 @@ using namespace realm;
 
     // determine classname from objectclass as className method has not yet been updated
     NSString *className = NSStringFromClass(objectClass);
-    bool isSwift = [RLMSwiftSupport isSwiftClassName:className];
-    if (isSwift) {
+    bool hasSwiftName = [RLMSwiftSupport isSwiftClassName:className];
+    if (hasSwiftName) {
         className = [RLMSwiftSupport demangleClassName:className];
     }
+    
+    static Class s_swiftObjectClass = NSClassFromString(@"RealmSwiftObject");
+    bool isSwift = hasSwiftName || [objectClass isSubclassOfClass:s_swiftObjectClass];
+    
     schema.className = className;
     schema.objectClass = objectClass;
     schema.accessorClass = objectClass;

--- a/RealmSwift/Tests/ObjectCreationTests.swift
+++ b/RealmSwift/Tests/ObjectCreationTests.swift
@@ -154,6 +154,7 @@ class ObjectCreationTests: TestCase {
     func testInitWithObjcName() {
         // Test that init doesn't crash going into non-swift init logic for renamed Swift classes.
         _ = SwiftObjcRenamedObject()
+        _ = SwiftObjcArbitrarilyRenamedObject()
     }
 
     // MARK: Creation tests
@@ -465,6 +466,21 @@ class ObjectCreationTests: TestCase {
 
         try! realm.write {
             realm.delete(realm.objects(SwiftObjcRenamedObject.self))
+        }
+    }
+
+    func testCreateWithDifferentObjcName() {
+
+        let realm = try! Realm()
+        try! realm.write {
+            let object = realm.create(SwiftObjcArbitrarilyRenamedObject.self)
+            object.boolCol = true
+        }
+
+        XCTAssertEqual(realm.objects(SwiftObjcArbitrarilyRenamedObject.self).count, 1)
+
+        try! realm.write {
+            realm.delete(realm.objects(SwiftObjcArbitrarilyRenamedObject.self))
         }
     }
 

--- a/RealmSwift/Tests/ObjectCreationTests.swift
+++ b/RealmSwift/Tests/ObjectCreationTests.swift
@@ -452,17 +452,17 @@ class ObjectCreationTests: TestCase {
         XCTAssert(object.objectCol == nil) // XCTAssertNil caused a NULL deref inside _swift_getClass
         XCTAssertEqual(object.arrayCol.count, 0)
     }
-    
+
     func testCreateWithObjcName() {
-        
+
         let realm = try! Realm()
         try! realm.write {
             let object = realm.create(SwiftObjcRenamedObject.self)
             object.stringCol = "string"
         }
-        
+
         XCTAssertEqual(realm.objects(SwiftObjcRenamedObject.self).count, 1)
-        
+
         try! realm.write {
             realm.delete(realm.objects(SwiftObjcRenamedObject.self))
         }

--- a/RealmSwift/Tests/ObjectCreationTests.swift
+++ b/RealmSwift/Tests/ObjectCreationTests.swift
@@ -452,6 +452,21 @@ class ObjectCreationTests: TestCase {
         XCTAssert(object.objectCol == nil) // XCTAssertNil caused a NULL deref inside _swift_getClass
         XCTAssertEqual(object.arrayCol.count, 0)
     }
+    
+    func testCreateWithObjcName() {
+        
+        let realm = try! Realm()
+        try! realm.write {
+            let object = realm.create(SwiftObjcRenamedObject.self)
+            object.stringCol = "string"
+        }
+        
+        XCTAssertEqual(realm.objects(SwiftObjcRenamedObject.self).count, 1)
+        
+        try! realm.write {
+            realm.delete(realm.objects(SwiftObjcRenamedObject.self))
+        }
+    }
 
     // test null object
     // test null list

--- a/RealmSwift/Tests/ObjectCreationTests.swift
+++ b/RealmSwift/Tests/ObjectCreationTests.swift
@@ -151,6 +151,11 @@ class ObjectCreationTests: TestCase {
             "object created via generic initializer should equal object created by calling initializer directly")
     }
 
+    func testInitWithObjcName() {
+        // Test that init doesn't crash going into non-swift init logic for renamed Swift classes.
+        _ = SwiftObjcRenamedObject()
+    }
+
     // MARK: Creation tests
 
     func testCreateWithDefaults() {

--- a/RealmSwift/Tests/SwiftTestObjects.swift
+++ b/RealmSwift/Tests/SwiftTestObjects.swift
@@ -435,3 +435,8 @@ class SwiftObjectiveCTypesObject: Object {
     dynamic var dataCol: NSData?
     dynamic var numCol: NSNumber? = 0
 }
+
+@objc(SwiftObjcRenamedObject)
+class SwiftObjcRenamedObject: Object {
+    dynamic var stringCol = ""
+}

--- a/RealmSwift/Tests/SwiftTestObjects.swift
+++ b/RealmSwift/Tests/SwiftTestObjects.swift
@@ -440,3 +440,8 @@ class SwiftObjectiveCTypesObject: Object {
 class SwiftObjcRenamedObject: Object {
     dynamic var stringCol = ""
 }
+
+@objc(SwiftObjcRenamedObjectWithTotallyDifferentName)
+class SwiftObjcArbitrarilyRenamedObject: Object {
+    dynamic var boolCol = false
+}


### PR DESCRIPTION
Previously, Realm would assert when creating a schema for this object
because it only considered files with modular class names to be Swift
files.

```
@objc(Foo) class Foo: Object {}
```

This is problematic for projects that do all manipulation of an
instance in Swift but still need to pass it between Objective-C classes.

Now we check for a dot in the name or inheriting from RealmSwiftObject.