### PR TITLE
Fix issues with automatic sync token refresh subsystem

### DIFF
--- a/Realm.xcodeproj/project.pbxproj
+++ b/Realm.xcodeproj/project.pbxproj
@@ -152,6 +152,8 @@
 		1ABF25701D52AB6200BAC441 /* RLMRealmConfiguration+Sync.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1ABF256E1D52AB6200BAC441 /* RLMRealmConfiguration+Sync.mm */; };
 		1AD3870C1D4A7FBB00479110 /* RLMSyncSession.h in Headers */ = {isa = PBXBuildFile; fileRef = 1AD3870A1D4A7FBB00479110 /* RLMSyncSession.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		1AD3870D1D4A7FBB00479110 /* RLMSyncSession.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1AD3870B1D4A7FBB00479110 /* RLMSyncSession.mm */; };
+		1AEC3E921E32EE8800E1EBE6 /* RLMSyncSessionRefreshHandle+ObjectServerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 1AEC3E8F1E32EE8100E1EBE6 /* RLMSyncSessionRefreshHandle+ObjectServerTests.m */; };
+		1AEC3E971E32F03100E1EBE6 /* RLMTestUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 1AEC3E941E32EF5100E1EBE6 /* RLMTestUtils.m */; };
 		1AF64DCF1DA3042B0081EB15 /* RLMSyncManager+ObjectServerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 1AF64DCC1DA304210081EB15 /* RLMSyncManager+ObjectServerTests.m */; };
 		1AF6EA481D36B1850014EB85 /* RLMAuthResponseModel.m in Sources */ = {isa = PBXBuildFile; fileRef = 1AF6EA461D36B1850014EB85 /* RLMAuthResponseModel.m */; };
 		1AF7EA961D340AF70001A9B5 /* RLMSyncManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 1AF7EA941D340AF70001A9B5 /* RLMSyncManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -725,6 +727,11 @@
 		1ABF256E1D52AB6200BAC441 /* RLMRealmConfiguration+Sync.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = "RLMRealmConfiguration+Sync.mm"; sourceTree = "<group>"; };
 		1AD3870A1D4A7FBB00479110 /* RLMSyncSession.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RLMSyncSession.h; sourceTree = "<group>"; };
 		1AD3870B1D4A7FBB00479110 /* RLMSyncSession.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = RLMSyncSession.mm; sourceTree = "<group>"; };
+		1AEC3E8D1E32EE0B00E1EBE6 /* RLMSyncSessionRefreshHandle.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RLMSyncSessionRefreshHandle.h; sourceTree = "<group>"; };
+		1AEC3E8E1E32EE8100E1EBE6 /* RLMSyncSessionRefreshHandle+ObjectServerTests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "RLMSyncSessionRefreshHandle+ObjectServerTests.h"; path = "Realm/ObjectServerTests/RLMSyncSessionRefreshHandle+ObjectServerTests.h"; sourceTree = "<group>"; };
+		1AEC3E8F1E32EE8100E1EBE6 /* RLMSyncSessionRefreshHandle+ObjectServerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "RLMSyncSessionRefreshHandle+ObjectServerTests.m"; path = "Realm/ObjectServerTests/RLMSyncSessionRefreshHandle+ObjectServerTests.m"; sourceTree = "<group>"; };
+		1AEC3E931E32EF5100E1EBE6 /* RLMTestUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RLMTestUtils.h; path = Realm/ObjectServerTests/RLMTestUtils.h; sourceTree = "<group>"; };
+		1AEC3E941E32EF5100E1EBE6 /* RLMTestUtils.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RLMTestUtils.m; path = Realm/ObjectServerTests/RLMTestUtils.m; sourceTree = "<group>"; };
 		1AF64DCB1DA304210081EB15 /* RLMSyncManager+ObjectServerTests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "RLMSyncManager+ObjectServerTests.h"; path = "Realm/ObjectServerTests/RLMSyncManager+ObjectServerTests.h"; sourceTree = "<group>"; };
 		1AF64DCC1DA304210081EB15 /* RLMSyncManager+ObjectServerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "RLMSyncManager+ObjectServerTests.m"; path = "Realm/ObjectServerTests/RLMSyncManager+ObjectServerTests.m"; sourceTree = "<group>"; };
 		1AF6EA451D36B1850014EB85 /* RLMAuthResponseModel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RLMAuthResponseModel.h; sourceTree = "<group>"; };
@@ -1094,8 +1101,12 @@
 				1AA5AE9A1D98A1B000ED8C27 /* Object-Server-Tests-Bridging-Header.h */,
 				1AF64DCB1DA304210081EB15 /* RLMSyncManager+ObjectServerTests.h */,
 				1AF64DCC1DA304210081EB15 /* RLMSyncManager+ObjectServerTests.m */,
