### PR TITLE
Allow generic user info to be passed up for client reset errors

### DIFF
--- a/Realm/RLMSyncManager.mm
+++ b/Realm/RLMSyncManager.mm
@@ -159,7 +159,6 @@ static dispatch_once_t s_onceToken;
         case RLMSyncSystemErrorKindClientReset: {
             // Client reset is a special case; the application can respond to it to a greater degree than
             // it can for most other errors.
-            mutableUserInfo = [@{} mutableCopy];
             mutableUserInfo[kRLMSyncPathOfRealmBackupCopyKey] = userInfo[@(realm::SyncError::c_recovery_file_path_key)];
             std::string original_path = [userInfo[@(realm::SyncError::c_original_file_path_key)] UTF8String];
             mutableUserInfo[kRLMSyncInitiateClientResetBlockKey] = ^{


### PR DESCRIPTION
This was a minor oversight on my part. There's no good reason to remove the generic error info from the `userInfo` for client reset errors, although it's not of much use to end users either.