### PR TITLE
Add object-level notifications with information about what properties changed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,13 +10,16 @@ Swift 3.0.0 is now the minimum Swift version supported.
 
 ### Enhancements
 
-* None.
+* Add change notifications for individual objects with an API similar to that
+  of collection notifications.
 
 ### Bugfixes
 
 * Fix Realm Objective-C compilation errors with Xcode 8.3 beta 1.
 * Fix several error handling issues when renewing expired authentication
   tokens for synchronized Realms.
+* Fix a race condition leading to bad_version exceptions being thrown in
+  Realm's background worker thread.
 
 2.3.0 Release notes (2017-01-19)
 =============================================================

--- a/Realm.xcodeproj/project.pbxproj
+++ b/Realm.xcodeproj/project.pbxproj
@@ -61,14 +61,6 @@
 		02AFB4671A80343600E11938 /* ResultsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 02AFB4621A80343600E11938 /* ResultsTests.m */; };
 		02AFB4681A80343600E11938 /* ResultsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 02AFB4621A80343600E11938 /* ResultsTests.m */; };
 		02E334C31A5F41C7009F8810 /* DynamicTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E81A1FBA1955FE0100FDED82 /* DynamicTests.m */; };
-		140CFE9F1DFABF5E006FB011 /* RLMSyncPermissionOffer.h in Headers */ = {isa = PBXBuildFile; fileRef = 140CFE981DFABF5E006FB011 /* RLMSyncPermissionOffer.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		140CFEA01DFABF5E006FB011 /* RLMSyncPermissionOffer.h in Headers */ = {isa = PBXBuildFile; fileRef = 140CFE981DFABF5E006FB011 /* RLMSyncPermissionOffer.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		140CFEA11DFABF5E006FB011 /* RLMSyncPermissionOffer.m in Sources */ = {isa = PBXBuildFile; fileRef = 140CFE991DFABF5E006FB011 /* RLMSyncPermissionOffer.m */; };
-		140CFEA21DFABF5E006FB011 /* RLMSyncPermissionOffer.m in Sources */ = {isa = PBXBuildFile; fileRef = 140CFE991DFABF5E006FB011 /* RLMSyncPermissionOffer.m */; };
-		140CFEA51DFABF5E006FB011 /* RLMSyncPermissionOfferResponse.h in Headers */ = {isa = PBXBuildFile; fileRef = 140CFE9B1DFABF5E006FB011 /* RLMSyncPermissionOfferResponse.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		140CFEA61DFABF5E006FB011 /* RLMSyncPermissionOfferResponse.h in Headers */ = {isa = PBXBuildFile; fileRef = 140CFE9B1DFABF5E006FB011 /* RLMSyncPermissionOfferResponse.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		140CFEA71DFABF5E006FB011 /* RLMSyncPermissionOfferResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = 140CFE9C1DFABF5E006FB011 /* RLMSyncPermissionOfferResponse.m */; };
-		140CFEA81DFABF5E006FB011 /* RLMSyncPermissionOfferResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = 140CFE9C1DFABF5E006FB011 /* RLMSyncPermissionOfferResponse.m */; };
 		14C4B43F1DC33481002FDEC8 /* RLMSyncPermissionChange.h in Headers */ = {isa = PBXBuildFile; fileRef = 14C4B4371DC33481002FDEC8 /* RLMSyncPermissionChange.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		14C4B4401DC33481002FDEC8 /* RLMSyncPermissionChange.h in Headers */ = {isa = PBXBuildFile; fileRef = 14C4B4371DC33481002FDEC8 /* RLMSyncPermissionChange.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		14C4B4411DC33481002FDEC8 /* RLMSyncPermissionChange.m in Sources */ = {isa = PBXBuildFile; fileRef = 14C4B4381DC33481002FDEC8 /* RLMSyncPermissionChange.m */; };
@@ -79,13 +71,10 @@
 		1A0512721D873F3300806AEC /* RLMSyncConfiguration.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1A3623661D8384BA00945A54 /* RLMSyncConfiguration.mm */; };
 		1A0512761D8746CD00806AEC /* RLMSyncConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = 1A3623651D8384BA00945A54 /* RLMSyncConfiguration.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		1A0512771D8746CD00806AEC /* RLMSyncConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = 1A3623651D8384BA00945A54 /* RLMSyncConfiguration.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		1A1536551DB045B500C0EC93 /* sync_config.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 1A15364A1DB045B500C0EC93 /* sync_config.hpp */; };
+		1A1536481DB0408A00C0EC93 /* RLMSyncUser+ObjectServerTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1AF64DD11DA304A90081EB15 /* RLMSyncUser+ObjectServerTests.mm */; };
 		1A1536581DB045B500C0EC93 /* sync_manager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1A15364D1DB045B500C0EC93 /* sync_manager.cpp */; };
-		1A1536591DB045B500C0EC93 /* sync_manager.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 1A15364E1DB045B500C0EC93 /* sync_manager.hpp */; };
 		1A15365C1DB045B500C0EC93 /* sync_session.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1A1536511DB045B500C0EC93 /* sync_session.cpp */; };
-		1A15365D1DB045B500C0EC93 /* sync_session.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 1A1536521DB045B500C0EC93 /* sync_session.hpp */; };
 		1A15365E1DB045B500C0EC93 /* sync_user.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1A1536531DB045B500C0EC93 /* sync_user.cpp */; };
-		1A15365F1DB045B500C0EC93 /* sync_user.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 1A1536541DB045B500C0EC93 /* sync_user.hpp */; };
 		1A1536601DB045C400C0EC93 /* sync_config.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 1A15364A1DB045B500C0EC93 /* sync_config.hpp */; };
 		1A1536631DB045CB00C0EC93 /* sync_manager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1A15364D1DB045B500C0EC93 /* sync_manager.cpp */; };
 		1A1536641DB045CD00C0EC93 /* sync_manager.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 1A15364E1DB045B500C0EC93 /* sync_manager.hpp */; };
@@ -97,43 +86,21 @@
 		1A1536741DB0464800C0EC93 /* sync_metadata.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1A15366F1DB0464800C0EC93 /* sync_metadata.cpp */; };
 		1A1536761DB0464F00C0EC93 /* sync_file.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1A15366D1DB0464800C0EC93 /* sync_file.cpp */; };
 		1A1536771DB0465400C0EC93 /* sync_metadata.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1A15366F1DB0464800C0EC93 /* sync_metadata.cpp */; };
-		1A2713D31E3AD126001F6BFC /* RLMSyncManager_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 1AF7EA981D340D1F0001A9B5 /* RLMSyncManager_Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		1A2713D41E3AD126001F6BFC /* RLMSyncManager_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 1AF7EA981D340D1F0001A9B5 /* RLMSyncManager_Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		1A2D7A521DA5BCEC006AD7D6 /* RLMMultiProcessTestCase.m in Sources */ = {isa = PBXBuildFile; fileRef = 027A4D2B1AB1012500AA46F9 /* RLMMultiProcessTestCase.m */; };
-		1A33C42B1DAEB9C4001E87AA /* RLMSyncUser_Private.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 1A33C42A1DAEB9C4001E87AA /* RLMSyncUser_Private.hpp */; };
 		1A33C4301DAEE445001E87AA /* RLMSyncSessionRefreshHandle.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1A33C42D1DAEE445001E87AA /* RLMSyncSessionRefreshHandle.mm */; };
 		1A33C4311DAEE445001E87AA /* RLMSyncSessionRefreshHandle.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1A33C42D1DAEE445001E87AA /* RLMSyncSessionRefreshHandle.mm */; };
 		1A3623681D8384BA00945A54 /* RLMSyncConfiguration.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1A3623661D8384BA00945A54 /* RLMSyncConfiguration.mm */; };
 		1A4FFC991D35A71000B4B65C /* RLMSyncUtil.h in Headers */ = {isa = PBXBuildFile; fileRef = 1A4FFC971D35A71000B4B65C /* RLMSyncUtil.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		1A64CA8B1D8763B400BC0F9B /* keychain_helper.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1A64CA891D8763B400BC0F9B /* keychain_helper.cpp */; };
-		1A64CA8C1D8763B400BC0F9B /* keychain_helper.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 1A64CA8A1D8763B400BC0F9B /* keychain_helper.hpp */; };
-		1A65BB1E1E202E7000192C01 /* thread_safe_reference.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 1AB2D36D1E16EB91007D0A3F /* thread_safe_reference.hpp */; };
-		1A65BB341E26D4A400192C01 /* thread_safe_reference.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1A65BB321E26D4A400192C01 /* thread_safe_reference.cpp */; };
-		1A65BB351E26D4A400192C01 /* thread_safe_reference.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 1A65BB331E26D4A400192C01 /* thread_safe_reference.hpp */; };
-		1A65BB361E26D4A900192C01 /* thread_safe_reference.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1A65BB321E26D4A400192C01 /* thread_safe_reference.cpp */; };
-		1A65BB371E26D4A900192C01 /* thread_safe_reference.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 1A65BB331E26D4A400192C01 /* thread_safe_reference.hpp */; };
 		1A6921D41D779774004C3232 /* RLMTokenModels.m in Sources */ = {isa = PBXBuildFile; fileRef = 1A6921D21D779774004C3232 /* RLMTokenModels.m */; };
 		1A7003081D5270C400FD9EE3 /* RLMSyncSession.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1AD3870B1D4A7FBB00479110 /* RLMSyncSession.mm */; };
 		1A7003091D5270C700FD9EE3 /* RLMSyncUtil.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1A84132E1D4BCCE600C5326F /* RLMSyncUtil.mm */; };
 		1A70030A1D5270CF00FD9EE3 /* RLMAuthResponseModel.m in Sources */ = {isa = PBXBuildFile; fileRef = 1AF6EA461D36B1850014EB85 /* RLMAuthResponseModel.m */; };
 		1A7003111D5270FF00FD9EE3 /* RLMSyncSession.h in Headers */ = {isa = PBXBuildFile; fileRef = 1AD3870A1D4A7FBB00479110 /* RLMSyncSession.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		1A7AFA731E29B756002744FA /* object.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1A7AFA711E29B756002744FA /* object.cpp */; };
-		1A7AFA741E29B756002744FA /* object.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 1A7AFA721E29B756002744FA /* object.hpp */; };
-		1A7AFA751E29B75C002744FA /* object.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1A7AFA711E29B756002744FA /* object.cpp */; };
-		1A7AFA761E29B75C002744FA /* object.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 1A7AFA721E29B756002744FA /* object.hpp */; };
-		1A7AFA7C1E29B7F4002744FA /* object_notifier.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1A7AFA7A1E29B7F4002744FA /* object_notifier.cpp */; };
-		1A7AFA7D1E29B7F4002744FA /* object_notifier.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 1A7AFA7B1E29B7F4002744FA /* object_notifier.hpp */; };
-		1A7AFA7E1E29B7FA002744FA /* object_notifier.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1A7AFA7A1E29B7F4002744FA /* object_notifier.cpp */; };
-		1A7AFA7F1E29B7FA002744FA /* object_notifier.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 1A7AFA7B1E29B7F4002744FA /* object_notifier.hpp */; };
 		1A7B823A1D51259F00750296 /* libz.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 1A7B82391D51259F00750296 /* libz.tbd */; };
 		1A7B823B1D5126D200750296 /* libz.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 1A7B82391D51259F00750296 /* libz.tbd */; };
 		1A7DE7071D38474F0029F0AE /* RLMSyncManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 1AF7EA941D340AF70001A9B5 /* RLMSyncManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		1A7DE70B1D3847670029F0AE /* RLMSyncUtil.h in Headers */ = {isa = PBXBuildFile; fileRef = 1A4FFC971D35A71000B4B65C /* RLMSyncUtil.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		1A81EDEB1E30872F0035F4E6 /* NSError+RLMSync.h in Headers */ = {isa = PBXBuildFile; fileRef = 1A81EDE91E30872F0035F4E6 /* NSError+RLMSync.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		1A81EDEC1E30872F0035F4E6 /* NSError+RLMSync.m in Sources */ = {isa = PBXBuildFile; fileRef = 1A81EDEA1E30872F0035F4E6 /* NSError+RLMSync.m */; };
-		1A81EDED1E3087410035F4E6 /* NSError+RLMSync.h in Headers */ = {isa = PBXBuildFile; fileRef = 1A81EDE91E30872F0035F4E6 /* NSError+RLMSync.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		1A81EDEE1E3087410035F4E6 /* NSError+RLMSync.m in Sources */ = {isa = PBXBuildFile; fileRef = 1A81EDEA1E30872F0035F4E6 /* NSError+RLMSync.m */; };
-		1A81EDF31E30A4780035F4E6 /* RLMSyncUser+ObjectServerTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1A81EDF01E30A4630035F4E6 /* RLMSyncUser+ObjectServerTests.mm */; };
 		1A84132F1D4BCCE600C5326F /* RLMSyncUtil.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1A84132E1D4BCCE600C5326F /* RLMSyncUtil.mm */; };
 		1A90FCBB1D3D37F50086A57F /* RLMSyncManager.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1AF7EA951D340AF70001A9B5 /* RLMSyncManager.mm */; };
 		1A90FCBC1D3D37F70086A57F /* RLMNetworkClient.m in Sources */ = {isa = PBXBuildFile; fileRef = 1AF7EA9A1D340E700001A9B5 /* RLMNetworkClient.m */; };
@@ -145,7 +112,7 @@
 		1AAF4D211D66585B00058FAD /* RLMSyncCredentials.h in Headers */ = {isa = PBXBuildFile; fileRef = 1AAF4D1F1D66585B00058FAD /* RLMSyncCredentials.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		1AAF4D221D66585B00058FAD /* RLMSyncCredentials.m in Sources */ = {isa = PBXBuildFile; fileRef = 1AAF4D201D66585B00058FAD /* RLMSyncCredentials.m */; };
 		1AAF4D231D665B2A00058FAD /* RLMSyncCredentials.h in Headers */ = {isa = PBXBuildFile; fileRef = 1AAF4D1F1D66585B00058FAD /* RLMSyncCredentials.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		1AB2D36F1E16EB91007D0A3F /* thread_safe_reference.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 1AB2D36D1E16EB91007D0A3F /* thread_safe_reference.hpp */; };
+		1AB2D36E1E16EB91007D0A3F /* thread_safe_reference.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1AB2D36C1E16EB91007D0A3F /* thread_safe_reference.cpp */; };
 		1AB605D31D495927007F53DE /* RealmCollection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AB605D21D495927007F53DE /* RealmCollection.swift */; };
 		1ABDCDAE1D792FEB003489E3 /* RLMSyncUser.h in Headers */ = {isa = PBXBuildFile; fileRef = 1ABDCDAD1D792FEB003489E3 /* RLMSyncUser.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		1ABDCDB01D793008003489E3 /* RLMSyncUser.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1ABDCDAF1D793008003489E3 /* RLMSyncUser.mm */; };
@@ -154,8 +121,6 @@
 		1ABF25701D52AB6200BAC441 /* RLMRealmConfiguration+Sync.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1ABF256E1D52AB6200BAC441 /* RLMRealmConfiguration+Sync.mm */; };
 		1AD3870C1D4A7FBB00479110 /* RLMSyncSession.h in Headers */ = {isa = PBXBuildFile; fileRef = 1AD3870A1D4A7FBB00479110 /* RLMSyncSession.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		1AD3870D1D4A7FBB00479110 /* RLMSyncSession.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1AD3870B1D4A7FBB00479110 /* RLMSyncSession.mm */; };
-		1AEC3E921E32EE8800E1EBE6 /* RLMSyncSessionRefreshHandle+ObjectServerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 1AEC3E8F1E32EE8100E1EBE6 /* RLMSyncSessionRefreshHandle+ObjectServerTests.m */; };
-		1AEC3E971E32F03100E1EBE6 /* RLMTestUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 1AEC3E941E32EF5100E1EBE6 /* RLMTestUtils.m */; };
 		1AF64DCF1DA3042B0081EB15 /* RLMSyncManager+ObjectServerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 1AF64DCC1DA304210081EB15 /* RLMSyncManager+ObjectServerTests.m */; };
 		1AF6EA481D36B1850014EB85 /* RLMAuthResponseModel.m in Sources */ = {isa = PBXBuildFile; fileRef = 1AF6EA461D36B1850014EB85 /* RLMAuthResponseModel.m */; };
 		1AF7EA961D340AF70001A9B5 /* RLMSyncManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 1AF7EA941D340AF70001A9B5 /* RLMSyncManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -171,27 +136,43 @@
 		29B7FDFB1C0DE8100023224E /* fileformat-pre-null.realm in Resources */ = {isa = PBXBuildFile; fileRef = 29B7FDF71C0DE76B0023224E /* fileformat-pre-null.realm */; };
 		29B7FDFC1C0DE8110023224E /* fileformat-pre-null.realm in Resources */ = {isa = PBXBuildFile; fileRef = 29B7FDF71C0DE76B0023224E /* fileformat-pre-null.realm */; };
 		29EDB8E41A7708E700458D80 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = E8839B2D19E31FD90047B1A8 /* main.m */; };
-		3F0543EB1C56F71500AA5322 /* realm_coordinator.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 3F0543E91C56F71500AA5322 /* realm_coordinator.hpp */; };
 		3F0543EC1C56F71500AA5322 /* realm_coordinator.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3F0543EA1C56F71500AA5322 /* realm_coordinator.cpp */; };
 		3F0543ED1C56F71900AA5322 /* realm_coordinator.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3F0543EA1C56F71500AA5322 /* realm_coordinator.cpp */; };
-		3F0543F81C56F78300AA5322 /* external_commit_helper.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 3F0543F61C56F78300AA5322 /* external_commit_helper.hpp */; };
+		3F0D87441E2EEC4C008C92AC /* RLMSyncPermissionOffer.h in Headers */ = {isa = PBXBuildFile; fileRef = 3F0D873E1E2EEC4C008C92AC /* RLMSyncPermissionOffer.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3F0D87461E2EEC4C008C92AC /* RLMSyncPermissionOfferResponse.h in Headers */ = {isa = PBXBuildFile; fileRef = 3F0D87401E2EEC4C008C92AC /* RLMSyncPermissionOfferResponse.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3F0D87471E2EEC4C008C92AC /* RLMSyncPermissionOffer.m in Sources */ = {isa = PBXBuildFile; fileRef = 3F0D87411E2EEC4C008C92AC /* RLMSyncPermissionOffer.m */; };
+		3F0D87481E2EEC4C008C92AC /* RLMSyncPermissionOfferResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = 3F0D87421E2EEC4C008C92AC /* RLMSyncPermissionOfferResponse.m */; };
+		3F0D874A1E2EEC57008C92AC /* RLMSyncPermissionOffer.h in Headers */ = {isa = PBXBuildFile; fileRef = 3F0D873E1E2EEC4C008C92AC /* RLMSyncPermissionOffer.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3F0D874C1E2EEC57008C92AC /* RLMSyncPermissionOfferResponse.h in Headers */ = {isa = PBXBuildFile; fileRef = 3F0D87401E2EEC4C008C92AC /* RLMSyncPermissionOfferResponse.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3F0D874D1E2EEC57008C92AC /* RLMSyncPermissionOffer.m in Sources */ = {isa = PBXBuildFile; fileRef = 3F0D87411E2EEC4C008C92AC /* RLMSyncPermissionOffer.m */; };
+		3F0D874E1E2EEC57008C92AC /* RLMSyncPermissionOfferResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = 3F0D87421E2EEC4C008C92AC /* RLMSyncPermissionOfferResponse.m */; };
 		3F1F47821B9612B300CD99A3 /* KVOTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 3F0F029D1B6FFE610046A4D5 /* KVOTests.mm */; };
 		3F1F47831B9656B900CD99A3 /* KVOTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 3F0F029D1B6FFE610046A4D5 /* KVOTests.mm */; };
+		3F222C4E1E26F51300CA0713 /* ThreadSafeReference.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F222C4D1E26F51300CA0713 /* ThreadSafeReference.swift */; };
 		3F2E66641CA0BA11004761D5 /* NotificationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 3F2E66611CA0B9D5004761D5 /* NotificationTests.m */; };
 		3F2E66651CA0BA12004761D5 /* NotificationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 3F2E66611CA0B9D5004761D5 /* NotificationTests.m */; };
 		3F336E8A1DA2FA14006CB5A0 /* RLMSyncConfiguration_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 1A36236A1D83868F00945A54 /* RLMSyncConfiguration_Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		3F336E8B1DA2FA15006CB5A0 /* RLMSyncConfiguration_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 1A36236A1D83868F00945A54 /* RLMSyncConfiguration_Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		3F643BED1CEA655800F6D0C8 /* mixed-column.realm in Resources */ = {isa = PBXBuildFile; fileRef = 3F643BEB1CEA654D00F6D0C8 /* mixed-column.realm */; };
 		3F643BEE1CEA655800F6D0C8 /* mixed-column.realm in Resources */ = {isa = PBXBuildFile; fileRef = 3F643BEB1CEA654D00F6D0C8 /* mixed-column.realm */; };
