### PR TITLE
Change our approach to resetting iOS simulators

### DIFF
--- a/scripts/reset-simulators.rb
+++ b/scripts/reset-simulators.rb
@@ -75,6 +75,7 @@ begin
 
   runtimes_by_platform = Hash.new { |hash, key| hash[key] = [] }
   runtimes.each do |runtime|
+    next unless runtime['availability'] == '(available)'
     runtimes_by_platform[platform_for_runtime(runtime)] << runtime
   end
 

--- a/scripts/reset-simulators.rb
+++ b/scripts/reset-simulators.rb
@@ -1,0 +1,100 @@
+#!/usr/bin/ruby
+
+require 'json'
+
+def platform_for_runtime(runtime)
+  runtime['identifier'].gsub(/com.apple.CoreSimulator.SimRuntime.([^-]+)-.*/, '\1')
+end
+
+def platform_for_device_type(device_type)
+  case device_type['identifier']
+  when /Watch/
+    'watchOS'
+  when /TV/
+    'tvOS'
+  else
+    'iOS'
+  end
+end
+
+def wait_for_core_simulator_service
+  # Run until we get a result since switching simulator versions often causes CoreSimulatorService to throw an exception.
+  while `xcrun simctl list devices`.empty?
+  end
+end
+
+def running_devices(devices)
+  devices.select { |device| device['state'] != 'Shutdown' }
+end
+
+def shutdown_simulator_devices(all_devices)
+  # Shut down any simulators that need it.
+  running_devices(all_devices).each do |device|
+    puts "Shutting down simulator #{device['udid']}"
+    system("xcrun simctl shutdown #{device['udid']}") or puts "    Failed to shut down simulator #{device['udid']}"
+  end
+end
+
+begin
+
+  # Kill all the current simulator processes as they may be from a different Xcode version
+  print 'Killing running Simulator processes...'
+  while system('pgrep -q Simulator')
+    system('pkill Simulator 2>/dev/null')
+    # CoreSimulatorService doesn't exit when sent SIGTERM
+    system('pkill -9 Simulator 2>/dev/null')
+  end
+  puts ' done!'
+
+  wait_for_core_simulator_service
+
+  system('xcrun simctl delete unavailable') or raise 'Failed to delete unavailable simulators'
+
+  # Shut down any running simulator devices. This may take multiple attempts if some
+  # simulators are currently in the process of booting or being created.
+  all_devices = []
+  (0..5).each do |shutdown_attempt|
+    devices_json = `xcrun simctl list devices -j`
+    all_devices = JSON.parse(devices_json)['devices'].flat_map { |_, devices| devices }
+    break if running_devices(all_devices).empty?
+
+    shutdown_simulator_devices all_devices
+    sleep shutdown_attempt if shutdown_attempt > 0
+  end
+
+  # Delete all simulators.
+  print 'Deleting all simulators...'
+  all_devices.each do |device|
+    system("xcrun simctl delete #{device['udid']}") or raise "Failed to delete simulator #{device['udid']}"
+  end
+  puts ' done!'
+
+  # Recreate all simulators.
+  runtimes = JSON.parse(`xcrun simctl list runtimes -j`)['runtimes']
+  device_types = JSON.parse(`xcrun simctl list devicetypes -j`)['devicetypes']
+
+  runtimes_by_platform = Hash.new { |hash, key| hash[key] = [] }
+  runtimes.each do |runtime|
+    runtimes_by_platform[platform_for_runtime(runtime)] << runtime
+  end
+
+  puts 'Creating fresh simulators...'
+  device_types.each do |device_type|
+    platform = platform_for_device_type(device_type)
+    runtimes_by_platform[platform].each do |runtime|
+      output = `xcrun simctl create '#{device_type['name']}' '#{device_type['identifier']}' '#{runtime['identifier']}' 2>&1`
+      next unless $? != 0
+
+      puts "Failed to create device of type #{device_type['identifier']} with runtime #{runtime['identifier']}:"
+      output.each_line do |line|
+        puts "    #{line}"
+      end
+    end
+  end
+  puts 'Done!'
+
+rescue
+  system('ps auxwww')
+  system('xcrun simctl list')
+  raise
+end

