### PR TITLE
Add `isAdmin` flag to `RLMSyncUser`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ x.x.x Release notes (yyyy-MM-dd)
 
 ### Bugfixes
 
-* Fix an issue where the project would fail to compile with clang 4.0.
+* None.
 
 2.5.0 Release notes (2017-03-28)
 =============================================================

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,12 @@ x.x.x Release notes (yyyy-MM-dd)
 
 ### Enhancements
 
-* None.
+* Add an `isAdmin` property to `RLMSyncUser` indicating whether a user is a
+  Realm Object Server administrator.
 
 ### Bugfixes
 
-* None.
+* Fix an issue where the project would fail to compile with clang 4.0.
 
 2.5.0 Release notes (2017-03-28)
 =============================================================

--- a/Realm/ObjectServerTests/RLMObjectServerTests.m
+++ b/Realm/ObjectServerTests/RLMObjectServerTests.m
@@ -242,6 +242,8 @@
     XCTAssertNil(badSession);
 }
 
+// FIXME: write a 'testUserIsAdminFlagProperlySet' test once we can properly create admin users
+
 #pragma mark - Basic Sync
 
 /// It should be possible to successfully open a Realm configured for sync with an access token.

--- a/Realm/ObjectServerTests/RLMObjectServerTests.m
+++ b/Realm/ObjectServerTests/RLMObjectServerTests.m
@@ -47,6 +47,7 @@
     XCTAssertTrue([firstUser.identity isEqualToString:secondUser.identity]);
     // Authentication server property should be properly set.
     XCTAssertEqualObjects(firstUser.authenticationServer, [RLMSyncTestCase authServerURL]);
+    XCTAssertFalse(firstUser.isAdmin);
 }
 
 /// A valid admin token should be able to log in a user.
@@ -57,7 +58,8 @@
     RLMSyncCredentials *credentials = [RLMSyncCredentials credentialsWithAccessToken:adminToken identity:@"test"];
     XCTAssertNotNil(credentials);
 
-    [self logInUserForCredentials:credentials server:[RLMObjectServerTests authServerURL]];
+    RLMSyncUser *user = [self logInUserForCredentials:credentials server:[RLMObjectServerTests authServerURL]];
+    XCTAssertTrue(user.isAdmin);
 }
 
 /// An invalid username/password credential should not be able to log in a user and a corresponding error should be generated.

--- a/Realm/RLMSyncUser.h
+++ b/Realm/RLMSyncUser.h
@@ -70,6 +70,11 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nullable, nonatomic, readonly) NSURL *authenticationServer;
 
 /**
+ Whether the user is an Realm Object Server administrator user.
+ */
+@property (nonatomic, readonly) BOOL isAdmin;
+
+/**
  The current state of the user.
  */
 @property (nonatomic, readonly) RLMSyncUserState state;

--- a/Realm/RLMSyncUser.h
+++ b/Realm/RLMSyncUser.h
@@ -70,7 +70,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nullable, nonatomic, readonly) NSURL *authenticationServer;
 
 /**
- Whether the user is an Realm Object Server administrator user.
+ Whether the user is an Realm Object Server administrator.
  */
 @property (nonatomic, readonly) BOOL isAdmin;
 

--- a/Realm/RLMSyncUser.mm
+++ b/Realm/RLMSyncUser.mm
@@ -178,6 +178,13 @@ using namespace realm;
     return [RLMRealm realmWithConfiguration:[RLMRealmConfiguration permissionConfigurationForUser:self] error:error];
 }
 
+- (BOOL)isAdmin {
+    if (!_user) {
+        return NO;
+    }
+    return _user->is_admin();
+}
+
 #pragma mark - Private API
 
 - (void)_unregisterRefreshHandleForURLPath:(NSString *)path {
@@ -256,6 +263,7 @@ using namespace realm;
                                                     userInfo:nil]);
                     return;
                 }
+                sync_user->set_is_admin(model.refreshToken.tokenData.isAdmin);
                 user->_user = sync_user;
                 completion(user, nil);
             }
