### PR TITLE
Fix `valueForKey:`/`valueForKeyPath:` returns incorrect results for `List` properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ x.x.x Release notes (yyyy-MM-dd)
 ### Bugfixes
 
 * Fix a deadlock when multiple processes open a Realm at the same time.
+* Fix `value(forKey:)`/`value(forKeyPath:)` returning incorrect values for `List` properties.
 
 2.5.1 Release notes (2017-04-05)
 =============================================================

--- a/Realm/RLMCollection.mm
+++ b/Realm/RLMCollection.mm
@@ -149,12 +149,9 @@ NSArray *RLMCollectionValueForKey(id<RLMFastEnumerable> collection, NSString *ke
         return results;
     }
 
-    RLMObject *accessor = RLMCreateManagedAccessor(info->rlmObjectSchema.accessorClass, realm, info);
-    realm::Table *table = info->table();
     for (size_t i = 0; i < count; i++) {
         size_t rowIndex = [collection indexInSource:i];
-        accessor->_row = (*table)[rowIndex];
-        RLMInitializeSwiftAccessorGenerics(accessor);
+        RLMObjectBase *accessor = RLMCreateObjectAccessor(realm, *info, rowIndex);
         [results addObject:[accessor valueForKey:key] ?: NSNull.null];
     }
 

--- a/Realm/RLMCollection.mm
+++ b/Realm/RLMCollection.mm
@@ -22,6 +22,7 @@
 #import "RLMObjectSchema_Private.hpp"
 #import "RLMObjectStore.h"
 #import "RLMObject_Private.hpp"
+#import "RLMProperty_Private.h"
 
 #import "collection_notifications.hpp"
 #import "list.hpp"
@@ -149,9 +150,23 @@ NSArray *RLMCollectionValueForKey(id<RLMFastEnumerable> collection, NSString *ke
         return results;
     }
 
+    for (RLMProperty *prop in info->rlmObjectSchema.swiftGenericProperties) {
+        if ([prop.name isEqual:key] && !prop.optional) {
+            for (size_t i = 0; i < count; i++) {
+                size_t rowIndex = [collection indexInSource:i];
+                RLMObjectBase *accessor = RLMCreateObjectAccessor(realm, *info, rowIndex);
+                [results addObject:[accessor valueForKey:key] ?: NSNull.null];
+            }
+            return results;
+        }
+    }
+
+    RLMObject *accessor = RLMCreateManagedAccessor(info->rlmObjectSchema.accessorClass, realm, info);
+    realm::Table *table = info->table();
     for (size_t i = 0; i < count; i++) {
         size_t rowIndex = [collection indexInSource:i];
-        RLMObjectBase *accessor = RLMCreateObjectAccessor(realm, *info, rowIndex);
+        accessor->_row = (*table)[rowIndex];
+        RLMInitializeSwiftAccessorGenerics(accessor);
         [results addObject:[accessor valueForKey:key] ?: NSNull.null];
     }
 

--- a/Realm/Tests/ArrayPropertyTests.m
+++ b/Realm/Tests/ArrayPropertyTests.m
@@ -637,6 +637,13 @@
     }
     [realm commitWriteTransaction];
 
+    RLM_GENERIC_ARRAY(EmployeeObject) *employeeObjects = [company valueForKey:@"employees"];
+    NSMutableArray *kvcAgeProperties = [NSMutableArray array];
+    for (EmployeeObject *employee in employeeObjects) {
+        [kvcAgeProperties addObject:@(employee.age)];
+    }
+    XCTAssertEqualObjects(kvcAgeProperties, ages);
+
     XCTAssertEqualObjects([company.employees valueForKey:@"age"], ages);
     XCTAssertTrue([[[company.employees valueForKey:@"self"] firstObject] isEqualToObject:company.employees.firstObject]);
     XCTAssertTrue([[[company.employees valueForKey:@"self"] lastObject] isEqualToObject:company.employees.lastObject]);

--- a/RealmSwift/Tests/CompactionTests.swift
+++ b/RealmSwift/Tests/CompactionTests.swift
@@ -26,7 +26,7 @@ import RealmSwift
 // to know if they ever change, so we have the test fail if these numbers fluctuate.
 private let expectedTotalBytesBefore = 655360
 private let expectedUsedBytesBefore = 56264
