### PR TITLE
Update LLDB support now that RLMResult's object schema hangs off the class info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ x.x.x Release notes (yyyy-MM-dd)
 * Fix compilation issues with Xcode 8.3 beta 2.
 * Fix incorrect sync progress notification values for Realms originally created
   using a version of Realm prior to 2.3.0.
+* Fix LLDB integration to be able to display summaries of `RLMResults` once more.
 
 2.4.2 Release notes (2017-01-30)
 =============================================================


### PR DESCRIPTION
Fixes #4667.