### PR TITLE
Fix some logic and test bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ x.x.x Release notes (yyyy-MM-dd)
 * Fix an issue where values set on a Realm object using `setValue(value:, forKey:)`
   that were not themselves Realm objects were not properly converted into Realm
   objects or checked for validity.
+* Fix an issue where `-[RLMSyncUser sessionForURL:]` could erronenously return a
+  non-nil value when passed in an invalid URL.
+* `SyncSession.Progress.fractionTransferred` now returns 1 if there are no
+  transferrable bytes.
 * Fix compilation issues with Xcode 8.3 beta 2.
 
 2.4.2 Release notes (2017-01-30)

--- a/Realm/ObjectServerTests/RLMObjectServerTests.m
+++ b/Realm/ObjectServerTests/RLMObjectServerTests.m
@@ -812,7 +812,9 @@
                                                                                          transferred = xfr;
                                                                                          transferrable = xfb;
                                                                                          callCount++;
-                                                                                         if (transferred >= transferrable && !hasBeenFulfilled) {
+                                                                                         if (transferrable > 0
+                                                                                             && transferred >= transferrable
+                                                                                             && !hasBeenFulfilled) {
                                                                                              [ex fulfill];
                                                                                              hasBeenFulfilled = YES;
                                                                                          }
@@ -824,7 +826,9 @@
         // The notifier should have been called at least twice: once at the beginning and at least once
         // to report progress.
         XCTAssert(callCount > 1);
-        XCTAssert(transferred >= transferrable);
+        XCTAssert(transferred >= transferrable,
+                  @"Transferred (%@) needs to be greater than or equal to transferrable (%@)",
+                  @(transferred), @(transferrable));
     } else {
         // Write lots of data to the Realm, then wait for it to be uploaded.
         [realm beginWriteTransaction];
@@ -866,7 +870,9 @@
                                                                                      transferred = xfr;
                                                                                      transferrable = xfb;
                                                                                      callCount++;
-                                                                                     if (transferred >= transferrable && !hasBeenFulfilled) {
+                                                                                     if (transferred > 0
+                                                                                         && transferred >= transferrable
+                                                                                         && !hasBeenFulfilled) {
                                                                                          [ex fulfill];
                                                                                          hasBeenFulfilled = YES;
                                                                                      }
@@ -883,7 +889,9 @@
     // The notifier should have been called at least twice: once at the beginning and at least once
     // to report progress.
     XCTAssert(callCount > 1);
-    XCTAssert(transferred >= transferrable);
+    XCTAssert(transferred >= transferrable,
+              @"Transferred (%@) needs to be greater than or equal to transferrable (%@)",
+              @(transferred), @(transferrable));
 }
 
 #pragma mark - Permissions

--- a/Realm/ObjectServerTests/RLMSyncTestCase.h
+++ b/Realm/ObjectServerTests/RLMSyncTestCase.h
@@ -49,7 +49,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (RLMRealm *)openRealmForURL:(NSURL *)url user:(RLMSyncUser *)user;
 
 /// Synchronously open a synced Realm. Also run a block right after the Realm is created.
-- (RLMRealm *)openRealmForURL:(NSURL *)url user:(RLMSyncUser *)user immediatelyBlock:(void(^)(void))block;
+- (RLMRealm *)openRealmForURL:(NSURL *)url user:(RLMSyncUser *)user immediatelyBlock:(nullable void(^)(void))block;
 
 /// Immediately open a synced Realm.
 - (RLMRealm *)immediatelyOpenRealmForURL:(NSURL *)url user:(RLMSyncUser *)user;

--- a/Realm/ObjectServerTests/RLMSyncTestCase.h
+++ b/Realm/ObjectServerTests/RLMSyncTestCase.h
@@ -48,6 +48,9 @@ NS_ASSUME_NONNULL_BEGIN
 /// Synchronously open a synced Realm and wait until the binding process has completed or failed.
 - (RLMRealm *)openRealmForURL:(NSURL *)url user:(RLMSyncUser *)user;
 
+/// Synchronously open a synced Realm. Also run a block right after the Realm is created.
+- (RLMRealm *)openRealmForURL:(NSURL *)url user:(RLMSyncUser *)user immediatelyBlock:(void(^)(void))block;
+
 /// Immediately open a synced Realm.
 - (RLMRealm *)immediatelyOpenRealmForURL:(NSURL *)url user:(RLMSyncUser *)user;
 

--- a/Realm/ObjectServerTests/RLMSyncTestCase.m
+++ b/Realm/ObjectServerTests/RLMSyncTestCase.m
@@ -120,6 +120,10 @@ static NSURL *syncDirectoryForChildProcess() {
 }
 
 - (RLMRealm *)openRealmForURL:(NSURL *)url user:(RLMSyncUser *)user {
+    return [self openRealmForURL:url user:user immediatelyBlock:^{ /* Do nothing */; }];
+}
+
+- (RLMRealm *)openRealmForURL:(NSURL *)url user:(RLMSyncUser *)user immediatelyBlock:(void(^)(void))block {
     const NSTimeInterval timeout = 4;
     dispatch_semaphore_t sema = dispatch_semaphore_create(0);
     RLMSyncManager.sharedManager.sessionCompletionNotifier = ^(NSError *error) {
@@ -130,6 +134,7 @@ static NSURL *syncDirectoryForChildProcess() {
     };
 
     RLMRealm *realm = [self immediatelyOpenRealmForURL:url user:user];
+    block();
     // Wait for login to succeed or fail.
     XCTAssert(dispatch_semaphore_wait(sema, dispatch_time(DISPATCH_TIME_NOW, (int64_t)(timeout * NSEC_PER_SEC))) == 0,
               @"Timed out while trying to asynchronously open Realm for URL: %@", url);

--- a/Realm/ObjectServerTests/RLMSyncTestCase.m
+++ b/Realm/ObjectServerTests/RLMSyncTestCase.m
@@ -120,7 +120,7 @@ static NSURL *syncDirectoryForChildProcess() {
 }
 
 - (RLMRealm *)openRealmForURL:(NSURL *)url user:(RLMSyncUser *)user {
-    return [self openRealmForURL:url user:user immediatelyBlock:^{ /* Do nothing */; }];
+    return [self openRealmForURL:url user:user immediatelyBlock:nil];
 }
 
 - (RLMRealm *)openRealmForURL:(NSURL *)url user:(RLMSyncUser *)user immediatelyBlock:(void(^)(void))block {
@@ -134,7 +134,9 @@ static NSURL *syncDirectoryForChildProcess() {
     };
 
     RLMRealm *realm = [self immediatelyOpenRealmForURL:url user:user];
-    block();
+    if (block) {
+        block();
+    }
     // Wait for login to succeed or fail.
     XCTAssert(dispatch_semaphore_wait(sema, dispatch_time(DISPATCH_TIME_NOW, (int64_t)(timeout * NSEC_PER_SEC))) == 0,
               @"Timed out while trying to asynchronously open Realm for URL: %@", url);

--- a/Realm/ObjectServerTests/SwiftObjectServerTests.swift
+++ b/Realm/ObjectServerTests/SwiftObjectServerTests.swift
@@ -159,16 +159,22 @@ class SwiftObjectServerTests: SwiftSyncTestCase {
             if isParent {
                 let session = user.session(for: realmURL)
                 XCTAssertNotNil(session)
+                let ex = expectation(description: "streaming-downloads-expectation")
+                var hasBeenFulfilled = false
                 let token = session!.addProgressNotification(for: .download, mode: .reportIndefinitely) { p in
                     callCount += 1
                     XCTAssert(p.transferredBytes >= transferred)
                     XCTAssert(p.transferrableBytes >= transferrable)
                     transferred = p.transferredBytes
                     transferrable = p.transferrableBytes
+                    if (transferred >= transferrable && !hasBeenFulfilled) {
+                        ex.fulfill()
+                        hasBeenFulfilled = true
+                    }
                 }
                 // Wait for the child process to upload all the data.
                 executeChild()
-                waitForDownloads(for: user, url: realmURL)
+                waitForExpectations(timeout: 10.0, handler: nil)
                 token!.stop()
                 XCTAssert(callCount > 1)
                 XCTAssert(transferred >= transferrable)
@@ -196,22 +202,27 @@ class SwiftObjectServerTests: SwiftSyncTestCase {
             let realm = try synchronouslyOpenRealm(url: realmURL, user: user)
             let session = user.session(for: realmURL)
             XCTAssertNotNil(session)
+            let ex = expectation(description: "streaming-uploads-expectation")
+            var hasBeenFulfilled = false
             let token = session!.addProgressNotification(for: .upload, mode: .reportIndefinitely) { p in
                 callCount += 1
                 XCTAssert(p.transferredBytes >= transferred)
                 XCTAssert(p.transferrableBytes >= transferrable)
                 transferred = p.transferredBytes
                 transferrable = p.transferrableBytes
+                if (transferred >= transferrable && !hasBeenFulfilled) {
+                    ex.fulfill()
+                    hasBeenFulfilled = true
+                }
             }
             try realm.write {
                 for _ in 0..<bigObjectCount {
                     realm.add(SwiftHugeSyncObject())
                 }
             }
-            waitForUploads(for: user, url: realmURL)
+            waitForExpectations(timeout: 10.0, handler: nil)
             token!.stop()
             XCTAssert(callCount > 1)
-            XCTAssertEqual(transferred, transferrable)
         } catch {
             XCTFail("Got an error: \(error) (process: \(isParent ? "parent" : "child"))")
         }

--- a/Realm/ObjectServerTests/SwiftObjectServerTests.swift
+++ b/Realm/ObjectServerTests/SwiftObjectServerTests.swift
@@ -167,7 +167,7 @@ class SwiftObjectServerTests: SwiftSyncTestCase {
                     XCTAssert(p.transferrableBytes >= transferrable)
                     transferred = p.transferredBytes
                     transferrable = p.transferrableBytes
-                    if (transferred >= transferrable && !hasBeenFulfilled) {
+                    if transferred >= transferrable && !hasBeenFulfilled {
                         ex.fulfill()
                         hasBeenFulfilled = true
                     }
@@ -210,7 +210,7 @@ class SwiftObjectServerTests: SwiftSyncTestCase {
                 XCTAssert(p.transferrableBytes >= transferrable)
                 transferred = p.transferredBytes
                 transferrable = p.transferrableBytes
-                if (transferred >= transferrable && !hasBeenFulfilled) {
+                if transferred >= transferrable && !hasBeenFulfilled {
                     ex.fulfill()
                     hasBeenFulfilled = true
                 }

--- a/Realm/ObjectServerTests/SwiftObjectServerTests.swift
+++ b/Realm/ObjectServerTests/SwiftObjectServerTests.swift
@@ -167,7 +167,7 @@ class SwiftObjectServerTests: SwiftSyncTestCase {
                     XCTAssert(p.transferrableBytes >= transferrable)
                     transferred = p.transferredBytes
                     transferrable = p.transferrableBytes
-                    if transferred >= transferrable && !hasBeenFulfilled {
+                    if p.transferredBytes > 0 && p.isTransferComplete && !hasBeenFulfilled {
                         ex.fulfill()
                         hasBeenFulfilled = true
                     }
@@ -210,7 +210,7 @@ class SwiftObjectServerTests: SwiftSyncTestCase {
                 XCTAssert(p.transferrableBytes >= transferrable)
                 transferred = p.transferredBytes
                 transferrable = p.transferrableBytes
-                if transferred >= transferrable && !hasBeenFulfilled {
+                if p.transferredBytes > 0 && p.isTransferComplete && !hasBeenFulfilled {
                     ex.fulfill()
                     hasBeenFulfilled = true
                 }
@@ -223,6 +223,7 @@ class SwiftObjectServerTests: SwiftSyncTestCase {
             waitForExpectations(timeout: 10.0, handler: nil)
             token!.stop()
             XCTAssert(callCount > 1)
+            XCTAssert(transferred >= transferrable)
         } catch {
             XCTFail("Got an error: \(error) (process: \(isParent ? "parent" : "child"))")
         }

--- a/Realm/RLMSyncUser.mm
+++ b/Realm/RLMSyncUser.mm
@@ -130,7 +130,10 @@ using namespace realm;
         return nil;
     }
     auto path = SyncManager::shared().path_for_realm(_user->identity(), [url.absoluteString UTF8String]);
-    return [[RLMSyncSession alloc] initWithSyncSession:_user->session_for_on_disk_path(path)];
+    if (auto session = _user->session_for_on_disk_path(path)) {
+        return [[RLMSyncSession alloc] initWithSyncSession:session];
+    }
+    return nil;
 }
 
 - (NSArray<RLMSyncSession *> *)allSessions {

--- a/RealmSwift/Sync.swift
+++ b/RealmSwift/Sync.swift
@@ -558,8 +558,12 @@ public extension SyncSession {
         public let transferrableBytes: Int
 
         /// The fraction of bytes transferred out of all transferrable bytes. If this value is 1,
-        /// no bytes are waiting to be transferred.
+        /// no bytes are waiting to be transferred (either all bytes have already been transferred,
+        /// or there are no bytes to be transferred in the first place).
         public var fractionTransferred: Double {
+            if transferrableBytes == 0 {
+                return 1
+            }
             let percentage = Double(transferredBytes) / Double(transferrableBytes)
             return percentage > 1 ? 1 : percentage
         }


### PR DESCRIPTION
Changes:
- Fixed an issue where a non-nil `RLMSyncSession` object with an nil underlying pointer could be returned when looking up a session for an invalid synced Realm URL
- Wrote two object server tests to verify fix
- Changed the way upload/download object server tests work to prevent them from sporadically failing

The upload/download object server tests sometimes fail because the upload or download completion callback occurs before the notification that indicates completion can be delivered. (Upon completion of the callback, the token is immediately stopped, and no further notifications will be delivered.) The fix in this PR prevents that spurious failure from occurring.