### PR TITLE
Fix not being able to enumerate objects in migration after deleting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ x.x.x Release notes (yyyy-MM-dd)
 
 * Support Realm model classes defined in Swift with overridden Objective-C
   names (e.g. `@objc(Foo) class SwiftFoo: Object {}`).
+* Fix `-[RLMMigration enumerateObjects:block:]` returning incorrect `oldObject`
+  objects when enumerating a class name after previously deleting a `newObject`.
 
 2.6.2 Release notes (2017-04-21)
 =============================================================

--- a/RealmSwift/Migration.swift
+++ b/RealmSwift/Migration.swift
@@ -137,7 +137,7 @@ public final class Migration {
      - parameter object: An object to be deleted from the Realm being migrated.
      */
     public func delete(_ object: MigrationObject) {
-        RLMDeleteObjectFromRealm(object, RLMObjectBaseRealm(object)!)
+        rlmMigration.delete(object.unsafeCastToRLMObject())
     }
 
     /**


### PR DESCRIPTION
Fixes https://github.com/realm/realm-cocoa/issues/3390

The cause of the issue is that when deleting objects, the number of objects does not match between the new schema and the old schema.

In the current version, this case crashes, so it will not be a big problem.
However, If inserting the same number of objects as deleted objects, it will not crash and can not be enumerated correctly (the order will not match between the old schema and the new schema), the issue becomes serious.

To solve this problem, defer deletion during migration and actually delete the object when migration finished.

CC @jpsim @tgoyne 