### PR TITLE
disable testMultipleProcessesTryingToInitializeSchema in debug mode

### DIFF
--- a/Realm/Tests/SchemaTests.mm
+++ b/Realm/Tests/SchemaTests.mm
@@ -753,6 +753,7 @@ RLM_ARRAY_TYPE(NotARealClass)
     XCTAssertNoThrow([[IntegerArrayPropertyObject alloc] initWithValue:(@[@0, @[@[@0]]])]);
 }
 
+#if !DEBUG
 - (void)testMultipleProcessesTryingToInitializeSchema {
     RLMRealm *syncRealm = [self realmWithTestPath];
 
@@ -808,6 +809,7 @@ RLM_ARRAY_TYPE(NotARealClass)
     [realm cancelWriteTransaction];
     dispatch_group_wait(group, DISPATCH_TIME_FOREVER);
 }
+#endif
 
 - (void)testOpeningFileWithDifferentClassSubsetsInDifferentProcesses {
     if (!self.isParent) {


### PR DESCRIPTION
since it occasionally fails on CI and its failure doesn't indicate something inherently broken with the patch being tested.

Addresses https://github.com/realm/realm-cocoa/issues/4585