+		3F6468371E3A9363007BD064 /* thread_safe_reference.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1AB2D36C1E16EB91007D0A3F /* thread_safe_reference.cpp */; };
+		3F67DB3C1E26D69C0024533D /* RLMThreadSafeReference.h in Headers */ = {isa = PBXBuildFile; fileRef = 3F67DB391E26D69C0024533D /* RLMThreadSafeReference.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3F67DB3E1E26D69C0024533D /* RLMThreadSafeReference.mm in Sources */ = {isa = PBXBuildFile; fileRef = 3F67DB3B1E26D69C0024533D /* RLMThreadSafeReference.mm */; };
+		3F67DB401E26D6A20024533D /* RLMThreadSafeReference.h in Headers */ = {isa = PBXBuildFile; fileRef = 3F67DB391E26D69C0024533D /* RLMThreadSafeReference.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3F67DB411E26D6AD0024533D /* RLMThreadSafeReference.mm in Sources */ = {isa = PBXBuildFile; fileRef = 3F67DB3B1E26D69C0024533D /* RLMThreadSafeReference.mm */; };
+		3F73BC861E3A871B00FE80B6 /* ThreadSafeReferenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F73BC841E3A870F00FE80B6 /* ThreadSafeReferenceTests.swift */; };
+		3F73BC911E3A877300FE80B6 /* RLMSyncSessionRefreshHandle+ObjectServerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 3F73BC891E3A876600FE80B6 /* RLMSyncSessionRefreshHandle+ObjectServerTests.m */; };
+		3F73BC921E3A877300FE80B6 /* RLMTestUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 3F73BC8B1E3A876600FE80B6 /* RLMTestUtils.m */; };
+		3F73BC951E3A878500FE80B6 /* NSError+RLMSync.h in Headers */ = {isa = PBXBuildFile; fileRef = 3F73BC931E3A878500FE80B6 /* NSError+RLMSync.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3F73BC961E3A878500FE80B6 /* NSError+RLMSync.m in Sources */ = {isa = PBXBuildFile; fileRef = 3F73BC941E3A878500FE80B6 /* NSError+RLMSync.m */; };
+		3F73BC971E3A879700FE80B6 /* NSError+RLMSync.h in Headers */ = {isa = PBXBuildFile; fileRef = 3F73BC931E3A878500FE80B6 /* NSError+RLMSync.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3F73BC981E3A879E00FE80B6 /* NSError+RLMSync.m in Sources */ = {isa = PBXBuildFile; fileRef = 3F73BC941E3A878500FE80B6 /* NSError+RLMSync.m */; };
 		3F75566B1BE94CCC0058BC7E /* results.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3F7556691BE94CCC0058BC7E /* results.cpp */; };
-		3F75566C1BE94CCC0058BC7E /* results.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 3F75566A1BE94CCC0058BC7E /* results.hpp */; };
 		3F75566D1BE94CEA0058BC7E /* results.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3F7556691BE94CCC0058BC7E /* results.cpp */; };
 		3F7556751BE95A0C0058BC7E /* AsyncTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 3F7556731BE95A050058BC7E /* AsyncTests.mm */; };
 		3F7556761BE95A0D0058BC7E /* AsyncTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 3F7556731BE95A050058BC7E /* AsyncTests.mm */; };
 		3F7A3FAE1CC6EB7300301A17 /* collection_change_builder.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3F7A3FAC1CC6EB7300301A17 /* collection_change_builder.cpp */; };
 		3F7A3FAF1CC6EB7300301A17 /* collection_change_builder.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3F7A3FAC1CC6EB7300301A17 /* collection_change_builder.cpp */; };
-		3F7A3FB01CC6EB7300301A17 /* collection_change_builder.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 3F7A3FAD1CC6EB7300301A17 /* collection_change_builder.hpp */; };
-		3F7A3FB11CC6EB7300301A17 /* collection_change_builder.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 3F7A3FAD1CC6EB7300301A17 /* collection_change_builder.hpp */; };
 		3F8DCA7519930FCB0008BD7F /* SwiftTestObjects.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8F8D90B196CB8DD00475368 /* SwiftTestObjects.swift */; };
 		3F8DCA7619930FCB0008BD7F /* SwiftArrayPropertyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E82FA60A195632F20043A3C3 /* SwiftArrayPropertyTests.swift */; };
 		3F8DCA7719930FCB0008BD7F /* SwiftArrayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E82FA60B195632F20043A3C3 /* SwiftArrayTests.swift */; };
@@ -202,27 +183,26 @@
 		3F8DCA7D19930FCB0008BD7F /* SwiftRealmTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E81A1FD01955FE0100FDED82 /* SwiftRealmTests.swift */; };
 		3F8DCA7E19930FCB0008BD7F /* SwiftUnicodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E891759A197A1B600068ACC6 /* SwiftUnicodeTests.swift */; };
 		3F9026111C625C5D006AE98E /* list.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3F90260F1C625C5D006AE98E /* list.cpp */; };
-		3F9026121C625C5D006AE98E /* list.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 3F9026101C625C5D006AE98E /* list.hpp */; };
 		3F9026131C625C63006AE98E /* list.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3F90260F1C625C5D006AE98E /* list.cpp */; };
 		3F9182441CD1713E00A50120 /* fileformat-old-date.realm in Resources */ = {isa = PBXBuildFile; fileRef = 3F9182421CD1712F00A50120 /* fileformat-old-date.realm */; };
 		3F9182451CD1713F00A50120 /* fileformat-old-date.realm in Resources */ = {isa = PBXBuildFile; fileRef = 3F9182421CD1712F00A50120 /* fileformat-old-date.realm */; };
-		3F9801A01C8E4F55000A8B07 /* collection_notifier.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 3F98019A1C8E4F55000A8B07 /* collection_notifier.hpp */; };
-		3F9801A11C8E4F55000A8B07 /* list_notifier.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 3F98019B1C8E4F55000A8B07 /* list_notifier.hpp */; };
-		3F9801A31C8E4F55000A8B07 /* weak_realm_notifier.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 3F98019D1C8E4F55000A8B07 /* weak_realm_notifier.hpp */; };
 		3F9801A41C8E4F55000A8B07 /* collection_notifier.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3F98019E1C8E4F55000A8B07 /* collection_notifier.cpp */; };
 		3F9801A51C8E4F55000A8B07 /* list_notifier.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3F98019F1C8E4F55000A8B07 /* list_notifier.cpp */; };
 		3F9801A61C8E4F5A000A8B07 /* collection_notifier.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3F98019E1C8E4F55000A8B07 /* collection_notifier.cpp */; };
 		3F9801A71C8E4F5A000A8B07 /* list_notifier.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3F98019F1C8E4F55000A8B07 /* list_notifier.cpp */; };
-		3F9801AA1C8E4F6B000A8B07 /* collection_notifications.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 3F9801A81C8E4F6B000A8B07 /* collection_notifications.hpp */; };
 		3F9801AB1C8E4F6B000A8B07 /* collection_notifications.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3F9801A91C8E4F6B000A8B07 /* collection_notifications.cpp */; };
 		3F9801AC1C8E4F6F000A8B07 /* collection_notifications.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3F9801A91C8E4F6B000A8B07 /* collection_notifications.cpp */; };
-		3F9801AF1C90FD2D000A8B07 /* results_notifier.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 3F9801AD1C90FD2D000A8B07 /* results_notifier.hpp */; };
 		3F9801B01C90FD2D000A8B07 /* results_notifier.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3F9801AE1C90FD2D000A8B07 /* results_notifier.cpp */; };
 		3F9801B11C90FD31000A8B07 /* results_notifier.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3F9801AE1C90FD2D000A8B07 /* results_notifier.cpp */; };
 		3F9863BB1D36876B00641C98 /* RLMClassInfo.mm in Sources */ = {isa = PBXBuildFile; fileRef = 3F9863B91D36876B00641C98 /* RLMClassInfo.mm */; };
 		3F9863BC1D36876B00641C98 /* RLMClassInfo.mm in Sources */ = {isa = PBXBuildFile; fileRef = 3F9863B91D36876B00641C98 /* RLMClassInfo.mm */; };
-		3F9863BD1D36876B00641C98 /* RLMClassInfo.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 3F9863BA1D36876B00641C98 /* RLMClassInfo.hpp */; };
-		3F9863BE1D36876B00641C98 /* RLMClassInfo.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 3F9863BA1D36876B00641C98 /* RLMClassInfo.hpp */; };
+		3FAB08481E1EC382001BC8DA /* object.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3FAB08441E1EC382001BC8DA /* object.cpp */; };
+		3FAB08491E1EC385001BC8DA /* object.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3FAB08441E1EC382001BC8DA /* object.cpp */; };
+		3FAB084A1E1EC3A2001BC8DA /* sync_client.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 1A15366C1DB0464800C0EC93 /* sync_client.hpp */; };
+		3FAB084B1E1EC3A2001BC8DA /* sync_file.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 1A15366E1DB0464800C0EC93 /* sync_file.hpp */; };
+		3FAB084C1E1EC3A2001BC8DA /* sync_metadata.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 1A1536701DB0464800C0EC93 /* sync_metadata.hpp */; };
+		3FAB08881E1EC51F001BC8DA /* object_notifier.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3FAB08861E1EC51F001BC8DA /* object_notifier.cpp */; };
+		3FAB08891E1EC526001BC8DA /* object_notifier.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3FAB08861E1EC51F001BC8DA /* object_notifier.cpp */; };
 		3FB4FA1719F5D2740020D53B /* SwiftTestObjects.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8F8D90B196CB8DD00475368 /* SwiftTestObjects.swift */; };
 		3FB4FA1819F5D2740020D53B /* SwiftArrayPropertyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E82FA60A195632F20043A3C3 /* SwiftArrayPropertyTests.swift */; };
 		3FB4FA1919F5D2740020D53B /* SwiftArrayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E82FA60B195632F20043A3C3 /* SwiftArrayTests.swift */; };
@@ -238,30 +218,18 @@
 		3FDCFEB619F6A8D3005E414A /* RLMSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = E88C36FF19745E5500C9963D /* RLMSupport.swift */; };
 		3FDE338D19C39A87003B7DBA /* RLMSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = E88C36FF19745E5500C9963D /* RLMSupport.swift */; };
 		3FEC4A3F1BBB18D400F009C3 /* SwiftSchemaTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FEC4A3D1BBB188B00F009C3 /* SwiftSchemaTests.swift */; };
-		4D49AA7B1D837EF8003ED789 /* ThreadSafeReferenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D49AA791D837E6B003ED789 /* ThreadSafeReferenceTests.swift */; };
 		5B77EACE1DCC5614006AB51D /* ObjectiveCSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B77EACD1DCC5614006AB51D /* ObjectiveCSupport.swift */; };
 		5BC537161DD5B8D70055C524 /* ObjectiveCSupportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BC537151DD5B8D70055C524 /* ObjectiveCSupportTests.swift */; };
-		5D02C78E1E2E871F0048C13E /* execution_context_id.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 5D02C78C1E2E871F0048C13E /* execution_context_id.hpp */; };
-		5D02C78F1E2E871F0048C13E /* object_accessor.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 5D02C78D1E2E871F0048C13E /* object_accessor.hpp */; };
-		5D02C7921E2E873F0048C13E /* aligned_union.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 5D02C7901E2E873F0048C13E /* aligned_union.hpp */; };
-		5D02C7931E2E873F0048C13E /* time.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 5D02C7911E2E873F0048C13E /* time.hpp */; };
 		5D03FB1F1E0DAFBA007D53EA /* PredicateUtilTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5D03FB1E1E0DAFBA007D53EA /* PredicateUtilTests.mm */; };
 		5D03FB201E0DAFBA007D53EA /* PredicateUtilTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5D03FB1E1E0DAFBA007D53EA /* PredicateUtilTests.mm */; };
 		5D128F2A1BE984E5001F4FBF /* Realm.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 5D659ED91BE04556006515A0 /* Realm.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		5D1534B81CCFF545008976D7 /* LinkingObjects.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D1534B71CCFF545008976D7 /* LinkingObjects.swift */; };
 		5D274C4D1D6D15D2006FEBB1 /* weak_realm_notifier.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5D274C4C1D6D15D2006FEBB1 /* weak_realm_notifier.cpp */; };
 		5D274C4E1D6D15FD006FEBB1 /* weak_realm_notifier.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5D274C4C1D6D15D2006FEBB1 /* weak_realm_notifier.cpp */; };
-		5D274C501D6D16A8006FEBB1 /* event_loop_signal.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 5D274C4F1D6D16A8006FEBB1 /* event_loop_signal.hpp */; };
-		5D274C531D6D16BA006FEBB1 /* event_loop_signal.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 5D274C521D6D16BA006FEBB1 /* event_loop_signal.hpp */; };
-		5D2E8F661C98DC0D00187B09 /* RLMProperty_Private.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 5D2E8F651C98DC0D00187B09 /* RLMProperty_Private.hpp */; };
-		5D2E8F671C98DC0D00187B09 /* RLMProperty_Private.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 5D2E8F651C98DC0D00187B09 /* RLMProperty_Private.hpp */; };
-		5D3E1A2E1C1FC6D5002913BA /* RLMPredicateUtil.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 5D3E1A2C1C1FC6D5002913BA /* RLMPredicateUtil.hpp */; };
 		5D3E1A2F1C1FC6D5002913BA /* RLMPredicateUtil.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5D3E1A2D1C1FC6D5002913BA /* RLMPredicateUtil.mm */; };
 		5D3E1A301C1FD1CF002913BA /* RLMPredicateUtil.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5D3E1A2D1C1FC6D5002913BA /* RLMPredicateUtil.mm */; };
-		5D3E1A311C1FD1D2002913BA /* RLMPredicateUtil.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 5D3E1A2C1C1FC6D5002913BA /* RLMPredicateUtil.hpp */; };
 		5D432B8D1CC0713F00A610A9 /* LinkingObjectsTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5D432B8C1CC0713F00A610A9 /* LinkingObjectsTests.mm */; };
 		5D432B8E1CC0713F00A610A9 /* LinkingObjectsTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5D432B8C1CC0713F00A610A9 /* LinkingObjectsTests.mm */; };
-		5D5AF7FD1D3D8F9C003036AB /* compiler.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 5D5AF7FC1D3D8F9C003036AB /* compiler.hpp */; };
 		5D6156EE1BE0689200A4BD3F /* Realm.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5D659ED91BE04556006515A0 /* Realm.framework */; };
 		5D6156FB1BE08E7E00A4BD3F /* PerformanceTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 3F04EA2D1992BEE400C2CE2E /* PerformanceTests.m */; };
 		5D6157051BE13CBB00A4BD3F /* strip-frameworks.sh in Resources */ = {isa = PBXBuildFile; fileRef = E81C393E1AE5CE6A00F03B56 /* strip-frameworks.sh */; };
@@ -295,15 +263,8 @@
 		5D659E9C1BE04556006515A0 /* schema.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3FE556421B9A43E5002A1129 /* schema.cpp */; };
 		5D659E9D1BE04556006515A0 /* shared_realm.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3FAE25531B8CEBBE00D01405 /* shared_realm.cpp */; };
 		5D659E9E1BE04556006515A0 /* transact_log_handler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3F1F47891B97ABA300CD99A3 /* transact_log_handler.cpp */; };
-		5D659EA01BE04556006515A0 /* external_commit_helper.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 3F2118A91B97CBE1005A4CFE /* external_commit_helper.hpp */; };
-		5D659EA11BE04556006515A0 /* index_set.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 3FBD05FB1B94E1C3004559CF /* index_set.hpp */; };
-		5D659EA21BE04556006515A0 /* object_schema.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 3FAE25581B8CEBBE00D01405 /* object_schema.hpp */; };
-		5D659EA31BE04556006515A0 /* object_store.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 3FAE25521B8CEBBE00D01405 /* object_store.hpp */; };
-		5D659EA41BE04556006515A0 /* property.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 3FAE25571B8CEBBE00D01405 /* property.hpp */; };
 		5D659EA51BE04556006515A0 /* Realm.h in Headers */ = {isa = PBXBuildFile; fileRef = E8D89B9D1955FC6D00CF2B9A /* Realm.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		5D659EA61BE04556006515A0 /* binding_context.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 3F62BA9E1BA0AB9000A4CEB2 /* binding_context.hpp */; };
 		5D659EA71BE04556006515A0 /* RLMAccessor.h in Headers */ = {isa = PBXBuildFile; fileRef = E81A1F631955FC9300FDED82 /* RLMAccessor.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		5D659EA81BE04556006515A0 /* RLMAnalytics.hpp in Headers */ = {isa = PBXBuildFile; fileRef = E83591941B3DF05C0035F2F3 /* RLMAnalytics.hpp */; };
 		5D659EA91BE04556006515A0 /* RLMArray.h in Headers */ = {isa = PBXBuildFile; fileRef = E81A1F661955FC9300FDED82 /* RLMArray.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		5D659EAA1BE04556006515A0 /* RLMArray_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 0237B5421A856F06004ACD57 /* RLMArray_Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		5D659EAB1BE04556006515A0 /* RLMCollection.h in Headers */ = {isa = PBXBuildFile; fileRef = 02B8EF5B19E7048D0045A93D /* RLMCollection.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -317,28 +278,20 @@
 		5D659EB41BE04556006515A0 /* RLMObjectBase_Dynamic.h in Headers */ = {isa = PBXBuildFile; fileRef = A05FA61E1B62C3900000C9B2 /* RLMObjectBase_Dynamic.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		5D659EB51BE04556006515A0 /* RLMObjectSchema.h in Headers */ = {isa = PBXBuildFile; fileRef = E81A1F711955FC9300FDED82 /* RLMObjectSchema.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		5D659EB61BE04556006515A0 /* RLMObjectSchema_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 29EDB8E91A7712E500458D80 /* RLMObjectSchema_Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		5D659EB71BE04556006515A0 /* RLMObjectSchema_Private.hpp in Headers */ = {isa = PBXBuildFile; fileRef = E81A1F701955FC9300FDED82 /* RLMObjectSchema_Private.hpp */; };
 		5D659EB81BE04556006515A0 /* RLMObjectStore.h in Headers */ = {isa = PBXBuildFile; fileRef = 29EDB8D71A7703C500458D80 /* RLMObjectStore.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		5D659EB91BE04556006515A0 /* RLMObservation.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 3F0F02AC1B6FFF3D0046A4D5 /* RLMObservation.hpp */; };
 		5D659EBA1BE04556006515A0 /* RLMOptionalBase.h in Headers */ = {isa = PBXBuildFile; fileRef = C0004BEB1B8E4FCF00304BF3 /* RLMOptionalBase.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		5D659EBC1BE04556006515A0 /* RLMProperty.h in Headers */ = {isa = PBXBuildFile; fileRef = E81A1F761955FC9300FDED82 /* RLMProperty.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		5D659EBD1BE04556006515A0 /* RLMProperty_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = E81A1F751955FC9300FDED82 /* RLMProperty_Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		5D659EBE1BE04556006515A0 /* RLMQueryUtil.hpp in Headers */ = {isa = PBXBuildFile; fileRef = E81A1F781955FC9300FDED82 /* RLMQueryUtil.hpp */; };
 		5D659EBF1BE04556006515A0 /* RLMRealm.h in Headers */ = {isa = PBXBuildFile; fileRef = E81A1F7B1955FC9300FDED82 /* RLMRealm.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		5D659EC01BE04556006515A0 /* RLMRealm_Dynamic.h in Headers */ = {isa = PBXBuildFile; fileRef = E8951F01196C96DE00D6461C /* RLMRealm_Dynamic.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		5D659EC11BE04556006515A0 /* RLMRealm_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 29EDB8E01A77070200458D80 /* RLMRealm_Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		5D659EC21BE04556006515A0 /* RLMRealmConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = C0D2DD051B6BDEA1004E8919 /* RLMRealmConfiguration.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		5D659EC31BE04556006515A0 /* RLMRealmConfiguration_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = C0D2DD0F1B6BE0DD004E8919 /* RLMRealmConfiguration_Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		5D659EC41BE04556006515A0 /* RLMRealmUtil.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 027A4D211AB100E000AA46F9 /* RLMRealmUtil.hpp */; settings = {ATTRIBUTES = (Private, ); }; };
 		5D659EC51BE04556006515A0 /* RLMResults.h in Headers */ = {isa = PBXBuildFile; fileRef = 02B8EF5819E601D80045A93D /* RLMResults.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		5D659EC61BE04556006515A0 /* RLMResults_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 29EDB8E51A7710B700458D80 /* RLMResults_Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		5D659EC71BE04556006515A0 /* RLMSchema.h in Headers */ = {isa = PBXBuildFile; fileRef = E81A1F7E1955FC9300FDED82 /* RLMSchema.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		5D659EC81BE04556006515A0 /* RLMSchema_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = E81A1F7D1955FC9300FDED82 /* RLMSchema_Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		5D659EC91BE04556006515A0 /* RLMSwiftSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 3FE79FF719BA6A5900780C9A /* RLMSwiftSupport.h */; };
-		5D659ECA1BE04556006515A0 /* RLMUpdateChecker.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 3F20DA2019BE1EA6007DE308 /* RLMUpdateChecker.hpp */; };
-		5D659ECB1BE04556006515A0 /* RLMUtil.hpp in Headers */ = {isa = PBXBuildFile; fileRef = E81A1F811955FC9300FDED82 /* RLMUtil.hpp */; };
-		5D659ECC1BE04556006515A0 /* schema.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 3FE556431B9A43E5002A1129 /* schema.hpp */; };
-		5D659ECD1BE04556006515A0 /* shared_realm.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 3FAE25541B8CEBBE00D01405 /* shared_realm.hpp */; };
 		5D659ED21BE04556006515A0 /* CHANGELOG.md in Resources */ = {isa = PBXBuildFile; fileRef = E81A1FB31955FCE000FDED82 /* CHANGELOG.md */; };
 		5D659ED51BE04556006515A0 /* LICENSE in Resources */ = {isa = PBXBuildFile; fileRef = E81A1FB41955FCE000FDED82 /* LICENSE */; };
 		5D660FDD1BE98C7C0021E04F /* RealmSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5D660FCC1BE98C560021E04F /* RealmSwift.framework */; };
@@ -378,9 +331,7 @@
 		5D66102A1BE98DD00021E04F /* Realm.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5D659ED91BE04556006515A0 /* Realm.framework */; };
 		5D66102E1BE98E500021E04F /* Realm.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 5D659ED91BE04556006515A0 /* Realm.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		5D66102F1BE98E540021E04F /* RealmSwift.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 5D660FCC1BE98C560021E04F /* RealmSwift.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		5DB591A91D063DF8001D8F93 /* atomic_shared_ptr.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 5DB591A61D063DF8001D8F93 /* atomic_shared_ptr.hpp */; };
 		5DB591AA1D063DF8001D8F93 /* format.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5DB591A71D063DF8001D8F93 /* format.cpp */; };
-		5DB591AB1D063DF8001D8F93 /* format.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 5DB591A81D063DF8001D8F93 /* format.hpp */; };
 		5DB591AC1D0775D2001D8F93 /* format.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5DB591A71D063DF8001D8F93 /* format.cpp */; };
 		5DD7557F1BE056DE002800DA /* external_commit_helper.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3F2118A81B97CBE1005A4CFE /* external_commit_helper.cpp */; };
 		5DD755801BE056DE002800DA /* index_set.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3FBD05FA1B94E1C3004559CF /* index_set.cpp */; };
