### PR TITLE
Mark -[RLMRealm init] as explicitly unavailable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ x.x.x Release notes (yyyy-MM-dd)
 * Add support for multi-level object equality comparisons against `NULL`.
 * Add support for the `[d]` modifier on string comparison operators to perform
   diacritic-insensitive comparisons.
+* Explicitly mark `[[RLMRealm alloc] init]` as unavailable.
 
 ### Bugfixes
 

--- a/Realm/RLMRealm.h
+++ b/Realm/RLMRealm.h
@@ -583,6 +583,24 @@ __deprecated_msg("Use `performMigrationForConfiguration:error:`") NS_REFINED_FOR
  */
 + (BOOL)performMigrationForConfiguration:(RLMRealmConfiguration *)configuration error:(NSError **)error;
 
+#pragma mark - Unavailable Methods
+
+/**
+ RLMRealm instances are cached internally by Realm and cannot be created directly.
+
+ Use `+[RLMRealm defaultRealm]`, `+[RLMRealm realmWithConfiguration:error:]` or
+ `+[RLMRealm realmWithURL]` to obtain a reference to an RLMRealm.
+ */
+- (instancetype)init __attribute__((unavailable("Use +defaultRealm, +realmWithConfiguration: or +realmWithURL:.")));
+
+/**
+ RLMRealm instances are cached internally by Realm and cannot be created directly.
+
+ Use `+[RLMRealm defaultRealm]`, `+[RLMRealm realmWithConfiguration:error:]` or
+ `+[RLMRealm realmWithURL]` to obtain a reference to an RLMRealm.
+ */
++ (instancetype)new __attribute__((unavailable("Use +defaultRealm, +realmWithConfiguration: or +realmWithURL:.")));
+
 @end
 
 /**

--- a/Realm/RLMRealm.mm
+++ b/Realm/RLMRealm.mm
@@ -137,6 +137,11 @@ NSData *RLMRealmValidatedEncryptionKey(NSData *key) {
     RLMSendAnalytics();
 }
 
+- (instancetype)initPrivate {
+    self = [super init];
+    return self;
+}
+
 - (BOOL)isEmpty {
     return realm::ObjectStore::is_empty(self.group);
 }
@@ -184,7 +189,7 @@ static id RLMAutorelease(__unsafe_unretained id value) {
 }
 
 + (instancetype)realmWithSharedRealm:(SharedRealm)sharedRealm schema:(RLMSchema *)schema {
-    RLMRealm *realm = [RLMRealm new];
+    RLMRealm *realm = [[RLMRealm alloc] initPrivate];
     realm->_realm = sharedRealm;
     realm->_dynamic = YES;
     realm->_schema = schema;
@@ -284,7 +289,7 @@ REALM_NOINLINE void RLMRealmTranslateException(NSError **error) {
     configuration = [configuration copy];
     Realm::Config& config = configuration.config;
 
-    RLMRealm *realm = [RLMRealm new];
+    RLMRealm *realm = [[RLMRealm alloc] initPrivate];
     realm->_dynamic = dynamic;
 
     // protects the realm cache and accessors cache


### PR DESCRIPTION
It doesn't work and trying to use it produces odd crashes. See #4776.