### PR TITLE
Fix crashes related to sync-applied schema changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,9 @@ x.x.x Release notes (yyyy-MM-dd)
 
 ### Bugfixes
 
-* None.
+* Fix incorrect column type assertions which could occur after schemas were
+  merged by sync.
+* Eliminate an empty write transaction when opening a synced Realm.
 
 2.4.4 Release notes (2017-03-13)
 =============================================================

--- a/Realm/RLMClassInfo.hpp
+++ b/Realm/RLMClassInfo.hpp
@@ -92,7 +92,9 @@ class RLMSchemaInfo {
     using impl = std::unordered_map<NSString *, RLMClassInfo>;
 public:
     RLMSchemaInfo() = default;
-    RLMSchemaInfo(RLMRealm *realm, RLMSchema *rlmSchema, realm::Schema const& schema);
+    RLMSchemaInfo(RLMRealm *realm);
+
+    RLMSchemaInfo clone(realm::Schema const& source_schema, RLMRealm *target_realm);
 
     // Look up by name, throwing if it's not present
     RLMClassInfo& operator[](NSString *name);

--- a/Realm/RLMObject.mm
+++ b/Realm/RLMObject.mm
@@ -110,7 +110,7 @@
     return RLMGetObjects(RLMRealm.defaultRealm, self.className, nil);
 }
 
-+ (RLMResults *)allObjectsInRealm:(RLMRealm *)realm {
++ (RLMResults *)allObjectsInRealm:(__unsafe_unretained RLMRealm *const)realm {
     return RLMGetObjects(realm, self.className, nil);
 }
 

--- a/Realm/RLMObjectStore.mm
+++ b/Realm/RLMObjectStore.mm
@@ -467,7 +467,9 @@ void RLMDeleteAllObjectsFromRealm(RLMRealm *realm) {
     }
 }
 