@@ -412,15 +363,8 @@
 		5DD7559A1BE056DE002800DA /* schema.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3FE556421B9A43E5002A1129 /* schema.cpp */; };
 		5DD7559B1BE056DE002800DA /* shared_realm.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3FAE25531B8CEBBE00D01405 /* shared_realm.cpp */; };
 		5DD7559C1BE056DE002800DA /* transact_log_handler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3F1F47891B97ABA300CD99A3 /* transact_log_handler.cpp */; };
-		5DD7559E1BE056DE002800DA /* external_commit_helper.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 3F2118A91B97CBE1005A4CFE /* external_commit_helper.hpp */; };
-		5DD7559F1BE056DE002800DA /* index_set.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 3FBD05FB1B94E1C3004559CF /* index_set.hpp */; };
-		5DD755A01BE056DE002800DA /* object_schema.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 3FAE25581B8CEBBE00D01405 /* object_schema.hpp */; };
-		5DD755A11BE056DE002800DA /* object_store.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 3FAE25521B8CEBBE00D01405 /* object_store.hpp */; };
-		5DD755A21BE056DE002800DA /* property.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 3FAE25571B8CEBBE00D01405 /* property.hpp */; };
 		5DD755A31BE056DE002800DA /* Realm.h in Headers */ = {isa = PBXBuildFile; fileRef = E8D89B9D1955FC6D00CF2B9A /* Realm.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		5DD755A41BE056DE002800DA /* binding_context.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 3F62BA9E1BA0AB9000A4CEB2 /* binding_context.hpp */; };
 		5DD755A51BE056DE002800DA /* RLMAccessor.h in Headers */ = {isa = PBXBuildFile; fileRef = E81A1F631955FC9300FDED82 /* RLMAccessor.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		5DD755A61BE056DE002800DA /* RLMAnalytics.hpp in Headers */ = {isa = PBXBuildFile; fileRef = E83591941B3DF05C0035F2F3 /* RLMAnalytics.hpp */; };
 		5DD755A71BE056DE002800DA /* RLMArray.h in Headers */ = {isa = PBXBuildFile; fileRef = E81A1F661955FC9300FDED82 /* RLMArray.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		5DD755A81BE056DE002800DA /* RLMArray_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 0237B5421A856F06004ACD57 /* RLMArray_Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		5DD755A91BE056DE002800DA /* RLMCollection.h in Headers */ = {isa = PBXBuildFile; fileRef = 02B8EF5B19E7048D0045A93D /* RLMCollection.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -434,28 +378,20 @@
 		5DD755B21BE056DE002800DA /* RLMObjectBase_Dynamic.h in Headers */ = {isa = PBXBuildFile; fileRef = A05FA61E1B62C3900000C9B2 /* RLMObjectBase_Dynamic.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		5DD755B31BE056DE002800DA /* RLMObjectSchema.h in Headers */ = {isa = PBXBuildFile; fileRef = E81A1F711955FC9300FDED82 /* RLMObjectSchema.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		5DD755B41BE056DE002800DA /* RLMObjectSchema_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 29EDB8E91A7712E500458D80 /* RLMObjectSchema_Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		5DD755B51BE056DE002800DA /* RLMObjectSchema_Private.hpp in Headers */ = {isa = PBXBuildFile; fileRef = E81A1F701955FC9300FDED82 /* RLMObjectSchema_Private.hpp */; };
 		5DD755B61BE056DE002800DA /* RLMObjectStore.h in Headers */ = {isa = PBXBuildFile; fileRef = 29EDB8D71A7703C500458D80 /* RLMObjectStore.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		5DD755B71BE056DE002800DA /* RLMObservation.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 3F0F02AC1B6FFF3D0046A4D5 /* RLMObservation.hpp */; };
 		5DD755B81BE056DE002800DA /* RLMOptionalBase.h in Headers */ = {isa = PBXBuildFile; fileRef = C0004BEB1B8E4FCF00304BF3 /* RLMOptionalBase.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		5DD755BA1BE056DE002800DA /* RLMProperty.h in Headers */ = {isa = PBXBuildFile; fileRef = E81A1F761955FC9300FDED82 /* RLMProperty.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		5DD755BB1BE056DE002800DA /* RLMProperty_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = E81A1F751955FC9300FDED82 /* RLMProperty_Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		5DD755BC1BE056DE002800DA /* RLMQueryUtil.hpp in Headers */ = {isa = PBXBuildFile; fileRef = E81A1F781955FC9300FDED82 /* RLMQueryUtil.hpp */; };
 		5DD755BD1BE056DE002800DA /* RLMRealm.h in Headers */ = {isa = PBXBuildFile; fileRef = E81A1F7B1955FC9300FDED82 /* RLMRealm.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		5DD755BE1BE056DE002800DA /* RLMRealm_Dynamic.h in Headers */ = {isa = PBXBuildFile; fileRef = E8951F01196C96DE00D6461C /* RLMRealm_Dynamic.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		5DD755BF1BE056DE002800DA /* RLMRealm_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 29EDB8E01A77070200458D80 /* RLMRealm_Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		5DD755C01BE056DE002800DA /* RLMRealmConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = C0D2DD051B6BDEA1004E8919 /* RLMRealmConfiguration.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		5DD755C11BE056DE002800DA /* RLMRealmConfiguration_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = C0D2DD0F1B6BE0DD004E8919 /* RLMRealmConfiguration_Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		5DD755C21BE056DE002800DA /* RLMRealmUtil.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 027A4D211AB100E000AA46F9 /* RLMRealmUtil.hpp */; settings = {ATTRIBUTES = (Private, ); }; };
 		5DD755C31BE056DE002800DA /* RLMResults.h in Headers */ = {isa = PBXBuildFile; fileRef = 02B8EF5819E601D80045A93D /* RLMResults.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		5DD755C41BE056DE002800DA /* RLMResults_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 29EDB8E51A7710B700458D80 /* RLMResults_Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		5DD755C51BE056DE002800DA /* RLMSchema.h in Headers */ = {isa = PBXBuildFile; fileRef = E81A1F7E1955FC9300FDED82 /* RLMSchema.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		5DD755C61BE056DE002800DA /* RLMSchema_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = E81A1F7D1955FC9300FDED82 /* RLMSchema_Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		5DD755C71BE056DE002800DA /* RLMSwiftSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 3FE79FF719BA6A5900780C9A /* RLMSwiftSupport.h */; };
-		5DD755C81BE056DE002800DA /* RLMUpdateChecker.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 3F20DA2019BE1EA6007DE308 /* RLMUpdateChecker.hpp */; };
-		5DD755C91BE056DE002800DA /* RLMUtil.hpp in Headers */ = {isa = PBXBuildFile; fileRef = E81A1F811955FC9300FDED82 /* RLMUtil.hpp */; };
-		5DD755CA1BE056DE002800DA /* schema.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 3FE556431B9A43E5002A1129 /* schema.hpp */; };
-		5DD755CB1BE056DE002800DA /* shared_realm.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 3FAE25541B8CEBBE00D01405 /* shared_realm.hpp */; };
 		5DD755E21BE05DAF002800DA /* Realm.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5DD755CF1BE056DE002800DA /* Realm.framework */; };
 		C042A48D1B7522A900771ED2 /* RealmConfigurationTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = C042A48C1B7522A900771ED2 /* RealmConfigurationTests.mm */; };
 		C042A48E1B7522A900771ED2 /* RealmConfigurationTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = C042A48C1B7522A900771ED2 /* RealmConfigurationTests.mm */; };
@@ -463,15 +399,6 @@
 		C0CDC0831B38DABB00C5716D /* UtilTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 021A88311AAFB5BE00EEAC84 /* UtilTests.mm */; };
 		C2841D5E1DDC673400943503 /* RLMSyncErrorResponseModel.m in Sources */ = {isa = PBXBuildFile; fileRef = C2841D5B1DDC673300943503 /* RLMSyncErrorResponseModel.m */; };
 		C2841D5F1DDC673400943503 /* RLMSyncErrorResponseModel.m in Sources */ = {isa = PBXBuildFile; fileRef = C2841D5B1DDC673300943503 /* RLMSyncErrorResponseModel.m */; };
-		D40BA0621D834CDE0041A9DF /* ThreadSafeReference.swift in Sources */ = {isa = PBXBuildFile; fileRef = D40BA0611D834CDE0041A9DF /* ThreadSafeReference.swift */; };
-		D41ABB831D80DC010031D38C /* RLMThreadSafeReference.h in Headers */ = {isa = PBXBuildFile; fileRef = D41ABB811D80DC010031D38C /* RLMThreadSafeReference.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		D41ABB841D80DC010031D38C /* RLMThreadSafeReference.h in Headers */ = {isa = PBXBuildFile; fileRef = D41ABB811D80DC010031D38C /* RLMThreadSafeReference.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		D41ABB851D80DC010031D38C /* RLMThreadSafeReference.mm in Sources */ = {isa = PBXBuildFile; fileRef = D41ABB821D80DC010031D38C /* RLMThreadSafeReference.mm */; };
-		D41ABB861D80DC010031D38C /* RLMThreadSafeReference.mm in Sources */ = {isa = PBXBuildFile; fileRef = D41ABB821D80DC010031D38C /* RLMThreadSafeReference.mm */; };
-		D41ABB881D80DE1D0031D38C /* RLMThreadSafeReference_Private.hpp in Headers */ = {isa = PBXBuildFile; fileRef = D41ABB871D80DE1D0031D38C /* RLMThreadSafeReference_Private.hpp */; };
-		D41ABB891D80DE1D0031D38C /* RLMThreadSafeReference_Private.hpp in Headers */ = {isa = PBXBuildFile; fileRef = D41ABB871D80DE1D0031D38C /* RLMThreadSafeReference_Private.hpp */; };
-		D43BAE441D8324FA002E0AEE /* ThreadSafeReferenceTests.m in Sources */ = {isa = PBXBuildFile; fileRef = D43BAE431D8324FA002E0AEE /* ThreadSafeReferenceTests.m */; };
-		D43BAE451D83250F002E0AEE /* ThreadSafeReferenceTests.m in Sources */ = {isa = PBXBuildFile; fileRef = D43BAE431D8324FA002E0AEE /* ThreadSafeReferenceTests.m */; };
 		E81A1FD51955FE0100FDED82 /* ArrayPropertyTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E81A1FB81955FE0100FDED82 /* ArrayPropertyTests.m */; settings = {COMPILER_FLAGS = "-fobjc-arc-exceptions"; }; };
 		E81A1FDB1955FE0100FDED82 /* EnumeratorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E81A1FBB1955FE0100FDED82 /* EnumeratorTests.m */; settings = {COMPILER_FLAGS = "-fobjc-arc-exceptions"; }; };
 		E81A1FDD1955FE0100FDED82 /* LinkTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E81A1FBC1955FE0100FDED82 /* LinkTests.m */; settings = {COMPILER_FLAGS = "-fobjc-arc-exceptions"; }; };
@@ -496,8 +423,6 @@
 		E856D21D195615A900FB2FCF /* QueryTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E81A1FC11955FE0100FDED82 /* QueryTests.m */; };
 		E856D21E195615A900FB2FCF /* RealmTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = E81A1FC31955FE0100FDED82 /* RealmTests.mm */; };
 		E856D21F195615B100FB2FCF /* RLMTestCase.m in Sources */ = {isa = PBXBuildFile; fileRef = E81A1FC51955FE0100FDED82 /* RLMTestCase.m */; };
-		E86900E21CC04F5B0008A8B6 /* RLMRealmConfiguration_Private.hpp in Headers */ = {isa = PBXBuildFile; fileRef = E86900E11CC04F5B0008A8B6 /* RLMRealmConfiguration_Private.hpp */; };
-		E86900E31CC04F5B0008A8B6 /* RLMRealmConfiguration_Private.hpp in Headers */ = {isa = PBXBuildFile; fileRef = E86900E11CC04F5B0008A8B6 /* RLMRealmConfiguration_Private.hpp */; };
 		E86E61241D91E4E200DC2419 /* RLMTestCase.m in Sources */ = {isa = PBXBuildFile; fileRef = E81A1FC51955FE0100FDED82 /* RLMTestCase.m */; };
 		E8917598197A1B350068ACC6 /* UnicodeTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E8917597197A1B350068ACC6 /* UnicodeTests.m */; };
 		E8917599197A1B350068ACC6 /* UnicodeTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E8917597197A1B350068ACC6 /* UnicodeTests.m */; };
