### PR TITLE
add docstring to NSError+RLMSync category

### DIFF
--- a/Realm/NSError+RLMSync.h
+++ b/Realm/NSError+RLMSync.h
@@ -20,6 +20,8 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+/// NSError category extension providing methods to get data out of Realm's
+/// "client reset" error.
 @interface NSError (RLMSync)
 
 /**


### PR DESCRIPTION
`master` is currently not at 100% doc coverage because of this. See https://ci.realm.io/job/objc_pr/4633/configuration=Release,swift_version=3.0.2,target=docs/console

```json
Undocumented Realm objc declarations:
{
  "warnings": [
    {
      "file": "/Users/realm/workspace/objc_pr/configuration/Release/swift_version/3.0.2/target/docs/Realm/NSError+RLMSync.h",
      "line": 23,
      "symbol": "NSError(RLMSync)",
      "symbol_kind": "sourcekitten.source.lang.objc.decl.category",
      "warning": "undocumented"
    }
  ],
  "source_directory": "/Users/realm/workspace/objc_pr/configuration/Release/swift_version/3.0.2/target/docs"
}
```