### PR TITLE
Fix use of nested subqueries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ x.x.x Release notes (yyyy-MM-dd)
 
 ### Bugfixes
 
-* None.
+* Fix queries containing nested `SUBQUERY` expressions.
 
 2.1.2 Release notes (2016--12-19)
 =============================================================

--- a/Realm.xcodeproj/project.pbxproj
+++ b/Realm.xcodeproj/project.pbxproj
@@ -216,6 +216,8 @@
 		3FEC4A3F1BBB18D400F009C3 /* SwiftSchemaTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FEC4A3D1BBB188B00F009C3 /* SwiftSchemaTests.swift */; };
 		5B77EACE1DCC5614006AB51D /* ObjectiveCSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B77EACD1DCC5614006AB51D /* ObjectiveCSupport.swift */; };
 		5BC537161DD5B8D70055C524 /* ObjectiveCSupportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BC537151DD5B8D70055C524 /* ObjectiveCSupportTests.swift */; };
+		5D03FB1F1E0DAFBA007D53EA /* PredicateUtilTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5D03FB1E1E0DAFBA007D53EA /* PredicateUtilTests.mm */; };
+		5D03FB201E0DAFBA007D53EA /* PredicateUtilTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5D03FB1E1E0DAFBA007D53EA /* PredicateUtilTests.mm */; };
 		5D128F2A1BE984E5001F4FBF /* Realm.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 5D659ED91BE04556006515A0 /* Realm.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		5D1534B81CCFF545008976D7 /* LinkingObjects.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D1534B71CCFF545008976D7 /* LinkingObjects.swift */; };
 		5D274C4D1D6D15D2006FEBB1 /* weak_realm_notifier.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5D274C4C1D6D15D2006FEBB1 /* weak_realm_notifier.cpp */; };
@@ -755,6 +757,7 @@
 		3FEC4A3D1BBB188B00F009C3 /* SwiftSchemaTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwiftSchemaTests.swift; sourceTree = "<group>"; };
 		5B77EACD1DCC5614006AB51D /* ObjectiveCSupport.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ObjectiveCSupport.swift; sourceTree = "<group>"; };
 		5BC537151DD5B8D70055C524 /* ObjectiveCSupportTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ObjectiveCSupportTests.swift; sourceTree = "<group>"; };
+		5D03FB1E1E0DAFBA007D53EA /* PredicateUtilTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = PredicateUtilTests.mm; sourceTree = "<group>"; };
 		5D1534B71CCFF545008976D7 /* LinkingObjects.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LinkingObjects.swift; sourceTree = "<group>"; };
 		5D274C4C1D6D15D2006FEBB1 /* weak_realm_notifier.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = weak_realm_notifier.cpp; sourceTree = "<group>"; };
 		5D274C4F1D6D16A8006FEBB1 /* event_loop_signal.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = event_loop_signal.hpp; sourceTree = "<group>"; };
@@ -1292,6 +1295,7 @@
 				021A88301AAFB5BE00EEAC84 /* ObjectSchemaTests.m */,
 				E81A1FBF1955FE0100FDED82 /* ObjectTests.m */,
 				3F04EA2D1992BEE400C2CE2E /* PerformanceTests.m */,
+				5D03FB1E1E0DAFBA007D53EA /* PredicateUtilTests.mm */,
 				02AFB4611A80343600E11938 /* PropertyTests.m */,
 				E81A1FC01955FE0100FDED82 /* PropertyTypeTest.mm */,
 				E81A1FC11955FE0100FDED82 /* QueryTests.m */,
@@ -2379,6 +2383,7 @@
 				E856D21E195615A900FB2FCF /* RealmTests.mm in Sources */,
 				02AFB4681A80343600E11938 /* ResultsTests.m in Sources */,
 				3FC767071BB9FE7500FE0AFC /* RLMMultiProcessTestCase.m in Sources */,
+				5D03FB201E0DAFBA007D53EA /* PredicateUtilTests.mm in Sources */,
 				3FDE338D19C39A87003B7DBA /* RLMSupport.swift in Sources */,
 				E856D21F195615B100FB2FCF /* RLMTestCase.m in Sources */,
 				028481CB19CCFC9C0097A416 /* RLMTestObjects.m in Sources */,
@@ -2402,6 +2407,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				5D03FB1F1E0DAFBA007D53EA /* PredicateUtilTests.mm in Sources */,
 				E81A1FD51955FE0100FDED82 /* ArrayPropertyTests.m in Sources */,
 				3F7556751BE95A0C0058BC7E /* AsyncTests.mm in Sources */,
 				02E334C31A5F41C7009F8810 /* DynamicTests.m in Sources */,

--- a/Realm/RLMPredicateUtil.hpp
+++ b/Realm/RLMPredicateUtil.hpp
@@ -16,6 +16,7 @@
 //
 
 #import <Foundation/Foundation.h>
+#import <functional>
 
-using ExpressionVisitor = NSExpression *(*)(NSExpression *);
+using ExpressionVisitor = std::function<NSExpression *(NSExpression *)>;
 NSPredicate *transformPredicate(NSPredicate *, ExpressionVisitor);

