### PR TITLE
Fix issue where non-RLMObject could be passed to `RLMArray` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ x.x.x Release notes (yyyy-MM-dd)
 
 * Fix synchronized Realms not downloading remote changes when an access token
   expires and there are no local changes to upload.
+* Fix an issue where values set on a Realm object using `setValue(value:, forKey:)`
+  that were not themselves Realm objects were not properly converted into Realm
+  objects or checked for validity.
 
 2.4.2 Release notes (2017-01-30)
 =============================================================

--- a/Realm/RLMObjectBase.mm
+++ b/Realm/RLMObjectBase.mm
@@ -189,7 +189,7 @@ id RLMCreateManagedAccessor(Class cls, __unsafe_unretained RLMRealm *realm, RLMC
         if (property.type == RLMPropertyTypeArray && [value conformsToProtocol:@protocol(NSFastEnumeration)]) {
             RLMArray *array = [object_getIvar(self, ivar) _rlmArray];
             [array removeAllObjects];
-            [array addObjects:value];
+            [array addObjects:validatedObjectForProperty(value, property, RLMSchema.partialSharedSchema)];
         }
         else if (property.optional) {
             RLMOptionalBase *optional = object_getIvar(self, ivar);

--- a/RealmSwift/Tests/ObjectTests.swift
+++ b/RealmSwift/Tests/ObjectTests.swift
@@ -250,6 +250,17 @@ class ObjectTests: TestCase {
         }
     }
 
+    func testSettingUnmanagedObjectValuesWithSwiftDictionary() {
+        let json: [String: Any] = ["name": "foo", "array": [["stringCol": "bar"]], "intArray": [["intCol": 50]]]
+        let object = SwiftArrayPropertyObject()
+        json.keys.forEach { key in
+            object.setValue(json[key], forKey: key)
+        }
+        XCTAssertEqual(object.name, "foo")
+        XCTAssertEqual(object.array[0].stringCol, "bar")
+        XCTAssertEqual(object.intArray[0].intCol, 50)
+    }
+
     func setAndTestAllTypes(_ setter: (SwiftObject, Any?, String) -> Void,
                             getter: (SwiftObject, String) -> (Any?), object: SwiftObject) {
         setter(object, true, "boolCol")

--- a/RealmSwift/Tests/ObjectTests.swift
+++ b/RealmSwift/Tests/ObjectTests.swift
@@ -261,6 +261,12 @@ class ObjectTests: TestCase {
         XCTAssertEqual(object.intArray[0].intCol, 50)
     }
 
+    func testSettingUnmanagedObjectValuesWithBadSwiftDictionary() {
+        let json: [String: Any] = ["name": "foo", "array": [["stringCol": NSObject()]], "intArray": [["intCol": 50]]]
+        let object = SwiftArrayPropertyObject()
+        assertThrows({ json.keys.forEach { key in object.setValue(json[key], forKey: key) } }())
+    }
+
     func setAndTestAllTypes(_ setter: (SwiftObject, Any?, String) -> Void,
                             getter: (SwiftObject, String) -> (Any?), object: SwiftObject) {
         setter(object, true, "boolCol")


### PR DESCRIPTION
Fixes #4335 

In some cases a non-`RLMObject` object could be passed down into methods expecting a `RLMObject`, which causes issues when ivars on that object are accessed. This requires an object to be validated before it can be passed further down the chain.