### PR TITLE
Use Xcode 8.2.x for build Realm.framework in GitHub release script

### DIFF
--- a/scripts/github_release.rb
+++ b/scripts/github_release.rb
@@ -16,8 +16,9 @@ SWIFT_ZIP = BUILD + "realm-swift-#{VERSION}.zip"
 CARTHAGE_ZIP = BUILD + 'Carthage.framework.zip'
 
 puts 'Creating Carthage release zip'
-system('carthage', 'build', '--no-skip-current') || exit(1)
+system({'DEVELOPER_DIR' => '/Applications/Xcode-8.2.app'}, 'carthage', 'build', '--no-skip-current') || exit(1)
 system('carthage', 'archive', 'Realm', '--output', CARTHAGE_ZIP.to_path) || exit(1)
+system('carthage', 'build', '--no-skip-current') || exit(1)
 system('carthage', 'archive', 'RealmSwift', '--output', CARTHAGE_ZIP.to_path) || exit(1)
 
 REPOSITORY = 'realm/realm-cocoa'


### PR DESCRIPTION
Build Realm.framework with Xcode 8.2 in GitHub release archive for Carthage.

@jpsim 