+				1AEC3E8E1E32EE8100E1EBE6 /* RLMSyncSessionRefreshHandle+ObjectServerTests.h */,
+				1AEC3E8F1E32EE8100E1EBE6 /* RLMSyncSessionRefreshHandle+ObjectServerTests.m */,
 				1A81EDEF1E30A4630035F4E6 /* RLMSyncUser+ObjectServerTests.h */,
 				1A81EDF01E30A4630035F4E6 /* RLMSyncUser+ObjectServerTests.mm */,
+				1AEC3E931E32EF5100E1EBE6 /* RLMTestUtils.h */,
+				1AEC3E941E32EF5100E1EBE6 /* RLMTestUtils.m */,
 			);
 			name = Utility;
 			sourceTree = "<group>";
@@ -1111,6 +1122,7 @@
 				1AF7EA9A1D340E700001A9B5 /* RLMNetworkClient.m */,
 				1A6921D11D779774004C3232 /* RLMTokenModels.h */,
 				1A6921D21D779774004C3232 /* RLMTokenModels.m */,
+				1AEC3E8D1E32EE0B00E1EBE6 /* RLMSyncSessionRefreshHandle.h */,
 				1A33C42C1DAEE445001E87AA /* RLMSyncSessionRefreshHandle.hpp */,
 				1A33C42D1DAEE445001E87AA /* RLMSyncSessionRefreshHandle.mm */,
 			);
@@ -2457,11 +2469,13 @@
 				E8267FF11D90B8E700E001C7 /* RLMObjectServerTests.m in Sources */,
 				1AA5AEA11D98C99800ED8C27 /* SwiftObjectServerTests.swift in Sources */,
 				1AA5AE981D989BE400ED8C27 /* SwiftSyncTestCase.swift in Sources */,
+				1AEC3E921E32EE8800E1EBE6 /* RLMSyncSessionRefreshHandle+ObjectServerTests.m in Sources */,
 				E86E61241D91E4E200DC2419 /* RLMTestCase.m in Sources */,
 				1AF64DCF1DA3042B0081EB15 /* RLMSyncManager+ObjectServerTests.m in Sources */,
 				1A2D7A521DA5BCEC006AD7D6 /* RLMMultiProcessTestCase.m in Sources */,
 				1A81EDF31E30A4780035F4E6 /* RLMSyncUser+ObjectServerTests.mm in Sources */,
 				1AA5AE9C1D98A68E00ED8C27 /* RLMSyncTestCase.m in Sources */,
