### PR TITLE
return Swift.Error from asyncOpen callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,10 @@ x.x.x Release notes (yyyy-MM-dd)
 
 ### Bugfixes
 
-* None.
+* Fix an issue where calling `Realm.asyncOpen(...)` with a synchronized Realm
+  configuration would crash in error cases rather than report the error.
+  This is a small source breaking change if you were relying on the error
+  being reported to be a `Realm.Error`.
 
 2.6.0 Release notes (2017-04-18)
 =============================================================

--- a/RealmSwift/Realm.swift
+++ b/RealmSwift/Realm.swift
@@ -108,7 +108,7 @@ public final class Realm {
      - parameter callbackQueue: The dispatch queue on which the callback should be run.
      - parameter callback:      A callback block. If the Realm was successfully opened, an
                                 it will be passed in as an argument.
-                                Otherwise, a `Realm.Error` describing what went wrong will be
+                                Otherwise, a `Swift.Error` describing what went wrong will be
                                 passed to the block instead.
 
      - note: The returned Realm is confined to the thread on which it was created.
@@ -118,9 +118,9 @@ public final class Realm {
      */
     public static func asyncOpen(configuration: Realm.Configuration = .defaultConfiguration,
                                  callbackQueue: DispatchQueue = .main,
-                                 callback: @escaping (Realm?, Realm.Error?) -> Void) {
-        RLMRealm.asyncOpen(with: configuration.rlmConfiguration, callbackQueue: callbackQueue) { rlmRealm, nsError in
-            callback(rlmRealm.flatMap(Realm.init), nsError as! Realm.Error?)
+                                 callback: @escaping (Realm?, Swift.Error?) -> Void) {
+        RLMRealm.asyncOpen(with: configuration.rlmConfiguration, callbackQueue: callbackQueue) { rlmRealm, error in
+            callback(rlmRealm.flatMap(Realm.init), error)
         }
     }
 


### PR DESCRIPTION
rather than Realm.Error, since not all reportable errors are Realm.Error members.

This is a small source breaking change if you were relying on the error being reported to be a `Realm.Error`.

Since 2.6 has only been out for a few hours I think it's safe to say that we don't have a large number of users who've written code that would break with this.

To avoid the source breaking change I think we'd need to make `RLMError` cases for all potential `RLMSyncErrorDomain` errors, which is also an option.

Fixes #4873.