### PR TITLE
update CI & packaging scripts to use Xcode 8.3.2

### DIFF
--- a/.jenkins.yml
+++ b/.jenkins.yml
@@ -5,7 +5,7 @@ xcode_version:
   - 8.0
   - 8.1
   - 8.2
-  - 8.3.1
+  - 8.3.2
 target:
   - osx
   - docs
@@ -42,15 +42,15 @@ configuration:
 # | 8.2   | Debug        | X   |      | X          |             |           |           |         |           |           |      |                |                   |                |                  |             |
 # | 8.2   | Release      | X   |      | X          | X           | X         | X         | X       | X         |           | X    |                |                   |                |                  |             |
 # | -------------------- | --- | ---- | ---------- | ----------- | --------- | --------- | ------- | --------- | --------- | ---- | -------------- | ----------------- | -------------- | ---------------- | ----------- |
-# | 8.3.1 | Debug        | X   |      |            | X           | X         | X         | X       |           |           | X    |                |                   |                |                  |             |
-# | 8.3.1 | Release      | X   | X    |            | X           | X         | X         | X       | X         | X         | X    | X              | X                 | X              |                  | X           |
+# | 8.3.2 | Debug        | X   |      |            | X           | X         | X         | X       |           |           | X    |                |                   |                |                  |             |
+# | 8.3.2 | Release      | X   | X    |            | X           | X         | X         | X       | X         | X         | X    | X              | X                 | X              |                  | X           |
 # +----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 
 exclude:
   ################
   # docs
   ################
-  # Just run on 8.3.1 Release
+  # Just run on 8.3.2 Release
   - xcode_version: 8.0
     target: docs
   - xcode_version: 8.1
@@ -64,14 +64,14 @@ exclude:
   # ios-static
   ################
   # Skip on 8.0/8.1 Debug
-  # Skip 8.3.1 altogether since it doesn't support the iOS 7 deployment target
+  # Skip 8.3.2 altogether since it doesn't support the iOS 7 deployment target
   - xcode_version: 8.0
     target: ios-static
     configuration: Debug
   - xcode_version: 8.1
     target: ios-static
     configuration: Debug
-  - xcode_version: 8.3.1
+  - xcode_version: 8.3.2
     target: ios-static
 
   ################
@@ -140,7 +140,7 @@ exclude:
   ################
   # swiftlint
   ################
-  # Just run on 8.3.1 Release
+  # Just run on 8.3.2 Release
   - xcode_version: 8.0
     target: swiftlint
   - xcode_version: 8.1
@@ -167,7 +167,7 @@ exclude:
   ################
   # osx-encryption
   ################
-  # Just run on 8.3.1 Release
+  # Just run on 8.3.2 Release
   - xcode_version: 8.0
     target: osx-encryption
   - xcode_version: 8.1
@@ -180,7 +180,7 @@ exclude:
   ################
   # osx-object-server
   ################
-  # Just run on 8.3.1 Release
+  # Just run on 8.3.2 Release
   - xcode_version: 8.0
     target: osx-object-server
   - xcode_version: 8.1
@@ -193,7 +193,7 @@ exclude:
   ################
   # ios-device-objc
   ################
-  # Just run on 8.3.1 Release
+  # Just run on 8.3.2 Release
   - xcode_version: 8.0
     target: ios-device-objc
   - xcode_version: 8.1
@@ -206,7 +206,7 @@ exclude:
   ################
   # ios-device-swift
   ################
-  # Just run on 8.3.1 Release
+  # Just run on 8.3.2 Release
   - xcode_version: 8.0
     target: ios-device-swift
   - xcode_version: 8.1
@@ -219,7 +219,7 @@ exclude:
   ################
   # tvos-device
   ################
-  # Just run on 8.3.1 Release
+  # Just run on 8.3.2 Release
   - xcode_version: 8.0
     target: tvos-device
   - xcode_version: 8.1

--- a/build.sh
+++ b/build.sh
@@ -385,7 +385,7 @@ download_sync() {
 COMMAND="$1"
 
 # Use Debug config if command ends with -debug, otherwise default to Release
-# Set IS_RUNNING_PACKAGING when running packaging steps to avoid running iOS static tests with Xcode 8.3.1
+# Set IS_RUNNING_PACKAGING when running packaging steps to avoid running iOS static tests with Xcode 8.3.2
 case "$COMMAND" in
     *-debug)
         COMMAND="${COMMAND%-debug}"
@@ -1165,7 +1165,7 @@ EOM
 
     "package-ios-swift")
         cd tightdb_objc
-        for version in 8.0 8.1 8.2 8.3.1; do
+        for version in 8.0 8.1 8.2 8.3.2; do
             REALM_XCODE_VERSION=$version
             REALM_SWIFT_VERSION=
             set_xcode_and_swift_versions
@@ -1179,7 +1179,7 @@ EOM
 
     "package-osx-swift")
         cd tightdb_objc
-        for version in 8.0 8.1 8.2 8.3.1; do
+        for version in 8.0 8.1 8.2 8.3.2; do
             REALM_XCODE_VERSION=$version
             REALM_SWIFT_VERSION=
             set_xcode_and_swift_versions
@@ -1202,7 +1202,7 @@ EOM
 
     "package-watchos-swift")
         cd tightdb_objc
-        for version in 8.0 8.1 8.2 8.3.1; do
+        for version in 8.0 8.1 8.2 8.3.2; do
             REALM_XCODE_VERSION=$version
             REALM_SWIFT_VERSION=
             set_xcode_and_swift_versions
@@ -1225,7 +1225,7 @@ EOM
 
     "package-tvos-swift")
         cd tightdb_objc
-        for version in 8.0 8.1 8.2 8.3.1; do
+        for version in 8.0 8.1 8.2 8.3.2; do
             REALM_XCODE_VERSION=$version
             REALM_SWIFT_VERSION=
             set_xcode_and_swift_versions


### PR DESCRIPTION
rather than 8.3.1. This will fail on CI until the new VMs with 8.3.2 are deployed.