--- a/Realm/Tests/PredicateUtilTests.mm
+++ b/Realm/Tests/PredicateUtilTests.mm
@@ -1,0 +1,59 @@
+//
+//  PredicateUtilTests.m
+//  Realm
+//
+//  Created by Mark Rowe on 12/23/16.
+//  Copyright © 2016 Realm. All rights reserved.
+//
+
+#import "RLMTestCase.h"
+
+#import "RLMPredicateUtil.hpp"
+
+@interface PredicateUtilTests : RLMTestCase
+
+@end
+
+@implementation PredicateUtilTests
+
+- (void)testVisitingAllExpresssionTypes {
+    auto testPredicate = [&](NSPredicate *predicate, size_t expectedExpressionCount) {
+        size_t visitCount = 0;
+        auto visitExpression = [&](NSExpression *expression) {
+            visitCount++;
+            return expression;
+        };
+        NSPredicate *transformedPredicate = transformPredicate(predicate, visitExpression);
+        XCTAssertEqualObjects(predicate, transformedPredicate);
+        XCTAssertEqual(visitCount, expectedExpressionCount);
+    };
+    auto testPredicateString = [=](NSString *predicateString, size_t expectedExpressionCount) {
+        return testPredicate([NSPredicate predicateWithFormat:predicateString], expectedExpressionCount);
+    };
+
+    testPredicateString(@"TRUEPREDICATE", 0);
+    testPredicateString(@"A == B", 2);
+    testPredicateString(@"A == B AND C == 1", 4);
+    testPredicateString(@"A.@count == 2", 2);
+    testPredicateString(@"SUBQUERY(collection, $variable, $variable.property == 1).@count > 2", 9);
+    testPredicateString(@"A IN {1, 2, 3}", 5);
+    testPredicateString(@"A IN B UNION C", 4);
+    testPredicateString(@"A IN B INTERSECT C", 4);
+    testPredicateString(@"A IN B MINUS C", 4);
+    testPredicateString(@"TERNARY(TRUEPREDICATE, A, B) == 1", 4);
+    testPredicateString(@"ANYKEY == 1", 2);
+    testPredicateString(@"SELF == 1", 2);
+
+    testPredicate([NSPredicate predicateWithBlock:^(id, NSDictionary*) { return NO; }], 0);
+
+    auto block = ^(id, NSArray *, NSMutableDictionary *) {
+        return @"Hello";
+    };
+    testPredicate([NSComparisonPredicate predicateWithLeftExpression:[NSExpression expressionForBlock:block arguments:nil]
+                                                     rightExpression:[NSExpression expressionForConstantValue:@"hello"]
+                                                            modifier:NSDirectPredicateModifier
+                                                                type:NSEqualToPredicateOperatorType
+                                                             options:0], 2);
+}
+
+@end

--- a/Realm/Tests/PredicateUtilTests.mm
+++ b/Realm/Tests/PredicateUtilTests.mm
@@ -1,10 +1,20 @@
+////////////////////////////////////////////////////////////////////////////
 //
-//  PredicateUtilTests.m
-//  Realm
+// Copyright 2016 Realm Inc.
 //
-//  Created by Mark Rowe on 12/23/16.
-//  Copyright © 2016 Realm. All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
 
 #import "RLMTestCase.h"
 
@@ -16,7 +26,7 @@
 
 @implementation PredicateUtilTests
 
-- (void)testVisitingAllExpresssionTypes {
+- (void)testVisitingAllExpressionTypes {
     auto testPredicate = [&](NSPredicate *predicate, size_t expectedExpressionCount) {
         size_t visitCount = 0;
         auto visitExpression = [&](NSExpression *expression) {

--- a/Realm/Tests/QueryTests.m
+++ b/Realm/Tests/QueryTests.m
@@ -1972,6 +1972,10 @@
     // Linking objects cannot contain null so their members cannot be compared with null.
     XCTAssertThrows([PersonObject objectsWhere:@"ANY parents == NULL"]);
 
+    // People that have a parent under the age of 31 where that parent has a parent over the age of 35 whose name is Michael.
+    RLMResults *r14 = [PersonObject objectsWhere:@"SUBQUERY(parents, $p1, $p1.age < 31 AND SUBQUERY($p1.parents, $p2, $p2.age > 35 AND $p2.name == 'Michael').@count > 0).@count > 0"];
+    XCTAssertEqualObjects(asArray(r14), (@[ hannah ]));
+
 
     // Add a new link and verify that the existing results update as expected.
     __block PersonObject *mackenzie;
@@ -2019,6 +2023,9 @@
 
     // All links are not equal to a detached row accessor so this will match all rows that are linked to.
     XCTAssertEqualObjects(asArray(r13), (@[ hannah, elijah, mark, jason, diane, carol, mackenzie ]));
+
+    // People that have a parent under the age of 31 where that parent has a parent over the age of 35 whose name is Michael.
+    XCTAssertEqualObjects(asArray(r14), (@[ hannah ]));
 }
 
 @end


### PR DESCRIPTION
The code to visit the expressions within a subquery expression was incorrectly accessing the `operand` property instead of the `collection` property, resulting in an exception being thrown.

Fixes #4469 and #3675.