### PR TITLE
Disable the ObjectStore Realm caching

### DIFF
--- a/Realm/RLMRealm.mm
+++ b/Realm/RLMRealm.mm
@@ -260,13 +260,14 @@ REALM_NOINLINE void RLMRealmTranslateException(NSError **error) {
 
 + (instancetype)realmWithConfiguration:(RLMRealmConfiguration *)configuration error:(NSError **)error {
     bool dynamic = configuration.dynamic;
+    bool cache = configuration.cache;
     bool readOnly = configuration.readOnly;
 
     {
         Realm::Config& config = configuration.config;
 
         // try to reuse existing realm first
-        if (config.cache || dynamic) {
+        if (cache || dynamic) {
             if (RLMRealm *realm = RLMGetThreadLocalCachedRealmForPath(config.path)) {
                 auto const& old_config = realm->_realm->config();
                 if (old_config.read_only() != config.read_only()) {
@@ -363,7 +364,7 @@ REALM_NOINLINE void RLMRealmTranslateException(NSError **error) {
         }
     }
 
-    if (config.cache) {
+    if (cache) {
         RLMCacheRealm(config.path, realm);
     }
 

--- a/Realm/RLMRealmConfiguration.mm
+++ b/Realm/RLMRealmConfiguration.mm
@@ -94,6 +94,8 @@ NSString *RLMRealmPathForFile(NSString *fileName) {
         static NSURL *defaultRealmURL = [NSURL fileURLWithPath:RLMRealmPathForFile(c_defaultRealmFileName)];
         self.fileURL = defaultRealmURL;
         self.schemaVersion = 0;
+        self.cache = YES;
+        _config.cache = false;
     }
 
     return self;
@@ -102,6 +104,7 @@ NSString *RLMRealmPathForFile(NSString *fileName) {
 - (instancetype)copyWithZone:(NSZone *)zone {
     RLMRealmConfiguration *configuration = [[[self class] allocWithZone:zone] init];
     configuration->_config = _config;
+    configuration->_cache = _cache;
     configuration->_dynamic = _dynamic;
     configuration->_migrationBlock = _migrationBlock;
     configuration->_customSchema = _customSchema;
@@ -243,15 +246,7 @@ static void RLMNSStringToStdString(std::string &out, NSString *in) {
 
 - (void)setDynamic:(bool)dynamic {
     _dynamic = dynamic;
-    _config.cache = !dynamic;
-}
-
-- (bool)cache {
-    return _config.cache;
-}
-
-- (void)setCache:(bool)cache {
-    _config.cache = cache;
+    self.cache = !dynamic;
 }
 
 - (bool)disableFormatUpgrade {

--- a/Realm/RLMRealmConfiguration.mm
+++ b/Realm/RLMRealmConfiguration.mm
@@ -95,6 +95,12 @@ NSString *RLMRealmPathForFile(NSString *fileName) {
         self.fileURL = defaultRealmURL;
         self.schemaVersion = 0;
         self.cache = YES;
+
+        // We have our own caching of RLMRealm instances, so the ObjectStore
+        // cache is at best pointless, and may result in broken behavior when
+        // a realm::Realm instance outlives the RLMRealm (due to collection
+        // notifiers being in the middle of running when the RLMRealm is
+        // dealloced) and then reused for a new RLMRealm
         _config.cache = false;
     }
 


### PR DESCRIPTION
Might fix https://secure.helpscout.net/conversation/343482861/0/?folderId=366246.

Since we still have the cache of obj-c RLMRealm instances the ObjectStore cache is at best a harmless waste of time, but if the Realm instance outlives the owning RLMRealm (perhaps due to a collection notifier for that Realm being in the middle of running when the RLMRealm is deallocaed?) the existing Realm instance may be handed to a new RLMRealm, which is not handled by the existing code and may cause more odd problems.