### PR TITLE
Add a test to ensure bridging `RLMError` to `Realm.Error`.

### DIFF
--- a/RealmSwift/Error.swift
+++ b/RealmSwift/Error.swift
@@ -28,7 +28,7 @@ extension Realm {
      ```swift
      let realm: Realm?
      do {
-         realm = Realm()
+         realm = try Realm()
      } catch Realm.Error.incompatibleLockFile {
          print("Realm Browser app may be attached to Realm on device?")
      }

--- a/RealmSwift/Tests/RealmTests.swift
+++ b/RealmSwift/Tests/RealmTests.swift
@@ -813,4 +813,23 @@ class RealmTests: TestCase {
             XCTAssertFalse(realm == otherThreadRealm)
         }
     }
+
+    func testCatchSpecificErrors() {
+        do {
+            _ = try Realm(configuration: Realm.Configuration(fileURL: URL(fileURLWithPath: "/dev/null/foo")))
+            XCTFail("Error should be thrown")
+        } catch Realm.Error.fileAccess {
+            // Success to catch the error
+        } catch {
+            XCTFail("Failed to brigde RLMError to Realm.Error")
+        }
+        do {
+            _ = try Realm(configuration: Realm.Configuration(fileURL: defaultRealmURL(), readOnly: true))
+            XCTFail("Error should be thrown")
+        } catch Realm.Error.fileNotFound {
+            // Success to catch the error
+        } catch {
+            XCTFail("Failed to brigde RLMError to Realm.Error")
+        }
+    }
 }


### PR DESCRIPTION
Make sure `RLMError` is correctly converted to `Realm.Error` and can catch errors using the `catch` clause.

CC @jpsim @austinzheng 