### PR TITLE
Improve the error message for a bad primary key type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ x.x.x Release notes (yyyy-MM-dd)
 * Add support for multi-level object equality comparisons against `NULL`.
 * Add support for the `[d]` modifier on string comparison operators to perform
   diacritic-insensitive comparisons.
+* Explicitly mark `[[RLMRealm alloc] init]` as unavailable.
+* Include the name of the problematic class in the error message when an
+  invalid property type is marked as the primary key.
 
 ### Bugfixes
 

--- a/Realm/RLMObjectSchema.mm
+++ b/Realm/RLMObjectSchema.mm
@@ -151,14 +151,15 @@ using namespace realm;
             @throw RLMException(@"Primary key property '%@' does not exist on object '%@'", primaryKey, className);
         }
         if (schema.primaryKeyProperty.type != RLMPropertyTypeInt && schema.primaryKeyProperty.type != RLMPropertyTypeString) {
-            @throw RLMException(@"Only 'string' and 'int' properties can be designated the primary key");
+            @throw RLMException(@"Property '%@' cannot be made the primary key of '%@' because it is not a 'string' or 'int' property.",
+                                primaryKey, className);
         }
     }
 
     for (RLMProperty *prop in schema.properties) {
         if (prop.optional && !RLMPropertyTypeIsNullable(prop.type)) {
-            @throw RLMException(@"Only 'string', 'binary', and 'object' properties can be made optional, and property '%@' is of type '%@'.",
-                                prop.name, RLMTypeToString(prop.type));
+            @throw RLMException(@"Property '%@.%@' cannot be made optional because optional '%@' properties are not supported.",
+                                className, prop.name, RLMTypeToString(prop.type));
         }
     }
 


### PR DESCRIPTION
Add the name of the property and the class to the error so that users actually have some idea of where to look to solve it.