### PR TITLE
return class name from `Object.className` instance method/var

### DIFF
--- a/RealmSwift/Object.swift
+++ b/RealmSwift/Object.swift
@@ -131,10 +131,10 @@ open class Object: RLMObjectBase {
 
     #if os(OSX)
     /// Helper to return the class name for an Object subclass.
-    public final override var className: String { return "" }
+    public final override var className: String { return objectSchema.className }
     #else
     /// Helper to return the class name for an Object subclass.
-    public final var className: String { return "" }
+    public final var className: String { return objectSchema.className }
     #endif
 
     /**
@@ -487,10 +487,10 @@ public class Object: RLMObjectBase {
 
     #if os(OSX)
     /// A helper property that returns the class name for an `Object` subclass.
-    public final override var className: String { return "" }
+    public final override var className: String { return objectSchema.className }
     #else
     /// A helper property that returns the class name for an `Object` subclass.
-    public final var className: String { return "" }
+    public final var className: String { return objectSchema.className }
     #endif
 
     /**


### PR DESCRIPTION
The intention when these were added was to prevent them from being overridden in user models by marking these overrides as `final`, since users were trying to change the name of the table in the Realm by returning a different value than the default.

However, the `static` keyword was omitted by accident, causing this to not work as intended at all.

So now that we need to keep this around to avoid a breaking change to conform to SemVer, might as well have it return the correct values.

Fixes #4456. /cc @tgoyne @bdash 