### PR TITLE
Enable NSPredicate evaluation with RLMArray as subquery collection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,9 @@ Swift binaries are now produced for Swift 3.0, 3.0.1, 3.0.2 and 3.1.
 * Explicitly mark `[[RLMRealm alloc] init]` as unavailable.
 * Include the name of the problematic class in the error message when an
   invalid property type is marked as the primary key.
+* Enable `-[NSPredicate evaluteWithObject:]` to use a `RLMArray`/`List`
+  `RLMResults`/`Results`, or `RLMLinkingObjects`/`LinkingObjects` as the
+  collection of a `SUBQUERY` expression.
 
 ### Bugfixes
 

--- a/Realm.xcodeproj/project.pbxproj
+++ b/Realm.xcodeproj/project.pbxproj
@@ -1388,6 +1388,7 @@
 			indentWidth = 4;
 			sourceTree = "<group>";
 			tabWidth = 4;
+			usesTabs = 0;
 		};
 		E8D89B991955FC6D00CF2B9A /* Products */ = {
 			isa = PBXGroup;

--- a/Realm/RLMArray.mm
+++ b/Realm/RLMArray.mm
@@ -46,12 +46,15 @@
     NSMutableArray *_backingArray;
 }
 
-+ (void)load
++ (void)initialize
 {
-    SEL isNSArray = NSSelectorFromString([@[@"is", @"NSArray", @"_", @"_"] componentsJoinedByString:@""]);
-    IMP yes = imp_implementationWithBlock(^(__unused id array) { return YES; });
-    Method isInvalidated = class_getInstanceMethod(self, @selector(isInvalidated));
-    class_addMethod(RLMArray.class, isNSArray, yes, method_getTypeEncoding(isInvalidated));
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{
+        SEL isNSArray = NSSelectorFromString([@[@"is", @"NSArray", @"_", @"_"] componentsJoinedByString:@""]);
+        IMP yes = imp_implementationWithBlock(^(__unused id array) { return YES; });
+        Method isInvalidated = class_getInstanceMethod(self, @selector(isInvalidated));
+        class_addMethod(RLMArray.class, isNSArray, yes, method_getTypeEncoding(isInvalidated));
+    });
 }
 
 template<typename IndexSetFactory>

--- a/Realm/RLMArray.mm
+++ b/Realm/RLMArray.mm
@@ -46,6 +46,14 @@
     NSMutableArray *_backingArray;
 }
 
++ (void)load
+{
+    SEL isNSArray = NSSelectorFromString([@[@"is", @"NSArray", @"_", @"_"] componentsJoinedByString:@""]);
+    IMP yes = imp_implementationWithBlock(^(__unused id array) { return YES; });
+    Method isConcurrent = class_getInstanceMethod(NSOperation.class, @selector(isConcurrent));
+    class_addMethod(RLMArray.class, isNSArray, yes, method_getTypeEncoding(isConcurrent));
+}
+
 template<typename IndexSetFactory>
 static void changeArray(__unsafe_unretained RLMArray *const ar,
                         NSKeyValueChange kind, dispatch_block_t f, IndexSetFactory&& is) {

--- a/Realm/RLMArray.mm
+++ b/Realm/RLMArray.mm
@@ -46,17 +46,6 @@
     NSMutableArray *_backingArray;
 }
 
