### PR TITLE
Improve handling of auth errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,19 @@ x.x.x Release notes (yyyy-MM-dd)
 
 ### Enhancements
 
-* None.
+* Expose additional authentication-related errors that might be reported by
+  a Realm Object Server.
+* An error handler can now be registered on `{RLM}SyncUser`s in order to
+  report authentication-related errors that affect the user.
 
 ### Bugfixes
 
 * Sorting Realm collection types no longer throws an exception on iOS 7.
+* Sync users are now automatically logged out upon receiving certain types
+  of errors that indicate they are no longer logged into the server. For
+  example, users who are authenticated using third-party credentials will find
+  themselves logged out of the Realm Object Server if the third-party identity
+  service indicates that their credential is no longer valid.
 
 2.9.1 Release notes (2017-08-01)
 =============================================================

--- a/Realm/ObjectServerTests/RLMObjectServerTests.mm
+++ b/Realm/ObjectServerTests/RLMObjectServerTests.mm
@@ -462,6 +462,38 @@
     [self waitForExpectationsWithTimeout:10 handler:nil];
 }
 
+- (void)testUserExpirationCallback {
+    NSString *username = NSStringFromSelector(_cmd);
+    RLMSyncCredentials *credentials = [RLMSyncCredentials credentialsWithUsername:username
+                                                                         password:@"a"
+                                                                         register:YES];
+    RLMSyncUser *user = [self logInUserForCredentials:credentials
+                                               server:[RLMObjectServerTests authServerURL]];
+
+    XCTestExpectation *ex = [self expectationWithDescription:@"callback should fire"];
+    // Set a callback on the user
+    __weak RLMSyncUser *weakUser = user;
+    __block BOOL invoked = NO;
+    user.errorHandler = ^(RLMSyncUser *u, NSError *error) {
+        XCTAssertEqualObjects(u.identity, weakUser.identity);
+        // Make sure we get the right error.
+        XCTAssertEqualObjects(error.domain, RLMSyncAuthErrorDomain);
+        XCTAssertEqual(error.code, RLMSyncAuthErrorInvalidCredential);
+        invoked = YES;
+        [ex fulfill];
+    };
+
+    // Screw up the token on the user using a debug API
+    [self manuallySetRefreshTokenForUser:user value:@"not_a_real_refresh_token"];
+
+    // Try to log in a Realm; this will cause our errorHandler block defined above to be fired.
+    __attribute__((objc_precise_lifetime)) RLMRealm *r = [self immediatelyOpenRealmForURL:REALM_URL() user:user];
+    if (!invoked) {
+        [self waitForExpectationsWithTimeout:10.0 handler:nil];
+    }
+    XCTAssertTrue(user.state == RLMSyncUserStateLoggedOut);
+}
+
 #pragma mark - Basic Sync
 
 /// It should be possible to successfully open a Realm configured for sync with an access token.

--- a/Realm/ObjectServerTests/RLMSyncTestCase.h
+++ b/Realm/ObjectServerTests/RLMSyncTestCase.h
@@ -107,6 +107,9 @@ NS_ASSUME_NONNULL_BEGIN
 /// Wait for uploads to complete while spinning the runloop. This method uses expectations.
 - (void)waitForUploadsForUser:(RLMSyncUser *)user url:(NSURL *)url error:(NSError **)error;
 
+/// Manually set the refresh token for a user. Used for testing invalid token conditions.
+- (void)manuallySetRefreshTokenForUser:(RLMSyncUser *)user value:(NSString *)tokenValue;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Realm/ObjectServerTests/RLMSyncTestCase.mm
+++ b/Realm/ObjectServerTests/RLMSyncTestCase.mm
@@ -346,6 +346,10 @@ static NSURL *syncDirectoryForChildProcess() {
     }
 }
 
