### PR TITLE
remove reset simulators script

### DIFF
--- a/scripts/reset-simulators.sh
+++ b/scripts/reset-simulators.sh
@@ -18,30 +18,3 @@ devices=""
 until [ "$devices" != "" ]; do
     devices="$(xcrun simctl list devices -j || true)"
 done
-
-# Shut down booted simulators
-echo "$devices" | ruby -rjson -e 'puts JSON.parse($stdin.read)["devices"].flat_map { |d| d[1] }.select { |d| d["state"] == "Booted" && d["availability"] == "(available)" }.map { |d| d["udid"] }' | while read udid; do
-    echo "shutting down simulator with ID: $udid"
-    xcrun simctl shutdown $udid
-done
-
-# Erase all available simulators
-echo "erasing simulators"
-echo "$devices" | ruby -rjson -e 'puts JSON.parse($stdin.read)["devices"].flat_map { |d| d[1] }.select { |d| d["availability"] == "(available)" }.map { |d| d["udid"] }' | while read udid; do
-    xcrun simctl erase $udid &
-done
-wait
-
-if [[ -a "${DEVELOPER_DIR}/Applications/Simulator.app" ]]; then
-    open "${DEVELOPER_DIR}/Applications/Simulator.app"
-fi
-
-# Wait until the boot completes
-echo "waiting for simulator to boot..."
-until xcrun simctl list devices -j | ruby -rjson -e 'exit JSON.parse($stdin.read)["devices"].flat_map { |d| d[1] }.any? { |d| d["availability"] == "(available)" && d["state"] == "Booted" }'; do
-    sleep 1
-done
-
-# Wait until the simulator is fully booted by waiting for it to launch SpringBoard
-xcrun simctl launch booted com.apple.springboard >/dev/null 2>&1 || true
-echo "simulator booted"


### PR DESCRIPTION
it's possible that this workaround is no longer needed now that Realm doesn't support building with Xcode 7 any more. Marked as "in progress" because it's possible a CI run will indicate that it is in fact still needed.