### PR TITLE
fix sync session being closed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ x.x.x Release notes (yyyy-MM-dd)
 
 ### Bugfixes
 
-* None.
+* Fix an issue where calling `Realm.asyncOpen(...)` with a synchronized Realm
+  configuration would fail with an "Operation canceled" error.
 
 2.6.1 Release notes (2017-04-18)
 =============================================================

--- a/Realm/RLMRealm.mm
+++ b/Realm/RLMRealm.mm
@@ -201,7 +201,6 @@ NSData *RLMRealmValidatedEncryptionKey(NSData *key) {
     }
     static dispatch_queue_t queue = dispatch_queue_create("io.realm.asyncOpenDispatchQueue", DISPATCH_QUEUE_CONCURRENT);
     dispatch_async(queue, ^{
-        (void)realmStrongRef;
         @autoreleasepool {
             RLMRealm *realm = [RLMRealm realmWithConfiguration:configuration error:&error];
             if (!realm || error) {
@@ -224,6 +223,7 @@ NSData *RLMRealmValidatedEncryptionKey(NSData *key) {
             }
             session->wait_for_download_completion([=](std::error_code error) {
                 dispatch_async(callbackQueue, ^{
+                    (void)realmStrongRef;
                     NSError *err = nil;
                     if (error == std::error_code{}) {
                         // Success


### PR DESCRIPTION
before `wait_for_download_completion` called back.

This fixes an error that @dhmspector was seeing in a demo app, and I've confirmed that this change works successfully in his app.