### PR TITLE
remove SwiftLint commands to disable valid docs rule

### DIFF
--- a/RealmSwift/Error.swift
+++ b/RealmSwift/Error.swift
@@ -96,7 +96,7 @@ extension Realm.Error: _BridgedStoredNSError {
 extension Realm.Error: Equatable {}
 
 /// Returns a Boolean indicating whether the errors are identical.
-public func == (lhs: Error, rhs: Error) -> Bool { // swiftlint:disable:this valid_docs
+public func == (lhs: Error, rhs: Error) -> Bool {
     return lhs._code == rhs._code
         && lhs._domain == rhs._domain
 }
@@ -107,6 +107,6 @@ public func == (lhs: Error, rhs: Error) -> Bool { // swiftlint:disable:this vali
  Pattern matching matching for `Realm.Error`, so that the instances can be used with Swift's
  `do { ... } catch { ... }` syntax.
 */
-public func ~= (lhs: Realm.Error, rhs: Error) -> Bool { // swiftlint:disable:this valid_docs
+public func ~= (lhs: Realm.Error, rhs: Error) -> Bool {
     return lhs == rhs
 }

--- a/RealmSwift/ObjectSchema.swift
+++ b/RealmSwift/ObjectSchema.swift
@@ -76,7 +76,7 @@ public final class ObjectSchema: CustomStringConvertible {
 
 extension ObjectSchema: Equatable {
     /// Returns whether the two object schemas are equal.
-    public static func == (lhs: ObjectSchema, rhs: ObjectSchema) -> Bool { // swiftlint:disable:this valid_docs
+    public static func == (lhs: ObjectSchema, rhs: ObjectSchema) -> Bool {
         return lhs.rlmObjectSchema.isEqual(to: rhs.rlmObjectSchema)
     }
 }

--- a/RealmSwift/Property.swift
+++ b/RealmSwift/Property.swift
@@ -63,7 +63,7 @@ public final class Property: CustomStringConvertible {
 
 extension Property: Equatable {
     /// Returns whether the two properties are equal.
-    public static func == (lhs: Property, rhs: Property) -> Bool { // swiftlint:disable:this valid_docs
+    public static func == (lhs: Property, rhs: Property) -> Bool {
         return lhs.rlmProperty.isEqual(to: rhs.rlmProperty)
     }
 }

--- a/RealmSwift/Realm.swift
+++ b/RealmSwift/Realm.swift
@@ -624,7 +624,7 @@ public final class Realm {
 
 extension Realm: Equatable {
     /// Returns whether two `Realm` isntances are equal.
-    public static func == (lhs: Realm, rhs: Realm) -> Bool { // swiftlint:disable:this valid_docs
+    public static func == (lhs: Realm, rhs: Realm) -> Bool {
         return lhs.rlmRealm == rhs.rlmRealm
     }
 }

--- a/RealmSwift/RealmCollection.swift
+++ b/RealmSwift/RealmCollection.swift
@@ -31,7 +31,7 @@ public final class RLMIterator<T: Object>: IteratorProtocol {
     }
 
     /// Advance to the next element and return it, or `nil` if no next element exists.
-    public func next() -> T? { // swiftlint:disable:this valid_docs
+    public func next() -> T? {
         let accessor = unsafeBitCast(generatorBase.next() as! Object?, to: Optional<T>.self)
         if let accessor = accessor {
             RLMInitializeSwiftAccessorGenerics(accessor)

--- a/RealmSwift/Schema.swift
+++ b/RealmSwift/Schema.swift
@@ -65,7 +65,7 @@ public final class Schema: CustomStringConvertible {
 
 extension Schema: Equatable {
     /// Returns whether the two schemas are equal.
-    public static func == (lhs: Schema, rhs: Schema) -> Bool { // swiftlint:disable:this valid_docs
+    public static func == (lhs: Schema, rhs: Schema) -> Bool {
         return lhs.rlmSchema.isEqual(to: rhs.rlmSchema)
     }
 }

--- a/RealmSwift/SortDescriptor.swift
+++ b/RealmSwift/SortDescriptor.swift
@@ -89,7 +89,6 @@ extension SortDescriptor: CustomStringConvertible {
 extension SortDescriptor: Equatable {
     /// Returns whether the two sort descriptors are equal.
     public static func == (lhs: SortDescriptor, rhs: SortDescriptor) -> Bool {
-        // swiftlint:disable:previous valid_docs
         return lhs.keyPath == rhs.keyPath &&
             lhs.ascending == lhs.ascending
     }


### PR DESCRIPTION
this rule hasn't worked ever since Swift 2.3, so there's no point in doing this anymore.