### PR TITLE
Revert "fix for #4534, find xcode without spotlight"

### DIFF
--- a/scripts/swift-version.sh
+++ b/scripts/swift-version.sh
@@ -1,64 +1,37 @@
-#!/usr/bin/env bash
-
 get_swift_version() {
-    "$1" --version 2>/dev/null | sed -ne 's/^Apple Swift version \([^\b ]*\).*/\1/p'
-}
-
-test_xcode_for_swift_version() {
-    if [ -z "$1" ] || [ -z "$2" ]; then
-        echo "test_xcode_for_swift_version called with empty parameter(s): `$1` or `$2`" >&2
-        exit 1
-    fi
-    local path=$1
-    local required_version=$2
-    
-    for swift in "$path"/Toolchains/*.xctoolchain/usr/bin/swift; do
-        if [[ $(get_swift_version "$swift") == "$required_version" ]]; then
-            return 0
-        fi
-    done
-    return 1
+    swift_command=$@
+    $swift_command --version 2>/dev/null | sed -ne 's/^Apple Swift version \([^\b ]*\).*/\1/p'
 }
 
 find_xcode_for_swift() {
-    local path required_version
-    
-    if [ -z "$1" ]; then
-        echo "find_xcode_for_swift requres a Swift version" >&2
-        exit 1
-    fi
-    required_version=$1
-    
-    # First check if the currently active one is fine, unless we are in a CI run
-    if [ -z "$JENKINS_HOME" ]; then
-        if [[ $(get_swift_version `xcrun -f swift`) = "$required_version" ]]; then
-            export DEVELOPER_DIR=$(xcode-select -p)
-            return 0
-        fi
+    # First check if the currently active one is fine
+    version="$(get_swift_version xcrun swift || true)"
+    if [[ "$version" = "$1" ]]; then
+        export DEVELOPER_DIR="$(xcode-select -p)"
+        return 0
     fi
 
-    # Check all of the items in /Applications that look promising per #4534
-    for path in /Applications/Xcode*.app/Contents/Developer; do
-        if test_xcode_for_swift_version "$path" "$required_version"; then
-            export DEVELOPER_DIR=$path
-            return 0
-        fi
+    local xcodes dev_dir version
+
+    # Check all installed copies of Xcode for the desired Swift version
+    xcodes=()
+    dev_dir="Contents/Developer"
+    for dir in $(mdfind "kMDItemCFBundleIdentifier == 'com.apple.dt.Xcode'" 2>/dev/null); do
+        [[ -d "$dir" && -n "$(ls -A "$dir/$dev_dir")" ]] && xcodes+=("$dir/$dev_dir")
     done
-    
-    # Use Spotlight to see if we can find others installed copies of Xcode
-    for path in $(mdfind "kMDItemCFBundleIdentifier == 'com.apple.dt.Xcode'" 2>/dev/null); do
-        path="$path/Contents/Developer"
-        if [ ! -d "$path" ]; then
-            continue
-        fi
-        if test_xcode_for_swift_version "$path" "$required_version"; then
-            export DEVELOPER_DIR=$path
-            return 0
-        fi
+
+    for xcode in "${xcodes[@]}"; do
+        for swift in "$xcode"/Toolchains/*.xctoolchain/usr/bin/swift; do
+            version="$(get_swift_version $swift)"
+            if [[ "$version" = "$1" ]]; then
+                export DEVELOPER_DIR="$xcode"
+                return 0
+            fi
+        done
     done
-    
-    echo "No version of Xcode found that supports Swift $required_version" >&2
-    exit 1
+
+    >&2 echo "No version of Xcode found that supports Swift $1"
+    return 1
 }
 
 if [[ "$REALM_SWIFT_VERSION" ]]; then
@@ -69,7 +42,3 @@ else
         export DEVELOPER_DIR="$(xcode-select -p)"
     fi
 fi
-
-return 2>/dev/null || { # only run if called directly
-    echo "Found Swift version $REALM_SWIFT_VERSION in $DEVELOPER_DIR"
-}


### PR DESCRIPTION
Reverts realm/realm-cocoa#4536

This was causing issues both when running on CI and locally. See https://ci.realm.io/job/objc_osx/1875/console and https://ci.realm.io/job/objc_ios/1857/console for examples.

Fails with the following error message:

```
Check dependencies
2017-01-18 13:07:51.435 xcodebuild[41326:920235] Error Domain=IDETestOperationsObserverErrorDomain Code=3 "Test operation was canceled. If you believe this error represents a bug, please attach the log file at /Users/jp/Projects/realm-cocoa/build/DerivedData/Realm/Logs/Test/F22480B2-1F81-4DD6-A0B4-FE5625567132/Session-ObjectServerTests-2017-01-18_130617-oP0uDI.log" UserInfo={NSLocalizedDescription=Test operation was canceled. If you believe this error represents a bug, please attach the log file at /Users/jp/Projects/realm-cocoa/build/DerivedData/Realm/Logs/Test/F22480B2-1F81-4DD6-A0B4-FE5625567132/Session-ObjectServerTests-2017-01-18_130617-oP0uDI.log}
“Use Legacy Swift Language Version” (SWIFT_VERSION) is required to be configured correctly for targets which use Swift. Use the [Edit > Convert > To Current Swift Syntax…] menu to choose a Swift version or use the Build Settings editor to configure the build setting directly.
warning: no umbrella header found for target 'RealmSwift', module map will not be generated
```