### PR TITLE
Add support for sorting based on simple key paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,30 @@ x.x.x Release notes (yyyy-MM-dd)
 
 ### API Breaking Changes
 
-* None.
+* The following Objective-C APIs have been deprecated in favor of newer or preferred versions:
+
+| Deprecated API                                              | New API                                                     |
+|:------------------------------------------------------------|:------------------------------------------------------------|
+| `-[RLMArray sortedResultsUsingProperty:]`                   | `-[RLMArray sortedResultsUsingKeyPath:]`                    |
+| `-[RLMCollection sortedResultsUsingProperty:]`              | `-[RLMCollection sortedResultsUsingKeyPath:]`               |
+| `-[RLMResults sortedResultsUsingProperty:]`                 | `-[RLMResults sortedResultsUsingKeyPath:]`                  |
+| `+[RLMSortDescriptor sortDescriptorWithProperty:ascending]` | `+[RLMSortDescriptor sortDescriptorWithKeyPath:ascending:]` |
+| `RLMSortDescriptor.property`                                | `RLMSortDescriptor.keyPath`                                 |
+
+* The following Swift APIs have been deprecated in favor of newer or preferred versions:
+
+| Deprecated API                                        | New API                                          |
+|:------------------------------------------------------|:-------------------------------------------------|
+| `LinkingObjects.sorted(byProperty:ascending:)`        | `LinkingObjects.sorted(byKeyPath:ascending:)`    |
+| `List.sorted(byProperty:ascending:)`                  | `List.sorted(byKeyPath:ascending:)`              |
+| `RealmCollection.sorted(byProperty:ascending:)`       | `RealmCollection.sorted(byKeyPath:ascending:)`   |
+| `Results.sorted(byProperty:ascending:)`               | `Results.sorted(byKeyPath:ascending:)`           |
+| `SortDescriptor(property:ascending:)`                 | `SortDescriptor(keyPath:ascending:)`             |
+| `SortDescriptor.property`                             | `SortDescriptor.keyPath`                         |
 
 ### Enhancements
 
-* None.
+* Realm collections can now be sorted by properties over to-one relationships.
 
 ### Bugfixes
 

--- a/Realm/RLMArray.h
+++ b/Realm/RLMArray.h
@@ -262,12 +262,23 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Returns a sorted `RLMResults` from the array.
 
+ @param keyPath     The key path to sort by.
+ @param ascending   The direction to sort in.
+
+ @return    An `RLMResults` sorted by the specified key path.
+ */
+- (RLMResults<RLMObjectType> *)sortedResultsUsingKeyPath:(NSString *)keyPath ascending:(BOOL)ascending;
+
+/**
+ Returns a sorted `RLMResults` from the array.
+
  @param property    The property name to sort by.
  @param ascending   The direction to sort in.
 
  @return    An `RLMResults` sorted by the specified property.
  */
-- (RLMResults<RLMObjectType> *)sortedResultsUsingProperty:(NSString *)property ascending:(BOOL)ascending;
+- (RLMResults<RLMObjectType> *)sortedResultsUsingProperty:(NSString *)property ascending:(BOOL)ascending
+    __deprecated_msg("Use `-sortedResultsUsingKeyPath:ascending:`");
 
 /**
  Returns a sorted `RLMResults` from the array.

--- a/Realm/RLMArray.mm
+++ b/Realm/RLMArray.mm
@@ -373,9 +373,14 @@ static void RLMValidateArrayBounds(__unsafe_unretained RLMArray *const ar,
     @throw RLMException(@"This method may only be called on RLMArray instances retrieved from an RLMRealm");
 }
 
+- (RLMResults *)sortedResultsUsingKeyPath:(NSString *)keyPath ascending:(BOOL)ascending
+{
+    return [self sortedResultsUsingDescriptors:@[[RLMSortDescriptor sortDescriptorWithKeyPath:keyPath ascending:ascending]]];
+}
+
 - (RLMResults *)sortedResultsUsingProperty:(NSString *)property ascending:(BOOL)ascending
 {
-    return [self sortedResultsUsingDescriptors:@[[RLMSortDescriptor sortDescriptorWithProperty:property ascending:ascending]]];
+    return [self sortedResultsUsingKeyPath:property ascending:ascending];
 }
 
 - (RLMResults *)sortedResultsUsingDescriptors:(NSArray<RLMSortDescriptor *> *)properties
@@ -419,21 +424,25 @@ static void RLMValidateArrayBounds(__unsafe_unretained RLMArray *const ar,
 }
 @end
 
-@interface RLMSortDescriptor ()
-@property (nonatomic, strong) NSString *property;
-@property (nonatomic, assign) BOOL ascending;
-@end
-
 @implementation RLMSortDescriptor
-+ (instancetype)sortDescriptorWithProperty:(NSString *)propertyName ascending:(BOOL)ascending {
+
++ (instancetype)sortDescriptorWithKeyPath:(NSString *)keyPath ascending:(BOOL)ascending {
     RLMSortDescriptor *desc = [[RLMSortDescriptor alloc] init];
-    desc->_property = propertyName;
+    desc->_keyPath = keyPath;
     desc->_ascending = ascending;
     return desc;
 }
 
++ (instancetype)sortDescriptorWithProperty:(NSString *)propertyName ascending:(BOOL)ascending {
+    return [RLMSortDescriptor sortDescriptorWithKeyPath:propertyName ascending:ascending];
+}
+
 - (instancetype)reversedSortDescriptor {
-    return [self.class sortDescriptorWithProperty:_property ascending:!_ascending];
+    return [self.class sortDescriptorWithKeyPath:_keyPath ascending:!_ascending];
+}
+
+- (NSString *)property {
+    return _keyPath;
 }
 
 @end

--- a/Realm/RLMArrayLinkView.mm
+++ b/Realm/RLMArrayLinkView.mm
@@ -366,7 +366,7 @@ static void RLMInsertObject(RLMArrayLinkView *ar, RLMObject *object, NSUInteger 
         return [RLMResults resultsWithObjectInfo:*_objectInfo results:std::move(results)];
     }
 
-    auto order = RLMSortDescriptorFromDescriptors(*_objectInfo->table(), properties);
+    auto order = RLMSortDescriptorFromDescriptors(*_objectInfo, properties);
     auto results = translateErrors([&] { return _backingList.sort(std::move(order)); });
     return [RLMResults resultsWithObjectInfo:*_objectInfo results:std::move(results)];
 }

--- a/Realm/RLMCollection.h
+++ b/Realm/RLMCollection.h
@@ -132,12 +132,23 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Returns a sorted `RLMResults` from the collection.
 
+ @param keyPath     The keyPath to sort by.
+ @param ascending   The direction to sort in.
+
+ @return    An `RLMResults` sorted by the specified key path.
+ */
+- (RLMResults *)sortedResultsUsingKeyPath:(NSString *)keyPath ascending:(BOOL)ascending;
+
+/**
+ Returns a sorted `RLMResults` from the collection.
+
  @param property    The property name to sort by.
  @param ascending   The direction to sort in.
 
  @return    An `RLMResults` sorted by the specified property.
  */
-- (RLMResults *)sortedResultsUsingProperty:(NSString *)property ascending:(BOOL)ascending;
+- (RLMResults *)sortedResultsUsingProperty:(NSString *)property ascending:(BOOL)ascending
+    __deprecated_msg("Use `-sortedResultsUsingKeyPath:ascending:`");
 
 /**
  Returns a sorted `RLMResults` from the collection.
@@ -248,9 +259,9 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark - Properties
 
 /**
- The name of the property which the sort descriptor orders results by.
+ The key path which the sort descriptor orders results by.
  */
-@property (nonatomic, readonly) NSString *property;
+@property (nonatomic, readonly) NSString *keyPath;
 
 /**
  Whether the descriptor sorts in ascending or descending order.
@@ -260,14 +271,27 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark - Methods
 
 /**
- Returns a new sort descriptor for the given property name and sort direction.
+ Returns a new sort descriptor for the given key path and sort direction.
  */
-+ (instancetype)sortDescriptorWithProperty:(NSString *)propertyName ascending:(BOOL)ascending;
++ (instancetype)sortDescriptorWithKeyPath:(NSString *)keyPath ascending:(BOOL)ascending;
 
 /**
  Returns a copy of the receiver with the sort direction reversed.
  */
 - (instancetype)reversedSortDescriptor;
+
+#pragma mark - Deprecated
+
+/**
+ The name of the property which the sort descriptor orders results by.
+ */
+@property (nonatomic, readonly) NSString *property __deprecated_msg("Use `-keyPath`");
+
+/**
+ Returns a new sort descriptor for the given property name and sort direction.
+ */
++ (instancetype)sortDescriptorWithProperty:(NSString *)propertyName ascending:(BOOL)ascending
+    __deprecated_msg("Use `+sortDescriptorWithKeyPath:ascending:`");
 
 @end
 

--- a/Realm/RLMQueryUtil.hpp
+++ b/Realm/RLMQueryUtil.hpp
@@ -24,10 +24,10 @@ namespace realm {
     class Group;
     class Query;
     class SortDescriptor;
-    class Table;
 }
 
 @class RLMObjectSchema, RLMProperty, RLMSchema, RLMSortDescriptor;
+class RLMClassInfo;
 
 extern NSString * const RLMPropertiesComparisonTypeMismatchException;
 extern NSString * const RLMUnsupportedTypesFoundInPropertyComparisonException;
