### PR TITLE
Removed Optional for 'realm' Property on Swift 'Results'

### DIFF
--- a/RealmSwift/Results.swift
+++ b/RealmSwift/Results.swift
@@ -100,8 +100,8 @@ public final class Results<T: Object>: NSObject, NSFastEnumeration {
 
     // MARK: Properties
 
-    /// The Realm which manages this results. Note that this property will never return `nil`.
-    public var realm: Realm? { return Realm(rlmResults.realm) }
+    /// The Realm which manages this results.
+    public var realm: Realm { return Realm(rlmResults.realm) }
 
     /**
      Indicates if the results are no longer valid.


### PR DESCRIPTION
There was no reason to be casting the `realm` property as an optional on `Results`. 

The `rlmResults.realm` is strongly retained and the internal initializer is neither throwing or failable, so there is no way for this to be `nil`.

The documentation even said: `Note that this property will never return nil`.