### PR TITLE
Align the thread id used for the RLMRealm cache with what the object store checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ x.x.x Release notes (yyyy-MM-dd)
   format migration is required, such as when moving from a file last accessed
   with Realm 0.x to 1.x, or 1.x to 2.x.
 * Fix queries containing nested `SUBQUERY` expressions.
+* Fix spurious incorrect thread exceptions when a thread id happens to be
+  reused while an RLMRealm instance from the old thread still exists.
 
 2.1.2 Release notes (2016--12-19)
 =============================================================

--- a/Realm/RLMRealmUtil.mm
+++ b/Realm/RLMRealmUtil.mm
@@ -43,10 +43,10 @@ void RLMCacheRealm(std::string const& path, RLMRealm *realm) {
     std::lock_guard<std::mutex> lock(s_realmCacheMutex);
     NSMapTable *realms = s_realmsPerPath[path];
     if (!realms) {
-        s_realmsPerPath[path] = realms = [NSMapTable mapTableWithKeyOptions:NSPointerFunctionsObjectPersonality
+        s_realmsPerPath[path] = realms = [NSMapTable mapTableWithKeyOptions:NSPointerFunctionsOpaquePersonality|NSPointerFunctionsOpaqueMemory
                                                                valueOptions:NSPointerFunctionsWeakMemory];
     }
-    [realms setObject:realm forKey:@(pthread_mach_thread_np(pthread_self()))];
+    [realms setObject:realm forKey:(__bridge id)pthread_self()];
 }
 
 RLMRealm *RLMGetAnyCachedRealmForPath(std::string const& path) {
@@ -55,9 +55,8 @@ RLMRealm *RLMGetAnyCachedRealmForPath(std::string const& path) {
 }
 
 RLMRealm *RLMGetThreadLocalCachedRealmForPath(std::string const& path) {
-    mach_port_t threadID = pthread_mach_thread_np(pthread_self());
     std::lock_guard<std::mutex> lock(s_realmCacheMutex);
-    return [s_realmsPerPath[path] objectForKey:@(threadID)];
+    return [s_realmsPerPath[path] objectForKey:(__bridge id)pthread_self()];
 }
 
 void RLMClearRealmCache() {


### PR DESCRIPTION
The object store uses `std::this_thread::get_id()` to verify that the Realm instance is being used on the correct thread, which derives its value from the pthread_t's pointer address and not the thread ID, which results in different behavior when the thread IDs are reused.

Probably fixes #4462.