+- (void)manuallySetRefreshTokenForUser:(RLMSyncUser *)user value:(NSString *)tokenValue {
+    [user _syncUser]->update_refresh_token(tokenValue.UTF8String);
+}
+
 // FIXME: remove this API once the new token system is implemented.
 - (void)primeSyncManagerWithSemaphore:(dispatch_semaphore_t)semaphore {
     if (semaphore == nil) {

--- a/Realm/ObjectServerTests/SwiftSyncTestCase.swift
+++ b/Realm/ObjectServerTests/SwiftSyncTestCase.swift
@@ -61,7 +61,10 @@ class SwiftSyncTestCase: RLMSyncTestCase {
         XCTAssert(0 == runChildAndWait(), "Tests in child process failed", file: file, line: line)
     }
 
-    func basicCredentials(register: Bool, usernameSuffix: String = "", file: StaticString = #file, line: UInt = #line) -> SyncCredentials {
+    func basicCredentials(register: Bool = true,
+                          usernameSuffix: String = "",
+                          file: StaticString = #file,
+                          line: UInt = #line) -> SyncCredentials {
         return .usernamePassword(username: "\(file)\(line)\(usernameSuffix)", password: "a", register: register)
     }
 

--- a/Realm/RLMNetworkClient.mm
+++ b/Realm/RLMNetworkClient.mm
@@ -256,6 +256,11 @@ static NSRange RLM_rangeForErrorType(RLMServerHTTPErrorCodeType type) {
                 case RLMSyncAuthErrorInvalidCredential:
                 case RLMSyncAuthErrorUserDoesNotExist:
                 case RLMSyncAuthErrorUserAlreadyExists:
+                case RLMSyncAuthErrorAccessDeniedOrInvalidPath:
+                case RLMSyncAuthErrorInvalidAccessToken:
+                case RLMSyncAuthErrorExpiredPermissionOffer:
+                case RLMSyncAuthErrorAmbiguousPermissionOffer:
+                case RLMSyncAuthErrorFileCannotBeShared:
                     *error = make_auth_error(responseModel);
                     break;
                 default:

--- a/Realm/RLMSyncConfiguration.mm
+++ b/Realm/RLMSyncConfiguration.mm
@@ -151,7 +151,7 @@ static BOOL isValidRealmURL(NSURL *url) {
                                                                                                    user:user
                                                                                                 session:std::move(session)
                                                                                         completionBlock:[RLMSyncManager sharedManager].sessionCompletionNotifier];
-            std::static_pointer_cast<CocoaSyncUserContext>(user->binding_context())->register_refresh_handle([path UTF8String], handle);
+            context_for(user).register_refresh_handle([path UTF8String], handle);
         };
         if (!errorHandler) {
             errorHandler = [=](std::shared_ptr<SyncSession> errored_session,

--- a/Realm/RLMSyncErrorResponseModel.h
+++ b/Realm/RLMSyncErrorResponseModel.h
@@ -23,14 +23,13 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface RLMSyncErrorResponseModel : NSObject RLM_SYNC_UNINITIALIZABLE
 
-@property (nonatomic, readonly, assign) NSInteger status;
-@property (nonatomic, readonly, assign) NSInteger code;
-@property (nonatomic, readonly, copy) NSString *title;
-@property (nonatomic, readonly, copy) NSString *hint;
+@property (nonatomic, readonly) NSInteger status;
+@property (nonatomic, readonly) NSInteger code;
+@property (nullable, nonatomic, readonly, copy) NSString *title;
+@property (nullable, nonatomic, readonly, copy) NSString *hint;
 
 - (instancetype)initWithDictionary:(NSDictionary *)jsonDictionary;
 
 @end
-
 
 NS_ASSUME_NONNULL_END

--- a/Realm/RLMSyncUser.h
+++ b/Realm/RLMSyncUser.h
@@ -53,6 +53,9 @@ typedef void(^RLMPermissionResultsBlock)(RLMSyncPermissionResults * _Nullable, N
 /// Exactly one of the two arguments will be populated.
 typedef void(^RLMRetrieveUserBlock)(RLMSyncUserInfo * _Nullable, NSError * _Nullable);
 
+/// A block type used to report an error related to a specific user.
+typedef void(^RLMUserErrorReportingBlock)(RLMSyncUser * _Nonnull, NSError * _Nonnull);
+
 NS_ASSUME_NONNULL_BEGIN
 
 /**
@@ -133,6 +136,21 @@ NS_SWIFT_UNAVAILABLE("Use the full version of this API.");
  taking up space.
  */
 - (void)logOut;
+
+/**
+ An optional error handler which can be set to notify the host application when
+ the user encounters an error. Errors reported by this error handler are always
+ `RLMSyncAuthError`s.
+
+ @note Check for `RLMSyncAuthErrorInvalidAccessToken` to see if the user has
+       been remotely logged out because its refresh token expired, or because the
+       third party authentication service providing the user's identity has
+       logged the user out.
+
+ @warning Regardless of whether an error handler is defined, certain user errors
+          will automatically cause the user to enter the logged out state.
+ */
+@property (nullable, nonatomic) RLMUserErrorReportingBlock errorHandler NS_REFINED_FOR_SWIFT;
 
 #pragma mark - Sessions
 

--- a/Realm/RLMSyncUser_Private.hpp
+++ b/Realm/RLMSyncUser_Private.hpp
@@ -39,6 +39,9 @@ public:
     void unregister_refresh_handle(const std::string& path);
     void invalidate_all_handles();
 
+    RLMUserErrorReportingBlock error_handler() const;
+    void set_error_handler(RLMUserErrorReportingBlock);
+
 private:
     /**
      A map of paths to 'refresh handles'.
@@ -48,8 +51,14 @@ private:
      paths (e.g. `/~/path/to/realm`).
      */
     std::unordered_map<std::string, RLMSyncSessionRefreshHandle *> m_refresh_handles;
-
     std::mutex m_mutex;
+
+    /**
+     An optional callback invoked when the authentication server reports the user as
+     being in an expired state.
+     */
+    RLMUserErrorReportingBlock m_error_handler;
+    mutable std::mutex m_error_handler_mutex;
 };
 
 @interface RLMSyncUser ()
@@ -58,7 +67,6 @@ private:
 - (std::shared_ptr<SyncUser>)_syncUser;
 - (nullable NSString *)_refreshToken;
 + (void)_setUpBindingContextFactory;
-
 @end
 
 using PermissionChangeCallback = std::function<void(std::exception_ptr)>;

--- a/Realm/RLMSyncUtil.h
+++ b/Realm/RLMSyncUtil.h
@@ -150,27 +150,42 @@ typedef RLM_ERROR_ENUM(NSInteger, RLMSyncError, RLMSyncErrorDomain) {
 /// An error which is related to authentication to a Realm Object Server.
 typedef RLM_ERROR_ENUM(NSInteger, RLMSyncAuthError, RLMSyncAuthErrorDomain) {
     /// An error that indicates that the response received from the authentication server was malformed.
-    RLMSyncAuthErrorBadResponse         = 1,
+    RLMSyncAuthErrorBadResponse                     = 1,
 
     /// An error that indicates that the supplied Realm path was invalid, or could not be resolved by the authentication
     /// server.
-    RLMSyncAuthErrorBadRemoteRealmPath  = 2,
+    RLMSyncAuthErrorBadRemoteRealmPath              = 2,
 
     /// An error that indicates that the response received from the authentication server was an HTTP error code. The
     /// `userInfo` dictionary contains the actual error code value.
-    RLMSyncAuthErrorHTTPStatusCodeError = 3,
+    RLMSyncAuthErrorHTTPStatusCodeError             = 3,
 
     /// An error that indicates a problem with the session (a specific Realm opened for sync).
-    RLMSyncAuthErrorClientSessionError  = 4,
+    RLMSyncAuthErrorClientSessionError              = 4,
 
     /// An error that indicates that the provided credentials are invalid.
-    RLMSyncAuthErrorInvalidCredential   = 611,
+    RLMSyncAuthErrorInvalidCredential               = 611,
 
     /// An error that indicates that the user with provided credentials does not exist.
-    RLMSyncAuthErrorUserDoesNotExist    = 612,
+    RLMSyncAuthErrorUserDoesNotExist                = 612,
 
     /// An error that indicates that the user cannot be registered as it exists already.
-    RLMSyncAuthErrorUserAlreadyExists   = 613,
+    RLMSyncAuthErrorUserAlreadyExists               = 613,
+
+    /// An error that indicates the path is invalid or the user doesn't have access to that Realm.
+    RLMSyncAuthErrorAccessDeniedOrInvalidPath       = 614,
+
+    /// An error that indicates the refresh token was invalid.
+    RLMSyncAuthErrorInvalidAccessToken              = 615,
+
+    /// An error that indicates the permission offer is expired.
+    RLMSyncAuthErrorExpiredPermissionOffer          = 701,
+
+    /// An error that indicates the permission offer is ambiguous.
+    RLMSyncAuthErrorAmbiguousPermissionOffer        = 702,
+
+    /// An error that indicates the file at the given path can't be shared.
+    RLMSyncAuthErrorFileCannotBeShared              = 703,
 };
 
 /**

--- a/Realm/RLMSyncUtil.mm
+++ b/Realm/RLMSyncUtil.mm
@@ -135,6 +135,11 @@ std::shared_ptr<SyncSession> sync_session_for_realm(RLMRealm *realm) {
     return nullptr;
 }
 
+CocoaSyncUserContext& context_for(const std::shared_ptr<realm::SyncUser>& user)
+{
+    return *std::static_pointer_cast<CocoaSyncUserContext>(user->binding_context());
+}
+
 NSError *make_auth_error_bad_response(NSDictionary *json) {
     return [NSError errorWithDomain:RLMSyncAuthErrorDomain
                                code:RLMSyncAuthErrorBadResponse
@@ -154,10 +159,14 @@ NSError *make_auth_error_client_issue() {
 }
 
 NSError *make_auth_error(RLMSyncErrorResponseModel *model) {
-    NSString *description = model.title;
-    return [NSError errorWithDomain:RLMSyncAuthErrorDomain
-                               code:model.code
-                           userInfo:description ? @{NSLocalizedDescriptionKey: description} : nil];
+    NSMutableDictionary<NSString *, NSString *> *userInfo = [NSMutableDictionary dictionaryWithCapacity:2];
+    if (NSString *description = model.title) {
+        [userInfo setObject:description forKey:NSLocalizedDescriptionKey];
+    }
+    if (NSString *hint = model.hint) {
+        [userInfo setObject:hint forKey:NSLocalizedRecoverySuggestionErrorKey];
+    }
+    return [NSError errorWithDomain:RLMSyncAuthErrorDomain code:model.code userInfo:userInfo];
 }
 
 NSError *make_permission_error_get(NSString *description, util::Optional<NSInteger> code) {

--- a/Realm/RLMSyncUtil_Private.hpp
+++ b/Realm/RLMSyncUtil_Private.hpp
@@ -24,11 +24,16 @@
 #import "realm/util/optional.hpp"
 
 @class RLMSyncErrorResponseModel;
+class CocoaSyncUserContext;
 
 realm::SyncSessionStopPolicy translateStopPolicy(RLMSyncStopPolicy stopPolicy);
 RLMSyncStopPolicy translateStopPolicy(realm::SyncSessionStopPolicy stop_policy);
 
 std::shared_ptr<realm::SyncSession> sync_session_for_realm(RLMRealm *realm);
+
+#pragma mark - Get user context
+
+CocoaSyncUserContext& context_for(const std::shared_ptr<realm::SyncUser>& user);
 
 #pragma mark - Error construction
 

--- a/Realm/Swift/RLMSupport.swift
+++ b/Realm/Swift/RLMSupport.swift
@@ -85,6 +85,62 @@ extension RLMCollection {
     }
 }
 
+// MARK: - Sync-related
+
+extension RLMSyncManager {
+    public static var shared: RLMSyncManager {
+        return __shared()
+    }
+}
+
+extension RLMSyncUser {
+    public static var current: RLMSyncUser? {
+        return __current()
+    }
+
+    public static var all: [String: RLMSyncUser] {
+        return __allUsers()
+    }
+
+    @nonobjc public var errorHandler: RLMUserErrorReportingBlock? {
+        get {
+            return __errorHandler
+        }
+        set {
+            __errorHandler = newValue
+        }
+    }
+
+    public static func logIn(with credentials: RLMSyncCredentials,
+                             server authServerURL: URL,
+                             timeout: TimeInterval = 30,
+                             onCompletion completion: @escaping RLMUserCompletionBlock) {
+        return __logIn(with: credentials,
+                       authServerURL: authServerURL,
+                       timeout: timeout,
+                       onCompletion: completion)
+    }
+
+    public func managementRealm() throws -> RLMRealm {
+        var error: NSError?
+        let realm = __managementRealmWithError(&error)
+        if let error = error {
+            throw error
+        }
+        return realm
+    }
+}
+
+extension RLMSyncSession {
+    public func addProgressNotification(for direction: RLMSyncProgressDirection,
+                                        mode: RLMSyncProgress,
+                                        block: @escaping RLMProgressNotificationBlock) -> RLMProgressNotificationToken? {
+        return __addProgressNotification(for: direction,
+                                         mode: mode,
+                                         block: block)
+    }
+}
+
 #if swift(>=3.1)
 // Collection conformance for RLMSyncPermissionResults.
 extension RLMSyncPermissionResults: RandomAccessCollection {

--- a/RealmSwift/Sync.swift
+++ b/RealmSwift/Sync.swift
@@ -289,6 +289,32 @@ extension SyncUser {
     }
 
     /**
+     An optional error handler which can be set to notify the host application when
+     the user encounters an error.
+     
+     - note: Check for `.invalidAccessToken` to see if the user has been remotely logged
+             out because its refresh token expired, or because the third party authentication
+             service providing the user's identity has logged the user out.
+
+     - warning: Regardless of whether an error handler is defined, certain user errors
+                will automatically cause the user to enter the logged out state.
+     */
+    @nonobjc public var errorHandler: ((SyncUser, SyncAuthError) -> Void)? {
+        get {
+            return __errorHandler
+        }
+        set {
+            if let newValue = newValue {
+                __errorHandler = { (user, error) in
+                    newValue(user, error as! SyncAuthError)
+                }
+            } else {
+                __errorHandler = nil
+            }
+        }
+    }
+
+    /**
      Returns an instance of the Management Realm owned by the user.
 
      This Realm can be used to control access permissions for Realms managed by the user.


### PR DESCRIPTION
Changes:
- Added support for multiple auth errors that weren't being handled before
- Fixed nullability annotations on an internal model object
- Auth errors now include the hint in `userInfo`, if one is provided
- Added another test

To do:
- [x] Handle 615 error by logging out user and asking user to refresh.