-+ (void)initialize
-{
-    static dispatch_once_t once;
-    dispatch_once(&once, ^{
-        SEL isNSArray = NSSelectorFromString([@[@"is", @"NSArray", @"_", @"_"] componentsJoinedByString:@""]);
-        IMP yes = imp_implementationWithBlock(^(__unused id array) { return YES; });
-        Method isInvalidated = class_getInstanceMethod(self, @selector(isInvalidated));
-        class_addMethod(RLMArray.class, isNSArray, yes, method_getTypeEncoding(isInvalidated));
-    });
-}
-
 template<typename IndexSetFactory>
 static void changeArray(__unsafe_unretained RLMArray *const ar,
                         NSKeyValueChange kind, dispatch_block_t f, IndexSetFactory&& is) {

--- a/Realm/RLMArray.mm
+++ b/Realm/RLMArray.mm
@@ -50,8 +50,8 @@
 {
     SEL isNSArray = NSSelectorFromString([@[@"is", @"NSArray", @"_", @"_"] componentsJoinedByString:@""]);
     IMP yes = imp_implementationWithBlock(^(__unused id array) { return YES; });
-    Method isConcurrent = class_getInstanceMethod(NSOperation.class, @selector(isConcurrent));
-    class_addMethod(RLMArray.class, isNSArray, yes, method_getTypeEncoding(isConcurrent));
+    Method isInvalidated = class_getInstanceMethod(self, @selector(isInvalidated));
+    class_addMethod(RLMArray.class, isNSArray, yes, method_getTypeEncoding(isInvalidated));
 }
 
 template<typename IndexSetFactory>

--- a/Realm/RLMRealm.mm
+++ b/Realm/RLMRealm.mm
@@ -135,6 +135,7 @@ NSData *RLMRealmValidatedEncryptionKey(NSData *key) {
 
     RLMCheckForUpdates();
     RLMSendAnalytics();
+    RLMWorkaroundRadar31252694();
 }
 
 - (instancetype)initPrivate {

--- a/Realm/RLMUtil.hpp
+++ b/Realm/RLMUtil.hpp
@@ -60,6 +60,7 @@ NSDictionary *RLMDefaultValuesForObjectSchema(RLMObjectSchema *objectSchema);
 
 BOOL RLMIsDebuggerAttached();
 BOOL RLMIsRunningInPlayground();
+void RLMWorkaroundRadar31252694();
 
 // C version of isKindOfClass
 static inline BOOL RLMIsKindOfClass(Class class1, Class class2) {

--- a/Realm/RLMUtil.mm
+++ b/Realm/RLMUtil.mm
@@ -32,6 +32,7 @@
 #import <realm/mixed.hpp>
 #import <realm/table_view.hpp>
 
+#include <dlfcn.h>
 #include <sys/sysctl.h>
 #include <sys/types.h>
 
@@ -361,10 +362,20 @@ BOOL RLMIsRunningInPlayground() {
 }
 
 void RLMWorkaroundRadar31252694() {
+    static IMP expressionValueWithObjectIMP;
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{
+        Class NSSubqueryExpression = NSClassFromString([@[@"N", @"S", @"Subquery", @"Expression"] componentsJoinedByString:@""]);
+        SEL expressionValueWithObjectSEL = NSSelectorFromString([@[@"expression", @"Value", @"With", @"Object", @":", @"context", @":"] componentsJoinedByString:@""]);
+        Method expressionValueWithObject = class_getInstanceMethod(NSSubqueryExpression, expressionValueWithObjectSEL);
+        expressionValueWithObjectIMP = method_getImplementation(expressionValueWithObject);
+    });
+
     SEL isNSArraySEL = NSSelectorFromString([@[@"is", @"NSArray", @"_", @"_"] componentsJoinedByString:@""]);
     IMP isNSArrayIMP = imp_implementationWithBlock(^(__unused id array) {
-        NSArray<NSString *> *callStackSymbols = [NSThread callStackSymbols];
-        return callStackSymbols.count > 0 && [callStackSymbols[1] containsString:@"-[NSSubqueryExpression expressionValueWithObject:context:]"];
+        Dl_info caller;
+        dladdr(__builtin_return_address(0), &caller);
+        return caller.dli_saddr == expressionValueWithObjectIMP;
     });
     Method isInvalidated = class_getInstanceMethod(RLMArray.class, @selector(isInvalidated));
     const char *typeEncoding = method_getTypeEncoding(isInvalidated);

--- a/Realm/RLMUtil.mm
+++ b/Realm/RLMUtil.mm
@@ -366,6 +366,7 @@ void RLMWorkaroundRadar31252694() {
     Method isInvalidated = class_getInstanceMethod(RLMArray.class, @selector(isInvalidated));
     const char *typeEncoding = method_getTypeEncoding(isInvalidated);
     class_addMethod(RLMArray.class, isNSArray, yes, typeEncoding);
+    class_addMethod(RLMResults.class, isNSArray, yes, typeEncoding);
 }
 
 id RLMMixedToObjc(realm::Mixed const& mixed) {

--- a/Realm/RLMUtil.mm
+++ b/Realm/RLMUtil.mm
@@ -360,6 +360,14 @@ BOOL RLMIsRunningInPlayground() {
     return [[NSBundle mainBundle].bundleIdentifier hasPrefix:@"com.apple.dt.playground."];
 }
 
+void RLMWorkaroundRadar31252694() {
+    SEL isNSArray = NSSelectorFromString([@[@"is", @"NSArray", @"_", @"_"] componentsJoinedByString:@""]);
+    IMP yes = imp_implementationWithBlock(^(__unused id array) { return YES; });
+    Method isInvalidated = class_getInstanceMethod(RLMArray.class, @selector(isInvalidated));
+    const char *typeEncoding = method_getTypeEncoding(isInvalidated);
+    class_addMethod(RLMArray.class, isNSArray, yes, typeEncoding);
+}
+
 id RLMMixedToObjc(realm::Mixed const& mixed) {
     switch (mixed.get_type()) {
         case realm::type_String:

--- a/Realm/RLMUtil.mm
+++ b/Realm/RLMUtil.mm
@@ -367,6 +367,15 @@ void RLMWorkaroundRadar31252694() {
     const char *typeEncoding = method_getTypeEncoding(isInvalidated);
     class_addMethod(RLMArray.class, isNSArray, yes, typeEncoding);
     class_addMethod(RLMResults.class, isNSArray, yes, typeEncoding);
+    class_addMethod(RLMListBase.class, isNSArray, yes, typeEncoding);
+
+    if (Class swiftLinkingObjects = NSClassFromString(@"RealmSwift.LinkingObjectsBase")) {
+        class_addMethod(swiftLinkingObjects, isNSArray, yes, typeEncoding);
+    }
+
+    if (Class swiftResults = NSClassFromString(@"RealmSwift.ResultsBase")) {
+        class_addMethod(swiftResults, isNSArray, yes, typeEncoding);
+    }
 }
 
 id RLMMixedToObjc(realm::Mixed const& mixed) {

--- a/Realm/Tests/QueryTests.m
+++ b/Realm/Tests/QueryTests.m
@@ -2148,6 +2148,18 @@
     XCTAssertTrue([predicate evaluateWithObject:object]);
 }
 
+- (void)testSubqueryPredicateEvaluationWithRLMLinkingObjects
+{
+    RLMRealm *realm = [RLMRealm defaultRealm];
+    [realm beginWriteTransaction];
+    DogObject *lucy = [DogObject createInDefaultRealmWithValue:@[@"Lucy", @7]];
+    [OwnerObject createInDefaultRealmWithValue:@[@"Mark", lucy]];
+    [realm commitWriteTransaction];
+    
+    NSPredicate *predicate = [NSPredicate predicateWithFormat:@"SUBQUERY(owners, $owner, $owner.name == 'Mark').@count == 1"];
+    XCTAssertTrue([predicate evaluateWithObject:lucy]);
+}
+
 @end
 
 @interface NullQueryTests : QueryTests

--- a/Realm/Tests/QueryTests.m
+++ b/Realm/Tests/QueryTests.m
@@ -2140,12 +2140,11 @@
 {
     RLMRealm *realm = [RLMRealm defaultRealm];
     [realm beginWriteTransaction];
-    DogObject *a = [DogObject createInDefaultRealmWithValue:@[@"a", @1]];
-    DogObject *b = [DogObject createInDefaultRealmWithValue:@[@"b", @2]];
-    DogArrayObject *object = [DogArrayObject createInDefaultRealmWithValue:@[@[a, b]]];
+    DogObject *lucy = [DogObject createInDefaultRealmWithValue:@[@"Lucy", @7]];
+    DogArrayObject *object = [DogArrayObject createInDefaultRealmWithValue:@[@[lucy]]];
     [realm commitWriteTransaction];
     
-    NSPredicate *predicate = [NSPredicate predicateWithFormat:@"SUBQUERY(dogs, $dog, $dog.age == 1).@count > 0"];
+    NSPredicate *predicate = [NSPredicate predicateWithFormat:@"SUBQUERY(dogs, $dog, $dog.age == 7).@count == 1"];
     XCTAssertTrue([predicate evaluateWithObject:object]);
 }
 

--- a/Realm/Tests/QueryTests.m
+++ b/Realm/Tests/QueryTests.m
@@ -2136,6 +2136,19 @@
     XCTAssertEqualObjects(asArray(r14), (@[ hannah ]));
 }
 
+- (void)testSubqueryPredicateEvaluationWithRLMArray
+{
+    RLMRealm *realm = [RLMRealm defaultRealm];
+    [realm beginWriteTransaction];
+    DogObject *a = [DogObject createInDefaultRealmWithValue:@[@"a", @1]];
+    DogObject *b = [DogObject createInDefaultRealmWithValue:@[@"b", @2]];
+    DogArrayObject *object = [DogArrayObject createInDefaultRealmWithValue:@[@[a, b]]];
+    [realm commitWriteTransaction];
+    
+    NSPredicate *predicate = [NSPredicate predicateWithFormat:@"SUBQUERY(dogs, $dog, $dog.age == 1).@count > 0"];
+    XCTAssertTrue([predicate evaluateWithObject:object]);
+}
+
 @end
 
 @interface NullQueryTests : QueryTests

--- a/Realm/Tests/QueryTests.m
+++ b/Realm/Tests/QueryTests.m
@@ -2160,6 +2160,17 @@
     XCTAssertTrue([predicate evaluateWithObject:lucy]);
 }
 
+- (void)testSubqueryPredicateEvaluationWithRLMResults
+{
+    RLMRealm *realm = [RLMRealm defaultRealm];
+    [realm beginWriteTransaction];
+    [DogObject createInDefaultRealmWithValue:@[@"Lucy", @7]];
+    [realm commitWriteTransaction];
+
+    NSPredicate *predicate = [NSPredicate predicateWithFormat:@"SUBQUERY(SELF, $dog, $dog.age == 7).@count == 1"];
+    XCTAssertTrue([predicate evaluateWithObject:[DogObject allObjects]]);
+}
+
 @end
 
 @interface NullQueryTests : QueryTests

--- a/RealmSwift/Results.swift
+++ b/RealmSwift/Results.swift
@@ -55,6 +55,10 @@ extension Int16: AddableType {}
 extension Int32: AddableType {}
 extension Int64: AddableType {}
 
+/// :nodoc:
+/// Internal class. Do not use directly. Used for reflection.
+public class ResultsBase: NSObject { }
+
 /**
  `Results` is an auto-updating container type in Realm returned from object queries.
 
@@ -75,7 +79,7 @@ extension Int64: AddableType {}
 
  Results instances cannot be directly instantiated.
  */
-public final class Results<T: Object>: NSObject, NSFastEnumeration {
+public final class Results<T: Object>: ResultsBase, NSFastEnumeration {
 
     internal let rlmResults: RLMResults<RLMObject>
 

--- a/RealmSwift/Tests/ListTests.swift
+++ b/RealmSwift/Tests/ListTests.swift
@@ -358,6 +358,17 @@ class ListTests: TestCase {
             XCTAssertEqual(0, object.arrayCol.count)
         }
     }
+
+    func testEvaluatingSubqueryPredicate() {
+        guard let array = array, let str1 = str1, let str2 = str2 else {
+            fatalError("Test precondition failure")
+        }
+
+        array.append(objectsIn: [str1, str2])
+
+        let predicate = NSPredicate(format: "SUBQUERY(SELF, $str, $str.stringCol == '1').@count == 1")
+        XCTAssertTrue(predicate.evaluate(with: array))
+    }
 }
 
 class ListStandaloneTests: ListTests {

--- a/RealmSwift/Tests/SwiftLinkTests.swift
+++ b/RealmSwift/Tests/SwiftLinkTests.swift
@@ -111,4 +111,23 @@ class SwiftLinkTests: TestCase {
 
         XCTAssertEqual(0, owners.count)
     }
+
+    func testEvaluatingSubqueryPredicate() {
+        let realm = realmWithTestPath()
+
+        let owner = SwiftOwnerObject()
+        owner.name = "Tim"
+        owner.dog = SwiftDogObject()
+        owner.dog!.dogName = "Harvie"
+
+        try! realm.write {
+            realm.add(owner)
+        }
+
+        let p1 = NSPredicate(format: "SUBQUERY(owners, $owner, $owner.name == 'Tim').@count == 1")
+        XCTAssertTrue(p1.evaluate(with: owner.dog))
+
+        let p2 = NSPredicate(format: "SUBQUERY(SELF, $dog, $dog.dogName == 'Harvie').@count == 1")
+        XCTAssertTrue(p2.evaluate(with: realm.objects(SwiftDogObject.self)))
+    }
 }


### PR DESCRIPTION
When evaluating an NSPredicate on an RLMObject, an exception is thrown if the subquery's collection is an RLMArray instance although it should work just fine.

`-[NSPredicate evaluateWithObject:]` eventually calls `-[NSSubqueryExpression expressionValueWithObject:context:]` when
the predicate is a subquery. The problem is that this method is incorrectly implemented, it goes roughly like this:

```objc
id collection = [self.collection expressionValueWithObject:object context:context];
if (![collection isNSArray__] || ![collection isNSSet__] || ![collection isNSOrderedSet__])
{
    NSString *reason = @"Can't perform collection evaluate with non-collection object."
    @throw [NSException exceptionWithName:NSInternalInconsistencyException reason:reason userInfo:nil];
}

for (id element in collection)
{
    // goes on with evaluation
}
```

So, instead of testing if the collection conforms to the `NSFastEnumeration` protocol (which RLMArray does) the
collection is tested against three known Foundation collections.

Pretending that RLMArray is an NSArray by implementing the `isNSArray__` method enables NSPredicate evaluation with RLMArray as subquery collection.

Since the `isNSArray__` method is not public, some care was taken to construct the selector dynamically.