### PR TITLE
Add support for multi-level object equality comparisons against NULL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ x.x.x Release notes (yyyy-MM-dd)
 
 ### Enhancements
 
-* None.
+* Add support for multi-level object equality comparisons against `NULL`.
 
 ### Bugfixes
 

--- a/Realm/RLMQueryUtil.mm
+++ b/Realm/RLMQueryUtil.mm
@@ -680,14 +680,15 @@ void QueryBuilder::add_link_constraint(NSPredicateOperatorType operatorType,
 void QueryBuilder::add_link_constraint(NSPredicateOperatorType operatorType,
                                        const ColumnReference& column,
                                        realm::null) {
-    RLMPrecondition(!column.has_links(), @"Unsupported operator", @"Multi-level object equality link queries are not supported.");
     RLMPrecondition(operatorType == NSEqualToPredicateOperatorType || operatorType == NSNotEqualToPredicateOperatorType,
                     @"Invalid operator type", @"Only 'Equal' and 'Not Equal' operators supported for object comparison");
-    if (operatorType == NSNotEqualToPredicateOperatorType) {
-        m_query.Not();
-    }
 
-    m_query.and_query(column.resolve<Link>().is_null());
+    if (operatorType == NSEqualToPredicateOperatorType) {
+        m_query.and_query(column.resolve<Link>() == null());
+    }
+    else {
+        m_query.and_query(column.resolve<Link>() != null());
+    }
 }
 
 template<typename T>

--- a/Realm/Tests/QueryTests.m
+++ b/Realm/Tests/QueryTests.m
@@ -1384,6 +1384,8 @@
     XCTAssertNoThrow(([CircleObject objectsInRealm:realm where:@"next = %@", circle]));
     XCTAssertNoThrow(([CircleObject objectsInRealm:realm where:@"next.next = %@", circle]));
     XCTAssertTrue([circle.next.next.next.next isEqualToObject:[CircleObject objectsInRealm:realm where:@"next = nil"].firstObject]);
+    XCTAssertTrue([circle.next.next.next isEqualToObject:[CircleObject objectsInRealm:realm where:@"next != nil AND next.next = nil"].firstObject]);
+    XCTAssertTrue([circle.next.next isEqualToObject:[CircleObject objectsInRealm:realm where:@"next.next != nil AND next.next.next = nil"].firstObject]);
 }
 
 - (void)testArrayMultiLevelLinkQuery


### PR DESCRIPTION
I apparently added core support for this back in v0.99 while working on querying over backlinks, but forgot to hook it up in the Cocoa binding because it wasn't relevant to backlinks.