### PR TITLE
CocoaPods `target has libraries with conflicting names ` error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ x.x.x Release notes (yyyy-MM-dd)
 
 ### Bugfixes
 
-* None.
+* Fixing CocoaPods installation with static libraries and multiple platforms.
 
 2.5.0 Release notes (2017-03-28)
 =============================================================

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ x.x.x Release notes (yyyy-MM-dd)
 
 ### Bugfixes
 
-* Fixing CocoaPods installation with static libraries and multiple platforms.
+* Fix CocoaPods installation with static libraries and multiple platforms.
 
 2.5.0 Release notes (2017-03-28)
 =============================================================

--- a/Realm.podspec
+++ b/Realm.podspec
@@ -79,16 +79,16 @@ Pod::Spec.new do |s|
   s.preserve_paths          = %w(build.sh include)
 
   s.ios.deployment_target   = '7.0'
-  s.ios.vendored_library    = 'core/librealm-ios.a'
+  s.ios.vendored_library    = 'core/librealmcore-ios.a'
 
   s.osx.deployment_target   = '10.9'
-  s.osx.vendored_library    = 'core/librealm-macosx.a'
+  s.osx.vendored_library    = 'core/librealmcore-macosx.a'
 
   s.watchos.deployment_target = '2.0'
-  s.watchos.vendored_library  = 'core/librealm-watchos.a'
+  s.watchos.vendored_library  = 'core/librealmcore-watchos.a'
 
   s.tvos.deployment_target = '9.0'
-  s.tvos.vendored_library  = 'core/librealm-tvos.a'
+  s.tvos.vendored_library  = 'core/librealmcore-tvos.a'
 
   s.subspec 'Headers' do |s|
     s.source_files          = public_header_files

--- a/build.sh
+++ b/build.sh
@@ -1016,6 +1016,10 @@ case "$COMMAND" in
           sh build.sh download-sync
           rm core
           mv sync-* core
+          mv core/librealm-ios.a core/librealmcore-ios.a
+          mv core/librealm-macosx.a core/librealmcore-macosx.a
+          mv core/librealm-tvos.a core/librealmcore-tvos.a
+          mv core/librealm-watchos.a core/librealmcore-watchos.a
         fi
 
         if [[ "$2" != "swift" ]]; then


### PR DESCRIPTION
Hello,

I think found a problem when integrating Realm with CocoaPods and using multiple platforms in a Podfile while integrating with CocoaPods static libraries instead of CocoaPods dynamic frameworks. The following Podfile is an example of the use case that does not work:

```
abstract_target "iOS" do
    platform :ios, "9.0"
    pod "Realm"
    target "iOSApp"
end

abstract_target "tvOS" do
    platform :tvos, "9.0"
    pod "Realm"
    target "tvApp"
end
```

The problem here is that CocoaPods exits with an error `[!] The 'Pods-iOS-XXX' target has libraries with conflicting names: librealm-ios.a`. This is due to the fact that

1. CocoaPods creates a target `libRealm-iOS.a`, scoped for the current platform
2. realm-cocoa ships the static library `core/librealm-ios.a`

Both have the same lowercase case which results in the conflicting names error. My suggestion for a fix is renaming `librealm-*.a` to `librealmcore-*.a` in the `cocoapods-setup` build phase while updating `vendored_library` in `Realm.podspec`. I'm a first time contributor, so I don't know the codebase nor the build process very well.