+				1AEC3E971E32F03100E1EBE6 /* RLMTestUtils.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Realm/ObjectServerTests/RLMSyncManager+ObjectServerTests.m
+++ b/Realm/ObjectServerTests/RLMSyncManager+ObjectServerTests.m
@@ -19,8 +19,7 @@
 #import "RLMSyncManager_Private.h"
 #import "RLMSyncManager+ObjectServerTests.h"
 #import "RLMSyncTestCase.h"
-
-#import <objc/runtime.h>
+#import "RLMTestUtils.h"
 
 @interface RLMSyncManager ()
 - (NSArray<RLMSyncUser *> *)_allUsers;
@@ -29,23 +28,7 @@
 @implementation RLMSyncManager (ObjectServerTests)
 
 + (void)load {
-    Class class = object_getClass((id)self);
-    SEL originalSelector = @selector(sharedManager);
-    SEL swizzledSelector = @selector(ost_sharedManager);
-    Method originalMethod = class_getClassMethod(class, originalSelector);
-    Method swizzledMethod = class_getClassMethod(class, swizzledSelector);
-
-    if (class_addMethod(class,
-                        originalSelector,
-                        method_getImplementation(swizzledMethod),
-                        method_getTypeEncoding(swizzledMethod))) {
-        class_replaceMethod(class,
-                            swizzledSelector,
-                            method_getImplementation(originalMethod),
-                            method_getTypeEncoding(originalMethod));
-    } else {
-        method_exchangeImplementations(originalMethod, swizzledMethod);
-    }
+    RLMSwapOutClassMethod(self, @selector(sharedManager),  @selector(ost_sharedManager));
 }
 
 + (instancetype)ost_sharedManager {

--- a/Realm/ObjectServerTests/RLMSyncSessionRefreshHandle+ObjectServerTests.h
+++ b/Realm/ObjectServerTests/RLMSyncSessionRefreshHandle+ObjectServerTests.h
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////
 //
-// Copyright 2016 Realm Inc.
+// Copyright 2017 Realm Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,17 +18,8 @@
 
 #import "RLMSyncSessionRefreshHandle.h"
 
-#import <memory>
+@interface RLMSyncSessionRefreshHandle (ObjectServerTests)
 
-namespace realm {
-class SyncSession;
-}
++ (void)calculateFireDateUsingTestLogic:(BOOL)forTest blockOnRefreshCompletion:(void(^)(BOOL))block;
 
-@class RLMSyncUser;
-
-@interface RLMSyncSessionRefreshHandle ()
-
-- (instancetype)initWithPathToRealm:(NSString *)path
-                               user:(RLMSyncUser *)user
-                            session:(std::shared_ptr<realm::SyncSession>)session;
 @end

--- a/Realm/ObjectServerTests/RLMSyncSessionRefreshHandle+ObjectServerTests.m
+++ b/Realm/ObjectServerTests/RLMSyncSessionRefreshHandle+ObjectServerTests.m
@@ -1,0 +1,66 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2017 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+#import "RLMSyncSessionRefreshHandle+ObjectServerTests.h"
+
+#import "RLMTestUtils.h"
+
+static BOOL s_calculateFireDatesWithTestLogic = NO;
+static void(^s_onRefreshCompletedOrErrored)(BOOL) = nil;
+
+@interface RLMSyncSessionRefreshHandle ()
++ (NSDate *)fireDateForTokenExpirationDate:(NSDate *)date;
+- (BOOL)_onRefreshCompletionWithError:(NSError *)error json:(NSDictionary *)json;
+@end
+
+@implementation RLMSyncSessionRefreshHandle (ObjectServerTests)
+
++ (void)calculateFireDateUsingTestLogic:(BOOL)forTest blockOnRefreshCompletion:(void(^)(BOOL))block {
+    s_onRefreshCompletedOrErrored = block;
+    s_calculateFireDatesWithTestLogic = forTest;
+}
+
++ (void)load {
+    RLMSwapOutClassMethod(self,
+                          @selector(fireDateForTokenExpirationDate:),
+                          @selector(ost_fireDateForTokenExpirationDate:));
+    RLMSwapOutInstanceMethod(self,
+                             @selector(_onRefreshCompletionWithError:json:),
+                             @selector(ost_onRefreshCompletionWithError:json:));
+}
+
++ (NSDate *)ost_fireDateForTokenExpirationDate:(__unused NSDate *)date {
+    if (s_calculateFireDatesWithTestLogic) {
+        // Force the refresh to take place one second later.
+        return [NSDate dateWithTimeIntervalSinceNow:1];
+    } else {
+        // Use the original logic.
+        return [self ost_fireDateForTokenExpirationDate:date];
+    }
+}
+
+- (BOOL)ost_onRefreshCompletionWithError:(NSError *)error json:(NSDictionary *)json {
+    BOOL status = [self ost_onRefreshCompletionWithError:error json:json];
+    // For the sake of testing, call a callback afterwards to let the test update its state.
+    if (s_onRefreshCompletedOrErrored) {
+        s_onRefreshCompletedOrErrored(status);
+    }
+    return status;
+}
+
+@end

--- a/Realm/ObjectServerTests/RLMSyncTestCase.m
+++ b/Realm/ObjectServerTests/RLMSyncTestCase.m
@@ -22,6 +22,7 @@
 #import <Realm/Realm.h>
 
 #import "RLMSyncManager+ObjectServerTests.h"
+#import "RLMSyncSessionRefreshHandle+ObjectServerTests.h"
 
 #if !TARGET_OS_MAC
 #error These tests can only be run on a macOS host.
@@ -265,6 +266,8 @@ static NSURL *syncDirectoryForChildProcess() {
 - (void)tearDown {
     [s_managerForTest prepareForDestruction];
     s_managerForTest = nil;
+    [RLMSyncSessionRefreshHandle calculateFireDateUsingTestLogic:NO blockOnRefreshCompletion:nil];
+
     [super tearDown];
 }
 

--- a/Realm/ObjectServerTests/RLMTestUtils.h
+++ b/Realm/ObjectServerTests/RLMTestUtils.h
@@ -16,19 +16,5 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-#import "RLMSyncSessionRefreshHandle.h"
-
-#import <memory>
-
-namespace realm {
-class SyncSession;
-}
-
-@class RLMSyncUser;
-
-@interface RLMSyncSessionRefreshHandle ()
-
-- (instancetype)initWithPathToRealm:(NSString *)path
-                               user:(RLMSyncUser *)user
-                            session:(std::shared_ptr<realm::SyncSession>)session;
-@end
+void RLMSwapOutClassMethod(id classObject, SEL original, SEL swizzled);
+void RLMSwapOutInstanceMethod(id classObject, SEL original, SEL swizzled);

--- a/Realm/ObjectServerTests/RLMTestUtils.m
+++ b/Realm/ObjectServerTests/RLMTestUtils.m
@@ -1,0 +1,53 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2016 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+#import <Foundation/Foundation.h>
+
+#import "RLMTestUtils.h"
+
+#import <objc/runtime.h>
+
+static void RLMSwapOutMethod(Class class,
+                             SEL original, Method originalMethod,
+                             SEL swizzled, Method swizzledMethod) {
+    if (class_addMethod(class,
+                        original,
+                        method_getImplementation(swizzledMethod),
+                        method_getTypeEncoding(swizzledMethod))) {
+        class_replaceMethod(class,
+                            swizzled,
+                            method_getImplementation(originalMethod),
+                            method_getTypeEncoding(originalMethod));
+    } else {
+        method_exchangeImplementations(originalMethod, swizzledMethod);
+    }
+}
+
+void RLMSwapOutClassMethod(id classObject, SEL original, SEL swizzled) {
+    Class class = object_getClass((id)classObject);
+    RLMSwapOutMethod(class,
+                     original, class_getClassMethod(class, original),
+                     swizzled, class_getClassMethod(class, swizzled));
+}
+
+void RLMSwapOutInstanceMethod(id classObject, SEL original, SEL swizzled) {
+    Class class = [classObject class];
+    RLMSwapOutMethod(class,
+                     original, class_getInstanceMethod(class, original),
+                     swizzled, class_getInstanceMethod(class, swizzled));
+}

--- a/Realm/RLMSyncConfiguration.mm
+++ b/Realm/RLMSyncConfiguration.mm
@@ -130,8 +130,8 @@ static BOOL isValidRealmURL(NSURL *url) {
             @throw RLMException(@"The provided URL (%@) was not a valid Realm URL.", [url absoluteString]);
         }
         auto bindHandler = [=](const std::string& path,
-                              const SyncConfig& config,
-                              const std::shared_ptr<SyncSession>& session) {
+                               const SyncConfig& config,
+                               const std::shared_ptr<SyncSession>& session) {
             [user _bindSessionWithPath:path
                                 config:config
                                session:session

--- a/Realm/RLMSyncSessionRefreshHandle.h
+++ b/Realm/RLMSyncSessionRefreshHandle.h
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////
 //
-// Copyright 2016 Realm Inc.
+// Copyright 2017 Realm Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,19 +16,15 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-#import "RLMSyncSessionRefreshHandle.h"
-
-#import <memory>
-
-namespace realm {
-class SyncSession;
-}
+#import <Foundation/Foundation.h>
 
 @class RLMSyncUser;
 
-@interface RLMSyncSessionRefreshHandle ()
+/// An object that handles refreshing a session's token periodically, as long
+/// as the session remains live and valid.
+@interface RLMSyncSessionRefreshHandle : NSObject
 
-- (instancetype)initWithPathToRealm:(NSString *)path
-                               user:(RLMSyncUser *)user
-                            session:(std::shared_ptr<realm::SyncSession>)session;
+- (void)scheduleRefreshTimer:(NSDate *)dateWhenTokenExpires;
+- (void)invalidate;
+
 @end

--- a/Realm/RLMSyncSessionRefreshHandle.mm
+++ b/Realm/RLMSyncSessionRefreshHandle.mm
@@ -33,40 +33,137 @@ using namespace realm;
 }
 
 @property (nonatomic, weak) RLMSyncUser *user;
-@property (nonatomic, strong) NSString *fullURLPath;
+@property (nonatomic, strong) NSString *pathToRealm;
 @property (nonatomic) NSTimer *timer;
 
 @end
 
 @implementation RLMSyncSessionRefreshHandle
 
-- (instancetype)initWithFullURLPath:(NSString *)urlPath
+- (instancetype)initWithPathToRealm:(NSString *)path
                                user:(RLMSyncUser *)user
                             session:(std::shared_ptr<realm::SyncSession>)session {
     if (self = [super init]) {
-        self.fullURLPath = urlPath;
+        self.pathToRealm = path;
         self.user = user;
-        _session = session;
+        _session = std::move(session);
         return self;
     }
     return nil;
 }
 
-- (void)invalidate {
+- (void)dealloc {
     [self.timer invalidate];
-    self.user = nil;
 }
 
-- (void)scheduleRefreshTimer:(NSTimeInterval)fireTime {
-    static const NSInteger refreshBuffer = 10;
+- (void)invalidate {
     [self.timer invalidate];
-    self.timer = [[NSTimer alloc] initWithFireDate:[NSDate dateWithTimeIntervalSince1970:(fireTime - refreshBuffer)]
-                                          interval:0
-                                            target:self
-                                          selector:@selector(timerFired:)
-                                          userInfo:nil
-                                           repeats:NO];
-    [[NSRunLoop currentRunLoop] addTimer:self.timer forMode:NSDefaultRunLoopMode];
+}
+
++ (NSDate *)fireDateForTokenExpirationDate:(NSDate *)date {
+    static const NSTimeInterval refreshBuffer = 10;
+    NSDate *fireDate = [date dateByAddingTimeInterval:-refreshBuffer];
+    // Only fire times in the future are valid.
+    return ([fireDate compare:[NSDate date]] != NSOrderedDescending ? fireDate : nil);
+}
+
+- (void)scheduleRefreshTimer:(NSDate *)dateWhenTokenExpires {
+    // Schedule the timer on the main queue.
+    // It's very likely that this method will be run on a side thread, for example
+    // on the thread that runs `NSURLSession`'s completion blocks. We can't be
+    // guaranteed that there's an existing runloop on those threads, and we don't want
+    // to create and start a new one if one doesn't already exist.
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [self.timer invalidate];
+        NSDate *fireDate = [RLMSyncSessionRefreshHandle fireDateForTokenExpirationDate:dateWhenTokenExpires];
+        if (!fireDate) {
+            [self.user _unregisterRefreshHandleForURLPath:self.pathToRealm];
+            return;
+        }
+        self.timer = [[NSTimer alloc] initWithFireDate:fireDate
+                                              interval:0
+                                                target:self
+                                              selector:@selector(timerFired:)
+                                              userInfo:nil
+                                               repeats:NO];
+        [[NSRunLoop currentRunLoop] addTimer:self.timer forMode:NSDefaultRunLoopMode];
+    });
+}
+
+/// Handler for network requests whose responses successfully parse into an auth response model.
+- (BOOL)_handleSuccessfulRequest:(RLMAuthResponseModel *)model strongUser:(RLMSyncUser *)user {
+    // Success
+    if (auto session = _session.lock()) {
+        if (session->state() != SyncSession::PublicState::Error) {
+            session->refresh_access_token([model.accessToken.token UTF8String], none);
+            NSDate *expiration = [NSDate dateWithTimeIntervalSince1970:model.accessToken.tokenData.expires];
+            [self scheduleRefreshTimer:expiration];
+            return YES;
+        }
+    }
+    // The session is dead or in a fatal error state.
+    [user _unregisterRefreshHandleForURLPath:self.pathToRealm];
+    [self.timer invalidate];
+    return NO;
+}
+
+/// Handler for network requests that failed before the JSON parsing stage.
+- (BOOL)_handleFailedRequest:(NSError *)error strongUser:(RLMSyncUser *)user {
+    // Something else went wrong
+    NSError *syncError = [NSError errorWithDomain:RLMSyncErrorDomain
+                                             code:RLMSyncErrorBadResponse
+                                         userInfo:@{kRLMSyncUnderlyingErrorKey: error}];
+    [[RLMSyncManager sharedManager] _fireError:syncError];
+    NSDate *nextFireDate = nil;
+    // Certain errors should trigger a retry.
+    if (error.domain == NSURLErrorDomain) {
+        switch (error.code) {
+            case NSURLErrorCannotConnectToHost:
+            case NSURLErrorNotConnectedToInternet:
+            case NSURLErrorNetworkConnectionLost:
+            case NSURLErrorTimedOut:
+            case NSURLErrorDNSLookupFailed:
+            case NSURLErrorCannotFindHost:
+                // FIXME: 10 seconds is an arbitrarily chosen value, consider rationalizing it.
+                nextFireDate = [NSDate dateWithTimeIntervalSinceNow:10];
+                break;
+            default:
+                break;
+        }
+        if (nextFireDate) {
+            [self scheduleRefreshTimer:nextFireDate];
+        } else {
+            [user _unregisterRefreshHandleForURLPath:self.pathToRealm];
+            [self.timer invalidate];
+        }
+    }
+    return NO;
+}
+
+- (BOOL)_onRefreshCompletionWithError:(NSError *)error json:(NSDictionary *)json {
+    RLMSyncUser *user = self.user;
+    if (!user) {
+        return NO;
+    }
+    if (json && !error) {
+        RLMAuthResponseModel *model = [[RLMAuthResponseModel alloc] initWithDictionary:json
+                                                                    requireAccessToken:YES
+                                                                   requireRefreshToken:NO];
+        if (model) {
+            return [self _handleSuccessfulRequest:model strongUser:user];
+        }
+        // Otherwise, malformed JSON
+        error = [NSError errorWithDomain:RLMSyncErrorDomain
+                                    code:RLMSyncErrorBadResponse
+                                userInfo:@{kRLMSyncErrorJSONKey: json}];
+        [user _unregisterRefreshHandleForURLPath:self.pathToRealm];
+        [self.timer invalidate];
+        [[RLMSyncManager sharedManager] _fireError:error];
+        return NO;
+    } else {
+        REALM_ASSERT(error);
+        return [self _handleFailedRequest:error strongUser:user];
+    }
 }
 
 - (void)timerFired:(__unused NSTimer *)timer {
@@ -76,79 +173,20 @@ using namespace realm;
     }
     RLMServerToken refreshToken = user._refreshToken;
     if (!refreshToken) {
-        [user _unregisterRefreshHandleForURLPath:self.fullURLPath];
+        [user _unregisterRefreshHandleForURLPath:self.pathToRealm];
         [self.timer invalidate];
         return;
     }
 
     NSDictionary *json = @{
                            kRLMSyncProviderKey: @"realm",
-                           kRLMSyncPathKey: self.fullURLPath,
+                           kRLMSyncPathKey: self.pathToRealm,
                            kRLMSyncDataKey: refreshToken,
                            kRLMSyncAppIDKey: [RLMSyncManager sharedManager].appID,
                            };
 
     RLMSyncCompletionBlock handler = ^(NSError *error, NSDictionary *json) {
-        if (json && !error) {
-            RLMAuthResponseModel *model = [[RLMAuthResponseModel alloc] initWithDictionary:json
-                                                                        requireAccessToken:YES
-                                                                       requireRefreshToken:NO];
-            if (!model) {
-                // Malformed JSON
-                error = [NSError errorWithDomain:RLMSyncErrorDomain
-                                            code:RLMSyncErrorBadResponse
-                                        userInfo:@{kRLMSyncErrorJSONKey: json}];
-                [user _unregisterRefreshHandleForURLPath:self.fullURLPath];
-                [self.timer invalidate];
-                [[RLMSyncManager sharedManager] _fireError:error];
-                return;
-            }
-
-            // Success
-            if (auto session = _session.lock()) {
-                if (session->state() != SyncSession::PublicState::Error) {
-                    session->refresh_access_token([model.accessToken.token UTF8String], none);
-                    [self scheduleRefreshTimer:model.accessToken.tokenData.expires];
-                    return;
-                }
-            }
-            // The session is dead or in a fatal error state.
-            [user _unregisterRefreshHandleForURLPath:self.fullURLPath];
-            [self.timer invalidate];
-            return;
-        }
-
-        // Something else went wrong
-        NSError *syncError = [NSError errorWithDomain:RLMSyncErrorDomain
-                                                 code:RLMSyncErrorBadResponse
-                                             userInfo:@{kRLMSyncUnderlyingErrorKey: error}];
-        [[RLMSyncManager sharedManager] _fireError:syncError];
-        NSTimeInterval nextFireDate = 0;
-        // Certain errors should trigger a retry.
-        if (error.domain == NSURLErrorDomain) {
-            switch (error.code) {
-                case NSURLErrorCannotConnectToHost:
-                    // FIXME: 120 seconds is an arbitrarily chosen value, consider rationalizing it.
-                    nextFireDate = [[NSDate dateWithTimeIntervalSinceNow:120] timeIntervalSince1970];
-                    break;
-                case NSURLErrorNotConnectedToInternet:
-                case NSURLErrorNetworkConnectionLost:
-                case NSURLErrorTimedOut:
-                case NSURLErrorDNSLookupFailed:
-                case NSURLErrorCannotFindHost:
-                    // FIXME: 30 seconds is an arbitrarily chosen value, consider rationalizing it.
-                    nextFireDate = [[NSDate dateWithTimeIntervalSinceNow:30] timeIntervalSince1970];
-                    break;
-                default:
-                    break;
-            }
-            if (nextFireDate > 0) {
-                [self scheduleRefreshTimer:nextFireDate];
-            } else {
-                [user _unregisterRefreshHandleForURLPath:self.fullURLPath];
-                [self.timer invalidate];
-            }
-        }
+        [self _onRefreshCompletionWithError:error json:json];
     };
     [RLMNetworkClient postRequestToEndpoint:RLMServerEndpointAuth
                                      server:user.authenticationServer

--- a/Realm/RLMSyncUser.mm
+++ b/Realm/RLMSyncUser.mm
@@ -39,6 +39,12 @@ using namespace realm;
 - (instancetype)initWithAuthServer:(nullable NSURL *)authServer NS_DESIGNATED_INITIALIZER;
 
 @property (nonatomic, readwrite) NSURL *authenticationServer;
+
+/**
+ All 'refresh handles' associated with Realms opened by this user. A refresh handle is
+ an object that encapsulates the concept of periodically refreshing the Realm's access
+ token before it expires. Tokens are indexed by their paths (e.g. `/~/path/to/realm`).
+ */
 @property (nonatomic) NSMutableDictionary<NSString *, RLMSyncSessionRefreshHandle *> *refreshHandles;
 
 @end
