### PR TITLE
Fix compilation issues with Xcode 8.3 beta 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ x.x.x Release notes (yyyy-MM-dd)
 * Fix an issue where values set on a Realm object using `setValue(value:, forKey:)`
   that were not themselves Realm objects were not properly converted into Realm
   objects or checked for validity.
+* Fix compilation issues with Xcode 8.3 beta 2.
 
 2.4.2 Release notes (2017-01-30)
 =============================================================

--- a/Realm/RLMResults.mm
+++ b/Realm/RLMResults.mm
@@ -420,7 +420,7 @@ static inline void RLMResultsValidateInWriteTransaction(__unsafe_unretained RLMR
             RLMClearTable(*_info);
         }
         else {
-            RLMTrackDeletions(_realm, ^{ _results.clear(); });
+            RLMTrackDeletions(_realm, [&] { _results.clear(); });
         }
     });
 }

--- a/Realm/RLMResults.mm
+++ b/Realm/RLMResults.mm
@@ -414,7 +414,7 @@ static inline void RLMResultsValidateInWriteTransaction(__unsafe_unretained RLMR
 }
 
 - (void)deleteObjectsFromRealm {
-    return translateErrors([&] {
+    try {
         if (_results.get_mode() == Results::Mode::Table) {
             RLMResultsValidateInWriteTransaction(self);
             RLMClearTable(*_info);
@@ -422,7 +422,10 @@ static inline void RLMResultsValidateInWriteTransaction(__unsafe_unretained RLMR
         else {
             RLMTrackDeletions(_realm, ^{ _results.clear(); });
         }
-    });
+    }
+    catch (...) {
+        throwError(nil);
+    }
 }
 
 - (NSString *)description {

--- a/Realm/RLMResults.mm
+++ b/Realm/RLMResults.mm
@@ -414,7 +414,7 @@ static inline void RLMResultsValidateInWriteTransaction(__unsafe_unretained RLMR
 }
 
 - (void)deleteObjectsFromRealm {
-    try {
+    return translateErrors([&] {
         if (_results.get_mode() == Results::Mode::Table) {
             RLMResultsValidateInWriteTransaction(self);
             RLMClearTable(*_info);
@@ -422,10 +422,7 @@ static inline void RLMResultsValidateInWriteTransaction(__unsafe_unretained RLMR
         else {
             RLMTrackDeletions(_realm, ^{ _results.clear(); });
         }
-    }
-    catch (...) {
-        throwError(nil);
-    }
+    });
 }
 
 - (NSString *)description {

--- a/RealmSwift/Error.swift
+++ b/RealmSwift/Error.swift
@@ -35,35 +35,7 @@ extension Realm {
      ```
     */
     public struct Error {
-        // swiftlint:disable:next nesting
-        public enum Code: Int {
-            /// - see: `Realm.Error.fail`
-            case fail
-
-            /// - see: `Realm.Error.fileAccess`
-            case fileAccess
-
-            /// - see: `Realm.Error.filePermissionDenied`
-            case filePermissionDenied
-
-            /// - see: `Realm.Error.fileExists`
-            case fileExists
-
-            /// - see: `Realm.Error.fileNotFound`
-            case fileNotFound
-
-            /// - see: `Realm.Error.incompatibleLockFile`
-            case incompatibleLockFile
-
-            /// - see: `Realm.Error.fileFormatUpgradeRequired`
-            case fileFormatUpgradeRequired
-
-            /// - see: `Realm.Error.addressSpaceExhausted`
-            case addressSpaceExhausted
-
-            /// - see: `Realm.Error.schemaMismatch`
-            case schemaMismatch
-        }
+        public typealias Code = RLMError.Code
 
         /// Error thrown by Realm if no other specific error is returned when a realm is opened.
         public static let fail: Code = .fail
@@ -99,27 +71,7 @@ extension Realm {
 
         /// :nodoc:
         public var code: Code {
-            let rlmError = _nsError as! RLMError
-            switch rlmError.code {
-            case .fail:
-                return .fail
-            case .fileAccess:
-                return .fileAccess
-            case .filePermissionDenied:
-                return .filePermissionDenied
-            case .fileExists:
-                return .fileExists
-            case .fileNotFound:
-                return .fileNotFound
-            case .incompatibleLockFile:
-                return .incompatibleLockFile
-            case .fileFormatUpgradeRequired:
-                return .fileFormatUpgradeRequired
-            case .addressSpaceExhausted:
-                return .addressSpaceExhausted
-            case .schemaMismatch:
-                return .schemaMismatch
-            }
+            return (_nsError as! RLMError).code
         }
 
         /// :nodoc:
@@ -137,12 +89,6 @@ extension Realm {
 extension Realm.Error: _BridgedStoredNSError {
     /// :nodoc:
     public static var _nsErrorDomain = RLMErrorDomain // swiftlint:disable:this variable_name
-}
-
-/// :nodoc:
-extension Realm.Error.Code: _ErrorCodeProtocol {
-    /// :nodoc:
-    public typealias _ErrorType = RLMError // swiftlint:disable:this type_name
 }
 
 // MARK: Equatable

--- a/RealmSwift/List.swift
+++ b/RealmSwift/List.swift
@@ -467,7 +467,7 @@ public final class List<T: Object>: ListBase {
     }
 }
 
-extension List : RealmCollection, RangeReplaceableCollection {
+extension List: RealmCollection, RangeReplaceableCollection {
     // MARK: Sequence Support
 
     /// Returns a `RLMIterator` that yields successive elements in the `List`.
@@ -477,10 +477,22 @@ extension List : RealmCollection, RangeReplaceableCollection {
 
     // MARK: RangeReplaceableCollection Support
 
+#if swift(>=3.1)
+    // These should not be necessary, but Swift 3.1's compiler fails to infer the `SubSequence`,
+    // and the standard library neglects to provide the default implementation of `subscript`
+    /// :nodoc:
+    public typealias SubSequence = RangeReplaceableRandomAccessSlice<List>
+
+    /// :nodoc:
+    public subscript(slice: Range<Int>) -> SubSequence {
+        return SubSequence(base: self, bounds: slice)
+    }
+#endif
+
     /**
      Replace the given `subRange` of elements with `newElements`.
 
-    - parameter subRange:    The range of elements to be replaced.
+    - parameter subrange:    The range of elements to be replaced.
     - parameter newElements: The new elements to be inserted into the List.
     */
     public func replaceSubrange<C: Collection>(_ subrange: Range<Int>, with newElements: C)

--- a/RealmSwift/Object.swift
+++ b/RealmSwift/Object.swift
@@ -263,8 +263,8 @@ open class Object: RLMObjectBase, ThreadConfined {
      :nodoc:
      */
     public func dynamicList(_ propertyName: String) -> List<DynamicObject> {
-        return unsafeBitCast(RLMDynamicGetByName(self, propertyName, true) as! RLMListBase,
-                             to: List<DynamicObject>.self)
+        return noWarnUnsafeBitCast(RLMDynamicGetByName(self, propertyName, true) as! RLMListBase,
+                                   to: List<DynamicObject>.self)
     }
 
     // MARK: Equatable

--- a/RealmSwift/Realm.swift
+++ b/RealmSwift/Realm.swift
@@ -302,7 +302,7 @@ public final class Realm {
         if update && schema[typeName]?.primaryKeyProperty == nil {
             throwRealmException("'\(typeName)' does not have a primary key and can not be updated")
         }
-        return unsafeBitCast(RLMCreateObjectInRealmWithValue(rlmRealm, typeName, value, update), to: T.self)
+        return unsafeDowncast(RLMCreateObjectInRealmWithValue(rlmRealm, typeName, value, update), to: T.self)
     }
 
     /**

--- a/RealmSwift/Realm.swift
+++ b/RealmSwift/Realm.swift
@@ -340,7 +340,8 @@ public final class Realm {
         if update && schema[typeName]?.primaryKeyProperty == nil {
             throwRealmException("'\(typeName)' does not have a primary key and can not be updated")
         }
-        return unsafeBitCast(RLMCreateObjectInRealmWithValue(rlmRealm, typeName, value, update), to: DynamicObject.self)
+        return noWarnUnsafeBitCast(RLMCreateObjectInRealmWithValue(rlmRealm, typeName, value, update),
+                                   to: DynamicObject.self)
     }
 
     // MARK: Deleting objects

--- a/RealmSwift/RealmCollection.swift
+++ b/RealmSwift/RealmCollection.swift
@@ -115,12 +115,16 @@ public enum RealmCollectionChange<T> {
         }
         if let change = change {
             return .update(value,
-                deletions: change.deletions as [Int],
-                insertions: change.insertions as [Int],
-                modifications: change.modifications as [Int])
+                deletions: forceCast(change.deletions, to: [Int].self),
+                insertions: forceCast(change.insertions, to: [Int].self),
+                modifications: forceCast(change.modifications, to: [Int].self))
         }
         return .initial(value)
     }
+}
+
+private func forceCast<A, U>(_ from: A, to type: U.Type) -> U {
+    return from as! U
 }
 
 /**
@@ -131,7 +135,6 @@ public protocol RealmCollection: RandomAccessCollection, LazyCollectionProtocol,
 
     /// The type of the objects contained in the collection.
     associatedtype Element: Object
-
 
     // MARK: Properties
 

--- a/RealmSwift/RealmCollection.swift
+++ b/RealmSwift/RealmCollection.swift
@@ -472,8 +472,7 @@ private final class _AnyRealmCollection<C: RealmCollection>: _AnyRealmCollection
     // MARK: Sequence Support
 
     override subscript(position: Int) -> C.Element {
-        // FIXME: it should be possible to avoid this force-casting
-        return unsafeBitCast(base[position as! C.Index], to: C.Element.self)
+        return base[position as! C.Index] as! C.Element
     }
 
     override func makeIterator() -> RLMIterator<Element> {

--- a/RealmSwift/Tests/KVOTests.swift
+++ b/RealmSwift/Tests/KVOTests.swift
@@ -90,9 +90,11 @@ class KVOTests: TestCase {
         let actualOld = changeDictionary![NSKeyValueChangeKey.oldKey]! as? T
         let actualNew = changeDictionary![NSKeyValueChangeKey.newKey]! as? T
 
-        XCTAssert(old == actualOld, "Old value: expected \(old), got \(actualOld)",
+        XCTAssert(old == actualOld,
+                  "Old value: expected \(String(describing: old)), got \(String(describing: actualOld))",
                   file: fileName, line: lineNumber)
-        XCTAssert(new == actualNew, "New value: expected \(new), got \(actualNew)",
+        XCTAssert(new == actualNew,
+                  "New value: expected \(String(describing: new)), got \(String(describing: actualNew))",
                   file: fileName, line: lineNumber)
 
         changeDictionary = nil

--- a/RealmSwift/Tests/ObjectAccessorTests.swift
+++ b/RealmSwift/Tests/ObjectAccessorTests.swift
@@ -299,21 +299,21 @@ class ObjectAccessorTests: TestCase {
         object.optInt64Col.value = nil
         XCTAssertNil(object.optInt64Col.value)
 
-        object.optFloatCol.value = -FLT_MAX
-        XCTAssertEqual(object.optFloatCol.value!, -FLT_MAX)
+        object.optFloatCol.value = -Float.greatestFiniteMagnitude
+        XCTAssertEqual(object.optFloatCol.value!, -Float.greatestFiniteMagnitude)
         object.optFloatCol.value = 0
         XCTAssertEqual(object.optFloatCol.value!, 0)
-        object.optFloatCol.value = FLT_MAX
-        XCTAssertEqual(object.optFloatCol.value!, FLT_MAX)
+        object.optFloatCol.value = Float.greatestFiniteMagnitude
+        XCTAssertEqual(object.optFloatCol.value!, Float.greatestFiniteMagnitude)
         object.optFloatCol.value = nil
         XCTAssertNil(object.optFloatCol.value)
 
-        object.optDoubleCol.value = -DBL_MAX
-        XCTAssertEqual(object.optDoubleCol.value!, -DBL_MAX)
+        object.optDoubleCol.value = -Double.greatestFiniteMagnitude
+        XCTAssertEqual(object.optDoubleCol.value!, -Double.greatestFiniteMagnitude)
         object.optDoubleCol.value = 0
         XCTAssertEqual(object.optDoubleCol.value!, 0)
-        object.optDoubleCol.value = DBL_MAX
-        XCTAssertEqual(object.optDoubleCol.value!, DBL_MAX)
+        object.optDoubleCol.value = Double.greatestFiniteMagnitude
+        XCTAssertEqual(object.optDoubleCol.value!, Double.greatestFiniteMagnitude)
         object.optDoubleCol.value = nil
         XCTAssertNil(object.optDoubleCol.value)
 

--- a/RealmSwift/Util.swift
+++ b/RealmSwift/Util.swift
@@ -21,6 +21,12 @@ import Realm
 
 // MARK: Internal Helpers
 
+// Swift 3.1 provides fixits for some of our uses of unsafeBitCast
+// to use unsafeDowncast instead, but the bitcast is required.
+internal func noWarnUnsafeBitCast<T, U>(_ x: T, to type: U.Type) -> U {
+    return unsafeBitCast(x, to: type)
+}
+
 internal func notFoundToNil(index: UInt) -> Int? {
     if index == UInt(NSNotFound) {
         return nil


### PR DESCRIPTION
Addresses #4586. Doesn't look like apple/swift#7136 made it into Xcode 8.3 beta 2, but at least [rdar://30215450](http://www.openradar.me/30215450) was resolved so we can conditionally fix Swift 3.1.

Thomas: do you have any ideas for a more correct fix for db13fba?