### PR TITLE
disable testMultipleProcessesTryingToInitializeSchema in debug mode

### DIFF
--- a/Realm/Tests/SchemaTests.mm
+++ b/Realm/Tests/SchemaTests.mm
@@ -753,6 +753,7 @@ RLM_ARRAY_TYPE(NotARealClass)
     XCTAssertNoThrow([[IntegerArrayPropertyObject alloc] initWithValue:(@[@0, @[@[@0]]])]);
 }
 
+#if !DEBUG
 - (void)testMultipleProcessesTryingToInitializeSchema {
     RLMRealm *syncRealm = [self realmWithTestPath];
 
@@ -808,6 +809,7 @@ RLM_ARRAY_TYPE(NotARealClass)
     [realm cancelWriteTransaction];
     dispatch_group_wait(group, DISPATCH_TIME_FOREVER);
 }
+#endif
 
 - (void)testOpeningFileWithDifferentClassSubsetsInDifferentProcesses {
     if (!self.isParent) {


### PR DESCRIPTION
since it occasionally fails on CI and its failure doesn't indicate something inherently broken with the patch being tested.

Addresses #4585

This was originally filed as #4781, but we closed that in the hopes that https://github.com/realm/realm-core/pull/2552 would have addressed this occasional failure, but this was seen again after integrating that here: https://ci.realm.io/job/objc_pr/5006/configuration=Debug,target=osx,xcode_version=8.0/