### PR TITLE
sort by 'key path' rather than 'property' in examples

### DIFF
--- a/examples/ios/objc/GroupedTableView/TableViewController.m
+++ b/examples/ios/objc/GroupedTableView/TableViewController.m
@@ -60,7 +60,7 @@ static NSString * const kTableName = @"table";
     self.objectsBySection = [NSMutableArray arrayWithCapacity:3];
     for (NSString *section in self.sectionTitles) {
         RLMResults *unsortedObjects = [DemoObject objectsWhere:@"sectionTitle == %@", section];
-        RLMResults *sortedObjects = [unsortedObjects sortedResultsUsingProperty:@"date" ascending:YES];
+        RLMResults *sortedObjects = [unsortedObjects sortedResultsUsingKeyPath:@"date" ascending:YES];
         [self.objectsBySection addObject:sortedObjects];
     }
     [self.tableView reloadData];

--- a/examples/ios/objc/TableView/TableViewController.m
+++ b/examples/ios/objc/TableView/TableViewController.m
@@ -46,7 +46,7 @@ static NSString * const kTableName = @"table";
 - (void)viewDidLoad
 {
     [super viewDidLoad];
-    self.array = [[DemoObject allObjects] sortedResultsUsingProperty:@"date" ascending:YES];
+    self.array = [[DemoObject allObjects] sortedResultsUsingKeyPath:@"date" ascending:YES];
     [self setupUI];
 
     // Set realm notification block

--- a/examples/ios/swift-3.0/GroupedTableView/TableViewController.swift
+++ b/examples/ios/swift-3.0/GroupedTableView/TableViewController.swift
@@ -55,7 +55,7 @@ class TableViewController: UITableViewController {
         }
         for section in sectionTitles {
             let unsortedObjects = realm.objects(DemoObject.self).filter("sectionTitle == '\(section)'")
-            let sortedObjects = unsortedObjects.sorted(byProperty: "date", ascending: true)
+            let sortedObjects = unsortedObjects.sorted(byKeyPath: "date", ascending: true)
             objectsBySection.append(sortedObjects)
         }
         tableView.reloadData()

--- a/examples/ios/swift-3.0/TableView/TableViewController.swift
+++ b/examples/ios/swift-3.0/TableView/TableViewController.swift
@@ -37,7 +37,7 @@ class Cell: UITableViewCell {
 class TableViewController: UITableViewController {
 
     let realm = try! Realm()
-    let results = try! Realm().objects(DemoObject.self).sorted(byProperty: "date")
+    let results = try! Realm().objects(DemoObject.self).sorted(byKeyPath: "date")
     var notificationToken: NotificationToken?
 
     override func viewDidLoad() {

--- a/examples/tvos/objc/DownloadCache/RepositoriesViewController.m
+++ b/examples/tvos/objc/DownloadCache/RepositoriesViewController.m
@@ -105,7 +105,7 @@
     if (self.searchField.text.length > 0) {
         self.results = [self.results objectsWhere:@"name contains[c] %@", self.searchField.text];
     }
-    self.results = [self.results sortedResultsUsingProperty:@"name" ascending:self.sortOrderControl.selectedSegmentIndex == 0];
+    self.results = [self.results sortedResultsUsingKeyPath:@"name" ascending:self.sortOrderControl.selectedSegmentIndex == 0];
 
     [self.collectionView reloadData];
 }

--- a/examples/tvos/objc/PreloadedData/PlacesViewController.m
+++ b/examples/tvos/objc/PreloadedData/PlacesViewController.m
@@ -63,7 +63,7 @@
     if (self.searchField.text.length > 0) {
         self.results = [self.results objectsWhere:@"postalCode beginswith %@", self.searchField.text];
     }
-    self.results = [self.results sortedResultsUsingProperty:@"postalCode" ascending:YES];
+    self.results = [self.results sortedResultsUsingKeyPath:@"postalCode" ascending:YES];
 
     [self.tableView reloadData];
 }

--- a/examples/tvos/swift-3.0/DownloadCache/RepositoriesViewController.swift
+++ b/examples/tvos/swift-3.0/DownloadCache/RepositoriesViewController.swift
@@ -101,7 +101,7 @@ class RepositoriesViewController: UICollectionViewController, UITextFieldDelegat
         if let text = searchField.text, !text.isEmpty {
             results = results?.filter("name contains[c] %@", text)
         }
-        results = results?.sorted(byProperty: "name", ascending: sortOrderControl!.selectedSegmentIndex == 0)
+        results = results?.sorted(byKeyPath: "name", ascending: sortOrderControl!.selectedSegmentIndex == 0)
 
         collectionView?.reloadData()
     }

--- a/examples/tvos/swift-3.0/PreloadedData/PlacesViewController.swift
+++ b/examples/tvos/swift-3.0/PreloadedData/PlacesViewController.swift
@@ -57,7 +57,7 @@ class PlacesViewController: UITableViewController, UITextFieldDelegate {
         if let text = searchField.text, !text.isEmpty {
             results = results?.filter("postalCode beginswith %@", text)
         }
-        results = results?.sorted(byProperty: "postalCode")
+        results = results?.sorted(byKeyPath: "postalCode")
 
         tableView?.reloadData()
     }


### PR DESCRIPTION
to avoid deprecated methods