--- a/scripts/reset-simulators.rb
+++ b/scripts/reset-simulators.rb
@@ -83,7 +83,7 @@ begin
     platform = platform_for_device_type(device_type)
     runtimes_by_platform[platform].each do |runtime|
       output = `xcrun simctl create '#{device_type['name']}' '#{device_type['identifier']}' '#{runtime['identifier']}' 2>&1`
-      next unless $? != 0
+      next if $? == 0
 
       puts "Failed to create device of type #{device_type['identifier']} with runtime #{runtime['identifier']}:"
       output.each_line do |line|

--- a/scripts/reset-simulators.sh
+++ b/scripts/reset-simulators.sh
@@ -6,43 +6,4 @@ set -e
 source "$(dirname "$0")/swift-version.sh"
 set_xcode_and_swift_versions
 
-while pgrep -q Simulator; do
-    # Kill all the current simulator processes as they may be from a
-    # different Xcode version
-    pkill Simulator 2>/dev/null || true
-    # CoreSimulatorService doesn't exit when sent SIGTERM
-    pkill -9 Simulator 2>/dev/null || true
-done
-
-# Run until we get a result since switching simulator versions often causes CoreSimulatorService to throw an exception.
-devices=""
-until [ "$devices" != "" ]; do
-    devices="$(xcrun simctl list devices -j || true)"
-done
-
-# Shut down booted simulators
-echo "$devices" | ruby -rjson -e 'puts JSON.parse($stdin.read)["devices"].flat_map { |d| d[1] }.select { |d| d["state"] == "Booted" && d["availability"] == "(available)" }.map { |d| d["udid"] }' | while read udid; do
-    echo "shutting down simulator with ID: $udid"
-    xcrun simctl shutdown $udid
-done
-
-# Erase all available simulators
-echo "erasing simulators"
-echo "$devices" | ruby -rjson -e 'puts JSON.parse($stdin.read)["devices"].flat_map { |d| d[1] }.select { |d| d["availability"] == "(available)" }.map { |d| d["udid"] }' | while read udid; do
-    xcrun simctl erase $udid &
-done
-wait
-
-if [[ -a "${DEVELOPER_DIR}/Applications/Simulator.app" ]]; then
-    open "${DEVELOPER_DIR}/Applications/Simulator.app"
-fi
-
-# Wait until the boot completes
-echo "waiting for simulator to boot..."
-until xcrun simctl list devices -j | ruby -rjson -e 'exit JSON.parse($stdin.read)["devices"].flat_map { |d| d[1] }.any? { |d| d["availability"] == "(available)" && d["state"] == "Booted" }'; do
-    sleep 1
-done
-
-# Wait until the simulator is fully booted by waiting for it to launch SpringBoard
-xcrun simctl launch booted com.apple.springboard >/dev/null 2>&1 || true
-echo "simulator booted"
+"$(dirname "$0")/reset-simulators.rb"


### PR DESCRIPTION
We used to do the following:
1. Kill any running simulator processes.
2. Shut down any running simulator devices.
3. Erase the contents of all simulator devices.
4. Launch Simulator.app.
5. Wait for Simulator.app to boot a simulator device.

Steps 3, 4 and 5 were somewhat problematic as there's no guarantee that the simulator devices will exist and be in a valid state that will allow Simulator.app to launch them. This often resulted in step 5, waiting for the simulator devices to boot, timing out.

We now do the following:
1. Kill any running simulator processes.
2. Delete any unavailable simulator devices.
3. Shut down any running simulator devices.
4. Delete all remaining simulator devices.
5. Create a fresh simulator device for each valid platform / device type
   combination.


Fixes #4095.