@@ -39,4 +39,4 @@ realm::Query RLMPredicateToQuery(NSPredicate *predicate, RLMObjectSchema *object
 RLMProperty *RLMValidatedProperty(RLMObjectSchema *objectSchema, NSString *columnName);
 
 // validate the array of RLMSortDescriptors and convert it to a realm::SortDescriptor
-realm::SortDescriptor RLMSortDescriptorFromDescriptors(realm::Table& table, NSArray<RLMSortDescriptor *> *descriptors);
+realm::SortDescriptor RLMSortDescriptorFromDescriptors(RLMClassInfo& classInfo, NSArray<RLMSortDescriptor *> *descriptors);

--- a/Realm/RLMQueryUtil.mm
+++ b/Realm/RLMQueryUtil.mm
@@ -860,7 +860,7 @@ struct KeyPath {
     bool containsToManyRelationship;
 };
 
-KeyPath key_path_from_string(RLMSchema* schema, RLMObjectSchema *objectSchema, NSString *keyPath)
+KeyPath key_path_from_string(RLMSchema *schema, RLMObjectSchema *objectSchema, NSString *keyPath)
 {
     RLMProperty *property;
     std::vector<RLMProperty *> links;

--- a/Realm/RLMQueryUtil.mm
+++ b/Realm/RLMQueryUtil.mm
@@ -854,7 +854,13 @@ void QueryBuilder::add_constraint(RLMPropertyType type, NSPredicateOperatorType 
     }
 }
 
-ColumnReference QueryBuilder::column_reference_from_key_path(RLMObjectSchema *objectSchema, NSString *keyPath, bool isAggregate)
+struct KeyPath {
+    std::vector<RLMProperty *> links;
+    RLMProperty *property;
+    bool containsToManyRelationship;
+};
+
+KeyPath key_path_from_string(RLMSchema* schema, RLMObjectSchema *objectSchema, NSString *keyPath)
 {
     RLMProperty *property;
     std::vector<RLMProperty *> links;
@@ -878,21 +884,28 @@ ColumnReference QueryBuilder::column_reference_from_key_path(RLMObjectSchema *ob
 
             links.push_back(property);
             REALM_ASSERT(property.objectClassName);
-            objectSchema = m_schema[property.objectClassName];
+            objectSchema = schema[property.objectClassName];
         }
 
         start = end + 1;
     } while (end != NSNotFound);
 
-    if (isAggregate && !keyPathContainsToManyRelationship) {
+    return {std::move(links), property, keyPathContainsToManyRelationship};
+}
+
+ColumnReference QueryBuilder::column_reference_from_key_path(RLMObjectSchema *objectSchema, NSString *keyPathString, bool isAggregate)
+{
+    auto keyPath = key_path_from_string(m_schema, objectSchema, keyPathString);
+
+    if (isAggregate && !keyPath.containsToManyRelationship) {
         @throw RLMPredicateException(@"Invalid predicate",
                                      @"Aggregate operations can only be used on key paths that include an array property");
-    } else if (!isAggregate && keyPathContainsToManyRelationship) {
+    } else if (!isAggregate && keyPath.containsToManyRelationship) {
         @throw RLMPredicateException(@"Invalid predicate",
                                      @"Key paths that include an array property must use aggregate operations");
     }
 
-    return ColumnReference(m_query, m_group, m_schema, property, std::move(links));
+    return ColumnReference(m_query, m_group, m_schema, keyPath.property, std::move(keyPath.links));
 }
 
 void validate_property_value(const ColumnReference& column,
@@ -1317,15 +1330,18 @@ void QueryBuilder::apply_predicate(NSPredicate *predicate, RLMObjectSchema *obje
     }
 }
 
-size_t RLMValidatedColumnForSort(Table& table, NSString *propName) {
-    RLMPrecondition([propName rangeOfString:@"."].location == NSNotFound,
-                    @"Invalid sort property", @"Cannot sort on '%@': sorting on key paths is not supported.", propName);
-    size_t column = table.get_column_index(propName.UTF8String);
-    RLMPrecondition(column != npos, @"Invalid sort property",
-                    @"Cannot sort on property '%@' on object of type '%s': property not found.",
-                    propName, ObjectStore::object_type_for_table_name(table.get_name()).data());
+std::vector<size_t> RLMValidatedColumnIndicesForSort(RLMClassInfo& classInfo, NSString *keyPathString)
+{
+    RLMPrecondition([keyPathString rangeOfString:@"@"].location == NSNotFound, @"Invalid key path for sort",
+                    @"Cannot sort on '%@': sorting on key paths that include collection operators is not supported.",
+                    keyPathString);
+    auto keyPath = key_path_from_string(classInfo.realm.schema, classInfo.rlmObjectSchema, keyPathString);
 
-    switch (auto type = static_cast<RLMPropertyType>(table.get_column_type(column))) {
+    RLMPrecondition(!keyPath.containsToManyRelationship, @"Invalid key path for sort",
+                    @"Cannot sort on '%@': sorting on key paths that include a to-many relationship is not supported.",
+                    keyPathString);
+
+    switch (keyPath.property.type) {
         case RLMPropertyTypeBool:
         case RLMPropertyTypeDate:
         case RLMPropertyTypeDouble:
@@ -1336,11 +1352,22 @@ size_t RLMValidatedColumnForSort(Table& table, NSString *propName) {
 
         default:
             @throw RLMPredicateException(@"Invalid sort property type",
-                                         @"Cannot sort on property '%@' on object of type '%s': sorting is only supported on bool, date, double, float, integer, and string properties, but property is of type %@.",
-                                         propName, ObjectStore::object_type_for_table_name(table.get_name()).data(),
-                                         RLMTypeToString(type));
+                                         @"Cannot sort on key path '%@' on object of type '%s': sorting is only supported on bool, date, double, float, integer, and string properties, but property is of type %@.",
+                                         keyPathString, classInfo.rlmObjectSchema.className, RLMTypeToString(keyPath.property.type));
     }
-    return column;
+
+    std::vector<size_t> columnIndices;
+    columnIndices.reserve(keyPath.links.size() + 1);
+
+    auto currentClassInfo = &classInfo;
+    for (RLMProperty *link : keyPath.links) {
+        auto tableColumn = currentClassInfo->tableColumn(link);
+        currentClassInfo = &currentClassInfo->linkTargetType(tableColumn);
+        columnIndices.push_back(tableColumn);
+    }
+    columnIndices.push_back(currentClassInfo->tableColumn(keyPath.property));
+
+    return columnIndices;
 }
 
 } // namespace
@@ -1366,16 +1393,16 @@ realm::Query RLMPredicateToQuery(NSPredicate *predicate, RLMObjectSchema *object
     return query;
 }
 
-realm::SortDescriptor RLMSortDescriptorFromDescriptors(realm::Table& table, NSArray<RLMSortDescriptor *> *descriptors) {
+realm::SortDescriptor RLMSortDescriptorFromDescriptors(RLMClassInfo& classInfo, NSArray<RLMSortDescriptor *> *descriptors) {
     std::vector<std::vector<size_t>> columnIndices;
     std::vector<bool> ascending;
     columnIndices.reserve(descriptors.count);
     ascending.reserve(descriptors.count);
 
     for (RLMSortDescriptor *descriptor in descriptors) {
-        columnIndices.push_back({RLMValidatedColumnForSort(table, descriptor.property)});
+        columnIndices.push_back(RLMValidatedColumnIndicesForSort(classInfo, descriptor.keyPath));
         ascending.push_back(descriptor.ascending);
     }
 
-    return {table, std::move(columnIndices), std::move(ascending)};
+    return {*classInfo.table(), std::move(columnIndices), std::move(ascending)};
 }

--- a/Realm/RLMResults.h
+++ b/Realm/RLMResults.h
@@ -160,12 +160,23 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Returns a sorted `RLMResults` from an existing results collection.
 
+ @param keyPath     The key path to sort by.
+ @param ascending   The direction to sort in.
+
+ @return    An `RLMResults` sorted by the specified key path.
+ */
+- (RLMResults<RLMObjectType> *)sortedResultsUsingKeyPath:(NSString *)keyPath ascending:(BOOL)ascending;
+
+/**
+ Returns a sorted `RLMResults` from an existing results collection.
+
  @param property    The property name to sort by.
  @param ascending   The direction to sort in.
 
  @return    An `RLMResults` sorted by the specified property.
  */
-- (RLMResults<RLMObjectType> *)sortedResultsUsingProperty:(NSString *)property ascending:(BOOL)ascending;
+- (RLMResults<RLMObjectType> *)sortedResultsUsingProperty:(NSString *)property ascending:(BOOL)ascending
+    __deprecated_msg("Use `-sortedResultsUsingKeyPath:ascending:`");
 
 /**
  Returns a sorted `RLMResults` from an existing results collection.

--- a/Realm/RLMResults.mm
+++ b/Realm/RLMResults.mm
@@ -355,8 +355,12 @@ static inline void RLMResultsValidateInWriteTransaction(__unsafe_unretained RLMR
     });
 }
 
+- (RLMResults *)sortedResultsUsingKeyPath:(NSString *)keyPath ascending:(BOOL)ascending {
+    return [self sortedResultsUsingDescriptors:@[[RLMSortDescriptor sortDescriptorWithKeyPath:keyPath ascending:ascending]]];
+}
+
 - (RLMResults *)sortedResultsUsingProperty:(NSString *)property ascending:(BOOL)ascending {
-    return [self sortedResultsUsingDescriptors:@[[RLMSortDescriptor sortDescriptorWithProperty:property ascending:ascending]]];
+    return [self sortedResultsUsingKeyPath:property ascending:ascending];
 }
 
 - (RLMResults *)sortedResultsUsingDescriptors:(NSArray<RLMSortDescriptor *> *)properties {
@@ -368,7 +372,7 @@ static inline void RLMResultsValidateInWriteTransaction(__unsafe_unretained RLMR
             return self;
         }
 
-        return [RLMResults resultsWithObjectInfo:*_info results:_results.sort(RLMSortDescriptorFromDescriptors(*_info->table(), properties))];
+        return [RLMResults resultsWithObjectInfo:*_info results:_results.sort(RLMSortDescriptorFromDescriptors(*_info, properties))];
     });
 }
 

--- a/Realm/Tests/ArrayPropertyTests.m
+++ b/Realm/Tests/ArrayPropertyTests.m
@@ -271,7 +271,7 @@
 
     XCTAssertThrows([intArray.intArray objectsWhere:@"intCol == 1"], @"Should throw on unmanaged RLMArray");
     XCTAssertThrows(([intArray.intArray objectsWithPredicate:[NSPredicate predicateWithFormat:@"intCol == %i", 1]]), @"Should throw on unmanaged RLMArray");
-    XCTAssertThrows([intArray.intArray sortedResultsUsingProperty:@"intCol" ascending:YES], @"Should throw on unmanaged RLMArray");
+    XCTAssertThrows([intArray.intArray sortedResultsUsingKeyPath:@"intCol" ascending:YES], @"Should throw on unmanaged RLMArray");
 
     XCTAssertEqual(0U, [intArray.intArray indexOfObjectWhere:@"intCol == 1"]);
     XCTAssertEqual(0U, ([intArray.intArray indexOfObjectWithPredicate:[NSPredicate predicateWithFormat:@"intCol == %i", 1]]));
@@ -780,8 +780,8 @@
     [realm commitWriteTransaction];
 
     bool (^checkOrder)(NSArray *, NSArray *, NSArray *) = ^bool(NSArray *properties, NSArray *ascending, NSArray *dogs) {
-        NSArray *sort = @[[RLMSortDescriptor sortDescriptorWithProperty:properties[0] ascending:[ascending[0] boolValue]],
-                          [RLMSortDescriptor sortDescriptorWithProperty:properties[1] ascending:[ascending[1] boolValue]]];
+        NSArray *sort = @[[RLMSortDescriptor sortDescriptorWithKeyPath:properties[0] ascending:[ascending[0] boolValue]],
+                          [RLMSortDescriptor sortDescriptorWithKeyPath:properties[1] ascending:[ascending[1] boolValue]]];
         RLMResults *actual = [array.dogs sortedResultsUsingDescriptors:sort];
 
         return [actual[0] isEqualToObject:dogs[0]]
@@ -1064,8 +1064,8 @@
         RLMAssertThrowsWithReasonMatching([array indexOfObjectWithPredicate:[NSPredicate predicateWithFormat:@"intCol = 0"]], @"thread");
         RLMAssertThrowsWithReasonMatching([array objectsWhere:@"intCol = 0"], @"thread");
         RLMAssertThrowsWithReasonMatching([array objectsWithPredicate:[NSPredicate predicateWithFormat:@"intCol = 0"]], @"thread");
-        RLMAssertThrowsWithReasonMatching([array sortedResultsUsingProperty:@"intCol" ascending:YES], @"thread");
-        RLMAssertThrowsWithReasonMatching([array sortedResultsUsingDescriptors:@[[RLMSortDescriptor sortDescriptorWithProperty:@"intCol" ascending:YES]]], @"thread");
+        RLMAssertThrowsWithReasonMatching([array sortedResultsUsingKeyPath:@"intCol" ascending:YES], @"thread");
+        RLMAssertThrowsWithReasonMatching([array sortedResultsUsingDescriptors:@[[RLMSortDescriptor sortDescriptorWithKeyPath:@"intCol" ascending:YES]]], @"thread");
         RLMAssertThrowsWithReasonMatching(array[0], @"thread");
         RLMAssertThrowsWithReasonMatching(array[0] = io, @"thread");
         RLMAssertThrowsWithReasonMatching([array valueForKey:@"intCol"], @"thread");
@@ -1112,8 +1112,8 @@
     XCTAssertNoThrow([array indexOfObjectWithPredicate:[NSPredicate predicateWithFormat:@"intCol = 0"]]);
     XCTAssertNoThrow([array objectsWhere:@"intCol = 0"]);
     XCTAssertNoThrow([array objectsWithPredicate:[NSPredicate predicateWithFormat:@"intCol = 0"]]);
-    XCTAssertNoThrow([array sortedResultsUsingProperty:@"intCol" ascending:YES]);
-    XCTAssertNoThrow([array sortedResultsUsingDescriptors:@[[RLMSortDescriptor sortDescriptorWithProperty:@"intCol" ascending:YES]]]);
+    XCTAssertNoThrow([array sortedResultsUsingKeyPath:@"intCol" ascending:YES]);
+    XCTAssertNoThrow([array sortedResultsUsingDescriptors:@[[RLMSortDescriptor sortDescriptorWithKeyPath:@"intCol" ascending:YES]]]);
     XCTAssertNoThrow(array[0]);
     XCTAssertNoThrow(array[0] = io);
     XCTAssertNoThrow([array valueForKey:@"intCol"]);
@@ -1149,8 +1149,8 @@
     RLMAssertThrowsWithReasonMatching([array indexOfObjectWithPredicate:[NSPredicate predicateWithFormat:@"intCol = 0"]], @"invalidated");
     RLMAssertThrowsWithReasonMatching([array objectsWhere:@"intCol = 0"], @"invalidated");
     RLMAssertThrowsWithReasonMatching([array objectsWithPredicate:[NSPredicate predicateWithFormat:@"intCol = 0"]], @"invalidated");
-    RLMAssertThrowsWithReasonMatching([array sortedResultsUsingProperty:@"intCol" ascending:YES], @"invalidated");
-    RLMAssertThrowsWithReasonMatching([array sortedResultsUsingDescriptors:@[[RLMSortDescriptor sortDescriptorWithProperty:@"intCol" ascending:YES]]], @"invalidated");
+    RLMAssertThrowsWithReasonMatching([array sortedResultsUsingKeyPath:@"intCol" ascending:YES], @"invalidated");
+    RLMAssertThrowsWithReasonMatching([array sortedResultsUsingDescriptors:@[[RLMSortDescriptor sortDescriptorWithKeyPath:@"intCol" ascending:YES]]], @"invalidated");
     RLMAssertThrowsWithReasonMatching(array[0], @"invalidated");
     RLMAssertThrowsWithReasonMatching(array[0] = io, @"invalidated");
     RLMAssertThrowsWithReasonMatching([array valueForKey:@"intCol"], @"invalidated");
@@ -1182,8 +1182,8 @@
     XCTAssertNoThrow([array indexOfObjectWithPredicate:[NSPredicate predicateWithFormat:@"intCol = 0"]]);
     XCTAssertNoThrow([array objectsWhere:@"intCol = 0"]);
     XCTAssertNoThrow([array objectsWithPredicate:[NSPredicate predicateWithFormat:@"intCol = 0"]]);
-    XCTAssertNoThrow([array sortedResultsUsingProperty:@"intCol" ascending:YES]);
-    XCTAssertNoThrow([array sortedResultsUsingDescriptors:@[[RLMSortDescriptor sortDescriptorWithProperty:@"intCol" ascending:YES]]]);
+    XCTAssertNoThrow([array sortedResultsUsingKeyPath:@"intCol" ascending:YES]);
+    XCTAssertNoThrow([array sortedResultsUsingDescriptors:@[[RLMSortDescriptor sortDescriptorWithKeyPath:@"intCol" ascending:YES]]]);
     XCTAssertNoThrow(array[0]);
     XCTAssertNoThrow([array valueForKey:@"intCol"]);
     XCTAssertNoThrow({for (__unused id obj in array);});

--- a/Realm/Tests/AsyncTests.mm
+++ b/Realm/Tests/AsyncTests.mm
@@ -117,7 +117,7 @@
 - (void)testResultsPerserveSort {
     __block XCTestExpectation *expectation = [self expectationWithDescription:@""];
     __block int expected = 0;
-    auto token = [[IntObject.allObjects sortedResultsUsingProperty:@"intCol" ascending:NO] addNotificationBlock:^(RLMResults *results, RLMCollectionChange *change, NSError *e) {
+    auto token = [[IntObject.allObjects sortedResultsUsingKeyPath:@"intCol" ascending:NO] addNotificationBlock:^(RLMResults *results, RLMCollectionChange *change, NSError *e) {
         XCTAssertEqual([results.firstObject intCol], expected);
         [expectation fulfill];
     }];
@@ -180,7 +180,7 @@
 - (void)testQueryingDeliveredSortedResults {
     __block XCTestExpectation *expectation = [self expectationWithDescription:@""];
     __block int expected = 0;
-    auto token = [[IntObject.allObjects sortedResultsUsingProperty:@"intCol" ascending:NO] addNotificationBlock:^(RLMResults *results, RLMCollectionChange *change, NSError *e) {
+    auto token = [[IntObject.allObjects sortedResultsUsingKeyPath:@"intCol" ascending:NO] addNotificationBlock:^(RLMResults *results, RLMCollectionChange *change, NSError *e) {
         XCTAssertEqual([[results objectsWhere:@"intCol < 10"].firstObject intCol], expected++);
         [expectation fulfill];
     }];
@@ -200,7 +200,7 @@
     __block XCTestExpectation *expectation = [self expectationWithDescription:@""];
     __block int expected = 0;
     auto token = [[IntObject allObjects] addNotificationBlock:^(RLMResults *results, RLMCollectionChange *change, NSError *e) {
-        XCTAssertEqual([[results sortedResultsUsingProperty:@"intCol" ascending:NO].firstObject intCol], expected++);
+        XCTAssertEqual([[results sortedResultsUsingKeyPath:@"intCol" ascending:NO].firstObject intCol], expected++);
         [expectation fulfill];
     }];
     [self waitForExpectationsWithTimeout:2.0 handler:nil];

--- a/Realm/Tests/LinkingObjectsTests.mm
+++ b/Realm/Tests/LinkingObjectsTests.mm
@@ -64,7 +64,7 @@
         XCTFail(@"Got an item in empty linking objects");
     }
 
-    XCTAssertEqual(0u, [don.parents sortedResultsUsingProperty:@"age" ascending:YES].count);
+    XCTAssertEqual(0u, [don.parents sortedResultsUsingKeyPath:@"age" ascending:YES].count);
     XCTAssertEqual(0u, [don.parents objectsWhere:@"TRUEPREDICATE"].count);
 
     XCTAssertNil([don.parents minOfProperty:@"age"]);

--- a/Realm/Tests/NotificationTests.m
+++ b/Realm/Tests/NotificationTests.m
@@ -201,7 +201,7 @@
 @implementation SortedNotificationTests
 - (RLMResults *)query {
     return [[IntObject objectsWhere:@"intCol > 0 AND intCol < 5"]
-            sortedResultsUsingProperty:@"intCol" ascending:NO];
+            sortedResultsUsingKeyPath:@"intCol" ascending:NO];
 }
 
 - (void)testMoveMatchingObjectDueToDeletionOfNonMatchingObject {

--- a/Realm/Tests/QueryTests.m
+++ b/Realm/Tests/QueryTests.m
@@ -596,10 +596,6 @@
     // sort invalid name
     RLMAssertThrowsWithReasonMatching([[AllTypesObject allObjects] sortedResultsUsingKeyPath:@"invalidCol" ascending:YES], @"'invalidCol'.* not found .*'AllTypesObject'");
     XCTAssertThrows([arrayOfAll.array sortedResultsUsingKeyPath:@"invalidCol" ascending:NO]);
-
-    // sort on key path
-    RLMAssertThrowsWithReasonMatching([[AllTypesObject allObjects] sortedResultsUsingKeyPath:@"collection.@count" ascending:YES], @"key paths that include collection operators");
-    XCTAssertThrows([arrayOfAll.array sortedResultsUsingKeyPath:@"collection.@count" ascending:NO]);
 }
 
 - (void)testSortByNoColumns {

--- a/Realm/Tests/QueryTests.m
+++ b/Realm/Tests/QueryTests.m
@@ -130,17 +130,17 @@
 
     // class not derived from RLMObject
     XCTAssertThrows([realm objects:@"NonRealmPersonObject" where:@"age > 25"], @"invalid object type");
-    XCTAssertThrows([[realm objects:@"NonRealmPersonObject" where:@"age > 25"] sortedResultsUsingProperty:@"age" ascending:YES], @"invalid object type");
+    XCTAssertThrows([[realm objects:@"NonRealmPersonObject" where:@"age > 25"] sortedResultsUsingKeyPath:@"age" ascending:YES], @"invalid object type");
 
     // empty string for class name
     XCTAssertThrows([realm objects:@"" where:@"age > 25"], @"missing class name");
-    XCTAssertThrows([[realm objects:@"" where:@"age > 25"] sortedResultsUsingProperty:@"age" ascending:YES], @"missing class name");
+    XCTAssertThrows([[realm objects:@"" where:@"age > 25"] sortedResultsUsingKeyPath:@"age" ascending:YES], @"missing class name");
 
     // nil class name
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wnonnull"
     XCTAssertThrows([realm objects:nil where:@"age > 25"], @"nil class name");
-    XCTAssertThrows([[realm objects:nil where:@"age > 25"] sortedResultsUsingProperty:@"age" ascending:YES], @"nil class name");
+    XCTAssertThrows([[realm objects:nil where:@"age > 25"] sortedResultsUsingKeyPath:@"age" ascending:YES], @"nil class name");
 #pragma clang diagnostic pop
 }
 
@@ -407,11 +407,11 @@
     RLMAssertCount(PersonObject, 2U, @"age > 28");
 
     // query on realm with order
-    RLMResults *results = [[PersonObject objectsInRealm:realm where:@"age > 28"] sortedResultsUsingProperty:@"age" ascending:YES];
+    RLMResults *results = [[PersonObject objectsInRealm:realm where:@"age > 28"] sortedResultsUsingKeyPath:@"age" ascending:YES];
     XCTAssertEqualObjects([results[0] name], @"Tim", @"Tim should be first results");
 
     // query on sorted results
-    results = [[[PersonObject allObjectsInRealm:realm] sortedResultsUsingProperty:@"age" ascending:YES] objectsWhere:@"age > 28"];
+    results = [[[PersonObject allObjectsInRealm:realm] sortedResultsUsingKeyPath:@"age" ascending:YES] objectsWhere:@"age > 28"];
     XCTAssertEqualObjects([results[0] name], @"Tim", @"Tim should be first results");
 }
 
@@ -494,7 +494,7 @@
     RLMAssertCount(PersonObject, 1U, @"age == 27");
 
     // with order
-    RLMResults *results = [[PersonObject objectsWhere:@"age > 28"] sortedResultsUsingProperty:@"age" ascending:YES];
+    RLMResults *results = [[PersonObject objectsWhere:@"age > 28"] sortedResultsUsingKeyPath:@"age" ascending:YES];
     PersonObject *tim = results[0];
     XCTAssertEqualObjects(tim.name, @"Tim", @"Tim should be first results");
 }
@@ -513,34 +513,34 @@
     RLMResults *all = [PersonObject allObjects];
     XCTAssertEqual(all.count, 3U, @"Expecting 3 results");
 
-    RLMResults *some = [[PersonObject objectsWhere:@"age > 28"] sortedResultsUsingProperty:@"age" ascending:YES];
+    RLMResults *some = [[PersonObject objectsWhere:@"age > 28"] sortedResultsUsingKeyPath:@"age" ascending:YES];
 
     // query/order on array
     RLMAssertCount(all, 1U, @"age == 27");
     RLMAssertCount(all, 0U, @"age == 28");
-    some = [some sortedResultsUsingProperty:@"age" ascending:NO];
+    some = [some sortedResultsUsingKeyPath:@"age" ascending:NO];
     XCTAssertEqualObjects([some[0] name], @"Ari", @"Ari should be first results");
 }
 
 - (void)verifySort:(RLMRealm *)realm column:(NSString *)column ascending:(BOOL)ascending expected:(id)val {
-    RLMResults *results = [[AllTypesObject allObjectsInRealm:realm] sortedResultsUsingProperty:column ascending:ascending];
+    RLMResults *results = [[AllTypesObject allObjectsInRealm:realm] sortedResultsUsingKeyPath:column ascending:ascending];
     AllTypesObject *obj = results[0];
     XCTAssertEqualObjects(obj[column], val, @"Array not sorted as expected - %@ != %@", obj[column], val);
 
     RLMArray *ar = (RLMArray *)[[[ArrayOfAllTypesObject allObjectsInRealm:realm] firstObject] array];
-    results = [ar sortedResultsUsingProperty:column ascending:ascending];
+    results = [ar sortedResultsUsingKeyPath:column ascending:ascending];
     obj = results[0];
     XCTAssertEqualObjects(obj[column], val, @"Array not sorted as expected - %@ != %@", obj[column], val);
 }
 
 - (void)verifySortWithAccuracy:(RLMRealm *)realm column:(NSString *)column ascending:(BOOL)ascending getter:(double(^)(id))getter expected:(double)val accuracy:(double)accuracy {
     // test TableView query
-    RLMResults *results = [[AllTypesObject allObjectsInRealm:realm] sortedResultsUsingProperty:column ascending:ascending];
+    RLMResults *results = [[AllTypesObject allObjectsInRealm:realm] sortedResultsUsingKeyPath:column ascending:ascending];
     XCTAssertEqualWithAccuracy(getter(results[0][column]), val, accuracy, @"Array not sorted as expected");
 
     // test LinkView query
     RLMArray *ar = (RLMArray *)[[[ArrayOfAllTypesObject allObjectsInRealm:realm] firstObject] array];
-    results = [ar sortedResultsUsingProperty:column ascending:ascending];
+    results = [ar sortedResultsUsingKeyPath:column ascending:ascending];
     XCTAssertEqualWithAccuracy(getter(results[0][column]), val, accuracy, @"Array not sorted as expected");
 }
 
@@ -594,12 +594,12 @@
     [self verifySort:realm column:@"stringCol" ascending:NO expected:@"cc"];
 
     // sort invalid name
-    RLMAssertThrowsWithReasonMatching([[AllTypesObject allObjects] sortedResultsUsingProperty:@"invalidCol" ascending:YES], @"'invalidCol'.* 'AllTypesObject'.* not found");
-    XCTAssertThrows([arrayOfAll.array sortedResultsUsingProperty:@"invalidCol" ascending:NO]);
+    RLMAssertThrowsWithReasonMatching([[AllTypesObject allObjects] sortedResultsUsingKeyPath:@"invalidCol" ascending:YES], @"'invalidCol'.* not found .*'AllTypesObject'");
+    XCTAssertThrows([arrayOfAll.array sortedResultsUsingKeyPath:@"invalidCol" ascending:NO]);
 
     // sort on key path
-    RLMAssertThrowsWithReasonMatching([[AllTypesObject allObjects] sortedResultsUsingProperty:@"key.path" ascending:YES], @"key paths is not supported");
-    XCTAssertThrows([arrayOfAll.array sortedResultsUsingProperty:@"key.path" ascending:NO]);
+    RLMAssertThrowsWithReasonMatching([[AllTypesObject allObjects] sortedResultsUsingKeyPath:@"collection.@count" ascending:YES], @"key paths that include collection operators");
+    XCTAssertThrows([arrayOfAll.array sortedResultsUsingKeyPath:@"collection.@count" ascending:NO]);
 }
 
 - (void)testSortByNoColumns {
@@ -628,8 +628,8 @@
     [realm commitWriteTransaction];
 
     bool (^checkOrder)(NSArray *, NSArray *, NSArray *) = ^bool(NSArray *properties, NSArray *ascending, NSArray *dogs) {
-        NSArray *sort = @[[RLMSortDescriptor sortDescriptorWithProperty:properties[0] ascending:[ascending[0] boolValue]],
-                          [RLMSortDescriptor sortDescriptorWithProperty:properties[1] ascending:[ascending[1] boolValue]]];
+        NSArray *sort = @[[RLMSortDescriptor sortDescriptorWithKeyPath:properties[0] ascending:[ascending[0] boolValue]],
+                          [RLMSortDescriptor sortDescriptorWithKeyPath:properties[1] ascending:[ascending[1] boolValue]]];
         RLMResults *actual = [DogObject.allObjects sortedResultsUsingDescriptors:sort];
         return [actual[0] isEqualToObject:dogs[0]]
             && [actual[1] isEqualToObject:dogs[1]]
@@ -646,6 +646,59 @@
     XCTAssertTrue(checkOrder(@[@"age", @"dogName"], @[@YES, @NO], @[b1, a1, b2, a2]));
     XCTAssertTrue(checkOrder(@[@"age", @"dogName"], @[@NO, @YES], @[a2, b2, a1, b1]));
     XCTAssertTrue(checkOrder(@[@"age", @"dogName"], @[@NO, @NO], @[b2, a2, b1, a1]));
+}
+
+- (void)testSortByKeyPath {
+    RLMRealm *realm = [self realm];
+
+    [realm beginWriteTransaction];
+    DogObject *lucy = [DogObject createInDefaultRealmWithValue:@[@"Lucy", @7]];
+    DogObject *freyja = [DogObject createInDefaultRealmWithValue:@[@"Freyja", @6]];
+    DogObject *ziggy = [DogObject createInDefaultRealmWithValue:@[@"Ziggy", @9]];
+
+    OwnerObject *mark = [OwnerObject createInDefaultRealmWithValue:@[@"Mark", freyja]];
+    OwnerObject *diane = [OwnerObject createInDefaultRealmWithValue:@[@"Diane", lucy]];
+    OwnerObject *hannah = [OwnerObject createInDefaultRealmWithValue:@[@"Hannah"]];
+    OwnerObject *don = [OwnerObject createInDefaultRealmWithValue:@[@"Don", ziggy]];
+    OwnerObject *diane_sr = [OwnerObject createInDefaultRealmWithValue:@[@"Diane Sr", ziggy]];
+
+    [realm commitWriteTransaction];
+
+    NSArray *(^asArray)(RLMResults *) = ^(RLMResults *results) {
+        return [[self evaluate:results] valueForKeyPath:@"self"];
+    };
+
+    RLMResults *r1 = [OwnerObject.allObjects sortedResultsUsingKeyPath:@"dog.age" ascending:YES];
+    XCTAssertEqualObjects(asArray(r1), (@[ mark, diane, don, diane_sr, hannah ]));
+
+    RLMResults *r2 = [OwnerObject.allObjects sortedResultsUsingKeyPath:@"dog.age" ascending:NO];
+    XCTAssertEqualObjects(asArray(r2), (@[ hannah, don, diane_sr, diane, mark ]));
+
+    RLMResults *r3 = [OwnerObject.allObjects sortedResultsUsingDescriptors:@[
+                         [RLMSortDescriptor sortDescriptorWithKeyPath:@"dog.age" ascending:YES],
+                         [RLMSortDescriptor sortDescriptorWithKeyPath:@"name" ascending:YES]
+    ]];
+    XCTAssertEqualObjects(asArray(r3), (@[ mark, diane, diane_sr, don, hannah ]));
+
+    RLMResults *r4 = [OwnerObject.allObjects sortedResultsUsingDescriptors:@[
+                         [RLMSortDescriptor sortDescriptorWithKeyPath:@"dog.age" ascending:NO],
+                         [RLMSortDescriptor sortDescriptorWithKeyPath:@"name" ascending:YES]
+    ]];
+    XCTAssertEqualObjects(asArray(r4), (@[ hannah, diane_sr, don, diane, mark ]));
+}
+
+- (void)testSortByUnspportedKeyPath {
+    // Array property
+    RLMAssertThrowsWithReasonMatching([DogArrayObject.allObjects sortedResultsUsingKeyPath:@"dogs.age" ascending:YES],
+                                      @"to-many relationship is not supported");
+
+    // Backlinks property
+    RLMAssertThrowsWithReasonMatching([DogObject.allObjects sortedResultsUsingKeyPath:@"owners.name" ascending:YES],
+                                      @"to-many relationship is not supported");
+
+    // Collection operator
+    RLMAssertThrowsWithReasonMatching([DogArrayObject.allObjects sortedResultsUsingKeyPath:@"dogs.@count" ascending:YES],
+                                      @"collection operators is not supported");
 }
 
 - (void)testSortedLinkViewWithDeletion {
@@ -669,7 +722,7 @@
 
     [realm commitWriteTransaction];
 
-    RLMResults *results = [arrayOfAll.array sortedResultsUsingProperty:@"stringCol" ascending:NO];
+    RLMResults *results = [arrayOfAll.array sortedResultsUsingKeyPath:@"stringCol" ascending:NO];
     XCTAssertEqualObjects([results[0] stringCol], @"cc");
 
     // delete cc, add d results should update
@@ -700,8 +753,8 @@
     ArrayPropertyObject *array = [ArrayPropertyObject createInRealm:realm withValue:@[@"name", @[], [IntObject allObjects]]];
     [realm commitWriteTransaction];
 
-    RLMResults *asc = [IntObject.allObjects sortedResultsUsingProperty:@"intCol" ascending:YES];
-    RLMResults *desc = [IntObject.allObjects sortedResultsUsingProperty:@"intCol" ascending:NO];
+    RLMResults *asc = [IntObject.allObjects sortedResultsUsingKeyPath:@"intCol" ascending:YES];
+    RLMResults *desc = [IntObject.allObjects sortedResultsUsingKeyPath:@"intCol" ascending:NO];
 
     // sanity check; would work even without sort order being preserved
     XCTAssertEqual(2, [[[asc objectsWhere:@"intCol >= 2"] firstObject] intCol]);
@@ -711,8 +764,8 @@
     XCTAssertEqual(3, [[[[desc objectsWhere:@"intCol >= 2"] objectsWhere:@"intCol < 4"] firstObject] intCol]);
 
     // same thing but on an linkview
-    asc = [array.intArray sortedResultsUsingProperty:@"intCol" ascending:YES];
-    desc = [array.intArray sortedResultsUsingProperty:@"intCol" ascending:NO];
+    asc = [array.intArray sortedResultsUsingKeyPath:@"intCol" ascending:YES];
+    desc = [array.intArray sortedResultsUsingKeyPath:@"intCol" ascending:NO];
 
     XCTAssertEqual(2, [[[asc objectsWhere:@"intCol >= 2"] firstObject] intCol]);
     XCTAssertEqual(4, [[[desc objectsWhere:@"intCol >= 2"] firstObject] intCol]);
@@ -1699,9 +1752,9 @@
 
     CompanyObject *co = CompanyObject.allObjects.firstObject;
     RLMResults *basic = [co.employees objectsWhere:@"age = 40"];
-    RLMResults *sort = [co.employees sortedResultsUsingProperty:@"name" ascending:YES];
-    RLMResults *sortQuery = [[co.employees sortedResultsUsingProperty:@"name" ascending:YES] objectsWhere:@"age = 40"];
-    RLMResults *querySort = [[co.employees objectsWhere:@"age = 40"] sortedResultsUsingProperty:@"name" ascending:YES];
+    RLMResults *sort = [co.employees sortedResultsUsingKeyPath:@"name" ascending:YES];
+    RLMResults *sortQuery = [[co.employees sortedResultsUsingKeyPath:@"name" ascending:YES] objectsWhere:@"age = 40"];
+    RLMResults *querySort = [[co.employees objectsWhere:@"age = 40"] sortedResultsUsingKeyPath:@"name" ascending:YES];
 
     XCTAssertEqual(1U, basic.count);
     XCTAssertEqual(2U, sort.count);
@@ -2080,9 +2133,9 @@
 
         RLMAssertCount(stringObjectClass, 1U, @"stringCol = ''");
 
-        RLMResults *sorted = [[stringObjectClass allObjectsInRealm:realm] sortedResultsUsingProperty:@"stringCol" ascending:YES];
+        RLMResults *sorted = [[stringObjectClass allObjectsInRealm:realm] sortedResultsUsingKeyPath:@"stringCol" ascending:YES];
         XCTAssertEqualObjects((@[NSNull.null, NSNull.null, @"", @"a", @"b"]), [sorted valueForKey:@"stringCol"]);
-        XCTAssertEqualObjects((@[@"b", @"a", @"", NSNull.null, NSNull.null]), [[sorted sortedResultsUsingProperty:@"stringCol" ascending:NO] valueForKey:@"stringCol"]);
+        XCTAssertEqualObjects((@[@"b", @"a", @"", NSNull.null, NSNull.null]), [[sorted sortedResultsUsingKeyPath:@"stringCol" ascending:NO] valueForKey:@"stringCol"]);
 
         [realm transactionWithBlock:^{
             [realm deleteObject:[stringObjectClass allObjectsInRealm:realm].firstObject];
@@ -2161,10 +2214,10 @@
         NumberObject *no0 = [NumberObject createInRealm:realm withValue:@[@0, @0.0f, @0.0, @NO]];
         for (RLMProperty *property in [[NumberObject alloc] init].objectSchema.properties) {
             NSString *name = property.name;
-            RLMResults *ascending = [[NumberObject allObjectsInRealm:realm] sortedResultsUsingProperty:name ascending:YES];
+            RLMResults *ascending = [[NumberObject allObjectsInRealm:realm] sortedResultsUsingKeyPath:name ascending:YES];
             XCTAssertEqualObjects([ascending valueForKey:name], ([@[noNull, no0, no1] valueForKey:name]));
 
-            RLMResults *descending = [[NumberObject allObjectsInRealm:realm] sortedResultsUsingProperty:name ascending:NO];
+            RLMResults *descending = [[NumberObject allObjectsInRealm:realm] sortedResultsUsingKeyPath:name ascending:NO];
             XCTAssertEqualObjects([descending valueForKey:name], ([@[no1, no0, noNull] valueForKey:name]));
         }
     }
@@ -2175,10 +2228,10 @@
         DateObject *doZero = [DateObject createInRealm:realm withValue:@[[NSDate dateWithTimeIntervalSince1970:0]]];
         DateObject *doNull = [DateObject createInRealm:realm withValue:@[NSNull.null]];
 
-        RLMResults *ascending = [[DateObject allObjectsInRealm:realm] sortedResultsUsingProperty:@"dateCol" ascending:YES];
+        RLMResults *ascending = [[DateObject allObjectsInRealm:realm] sortedResultsUsingKeyPath:@"dateCol" ascending:YES];
         XCTAssertEqualObjects([ascending valueForKey:@"dateCol"], ([@[doNull, doNegative, doZero, doPositive] valueForKey:@"dateCol"]));
 
-        RLMResults *descending = [[DateObject allObjectsInRealm:realm] sortedResultsUsingProperty:@"dateCol" ascending:NO];
+        RLMResults *descending = [[DateObject allObjectsInRealm:realm] sortedResultsUsingKeyPath:@"dateCol" ascending:NO];
         XCTAssertEqualObjects([descending valueForKey:@"dateCol"], ([@[doPositive, doZero, doNegative, doNull] valueForKey:@"dateCol"]));
     }
 
@@ -2189,10 +2242,10 @@
         StringObject *soNull = [StringObject createInRealm:realm withValue:@[NSNull.null]];
         StringObject *soAB = [StringObject createInRealm:realm withValue:@[@"AB"]];
 
-        RLMResults *ascending = [[StringObject allObjectsInRealm:realm] sortedResultsUsingProperty:@"stringCol" ascending:YES];
+        RLMResults *ascending = [[StringObject allObjectsInRealm:realm] sortedResultsUsingKeyPath:@"stringCol" ascending:YES];
         XCTAssertEqualObjects([ascending valueForKey:@"stringCol"], ([@[soNull, soEmpty, soA, soAB, soB] valueForKey:@"stringCol"]));
 
-        RLMResults *descending = [[StringObject allObjectsInRealm:realm] sortedResultsUsingProperty:@"stringCol" ascending:NO];
+        RLMResults *descending = [[StringObject allObjectsInRealm:realm] sortedResultsUsingKeyPath:@"stringCol" ascending:NO];
         XCTAssertEqualObjects([descending valueForKey:@"stringCol"], ([@[soB, soAB, soA, soEmpty, soNull] valueForKey:@"stringCol"]));
     }
 

--- a/Realm/Tests/RLMTestObjects.m
+++ b/Realm/Tests/RLMTestObjects.m
@@ -124,6 +124,12 @@
 #pragma mark OwnerObject
 
 @implementation OwnerObject
+
+- (BOOL)isEqual:(id)other
+{
+    return [self isEqualToObject:other];
+}
+
 @end
 
 #pragma mark - Specific Use Objects

--- a/Realm/Tests/RealmTests.mm
+++ b/Realm/Tests/RealmTests.mm
@@ -1490,7 +1490,7 @@
     RLMResults *results = [IntObject allObjectsInRealm:realm];
     XCTAssertEqual(0U, results.count);
     XCTAssertEqual(results, [results objectsWhere:@"intCol = 5"]);
-    XCTAssertEqual(results, [results sortedResultsUsingProperty:@"intCol" ascending:YES]);
+    XCTAssertEqual(results, [results sortedResultsUsingKeyPath:@"intCol" ascending:YES]);
     XCTAssertThrows([results objectAtIndex:0]);
     XCTAssertEqual(NSNotFound, [results indexOfObject:self.nonLiteralNil]);
     XCTAssertEqual(NSNotFound, [results indexOfObjectWhere:@"intCol = 5"]);

--- a/Realm/Tests/ResultsTests.m
+++ b/Realm/Tests/ResultsTests.m
@@ -451,7 +451,7 @@
     RLMAssertThrowsWithReasonMatching([results indexOfObject:deletedObject], @"Object has been invalidated");
 
     // reverse order from sort
-    results = [[EmployeeObject objectsWhere:@"hired = YES"] sortedResultsUsingProperty:@"age" ascending:YES];
+    results = [[EmployeeObject objectsWhere:@"hired = YES"] sortedResultsUsingKeyPath:@"age" ascending:YES];
     XCTAssertEqual(1U, [results indexOfObject:po1]);
     XCTAssertEqual(0U, [results indexOfObject:po3]);
     XCTAssertEqual((NSUInteger)NSNotFound, [results indexOfObject:po2]);
@@ -490,7 +490,7 @@
     XCTAssertEqual(2U, ([results indexOfObjectWhere:@"age = %d", 25]));
     XCTAssertEqual((NSUInteger)NSNotFound, ([results indexOfObjectWhere:@"age = %d", 35]));
 
-    results = [[EmployeeObject allObjects] sortedResultsUsingProperty:@"age" ascending:YES];
+    results = [[EmployeeObject allObjects] sortedResultsUsingKeyPath:@"age" ascending:YES];
     NSUInteger youngestHired = [results indexOfObjectWhere:@"hired = YES"];
     XCTAssertEqual(0U, youngestHired);
     XCTAssertEqualObjects(@"Jill", [results[youngestHired] name]);
@@ -532,8 +532,8 @@
 
     RLMResults *subarray = nil;
     {
-        __attribute((objc_precise_lifetime)) RLMResults *results = [[EmployeeObject allObjects] sortedResultsUsingProperty:@"age" ascending:YES];
-        subarray = [results sortedResultsUsingProperty:@"age" ascending:NO];
+        __attribute((objc_precise_lifetime)) RLMResults *results = [[EmployeeObject allObjects] sortedResultsUsingKeyPath:@"age" ascending:YES];
+        subarray = [results sortedResultsUsingKeyPath:@"age" ascending:NO];
     }
 
     [realm beginWriteTransaction];
@@ -556,8 +556,8 @@
     [EmployeeObject createInRealm:realm withValue:@{@"name": @"C", @"age": @40, @"hired": @YES}];
     [realm commitWriteTransaction];
 
-    RLMResults *sortedAge = [[EmployeeObject allObjects] sortedResultsUsingProperty:@"age" ascending:YES];
-    RLMResults *sortedName = [sortedAge sortedResultsUsingProperty:@"name" ascending:NO];
+    RLMResults *sortedAge = [[EmployeeObject allObjects] sortedResultsUsingKeyPath:@"age" ascending:YES];
+    RLMResults *sortedName = [sortedAge sortedResultsUsingKeyPath:@"name" ascending:NO];
 
     XCTAssertEqual(20, [(EmployeeObject *)sortedAge[0] age]);
     XCTAssertEqual(40, [(EmployeeObject *)sortedName[0] age]);
@@ -566,9 +566,9 @@
 - (void)testRerunningSortedQuery {
     RLMRealm *realm = [RLMRealm defaultRealm];
 
-    RLMResults *sortedAge = [[EmployeeObject allObjects] sortedResultsUsingProperty:@"age" ascending:YES];
+    RLMResults *sortedAge = [[EmployeeObject allObjects] sortedResultsUsingKeyPath:@"age" ascending:YES];
     [sortedAge lastObject]; // Force creation of the TableView
-    RLMResults *sortedName = [sortedAge sortedResultsUsingProperty:@"name" ascending:NO];
+    RLMResults *sortedName = [sortedAge sortedResultsUsingKeyPath:@"name" ascending:NO];
     [sortedName lastObject]; // Force creation of the TableView
     RLMResults *filtered = [sortedName objectsWhere:@"age > 20"];
     [filtered lastObject]; // Force creation of the TableView
@@ -825,8 +825,8 @@ static vm_size_t get_resident_size() {
     XCTAssertNoThrow([results indexOfObjectWithPredicate:[NSPredicate predicateWithFormat:@"intCol = 0"]]);
     XCTAssertNoThrow([results objectsWhere:@"intCol = 0"]);
     XCTAssertNoThrow([results objectsWithPredicate:[NSPredicate predicateWithFormat:@"intCol = 0"]]);
-    XCTAssertNoThrow([results sortedResultsUsingProperty:@"intCol" ascending:YES]);
-    XCTAssertNoThrow([results sortedResultsUsingDescriptors:@[[RLMSortDescriptor sortDescriptorWithProperty:@"intCol" ascending:YES]]]);
+    XCTAssertNoThrow([results sortedResultsUsingKeyPath:@"intCol" ascending:YES]);
+    XCTAssertNoThrow([results sortedResultsUsingDescriptors:@[[RLMSortDescriptor sortDescriptorWithKeyPath:@"intCol" ascending:YES]]]);
     XCTAssertNoThrow([results minOfProperty:@"intCol"]);
     XCTAssertNoThrow([results maxOfProperty:@"intCol"]);
     XCTAssertNoThrow([results sumOfProperty:@"intCol"]);
@@ -844,8 +844,8 @@ static vm_size_t get_resident_size() {
         XCTAssertThrows([results indexOfObjectWithPredicate:[NSPredicate predicateWithFormat:@"intCol = 0"]]);
         XCTAssertThrows([results objectsWhere:@"intCol = 0"]);
         XCTAssertThrows([results objectsWithPredicate:[NSPredicate predicateWithFormat:@"intCol = 0"]]);
-        XCTAssertThrows([results sortedResultsUsingProperty:@"intCol" ascending:YES]);
-        XCTAssertThrows([results sortedResultsUsingDescriptors:@[[RLMSortDescriptor sortDescriptorWithProperty:@"intCol" ascending:YES]]]);
+        XCTAssertThrows([results sortedResultsUsingKeyPath:@"intCol" ascending:YES]);
+        XCTAssertThrows([results sortedResultsUsingDescriptors:@[[RLMSortDescriptor sortDescriptorWithKeyPath:@"intCol" ascending:YES]]]);
         XCTAssertThrows([results minOfProperty:@"intCol"]);
         XCTAssertThrows([results maxOfProperty:@"intCol"]);
         XCTAssertThrows([results sumOfProperty:@"intCol"]);
@@ -871,8 +871,8 @@ static vm_size_t get_resident_size() {
     XCTAssertNoThrow([results indexOfObjectWithPredicate:[NSPredicate predicateWithFormat:@"intCol = 0"]]);
     XCTAssertNoThrow([results objectsWhere:@"intCol = 0"]);
     XCTAssertNoThrow([results objectsWithPredicate:[NSPredicate predicateWithFormat:@"intCol = 0"]]);
-    XCTAssertNoThrow([results sortedResultsUsingProperty:@"intCol" ascending:YES]);
-    XCTAssertNoThrow([results sortedResultsUsingDescriptors:@[[RLMSortDescriptor sortDescriptorWithProperty:@"intCol" ascending:YES]]]);
+    XCTAssertNoThrow([results sortedResultsUsingKeyPath:@"intCol" ascending:YES]);
+    XCTAssertNoThrow([results sortedResultsUsingDescriptors:@[[RLMSortDescriptor sortDescriptorWithKeyPath:@"intCol" ascending:YES]]]);
     XCTAssertNoThrow([results minOfProperty:@"intCol"]);
     XCTAssertNoThrow([results maxOfProperty:@"intCol"]);
     XCTAssertNoThrow([results sumOfProperty:@"intCol"]);
@@ -892,8 +892,8 @@ static vm_size_t get_resident_size() {
     XCTAssertThrows([results indexOfObjectWithPredicate:[NSPredicate predicateWithFormat:@"intCol = 0"]]);
     XCTAssertThrows([results objectsWhere:@"intCol = 0"]);
     XCTAssertThrows([results objectsWithPredicate:[NSPredicate predicateWithFormat:@"intCol = 0"]]);
-    XCTAssertThrows([results sortedResultsUsingProperty:@"intCol" ascending:YES]);
-    XCTAssertThrows([results sortedResultsUsingDescriptors:@[[RLMSortDescriptor sortDescriptorWithProperty:@"intCol" ascending:YES]]]);
+    XCTAssertThrows([results sortedResultsUsingKeyPath:@"intCol" ascending:YES]);
+    XCTAssertThrows([results sortedResultsUsingDescriptors:@[[RLMSortDescriptor sortDescriptorWithKeyPath:@"intCol" ascending:YES]]]);
     XCTAssertThrows([results minOfProperty:@"intCol"]);
     XCTAssertThrows([results maxOfProperty:@"intCol"]);
     XCTAssertThrows([results sumOfProperty:@"intCol"]);
@@ -911,10 +911,10 @@ static vm_size_t get_resident_size() {
         object = [IntegerArrayPropertyObject createInDefaultRealmWithValue:@[ @0, @[ intObject ] ]];
     }];
 
-    RLMResults *results = [object.array sortedResultsUsingProperty:@"intCol" ascending:YES];
+    RLMResults *results = [object.array sortedResultsUsingKeyPath:@"intCol" ascending:YES];
     [results firstObject];
 
-    RLMResults *unevaluatedResults = [object.array sortedResultsUsingProperty:@"intCol" ascending:YES];
+    RLMResults *unevaluatedResults = [object.array sortedResultsUsingKeyPath:@"intCol" ascending:YES];
 
     [realm transactionWithBlock:^{
         [realm deleteObject:object];

--- a/Realm/Tests/Swift/SwiftArrayTests.swift
+++ b/Realm/Tests/Swift/SwiftArrayTests.swift
@@ -505,8 +505,8 @@ class SwiftArrayTests: RLMTestCase {
         _ = makeEmployee(realm, 40, "C", true)
         try! realm.commitWriteTransaction()
 
-        let sortedByAge = EmployeeObject.allObjects(in: realm).sortedResults(usingProperty: "age", ascending: true)
-        let sortedByName = sortedByAge.sortedResults(usingProperty: "name", ascending: false)
+        let sortedByAge = EmployeeObject.allObjects(in: realm).sortedResults(usingKeyPath: "age", ascending: true)
+        let sortedByName = sortedByAge.sortedResults(usingKeyPath: "name", ascending: false)
 
         XCTAssertEqual(Int32(20), (sortedByAge[0] as! EmployeeObject).age)
         XCTAssertEqual(Int32(40), (sortedByName[0] as! EmployeeObject).age)

--- a/Realm/Tests/Swift/SwiftRealmTests.swift
+++ b/Realm/Tests/Swift/SwiftRealmTests.swift
@@ -115,12 +115,12 @@ class SwiftRealmTests: RLMTestCase {
     func testUpdatingSortedArrayAfterBackgroundUpdate() {
         let realm = realmWithTestPath()
         let objs = SwiftIntObject.allObjects(in: realm)
-        let objects = SwiftIntObject.allObjects(in: realm).sortedResults(usingProperty: "intCol", ascending: true)
+        let objects = SwiftIntObject.allObjects(in: realm).sortedResults(usingKeyPath: "intCol", ascending: true)
         let updateComplete = expectation(description: "background update complete")
 
         let token = realm.addNotificationBlock() { (_, _) in
             XCTAssertEqual(objs.count, UInt(2))
-            XCTAssertEqual(objs.sortedResults(usingProperty: "intCol", ascending: true).count, UInt(2))
+            XCTAssertEqual(objs.sortedResults(usingKeyPath: "intCol", ascending: true).count, UInt(2))
             XCTAssertEqual(objects.count, UInt(2))
             updateComplete.fulfill()
         }

--- a/RealmSwift/LinkingObjects.swift
+++ b/RealmSwift/LinkingObjects.swift
@@ -220,6 +220,23 @@ public final class LinkingObjects<T: Object>: LinkingObjectsBase {
     /**
      Returns a `Results` containing all the linking objects, but sorted.
 
+     Objects are sorted based on the values of the given key path. For example, to sort a collection of `Student`s from
+     youngest to oldest based on their `age` property, you might call
+     `students.sorted(byKeyPath: "age", ascending: true)`.
+
+     - warning: Collections may only be sorted by properties of boolean, `Date`, `NSDate`, single and double-precision
+                floating point, integer, and string types.
+
+     - parameter keyPath:  The key path to sort by.
+     - parameter ascending: The direction to sort in.
+     */
+    public func sorted(byKeyPath keyPath: String, ascending: Bool = true) -> Results<T> {
+        return sorted(by: [SortDescriptor(keyPath: keyPath, ascending: ascending)])
+    }
+
+    /**
+     Returns a `Results` containing all the linking objects, but sorted.
+
      Objects are sorted based on the values of the given property. For example, to sort a collection of `Student`s from
      youngest to oldest based on their `age` property, you might call
      `students.sorted(byProperty: "age", ascending: true)`.
@@ -230,8 +247,9 @@ public final class LinkingObjects<T: Object>: LinkingObjectsBase {
      - parameter property:  The name of the property to sort by.
      - parameter ascending: The direction to sort in.
      */
+    @available(*, deprecated, renamed: "sorted(byKeyPath:ascending:)")
     public func sorted(byProperty property: String, ascending: Bool = true) -> Results<T> {
-        return sorted(by: [SortDescriptor(property: property, ascending: ascending)])
+        return sorted(byKeyPath: property, ascending: ascending)
     }
 
     /**
@@ -240,7 +258,7 @@ public final class LinkingObjects<T: Object>: LinkingObjectsBase {
      - warning: Collections may only be sorted by properties of boolean, `Date`, `NSDate`, single and double-precision
                 floating point, integer, and string types.
 
-     - see: `sorted(byProperty:ascending:)`
+     - see: `sorted(byKeyPath:ascending:)`
 
      - parameter sortDescriptors: A sequence of `SortDescriptor`s to sort by.
      */
@@ -410,7 +428,7 @@ extension LinkingObjects {
     @available(*, unavailable, renamed: "index(matching:_:)")
     public func index(of predicateFormat: String, _ args: Any...) -> Int? { fatalError() }
 
-    @available(*, unavailable, renamed: "sorted(byProperty:ascending:)")
+    @available(*, unavailable, renamed: "sorted(byKeyPath:ascending:)")
     public func sorted(_ property: String, ascending: Bool = true) -> Results<T> { fatalError() }
 
     @available(*, unavailable, renamed: "sorted(by:)")
@@ -633,17 +651,17 @@ public final class LinkingObjects<T: Object>: LinkingObjectsBase {
     /**
      Returns a `Results` containing all the linking objects, but sorted.
 
-     Objects are sorted based on the values of the given property. For example, to sort a collection of `Student`s from
+     Objects are sorted based on the values of the given key path. For example, to sort a collection of `Student`s from
      youngest to oldest based on their `age` property, you might call `students.sorted("age", ascending: true)`.
 
      - warning: Collections may only be sorted by properties of boolean, `NSDate`, single and double-precision floating
                 point, integer, and string types.
 
-     - parameter property:  The name of the property to sort by.
+     - parameter keyPath:  The key path to sort by.
      - parameter ascending: The direction to sort in.
      */
-    public func sorted(property: String, ascending: Bool = true) -> Results<T> {
-        return sorted([SortDescriptor(property: property, ascending: ascending)])
+    public func sorted(keyPath: String, ascending: Bool = true) -> Results<T> {
+        return sorted([SortDescriptor(keyPath: keyPath, ascending: ascending)])
     }
 
     /**

--- a/RealmSwift/List.swift
+++ b/RealmSwift/List.swift
@@ -192,6 +192,23 @@ public final class List<T: Object>: ListBase {
     /**
      Returns a `Results` containing the objects in the list, but sorted.
 
+     Objects are sorted based on the values of the given key path. For example, to sort a list of `Student`s from
+     youngest to oldest based on their `age` property, you might call
+     `students.sorted(byKeyPath: "age", ascending: true)`.
+
+     - warning: Lists may only be sorted by properties of boolean, `Date`, `NSDate`, single and double-precision
+                floating point, integer, and string types.
+
+     - parameter keyPath:  The key path to sort by.
+     - parameter ascending: The direction to sort in.
+     */
+    public func sorted(byKeyPath keyPath: String, ascending: Bool = true) -> Results<T> {
+        return sorted(by: [SortDescriptor(keyPath: keyPath, ascending: ascending)])
+    }
+
+    /**
+     Returns a `Results` containing the objects in the list, but sorted.
+
      Objects are sorted based on the values of the given property. For example, to sort a list of `Student`s from
      youngest to oldest based on their `age` property, you might call
      `students.sorted(byProperty: "age", ascending: true)`.
@@ -202,8 +219,9 @@ public final class List<T: Object>: ListBase {
      - parameter property:  The name of the property to sort by.
      - parameter ascending: The direction to sort in.
      */
+    @available(*, deprecated, renamed: "sorted(byKeyPath:ascending:)")
     public func sorted(byProperty property: String, ascending: Bool = true) -> Results<T> {
-        return sorted(by: [SortDescriptor(property: property, ascending: ascending)])
+        return sorted(byKeyPath: property, ascending: ascending)
     }
 
     /**
@@ -212,7 +230,7 @@ public final class List<T: Object>: ListBase {
      - warning: Lists may only be sorted by properties of boolean, `Date`, `NSDate`, single and double-precision
                 floating point, integer, and string types.
 
-     - see: `sorted(byProperty:ascending:)`
+     - see: `sorted(byKeyPath:ascending:)`
     */
     public func sorted<S: Sequence>(by sortDescriptors: S) -> Results<T> where S.Iterator.Element == SortDescriptor {
         return Results<T>(_rlmArray.sortedResults(using: sortDescriptors.map { $0.rlmSortDescriptorValue }))
@@ -517,7 +535,7 @@ extension List {
     @available(*, unavailable, renamed: "index(matching:_:)")
     public func index(of predicateFormat: String, _ args: Any...) -> Int? { fatalError() }
 
-    @available(*, unavailable, renamed: "sorted(byProperty:ascending:)")
+    @available(*, unavailable, renamed: "sorted(byKeyPath:ascending:)")
     public func sorted(_ property: String, ascending: Bool = true) -> Results<T> { fatalError() }
 
     @available(*, unavailable, renamed: "sorted(by:)")
@@ -712,17 +730,17 @@ public final class List<T: Object>: ListBase {
     /**
      Returns a `Results` containing the objects in the list, but sorted.
 
-     Objects are sorted based on the values of the given property. For example, to sort a list of `Student`s from
+     Objects are sorted based on the values of the given key path. For example, to sort a list of `Student`s from
      youngest to oldest based on their `age` property, you might call `students.sorted("age", ascending: true)`.
 
      - warning: Lists may only be sorted by properties of boolean, `NSDate`, single and double-precision floating point,
                 integer, and string types.
 
-     - parameter property:  The name of the property to sort by.
+     - parameter keyPath:  The key path to sort by.
      - parameter ascending: The direction to sort in.
      */
-    public func sorted(property: String, ascending: Bool = true) -> Results<T> {
-        return sorted([SortDescriptor(property: property, ascending: ascending)])
+    public func sorted(keyPath: String, ascending: Bool = true) -> Results<T> {
+        return sorted([SortDescriptor(keyPath: keyPath, ascending: ascending)])
     }
 
     /**

--- a/RealmSwift/ObjectiveCSupport.swift
+++ b/RealmSwift/ObjectiveCSupport.swift
@@ -163,7 +163,7 @@ public final class ObjectiveCSupport {
 
     /// Convert a `RLMSortDescriptor` to a `SortDescriptor`.
     public static func convert(object: RLMSortDescriptor) -> SortDescriptor {
-        return SortDescriptor(property: object.property, ascending: object.ascending)
+        return SortDescriptor(keyPath: object.keyPath, ascending: object.ascending)
     }
 
     /// Convert a `SyncCredentials` to a `RLMSyncCredentials`.

--- a/RealmSwift/RealmCollection.swift
+++ b/RealmSwift/RealmCollection.swift
@@ -195,6 +195,21 @@ public protocol RealmCollection: RandomAccessCollection, LazyCollectionProtocol,
     /**
      Returns a `Results` containing the objects in the collection, but sorted.
 
+     Objects are sorted based on the values of the given key path. For example, to sort a collection of `Student`s from
+     youngest to oldest based on their `age` property, you might call
+     `students.sorted(byKeyPath: "age", ascending: true)`.
+
+     - warning: Collections may only be sorted by properties of boolean, `Date`, `NSDate`, single and double-precision
+                floating point, integer, and string types.
+
+     - parameter keyPath:   The key path to sort by.
+     - parameter ascending: The direction to sort in.
+     */
+    func sorted(byKeyPath keyPath: String, ascending: Bool) -> Results<Element>
+
+    /**
+     Returns a `Results` containing the objects in the collection, but sorted.
+
      Objects are sorted based on the values of the given property. For example, to sort a collection of `Student`s from
      youngest to oldest based on their `age` property, you might call
      `students.sorted(byProperty: "age", ascending: true)`.
@@ -205,6 +220,7 @@ public protocol RealmCollection: RandomAccessCollection, LazyCollectionProtocol,
      - parameter property:  The name of the property to sort by.
      - parameter ascending: The direction to sort in.
      */
+    @available(*, deprecated, renamed: "sorted(byKeyPath:ascending:)")
     func sorted(byProperty property: String, ascending: Bool) -> Results<Element>
 
     /**
@@ -213,7 +229,7 @@ public protocol RealmCollection: RandomAccessCollection, LazyCollectionProtocol,
      - warning: Collections may only be sorted by properties of boolean, `Date`, `NSDate`, single and double-precision
                 floating point, integer, and string types.
 
-     - see: `sorted(byProperty:ascending:)`
+     - see: `sorted(byKeyPath:ascending:)`
 
      - parameter sortDescriptors: A sequence of `SortDescriptor`s to sort by.
      */
@@ -363,7 +379,7 @@ private class _AnyRealmCollectionBase<T: Object> {
     func index(matching predicateFormat: String, _ args: Any...) -> Int? { fatalError() }
     func filter(_ predicateFormat: String, _ args: Any...) -> Results<Element> { fatalError() }
     func filter(_ predicate: NSPredicate) -> Results<Element> { fatalError() }
-    func sorted(byProperty property: String, ascending: Bool) -> Results<Element> { fatalError() }
+    func sorted(byKeyPath keyPath: String, ascending: Bool) -> Results<Element> { fatalError() }
     func sorted<S: Sequence>(by sortDescriptors: S) -> Results<Element> where S.Iterator.Element == SortDescriptor {
         fatalError()
     }
@@ -416,8 +432,8 @@ private final class _AnyRealmCollection<C: RealmCollection>: _AnyRealmCollection
 
     // MARK: Sorting
 
-    override func sorted(byProperty property: String, ascending: Bool) -> Results<C.Element> {
-        return base.sorted(byProperty: property, ascending: ascending)
+    override func sorted(byKeyPath keyPath: String, ascending: Bool) -> Results<C.Element> {
+        return base.sorted(byKeyPath: keyPath, ascending: ascending)
     }
 
     override func sorted<S: Sequence>
@@ -575,6 +591,23 @@ public final class AnyRealmCollection<T: Object>: RealmCollection {
     /**
      Returns a `Results` containing the objects in the collection, but sorted.
 
+     Objects are sorted based on the values of the given key path. For example, to sort a collection of `Student`s from
+     youngest to oldest based on their `age` property, you might call
+     `students.sorted(byKeyPath: "age", ascending: true)`.
+
+     - warning:  Collections may only be sorted by properties of boolean, `Date`, `NSDate`, single and double-precision
+                 floating point, integer, and string types.
+
+     - parameter keyPath:  The key path to sort by.
+     - parameter ascending: The direction to sort in.
+     */
+    public func sorted(byKeyPath keyPath: String, ascending: Bool) -> Results<Element> {
+        return base.sorted(byKeyPath: keyPath, ascending: ascending)
+    }
+
+    /**
+     Returns a `Results` containing the objects in the collection, but sorted.
+
      Objects are sorted based on the values of the given property. For example, to sort a collection of `Student`s from
      youngest to oldest based on their `age` property, you might call
      `students.sorted(byProperty: "age", ascending: true)`.
@@ -585,8 +618,9 @@ public final class AnyRealmCollection<T: Object>: RealmCollection {
      - parameter property:  The name of the property to sort by.
      - parameter ascending: The direction to sort in.
      */
+    @available(*, deprecated, renamed: "sorted(byKeyPath:ascending:)")
     public func sorted(byProperty property: String, ascending: Bool) -> Results<Element> {
-        return base.sorted(byProperty: property, ascending: ascending)
+        return sorted(byKeyPath: property, ascending: ascending)
     }
 
     /**
@@ -595,7 +629,7 @@ public final class AnyRealmCollection<T: Object>: RealmCollection {
      - warning:  Collections may only be sorted by properties of boolean, `Date`, `NSDate`, single and double-precision
                  floating point, integer, and string types.
 
-     - see: `sorted(byProperty:ascending:)`
+     - see: `sorted(byKeyPath:ascending:)`
 
      - parameter sortDescriptors: A sequence of `SortDescriptor`s to sort by.
      */
@@ -782,7 +816,7 @@ extension AnyRealmCollection {
     @available(*, unavailable, renamed: "index(matching:_:)")
     public func index(of predicateFormat: String, _ args: AnyObject...) -> Int? { fatalError() }
 
-    @available(*, unavailable, renamed: "sorted(byProperty:ascending:)")
+    @available(*, unavailable, renamed: "sorted(byKeyPath:ascending:)")
     public func sorted(_ property: String, ascending: Bool = true) -> Results<T> { fatalError() }
 
     @available(*, unavailable, renamed: "sorted(by:)")
@@ -974,17 +1008,17 @@ public protocol RealmCollectionType: CollectionType, CustomStringConvertible {
     /**
      Returns a `Results` containing the objects in the collection, but sorted.
 
-     Objects are sorted based on the values of the given property. For example, to sort a collection of `Student`s from
+     Objects are sorted based on the values of the given key path. For example, to sort a collection of `Student`s from
      youngest to oldest based on their `age` property, you might call
-     `students.sorted(byProperty: "age", ascending: true)`.
+     `students.sorted(byKeyPath: "age", ascending: true)`.
 
      - warning: Collections may only be sorted by properties of boolean, `Date`, `NSDate`, single and double-precision
                 floating point, integer, and string types.
 
-     - parameter property:  The name of the property to sort by.
+     - parameter keyPath:   The key path to sort by.
      - parameter ascending: The direction to sort in.
      */
-    func sorted(byProperty: String, ascending: Bool) -> Results<Element>
+    func sorted(byKeyPath: String, ascending: Bool) -> Results<Element>
 
     /**
      Returns a `Results` containing the objects in the collection, but sorted.
@@ -992,7 +1026,7 @@ public protocol RealmCollectionType: CollectionType, CustomStringConvertible {
      - warning: Collections may only be sorted by properties of boolean, `Date`, `NSDate`, single and double-precision
                 floating point, integer, and string types.
 
-     - see: `sorted(byProperty:ascending:)`
+     - see: `sorted(byKeyPath:ascending:)`
 
      - parameter sortDescriptors: A sequence of `SortDescriptor`s to sort by.
      */

--- a/RealmSwift/Results.swift
+++ b/RealmSwift/Results.swift
@@ -224,6 +224,23 @@ public final class Results<T: Object>: NSObject, NSFastEnumeration {
     /**
      Returns a `Results` containing the objects represented by the results, but sorted.
 
+     Objects are sorted based on the values of the given key path. For example, to sort a collection of `Student`s from
+     youngest to oldest based on their `age` property, you might call
+     `students.sorted(byKeyPath: "age", ascending: true)`.
+
+     - warning: Collections may only be sorted by properties of boolean, `Date`, `NSDate`, single and double-precision
+                floating point, integer, and string types.
+
+     - parameter keyPath:   The key path to sort by.
+     - parameter ascending: The direction to sort in.
+     */
+    public func sorted(byKeyPath keyPath: String, ascending: Bool = true) -> Results<T> {
+        return sorted(by: [SortDescriptor(keyPath: keyPath, ascending: ascending)])
+    }
+
+    /**
+     Returns a `Results` containing the objects represented by the results, but sorted.
+
      Objects are sorted based on the values of the given property. For example, to sort a collection of `Student`s from
      youngest to oldest based on their `age` property, you might call
      `students.sorted(byProperty: "age", ascending: true)`.
@@ -234,8 +251,9 @@ public final class Results<T: Object>: NSObject, NSFastEnumeration {
      - parameter property:  The name of the property to sort by.
      - parameter ascending: The direction to sort in.
      */
+    @available(*, deprecated, renamed: "sorted(byKeyPath:ascending:)")
     public func sorted(byProperty property: String, ascending: Bool = true) -> Results<T> {
-        return sorted(by: [SortDescriptor(property: property, ascending: ascending)])
+        return sorted(byKeyPath: property, ascending: ascending)
     }
 
     /**
@@ -244,7 +262,7 @@ public final class Results<T: Object>: NSObject, NSFastEnumeration {
      - warning: Collections may only be sorted by properties of boolean, `Date`, `NSDate`, single and double-precision
                 floating point, integer, and string types.
 
-     - see: `sorted(byProperty:ascending:)`
+     - see: `sorted(byKeyPath:ascending:)`
 
      - parameter sortDescriptors: A sequence of `SortDescriptor`s to sort by.
      */
@@ -406,7 +424,7 @@ extension Results {
     @available(*, unavailable, renamed: "index(matching:_:)")
     public func index(of predicateFormat: String, _ args: AnyObject...) -> Int? { fatalError() }
 
-    @available(*, unavailable, renamed: "sorted(byProperty:ascending:)")
+    @available(*, unavailable, renamed: "sorted(byKeyPath:ascending:)")
     public func sorted(_ property: String, ascending: Bool = true) -> Results<T> { fatalError() }
 
     @available(*, unavailable, renamed: "sorted(by:)")
@@ -651,17 +669,17 @@ public final class Results<T: Object>: ResultsBase {
     /**
      Returns a `Results` containing the objects represented by the results, but sorted.
 
-     Objects are sorted based on the values of the given property. For example, to sort a collection of `Student`s from
+     Objects are sorted based on the values of the given key path. For example, to sort a collection of `Student`s from
      youngest to oldest based on their `age` property, you might call `students.sorted("age", ascending: true)`.
 
      - warning: Collections may only be sorted by properties of boolean, `NSDate`, single and double-precision floating
                 point, integer, and string types.
 
-     - parameter property:  The name of the property to sort by.
+     - parameter keyPath:  The key path to sort by.
      - parameter ascending: The direction to sort in.
      */
-    public func sorted(property: String, ascending: Bool = true) -> Results<T> {
-        return sorted([SortDescriptor(property: property, ascending: ascending)])
+    public func sorted(keyPath: String, ascending: Bool = true) -> Results<T> {
+        return sorted([SortDescriptor(keyPath: keyPath, ascending: ascending)])
     }
 
     /**
@@ -670,7 +688,7 @@ public final class Results<T: Object>: ResultsBase {
      - warning: Collections may only be sorted by properties of boolean, `NSDate`, single and double-precision floating
                 point, integer, and string types.
 
-     - see: `sorted(byProperty:ascending:)`
+     - see: `sorted(byKeyPath:ascending:)`
 
      - parameter sortDescriptors: A sequence of `SortDescriptor`s to sort by.
      */

--- a/RealmSwift/SortDescriptor.swift
+++ b/RealmSwift/SortDescriptor.swift
@@ -22,43 +22,51 @@ import Realm
 #if swift(>=3.0)
 
 /**
- A `SortDescriptor` stores a property name and a sort order for use with `sorted(sortDescriptors:)`. It is similar to
+ A `SortDescriptor` stores a key path and a sort order for use with `sorted(sortDescriptors:)`. It is similar to
  `NSSortDescriptor`, but supports only the subset of functionality which can be efficiently run by Realm's query engine.
  */
 public struct SortDescriptor {
 
     // MARK: Properties
 
-    /// The name of the property which the sort descriptor orders results by.
-    public let property: String
+    /// The key path which the sort descriptor orders results by.
+    public let keyPath: String
 
     /// Whether this descriptor sorts in ascending or descending order.
     public let ascending: Bool
 
     /// Converts the receiver to an `RLMSortDescriptor`.
     internal var rlmSortDescriptorValue: RLMSortDescriptor {
-        return RLMSortDescriptor(property: property, ascending: ascending)
+        return RLMSortDescriptor(keyPath: keyPath, ascending: ascending)
     }
 
     // MARK: Initializers
 
     /**
-     Creates a sort descriptor with the given property and sort order values.
+     Creates a sort descriptor with the given key path and sort order values.
 
-     - parameter property:  The name of the property which the sort descriptor orders results by.
+     - parameter keyPath:  The key path which the sort descriptor orders results by.
      - parameter ascending: Whether the descriptor sorts in ascending or descending order.
      */
-    public init(property: String, ascending: Bool = true) {
-        self.property = property
+    public init(keyPath: String, ascending: Bool = true) {
+        self.keyPath = keyPath
         self.ascending = ascending
+    }
+
+    @available(*, deprecated, renamed: "init(keyPath:ascending:)")
+    public init(property: String, ascending: Bool = true) {
+        self.init(keyPath: property, ascending: ascending)
     }
 
     // MARK: Functions
 
     /// Returns a copy of the sort descriptor with the sort order reversed.
     public func reversed() -> SortDescriptor {
-        return SortDescriptor(property: property, ascending: !ascending)
+        return SortDescriptor(keyPath: keyPath, ascending: !ascending)
     }
+
+    @available(*, unavailable, renamed: "keyPath")
+    public var property: String { return keyPath }
 }
 
 // MARK: CustomStringConvertible
@@ -67,7 +75,7 @@ extension SortDescriptor: CustomStringConvertible {
     /// A human-readable description of the sort descriptor.
     public var description: String {
         let direction = ascending ? "ascending" : "descending"
-        return "SortDescriptor (property: \(property), direction: \(direction))"
+        return "SortDescriptor(keyPath: \(keyPath), direction: \(direction))"
     }
 }
 
@@ -78,7 +86,7 @@ extension SortDescriptor: Equatable {}
 /// Returns whether the two sort descriptors are equal.
 public func == (lhs: SortDescriptor, rhs: SortDescriptor) -> Bool {
     // swiftlint:disable:previous valid_docs
-    return lhs.property == rhs.property &&
+    return lhs.keyPath == rhs.keyPath &&
         lhs.ascending == lhs.ascending
 }
 
@@ -95,7 +103,7 @@ extension SortDescriptor: ExpressibleByStringLiteral {
      - parameter unicodeScalarLiteral: Property name literal.
     */
     public init(unicodeScalarLiteral value: UnicodeScalarLiteralType) {
-        self.init(property: value)
+        self.init(keyPath: value)
     }
 
     /**
@@ -104,7 +112,7 @@ extension SortDescriptor: ExpressibleByStringLiteral {
      - parameter extendedGraphemeClusterLiteral: Property name literal.
      */
     public init(extendedGraphemeClusterLiteral value: ExtendedGraphemeClusterLiteralType) {
-        self.init(property: value)
+        self.init(keyPath: value)
     }
 
     /**
@@ -113,7 +121,7 @@ extension SortDescriptor: ExpressibleByStringLiteral {
      - parameter stringLiteral: Property name literal.
      */
     public init(stringLiteral value: StringLiteralType) {
-        self.init(property: value)
+        self.init(keyPath: value)
     }
 }
 
@@ -129,36 +137,44 @@ public struct SortDescriptor {
 
     // MARK: Properties
 
-    /// The name of the property which the sort descriptor orders results by.
-    public let property: String
+    /// The key path which the sort descriptor orders results by.
+    public let keyPath: String
 
     /// Whether the descriptor sorts in ascending or descending order.
     public let ascending: Bool
 
     /// Converts the receiver to an `RLMSortDescriptor`
     internal var rlmSortDescriptorValue: RLMSortDescriptor {
-        return RLMSortDescriptor(property: property, ascending: ascending)
+        return RLMSortDescriptor(keyPath: keyPath, ascending: ascending)
     }
 
     // MARK: Initializers
 
     /**
-     Creates a sort descriptor with the given property and sort order values.
+     Creates a sort descriptor with the given key path and sort order values.
 
-    - parameter property:  The name of the property which the sort descriptor orders results by.
+    - parameter keyPath:   The key path which the sort descriptor orders results by.
     - parameter ascending: Whether the descriptor sorts in ascending or descending order.
     */
-    public init(property: String, ascending: Bool = true) {
-        self.property = property
+    public init(keyPath: String, ascending: Bool = true) {
+        self.keyPath = keyPath
         self.ascending = ascending
+    }
+
+    @available(*, deprecated, renamed="init(keyPath:ascending:)")
+    public init(property: String, ascending: Bool = true) {
+        self.init(keyPath: property, ascending: ascending)
     }
 
     // MARK: Functions
 
     /// Returns a copy of the sort descriptor with the sort order reversed.
     public func reversed() -> SortDescriptor {
-        return SortDescriptor(property: property, ascending: !ascending)
+        return SortDescriptor(keyPath: keyPath, ascending: !ascending)
     }
+
+    @available(*, unavailable, renamed="keyPath")
+    public var property: String { return keyPath }
 }
 
 // MARK: CustomStringConvertible
@@ -167,7 +183,7 @@ extension SortDescriptor: CustomStringConvertible {
     /// Returns a human-readable description of the sort descriptor.
     public var description: String {
         let direction = ascending ? "ascending" : "descending"
-        return "SortDescriptor (property: \(property), direction: \(direction))"
+        return "SortDescriptor(keyPath: \(keyPath), direction: \(direction))"
     }
 }
 
@@ -178,7 +194,7 @@ extension SortDescriptor: Equatable {}
 /// Returns whether the two sort descriptors are equal.
 public func == (lhs: SortDescriptor, rhs: SortDescriptor) -> Bool {
     // swiftlint:disable:previous valid_docs
-    return lhs.property == rhs.property &&
+    return lhs.keyPath == rhs.keyPath &&
         lhs.ascending == lhs.ascending
 }
 
@@ -198,7 +214,7 @@ extension SortDescriptor: StringLiteralConvertible {
      - parameter unicodeScalarLiteral: Property name literal.
     */
     public init(unicodeScalarLiteral value: UnicodeScalarLiteralType) {
-        self.init(property: value)
+        self.init(keyPath: value)
     }
 
     /**
@@ -207,7 +223,7 @@ extension SortDescriptor: StringLiteralConvertible {
      - parameter extendedGraphemeClusterLiteral: Property name literal.
     */
     public init(extendedGraphemeClusterLiteral value: ExtendedGraphemeClusterLiteralType) {
-        self.init(property: value)
+        self.init(keyPath: value)
     }
 
     /**
@@ -216,7 +232,7 @@ extension SortDescriptor: StringLiteralConvertible {
      - parameter stringLiteral: Property name literal.
     */
     public init(stringLiteral value: StringLiteralType) {
-        self.init(property: value)
+        self.init(keyPath: value)
     }
 }
 

--- a/RealmSwift/SortDescriptor.swift
+++ b/RealmSwift/SortDescriptor.swift
@@ -45,7 +45,7 @@ public struct SortDescriptor {
     /**
      Creates a sort descriptor with the given key path and sort order values.
 
-     - parameter keyPath:  The key path which the sort descriptor orders results by.
+     - parameter keyPath:   The key path which the sort descriptor orders results by.
      - parameter ascending: Whether the descriptor sorts in ascending or descending order.
      */
     public init(keyPath: String, ascending: Bool = true) {
@@ -53,6 +53,12 @@ public struct SortDescriptor {
         self.ascending = ascending
     }
 
+    /**
+     Creates a sort descriptor with the given property and sort order values.
+
+     - parameter property:  The property which the sort descriptor orders results by.
+     - parameter ascending: Whether the descriptor sorts in ascending or descending order.
+     */
     @available(*, deprecated, renamed: "init(keyPath:ascending:)")
     public init(property: String, ascending: Bool = true) {
         self.init(keyPath: property, ascending: ascending)
@@ -65,7 +71,8 @@ public struct SortDescriptor {
         return SortDescriptor(keyPath: keyPath, ascending: !ascending)
     }
 
-    @available(*, unavailable, renamed: "keyPath")
+    /// The key path which the sort descriptor orders results by.
+    @available(*, deprecated, renamed: "keyPath")
     public var property: String { return keyPath }
 }
 
@@ -161,6 +168,12 @@ public struct SortDescriptor {
         self.ascending = ascending
     }
 
+    /**
+     Creates a sort descriptor with the given key path and sort order values.
+
+     - parameter property:  The property which the sort descriptor orders results by.
+     - parameter ascending: Whether the descriptor sorts in ascending or descending order.
+     */
     @available(*, deprecated, renamed="init(keyPath:ascending:)")
     public init(property: String, ascending: Bool = true) {
         self.init(keyPath: property, ascending: ascending)
@@ -173,7 +186,8 @@ public struct SortDescriptor {
         return SortDescriptor(keyPath: keyPath, ascending: !ascending)
     }
 
-    @available(*, unavailable, renamed="keyPath")
+    /// The key which the sort descriptor orders results by.
+    @available(*, deprecated, renamed="keyPath")
     public var property: String { return keyPath }
 }
 

--- a/RealmSwift/Tests/ObjectSchemaInitializationTests.swift
+++ b/RealmSwift/Tests/ObjectSchemaInitializationTests.swift
@@ -240,7 +240,7 @@ class SwiftObjectWithEnum: SwiftFakeObject {
 }
 
 class SwiftObjectWithStruct: SwiftFakeObject {
-    var swiftStruct = SortDescriptor(property: "prop")
+    var swiftStruct = SortDescriptor(keyPath: "prop")
 }
 
 class SwiftObjectWithDatePrimaryKey: SwiftFakeObject {
@@ -517,7 +517,7 @@ class SwiftObjectWithEnum: SwiftFakeObject {
 }
 
 class SwiftObjectWithStruct: SwiftFakeObject {
-    var swiftStruct = SortDescriptor(property: "prop")
+    var swiftStruct = SortDescriptor(keyPath: "prop")
 }
 
 class SwiftObjectWithDatePrimaryKey: SwiftFakeObject {

--- a/RealmSwift/Tests/ObjectiveCSupportTests.swift
+++ b/RealmSwift/Tests/ObjectiveCSupportTests.swift
@@ -52,9 +52,9 @@ class ObjectiveCSupportTests: TestCase {
         XCTAssertEqual(rlmRealm.allObjects("SwiftObject").count, 1)
 
         let sortDescriptor: RealmSwift.SortDescriptor = "property"
-        XCTAssertEqual(sortDescriptor.property,
-                       ObjectiveCSupport.convert(object: sortDescriptor).property,
-                       "SortDescriptor.property must be equal to RLMSortDescriptor.property")
+        XCTAssertEqual(sortDescriptor.keyPath,
+                       ObjectiveCSupport.convert(object: sortDescriptor).keyPath,
+                       "SortDescriptor.keyPath must be equal to RLMSortDescriptor.keyPath")
         XCTAssertEqual(sortDescriptor.ascending,
                        ObjectiveCSupport.convert(object: sortDescriptor).ascending,
                        "SortDescriptor.ascending must be equal to RLMSortDescriptor.ascending")
@@ -127,9 +127,9 @@ class ObjectiveCSupportTests: TestCase {
         XCTAssertEqual(rlmRealm.allObjects("SwiftObject").count, 1)
 
         let sortDescriptor: RealmSwift.SortDescriptor = "property"
-        XCTAssertEqual(sortDescriptor.property,
-                       ObjectiveCSupport.convert(sortDescriptor).property,
-                       "SortDescriptor.property must be equal to RLMSortDescriptor.property")
+        XCTAssertEqual(sortDescriptor.keyPath,
+                       ObjectiveCSupport.convert(sortDescriptor).keyPath,
+                       "SortDescriptor.keyPath must be equal to RLMSortDescriptor.keyPath")
         XCTAssertEqual(sortDescriptor.ascending,
                        ObjectiveCSupport.convert(sortDescriptor).ascending,
                        "SortDescriptor.ascending must be equal to RLMSortDescriptor.ascending")

--- a/RealmSwift/Tests/PerformanceTests.swift
+++ b/RealmSwift/Tests/PerformanceTests.swift
@@ -334,7 +334,7 @@ class SwiftPerformanceTests: TestCase {
             }
         }
         measure {
-            _ = realm.objects(SwiftIntObject.self).sorted(byProperty: "intCol", ascending: true).last
+            _ = realm.objects(SwiftIntObject.self).sorted(byKeyPath: "intCol", ascending: true).last
         }
     }
 

--- a/RealmSwift/Tests/RealmCollectionTypeTests.swift
+++ b/RealmSwift/Tests/RealmCollectionTypeTests.swift
@@ -311,15 +311,19 @@ class RealmCollectionTypeTests: TestCase {
         guard let collection = collection else {
             fatalError("Test precondition failed")
         }
-        var sorted = collection.sorted(byProperty: "stringCol", ascending: true)
+        var sorted = collection.sorted(byKeyPath: "stringCol", ascending: true)
         XCTAssertEqual("1", sorted[0].stringCol)
         XCTAssertEqual("2", sorted[1].stringCol)
 
-        sorted = collection.sorted(byProperty: "stringCol", ascending: false)
+        sorted = collection.sorted(byKeyPath: "stringCol", ascending: false)
         XCTAssertEqual("2", sorted[0].stringCol)
         XCTAssertEqual("1", sorted[1].stringCol)
 
-        assertThrows(collection.sorted(byProperty: "noSuchCol", ascending: true), named: "Invalid sort property")
+        sorted = collection.sorted(byKeyPath: "linkCol.id", ascending: true)
+        XCTAssertEqual("1", sorted[0].stringCol)
+        XCTAssertEqual("2", sorted[1].stringCol)
+
+        assertThrows(collection.sorted(byKeyPath: "noSuchCol", ascending: true), named: "Invalid property name")
     }
 
     func testSortWithDescriptor() {
@@ -329,19 +333,19 @@ class RealmCollectionTypeTests: TestCase {
         XCTAssertEqual(collection[0], notActuallySorted[0])
         XCTAssertEqual(collection[1], notActuallySorted[1])
 
-        var sorted = collection.sorted(by: [SortDescriptor(property: "intCol", ascending: true)])
+        var sorted = collection.sorted(by: [SortDescriptor(keyPath: "intCol", ascending: true)])
         XCTAssertEqual(1, sorted[0].intCol)
         XCTAssertEqual(2, sorted[1].intCol)
 
-        sorted = collection.sorted(by: [SortDescriptor(property: "doubleCol", ascending: false),
-            SortDescriptor(property: "intCol", ascending: false)])
+        sorted = collection.sorted(by: [SortDescriptor(keyPath: "doubleCol", ascending: false),
+            SortDescriptor(keyPath: "intCol", ascending: false)])
         XCTAssertEqual(2.22, sorted[0].doubleCol)
         XCTAssertEqual(3, sorted[0].intCol)
         XCTAssertEqual(2.22, sorted[1].doubleCol)
         XCTAssertEqual(2, sorted[1].intCol)
         XCTAssertEqual(1.11, sorted[2].doubleCol)
 
-        assertThrows(collection.sorted(by: [SortDescriptor(property: "noSuchCol")]), named: "Invalid sort property")
+        assertThrows(collection.sorted(by: [SortDescriptor(keyPath: "noSuchCol")]), named: "Invalid property name")
     }
 
     func testMin() {
@@ -843,9 +847,9 @@ class ListStandaloneRealmCollectionTypeTests: ListRealmCollectionTypeTests {
 
     override func testSortWithDescriptor() {
         let collection = getAggregateableCollection()
-        assertThrows(collection.sorted(by: [SortDescriptor(property: "intCol", ascending: true)]))
-        assertThrows(collection.sorted(by: [SortDescriptor(property: "doubleCol", ascending: false),
-            SortDescriptor(property: "intCol", ascending: false)]))
+        assertThrows(collection.sorted(by: [SortDescriptor(keyPath: "intCol", ascending: true)]))
+        assertThrows(collection.sorted(by: [SortDescriptor(keyPath: "doubleCol", ascending: false),
+            SortDescriptor(keyPath: "intCol", ascending: false)]))
     }
 
     override func testFastEnumerationWithMutation() {
@@ -872,8 +876,8 @@ class ListStandaloneRealmCollectionTypeTests: ListRealmCollectionTypeTests {
         guard let collection = collection else {
             fatalError("Test precondition failed")
         }
-        assertThrows(collection.sorted(byProperty: "stringCol", ascending: true))
-        assertThrows(collection.sorted(byProperty: "noSuchCol", ascending: true))
+        assertThrows(collection.sorted(byKeyPath: "stringCol", ascending: true))
+        assertThrows(collection.sorted(byKeyPath: "noSuchCol", ascending: true))
     }
 
     override func testFilterFormat() {
@@ -1365,7 +1369,11 @@ class RealmCollectionTypeTests: TestCase {
         XCTAssertEqual("2", sorted[0].stringCol)
         XCTAssertEqual("1", sorted[1].stringCol)
 
-        assertThrows(self.collection.sorted("noSuchCol", ascending: true), named: "Invalid sort property")
+        sorted = collection.sorted("linkCol.id", ascending: true)
+        XCTAssertEqual("1", sorted[0].stringCol)
+        XCTAssertEqual("2", sorted[1].stringCol)
+
+        assertThrows(self.collection.sorted("noSuchCol", ascending: true), named: "Invalid property name")
     }
 
     func testSortWithDescriptor() {
@@ -1375,19 +1383,19 @@ class RealmCollectionTypeTests: TestCase {
         XCTAssertEqual(collection[0], notActuallySorted[0])
         XCTAssertEqual(collection[1], notActuallySorted[1])
 
-        var sorted = collection.sorted([SortDescriptor(property: "intCol", ascending: true)])
+        var sorted = collection.sorted([SortDescriptor(keyPath: "intCol", ascending: true)])
         XCTAssertEqual(1, sorted[0].intCol)
         XCTAssertEqual(2, sorted[1].intCol)
 
-        sorted = collection.sorted([SortDescriptor(property: "doubleCol", ascending: false),
-            SortDescriptor(property: "intCol", ascending: false)])
+        sorted = collection.sorted([SortDescriptor(keyPath: "doubleCol", ascending: false),
+            SortDescriptor(keyPath: "intCol", ascending: false)])
         XCTAssertEqual(2.22, sorted[0].doubleCol)
         XCTAssertEqual(3, sorted[0].intCol)
         XCTAssertEqual(2.22, sorted[1].doubleCol)
         XCTAssertEqual(2, sorted[1].intCol)
         XCTAssertEqual(1.11, sorted[2].doubleCol)
 
-        assertThrows(collection.sorted([SortDescriptor(property: "noSuchCol")]), named: "Invalid sort property")
+        assertThrows(collection.sorted([SortDescriptor(keyPath: "noSuchCol")]), named: "Invalid property name")
     }
 
     func testMin() {
@@ -1841,9 +1849,9 @@ class ListUnmanagedRealmCollectionTypeTests: ListRealmCollectionTypeTests {
 
     override func testSortWithDescriptor() {
         let collection = getAggregateableCollection()
-        assertThrows(collection.sorted([SortDescriptor(property: "intCol", ascending: true)]))
-        assertThrows(collection.sorted([SortDescriptor(property: "doubleCol", ascending: false),
-            SortDescriptor(property: "intCol", ascending: false)]))
+        assertThrows(collection.sorted([SortDescriptor(keyPath: "intCol", ascending: true)]))
+        assertThrows(collection.sorted([SortDescriptor(keyPath: "doubleCol", ascending: false),
+            SortDescriptor(keyPath: "intCol", ascending: false)]))
     }
 
     override func testFastEnumerationWithMutation() {

--- a/RealmSwift/Tests/SortDescriptorTests.swift
+++ b/RealmSwift/Tests/SortDescriptorTests.swift
@@ -23,7 +23,7 @@ import RealmSwift
 
 class SortDescriptorTests: TestCase {
 
-    let sortDescriptor = SortDescriptor(property: "property")
+    let sortDescriptor = SortDescriptor(keyPath: "property")
 
     func testAscendingDefaultsToTrue() {
         XCTAssertTrue(sortDescriptor.ascending)
@@ -31,13 +31,13 @@ class SortDescriptorTests: TestCase {
 
     func testReversedReturnsReversedDescriptor() {
         let reversed = sortDescriptor.reversed()
-        XCTAssertEqual(reversed.property, sortDescriptor.property, "Property should stay the same when reversed.")
+        XCTAssertEqual(reversed.keyPath, sortDescriptor.keyPath, "Key path should stay the same when reversed.")
         XCTAssertFalse(reversed.ascending)
         XCTAssertTrue(reversed.reversed().ascending)
     }
 
     func testDescription() {
-        XCTAssertEqual(sortDescriptor.description, "SortDescriptor (property: property, direction: ascending)")
+        XCTAssertEqual(sortDescriptor.description, "SortDescriptor(keyPath: property, direction: ascending)")
     }
 
     func testStringLiteralConvertible() {
@@ -51,7 +51,7 @@ class SortDescriptorTests: TestCase {
 
 class SortDescriptorTests: TestCase {
 
-    let sortDescriptor = SortDescriptor(property: "property")
+    let sortDescriptor = SortDescriptor(keyPath: "property")
 
     func testAscendingDefaultsToTrue() {
         XCTAssertTrue(sortDescriptor.ascending)
@@ -59,13 +59,13 @@ class SortDescriptorTests: TestCase {
 
     func testReversedReturnsReversedDescriptor() {
         let reversed = sortDescriptor.reversed()
-        XCTAssertEqual(reversed.property, sortDescriptor.property, "Property should stay the same when reversed.")
+        XCTAssertEqual(reversed.keyPath, sortDescriptor.keyPath, "Property should stay the same when reversed.")
         XCTAssertFalse(reversed.ascending)
         XCTAssertTrue(reversed.reversed().ascending)
     }
 
     func testDescription() {
-        XCTAssertEqual(sortDescriptor.description, "SortDescriptor (property: property, direction: ascending)")
+        XCTAssertEqual(sortDescriptor.description, "SortDescriptor(keyPath: property, direction: ascending)")
     }
 
     func testStringLiteralConvertible() {


### PR DESCRIPTION
This allows for sorting over to-one relationships. Key paths that include to-many relationships, collection operators, or non-persisted properties are not supported.