@@ -666,12 +591,6 @@
 		02B8EF5B19E7048D0045A93D /* RLMCollection.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RLMCollection.h; sourceTree = "<group>"; };
 		02E334C21A5F3C45009F8810 /* Realm.modulemap */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.module-map"; path = Realm.modulemap; sourceTree = "<group>"; };
 		02E334C41A5F4923009F8810 /* RLMRealm_Private.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = RLMRealm_Private.hpp; sourceTree = "<group>"; };
-		140CFE971DFABF5E006FB011 /* RLMSyncPermissionOffer_Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RLMSyncPermissionOffer_Private.h; sourceTree = "<group>"; };
-		140CFE981DFABF5E006FB011 /* RLMSyncPermissionOffer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RLMSyncPermissionOffer.h; sourceTree = "<group>"; };
-		140CFE991DFABF5E006FB011 /* RLMSyncPermissionOffer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RLMSyncPermissionOffer.m; sourceTree = "<group>"; };
-		140CFE9A1DFABF5E006FB011 /* RLMSyncPermissionOfferResponse_Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RLMSyncPermissionOfferResponse_Private.h; sourceTree = "<group>"; };
-		140CFE9B1DFABF5E006FB011 /* RLMSyncPermissionOfferResponse.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RLMSyncPermissionOfferResponse.h; sourceTree = "<group>"; };
-		140CFE9C1DFABF5E006FB011 /* RLMSyncPermissionOfferResponse.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RLMSyncPermissionOfferResponse.m; sourceTree = "<group>"; };
 		14C4B4371DC33481002FDEC8 /* RLMSyncPermissionChange.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RLMSyncPermissionChange.h; sourceTree = "<group>"; };
 		14C4B4381DC33481002FDEC8 /* RLMSyncPermissionChange.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RLMSyncPermissionChange.m; sourceTree = "<group>"; };
 		1A0512731D87413000806AEC /* RLMSyncUtil_Private.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = RLMSyncUtil_Private.hpp; sourceTree = "<group>"; };
@@ -698,20 +617,10 @@
 		1A4FFC971D35A71000B4B65C /* RLMSyncUtil.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RLMSyncUtil.h; sourceTree = "<group>"; };
 		1A64CA891D8763B400BC0F9B /* keychain_helper.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = keychain_helper.cpp; sourceTree = "<group>"; };
 		1A64CA8A1D8763B400BC0F9B /* keychain_helper.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = keychain_helper.hpp; sourceTree = "<group>"; };
-		1A65BB321E26D4A400192C01 /* thread_safe_reference.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = thread_safe_reference.cpp; sourceTree = "<group>"; };
-		1A65BB331E26D4A400192C01 /* thread_safe_reference.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = thread_safe_reference.hpp; sourceTree = "<group>"; };
 		1A6921D11D779774004C3232 /* RLMTokenModels.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RLMTokenModels.h; sourceTree = "<group>"; };
 		1A6921D21D779774004C3232 /* RLMTokenModels.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RLMTokenModels.m; sourceTree = "<group>"; };
-		1A7AFA711E29B756002744FA /* object.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = object.cpp; sourceTree = "<group>"; };
-		1A7AFA721E29B756002744FA /* object.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = object.hpp; sourceTree = "<group>"; };
-		1A7AFA7A1E29B7F4002744FA /* object_notifier.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = object_notifier.cpp; sourceTree = "<group>"; };
-		1A7AFA7B1E29B7F4002744FA /* object_notifier.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = object_notifier.hpp; sourceTree = "<group>"; };
 		1A7B82391D51259F00750296 /* libz.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libz.tbd; path = usr/lib/libz.tbd; sourceTree = SDKROOT; };
 		1A7DE7021D38460B0029F0AE /* Sync.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Sync.swift; sourceTree = "<group>"; };
-		1A81EDE91E30872F0035F4E6 /* NSError+RLMSync.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSError+RLMSync.h"; sourceTree = "<group>"; };
-		1A81EDEA1E30872F0035F4E6 /* NSError+RLMSync.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSError+RLMSync.m"; sourceTree = "<group>"; };
-		1A81EDEF1E30A4630035F4E6 /* RLMSyncUser+ObjectServerTests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "RLMSyncUser+ObjectServerTests.h"; path = "Realm/ObjectServerTests/RLMSyncUser+ObjectServerTests.h"; sourceTree = "<group>"; };
-		1A81EDF01E30A4630035F4E6 /* RLMSyncUser+ObjectServerTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = "RLMSyncUser+ObjectServerTests.mm"; path = "Realm/ObjectServerTests/RLMSyncUser+ObjectServerTests.mm"; sourceTree = "<group>"; };
 		1A84132E1D4BCCE600C5326F /* RLMSyncUtil.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = RLMSyncUtil.mm; sourceTree = "<group>"; };
 		1AA5AE961D989BE000ED8C27 /* SwiftSyncTestCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; name = SwiftSyncTestCase.swift; path = Realm/ObjectServerTests/SwiftSyncTestCase.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		1AA5AE9A1D98A1B000ED8C27 /* Object-Server-Tests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "Object-Server-Tests-Bridging-Header.h"; path = "Realm/ObjectServerTests/Object-Server-Tests-Bridging-Header.h"; sourceTree = "<group>"; };
@@ -720,6 +629,7 @@
 		1AA5AE9F1D98C99500ED8C27 /* SwiftObjectServerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SwiftObjectServerTests.swift; path = Realm/ObjectServerTests/SwiftObjectServerTests.swift; sourceTree = "<group>"; };
 		1AAF4D1F1D66585B00058FAD /* RLMSyncCredentials.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RLMSyncCredentials.h; sourceTree = "<group>"; };
 		1AAF4D201D66585B00058FAD /* RLMSyncCredentials.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RLMSyncCredentials.m; sourceTree = "<group>"; };
+		1AB2D36C1E16EB91007D0A3F /* thread_safe_reference.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = thread_safe_reference.cpp; sourceTree = "<group>"; };
 		1AB2D36D1E16EB91007D0A3F /* thread_safe_reference.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = thread_safe_reference.hpp; sourceTree = "<group>"; };
 		1AB605D21D495927007F53DE /* RealmCollection.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RealmCollection.swift; sourceTree = "<group>"; };
 		1ABDCDAD1D792FEB003489E3 /* RLMSyncUser.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RLMSyncUser.h; sourceTree = "<group>"; };
@@ -729,13 +639,10 @@
 		1ABF256E1D52AB6200BAC441 /* RLMRealmConfiguration+Sync.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = "RLMRealmConfiguration+Sync.mm"; sourceTree = "<group>"; };
 		1AD3870A1D4A7FBB00479110 /* RLMSyncSession.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RLMSyncSession.h; sourceTree = "<group>"; };
 		1AD3870B1D4A7FBB00479110 /* RLMSyncSession.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = RLMSyncSession.mm; sourceTree = "<group>"; };
-		1AEC3E8D1E32EE0B00E1EBE6 /* RLMSyncSessionRefreshHandle.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RLMSyncSessionRefreshHandle.h; sourceTree = "<group>"; };
-		1AEC3E8E1E32EE8100E1EBE6 /* RLMSyncSessionRefreshHandle+ObjectServerTests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "RLMSyncSessionRefreshHandle+ObjectServerTests.h"; path = "Realm/ObjectServerTests/RLMSyncSessionRefreshHandle+ObjectServerTests.h"; sourceTree = "<group>"; };
-		1AEC3E8F1E32EE8100E1EBE6 /* RLMSyncSessionRefreshHandle+ObjectServerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "RLMSyncSessionRefreshHandle+ObjectServerTests.m"; path = "Realm/ObjectServerTests/RLMSyncSessionRefreshHandle+ObjectServerTests.m"; sourceTree = "<group>"; };
-		1AEC3E931E32EF5100E1EBE6 /* RLMTestUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RLMTestUtils.h; path = Realm/ObjectServerTests/RLMTestUtils.h; sourceTree = "<group>"; };
-		1AEC3E941E32EF5100E1EBE6 /* RLMTestUtils.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RLMTestUtils.m; path = Realm/ObjectServerTests/RLMTestUtils.m; sourceTree = "<group>"; };
 		1AF64DCB1DA304210081EB15 /* RLMSyncManager+ObjectServerTests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "RLMSyncManager+ObjectServerTests.h"; path = "Realm/ObjectServerTests/RLMSyncManager+ObjectServerTests.h"; sourceTree = "<group>"; };
 		1AF64DCC1DA304210081EB15 /* RLMSyncManager+ObjectServerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "RLMSyncManager+ObjectServerTests.m"; path = "Realm/ObjectServerTests/RLMSyncManager+ObjectServerTests.m"; sourceTree = "<group>"; };
+		1AF64DD01DA304A90081EB15 /* RLMSyncUser+ObjectServerTests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "RLMSyncUser+ObjectServerTests.h"; path = "Realm/ObjectServerTests/RLMSyncUser+ObjectServerTests.h"; sourceTree = "<group>"; };
+		1AF64DD11DA304A90081EB15 /* RLMSyncUser+ObjectServerTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = "RLMSyncUser+ObjectServerTests.mm"; path = "Realm/ObjectServerTests/RLMSyncUser+ObjectServerTests.mm"; sourceTree = "<group>"; };
 		1AF6EA451D36B1850014EB85 /* RLMAuthResponseModel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RLMAuthResponseModel.h; sourceTree = "<group>"; };
 		1AF6EA461D36B1850014EB85 /* RLMAuthResponseModel.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RLMAuthResponseModel.m; sourceTree = "<group>"; };
 		1AF7EA941D340AF70001A9B5 /* RLMSyncManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RLMSyncManager.h; sourceTree = "<group>"; };
@@ -757,6 +664,12 @@
 		3F0543E91C56F71500AA5322 /* realm_coordinator.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = realm_coordinator.hpp; sourceTree = "<group>"; };
 		3F0543EA1C56F71500AA5322 /* realm_coordinator.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = realm_coordinator.cpp; sourceTree = "<group>"; };
 		3F0543F61C56F78300AA5322 /* external_commit_helper.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = external_commit_helper.hpp; sourceTree = "<group>"; };
+		3F0D873D1E2EEC4C008C92AC /* RLMSyncPermissionOffer_Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RLMSyncPermissionOffer_Private.h; sourceTree = "<group>"; };
+		3F0D873E1E2EEC4C008C92AC /* RLMSyncPermissionOffer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RLMSyncPermissionOffer.h; sourceTree = "<group>"; };
+		3F0D873F1E2EEC4C008C92AC /* RLMSyncPermissionOfferResponse_Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RLMSyncPermissionOfferResponse_Private.h; sourceTree = "<group>"; };
+		3F0D87401E2EEC4C008C92AC /* RLMSyncPermissionOfferResponse.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RLMSyncPermissionOfferResponse.h; sourceTree = "<group>"; };
+		3F0D87411E2EEC4C008C92AC /* RLMSyncPermissionOffer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RLMSyncPermissionOffer.m; sourceTree = "<group>"; };
+		3F0D87421E2EEC4C008C92AC /* RLMSyncPermissionOfferResponse.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RLMSyncPermissionOfferResponse.m; sourceTree = "<group>"; };
 		3F0F029D1B6FFE610046A4D5 /* KVOTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = KVOTests.mm; sourceTree = "<group>"; };
 		3F0F02AC1B6FFF3D0046A4D5 /* RLMObservation.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = RLMObservation.hpp; sourceTree = "<group>"; };
 		3F0F02AD1B6FFF3D0046A4D5 /* RLMObservation.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = RLMObservation.mm; sourceTree = "<group>"; };
@@ -767,14 +680,27 @@
 		3F20DA2119BE1EA6007DE308 /* RLMUpdateChecker.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = RLMUpdateChecker.mm; sourceTree = "<group>"; };
 		3F2118A81B97CBE1005A4CFE /* external_commit_helper.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = external_commit_helper.cpp; sourceTree = "<group>"; };
 		3F2118A91B97CBE1005A4CFE /* external_commit_helper.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = external_commit_helper.hpp; sourceTree = "<group>"; };
+		3F222C4D1E26F51300CA0713 /* ThreadSafeReference.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ThreadSafeReference.swift; sourceTree = "<group>"; };
 		3F2E66611CA0B9D5004761D5 /* NotificationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NotificationTests.m; sourceTree = "<group>"; };
 		3F44109E19953F5900223146 /* RLMTestObjects.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RLMTestObjects.h; sourceTree = "<group>"; };
 		3F452EC519C2279800AFC154 /* RLMSwiftSupport.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RLMSwiftSupport.m; path = Realm/RLMSwiftSupport.m; sourceTree = SOURCE_ROOT; };
 		3F4E324B1B98C6C700183A69 /* RLMSchema_Private.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = RLMSchema_Private.hpp; sourceTree = "<group>"; };
 		3F62BA9E1BA0AB9000A4CEB2 /* binding_context.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = binding_context.hpp; sourceTree = "<group>"; };
 		3F643BEB1CEA654D00F6D0C8 /* mixed-column.realm */ = {isa = PBXFileReference; lastKnownFileType = file; path = "mixed-column.realm"; sourceTree = "<group>"; };
+		3F6468381E3A98B1007BD064 /* RLMSyncSessionRefreshHandle.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RLMSyncSessionRefreshHandle.h; sourceTree = "<group>"; };
+		3F67DB391E26D69C0024533D /* RLMThreadSafeReference.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RLMThreadSafeReference.h; sourceTree = "<group>"; };
+		3F67DB3A1E26D69C0024533D /* RLMThreadSafeReference_Private.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = RLMThreadSafeReference_Private.hpp; sourceTree = "<group>"; };
+		3F67DB3B1E26D69C0024533D /* RLMThreadSafeReference.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = RLMThreadSafeReference.mm; sourceTree = "<group>"; };
 		3F68BFCD1B558CA800D50FBD /* RLMPrefix.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RLMPrefix.h; sourceTree = "<group>"; };
 		3F6B89AE19EF40BA004E8EA8 /* librealm-ios.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = "librealm-ios.a"; path = "../core/librealm-ios.a"; sourceTree = "<group>"; };
+		3F73BC841E3A870F00FE80B6 /* ThreadSafeReferenceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ThreadSafeReferenceTests.swift; sourceTree = "<group>"; };
+		3F73BC871E3A876600FE80B6 /* ObjectServerTests-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = "ObjectServerTests-Info.plist"; path = "Realm/ObjectServerTests/ObjectServerTests-Info.plist"; sourceTree = "<group>"; };
+		3F73BC881E3A876600FE80B6 /* RLMSyncSessionRefreshHandle+ObjectServerTests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "RLMSyncSessionRefreshHandle+ObjectServerTests.h"; path = "Realm/ObjectServerTests/RLMSyncSessionRefreshHandle+ObjectServerTests.h"; sourceTree = "<group>"; };
+		3F73BC891E3A876600FE80B6 /* RLMSyncSessionRefreshHandle+ObjectServerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "RLMSyncSessionRefreshHandle+ObjectServerTests.m"; path = "Realm/ObjectServerTests/RLMSyncSessionRefreshHandle+ObjectServerTests.m"; sourceTree = "<group>"; };
+		3F73BC8A1E3A876600FE80B6 /* RLMTestUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RLMTestUtils.h; path = Realm/ObjectServerTests/RLMTestUtils.h; sourceTree = "<group>"; };
+		3F73BC8B1E3A876600FE80B6 /* RLMTestUtils.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RLMTestUtils.m; path = Realm/ObjectServerTests/RLMTestUtils.m; sourceTree = "<group>"; };
+		3F73BC931E3A878500FE80B6 /* NSError+RLMSync.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSError+RLMSync.h"; sourceTree = "<group>"; };
+		3F73BC941E3A878500FE80B6 /* NSError+RLMSync.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSError+RLMSync.m"; sourceTree = "<group>"; };
 		3F7556691BE94CCC0058BC7E /* results.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = results.cpp; sourceTree = "<group>"; };
 		3F75566A1BE94CCC0058BC7E /* results.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = results.hpp; sourceTree = "<group>"; };
 		3F7556731BE95A050058BC7E /* AsyncTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = AsyncTests.mm; sourceTree = "<group>"; };
@@ -794,6 +720,12 @@
 		3F9801AE1C90FD2D000A8B07 /* results_notifier.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = results_notifier.cpp; sourceTree = "<group>"; };
 		3F9863B91D36876B00641C98 /* RLMClassInfo.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = RLMClassInfo.mm; sourceTree = "<group>"; };
 		3F9863BA1D36876B00641C98 /* RLMClassInfo.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = RLMClassInfo.hpp; sourceTree = "<group>"; };
+		3FAB08411E1EC382001BC8DA /* execution_context_id.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = execution_context_id.hpp; sourceTree = "<group>"; };
+		3FAB08421E1EC382001BC8DA /* object_accessor.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = object_accessor.hpp; sourceTree = "<group>"; };
+		3FAB08431E1EC382001BC8DA /* object.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = object.hpp; sourceTree = "<group>"; };
+		3FAB08441E1EC382001BC8DA /* object.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = object.cpp; sourceTree = "<group>"; };
+		3FAB08851E1EC51F001BC8DA /* object_notifier.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = object_notifier.hpp; sourceTree = "<group>"; };
+		3FAB08861E1EC51F001BC8DA /* object_notifier.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = object_notifier.cpp; sourceTree = "<group>"; };
 		3FAE25511B8CEBBE00D01405 /* object_store.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = object_store.cpp; sourceTree = "<group>"; };
 		3FAE25521B8CEBBE00D01405 /* object_store.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = object_store.hpp; sourceTree = "<group>"; };
 		3FAE25531B8CEBBE00D01405 /* shared_realm.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = shared_realm.cpp; sourceTree = "<group>"; };
@@ -809,13 +741,8 @@
 		3FE556431B9A43E5002A1129 /* schema.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = schema.hpp; sourceTree = "<group>"; };
 		3FE79FF719BA6A5900780C9A /* RLMSwiftSupport.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RLMSwiftSupport.h; sourceTree = "<group>"; };
 		3FEC4A3D1BBB188B00F009C3 /* SwiftSchemaTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwiftSchemaTests.swift; sourceTree = "<group>"; };
-		4D49AA791D837E6B003ED789 /* ThreadSafeReferenceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ThreadSafeReferenceTests.swift; sourceTree = "<group>"; };
 		5B77EACD1DCC5614006AB51D /* ObjectiveCSupport.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ObjectiveCSupport.swift; sourceTree = "<group>"; };
 		5BC537151DD5B8D70055C524 /* ObjectiveCSupportTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ObjectiveCSupportTests.swift; sourceTree = "<group>"; };
-		5D02C78C1E2E871F0048C13E /* execution_context_id.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = execution_context_id.hpp; sourceTree = "<group>"; };
-		5D02C78D1E2E871F0048C13E /* object_accessor.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = object_accessor.hpp; sourceTree = "<group>"; };
-		5D02C7901E2E873F0048C13E /* aligned_union.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = aligned_union.hpp; sourceTree = "<group>"; };
-		5D02C7911E2E873F0048C13E /* time.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = time.hpp; sourceTree = "<group>"; };
 		5D03FB1E1E0DAFBA007D53EA /* PredicateUtilTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = PredicateUtilTests.mm; sourceTree = "<group>"; };
 		5D1534B71CCFF545008976D7 /* LinkingObjects.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LinkingObjects.swift; sourceTree = "<group>"; };
 		5D274C4C1D6D15D2006FEBB1 /* weak_realm_notifier.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = weak_realm_notifier.cpp; sourceTree = "<group>"; };
@@ -890,11 +817,6 @@
 		C0D6E4101AFBFAF7001F3027 /* RLMAssertions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RLMAssertions.h; sourceTree = "<group>"; };
 		C2841D5A1DDC673300943503 /* RLMSyncErrorResponseModel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RLMSyncErrorResponseModel.h; sourceTree = "<group>"; };
 		C2841D5B1DDC673300943503 /* RLMSyncErrorResponseModel.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RLMSyncErrorResponseModel.m; sourceTree = "<group>"; };
-		D40BA0611D834CDE0041A9DF /* ThreadSafeReference.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ThreadSafeReference.swift; sourceTree = "<group>"; };
-		D41ABB811D80DC010031D38C /* RLMThreadSafeReference.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RLMThreadSafeReference.h; sourceTree = "<group>"; };
-		D41ABB821D80DC010031D38C /* RLMThreadSafeReference.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = RLMThreadSafeReference.mm; sourceTree = "<group>"; };
-		D41ABB871D80DE1D0031D38C /* RLMThreadSafeReference_Private.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = RLMThreadSafeReference_Private.hpp; sourceTree = "<group>"; };
-		D43BAE431D8324FA002E0AEE /* ThreadSafeReferenceTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ThreadSafeReferenceTests.m; sourceTree = "<group>"; };
 		E81A1F621955FC9300FDED82 /* Realm-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "Realm-Info.plist"; sourceTree = "<group>"; };
 		E81A1F631955FC9300FDED82 /* RLMAccessor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RLMAccessor.h; sourceTree = "<group>"; };
 		E81A1F641955FC9300FDED82 /* RLMAccessor.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = RLMAccessor.mm; sourceTree = "<group>"; };
@@ -1030,20 +952,20 @@
 		02D9AFB61B22487E00A1BD87 /* ObjectStore */ = {
 			isa = PBXGroup;
 			children = (
-				1A1536491DB045A800C0EC93 /* sync */,
 				3FF0B0A31BA861F200E74157 /* impl */,
+				1A1536491DB045A800C0EC93 /* sync */,
 				5DB591A51D063DE5001D8F93 /* util */,
 				3F62BA9E1BA0AB9000A4CEB2 /* binding_context.hpp */,
 				3F9801A91C8E4F6B000A8B07 /* collection_notifications.cpp */,
 				3F9801A81C8E4F6B000A8B07 /* collection_notifications.hpp */,
-				5D02C78C1E2E871F0048C13E /* execution_context_id.hpp */,
+				3FAB08411E1EC382001BC8DA /* execution_context_id.hpp */,
 				3FBD05FA1B94E1C3004559CF /* index_set.cpp */,
 				3FBD05FB1B94E1C3004559CF /* index_set.hpp */,
 				3F90260F1C625C5D006AE98E /* list.cpp */,
 				3F9026101C625C5D006AE98E /* list.hpp */,
-				1A7AFA711E29B756002744FA /* object.cpp */,
-				1A7AFA721E29B756002744FA /* object.hpp */,
-				5D02C78D1E2E871F0048C13E /* object_accessor.hpp */,
+				3FAB08441E1EC382001BC8DA /* object.cpp */,
+				3FAB08431E1EC382001BC8DA /* object.hpp */,
+				3FAB08421E1EC382001BC8DA /* object_accessor.hpp */,
 				3FAE25561B8CEBBE00D01405 /* object_schema.cpp */,
 				3FAE25581B8CEBBE00D01405 /* object_schema.hpp */,
 				3FAE25511B8CEBBE00D01405 /* object_store.cpp */,
@@ -1055,8 +977,8 @@
 				3FE556431B9A43E5002A1129 /* schema.hpp */,
 				3FAE25531B8CEBBE00D01405 /* shared_realm.cpp */,
 				3FAE25541B8CEBBE00D01405 /* shared_realm.hpp */,
-				1A65BB321E26D4A400192C01 /* thread_safe_reference.cpp */,
-				1A65BB331E26D4A400192C01 /* thread_safe_reference.hpp */,
+				1AB2D36C1E16EB91007D0A3F /* thread_safe_reference.cpp */,
+				1AB2D36D1E16EB91007D0A3F /* thread_safe_reference.hpp */,
 			);
 			name = ObjectStore;
 			path = ObjectStore/src;
@@ -1101,14 +1023,11 @@
 			isa = PBXGroup;
 			children = (
 				1AA5AE9A1D98A1B000ED8C27 /* Object-Server-Tests-Bridging-Header.h */,
+				3F73BC871E3A876600FE80B6 /* ObjectServerTests-Info.plist */,
 				1AF64DCB1DA304210081EB15 /* RLMSyncManager+ObjectServerTests.h */,
 				1AF64DCC1DA304210081EB15 /* RLMSyncManager+ObjectServerTests.m */,
-				1AEC3E8E1E32EE8100E1EBE6 /* RLMSyncSessionRefreshHandle+ObjectServerTests.h */,
-				1AEC3E8F1E32EE8100E1EBE6 /* RLMSyncSessionRefreshHandle+ObjectServerTests.m */,
-				1A81EDEF1E30A4630035F4E6 /* RLMSyncUser+ObjectServerTests.h */,
-				1A81EDF01E30A4630035F4E6 /* RLMSyncUser+ObjectServerTests.mm */,
-				1AEC3E931E32EF5100E1EBE6 /* RLMTestUtils.h */,
-				1AEC3E941E32EF5100E1EBE6 /* RLMTestUtils.m */,
+				1AF64DD01DA304A90081EB15 /* RLMSyncUser+ObjectServerTests.h */,
+				1AF64DD11DA304A90081EB15 /* RLMSyncUser+ObjectServerTests.mm */,
 			);
 			name = Utility;
 			sourceTree = "<group>";
@@ -1118,15 +1037,14 @@
 			children = (
 				1AF6EA451D36B1850014EB85 /* RLMAuthResponseModel.h */,
 				1AF6EA461D36B1850014EB85 /* RLMAuthResponseModel.m */,
-				C2841D5A1DDC673300943503 /* RLMSyncErrorResponseModel.h */,
-				C2841D5B1DDC673300943503 /* RLMSyncErrorResponseModel.m */,
 				1AF7EA991D340E700001A9B5 /* RLMNetworkClient.h */,
 				1AF7EA9A1D340E700001A9B5 /* RLMNetworkClient.m */,
-				1A6921D11D779774004C3232 /* RLMTokenModels.h */,
-				1A6921D21D779774004C3232 /* RLMTokenModels.m */,
-				1AEC3E8D1E32EE0B00E1EBE6 /* RLMSyncSessionRefreshHandle.h */,
+				C2841D5A1DDC673300943503 /* RLMSyncErrorResponseModel.h */,
+				C2841D5B1DDC673300943503 /* RLMSyncErrorResponseModel.m */,
 				1A33C42C1DAEE445001E87AA /* RLMSyncSessionRefreshHandle.hpp */,
 				1A33C42D1DAEE445001E87AA /* RLMSyncSessionRefreshHandle.mm */,
+				1A6921D11D779774004C3232 /* RLMTokenModels.h */,
+				1A6921D21D779774004C3232 /* RLMTokenModels.m */,
 			);
 			name = Private;
 			sourceTree = "<group>";
@@ -1135,38 +1053,39 @@
 			isa = PBXGroup;
 			children = (
 				1AD3870E1D4A827C00479110 /* Private */,
+				3F73BC931E3A878500FE80B6 /* NSError+RLMSync.h */,
+				3F73BC941E3A878500FE80B6 /* NSError+RLMSync.m */,
 				1ABF256D1D52AB6200BAC441 /* RLMRealmConfiguration+Sync.h */,
 				1ABF256E1D52AB6200BAC441 /* RLMRealmConfiguration+Sync.mm */,
 				1A3623651D8384BA00945A54 /* RLMSyncConfiguration.h */,
+				1A3623661D8384BA00945A54 /* RLMSyncConfiguration.mm */,
 				1A36236A1D83868F00945A54 /* RLMSyncConfiguration_Private.h */,
 				1A4AC06D1D8BA86200DC9736 /* RLMSyncConfiguration_Private.hpp */,
-				1A3623661D8384BA00945A54 /* RLMSyncConfiguration.mm */,
 				1AAF4D1F1D66585B00058FAD /* RLMSyncCredentials.h */,
 				1AAF4D201D66585B00058FAD /* RLMSyncCredentials.m */,
 				1AF7EA941D340AF70001A9B5 /* RLMSyncManager.h */,
-				1AF7EA981D340D1F0001A9B5 /* RLMSyncManager_Private.h */,
 				1AF7EA951D340AF70001A9B5 /* RLMSyncManager.mm */,
+				1AF7EA981D340D1F0001A9B5 /* RLMSyncManager_Private.h */,
 				14C4B4371DC33481002FDEC8 /* RLMSyncPermissionChange.h */,
-				E8C6EAEF1DD65B8C00EC1A03 /* RLMSyncPermissionChange_Private.h */,
 				14C4B4381DC33481002FDEC8 /* RLMSyncPermissionChange.m */,
-				140CFE981DFABF5E006FB011 /* RLMSyncPermissionOffer.h */,
-				140CFE971DFABF5E006FB011 /* RLMSyncPermissionOffer_Private.h */,
-				140CFE991DFABF5E006FB011 /* RLMSyncPermissionOffer.m */,
-				140CFE9B1DFABF5E006FB011 /* RLMSyncPermissionOfferResponse.h */,
-				140CFE9A1DFABF5E006FB011 /* RLMSyncPermissionOfferResponse_Private.h */,
-				140CFE9C1DFABF5E006FB011 /* RLMSyncPermissionOfferResponse.m */,
+				E8C6EAEF1DD65B8C00EC1A03 /* RLMSyncPermissionChange_Private.h */,
+				3F0D873E1E2EEC4C008C92AC /* RLMSyncPermissionOffer.h */,
+				3F0D87411E2EEC4C008C92AC /* RLMSyncPermissionOffer.m */,
+				3F0D873D1E2EEC4C008C92AC /* RLMSyncPermissionOffer_Private.h */,
+				3F0D87401E2EEC4C008C92AC /* RLMSyncPermissionOfferResponse.h */,
+				3F0D87421E2EEC4C008C92AC /* RLMSyncPermissionOfferResponse.m */,
+				3F0D873F1E2EEC4C008C92AC /* RLMSyncPermissionOfferResponse_Private.h */,
 				1AD3870A1D4A7FBB00479110 /* RLMSyncSession.h */,
-				1ABF256A1D528B9900BAC441 /* RLMSyncSession_Private.hpp */,
 				1AD3870B1D4A7FBB00479110 /* RLMSyncSession.mm */,
+				1ABF256A1D528B9900BAC441 /* RLMSyncSession_Private.hpp */,
+				3F6468381E3A98B1007BD064 /* RLMSyncSessionRefreshHandle.h */,
 				1ABDCDAD1D792FEB003489E3 /* RLMSyncUser.h */,
-				1A33C42A1DAEB9C4001E87AA /* RLMSyncUser_Private.hpp */,
 				1ABDCDAF1D793008003489E3 /* RLMSyncUser.mm */,
+				1A33C42A1DAEB9C4001E87AA /* RLMSyncUser_Private.hpp */,
 				1A4FFC971D35A71000B4B65C /* RLMSyncUtil.h */,
+				1A84132E1D4BCCE600C5326F /* RLMSyncUtil.mm */,
 				1A1C6E241D3FFCF70077B6E7 /* RLMSyncUtil_Private.h */,
 				1A0512731D87413000806AEC /* RLMSyncUtil_Private.hpp */,
-				1A84132E1D4BCCE600C5326F /* RLMSyncUtil.mm */,
-				1A81EDE91E30872F0035F4E6 /* NSError+RLMSync.h */,
-				1A81EDEA1E30872F0035F4E6 /* NSError+RLMSync.m */,
 			);
 			name = Sync;
 			sourceTree = "<group>";
@@ -1204,8 +1123,8 @@
 				3F0543F61C56F78300AA5322 /* external_commit_helper.hpp */,
 				3F98019F1C8E4F55000A8B07 /* list_notifier.cpp */,
 				3F98019B1C8E4F55000A8B07 /* list_notifier.hpp */,
-				1A7AFA7A1E29B7F4002744FA /* object_notifier.cpp */,
-				1A7AFA7B1E29B7F4002744FA /* object_notifier.hpp */,
+				3FAB08861E1EC51F001BC8DA /* object_notifier.cpp */,
+				3FAB08851E1EC51F001BC8DA /* object_notifier.hpp */,
 				3F0543EA1C56F71500AA5322 /* realm_coordinator.cpp */,
 				3F0543E91C56F71500AA5322 /* realm_coordinator.hpp */,
 				3F9801AE1C90FD2D000A8B07 /* results_notifier.cpp */,
@@ -1280,7 +1199,7 @@
 				5D660FEF1BE98D670021E04F /* SortDescriptor.swift */,
 				E8BF67FB1C24D07100E591CD /* SwiftVersion.swift */,
 				1A7DE7021D38460B0029F0AE /* Sync.swift */,
-				D40BA0611D834CDE0041A9DF /* ThreadSafeReference.swift */,
+				3F222C4D1E26F51300CA0713 /* ThreadSafeReference.swift */,
 				5D660FF01BE98D670021E04F /* Util.swift */,
 			);
 			path = RealmSwift;