@@ -276,7 +284,10 @@ using namespace realm;
                                      completionBlock:(nonnull RLMUserCompletionBlock)completion {
     NSString *identity = credentials.userInfo[kRLMSyncIdentityKey];
     NSAssert(identity != nil, @"Improperly created direct access token credential.");
-    auto sync_user = SyncManager::shared().get_user([identity UTF8String], [credentials.token UTF8String], none, true);
+    auto sync_user = SyncManager::shared().get_user([identity UTF8String],
+                                                    [credentials.token UTF8String],
+                                                    none,
+                                                    SyncUser::TokenType::Admin);
     if (!sync_user) {
         completion(nil, [NSError errorWithDomain:RLMSyncErrorDomain
                                             code:RLMSyncErrorClientSessionError

--- a/Realm/RLMSyncUtil_Private.h
+++ b/Realm/RLMSyncUtil_Private.h
@@ -75,6 +75,13 @@ if (![data isKindOfClass:[NSString class]]) { data = nil; } \
 self.prop_macro_val = data; \
 } \
 
+#define RLM_SYNC_PARSE_OPTIONAL_BOOL(json_macro_val, key_macro_val, prop_macro_val) \
+{ \
+id data = json_macro_val[key_macro_val]; \
+if (![data isKindOfClass:[NSNumber class]]) { data = @NO; } \
+self.prop_macro_val = [data boolValue]; \
+} \
+
 /// A macro to parse a double out of a JSON dictionary, or return nil.
 #define RLM_SYNC_PARSE_DOUBLE_OR_ABORT(json_macro_val, key_macro_val, prop_macro_val) \
 { \

--- a/Realm/RLMTokenModels.h
+++ b/Realm/RLMTokenModels.h
@@ -40,6 +40,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, nullable, readonly) NSString *appID;
 @property (nonatomic, nullable, readonly) NSString *path;
 @property (nonatomic, readonly) NSTimeInterval expires;
+@property (nonatomic, readonly) BOOL isAdmin;
 //@property (nonatomic, readonly) NSArray *access;
 
 - (instancetype)initWithDictionary:(NSDictionary *)jsonDictionary;

--- a/Realm/RLMTokenModels.m
+++ b/Realm/RLMTokenModels.m
@@ -22,6 +22,7 @@
 static const NSString *const kRLMSyncTokenDataKey       = @"token_data";
 static const NSString *const kRLMSyncTokenKey           = @"token";
 static const NSString *const kRLMSyncExpiresKey         = @"expires";
+static const NSString *const kRLMSyncIsAdminKey         = @"is_admin";
 
 @interface RLMTokenDataModel ()
 
@@ -29,6 +30,7 @@ static const NSString *const kRLMSyncExpiresKey         = @"expires";
 @property (nonatomic, readwrite) NSString *appID;
 @property (nonatomic, readwrite) NSString *path;
 @property (nonatomic, readwrite) NSTimeInterval expires;
+@property (nonatomic, readwrite) BOOL isAdmin;
 //@property (nonatomic, readwrite) NSArray *access;
 
 @end
@@ -37,9 +39,11 @@ static const NSString *const kRLMSyncExpiresKey         = @"expires";
 
 - (instancetype)initWithDictionary:(NSDictionary *)jsonDictionary {
     if (self = [super init]) {
+        self.isAdmin = NO;
         RLM_SYNC_PARSE_STRING_OR_ABORT(jsonDictionary, kRLMSyncIdentityKey, identity);
         RLM_SYNC_PARSE_OPTIONAL_STRING(jsonDictionary, kRLMSyncAppIDKey, appID);
         RLM_SYNC_PARSE_OPTIONAL_STRING(jsonDictionary, kRLMSyncPathKey, path);
+        RLM_SYNC_PARSE_OPTIONAL_BOOL(jsonDictionary, kRLMSyncIsAdminKey, isAdmin);
         RLM_SYNC_PARSE_DOUBLE_OR_ABORT(jsonDictionary, kRLMSyncExpiresKey, expires);
         return self;
     }


### PR DESCRIPTION
Changes:
- Sync users now expose a property indicating whether or not they are Realm Object Server administrator users

Requires: https://github.com/realm/realm-object-store/pull/396

To do:
- [x] Verify it works with a version of ROS with the corresponding server change
- [x] Write test(s)