-private let expectedUsedBytesBeforeMargin = 64.0 // allow for +-64B variation across platforms
+private let expectedUsedBytesBeforeMargin = 184.0 // allow for +-184B variation across platforms
 private let expectedTotalBytesAfter = 57344
 private let expectedTotalBytesAfterMargin = 8192.0 // allow for +-8KB variation across platforms
 private var count = 1000

--- a/RealmSwift/Tests/ListTests.swift
+++ b/RealmSwift/Tests/ListTests.swift
@@ -358,6 +358,25 @@ class ListTests: TestCase {
             XCTAssertEqual(0, object.arrayCol.count)
         }
     }
+
+    func testValueForKey() {
+        let realm = try! Realm()
+        try! realm.write {
+            for value in [1, 2] {
+                let object = SwiftArrayPropertyObject()
+                object.intArray.append(SwiftIntObject(value: [value]))
+                realm.add(object)
+            }
+        }
+
+        let objects = realm.objects(SwiftArrayPropertyObject.self)
+
+        let properties = Array(objects.flatMap({ $0.intArray.map({ $0.intCol }) }))
+        let listsOfObjects = objects.value(forKeyPath: "intArray") as! [List<SwiftIntObject>]
+        let kvcPropertiess = Array(listsOfObjects.flatMap({ $0.map({ $0.intCol }) }))
+
+        XCTAssertEqual(properties, kvcPropertiess)
+    }
 }
 
 class ListStandaloneTests: ListTests {

--- a/RealmSwift/Tests/ListTests.swift
+++ b/RealmSwift/Tests/ListTests.swift
@@ -373,9 +373,9 @@ class ListTests: TestCase {
 
         let properties = Array(objects.flatMap({ $0.intArray.map({ $0.intCol }) }))
         let listsOfObjects = objects.value(forKeyPath: "intArray") as! [List<SwiftIntObject>]
-        let kvcPropertiess = Array(listsOfObjects.flatMap({ $0.map({ $0.intCol }) }))
+        let kvcProperties = Array(listsOfObjects.flatMap({ $0.map({ $0.intCol }) }))
 
-        XCTAssertEqual(properties, kvcPropertiess)
+        XCTAssertEqual(properties, kvcProperties)
     }
 }
 

