### PR TITLE
Fix an issue that crashing by failing to cast `RLMError.Code` when bridging `RLMError` to `Realm.Error`

### DIFF
--- a/RealmSwift/Error.swift
+++ b/RealmSwift/Error.swift
@@ -28,50 +28,49 @@ extension Realm {
      ```swift
      let realm: Realm?
      do {
-         realm = Realm()
+         realm = try Realm()
      } catch Realm.Error.incompatibleLockFile {
          print("Realm Browser app may be attached to Realm on device?")
      }
      ```
     */
     public struct Error {
-        public typealias Code = RLMError.Code
-
         /// Error thrown by Realm if no other specific error is returned when a realm is opened.
-        public static let fail: Code = .fail
+        public static let fail = RLMError.fail
 
         /// Error thrown by Realm for any I/O related exception scenarios when a realm is opened.
-        public static let fileAccess: Code = .fileAccess
+        public static let fileAccess = RLMError.fileAccess
 
         /// Error thrown by Realm if the user does not have permission to open or create
         /// the specified file in the specified access mode when the realm is opened.
-        public static let filePermissionDenied: Code = .filePermissionDenied
+        public static let filePermissionDenied = RLMError.filePermissionDenied
 
         /// Error thrown by Realm if the file already exists when a copy should be written.
-        public static let fileExists: Code = .fileExists
+        public static let fileExists = RLMError.fileExists
 
         /// Error thrown by Realm if no file was found when a realm was opened as
         /// read-only or if the directory part of the specified path was not found
         /// when a copy should be written.
-        public static let fileNotFound: Code = .fileNotFound
+        public static let fileNotFound = RLMError.fileNotFound
 
         /// Error thrown by Realm if the database file is currently open in another process which
         /// cannot share with the current process due to an architecture mismatch.
-        public static let incompatibleLockFile: Code = .incompatibleLockFile
+        public static let incompatibleLockFile = RLMError.incompatibleLockFile
 
         /// Error thrown by Realm if a file format upgrade is required to open the file,
         /// but upgrades were explicitly disabled.
-        public static let fileFormatUpgradeRequired: Code = .fileFormatUpgradeRequired
+        public static let fileFormatUpgradeRequired = RLMError.fileFormatUpgradeRequired
 
         /// Error thrown by Realm if there is insufficient available address space.
-        public static let addressSpaceExhausted: Code = .addressSpaceExhausted
+        public static let addressSpaceExhausted = RLMError.addressSpaceExhausted
 
         /// Error thrown by Realm if there is a schema version mismatch, so that a migration is required.
-        public static let schemaMismatch: Code = .schemaMismatch
+        public static let schemaMismatch = RLMError.schemaMismatch
 
         /// :nodoc:
-        public var code: Code {
-            return (_nsError as! RLMError).code
+        public var code: RLMError.Code {
+            let rlmError = _nsError as! RLMError
+            return rlmError.code
         }
 
         /// :nodoc:

--- a/RealmSwift/Tests/RealmTests.swift
+++ b/RealmSwift/Tests/RealmTests.swift
@@ -813,4 +813,14 @@ class RealmTests: TestCase {
             XCTAssertFalse(realm == otherThreadRealm)
         }
     }
+
+    func testCatchSpecificErrors() {
+        do {
+            _ = try Realm(configuration: Realm.Configuration(fileURL: URL(fileURLWithPath: "/dev/null/foo")))
+        } catch Realm.Error.fileAccess {
+
+        } catch {
+            XCTFail("Failed to brigde RLMError to Realm.Error")
+        }
+    }
 }


### PR DESCRIPTION
Fix an issue that crashing by failing to cast `RLMError.Code` when bridging `RLMError` to `Realm.Error`

Currently, the following code crashes 

```swift
 let realm: Realm?
 do {
     realm = try Realm()
 } catch Realm.Error.incompatibleLockFile {
     print("Realm Browser app may be attached to Realm on device?")
 }
```

with the error below.
```
Could not cast value of type '__C.RLMError.Code' (0x101b501b8) to 'RealmSwift.Realm.Error.Code' (0x101e78e00).
```

CC @jpsim @austinzheng 