@@ -1295,10 +1214,10 @@
 				5D6610011BE98D880021E04F /* MigrationTests.swift */,
 				5D6610021BE98D880021E04F /* ObjectAccessorTests.swift */,
 				5D6610031BE98D880021E04F /* ObjectCreationTests.swift */,
+				5BC537151DD5B8D70055C524 /* ObjectiveCSupportTests.swift */,
 				5D6610041BE98D880021E04F /* ObjectSchemaInitializationTests.swift */,
 				5D6610051BE98D880021E04F /* ObjectSchemaTests.swift */,
 				5D6610061BE98D880021E04F /* ObjectTests.swift */,
-				5BC537151DD5B8D70055C524 /* ObjectiveCSupportTests.swift */,
 				5D6610071BE98D880021E04F /* PerformanceTests.swift */,
 				5D6610081BE98D880021E04F /* PropertyTests.swift */,
 				5D6610091BE98D880021E04F /* RealmCollectionTypeTests.swift */,
@@ -1310,9 +1229,9 @@
 				5D6610101BE98D880021E04F /* SwiftTestObjects.swift */,
 				5D6610111BE98D880021E04F /* SwiftUnicodeTests.swift */,
 				5D6610121BE98D880021E04F /* TestCase.swift */,
-				4D49AA791D837E6B003ED789 /* ThreadSafeReferenceTests.swift */,
 				5D6610131BE98D880021E04F /* TestUtils.h */,
 				5D6610141BE98D880021E04F /* TestUtils.mm */,
+				3F73BC841E3A870F00FE80B6 /* ThreadSafeReferenceTests.swift */,
 			);
 			name = "RealmSwift Tests";
 			path = RealmSwift/Tests;
@@ -1330,13 +1249,11 @@
 			isa = PBXGroup;
 			children = (
 				5D274C511D6D16BA006FEBB1 /* apple */,
-				5D02C7901E2E873F0048C13E /* aligned_union.hpp */,
 				5DB591A61D063DF8001D8F93 /* atomic_shared_ptr.hpp */,
 				5D5AF7FC1D3D8F9C003036AB /* compiler.hpp */,
 				5D274C4F1D6D16A8006FEBB1 /* event_loop_signal.hpp */,
 				5DB591A71D063DF8001D8F93 /* format.cpp */,
 				5DB591A81D063DF8001D8F93 /* format.hpp */,
-				5D02C7911E2E873F0048C13E /* time.hpp */,
 			);
 			path = util;
 			sourceTree = "<group>";
@@ -1395,7 +1312,6 @@
 				3F44109E19953F5900223146 /* RLMTestObjects.h */,
 				E81A1FC71955FE0100FDED82 /* RLMTestObjects.m */,
 				0207AB86195DFA15007EFB12 /* SchemaTests.mm */,
-				D43BAE431D8324FA002E0AEE /* ThreadSafeReferenceTests.m */,
 				E81A1FD11955FE0100FDED82 /* TransactionTests.m */,
 				E8917597197A1B350068ACC6 /* UnicodeTests.m */,
 				021A88311AAFB5BE00EEAC84 /* UtilTests.mm */,
@@ -1408,8 +1324,12 @@
 			children = (
 				1AA5AEA21D98CA5300ED8C27 /* Utility */,
 				E8267FF01D90B8E700E001C7 /* RLMObjectServerTests.m */,
+				3F73BC881E3A876600FE80B6 /* RLMSyncSessionRefreshHandle+ObjectServerTests.h */,
+				3F73BC891E3A876600FE80B6 /* RLMSyncSessionRefreshHandle+ObjectServerTests.m */,
 				1AA5AE9D1D98A6D800ED8C27 /* RLMSyncTestCase.h */,
 				1AA5AE9B1D98A68E00ED8C27 /* RLMSyncTestCase.m */,
+				3F73BC8A1E3A876600FE80B6 /* RLMTestUtils.h */,
+				3F73BC8B1E3A876600FE80B6 /* RLMTestUtils.m */,
 				1AA5AE9F1D98C99500ED8C27 /* SwiftObjectServerTests.swift */,
 				1AA5AE961D989BE000ED8C27 /* SwiftSyncTestCase.swift */,
 			);
@@ -1533,9 +1453,9 @@
 				3F4E324B1B98C6C700183A69 /* RLMSchema_Private.hpp */,
 				3FE79FF719BA6A5900780C9A /* RLMSwiftSupport.h */,
 				3F452EC519C2279800AFC154 /* RLMSwiftSupport.m */,
-				D41ABB811D80DC010031D38C /* RLMThreadSafeReference.h */,
-				D41ABB871D80DE1D0031D38C /* RLMThreadSafeReference_Private.hpp */,
-				D41ABB821D80DC010031D38C /* RLMThreadSafeReference.mm */,
+				3F67DB391E26D69C0024533D /* RLMThreadSafeReference.h */,
+				3F67DB3B1E26D69C0024533D /* RLMThreadSafeReference.mm */,
+				3F67DB3A1E26D69C0024533D /* RLMThreadSafeReference_Private.hpp */,
 				3F20DA2019BE1EA6007DE308 /* RLMUpdateChecker.hpp */,
 				3F20DA2119BE1EA6007DE308 /* RLMUpdateChecker.mm */,
 				E81A1F811955FC9300FDED82 /* RLMUtil.hpp */,
@@ -1586,80 +1506,32 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				140CFEA51DFABF5E006FB011 /* RLMSyncPermissionOfferResponse.h in Headers */,
-				5DB591A91D063DF8001D8F93 /* atomic_shared_ptr.hpp in Headers */,
-				5D659EA61BE04556006515A0 /* binding_context.hpp in Headers */,
-				3F7A3FB01CC6EB7300301A17 /* collection_change_builder.hpp in Headers */,
-				D41ABB881D80DE1D0031D38C /* RLMThreadSafeReference_Private.hpp in Headers */,
-				3F9801AA1C8E4F6B000A8B07 /* collection_notifications.hpp in Headers */,
-				E8C6EAF51DD66C0C00EC1A03 /* RLMSyncUtil_Private.h in Headers */,
-				3F9801A01C8E4F55000A8B07 /* collection_notifier.hpp in Headers */,
-				5D5AF7FD1D3D8F9C003036AB /* compiler.hpp in Headers */,
-				5D274C531D6D16BA006FEBB1 /* event_loop_signal.hpp in Headers */,
-				1A7AFA7D1E29B7F4002744FA /* object_notifier.hpp in Headers */,
-				5D02C7931E2E873F0048C13E /* time.hpp in Headers */,
-				5D274C501D6D16A8006FEBB1 /* event_loop_signal.hpp in Headers */,
-				5D659EA01BE04556006515A0 /* external_commit_helper.hpp in Headers */,
-				5D02C78F1E2E871F0048C13E /* object_accessor.hpp in Headers */,
-				1A7AFA741E29B756002744FA /* object.hpp in Headers */,
-				3F0543F81C56F78300AA5322 /* external_commit_helper.hpp in Headers */,
-				1A2713D31E3AD126001F6BFC /* RLMSyncManager_Private.h in Headers */,
-				1A1536591DB045B500C0EC93 /* sync_manager.hpp in Headers */,
-				5DB591AB1D063DF8001D8F93 /* format.hpp in Headers */,
-				5D659EA11BE04556006515A0 /* index_set.hpp in Headers */,
-				1A64CA8C1D8763B400BC0F9B /* keychain_helper.hpp in Headers */,
-				3F9026121C625C5D006AE98E /* list.hpp in Headers */,
-				3F9801A11C8E4F55000A8B07 /* list_notifier.hpp in Headers */,
-				5D659EA21BE04556006515A0 /* object_schema.hpp in Headers */,
-				5D659EA31BE04556006515A0 /* object_store.hpp in Headers */,
-				5D659EA41BE04556006515A0 /* property.hpp in Headers */,
+				3F73BC951E3A878500FE80B6 /* NSError+RLMSync.h in Headers */,
 				5D659EA51BE04556006515A0 /* Realm.h in Headers */,
-				140CFE9F1DFABF5E006FB011 /* RLMSyncPermissionOffer.h in Headers */,
-				3F0543EB1C56F71500AA5322 /* realm_coordinator.hpp in Headers */,
-				3F75566C1BE94CCC0058BC7E /* results.hpp in Headers */,
-				3F9801AF1C90FD2D000A8B07 /* results_notifier.hpp in Headers */,
 				5D659EA71BE04556006515A0 /* RLMAccessor.h in Headers */,
-				5D659EA81BE04556006515A0 /* RLMAnalytics.hpp in Headers */,
-				1A81EDEB1E30872F0035F4E6 /* NSError+RLMSync.h in Headers */,
 				5D659EA91BE04556006515A0 /* RLMArray.h in Headers */,
 				5D659EAA1BE04556006515A0 /* RLMArray_Private.h in Headers */,
-				3F9863BD1D36876B00641C98 /* RLMClassInfo.hpp in Headers */,
 				5D659EAB1BE04556006515A0 /* RLMCollection.h in Headers */,
 				5D659EAC1BE04556006515A0 /* RLMConstants.h in Headers */,
 				5D659EAE1BE04556006515A0 /* RLMListBase.h in Headers */,
 				5D659EAF1BE04556006515A0 /* RLMMigration.h in Headers */,
 				5D659EB01BE04556006515A0 /* RLMMigration_Private.h in Headers */,
 				5D659EB11BE04556006515A0 /* RLMObject.h in Headers */,
-				5D02C78E1E2E871F0048C13E /* execution_context_id.hpp in Headers */,
 				5D659EB21BE04556006515A0 /* RLMObject_Private.h in Headers */,
 				5D659EB31BE04556006515A0 /* RLMObjectBase.h in Headers */,
 				5D659EB41BE04556006515A0 /* RLMObjectBase_Dynamic.h in Headers */,
 				5D659EB51BE04556006515A0 /* RLMObjectSchema.h in Headers */,
-				D41ABB831D80DC010031D38C /* RLMThreadSafeReference.h in Headers */,
 				5D659EB61BE04556006515A0 /* RLMObjectSchema_Private.h in Headers */,
-				5D659EB71BE04556006515A0 /* RLMObjectSchema_Private.hpp in Headers */,
 				5D659EB81BE04556006515A0 /* RLMObjectStore.h in Headers */,
-				5D659EB91BE04556006515A0 /* RLMObservation.hpp in Headers */,
 				5D659EBA1BE04556006515A0 /* RLMOptionalBase.h in Headers */,
-				5D3E1A2E1C1FC6D5002913BA /* RLMPredicateUtil.hpp in Headers */,
 				5D659EBC1BE04556006515A0 /* RLMProperty.h in Headers */,
 				5D659EBD1BE04556006515A0 /* RLMProperty_Private.h in Headers */,
-				5D2E8F661C98DC0D00187B09 /* RLMProperty_Private.hpp in Headers */,
-				5D659EBE1BE04556006515A0 /* RLMQueryUtil.hpp in Headers */,
 				5D659EBF1BE04556006515A0 /* RLMRealm.h in Headers */,
-				14C4B43F1DC33481002FDEC8 /* RLMSyncPermissionChange.h in Headers */,
-				1AB2D36F1E16EB91007D0A3F /* thread_safe_reference.hpp in Headers */,
 				5D659EC01BE04556006515A0 /* RLMRealm_Dynamic.h in Headers */,
-				1A15365F1DB045B500C0EC93 /* sync_user.hpp in Headers */,
 				5D659EC11BE04556006515A0 /* RLMRealm_Private.h in Headers */,
 				1ABF256F1D52AB6200BAC441 /* RLMRealmConfiguration+Sync.h in Headers */,
 				5D659EC21BE04556006515A0 /* RLMRealmConfiguration.h in Headers */,
 				5D659EC31BE04556006515A0 /* RLMRealmConfiguration_Private.h in Headers */,
-				E86900E21CC04F5B0008A8B6 /* RLMRealmConfiguration_Private.hpp in Headers */,
-				1A33C42B1DAEB9C4001E87AA /* RLMSyncUser_Private.hpp in Headers */,
-				5D659EC41BE04556006515A0 /* RLMRealmUtil.hpp in Headers */,
-				5D02C7921E2E873F0048C13E /* aligned_union.hpp in Headers */,
-				1A15365D1DB045B500C0EC93 /* sync_session.hpp in Headers */,
 				5D659EC51BE04556006515A0 /* RLMResults.h in Headers */,
 				5D659EC61BE04556006515A0 /* RLMResults_Private.h in Headers */,
 				5D659EC71BE04556006515A0 /* RLMSchema.h in Headers */,
@@ -1669,16 +1541,14 @@
 				3F336E8B1DA2FA15006CB5A0 /* RLMSyncConfiguration_Private.h in Headers */,
 				1AAF4D211D66585B00058FAD /* RLMSyncCredentials.h in Headers */,
 				1AF7EA961D340AF70001A9B5 /* RLMSyncManager.h in Headers */,
+				14C4B43F1DC33481002FDEC8 /* RLMSyncPermissionChange.h in Headers */,
+				3F0D87441E2EEC4C008C92AC /* RLMSyncPermissionOffer.h in Headers */,
+				3F0D87461E2EEC4C008C92AC /* RLMSyncPermissionOfferResponse.h in Headers */,
 				1AD3870C1D4A7FBB00479110 /* RLMSyncSession.h in Headers */,
-				1A65BB351E26D4A400192C01 /* thread_safe_reference.hpp in Headers */,
 				1ABDCDAE1D792FEB003489E3 /* RLMSyncUser.h in Headers */,
 				1A4FFC991D35A71000B4B65C /* RLMSyncUtil.h in Headers */,
