### PR TITLE
delete derived data if pcm file needs to be rebuilt

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1049,6 +1049,9 @@ EOM
             sh build.sh verify-$target 2>&1 | tee build/build.log | xcpretty -r junit -o build/reports/junit.xml || failed=1
             if [ "$failed" = "1" ] && cat build/build.log | grep -E 'DTXProxyChannel|DTXChannel|out of date and needs to be rebuilt|operation never finished bootstrapping'; then
                 echo "Known Xcode error detected. Running job again."
+                if cat build/build.log | grep -E 'out of date and needs to be rebuilt'; then
+                    rm -rf build/DerivedData
+                fi
                 failed=0
                 sh build.sh verify-$target | tee build/build.log | xcpretty -r junit -o build/reports/junit.xml || failed=1
             elif [ "$failed" = "1" ] && tail ~/Library/Logs/CoreSimulator/CoreSimulator.log | grep -E "Operation not supported|Failed to lookup com.apple.coreservices.lsuseractivity.simulatorsupport"; then


### PR DESCRIPTION
For errors such as:

> module file '.../build/DerivedData/.../Module.pcm' is out of date
> and needs to be rebuilt

We should actually delete the derived data directory in order to
rebuild the pcm file