### PR TITLE
Change the way a private header is used by the object server test code

### DIFF
--- a/Realm.xcodeproj/project.pbxproj
+++ b/Realm.xcodeproj/project.pbxproj
@@ -97,6 +97,8 @@
 		1A1536741DB0464800C0EC93 /* sync_metadata.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1A15366F1DB0464800C0EC93 /* sync_metadata.cpp */; };
 		1A1536761DB0464F00C0EC93 /* sync_file.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1A15366D1DB0464800C0EC93 /* sync_file.cpp */; };
 		1A1536771DB0465400C0EC93 /* sync_metadata.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1A15366F1DB0464800C0EC93 /* sync_metadata.cpp */; };
+		1A2713D31E3AD126001F6BFC /* RLMSyncManager_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 1AF7EA981D340D1F0001A9B5 /* RLMSyncManager_Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		1A2713D41E3AD126001F6BFC /* RLMSyncManager_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 1AF7EA981D340D1F0001A9B5 /* RLMSyncManager_Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		1A2D7A521DA5BCEC006AD7D6 /* RLMMultiProcessTestCase.m in Sources */ = {isa = PBXBuildFile; fileRef = 027A4D2B1AB1012500AA46F9 /* RLMMultiProcessTestCase.m */; };
 		1A33C42B1DAEB9C4001E87AA /* RLMSyncUser_Private.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 1A33C42A1DAEB9C4001E87AA /* RLMSyncUser_Private.hpp */; };
 		1A33C4301DAEE445001E87AA /* RLMSyncSessionRefreshHandle.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1A33C42D1DAEE445001E87AA /* RLMSyncSessionRefreshHandle.mm */; };
@@ -1601,6 +1603,7 @@
 				5D02C78F1E2E871F0048C13E /* object_accessor.hpp in Headers */,
 				1A7AFA741E29B756002744FA /* object.hpp in Headers */,
 				3F0543F81C56F78300AA5322 /* external_commit_helper.hpp in Headers */,
+				1A2713D31E3AD126001F6BFC /* RLMSyncManager_Private.h in Headers */,
 				1A1536591DB045B500C0EC93 /* sync_manager.hpp in Headers */,
 				5DB591AB1D063DF8001D8F93 /* format.hpp in Headers */,
 				5D659EA11BE04556006515A0 /* index_set.hpp in Headers */,
@@ -1747,6 +1750,7 @@
 				5DD755C21BE056DE002800DA /* RLMRealmUtil.hpp in Headers */,
 				5DD755C31BE056DE002800DA /* RLMResults.h in Headers */,
 				5DD755C41BE056DE002800DA /* RLMResults_Private.h in Headers */,
+				1A2713D41E3AD126001F6BFC /* RLMSyncManager_Private.h in Headers */,
 				5DD755C51BE056DE002800DA /* RLMSchema.h in Headers */,
 				5DD755C61BE056DE002800DA /* RLMSchema_Private.h in Headers */,
 				5DD755C71BE056DE002800DA /* RLMSwiftSupport.h in Headers */,

--- a/Realm/ObjectServerTests/RLMSyncManager+ObjectServerTests.m
+++ b/Realm/ObjectServerTests/RLMSyncManager+ObjectServerTests.m
@@ -16,7 +16,7 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-#import "RLMSyncManager_Private.h"
+#import <Realm/RLMSyncManager_Private.h>
 #import "RLMSyncManager+ObjectServerTests.h"
 #import "RLMSyncTestCase.h"
 #import "RLMTestUtils.h"


### PR DESCRIPTION
Fixes an issue where the object server tests target refused to build after JP's module changes.