-				5D659ECA1BE04556006515A0 /* RLMUpdateChecker.hpp in Headers */,
-				1A1536551DB045B500C0EC93 /* sync_config.hpp in Headers */,
-				5D659ECB1BE04556006515A0 /* RLMUtil.hpp in Headers */,
-				5D659ECC1BE04556006515A0 /* schema.hpp in Headers */,
-				5D659ECD1BE04556006515A0 /* shared_realm.hpp in Headers */,
-				3F9801A31C8E4F55000A8B07 /* weak_realm_notifier.hpp in Headers */,
+				E8C6EAF51DD66C0C00EC1A03 /* RLMSyncUtil_Private.h in Headers */,
+				3F67DB3C1E26D69C0024533D /* RLMThreadSafeReference.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1693,64 +1563,34 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				5DD755A41BE056DE002800DA /* binding_context.hpp in Headers */,
-				3F7A3FB11CC6EB7300301A17 /* collection_change_builder.hpp in Headers */,
-				5DD7559E1BE056DE002800DA /* external_commit_helper.hpp in Headers */,
-				D41ABB891D80DE1D0031D38C /* RLMThreadSafeReference_Private.hpp in Headers */,
-				5DD7559F1BE056DE002800DA /* index_set.hpp in Headers */,
-				5DD755A01BE056DE002800DA /* object_schema.hpp in Headers */,
-				5DD755A11BE056DE002800DA /* object_store.hpp in Headers */,
-				140CFEA61DFABF5E006FB011 /* RLMSyncPermissionOfferResponse.h in Headers */,
-				5DD755A21BE056DE002800DA /* property.hpp in Headers */,
+				3F73BC971E3A879700FE80B6 /* NSError+RLMSync.h in Headers */,
 				5DD755A31BE056DE002800DA /* Realm.h in Headers */,
 				5DD755A51BE056DE002800DA /* RLMAccessor.h in Headers */,
-				5DD755A61BE056DE002800DA /* RLMAnalytics.hpp in Headers */,
-				1A7AFA7F1E29B7FA002744FA /* object_notifier.hpp in Headers */,
-				1A81EDED1E3087410035F4E6 /* NSError+RLMSync.h in Headers */,
 				5DD755A71BE056DE002800DA /* RLMArray.h in Headers */,
 				5DD755A81BE056DE002800DA /* RLMArray_Private.h in Headers */,
-				E8C6EAF41DD66C0C00EC1A03 /* RLMSyncUtil_Private.h in Headers */,
-				1A15366A1DB045D800C0EC93 /* sync_user.hpp in Headers */,
-				3F9863BE1D36876B00641C98 /* RLMClassInfo.hpp in Headers */,
 				5DD755A91BE056DE002800DA /* RLMCollection.h in Headers */,
 				5DD755AA1BE056DE002800DA /* RLMConstants.h in Headers */,
 				5DD755AC1BE056DE002800DA /* RLMListBase.h in Headers */,
-				1A7AFA761E29B75C002744FA /* object.hpp in Headers */,
 				5DD755AD1BE056DE002800DA /* RLMMigration.h in Headers */,
-				1A65BB1E1E202E7000192C01 /* thread_safe_reference.hpp in Headers */,
 				5DD755AE1BE056DE002800DA /* RLMMigration_Private.h in Headers */,
 				5DD755AF1BE056DE002800DA /* RLMObject.h in Headers */,
 				5DD755B01BE056DE002800DA /* RLMObject_Private.h in Headers */,
 				5DD755B11BE056DE002800DA /* RLMObjectBase.h in Headers */,
 				5DD755B21BE056DE002800DA /* RLMObjectBase_Dynamic.h in Headers */,
 				5DD755B31BE056DE002800DA /* RLMObjectSchema.h in Headers */,
-				1A1536601DB045C400C0EC93 /* sync_config.hpp in Headers */,
 				5DD755B41BE056DE002800DA /* RLMObjectSchema_Private.h in Headers */,
-				5DD755B51BE056DE002800DA /* RLMObjectSchema_Private.hpp in Headers */,
 				5DD755B61BE056DE002800DA /* RLMObjectStore.h in Headers */,
-				5DD755B71BE056DE002800DA /* RLMObservation.hpp in Headers */,
 				5DD755B81BE056DE002800DA /* RLMOptionalBase.h in Headers */,
-				5D3E1A311C1FD1D2002913BA /* RLMPredicateUtil.hpp in Headers */,
-				14C4B4401DC33481002FDEC8 /* RLMSyncPermissionChange.h in Headers */,
 				5DD755BA1BE056DE002800DA /* RLMProperty.h in Headers */,
-				140CFEA01DFABF5E006FB011 /* RLMSyncPermissionOffer.h in Headers */,
-				1A1536681DB045D400C0EC93 /* sync_session.hpp in Headers */,
 				5DD755BB1BE056DE002800DA /* RLMProperty_Private.h in Headers */,
-				5D2E8F671C98DC0D00187B09 /* RLMProperty_Private.hpp in Headers */,
-				5DD755BC1BE056DE002800DA /* RLMQueryUtil.hpp in Headers */,
-				D41ABB841D80DC010031D38C /* RLMThreadSafeReference.h in Headers */,
 				5DD755BD1BE056DE002800DA /* RLMRealm.h in Headers */,
 				5DD755BE1BE056DE002800DA /* RLMRealm_Dynamic.h in Headers */,
 				5DD755BF1BE056DE002800DA /* RLMRealm_Private.h in Headers */,
 				1AFEF8421D52CD8F00495005 /* RLMRealmConfiguration+Sync.h in Headers */,
 				5DD755C01BE056DE002800DA /* RLMRealmConfiguration.h in Headers */,
-				1A65BB371E26D4A900192C01 /* thread_safe_reference.hpp in Headers */,
 				5DD755C11BE056DE002800DA /* RLMRealmConfiguration_Private.h in Headers */,
-				E86900E31CC04F5B0008A8B6 /* RLMRealmConfiguration_Private.hpp in Headers */,
-				5DD755C21BE056DE002800DA /* RLMRealmUtil.hpp in Headers */,
 				5DD755C31BE056DE002800DA /* RLMResults.h in Headers */,
 				5DD755C41BE056DE002800DA /* RLMResults_Private.h in Headers */,
-				1A2713D41E3AD126001F6BFC /* RLMSyncManager_Private.h in Headers */,
 				5DD755C51BE056DE002800DA /* RLMSchema.h in Headers */,
 				5DD755C61BE056DE002800DA /* RLMSchema_Private.h in Headers */,
 				5DD755C71BE056DE002800DA /* RLMSwiftSupport.h in Headers */,
@@ -1758,14 +1598,21 @@
 				3F336E8A1DA2FA14006CB5A0 /* RLMSyncConfiguration_Private.h in Headers */,
 				1AAF4D231D665B2A00058FAD /* RLMSyncCredentials.h in Headers */,
 				1A7DE7071D38474F0029F0AE /* RLMSyncManager.h in Headers */,
-				1A1536641DB045CD00C0EC93 /* sync_manager.hpp in Headers */,
+				14C4B4401DC33481002FDEC8 /* RLMSyncPermissionChange.h in Headers */,
+				3F0D874A1E2EEC57008C92AC /* RLMSyncPermissionOffer.h in Headers */,
+				3F0D874C1E2EEC57008C92AC /* RLMSyncPermissionOfferResponse.h in Headers */,
 				1A7003111D5270FF00FD9EE3 /* RLMSyncSession.h in Headers */,
 				1ABDCDB11D793012003489E3 /* RLMSyncUser.h in Headers */,
 				1A7DE70B1D3847670029F0AE /* RLMSyncUtil.h in Headers */,
-				5DD755C81BE056DE002800DA /* RLMUpdateChecker.hpp in Headers */,
-				5DD755C91BE056DE002800DA /* RLMUtil.hpp in Headers */,
-				5DD755CA1BE056DE002800DA /* schema.hpp in Headers */,
-				5DD755CB1BE056DE002800DA /* shared_realm.hpp in Headers */,
+				E8C6EAF41DD66C0C00EC1A03 /* RLMSyncUtil_Private.h in Headers */,
+				3F67DB401E26D6A20024533D /* RLMThreadSafeReference.h in Headers */,
+				3FAB084A1E1EC3A2001BC8DA /* sync_client.hpp in Headers */,
+				1A1536601DB045C400C0EC93 /* sync_config.hpp in Headers */,
+				3FAB084B1E1EC3A2001BC8DA /* sync_file.hpp in Headers */,
+				1A1536641DB045CD00C0EC93 /* sync_manager.hpp in Headers */,
+				3FAB084C1E1EC3A2001BC8DA /* sync_metadata.hpp in Headers */,
+				1A1536681DB045D400C0EC93 /* sync_session.hpp in Headers */,
+				1A15366A1DB045D800C0EC93 /* sync_user.hpp in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2269,15 +2116,14 @@
 				5DB591AA1D063DF8001D8F93 /* format.cpp in Sources */,
 				5D659E821BE04556006515A0 /* index_set.cpp in Sources */,
 				1A64CA8B1D8763B400BC0F9B /* keychain_helper.cpp in Sources */,
-				C2841D5E1DDC673400943503 /* RLMSyncErrorResponseModel.m in Sources */,
-				14C4B4411DC33481002FDEC8 /* RLMSyncPermissionChange.m in Sources */,
 				3F9026111C625C5D006AE98E /* list.cpp in Sources */,
 				3F9801A51C8E4F55000A8B07 /* list_notifier.cpp in Sources */,
+				3F73BC961E3A878500FE80B6 /* NSError+RLMSync.m in Sources */,
+				3FAB08481E1EC382001BC8DA /* object.cpp in Sources */,
+				3FAB08881E1EC51F001BC8DA /* object_notifier.cpp in Sources */,
 				5D659E831BE04556006515A0 /* object_schema.cpp in Sources */,
 				5D659E841BE04556006515A0 /* object_store.cpp in Sources */,
-				1A81EDEC1E30872F0035F4E6 /* NSError+RLMSync.m in Sources */,
 				3F0543EC1C56F71500AA5322 /* realm_coordinator.cpp in Sources */,
-				1A7AFA731E29B756002744FA /* object.cpp in Sources */,
 				3F75566B1BE94CCC0058BC7E /* results.cpp in Sources */,
 				3F9801B01C90FD2D000A8B07 /* results_notifier.cpp in Sources */,
 				5D659E851BE04556006515A0 /* RLMAccessor.mm in Sources */,
@@ -2296,39 +2142,40 @@
 				5D659E8E1BE04556006515A0 /* RLMObjectSchema.mm in Sources */,
 				5D659E8F1BE04556006515A0 /* RLMObjectStore.mm in Sources */,
 				5D659E901BE04556006515A0 /* RLMObservation.mm in Sources */,
-				1A1536741DB0464800C0EC93 /* sync_metadata.cpp in Sources */,
-				140CFEA71DFABF5E006FB011 /* RLMSyncPermissionOfferResponse.m in Sources */,
 				5D659E911BE04556006515A0 /* RLMOptionalBase.mm in Sources */,
-				1A15365C1DB045B500C0EC93 /* sync_session.cpp in Sources */,
 				5D3E1A2F1C1FC6D5002913BA /* RLMPredicateUtil.mm in Sources */,
 				5D659E921BE04556006515A0 /* RLMProperty.mm in Sources */,
 				5D659E931BE04556006515A0 /* RLMQueryUtil.mm in Sources */,
 				5D659E941BE04556006515A0 /* RLMRealm.mm in Sources */,
 				1ABF25701D52AB6200BAC441 /* RLMRealmConfiguration+Sync.mm in Sources */,
 				5D659E951BE04556006515A0 /* RLMRealmConfiguration.mm in Sources */,
-				1A65BB341E26D4A400192C01 /* thread_safe_reference.cpp in Sources */,
 				5D659E961BE04556006515A0 /* RLMRealmUtil.mm in Sources */,
 				5D659E971BE04556006515A0 /* RLMResults.mm in Sources */,
-				140CFEA11DFABF5E006FB011 /* RLMSyncPermissionOffer.m in Sources */,
 				5D659E981BE04556006515A0 /* RLMSchema.mm in Sources */,
 				5D659E991BE04556006515A0 /* RLMSwiftSupport.m in Sources */,
-				1A33C4301DAEE445001E87AA /* RLMSyncSessionRefreshHandle.mm in Sources */,
-				1A1536721DB0464800C0EC93 /* sync_file.cpp in Sources */,
 				1A3623681D8384BA00945A54 /* RLMSyncConfiguration.mm in Sources */,
-				1A7AFA7C1E29B7F4002744FA /* object_notifier.cpp in Sources */,
 				1AAF4D221D66585B00058FAD /* RLMSyncCredentials.m in Sources */,
+				C2841D5E1DDC673400943503 /* RLMSyncErrorResponseModel.m in Sources */,
 				1AF7EA971D340AF70001A9B5 /* RLMSyncManager.mm in Sources */,
+				14C4B4411DC33481002FDEC8 /* RLMSyncPermissionChange.m in Sources */,
+				3F0D87471E2EEC4C008C92AC /* RLMSyncPermissionOffer.m in Sources */,
+				3F0D87481E2EEC4C008C92AC /* RLMSyncPermissionOfferResponse.m in Sources */,
 				1AD3870D1D4A7FBB00479110 /* RLMSyncSession.mm in Sources */,
-				1A15365E1DB045B500C0EC93 /* sync_user.cpp in Sources */,
+				1A33C4301DAEE445001E87AA /* RLMSyncSessionRefreshHandle.mm in Sources */,
 				1ABDCDB01D793008003489E3 /* RLMSyncUser.mm in Sources */,
 				1A84132F1D4BCCE600C5326F /* RLMSyncUtil.mm in Sources */,
+				3F67DB3E1E26D69C0024533D /* RLMThreadSafeReference.mm in Sources */,
 				1A6921D41D779774004C3232 /* RLMTokenModels.m in Sources */,
 				5D659E9A1BE04556006515A0 /* RLMUpdateChecker.mm in Sources */,
 				5D659E9B1BE04556006515A0 /* RLMUtil.mm in Sources */,
 				5D659E9C1BE04556006515A0 /* schema.cpp in Sources */,
-				1A1536581DB045B500C0EC93 /* sync_manager.cpp in Sources */,
 				5D659E9D1BE04556006515A0 /* shared_realm.cpp in Sources */,
-				D41ABB851D80DC010031D38C /* RLMThreadSafeReference.mm in Sources */,
+				1A1536721DB0464800C0EC93 /* sync_file.cpp in Sources */,
+				1A1536581DB045B500C0EC93 /* sync_manager.cpp in Sources */,
+				1A1536741DB0464800C0EC93 /* sync_metadata.cpp in Sources */,
+				1A15365C1DB045B500C0EC93 /* sync_session.cpp in Sources */,
+				1A15365E1DB045B500C0EC93 /* sync_user.cpp in Sources */,
+				1AB2D36E1E16EB91007D0A3F /* thread_safe_reference.cpp in Sources */,
 				5D659E9E1BE04556006515A0 /* transact_log_handler.cpp in Sources */,
 				5D274C4D1D6D15D2006FEBB1 /* weak_realm_notifier.cpp in Sources */,
 			);
@@ -2344,7 +2191,7 @@
 				5D660FF21BE98D670021E04F /* List.swift in Sources */,
 				5D660FF31BE98D670021E04F /* Migration.swift in Sources */,
 				5D660FF41BE98D670021E04F /* Object.swift in Sources */,
-				D40BA0621D834CDE0041A9DF /* ThreadSafeReference.swift in Sources */,
+				5B77EACE1DCC5614006AB51D /* ObjectiveCSupport.swift in Sources */,
 				5D660FF51BE98D670021E04F /* ObjectSchema.swift in Sources */,
 				5D660FF61BE98D670021E04F /* Optional.swift in Sources */,
 				5D660FF71BE98D670021E04F /* Property.swift in Sources */,
@@ -2354,9 +2201,9 @@
 				5D660FFB1BE98D670021E04F /* Results.swift in Sources */,
 				5D660FFC1BE98D670021E04F /* Schema.swift in Sources */,
 				5D660FFD1BE98D670021E04F /* SortDescriptor.swift in Sources */,
-				5B77EACE1DCC5614006AB51D /* ObjectiveCSupport.swift in Sources */,
 				E8BF67FC1C24D07100E591CD /* SwiftVersion.swift in Sources */,
 				1AFEF8431D52D2C900495005 /* Sync.swift in Sources */,
+				3F222C4E1E26F51300CA0713 /* ThreadSafeReference.swift in Sources */,
 				5D660FFE1BE98D670021E04F /* Util.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -2370,13 +2217,12 @@
 				5D6610171BE98D880021E04F /* MigrationTests.swift in Sources */,
 				5D6610181BE98D880021E04F /* ObjectAccessorTests.swift in Sources */,
 				5D6610191BE98D880021E04F /* ObjectCreationTests.swift in Sources */,
+				5BC537161DD5B8D70055C524 /* ObjectiveCSupportTests.swift in Sources */,
 				5D66101A1BE98D880021E04F /* ObjectSchemaInitializationTests.swift in Sources */,
 				5D66101B1BE98D880021E04F /* ObjectSchemaTests.swift in Sources */,
 				5D66101C1BE98D880021E04F /* ObjectTests.swift in Sources */,
-				4D49AA7B1D837EF8003ED789 /* ThreadSafeReferenceTests.swift in Sources */,
 				5D66101D1BE98D880021E04F /* PerformanceTests.swift in Sources */,
 				5D66101E1BE98D880021E04F /* PropertyTests.swift in Sources */,
-				5BC537161DD5B8D70055C524 /* ObjectiveCSupportTests.swift in Sources */,
 				5D66101F1BE98D880021E04F /* RealmCollectionTypeTests.swift in Sources */,
 				5D6610201BE98D880021E04F /* RealmConfigurationTests.swift in Sources */,
 				5D6610211BE98D880021E04F /* RealmTests.swift in Sources */,
@@ -2387,6 +2233,7 @@
 				5D6610261BE98D880021E04F /* SwiftUnicodeTests.swift in Sources */,
 				5D6610271BE98D880021E04F /* TestCase.swift in Sources */,
 				5D6610281BE98D880021E04F /* TestUtils.mm in Sources */,
+				3F73BC861E3A871B00FE80B6 /* ThreadSafeReferenceTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2401,19 +2248,17 @@
 				5DB591AC1D0775D2001D8F93 /* format.cpp in Sources */,
 				5DD755801BE056DE002800DA /* index_set.cpp in Sources */,
 				E8FD2E381D93345100569F10 /* keychain_helper.cpp in Sources */,
-				C2841D5F1DDC673400943503 /* RLMSyncErrorResponseModel.m in Sources */,
-				14C4B4421DC33481002FDEC8 /* RLMSyncPermissionChange.m in Sources */,
 				3F9026131C625C63006AE98E /* list.cpp in Sources */,
 				3F9801A71C8E4F5A000A8B07 /* list_notifier.cpp in Sources */,
+				3F73BC981E3A879E00FE80B6 /* NSError+RLMSync.m in Sources */,
+				3FAB08491E1EC385001BC8DA /* object.cpp in Sources */,
+				3FAB08891E1EC526001BC8DA /* object_notifier.cpp in Sources */,
 				5DD755811BE056DE002800DA /* object_schema.cpp in Sources */,
 				5DD755821BE056DE002800DA /* object_store.cpp in Sources */,
-				1A81EDEE1E3087410035F4E6 /* NSError+RLMSync.m in Sources */,
 				3F0543ED1C56F71900AA5322 /* realm_coordinator.cpp in Sources */,
-				1A7AFA751E29B75C002744FA /* object.cpp in Sources */,
 				3F75566D1BE94CEA0058BC7E /* results.cpp in Sources */,
 				3F9801B11C90FD31000A8B07 /* results_notifier.cpp in Sources */,
 				5DD755831BE056DE002800DA /* RLMAccessor.mm in Sources */,
-				1A33C4311DAEE445001E87AA /* RLMSyncSessionRefreshHandle.mm in Sources */,
 				5DD755841BE056DE002800DA /* RLMAnalytics.mm in Sources */,
 				5DD755851BE056DE002800DA /* RLMArray.mm in Sources */,
 				5DD755861BE056DE002800DA /* RLMArrayLinkView.mm in Sources */,
@@ -2428,39 +2273,41 @@
 				5DD7558B1BE056DE002800DA /* RLMObjectBase.mm in Sources */,
 				5DD7558C1BE056DE002800DA /* RLMObjectSchema.mm in Sources */,
 				5DD7558D1BE056DE002800DA /* RLMObjectStore.mm in Sources */,