--- a/RealmSwift/Tests/ListTests.swift
+++ b/RealmSwift/Tests/ListTests.swift
@@ -360,22 +360,42 @@ class ListTests: TestCase {
     }
 
     func testValueForKey() {
-        let realm = try! Realm()
-        try! realm.write {
-            for value in [1, 2] {
-                let object = SwiftArrayPropertyObject()
-                object.intArray.append(SwiftIntObject(value: [value]))
-                realm.add(object)
+        do {
+            let realm = try! Realm()
+            try! realm.write {
+                for value in [1, 2] {
+                    let object = SwiftArrayPropertyObject()
+                    object.intArray.append(SwiftIntObject(value: [value]))
+                    realm.add(object)
+                }
             }
+
+            let objects = realm.objects(SwiftArrayPropertyObject.self)
+
+            let properties = Array(objects.flatMap { $0.intArray.map { $0.intCol }})
+            let listsOfObjects = objects.value(forKeyPath: "intArray") as! [List<SwiftIntObject>]
+            let kvcProperties = Array(listsOfObjects.flatMap { $0.map { $0.intCol }})
+
+            XCTAssertEqual(properties, kvcProperties)
         }
+        do {
+            let realm = try! Realm()
+            try! realm.write {
+                for value in [1, 2] {
+                    let object = SwiftOptionalObject()
+                    object.optIntCol.value = value
+                    realm.add(object)
+                }
+            }
 
-        let objects = realm.objects(SwiftArrayPropertyObject.self)
+            let objects = realm.objects(SwiftOptionalObject.self)
 
-        let properties = Array(objects.flatMap({ $0.intArray.map({ $0.intCol }) }))
-        let listsOfObjects = objects.value(forKeyPath: "intArray") as! [List<SwiftIntObject>]
-        let kvcProperties = Array(listsOfObjects.flatMap({ $0.map({ $0.intCol }) }))
+            let properties = Array(objects.flatMap { $0.optIntCol.value })
+            let listsOfObjects = objects.value(forKeyPath: "optIntCol") as! [Int]
+            let kvcProperties = Array(listsOfObjects.flatMap { $0 })
 
-        XCTAssertEqual(properties, kvcProperties)
+            XCTAssertEqual(properties, kvcProperties)
+        }
     }
 }
 

--- a/RealmSwift/Tests/ListTests.swift
+++ b/RealmSwift/Tests/ListTests.swift
@@ -364,37 +364,183 @@ class ListTests: TestCase {
             let realm = try! Realm()
             try! realm.write {
                 for value in [1, 2] {
-                    let object = SwiftArrayPropertyObject()
-                    object.intArray.append(SwiftIntObject(value: [value]))
-                    realm.add(object)
+                    let listObject = SwiftListOfSwiftObject()
+                    let object = SwiftObject()
+                    object.intCol = value
+                    object.doubleCol = Double(value)
+                    object.stringCol = String(value)
+                    listObject.array.append(object)
+                    realm.add(listObject)
                 }
             }
 
-            let objects = realm.objects(SwiftArrayPropertyObject.self)
+            do {
+                let objects = realm.objects(SwiftListOfSwiftObject.self)
 
-            let properties = Array(objects.flatMap { $0.intArray.map { $0.intCol }})
-            let listsOfObjects = objects.value(forKeyPath: "intArray") as! [List<SwiftIntObject>]
-            let kvcProperties = Array(listsOfObjects.flatMap { $0.map { $0.intCol }})
+                let properties = Array(objects.flatMap { $0.array.map { $0.intCol }})
+                let listsOfObjects = objects.value(forKeyPath: "array") as! [List<SwiftObject>]
+                let kvcProperties = Array(listsOfObjects.flatMap { $0.map { $0.intCol }})
 
-            XCTAssertEqual(properties, kvcProperties)
+                XCTAssertEqual(properties, kvcProperties)
+            }
+            do {
+                let objects = realm.objects(SwiftListOfSwiftObject.self)
+
+                let properties = Array(objects.flatMap { $0.array.map { $0.doubleCol }})
+                let listsOfObjects = objects.value(forKeyPath: "array") as! [List<SwiftObject>]
+                let kvcProperties = Array(listsOfObjects.flatMap { $0.map { $0.doubleCol }})
+
+                XCTAssertEqual(properties, kvcProperties)
+            }
+            do {
+                let objects = realm.objects(SwiftListOfSwiftObject.self)
+
+                let properties = Array(objects.flatMap { $0.array.map { $0.stringCol }})
+                let listsOfObjects = objects.value(forKeyPath: "array") as! [List<SwiftObject>]
+                let kvcProperties = Array(listsOfObjects.flatMap { $0.map { $0.stringCol }})
+
+                XCTAssertEqual(properties, kvcProperties)
+            }
+
+            do {
+                let realm = try! Realm()
+                do {
+                    let objects = realm.objects(SwiftObject.self)
+
+                    let properties = Array(objects.flatMap { $0.intCol })
+                    let listsOfObjects = objects.value(forKeyPath: "intCol") as! [Int]
+                    let kvcProperties = Array(listsOfObjects.flatMap { $0 })
+
+                    XCTAssertEqual(properties, kvcProperties)
+                }
+                do {
+                    let objects = realm.objects(SwiftObject.self)
+
+                    let properties = Array(objects.flatMap { $0.doubleCol })
+                    let listsOfObjects = objects.value(forKeyPath: "doubleCol") as! [Double]
+                    let kvcProperties = Array(listsOfObjects.flatMap { $0 })
+
+                    XCTAssertEqual(properties, kvcProperties)
+                }
+                do {
+                    let objects = realm.objects(SwiftObject.self)
+
+                    let properties = Array(objects.flatMap { $0.stringCol })
+                    let listsOfObjects = objects.value(forKeyPath: "stringCol") as! [String]
+                    let kvcProperties = Array(listsOfObjects.flatMap { $0 })
+
+                    XCTAssertEqual(properties, kvcProperties)
+                }
+            }
         }
+
         do {
             let realm = try! Realm()
             try! realm.write {
                 for value in [1, 2] {
+                    let listObject = SwiftListOfSwiftOptionalObject()
                     let object = SwiftOptionalObject()
                     object.optIntCol.value = value
-                    realm.add(object)
+                    object.optInt8Col.value = Int8(value)
+                    object.optDoubleCol.value = Double(value)
+                    object.optStringCol = String(value)
+                    object.optNSStringCol = NSString(format: "%d", value)
+                    listObject.array.append(object)
+                    realm.add(listObject)
                 }
             }
 
-            let objects = realm.objects(SwiftOptionalObject.self)
+            do {
+                let objects = realm.objects(SwiftListOfSwiftOptionalObject.self)
 
-            let properties = Array(objects.flatMap { $0.optIntCol.value })
-            let listsOfObjects = objects.value(forKeyPath: "optIntCol") as! [Int]
-            let kvcProperties = Array(listsOfObjects.flatMap { $0 })
+                let properties = Array(objects.flatMap { $0.array.flatMap { $0.optIntCol.value }})
+                let listsOfObjects = objects.value(forKeyPath: "array") as! [List<SwiftOptionalObject>]
+                let kvcProperties = Array(listsOfObjects.flatMap { $0.flatMap { $0.optIntCol.value }})
 
-            XCTAssertEqual(properties, kvcProperties)
+                XCTAssertEqual(properties, kvcProperties)
+            }
+            do {
+                let objects = realm.objects(SwiftListOfSwiftOptionalObject.self)
+
+                let properties = Array(objects.flatMap { $0.array.flatMap { $0.optInt8Col.value }})
+                let listsOfObjects = objects.value(forKeyPath: "array") as! [List<SwiftOptionalObject>]
+                let kvcProperties = Array(listsOfObjects.flatMap { $0.flatMap { $0.optInt8Col.value }})
+
+                XCTAssertEqual(properties, kvcProperties)
+            }
+            do {
+                let objects = realm.objects(SwiftListOfSwiftOptionalObject.self)
+
+                let properties = Array(objects.flatMap { $0.array.flatMap { $0.optDoubleCol.value }})
+                let listsOfObjects = objects.value(forKeyPath: "array") as! [List<SwiftOptionalObject>]
+                let kvcProperties = Array(listsOfObjects.flatMap { $0.flatMap { $0.optDoubleCol.value }})
+
+                XCTAssertEqual(properties, kvcProperties)
+            }
+            do {
+                let objects = realm.objects(SwiftListOfSwiftOptionalObject.self)
+
+                let properties = Array(objects.flatMap { $0.array.flatMap { $0.optStringCol }})
+                let listsOfObjects = objects.value(forKeyPath: "array") as! [List<SwiftOptionalObject>]
+                let kvcProperties = Array(listsOfObjects.flatMap { $0.flatMap { $0.optStringCol }})
+
+                XCTAssertEqual(properties, kvcProperties)
+            }
+            do {
+                let objects = realm.objects(SwiftListOfSwiftOptionalObject.self)
+
+                let properties = Array(objects.flatMap { $0.array.flatMap { $0.optNSStringCol }})
+                let listsOfObjects = objects.value(forKeyPath: "array") as! [List<SwiftOptionalObject>]
+                let kvcProperties = Array(listsOfObjects.flatMap { $0.flatMap { $0.optNSStringCol }})
+
+                XCTAssertEqual(properties, kvcProperties)
+            }
+
+            do {
+                let objects = realm.objects(SwiftOptionalObject.self)
+
+                let properties = Array(objects.flatMap { $0.optIntCol.value })
+                let listsOfObjects = objects.value(forKeyPath: "optIntCol") as! [Int]
+                let kvcProperties = Array(listsOfObjects.flatMap { $0 })
+
+                XCTAssertEqual(properties, kvcProperties)
+            }
+            do {
+                let objects = realm.objects(SwiftOptionalObject.self)
+
+                let properties = Array(objects.flatMap { $0.optInt8Col.value })
+                let listsOfObjects = objects.value(forKeyPath: "optInt8Col") as! [Int8]
+                let kvcProperties = Array(listsOfObjects.flatMap { $0 })
+
+                XCTAssertEqual(properties, kvcProperties)
+            }
+            do {
+                let objects = realm.objects(SwiftOptionalObject.self)
+
+                let properties = Array(objects.flatMap { $0.optDoubleCol.value })
+                let listsOfObjects = objects.value(forKeyPath: "optDoubleCol") as! [Double]
+                let kvcProperties = Array(listsOfObjects.flatMap { $0 })
+
+                XCTAssertEqual(properties, kvcProperties)
+            }
+            do {
+                let objects = realm.objects(SwiftOptionalObject.self)
+
+                let properties = Array(objects.flatMap { $0.optStringCol })
+                let listsOfObjects = objects.value(forKeyPath: "optStringCol") as! [String]
+                let kvcProperties = Array(listsOfObjects.flatMap { $0 })
+
+                XCTAssertEqual(properties, kvcProperties)
+            }
+            do {
+                let objects = realm.objects(SwiftOptionalObject.self)
+
+                let properties = Array(objects.flatMap { $0.optNSStringCol })
+                let listsOfObjects = objects.value(forKeyPath: "optNSStringCol") as! [NSString]
+                let kvcProperties = Array(listsOfObjects.flatMap { $0 })
+
+                XCTAssertEqual(properties, kvcProperties)
+            }
         }
     }
 }

