### PR TITLE
add note about plugin menu item not being displayed in Xcode 8

### DIFF
--- a/plugin/README.md
+++ b/plugin/README.md
@@ -6,6 +6,8 @@ The Realm Plugin for Xcode adds several useful features for developing with Real
    persisted RLMObjects in the debugger pane.
 2. File templates for RLMObject subclasses.
 3. A menu item in Xcode's 'File' menu to quickly launch the Realm Browser.
+   Note that this item will only appear in Xcode 7 and in unsigned versions of
+   Xcode 8 or later (not recommended).
 
 To install the Realm Plugin, open `RealmPlugin.xcodeproj` and Build. This will
 prompt for your password. After building the plugin, restart Xcode.


### PR DESCRIPTION
There was some user confusion in https://github.com/realm/realm-cocoa/issues/4730.