-				1A1536771DB0465400C0EC93 /* sync_metadata.cpp in Sources */,
-				140CFEA81DFABF5E006FB011 /* RLMSyncPermissionOfferResponse.m in Sources */,
 				5DD7558E1BE056DE002800DA /* RLMObservation.mm in Sources */,
-				1A1536671DB045D200C0EC93 /* sync_session.cpp in Sources */,
 				5DD7558F1BE056DE002800DA /* RLMOptionalBase.mm in Sources */,
 				5D3E1A301C1FD1CF002913BA /* RLMPredicateUtil.mm in Sources */,
 				5DD755901BE056DE002800DA /* RLMProperty.mm in Sources */,
 				5DD755911BE056DE002800DA /* RLMQueryUtil.mm in Sources */,
 				5DD755921BE056DE002800DA /* RLMRealm.mm in Sources */,
 				1AFEF8411D52CD8D00495005 /* RLMRealmConfiguration+Sync.mm in Sources */,
-				1A65BB361E26D4A900192C01 /* thread_safe_reference.cpp in Sources */,
 				5DD755931BE056DE002800DA /* RLMRealmConfiguration.mm in Sources */,
 				5DD755941BE056DE002800DA /* RLMRealmUtil.mm in Sources */,
-				140CFEA21DFABF5E006FB011 /* RLMSyncPermissionOffer.m in Sources */,
 				5DD755951BE056DE002800DA /* RLMResults.mm in Sources */,
 				5DD755961BE056DE002800DA /* RLMSchema.mm in Sources */,
 				5DD755971BE056DE002800DA /* RLMSwiftSupport.m in Sources */,
-				1A1536761DB0464F00C0EC93 /* sync_file.cpp in Sources */,
 				1A0512721D873F3300806AEC /* RLMSyncConfiguration.mm in Sources */,
-				1A7AFA7E1E29B7FA002744FA /* object_notifier.cpp in Sources */,
 				17051FD01D93E0CC00EF8E67 /* RLMSyncCredentials.m in Sources */,
+				C2841D5F1DDC673400943503 /* RLMSyncErrorResponseModel.m in Sources */,
 				1A90FCBB1D3D37F50086A57F /* RLMSyncManager.mm in Sources */,
+				14C4B4421DC33481002FDEC8 /* RLMSyncPermissionChange.m in Sources */,
+				3F0D874D1E2EEC57008C92AC /* RLMSyncPermissionOffer.m in Sources */,
+				3F0D874E1E2EEC57008C92AC /* RLMSyncPermissionOfferResponse.m in Sources */,
 				1A7003081D5270C400FD9EE3 /* RLMSyncSession.mm in Sources */,
+				1A33C4311DAEE445001E87AA /* RLMSyncSessionRefreshHandle.mm in Sources */,
 				17051FCE1D93DA0A00EF8E67 /* RLMSyncUser.mm in Sources */,
-				1A1536691DB045D600C0EC93 /* sync_user.cpp in Sources */,
 				1A7003091D5270C700FD9EE3 /* RLMSyncUtil.mm in Sources */,
+				3F67DB411E26D6AD0024533D /* RLMThreadSafeReference.mm in Sources */,
 				17051FCF1D93E05D00EF8E67 /* RLMTokenModels.m in Sources */,
 				5DD755981BE056DE002800DA /* RLMUpdateChecker.mm in Sources */,
 				5DD755991BE056DE002800DA /* RLMUtil.mm in Sources */,
 				5DD7559A1BE056DE002800DA /* schema.cpp in Sources */,
 				5DD7559B1BE056DE002800DA /* shared_realm.cpp in Sources */,
+				1A1536761DB0464F00C0EC93 /* sync_file.cpp in Sources */,
 				1A1536631DB045CB00C0EC93 /* sync_manager.cpp in Sources */,
-				D41ABB861D80DC010031D38C /* RLMThreadSafeReference.mm in Sources */,
+				1A1536771DB0465400C0EC93 /* sync_metadata.cpp in Sources */,
+				1A1536671DB045D200C0EC93 /* sync_session.cpp in Sources */,
+				1A1536691DB045D600C0EC93 /* sync_user.cpp in Sources */,
+				3F6468371E3A9363007BD064 /* thread_safe_reference.cpp in Sources */,
 				5DD7559C1BE056DE002800DA /* transact_log_handler.cpp in Sources */,
 				5D274C4E1D6D15FD006FEBB1 /* weak_realm_notifier.cpp in Sources */,
 			);
@@ -2470,16 +2317,16 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				1A2D7A521DA5BCEC006AD7D6 /* RLMMultiProcessTestCase.m in Sources */,
 				E8267FF11D90B8E700E001C7 /* RLMObjectServerTests.m in Sources */,
+				1AF64DCF1DA3042B0081EB15 /* RLMSyncManager+ObjectServerTests.m in Sources */,
+				3F73BC911E3A877300FE80B6 /* RLMSyncSessionRefreshHandle+ObjectServerTests.m in Sources */,
+				1AA5AE9C1D98A68E00ED8C27 /* RLMSyncTestCase.m in Sources */,
+				1A1536481DB0408A00C0EC93 /* RLMSyncUser+ObjectServerTests.mm in Sources */,
+				E86E61241D91E4E200DC2419 /* RLMTestCase.m in Sources */,
+				3F73BC921E3A877300FE80B6 /* RLMTestUtils.m in Sources */,
 				1AA5AEA11D98C99800ED8C27 /* SwiftObjectServerTests.swift in Sources */,
 				1AA5AE981D989BE400ED8C27 /* SwiftSyncTestCase.swift in Sources */,
-				1AEC3E921E32EE8800E1EBE6 /* RLMSyncSessionRefreshHandle+ObjectServerTests.m in Sources */,
-				E86E61241D91E4E200DC2419 /* RLMTestCase.m in Sources */,
-				1AF64DCF1DA3042B0081EB15 /* RLMSyncManager+ObjectServerTests.m in Sources */,
-				1A2D7A521DA5BCEC006AD7D6 /* RLMMultiProcessTestCase.m in Sources */,
-				1A81EDF31E30A4780035F4E6 /* RLMSyncUser+ObjectServerTests.mm in Sources */,
-				1AA5AE9C1D98A68E00ED8C27 /* RLMSyncTestCase.m in Sources */,
-				1AEC3E971E32F03100E1EBE6 /* RLMTestUtils.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2501,15 +2348,14 @@
 				021A88371AAFB5CE00EEAC84 /* ObjectSchemaTests.m in Sources */,
 				E856D21B195615A900FB2FCF /* ObjectTests.m in Sources */,
 				5D6156FB1BE08E7E00A4BD3F /* PerformanceTests.m in Sources */,
+				5D03FB201E0DAFBA007D53EA /* PredicateUtilTests.mm in Sources */,
 				02AFB4641A80343600E11938 /* PropertyTests.m in Sources */,
 				E856D21C195615A900FB2FCF /* PropertyTypeTest.mm in Sources */,
 				E856D21D195615A900FB2FCF /* QueryTests.m in Sources */,
 				C042A48E1B7522A900771ED2 /* RealmConfigurationTests.mm in Sources */,
-				D43BAE451D83250F002E0AEE /* ThreadSafeReferenceTests.m in Sources */,
 				E856D21E195615A900FB2FCF /* RealmTests.mm in Sources */,
 				02AFB4681A80343600E11938 /* ResultsTests.m in Sources */,
 				3FC767071BB9FE7500FE0AFC /* RLMMultiProcessTestCase.m in Sources */,
-				5D03FB201E0DAFBA007D53EA /* PredicateUtilTests.mm in Sources */,
 				3FDE338D19C39A87003B7DBA /* RLMSupport.swift in Sources */,
 				E856D21F195615B100FB2FCF /* RLMTestCase.m in Sources */,
 				028481CB19CCFC9C0097A416 /* RLMTestObjects.m in Sources */,
@@ -2533,7 +2379,6 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				5D03FB1F1E0DAFBA007D53EA /* PredicateUtilTests.mm in Sources */,
 				E81A1FD51955FE0100FDED82 /* ArrayPropertyTests.m in Sources */,
 				3F7556751BE95A0C0058BC7E /* AsyncTests.mm in Sources */,
 				02E334C31A5F41C7009F8810 /* DynamicTests.m in Sources */,
@@ -2548,6 +2393,7 @@
 				E81A1FE11955FE0100FDED82 /* ObjectInterfaceTests.m in Sources */,
 				021A88361AAFB5CD00EEAC84 /* ObjectSchemaTests.m in Sources */,
 				E81A1FE31955FE0100FDED82 /* ObjectTests.m in Sources */,
+				5D03FB1F1E0DAFBA007D53EA /* PredicateUtilTests.mm in Sources */,
 				02AFB4631A80343600E11938 /* PropertyTests.m in Sources */,
 				E81A1FE51955FE0100FDED82 /* PropertyTypeTest.mm in Sources */,
 				E81A1FE71955FE0100FDED82 /* QueryTests.m in Sources */,
@@ -2558,7 +2404,6 @@
 				3FDCFEB619F6A8D3005E414A /* RLMSupport.swift in Sources */,
 				E81A1FEE1955FE0100FDED82 /* RLMTestCase.m in Sources */,
 				297FBEFB1C19F696009D1118 /* RLMTestCaseUtils.swift in Sources */,
-				D43BAE441D8324FA002E0AEE /* ThreadSafeReferenceTests.m in Sources */,
 				028481EF19CD032C0097A416 /* RLMTestObjects.m in Sources */,
 				0207AB89195DFA15007EFB12 /* SchemaTests.mm in Sources */,
 				3FB4FA1819F5D2740020D53B /* SwiftArrayPropertyTests.swift in Sources */,

--- a/Realm/ObjectServerTests/RLMSyncManager+ObjectServerTests.m
+++ b/Realm/ObjectServerTests/RLMSyncManager+ObjectServerTests.m
@@ -16,7 +16,7 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-#import <Realm/RLMSyncManager_Private.h>
+#import "RLMSyncManager_Private.h"
 #import "RLMSyncManager+ObjectServerTests.h"
 #import "RLMSyncTestCase.h"
 #import "RLMTestUtils.h"

--- a/Realm/RLMObject.h
+++ b/Realm/RLMObject.h
@@ -23,10 +23,12 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+@class RLMNotificationToken;
+@class RLMObjectSchema;
+@class RLMPropertyChange;
 @class RLMPropertyDescriptor;
 @class RLMRealm;
 @class RLMResults;
-@class RLMObjectSchema;
 
 /**
  `RLMObject` is a base class for model objects representing data stored in Realms.
@@ -39,13 +41,13 @@ NS_ASSUME_NONNULL_BEGIN
      @property NSString *name;
      @property BOOL      adopted;
      @end
- 
+
      // Dog.m
      @implementation Dog
      @end //none needed
- 
+
  ### Supported property types
- 
+
  - `NSString`
  - `NSInteger`, `int`, `long`, `float`, and `double`
  - `BOOL` or `bool`
@@ -56,17 +58,17 @@ NS_ASSUME_NONNULL_BEGIN
  - `RLMArray<X>`, where `X` is an `RLMObject` subclass, to model many-to-many relationships.
 
  ### Querying
- 
+
  You can initiate queries directly via the class methods: `allObjects`, `objectsWhere:`, and `objectsWithPredicate:`.
  These methods allow you to easily query a custom subclass for instances of that class in the default Realm.
- 
+
  To search in a Realm other than the default Realm, use the `allObjectsInRealm:`, `objectsInRealm:where:`,
  and `objectsInRealm:withPredicate:` class methods.
- 
+
  @see `RLMRealm`
- 
+
  ### Relationships
- 
+
  See our [Cocoa guide](https://realm.io/docs/objc/latest#relationships) for more details.
 
  ### Key-Value Observing
@@ -74,7 +76,7 @@ NS_ASSUME_NONNULL_BEGIN
  All `RLMObject` properties (including properties you create in subclasses) are
  [Key-Value Observing compliant](https://developer.apple.com/library/mac/documentation/Cocoa/Conceptual/KeyValueObserving/KeyValueObserving.html),
  except for `realm` and `objectSchema`.
- 
+
  Keep the following tips in mind when observing Realm objects:
 
  1. Unlike `NSMutableArray` properties, `RLMArray` properties do not require
@@ -100,7 +102,7 @@ NS_ASSUME_NONNULL_BEGIN
  Creates an unmanaged instance of a Realm object.
 
  Call `addObject:` on an `RLMRealm` instance to add an unmanaged object into that Realm.
- 
+
  @see `[RLMRealm addObject:]`
  */
 - (instancetype)init NS_DESIGNATED_INITIALIZER;
@@ -108,11 +110,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  Creates an unmanaged instance of a Realm object.
- 
+
  Pass in an `NSArray` or `NSDictionary` instance to set the values of the object's properties.
 
  Call `addObject:` on an `RLMRealm` instance to add an unmanaged object into that Realm.
- 
+
  @see `[RLMRealm addObject:]`
  */
 - (instancetype)initWithValue:(id)value NS_DESIGNATED_INITIALIZER;
@@ -123,17 +125,17 @@ NS_ASSUME_NONNULL_BEGIN
 
  @warning Do not override. Realm relies on this method returning the exact class
           name.
- 
+
  @return  The class name for the model class.
  */
 + (NSString *)className;
 
 /**
  Creates an instance of a Realm object with a given value, and adds it to the default Realm.
- 
+
  If nested objects are included in the argument, `createInDefaultRealmWithValue:` will be recursively called
  on them.
- 
+
  The `value` argument can be a key-value coding compliant object, an array or dictionary returned from the methods in
  `NSJSONSerialization`, or an array containing one element for each managed property. An exception will be thrown if
  any required properties are not present and those properties were not defined with default values.
@@ -149,10 +151,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  Creates an instance of a Realm object with a given value, and adds it to the specified Realm.
- 
+
  If nested objects are included in the argument, `createInRealm:withValue:` will be recursively called
  on them.
- 
+
  The `value` argument can be a key-value coding compliant object, an array or dictionary returned from the methods in
  `NSJSONSerialization`, or an array containing one element for each managed property. An exception will be thrown if any
  required properties are not present and those properties were not defined with default values.
@@ -173,13 +175,13 @@ NS_ASSUME_NONNULL_BEGIN
  This method may only be called on Realm object types with a primary key defined. If there is already
  an object with the same primary key value in the default Realm, its values are updated and the object
  is returned. Otherwise, this method creates and populates a new instance of the object in the default Realm.
- 
+
  If nested objects are included in the argument, `createOrUpdateInDefaultRealmWithValue:` will be
  recursively called on them if they have primary keys, `createInDefaultRealmWithValue:` if they do not.
 
  If the argument is a Realm object already managed by the default Realm, the argument's type is the same
  as the receiver, and the objects have identical values for their managed properties, this method does nothing.
- 
+
  The `value` argument is used to populate the object. It can be a key-value coding compliant object, an array or
  dictionary returned from the methods in `NSJSONSerialization`, or an array containing one element for each managed
  property. An exception will be thrown if any required properties are not present and those properties were not defined
@@ -200,13 +202,13 @@ NS_ASSUME_NONNULL_BEGIN
  This method may only be called on Realm object types with a primary key defined. If there is already
  an object with the same primary key value in the given Realm, its values are updated and the object
  is returned. Otherwise this method creates and populates a new instance of this object in the given Realm.
- 
+
  If nested objects are included in the argument, `createOrUpdateInRealm:withValue:` will be
  recursively called on them if they have primary keys, `createInRealm:withValue:` if they do not.
 
  If the argument is a Realm object already managed by the given Realm, the argument's type is the same
  as the receiver, and the objects have identical values for their managed properties, this method does nothing.
- 
+
  The `value` argument is used to populate the object. It can be a key-value coding compliant object, an array or
  dictionary returned from the methods in `NSJSONSerialization`, or an array containing one element for each managed
  property. An exception will be thrown if any required properties are not present and those properties were not defined
@@ -236,7 +238,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  Indicates if the object can no longer be accessed because it is now invalid.
- 
+
  An object can no longer be accessed if the object has been deleted from the Realm that manages it, or
  if `invalidate` is called on that Realm.
  */
@@ -247,7 +249,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  Returns an array of property names for properties which should be indexed.
- 
+
  Only string, integer, boolean, and `NSDate` properties are supported.
 
  @return    An array of property names.
@@ -256,14 +258,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  Override this method to specify the default values to be used for each property.
- 
+
  @return    A dictionary mapping property names to their default values.
  */
 + (nullable NSDictionary *)defaultPropertyValues;
 
 /**
  Override this method to specify the name of a property to be used as the primary key.
- 
+
  Only properties of types `RLMPropertyTypeString` and `RLMPropertyTypeInt` can be designated as the primary key.
  Primary key properties enforce uniqueness for each value whenever the property is set, which incurs minor overhead.
  Indexes are created automatically for primary key properties.
@@ -286,7 +288,7 @@ NS_ASSUME_NONNULL_BEGIN
  By default, all properties of a type whose values can be set to `nil` are considered optional properties.
  To require that an object in a Realm always store a non-`nil` value for a property,
  add the name of the property to the array returned from this method.
- 
+
  Properties of `RLMObject` type cannot be non-optional. Array and `NSNumber` properties
  can be non-optional, but there is no reason to do so: arrays do not support storing nil, and
  if you want a non-optional number you should instead use the primitive type.
@@ -297,7 +299,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  Override this method to provide information related to properties containing linking objects.
- 
+
  Each property of type `RLMLinkingObjects` must have a key in the dictionary returned by this method consisting
  of the property name. The corresponding value must be an instance of `RLMPropertyDescriptor` that describes the class
  and property that the property is linked to.
@@ -313,16 +315,16 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  Returns all objects of this object type from the default Realm.
- 
+
  @return    An `RLMResults` containing all objects of this type in the default Realm.
  */
 + (RLMResults *)allObjects;
 
 /**
  Returns all objects of this object type matching the given predicate from the default Realm.
- 
+
  @param predicateFormat A predicate format string, optionally followed by a variable number of arguments.
- 
+
  @return    An `RLMResults` containing all objects of this type in the default Realm that match the given predicate.
  */
 + (RLMResults *)objectsWhere:(NSString *)predicateFormat, ...;
@@ -403,12 +405,64 @@ NS_ASSUME_NONNULL_BEGIN
  */
 + (nullable instancetype)objectInRealm:(RLMRealm *)realm forPrimaryKey:(nullable id)primaryKey;
 