--- a/RealmSwift/Tests/ListTests.swift
+++ b/RealmSwift/Tests/ListTests.swift
@@ -509,7 +509,11 @@ class ListTests: TestCase {
                 let objects = realm.objects(SwiftOptionalObject.self)
 
                 let properties = Array(objects.flatMap { $0.optInt8Col.value })
+#if swift(>=3.1)
                 let listsOfObjects = objects.value(forKeyPath: "optInt8Col") as! [Int8]
+#else
+                let listsOfObjects = (objects.value(forKeyPath: "optInt8Col") as! [NSNumber]).map { $0.int8Value }
+#endif
                 let kvcProperties = Array(listsOfObjects.flatMap { $0 })
 
                 XCTAssertEqual(properties, kvcProperties)

--- a/RealmSwift/Tests/PerformanceTests.swift
+++ b/RealmSwift/Tests/PerformanceTests.swift
@@ -481,4 +481,90 @@ class SwiftPerformanceTests: TestCase {
             token.stop()
         }
     }
+
+    func testValueForKeyForListObjects() {
+        let realm = try! Realm()
+        try! realm.write {
+            for value in 0..<10000 {
+                let listObject = SwiftListOfSwiftObject()
+                let object = SwiftObject()
+                object.intCol = value
+                object.stringCol = String(value)
+                listObject.array.append(object)
+                realm.add(listObject)
+            }
+        }
+        let objects = realm.objects(SwiftListOfSwiftObject.self)
+        measure {
+            _ = objects.value(forKeyPath: "array") as! [List<SwiftListOfSwiftObject>]
+        }
+    }
+
+    func testValueForKeyForIntObjects() {
+        let realm = try! Realm()
+        try! realm.write {
+            for value in 0..<10000 {
+                autoreleasepool {
+                    let object = SwiftObject()
+                    object.intCol = value
+                    realm.add(object)
+                }
+            }
+        }
+        let objects = realm.objects(SwiftObject.self)
+        measure {
+            _ = objects.value(forKeyPath: "intCol") as! [Int]
+        }
+    }
+
+    func testValueForKeyForStringObjects() {
+        let realm = try! Realm()
+        try! realm.write {
+            for value in 0..<10000 {
+                autoreleasepool {
+                    let object = SwiftObject()
+                    object.stringCol = String(value)
+                    realm.add(object)
+                }
+            }
+        }
+        let objects = realm.objects(SwiftObject.self)
+        measure {
+            _ = objects.value(forKeyPath: "stringCol") as! [String]
+        }
+    }
+
+    func testValueForKeyForOptionalIntObjects() {
+        let realm = try! Realm()
+        try! realm.write {
+            for value in 0..<10000 {
+                autoreleasepool {
+                    let object = SwiftOptionalObject()
+                    object.optIntCol.value = value
+                    realm.add(object)
+                }
+            }
+        }
+        let objects = realm.objects(SwiftOptionalObject.self)
+        measure {
+            _ = objects.value(forKeyPath: "optIntCol") as! [Int]
+        }
+    }
+
+    func testValueForKeyForOptionalStringObjects() {
+        let realm = try! Realm()
+        try! realm.write {
+            for value in 0..<10000 {
+                autoreleasepool {
+                    let object = SwiftOptionalObject()
+                    object.optStringCol = String(value)
+                    realm.add(object)
+                }
+            }
+        }
+        let objects = realm.objects(SwiftOptionalObject.self)
+        measure {
+            _ = objects.value(forKeyPath: "optStringCol") as! [String]
+        }
+    }
 }

--- a/RealmSwift/Tests/SwiftTestObjects.swift
+++ b/RealmSwift/Tests/SwiftTestObjects.swift
@@ -193,6 +193,10 @@ class SwiftListOfSwiftObject: Object {
     let array = List<SwiftObject>()
 }
 
+class SwiftListOfSwiftOptionalObject: Object {
+    let array = List<SwiftOptionalObject>()
+}
+
 class SwiftArrayPropertySubclassObject: SwiftArrayPropertyObject {
     let boolArray = List<SwiftBoolObject>()
 }


### PR DESCRIPTION
Fixes https://github.com/realm/realm-cocoa/issues/4251

Modified to create different accessors for each element in the List.

CC @tgoyne @bdash @jpsim 