### PR TITLE
Fix incorrect comparison of date objects

### DIFF
--- a/Realm.xcodeproj/project.pbxproj
+++ b/Realm.xcodeproj/project.pbxproj
@@ -86,6 +86,7 @@
 		1A1536741DB0464800C0EC93 /* sync_metadata.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1A15366F1DB0464800C0EC93 /* sync_metadata.cpp */; };
 		1A1536761DB0464F00C0EC93 /* sync_file.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1A15366D1DB0464800C0EC93 /* sync_file.cpp */; };
 		1A1536771DB0465400C0EC93 /* sync_metadata.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1A15366F1DB0464800C0EC93 /* sync_metadata.cpp */; };
+		1A2713D71E3BBAC8001F6BFC /* RLMAncillaryObjectServerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 1A2713D51E3BBAC4001F6BFC /* RLMAncillaryObjectServerTests.m */; };
 		1A2D7A521DA5BCEC006AD7D6 /* RLMMultiProcessTestCase.m in Sources */ = {isa = PBXBuildFile; fileRef = 027A4D2B1AB1012500AA46F9 /* RLMMultiProcessTestCase.m */; };
 		1A33C4301DAEE445001E87AA /* RLMSyncSessionRefreshHandle.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1A33C42D1DAEE445001E87AA /* RLMSyncSessionRefreshHandle.mm */; };
 		1A33C4311DAEE445001E87AA /* RLMSyncSessionRefreshHandle.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1A33C42D1DAEE445001E87AA /* RLMSyncSessionRefreshHandle.mm */; };
@@ -607,6 +608,7 @@
 		1A15366F1DB0464800C0EC93 /* sync_metadata.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = sync_metadata.cpp; path = sync/impl/sync_metadata.cpp; sourceTree = "<group>"; };
 		1A1536701DB0464800C0EC93 /* sync_metadata.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = sync_metadata.hpp; path = sync/impl/sync_metadata.hpp; sourceTree = "<group>"; };
 		1A1C6E241D3FFCF70077B6E7 /* RLMSyncUtil_Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RLMSyncUtil_Private.h; sourceTree = "<group>"; };
+		1A2713D51E3BBAC4001F6BFC /* RLMAncillaryObjectServerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RLMAncillaryObjectServerTests.m; path = Realm/ObjectServerTests/RLMAncillaryObjectServerTests.m; sourceTree = "<group>"; };
 		1A33C42A1DAEB9C4001E87AA /* RLMSyncUser_Private.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = RLMSyncUser_Private.hpp; sourceTree = "<group>"; };
 		1A33C42C1DAEE445001E87AA /* RLMSyncSessionRefreshHandle.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = RLMSyncSessionRefreshHandle.hpp; sourceTree = "<group>"; };
 		1A33C42D1DAEE445001E87AA /* RLMSyncSessionRefreshHandle.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = RLMSyncSessionRefreshHandle.mm; sourceTree = "<group>"; };
@@ -1324,6 +1326,7 @@
 			children = (
 				1AA5AEA21D98CA5300ED8C27 /* Utility */,
 				E8267FF01D90B8E700E001C7 /* RLMObjectServerTests.m */,
+				1A2713D51E3BBAC4001F6BFC /* RLMAncillaryObjectServerTests.m */,
 				3F73BC881E3A876600FE80B6 /* RLMSyncSessionRefreshHandle+ObjectServerTests.h */,
 				3F73BC891E3A876600FE80B6 /* RLMSyncSessionRefreshHandle+ObjectServerTests.m */,
 				1AA5AE9D1D98A6D800ED8C27 /* RLMSyncTestCase.h */,
@@ -2326,6 +2329,7 @@
 				E86E61241D91E4E200DC2419 /* RLMTestCase.m in Sources */,
 				3F73BC921E3A877300FE80B6 /* RLMTestUtils.m in Sources */,
 				1AA5AEA11D98C99800ED8C27 /* SwiftObjectServerTests.swift in Sources */,