@@ -183,9 +189,9 @@ using namespace realm;
                   completion:(RLMSyncBasicErrorReportingBlock)completion
                 isStandalone:(__unused BOOL)standalone {
     NSURL *realmURL = [NSURL URLWithString:@(config.realm_url.c_str())];
-    RLMServerPath unresolvedURL = [realmURL path];
+    RLMServerPath pathToRealm = [realmURL path];
     NSDictionary *json = @{
-                           kRLMSyncPathKey: unresolvedURL,
+                           kRLMSyncPathKey: pathToRealm,
                            kRLMSyncProviderKey: @"realm",
                            kRLMSyncDataKey: @(_user->refresh_token().c_str()),
                            kRLMSyncAppIDKey: [RLMSyncManager sharedManager].appID,
@@ -223,12 +229,13 @@ using namespace realm;
             bool success = session->state() != SyncSession::PublicState::Error;
             if (success) {
                 // Schedule the session for automatic refreshing on a timer.
-                auto handle = [[RLMSyncSessionRefreshHandle alloc] initWithFullURLPath:resolvedURLString
+                auto handle = [[RLMSyncSessionRefreshHandle alloc] initWithPathToRealm:pathToRealm
                                                                                   user:self
                                                                                session:session];
                 [self.refreshHandles[resolvedURLString] invalidate];
                 self.refreshHandles[resolvedURLString] = handle;
-                [handle scheduleRefreshTimer:model.accessToken.tokenData.expires];
+                NSDate *expires = [NSDate dateWithTimeIntervalSince1970:model.accessToken.tokenData.expires];
+                [handle scheduleRefreshTimer:expires];
             }
             if (completion) {
                 completion(success ? nil : [NSError errorWithDomain:RLMSyncErrorDomain


### PR DESCRIPTION
Changes:
- Sync token refresh timers will now be registered upon the main queue
- Sync token refresh handles will now be properly created with the path to the Realm (instead of the full URL)
- Made the logic to calculate the time at which the token is refreshed more resilient to bad values

Fixes https://github.com/realm/realm-cocoa/issues/4569. Related to https://github.com/realm/realm-sync/issues/1114 and https://github.com/realm/RealmTasks/issues/384.