### PR TITLE
Fix error behavior when binding session for the first time

### DIFF
--- a/Realm/RLMSyncConfiguration.mm
+++ b/Realm/RLMSyncConfiguration.mm
@@ -129,14 +129,12 @@ static BOOL isValidRealmURL(NSURL *url) {
         if (!isValidRealmURL(url)) {
             @throw RLMException(@"The provided URL (%@) was not a valid Realm URL.", [url absoluteString]);
         }
-        auto bindHandler = [=](const std::string& path,
+        auto bindHandler = [=](auto&,
                                const SyncConfig& config,
                                const std::shared_ptr<SyncSession>& session) {
-            [user _bindSessionWithPath:path
-                                config:config
-                               session:session
-                            completion:[RLMSyncManager sharedManager].sessionCompletionNotifier
-                          isStandalone:NO];
+            [user _bindSessionWithConfig:config
+                                 session:session
+                              completion:[RLMSyncManager sharedManager].sessionCompletionNotifier];
         };
         if (!errorHandler) {
             errorHandler = [=](std::shared_ptr<SyncSession> errored_session,

--- a/Realm/RLMSyncSessionRefreshHandle.hpp
+++ b/Realm/RLMSyncSessionRefreshHandle.hpp
@@ -18,6 +18,8 @@
 
 #import "RLMSyncSessionRefreshHandle.h"
 
+#import "RLMSyncUtil_Private.h"
+
 #import <memory>
 
 namespace realm {
@@ -28,7 +30,13 @@ class SyncSession;
 
 @interface RLMSyncSessionRefreshHandle ()
 
-- (instancetype)initWithPathToRealm:(NSString *)path
-                               user:(RLMSyncUser *)user
-                            session:(std::shared_ptr<realm::SyncSession>)session;
+NS_ASSUME_NONNULL_BEGIN
+
+- (instancetype)initWithRealmURL:(NSURL *)realmURL
+                            user:(RLMSyncUser *)user
+                         session:(std::shared_ptr<realm::SyncSession>)session
+                 completionBlock:(nullable RLMSyncBasicErrorReportingBlock)completionBlock;
+
+NS_ASSUME_NONNULL_END
+
 @end

--- a/Realm/RLMSyncSessionRefreshHandle.mm
+++ b/Realm/RLMSyncSessionRefreshHandle.mm
@@ -23,40 +23,62 @@
 #import "RLMSyncManager_Private.h"
 #import "RLMSyncUser_Private.hpp"
 #import "RLMTokenModels.h"
+#import "RLMUtil.hpp"
 
 #import "sync/sync_session.hpp"
+
+typedef NS_ENUM(NSUInteger, RLMSyncHandleMode) {
+    RLMSyncHandleModeBind,          // Initial `bind` of a session
+    RLMSyncHandleModeRetryBind,     // Retrying the initial `bind` of a session
+    RLMSyncHandleModeRefresh,       // Preemptive refreshing of a session
+};
 
 using namespace realm;
 
 @interface RLMSyncSessionRefreshHandle () {
     std::weak_ptr<SyncSession> _session;
+    std::shared_ptr<SyncSession> _strongSession;
 }
 
 @property (nonatomic, weak) RLMSyncUser *user;
 @property (nonatomic, strong) NSString *pathToRealm;
 @property (nonatomic) NSTimer *timer;
+@property (nonatomic) RLMSyncHandleMode mode;
+
+@property (nonatomic) NSURL *realmURL;
+@property (nonatomic, copy) RLMSyncBasicErrorReportingBlock completionBlock;
 
 @end
 
 @implementation RLMSyncSessionRefreshHandle
 
-- (instancetype)initWithPathToRealm:(NSString *)path
-                               user:(RLMSyncUser *)user
-                            session:(std::shared_ptr<realm::SyncSession>)session {
+- (instancetype)initWithRealmURL:(NSURL *)realmURL
+                            user:(RLMSyncUser *)user
+                         session:(std::shared_ptr<realm::SyncSession>)session
+                 completionBlock:(RLMSyncBasicErrorReportingBlock)completionBlock {
     if (self = [super init]) {
+        NSString *path = [realmURL path];
         self.pathToRealm = path;
         self.user = user;
-        _session = std::move(session);
+        self.mode = RLMSyncHandleModeBind;
+        self.completionBlock = completionBlock;
+        self.realmURL = realmURL;
+        // For the initial bind, we want to prolong the session's lifetime.
+        _strongSession = std::move(session);
+        // Immediately fire off the network request.
+        [self _timerFired:nil];
         return self;
     }
     return nil;
 }
 
 - (void)dealloc {
+    _strongSession = nullptr;
     [self.timer invalidate];
 }
 
 - (void)invalidate {
+    _strongSession = nullptr;
     [self.timer invalidate];
 }
 
@@ -83,7 +105,7 @@ using namespace realm;
         self.timer = [[NSTimer alloc] initWithFireDate:fireDate
                                               interval:0
                                                 target:self
-                                              selector:@selector(timerFired:)
+                                              selector:@selector(_timerFired:)
                                               userInfo:nil
                                                repeats:NO];
         [[NSRunLoop currentRunLoop] addTimer:self.timer forMode:NSDefaultRunLoopMode];
@@ -93,29 +115,72 @@ using namespace realm;
 /// Handler for network requests whose responses successfully parse into an auth response model.
 - (BOOL)_handleSuccessfulRequest:(RLMAuthResponseModel *)model strongUser:(RLMSyncUser *)user {
     // Success
-    if (auto session = _session.lock()) {
-        if (session->state() != SyncSession::PublicState::Error) {
-            session->refresh_access_token([model.accessToken.token UTF8String], none);
-            NSDate *expiration = [NSDate dateWithTimeIntervalSince1970:model.accessToken.tokenData.expires];
-            [self scheduleRefreshTimer:expiration];
-            return YES;
+    std::shared_ptr<SyncSession> session = (self.mode == RLMSyncHandleModeBind ? _strongSession : _session.lock());
+    if (!session) {
+        // The session is dead or in a fatal error state.
+        [user _unregisterRefreshHandleForURLPath:self.pathToRealm];
+        [self invalidate];
+        return NO;
+    }
+    bool success = session->state() != SyncSession::PublicState::Error;
+    if (success) {
+        NSString *resolvedURLString = nil;
+        util::Optional<std::string> resolved_url = none;
+        if (self.mode != RLMSyncHandleModeRefresh) {
+            RLMServerPath resolvedPath = model.accessToken.tokenData.path;
+            // Munge the path back onto the original URL, because the `sync` API expects an entire URL.
+            NSURLComponents *urlBuffer = [NSURLComponents componentsWithURL:self.realmURL
+                                                    resolvingAgainstBaseURL:YES];
+            urlBuffer.path = resolvedPath;
+            resolvedURLString = [[urlBuffer URL] absoluteString];
+            if (resolvedURLString) {
+                resolved_url = {resolvedURLString.UTF8String};
+            } else {
+                @throw RLMException(@"Resolved path returned from the server was invalid (%@).", resolvedPath);
+            }
+        }
+        session->refresh_access_token([model.accessToken.token UTF8String], resolved_url);
+        success = session->state() != SyncSession::PublicState::Error;
+        if (success) {
+            switch (self.mode) {
+                case RLMSyncHandleModeBind:
+                    _session = std::move(_strongSession);
+                    _strongSession = nullptr;
+                    REALM_FALLTHROUGH;
+                case RLMSyncHandleModeRetryBind:
+                    // Any successful request moves the state into RLMSyncHandleModeRefresh.
+                    self.mode = RLMSyncHandleModeRefresh;
+                    REALM_FALLTHROUGH;
+                case RLMSyncHandleModeRefresh:
+                    NSDate *expires = [NSDate dateWithTimeIntervalSince1970:model.accessToken.tokenData.expires];
+                    [self scheduleRefreshTimer:expires];
+                    break;
+            }
+        } else {
+            // The session is dead or in a fatal error state.
+            [user _unregisterRefreshHandleForURLPath:self.pathToRealm];
+            [self invalidate];
         }
     }
-    // The session is dead or in a fatal error state.
-    [user _unregisterRefreshHandleForURLPath:self.pathToRealm];
-    [self.timer invalidate];
-    return NO;
+    if (self.completionBlock) {
+        self.completionBlock(success ? nil : [NSError errorWithDomain:RLMSyncErrorDomain
+                                                                 code:RLMSyncErrorClientSessionError
+                                                             userInfo:nil]);
+    }
+    return success;
 }
 
 /// Handler for network requests that failed before the JSON parsing stage.
 - (BOOL)_handleFailedRequest:(NSError *)error strongUser:(RLMSyncUser *)user {
-    // Something else went wrong
     NSError *syncError = [NSError errorWithDomain:RLMSyncErrorDomain
                                              code:RLMSyncErrorBadResponse
                                          userInfo:@{kRLMSyncUnderlyingErrorKey: error}];
+    if (self.completionBlock) {
+        self.completionBlock(syncError);
+    }
     [[RLMSyncManager sharedManager] _fireError:syncError];
-    NSDate *nextFireDate = nil;
-    // Certain errors should trigger a retry.
+    // Certain errors related to network connectivity should trigger a retry.
+    NSDate *nextTryDate = nil;
     if (error.domain == NSURLErrorDomain) {
         switch (error.code) {
             case NSURLErrorCannotConnectToHost:
@@ -125,21 +190,34 @@ using namespace realm;
             case NSURLErrorDNSLookupFailed:
             case NSURLErrorCannotFindHost:
                 // FIXME: 10 seconds is an arbitrarily chosen value, consider rationalizing it.
-                nextFireDate = [NSDate dateWithTimeIntervalSinceNow:10];
+                nextTryDate = [NSDate dateWithTimeIntervalSinceNow:10];
                 break;
             default:
                 break;
         }
-        if (nextFireDate) {
-            [self scheduleRefreshTimer:nextFireDate];
-        } else {
-            [user _unregisterRefreshHandleForURLPath:self.pathToRealm];
-            [self.timer invalidate];
-        }
     }
+    if (!nextTryDate) {
+        // This error isn't a network failure error. Just invalidate the refresh handle and stop.
+        [user _unregisterRefreshHandleForURLPath:self.pathToRealm];
+        [self invalidate];
+        return NO;
+    }
+    switch (self.mode) {
+        case RLMSyncHandleModeBind:
+            // A failed initial bind always results in retry binds.
+            _session = std::move(_strongSession);
+            _strongSession = nullptr;
+            self.mode = RLMSyncHandleModeRetryBind;
+            break;
+        case RLMSyncHandleModeRetryBind:
+        case RLMSyncHandleModeRefresh:
+            break;
+    }
+    [self scheduleRefreshTimer:nextTryDate];
     return NO;
 }
 
+/// Callback handler for network requests.
 - (BOOL)_onRefreshCompletionWithError:(NSError *)error json:(NSDictionary *)json {
     RLMSyncUser *user = self.user;
     if (!user) {
@@ -158,6 +236,9 @@ using namespace realm;
                                 userInfo:@{kRLMSyncErrorJSONKey: json}];
         [user _unregisterRefreshHandleForURLPath:self.pathToRealm];
         [self.timer invalidate];
+        if (self.completionBlock) {
+            self.completionBlock(error);
+        }
         [[RLMSyncManager sharedManager] _fireError:error];
         return NO;
     } else {
@@ -166,7 +247,7 @@ using namespace realm;
     }
 }
 
-- (void)timerFired:(__unused NSTimer *)timer {
+- (void)_timerFired:(__unused NSTimer *)timer {
     RLMSyncUser *user = self.user;
     if (!user) {
         return;

--- a/Realm/RLMSyncSessionRefreshHandle.mm
+++ b/Realm/RLMSyncSessionRefreshHandle.mm
@@ -107,7 +107,7 @@ using namespace realm;
 /// Handler for network requests whose responses successfully parse into an auth response model.
 - (BOOL)_handleSuccessfulRequest:(RLMAuthResponseModel *)model strongUser:(RLMSyncUser *)user {
     // Success
-    std::shared_ptr<SyncSession> session = _strongSession ?: _session.lock();
+    std::shared_ptr<SyncSession> session = _session.lock();
     if (!session) {
         // The session is dead or in a fatal error state.
         [user _unregisterRefreshHandleForURLPath:self.pathToRealm];

--- a/Realm/RLMSyncUser_Private.hpp
+++ b/Realm/RLMSyncUser_Private.hpp
@@ -34,11 +34,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface RLMSyncUser ()
 
-- (void)_bindSessionWithPath:(const std::string&)path
-                      config:(const SyncConfig&)config
-                     session:(std::shared_ptr<SyncSession>)session
-                  completion:(nullable RLMSyncBasicErrorReportingBlock)completion
-                isStandalone:(BOOL)standalone;
+- (void)_bindSessionWithConfig:(const SyncConfig&)config
+                       session:(std::shared_ptr<SyncSession>)session
+                    completion:(RLMSyncBasicErrorReportingBlock)completion;
 
 - (instancetype)initWithSyncUser:(std::shared_ptr<SyncUser>)user;
 - (std::shared_ptr<SyncUser>)_syncUser;


### PR DESCRIPTION
~Changes:~
- ~If the initial bind-session network request fails due to a network error, the request will be automatically retried. (This is how the pre-emptive token refreshing system works already.)~
- ~Changed some internal APIs to remove unused arguments and make implementing the above easier~

Fix error behavior when binding session for the first time

Changes:
- Improved the refresh handle logic to handle both initial binds and refreshing
- Removed the code in `RLMSyncUser.mm` to handle initial binds
- This means that initial binds that fail because of network conditions will use the same retry logic as refresh attempts