+				1A2713D71E3BBAC8001F6BFC /* RLMAncillaryObjectServerTests.m in Sources */,
 				1AA5AE981D989BE400ED8C27 /* SwiftSyncTestCase.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Realm/ObjectServerTests/RLMAncillaryObjectServerTests.m
+++ b/Realm/ObjectServerTests/RLMAncillaryObjectServerTests.m
@@ -51,8 +51,8 @@
     date = [NSDate dateWithTimeIntervalSince1970:(date.timeIntervalSince1970 + 100)];
     NSDate *fireDate = [RLMSyncSessionRefreshHandle fireDateForTokenExpirationDate:date nowDate:nowDate];
     XCTAssertNotNil(fireDate);
-    XCTAssertTrue(fireDate.timeIntervalSinceReferenceDate > nowDate.timeIntervalSinceReferenceDate);
-    XCTAssertTrue(fireDate.timeIntervalSinceReferenceDate < date.timeIntervalSinceReferenceDate);
+    XCTAssertGreaterThan(fireDate.timeIntervalSinceReferenceDate, nowDate.timeIntervalSinceReferenceDate);
+    XCTAssertLessThan(fireDate.timeIntervalSinceReferenceDate, date.timeIntervalSinceReferenceDate);
 }
 
 @end

--- a/Realm/ObjectServerTests/RLMAncillaryObjectServerTests.m
+++ b/Realm/ObjectServerTests/RLMAncillaryObjectServerTests.m
@@ -1,0 +1,58 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2017 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+#import <XCTest/XCTest.h>
+
+#import "RLMSyncSessionRefreshHandle+ObjectServerTests.h"
+
+@interface RLMAncillaryObjectServerTests : XCTestCase
+@end
+
+@interface RLMSyncSessionRefreshHandle ()
++ (NSDate *)fireDateForTokenExpirationDate:(NSDate *)date nowDate:(NSDate *)nowDate;
+@end
+
+@implementation RLMAncillaryObjectServerTests
+
+/// Ensure the `fireDateForTokenExpirationDate:nowDate:` method works properly.
+/// Rationale: we swizzle this method out for our end-to-end tests, so we need to verify the original works.
+- (void)testRefreshHandleDateComparison {
+    [RLMSyncSessionRefreshHandle calculateFireDateUsingTestLogic:NO blockOnRefreshCompletion:nil];
+
+    // The method should return nil if the dates are equal in value.
+    NSDate *date = [NSDate date];
+    NSDate *nowDate = [NSDate dateWithTimeIntervalSince1970:date.timeIntervalSince1970];
+    XCTAssertNil([RLMSyncSessionRefreshHandle fireDateForTokenExpirationDate:date nowDate:nowDate]);
+
+    // The method should return nil if the expiration date is in the past.
+    date = [NSDate dateWithTimeIntervalSince1970:(date.timeIntervalSince1970 - 1)];
+    XCTAssertNil([RLMSyncSessionRefreshHandle fireDateForTokenExpirationDate:date nowDate:nowDate]);
+
+    // The method should return nil if the expiration date is not far enough forward in the future.
+    date = [NSDate dateWithTimeIntervalSince1970:(date.timeIntervalSince1970 + 1)];
+    XCTAssertNil([RLMSyncSessionRefreshHandle fireDateForTokenExpirationDate:date nowDate:nowDate]);
+
+    // The method should return an actual date if the expiration date is far enough forward in the future.
+    date = [NSDate dateWithTimeIntervalSince1970:(date.timeIntervalSince1970 + 100)];
+    NSDate *fireDate = [RLMSyncSessionRefreshHandle fireDateForTokenExpirationDate:date nowDate:nowDate];
+    XCTAssertNotNil(fireDate);
+    XCTAssertTrue(fireDate.timeIntervalSinceReferenceDate > nowDate.timeIntervalSinceReferenceDate);
+    XCTAssertTrue(fireDate.timeIntervalSinceReferenceDate < date.timeIntervalSinceReferenceDate);
+}
+
+@end

--- a/Realm/ObjectServerTests/RLMSyncSessionRefreshHandle+ObjectServerTests.m
+++ b/Realm/ObjectServerTests/RLMSyncSessionRefreshHandle+ObjectServerTests.m
@@ -24,7 +24,7 @@ static BOOL s_calculateFireDatesWithTestLogic = NO;
 static void(^s_onRefreshCompletedOrErrored)(BOOL) = nil;
 
 @interface RLMSyncSessionRefreshHandle ()
-+ (NSDate *)fireDateForTokenExpirationDate:(NSDate *)date;
++ (NSDate *)fireDateForTokenExpirationDate:(NSDate *)date nowDate:(NSDate *)date;
 - (BOOL)_onRefreshCompletionWithError:(NSError *)error json:(NSDictionary *)json;
 @end
 
@@ -37,20 +37,20 @@ static void(^s_onRefreshCompletedOrErrored)(BOOL) = nil;
 
 + (void)load {
     RLMSwapOutClassMethod(self,
-                          @selector(fireDateForTokenExpirationDate:),
-                          @selector(ost_fireDateForTokenExpirationDate:));
+                          @selector(fireDateForTokenExpirationDate:nowDate:),
+                          @selector(ost_fireDateForTokenExpirationDate:nowDate:));
     RLMSwapOutInstanceMethod(self,
                              @selector(_onRefreshCompletionWithError:json:),
                              @selector(ost_onRefreshCompletionWithError:json:));
 }
 
-+ (NSDate *)ost_fireDateForTokenExpirationDate:(__unused NSDate *)date {
++ (NSDate *)ost_fireDateForTokenExpirationDate:(NSDate *)date nowDate:(NSDate *)nowDate {
     if (s_calculateFireDatesWithTestLogic) {
         // Force the refresh to take place one second later.
         return [NSDate dateWithTimeIntervalSinceNow:1];
     } else {
         // Use the original logic.
-        return [self ost_fireDateForTokenExpirationDate:date];
+        return [self ost_fireDateForTokenExpirationDate:date nowDate:nowDate];
     }
 }
 

--- a/Realm/RLMSyncSessionRefreshHandle.mm
+++ b/Realm/RLMSyncSessionRefreshHandle.mm
@@ -74,11 +74,11 @@ using namespace realm;
     [self.timer invalidate];
 }
 
-+ (NSDate *)fireDateForTokenExpirationDate:(NSDate *)date {
++ (NSDate *)fireDateForTokenExpirationDate:(NSDate *)date nowDate:(NSDate *)nowDate {
     static const NSTimeInterval refreshBuffer = 10;
     NSDate *fireDate = [date dateByAddingTimeInterval:-refreshBuffer];
     // Only fire times in the future are valid.
-    return ([fireDate compare:[NSDate date]] != NSOrderedDescending ? fireDate : nil);
+    return ([fireDate compare:nowDate] == NSOrderedDescending ? fireDate : nil);
 }
 
 - (void)scheduleRefreshTimer:(NSDate *)dateWhenTokenExpires {
@@ -89,7 +89,8 @@ using namespace realm;
     // to create and start a new one if one doesn't already exist.
     dispatch_async(dispatch_get_main_queue(), ^{
         [self.timer invalidate];
-        NSDate *fireDate = [RLMSyncSessionRefreshHandle fireDateForTokenExpirationDate:dateWhenTokenExpires];
+        NSDate *fireDate = [RLMSyncSessionRefreshHandle fireDateForTokenExpirationDate:dateWhenTokenExpires
+                                                                               nowDate:[NSDate date]];
         if (!fireDate) {
             [self.user _unregisterRefreshHandleForURLPath:self.pathToRealm];
             return;


### PR DESCRIPTION
The actual change is line 81 in `RLMSyncSessionRefreshHandle.mm`.

I will make sure I write tests to exercise the original implementations of any methods I swizzle out for tests in the future.