### PR TITLE
Fix async open interaction with read-only Realms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ x.x.x Release notes (yyyy-MM-dd)
   names (e.g. `@objc(Foo) class SwiftFoo: Object {}`).
 * Fix `-[RLMMigration enumerateObjects:block:]` returning incorrect `oldObject`
   objects when enumerating a class name after previously deleting a `newObject`.
+* Fix an issue where `Realm.asyncOpen(...)` would fail to work when opening a
+  synchronized Realm for which the user only had read permissions.
 
 2.6.2 Release notes (2017-04-21)
 =============================================================


### PR DESCRIPTION
Changes:
- async open no longer opens a synced Realm conventionally at the beginning, causing data to be written to the server

This change is verified through a unit test in an upcoming PR. (It is not included in this PR because it contains a large number of upcoming dependencies that would be impractical to port into this PR.)