### PR TITLE
Add validation for Swift property names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ x.x.x Release notes (yyyy-MM-dd)
 * Fix incorrect sync progress notification values for Realms originally created
   using a version of Realm prior to 2.3.0.
 * Fix LLDB integration to be able to display summaries of `RLMResults` once more.
+* Reject Swift properties with names which cause them to fall in to ARC method
+  families rather than crashing when they are accessed.
 
 2.4.2 Release notes (2017-01-30)
 =============================================================

--- a/Realm/RLMProperty_Private.h
+++ b/Realm/RLMProperty_Private.h
@@ -26,6 +26,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 BOOL RLMPropertyTypeIsNullable(RLMPropertyType propertyType);
 BOOL RLMPropertyTypeIsComputed(RLMPropertyType propertyType);
+FOUNDATION_EXTERN void RLMValidateSwiftPropertyName(NSString *name);
 
 // private property interface
 @interface RLMProperty () {

--- a/Realm/Tests/PropertyTests.m
+++ b/Realm/Tests/PropertyTests.m
@@ -117,4 +117,26 @@
     XCTAssertNotEqualObjects(property1, property2);
 }
 
+- (void)testSwiftPropertyNameValidation {
+    RLMAssertThrows(RLMValidateSwiftPropertyName(@"alloc"));
+    RLMAssertThrows(RLMValidateSwiftPropertyName(@"_alloc"));
+    RLMAssertThrows(RLMValidateSwiftPropertyName(@"allocOject"));
+    RLMAssertThrows(RLMValidateSwiftPropertyName(@"_allocOject"));
+    RLMAssertThrows(RLMValidateSwiftPropertyName(@"alloc_object"));
+    RLMAssertThrows(RLMValidateSwiftPropertyName(@"_alloc_object"));
+    RLMAssertThrows(RLMValidateSwiftPropertyName(@"new"));
+    RLMAssertThrows(RLMValidateSwiftPropertyName(@"copy"));
+    RLMAssertThrows(RLMValidateSwiftPropertyName(@"mutableCopy"));
+
+    // Swift doesn't infer family from `init`
+    XCTAssertNoThrow(RLMValidateSwiftPropertyName(@"init"));
+    XCTAssertNoThrow(RLMValidateSwiftPropertyName(@"_init"));
+    XCTAssertNoThrow(RLMValidateSwiftPropertyName(@"initWithValue"));
+
+    // Lowercase letter after family name
+    XCTAssertNoThrow(RLMValidateSwiftPropertyName(@"allocate"));
+
+    XCTAssertNoThrow(RLMValidateSwiftPropertyName(@"__alloc"));
+}
+
 @end

--- a/RealmSwift/Tests/ObjectSchemaInitializationTests.swift
+++ b/RealmSwift/Tests/ObjectSchemaInitializationTests.swift
@@ -122,6 +122,8 @@ class ObjectSchemaInitializationTests: TestCase {
                      "Should throw when not ignoring a property of a type we can't persist")
         assertThrows(RLMObjectSchema(forObjectClass: SwiftObjectWithOptionalStringArray.self),
                      "Should throw when not ignoring a property of a type we can't persist")
+        assertThrows(RLMObjectSchema(forObjectClass: SwiftObjectWithBadPropertyName.self),
+                     "Should throw when not ignoring a property with a name we don't support")
 
         // Shouldn't throw when not ignoring a property of a type we can't persist if it's not dynamic
         _ = RLMObjectSchema(forObjectClass: SwiftObjectWithEnum.self)
@@ -289,4 +291,8 @@ extension Set: RealmOptionalType { }
 
 class SwiftObjectWithNonRealmOptionalType: SwiftFakeObject {
     let set = RealmOptional<Set<Int>>()
+}
+
+class SwiftObjectWithBadPropertyName: SwiftFakeObject {
+    dynamic var newValue = false
 }


### PR DESCRIPTION
Swift properties which fall in to any of the ARC method families don't work properly via KVC, so we can't support them and will either leak memory or crash when trying to use them (currently we crash).

Trying to use properties with these names is a compilation error in Objective-C, so it's not an issue there.