-RLMResults *RLMGetObjects(RLMRealm *realm, NSString *objectClassName, NSPredicate *predicate) {
+RLMResults *RLMGetObjects(__unsafe_unretained RLMRealm *const realm,
+                          NSString *objectClassName,
+                          NSPredicate *predicate) {
     RLMVerifyRealmRead(realm);
 
     // create view from table and predicate

--- a/Realm/RLMRealm.mm
+++ b/Realm/RLMRealm.mm
@@ -178,16 +178,12 @@ static id RLMAutorelease(__unsafe_unretained id value) {
     return value ? (__bridge id)CFAutorelease((__bridge_retained CFTypeRef)value) : nil;
 }
 
-static void RLMRealmSetSchemaAndAlign(RLMRealm *realm, RLMSchema *targetSchema) {
-    realm.schema = targetSchema;
-    realm->_info = RLMSchemaInfo(realm, targetSchema, realm->_realm->schema());
-}
-
 + (instancetype)realmWithSharedRealm:(SharedRealm)sharedRealm schema:(RLMSchema *)schema {
     RLMRealm *realm = [RLMRealm new];
     realm->_realm = sharedRealm;
     realm->_dynamic = YES;
-    RLMRealmSetSchemaAndAlign(realm, schema);
+    realm->_schema = schema;
+    realm->_info = RLMSchemaInfo(realm);
     return RLMAutorelease(realm);
 }
 
@@ -298,18 +294,21 @@ REALM_NOINLINE void RLMRealmTranslateException(NSError **error) {
         return nil;
     }
 
-    RLMSchema *cachedRealmSchema;
+    // if we have a cached realm on another thread we can skip a few steps and
+    // just grab its schema
     @autoreleasepool {
         // ensure that cachedRealm doesn't end up in this thread's autorelease pool
-        cachedRealmSchema = RLMGetAnyCachedRealmForPath(config.path).schema;
+        if (auto cachedRealm = RLMGetAnyCachedRealmForPath(config.path)) {
+            realm->_realm->set_schema_subset(cachedRealm->_realm->schema());
+            realm->_schema = cachedRealm.schema;
+            realm->_info = cachedRealm->_info.clone(cachedRealm->_realm->schema(), realm);
+        }
     }
 
-    // if we have a cached realm on another thread, copy without a transaction
-    if (cachedRealmSchema) {
-        RLMRealmSetSchemaAndAlign(realm, cachedRealmSchema);
-    }
+    if (realm->_schema) { }
     else if (dynamic) {
-        RLMRealmSetSchemaAndAlign(realm, [RLMSchema dynamicSchemaFromObjectStoreSchema:realm->_realm->schema()]);
+        realm->_schema = [RLMSchema dynamicSchemaFromObjectStoreSchema:realm->_realm->schema()];
+        realm->_info = RLMSchemaInfo(realm);
     }
     else {
         // set/align schema or perform migration if needed
@@ -344,7 +343,8 @@ REALM_NOINLINE void RLMRealmTranslateException(NSError **error) {
             return nil;
         }
 
-        RLMRealmSetSchemaAndAlign(realm, schema);
+        realm->_schema = schema;
+        realm->_info = RLMSchemaInfo(realm);
         RLMRealmCreateAccessors(realm.schema);
 
         if (!readOnly) {

--- a/Realm/RLMRealm.mm
+++ b/Realm/RLMRealm.mm
@@ -173,7 +173,7 @@ NSData *RLMRealmValidatedEncryptionKey(NSData *key) {
 // ARC tries to eliminate calls to autorelease when the value is then immediately
 // returned, but this results in significantly different semantics between debug
 // and release builds for RLMRealm, so force it to always autorelease.
-static id RLMAutorelease(id value) {
+static id RLMAutorelease(__unsafe_unretained id value) {
     // +1 __bridge_retained, -1 CFAutorelease
     return value ? (__bridge id)CFAutorelease((__bridge_retained CFTypeRef)value) : nil;
 }

--- a/Realm/RLMRealmUtil.mm
+++ b/Realm/RLMRealmUtil.mm
@@ -39,7 +39,7 @@
 static std::mutex& s_realmCacheMutex = *new std::mutex();
 static std::map<std::string, NSMapTable *>& s_realmsPerPath = *new std::map<std::string, NSMapTable *>();
 
-void RLMCacheRealm(std::string const& path, RLMRealm *realm) {
+void RLMCacheRealm(std::string const& path, __unsafe_unretained RLMRealm *const realm) {
     std::lock_guard<std::mutex> lock(s_realmCacheMutex);
     NSMapTable *realms = s_realmsPerPath[path];
     if (!realms) {
@@ -138,6 +138,6 @@ private:
 } // anonymous namespace
 
 
-std::unique_ptr<realm::BindingContext> RLMCreateBindingContext(RLMRealm *realm) {
+std::unique_ptr<realm::BindingContext> RLMCreateBindingContext(__unsafe_unretained RLMRealm *const realm) {
     return std::unique_ptr<realm::BindingContext>(new RLMNotificationHelper(realm));
 }

--- a/Realm/Tests/NotificationTests.m
+++ b/Realm/Tests/NotificationTests.m
@@ -898,6 +898,13 @@ static void ExpectChange(id self, NSArray *deletions, NSArray *insertions, NSArr
     _propertyNames = [_obj.objectSchema.properties valueForKey:@"name"];
 }
 
+- (void)tearDown {
+    _values = nil;
+    _initialValues = nil;
+    _obj = nil;
+    [super tearDown];
+}
+
 - (void)testDeleteObservedObject {
     XCTestExpectation *expectation = [self expectationWithDescription:@""];
     RLMNotificationToken *token = [_obj addNotificationBlock:^(BOOL deleted, NSArray *changes, NSError *error) {

--- a/Realm/Tests/PerformanceTests.m
+++ b/Realm/Tests/PerformanceTests.m
@@ -397,6 +397,18 @@ static RLMRealm *s_smallRealm, *s_mediumRealm, *s_largeRealm;
     }];
 }
 
+- (void)testInvalidateRefresh {
+    RLMRealm *realm = [self testRealm];
+    [self measureBlock:^{
+        for (int i = 0; i < 50000; ++i) {
+            @autoreleasepool {
+                [realm invalidate];
+                [realm refresh];
+            }
+        }
+    }];
+}
+
 - (void)testCommitWriteTransaction {
     [self measureMetrics:self.class.defaultPerformanceMetrics automaticallyStartMeasuring:NO forBlock:^{
         RLMRealm *realm = self.testRealm;


### PR DESCRIPTION
Schema changes made while a RLMRealm instance existed but did not have a read transaction were not being handled, which would result in many assorted crashes (usually involving an incorrect column type assertion) if the schema was changed in a way that needed handling. This normally could only occur when sync merge resolution reorders columns, as the simple multi-process case would only add new tables or new columns to the end.

The only functional change here other than bumping the objectstore version to one with the relevant fixes is that we now need to explicitly set the schema on the OS Realm object even when we already have the Realm open on a different thread. The addition of `RLMSchemaInfo::clone()` is an optimization to offset the performance impact of this, and the other changes are just things that made debugging some issues I ran into while testing this less annoying.

Fixes #4687 .