+#pragma mark - Notifications
+
+/**
+ A callback block for RLMObject notifications.
+
+ If the object is deleted from the managing Realm, the block is called with
+ `deleted` set to `true` and the other two arguments are `nil`. The block will
+ never be called again after this.
+
+ If the object is modified, the block will be called with `deleted` set to
+ `false`, a `nil` `error, and an array of `RLMPropertyChange` objects which
+ indicate which properties of the objects were modified.
+
+ If an error occurs, `deleted` will be false, `changes` will be `nil`, and
+ `error` will include information about the error. The block will never be
+ called again after an error occurs.
+ */
+typedef void (^RLMObjectChangeBlock)(bool deleted, NSArray<RLMPropertyChange *> *_Nullable changes, NSError *_Nullable error);
+
+/**
+ Registers a block to be called each time the object changes.
+
+ The block will be asynchronously called after each write transaction which
+ deletes the object or modifies any of the managed properties of the object,
+ including self-assignments that set a property to its existing value. For write
+ transactions performed on different threads the block will be called when the
+ Realm is (auto)refreshed, while for local write transactions it will be called
+ at some point in the future after the write transaction is committed.
+
+ Notifications are delivered via the standard run loop, and so can't be
+ delivered while the run loop is blocked by other activity. When
+ notifications can't be delivered instantly, multiple notifications may be
+ coalesced into a single notification.
+
+ Unlike with `RLMArray` and `RLMResults`, there is no "initial" callback made
+ after you add a new notification block.
+
+ You must retain the returned token for as long as you want updates to continue
+ to be sent to the block. To stop receiving updates, call `-stop` on the token.
+
+ It is safe to capture a strong reference to the observed object within the
+ callback block. There is no retain cycle due to that the callback is retained
+ by the returned token and not by the object itself.
+
+ @warning This method cannot be called during a write transaction, when the
+          containing Realm is read-only, or on an unmanaged object.
+
+ @param block The block to be called whenever a change occurs.
+ @return A token which must be held for as long as you want updates to be delivered.
+ */
+- (RLMNotificationToken *)addNotificationBlock:(RLMObjectChangeBlock)block;
+
 #pragma mark - Other Instance Methods
 
 /**
  Returns YES if another Realm object instance points to the same object as the receiver in the Realm managing
  the receiver.
- 
+
  For object types with a primary, key, `isEqual:` is overridden to use this method (along with a corresponding
  implementation for `hash`).
 
@@ -428,13 +482,41 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
+/**
+ Information about a specific property which changed in an RLMObject change notification.
+ */
+@interface RLMPropertyChange : NSObject
+
+/**
+ The name of the property which changed.
+ */
+@property (nonatomic, strong) NSString *name;
+
+/**
+ The value of the property before the change occurred. This will always be `nil`
+ if the change happened on the same thread as the notification and for `RLMArray`
+ properties.
+
+ For object properties this will give the object which was previously linked to,
+ but that object will have its new values and not the values it had before the
+ changes. This means that `previousValue` may be a deleted object.
+ */
+@property (nonatomic, strong, nullable) id previousValue;
+
+/**
+ The value of the property after the change occurred. This will always be `nil`
+ for `RLMArray` properties.
+ */
+@property (nonatomic, strong, nullable) id value;
+@end
+
 #pragma mark - RLMArray Property Declaration
 
 /**
  Properties on `RLMObject`s of type `RLMArray` must have an associated type. A type is associated
  with an `RLMArray` property by defining a protocol for the object type that the array should contain.
  To define the protocol for an object, you can use the macro RLM_ARRAY_TYPE:
- 
+
      RLM_ARRAY_TYPE(ObjectType)
      ...
      @property RLMArray<ObjectType *><ObjectType> *arrayOfObjectTypes;

--- a/Realm/RLMObject.h
+++ b/Realm/RLMObject.h
@@ -411,39 +411,45 @@ NS_ASSUME_NONNULL_BEGIN
  A callback block for RLMObject notifications.
 
  If the object is deleted from the managing Realm, the block is called with
- `deleted` set to `true` and the other two arguments are `nil`. The block will
+ `deleted` set to `YES` and the other two arguments are `nil`. The block will
  never be called again after this.
 
  If the object is modified, the block will be called with `deleted` set to
- `false`, a `nil` `error, and an array of `RLMPropertyChange` objects which
+ `NO`, a `nil` `error, and an array of `RLMPropertyChange` objects which
  indicate which properties of the objects were modified.
 
- If an error occurs, `deleted` will be false, `changes` will be `nil`, and
+ If an error occurs, `deleted` will be `NO`, `changes` will be `nil`, and
  `error` will include information about the error. The block will never be
  called again after an error occurs.
  */
-typedef void (^RLMObjectChangeBlock)(bool deleted, NSArray<RLMPropertyChange *> *_Nullable changes, NSError *_Nullable error);
+typedef void (^RLMObjectChangeBlock)(BOOL deleted,
+                                     NSArray<RLMPropertyChange *> *_Nullable changes,
+                                     NSError *_Nullable error);
 
 /**
  Registers a block to be called each time the object changes.
 
  The block will be asynchronously called after each write transaction which
  deletes the object or modifies any of the managed properties of the object,
- including self-assignments that set a property to its existing value. For write
- transactions performed on different threads the block will be called when the
- Realm is (auto)refreshed, while for local write transactions it will be called
- at some point in the future after the write transaction is committed.
+ including self-assignments that set a property to its existing value.
+
+ For write transactions performed on different threads or in differen
+ processes, the block will be called when the managing Realm is
+ (auto)refreshed to a version including the changes, while for local write
+ transactions it will be called at some point in the future after the write
+ transaction is committed.
 
  Notifications are delivered via the standard run loop, and so can't be
- delivered while the run loop is blocked by other activity. When
- notifications can't be delivered instantly, multiple notifications may be
- coalesced into a single notification.
+ delivered while the run loop is blocked by other activity. When notifications
+ can't be delivered instantly, multiple notifications may be coalesced into a
+ single notification.
 
  Unlike with `RLMArray` and `RLMResults`, there is no "initial" callback made
  after you add a new notification block.
 
- You must retain the returned token for as long as you want updates to continue
- to be sent to the block. To stop receiving updates, call `-stop` on the token.
+ Only objects which are managed by a Realm can be observed in this way. You
+ must retain the returned token for as long as you want updates to be sent to
+ the block. To stop receiving updates, call `stop` on the token.
 
  It is safe to capture a strong reference to the observed object within the
  callback block. There is no retain cycle due to that the callback is retained
@@ -483,7 +489,7 @@ typedef void (^RLMObjectChangeBlock)(bool deleted, NSArray<RLMPropertyChange *> 
 @end
 
 /**
- Information about a specific property which changed in an RLMObject change notification.
+ Information about a specific property which changed in an `RLMObject` change notification.
  */
 @interface RLMPropertyChange : NSObject
 
@@ -499,7 +505,8 @@ typedef void (^RLMObjectChangeBlock)(bool deleted, NSArray<RLMPropertyChange *> 
 
  For object properties this will give the object which was previously linked to,
  but that object will have its new values and not the values it had before the
- changes. This means that `previousValue` may be a deleted object.
+ changes. This means that `previousValue` may be a deleted object, and you will
+ need to check `invalidated` before accessing any of its properties.
  */
 @property (nonatomic, readonly, strong, nullable) id previousValue;
 

--- a/Realm/RLMObject.h
+++ b/Realm/RLMObject.h
@@ -490,7 +490,7 @@ typedef void (^RLMObjectChangeBlock)(bool deleted, NSArray<RLMPropertyChange *> 
 /**
  The name of the property which changed.
  */
-@property (nonatomic, strong) NSString *name;
+@property (nonatomic, readonly, strong) NSString *name;
 
 /**
  The value of the property before the change occurred. This will always be `nil`
@@ -501,13 +501,13 @@ typedef void (^RLMObjectChangeBlock)(bool deleted, NSArray<RLMPropertyChange *> 
  but that object will have its new values and not the values it had before the
  changes. This means that `previousValue` may be a deleted object.
  */
-@property (nonatomic, strong, nullable) id previousValue;
+@property (nonatomic, readonly, strong, nullable) id previousValue;
 
 /**
  The value of the property after the change occurred. This will always be `nil`
  for `RLMArray` properties.
  */
-@property (nonatomic, strong, nullable) id value;
+@property (nonatomic, readonly, strong, nullable) id value;
 @end
 
 #pragma mark - RLMArray Property Declaration

--- a/Realm/RLMObject.mm
+++ b/Realm/RLMObject.mm
@@ -19,11 +19,17 @@
 #import "RLMObject_Private.hpp"
 
 #import "RLMAccessor.h"
+#import "RLMArray.h"
+#import "RLMCollection_Private.hpp"
 #import "RLMObjectSchema_Private.hpp"
 #import "RLMObjectStore.h"
+#import "RLMProperty.h"
 #import "RLMQueryUtil.hpp"
 #import "RLMRealm_Private.hpp"
 #import "RLMSchema_Private.h"
+
+#import "collection_notifications.hpp"
+#import "object.hpp"
 
 // We declare things in RLMObject which are actually implemented in RLMObjectBase
 // for documentation's sake, which leads to -Wunimplemented-method warnings.
@@ -148,6 +154,29 @@
     return [object isKindOfClass:RLMObject.class] && RLMObjectBaseAreEqual(self, object);
 }
 
+- (RLMNotificationToken *)addNotificationBlock:(RLMObjectChangeBlock)block {
+    return RLMObjectAddNotificationBlock(self, ^(NSArray<NSString *> *propertyNames,
+                                                 NSArray *oldValues, NSArray *newValues, NSError *error) {
+        if (error) {
+            block(false, nil, error);
+        }
+        else if (!propertyNames) {
+            block(true, nil, nil);
+        }
+        else {
+            auto properties = [NSMutableArray arrayWithCapacity:propertyNames.count];
+            for (NSUInteger i = 0, count = propertyNames.count; i < count; ++i) {
+                auto prop = [RLMPropertyChange new];
+                prop.name = propertyNames[i];
+                prop.previousValue = RLMCoerceToNil(oldValues[i]);
+                prop.value = RLMCoerceToNil(newValues[i]);
+                [properties addObject:prop];
+            }
+            block(false, properties, nil);
+        }
+    });
+}
+
 + (NSString *)className {
     return [super className];
 }
@@ -228,4 +257,111 @@
     return copy;
 }
 
+@end
+
+@interface RLMObjectNotificationToken : RLMCancellationToken
+@end
+@implementation RLMObjectNotificationToken {
+@public
+    realm::Object _object;
+}
+@end
+
+RLMNotificationToken *RLMObjectAddNotificationBlock(RLMObjectBase *obj, RLMObjectNotificationCallback block) {
+    if (!obj->_realm) {
+        @throw RLMException(@"Only objects which are managed by a Realm support change notifications");
+    }
+    [obj->_realm verifyNotificationsAreSupported];
+
+    struct {
+        void (^block)(NSArray<NSString *> *, NSArray *, NSArray *, NSError *);
+        RLMObjectBase *object;
+
+        NSArray<NSString *> *propertyNames = nil;
+        NSArray *oldValues = nil;
+        bool deleted = false;
+
+        void populateProperties(realm::CollectionChangeSet const& c) {
+            if (propertyNames) {
+                return;
+            }
+            if (!c.deletions.empty()) {
+                deleted = true;
+                return;
+            }
+            if (c.columns.empty()) {
+                return;
+            }
+
+            auto properties = [NSMutableArray new];
+            for (size_t i = 0; i < c.columns.size(); ++i) {
+                if (c.columns[i].empty()) {
+                    continue;
+                }
+                if (auto prop = object->_info->propertyForTableColumn(i)) {
+                    [properties addObject:prop.name];
+                }
+            }
+            if (properties.count) {
+                propertyNames = properties;
+            }
+        }
+
+        NSArray *readValues(realm::CollectionChangeSet const& c) {
+            if (c.empty()) {
+                return nil;
+            }
+            populateProperties(c);
+            if (!propertyNames) {
+                return nil;
+            }
+
+            auto values = [NSMutableArray arrayWithCapacity:propertyNames.count];
+            for (NSString *name in propertyNames) {
+                id value = [object valueForKey:name];
+                if (!value || [value isKindOfClass:[RLMArray class]]) {
+                    [values addObject:NSNull.null];
+                }
+                else {
+                    [values addObject:value];
+                }
+            }
+            return values;
+        }
+
+        void before(realm::CollectionChangeSet const& c) {
+            oldValues = readValues(c);
+        }
+
+        void after(realm::CollectionChangeSet const& c) {
+            auto newValues = readValues(c);
+            if (deleted) {
+                block(nil, nil, nil, nil);
+            }
+            else if (newValues) {
+                block(propertyNames, oldValues, newValues, nil);
+            }
+            propertyNames = nil;
+            oldValues = nil;
+        }
+
+        void error(std::exception_ptr err) {
+            try {
+                rethrow_exception(err);
+            }
+            catch (...) {
+                NSError *error = nil;
+                RLMRealmTranslateException(&error);
+                block(nil, nil, nil, error);
+            }
+        }
+    } callback{block, obj};
+
+    realm::Object object(obj->_realm->_realm, *obj->_info->objectSchema, obj->_row);
+    auto token = [[RLMObjectNotificationToken alloc] initWithToken:object.add_notification_block(callback) realm:obj->_realm];
+    token->_object = std::move(object);
+    return token;
+}
+
+@implementation RLMPropertyChange
 @end

--- a/Realm/RLMObject.mm
+++ b/Realm/RLMObject.mm
@@ -31,6 +31,12 @@
 #import "collection_notifications.hpp"
 #import "object.hpp"
 
+@interface RLMPropertyChange ()
+@property (nonatomic, readwrite, strong) NSString *name;
+@property (nonatomic, readwrite, strong, nullable) id previousValue;
+@property (nonatomic, readwrite, strong, nullable) id value;
+@end
+
 // We declare things in RLMObject which are actually implemented in RLMObjectBase
 // for documentation's sake, which leads to -Wunimplemented-method warnings.
 // Other alternatives to this would be to disable -Wunimplemented-method for this

--- a/Realm/RLMObject_Private.h
+++ b/Realm/RLMObject_Private.h
@@ -75,6 +75,12 @@ FOUNDATION_EXTERN id _Nullable RLMValidatedValueForProperty(id object, NSString 
 // Compare two RLObjectBases
 FOUNDATION_EXTERN BOOL RLMObjectBaseAreEqual(RLMObjectBase * _Nullable o1, RLMObjectBase * _Nullable o2);
 
+typedef void (^RLMObjectNotificationCallback)(NSArray<NSString *> *_Nullable propertyNames,
+                                              NSArray *_Nullable oldValues,
+                                              NSArray *_Nullable newValues,
+                                              NSError *_Nullable error);
+FOUNDATION_EXTERN RLMNotificationToken *RLMObjectAddNotificationBlock(RLMObjectBase *obj, RLMObjectNotificationCallback block);
+
 // Get ObjectUil class for objc or swift
 FOUNDATION_EXTERN Class RLMObjectUtilClass(BOOL isSwift);
 

--- a/Realm/RLMSyncManager_Private.h
+++ b/Realm/RLMSyncManager_Private.h
@@ -16,7 +16,7 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-#import "RLMSyncManager.h"
+#import <Realm/RLMSyncManager.h>
 
 #import "RLMSyncUtil_Private.h"
 

--- a/Realm/Tests/TestUtils.mm
+++ b/Realm/Tests/TestUtils.mm
@@ -19,8 +19,8 @@
 #import "TestUtils.h"
 
 #import <Realm/Realm.h>
-#import <Realm/RLMRealmUtil.hpp>
 #import <Realm/RLMSchema_Private.h>
+#import "RLMRealmUtil.hpp"
 
 void RLMAssertThrowsWithReasonMatchingSwift(XCTestCase *self, dispatch_block_t block, NSString *regexString, NSString *message, NSString *fileName, NSUInteger lineNumber) {
     BOOL didThrow = NO;

--- a/RealmSwift/RealmCollection.swift
+++ b/RealmSwift/RealmCollection.swift
@@ -81,14 +81,16 @@ public final class RLMIterator<T: Object>: IteratorProtocol {
  */
 public enum RealmCollectionChange<T> {
     /**
-     `.initial` indicates that the initial run of the query has completed (if applicable), and the collection can now be
-     used without performing any blocking work.
+     `.initial` indicates that the initial run of the query has completed (if
+     applicable), and the collection can now be used without performing any
+     blocking work.
      */
     case initial(T)
 
     /**
-     `.update` indicates that a write transaction has been committed which either changed which objects
-     are in the collection, and/or modified one or more of the objects in the collection.
+     `.update` indicates that a write transaction has been committed which
+     either changed which objects are in the collection, and/or modified one
+     or more of the objects in the collection.
 
      All three of the change arrays are always sorted in ascending order.
 
@@ -99,9 +101,11 @@ public enum RealmCollectionChange<T> {
     case update(T, deletions: [Int], insertions: [Int], modifications: [Int])
 
     /**
-     If an error occurs, notification blocks are called one time with a `.error` result and an `NSError` containing
-     details about the error. This can only currently happen if the Realm is opened on a background worker thread to
-     calculate the change set.
+     If an error occurs, notification blocks are called one time with a `.error`
+     result and an `NSError` containing details about the error. This can only
+     currently happen if opening the Realm on a background thread to calcuate
+     the change set fails. The callback will never be called again after it is
+     invoked with a .error value.
      */
     case error(Error)
 

--- a/RealmSwift/Tests/ObjectTests.swift
+++ b/RealmSwift/Tests/ObjectTests.swift
@@ -437,4 +437,134 @@ class ObjectTests: TestCase {
         XCTAssertEqual(data, object.dataCol)
         XCTAssertEqual(42, object.numCol)
     }
+
+    func testDeleteObservedObject() {
+        let realm = try! Realm()
+        realm.beginWrite()
+        let object = realm.create(SwiftIntObject.self, value: [0])
+        try! realm.commitWrite()
+
+        let exp = expectation(description: "")
+        let token = object.addNotificationBlock { change in
+            if case .deleted = change {
+            } else {
+                XCTFail("expected .deleted, got \(change)")
+            }
+            exp.fulfill()
+        }
+
+        realm.beginWrite()
+        realm.delete(object)
+        try! realm.commitWrite()
+
+        waitForExpectations(timeout: 2)
+        token.stop()
+    }
+
+    func expectChange<T: Equatable, U: Equatable>(_ name: String, _ old: T?, _ new: U?) -> ((ObjectChange) -> Void) {
+        let exp = expectation(description: "")
+        return { change in
+            if case .change(let properties) = change {
+                XCTAssertEqual(properties.count, 1)
+                if let prop = properties.first {
+                    XCTAssertEqual(prop.name, name)
+                    XCTAssertEqual(prop.oldValue as? T, old)
+                    XCTAssertEqual(prop.newValue as? U, new)
+                }
+            } else {
+                XCTFail("expected .change, got \(change)")
+            }
+            exp.fulfill()
+        }
+    }
+
+    func testModifyObservedObjectLocally() {
+        let realm = try! Realm()
+        realm.beginWrite()
+        let object = realm.create(SwiftIntObject.self, value: [1])
+        try! realm.commitWrite()
+
+        let token = object.addNotificationBlock(expectChange("intCol", Int?.none, 2))
+        try! realm.write {
+            object.intCol = 2
+        }
+
+        waitForExpectations(timeout: 2)
+        token.stop()
+    }
+
+    func testModifyObservedObjectRemotely() {
+        let realm = try! Realm()
+        realm.beginWrite()
+        let object = realm.create(SwiftIntObject.self, value: [1])
+        try! realm.commitWrite()
+
+        let token = object.addNotificationBlock(expectChange("intCol", 1, 2))
+        dispatchSyncNewThread {
+            let realm = try! Realm()
+            try! realm.write {
+                realm.objects(SwiftIntObject.self).first!.intCol = 2
+            }
+        }
+
+        waitForExpectations(timeout: 2)
+        token.stop()
+    }
+
+    func testListPropertyNotifications() {
+        let realm = try! Realm()
+        realm.beginWrite()
+        let object = realm.create(SwiftRecursiveObject.self, value: [[]])
+        try! realm.commitWrite()
+
+        let token = object.addNotificationBlock(expectChange("objects", Int?.none, Int?.none))
+        dispatchSyncNewThread {
+            let realm = try! Realm()
+            try! realm.write {
+                let obj = realm.objects(SwiftRecursiveObject.self).first!
+                obj.objects.append(obj)
+            }
+        }
+
+        waitForExpectations(timeout: 2)
+        token.stop()
+    }
+
+    func testOptionalPropertyNotifications() {
+        let realm = try! Realm()
+        let object = SwiftOptionalDefaultValuesObject()
+        try! realm.write {
+            realm.add(object)
+        }
+
+        var token = object.addNotificationBlock(expectChange("optIntCol", 1, 2))
+        dispatchSyncNewThread {
+            let realm = try! Realm()
+            try! realm.write {
+                realm.objects(SwiftOptionalDefaultValuesObject.self).first!.optIntCol.value = 2
+            }
+        }
+        waitForExpectations(timeout: 2)
+        token.stop()
+
+        token = object.addNotificationBlock(expectChange("optIntCol", 2, Int?.none))
+        dispatchSyncNewThread {
+            let realm = try! Realm()
+            try! realm.write {
+                realm.objects(SwiftOptionalDefaultValuesObject.self).first!.optIntCol.value = nil
+            }
+        }
+        waitForExpectations(timeout: 2)
+        token.stop()
+
+        token = object.addNotificationBlock(expectChange("optIntCol", Int?.none, 3))
+        dispatchSyncNewThread {
+            let realm = try! Realm()
+            try! realm.write {
+                realm.objects(SwiftOptionalDefaultValuesObject.self).first!.optIntCol.value = 3
+            }
+        }
+        waitForExpectations(timeout: 2)
+        token.stop()
+    }
 }

--- a/RealmSwift/Tests/TestUtils.mm
+++ b/RealmSwift/Tests/TestUtils.mm
@@ -19,8 +19,9 @@
 #import "TestUtils.h"
 
 #import <Realm/Realm.h>
-#import <Realm/RLMRealmUtil.hpp>
 #import <Realm/RLMSchema_Private.h>
+
+#import "RLMRealmUtil.hpp"
 
 // This ensures the shared schema is initialized outside of of a test case,
 // so if an exception is thrown, it will kill the test process rather than


### PR DESCRIPTION
~~The Swift 2 version of the code currently doesn't compile (I need to reinstall Xcode 7) and~~ there's probably a few more things that could use testing, but otherwise I think this is all ready for review. The Swift API should be exactly what was originally proposed (with parts 1-4 implemented (i.e. everything but keypath filtering)), with the obj-c API "inspired" by that and the exist collection notifications.