### PR TITLE
use underscore for unused Swift closure parameters

### DIFF
--- a/RealmSwift/LinkingObjects.swift
+++ b/RealmSwift/LinkingObjects.swift
@@ -355,7 +355,7 @@ public final class LinkingObjects<T: Object>: LinkingObjectsBase {
      - returns: A token which must be held for as long as you want updates to be delivered.
      */
     public func addNotificationBlock(_ block: @escaping (RealmCollectionChange<LinkingObjects>) -> Void) -> NotificationToken {
-        return rlmResults.addNotificationBlock { results, change, error in
+        return rlmResults.addNotificationBlock { _, change, error in
             block(RealmCollectionChange.fromObjc(value: self, change: change, error: error))
         }
     }

--- a/RealmSwift/List.swift
+++ b/RealmSwift/List.swift
@@ -445,7 +445,7 @@ public final class List<T: Object>: ListBase {
      - returns: A token which must be held for as long as you want updates to be delivered.
      */
     public func addNotificationBlock(_ block: @escaping (RealmCollectionChange<List>) -> Void) -> NotificationToken {
-        return _rlmArray.addNotificationBlock { list, change, error in
+        return _rlmArray.addNotificationBlock { _, change, error in
             block(RealmCollectionChange.fromObjc(value: self, change: change, error: error))
         }
     }

--- a/RealmSwift/Results.swift
+++ b/RealmSwift/Results.swift
@@ -356,7 +356,7 @@ public final class Results<T: Object>: NSObject, NSFastEnumeration {
      - returns: A token which must be held for as long as you want updates to be delivered.
      */
     public func addNotificationBlock(_ block: @escaping (RealmCollectionChange<Results>) -> Void) -> NotificationToken {
-        return rlmResults.addNotificationBlock { results, change, error in
+        return rlmResults.addNotificationBlock { _, change, error in
             block(RealmCollectionChange.fromObjc(value: self, change: change, error: error))
         }
     }

--- a/RealmSwift/Tests/MigrationTests.swift
+++ b/RealmSwift/Tests/MigrationTests.swift
@@ -94,7 +94,7 @@ class MigrationTests: TestCase {
 
         var didRun = false
         let config = Realm.Configuration(fileURL: defaultRealmURL(), schemaVersion: 1,
-                                         migrationBlock: { _, _ in didRun = true })
+                                         migrationBlock: { _ in didRun = true })
         Realm.Configuration.defaultConfiguration = config
 
         try! Realm.performMigration()
@@ -144,7 +144,7 @@ class MigrationTests: TestCase {
             realmWithSingleClassProperties(defaultRealmURL(), className: "SwiftStringObject", properties: [prop])
         }
 
-        migrateAndTestDefaultRealm { migration, oldSchemaVersion in
+        migrateAndTestDefaultRealm { migration, _ in
             XCTAssertEqual(migration.oldSchema.objectSchema.count, 1)
             XCTAssertGreaterThan(migration.newSchema.objectSchema.count, 1)
             XCTAssertEqual(migration.oldSchema.objectSchema[0].properties.count, 1)
@@ -159,12 +159,12 @@ class MigrationTests: TestCase {
             _ = try! Realm()
         }
 
-        migrateAndTestDefaultRealm { migration, oldSchemaVersion in
-            migration.enumerateObjects(ofType: "SwiftStringObject", { oldObj, newObj in
+        migrateAndTestDefaultRealm { migration, _ in
+            migration.enumerateObjects(ofType: "SwiftStringObject", { _ in
                 XCTFail("No objects to enumerate")
             })
 
-            migration.enumerateObjects(ofType: "NoSuchClass", {oldObj, newObj in}) // shouldn't throw
+            migration.enumerateObjects(ofType: "NoSuchClass", { _ in }) // shouldn't throw
         }
 
         autoreleasepool {
@@ -175,7 +175,7 @@ class MigrationTests: TestCase {
             }
         }
 
-        migrateAndTestDefaultRealm(2) { migration, oldSchemaVersion in
+        migrateAndTestDefaultRealm(2) { migration, _ in
             var count = 0
             migration.enumerateObjects(ofType: "SwiftStringObject", { oldObj, newObj in
                 XCTAssertEqual(newObj!.objectSchema.className, "SwiftStringObject")
@@ -195,7 +195,7 @@ class MigrationTests: TestCase {
             }
         }
 
-        migrateAndTestDefaultRealm(3) { migration, oldSchemaVersion in
+        migrateAndTestDefaultRealm(3) { migration, _ in
             migration.enumerateObjects(ofType: "SwiftArrayPropertyObject") { oldObject, newObject in
                 XCTAssertTrue(oldObject! as AnyObject is MigrationObject)
                 XCTAssertTrue(newObject! as AnyObject is MigrationObject)
@@ -223,7 +223,7 @@ class MigrationTests: TestCase {
             }
         }
 
-        migrateAndTestDefaultRealm(4) { migration, oldSchemaVersion in
+        migrateAndTestDefaultRealm(4) { migration, _ in
             migration.enumerateObjects(ofType: "SwiftOptionalObject") { oldObject, newObject in
                 XCTAssertTrue(oldObject! as AnyObject is MigrationObject)
                 XCTAssertTrue(newObject! as AnyObject is MigrationObject)
@@ -260,7 +260,7 @@ class MigrationTests: TestCase {
             _ = try! Realm()
         }
 
-        migrateAndTestDefaultRealm { migration, oldSchemaVersion in
+        migrateAndTestDefaultRealm { migration, _ in
             migration.create("SwiftStringObject", value: ["string"])
             migration.create("SwiftStringObject", value: ["stringCol": "string"])
             migration.create("SwiftStringObject")
@@ -285,9 +285,9 @@ class MigrationTests: TestCase {
             }
         }
 
-        migrateAndTestDefaultRealm { migration, oldSchemaVersion in
+        migrateAndTestDefaultRealm { migration, _ in
             var deleted = false
-            migration.enumerateObjects(ofType: "SwiftStringObject", { oldObj, newObj in
+            migration.enumerateObjects(ofType: "SwiftStringObject", { _, newObj in
                 if deleted == false {
                     migration.delete(newObj!)
                     deleted = true
@@ -362,7 +362,7 @@ class MigrationTests: TestCase {
             }
         }
 
-        migrateAndTestDefaultRealm { migration, oldSchemaVersion in
+        migrateAndTestDefaultRealm { migration, _ in
             var enumerated = false
             migration.enumerateObjects(ofType: "SwiftObject", { oldObj, newObj in
                 XCTAssertEqual((oldObj!["boolCol"] as! Bool), true)
@@ -470,7 +470,7 @@ class MigrationTests: TestCase {
         }
 
         var config = Realm.Configuration(fileURL: defaultRealmURL(), objectTypes: [SwiftEmployeeObject.self])
-        config.migrationBlock = { _, _ in
+        config.migrationBlock = { _ in
             XCTFail("Migration block should not be called")
         }
         config.deleteRealmIfMigrationNeeded = true
@@ -504,7 +504,7 @@ class MigrationTests: TestCase {
             }
         }
 
-        let migrationBlock: MigrationBlock = { _, _ in
+        let migrationBlock: MigrationBlock = { _ in
             XCTFail("Migration block should not be called")
         }
         let config = Realm.Configuration(fileURL: defaultRealmURL(),
@@ -589,7 +589,7 @@ class MigrationTests: TestCase {
 
         var didRun = false
         let config = Realm.Configuration(fileURL: defaultRealmURL(), schemaVersion: 1,
-                                         migrationBlock: { _, _ in didRun = true })
+                                         migrationBlock: { _ in didRun = true })
         Realm.Configuration.defaultConfiguration = config
 
         try! Realm.performMigration()
@@ -964,7 +964,7 @@ class MigrationTests: TestCase {
         }
 
         var config = Realm.Configuration(fileURL: defaultRealmURL(), objectTypes: [SwiftEmployeeObject.self])
-        config.migrationBlock = { _, _ in
+        config.migrationBlock = { _ in
             XCTFail("Migration block should not be called")
         }
         config.deleteRealmIfMigrationNeeded = true
@@ -998,7 +998,7 @@ class MigrationTests: TestCase {
             }
         }
 
-        let migrationBlock: MigrationBlock = { _, _ in
+        let migrationBlock: MigrationBlock = { _ in
             XCTFail("Migration block should not be called")
         }
         let config = Realm.Configuration(fileURL: defaultRealmURL(),

--- a/RealmSwift/Tests/ObjectTests.swift
+++ b/RealmSwift/Tests/ObjectTests.swift
@@ -350,7 +350,7 @@ class ObjectTests: TestCase {
         autoreleasepool {
             var enumerated = false
             let configuration = Realm.Configuration(schemaVersion: 1, migrationBlock: { migration, _ in
-                migration.enumerateObjects(ofType: SwiftObject.className()) { oldObject, newObject in
+                migration.enumerateObjects(ofType: SwiftObject.className()) { _, newObject in
                     if let newObject = newObject {
                         block(newObject, migration)
                         enumerated = true

--- a/RealmSwift/Tests/RealmCollectionTypeTests.swift
+++ b/RealmSwift/Tests/RealmCollectionTypeTests.swift
@@ -501,7 +501,7 @@ class RealmCollectionTypeTests: TestCase {
 
         // add a second notification and wait for it
         theExpectation = expectation(description: "")
-        let token2 = collection.addNotificationBlock { (changes: RealmCollectionChange) in
+        let token2 = collection.addNotificationBlock { _ in
             theExpectation.fulfill()
         }
         waitForExpectations(timeout: 1, handler: nil)
@@ -788,7 +788,7 @@ class ListRealmCollectionTypeTests: RealmCollectionTypeTests {
 
         // add a second notification and wait for it
         theExpectation = expectation(description: "")
-        let token2 = collection.addNotificationBlock { (changes: RealmCollectionChange) in
+        let token2 = collection.addNotificationBlock { _ in
             theExpectation.fulfill()
         }
         waitForExpectations(timeout: 1, handler: nil)
@@ -990,12 +990,12 @@ class ListStandaloneRealmCollectionTypeTests: ListRealmCollectionTypeTests {
         guard let collection = collection else {
             fatalError("Test precondition failed")
         }
-        assertThrows(collection.addNotificationBlock { (changes: RealmCollectionChange) in })
+        assertThrows(collection.addNotificationBlock { _ in })
     }
 
     override func testAddNotificationBlockDirect() {
         let collection = collectionBase()
-        assertThrows(collection.addNotificationBlock { (changes: RealmCollectionChange) in })
+        assertThrows(collection.addNotificationBlock { _ in })
     }
 }
 

--- a/RealmSwift/Tests/RealmTests.swift
+++ b/RealmSwift/Tests/RealmTests.swift
@@ -694,7 +694,7 @@ class RealmTests: TestCase {
     func testRemoveNotification() {
         let realm = try! Realm()
         var notificationCalled = false
-        let token = realm.addNotificationBlock { (notification, realm) -> Void in
+        let token = realm.addNotificationBlock { (_, realm) -> Void in
             XCTAssertEqual(realm.configuration.fileURL, self.defaultRealmURL())
             notificationCalled = true
         }


### PR DESCRIPTION
this will be enforced in future SwiftLint versions