### PR TITLE
Clear List when setting to nil/NSNull using KVC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ x.x.x Release notes (yyyy-MM-dd)
   objects when enumerating a class name after previously deleting a `newObject`.
 * Fix an issue where `Realm.asyncOpen(...)` would fail to work when opening a
   synchronized Realm for which the user only had read permissions.
+* Using KVC to set a `List` property to `nil` now clears it to match the
+  behavior of `RLMArray` properties.
 
 2.6.2 Release notes (2017-04-21)
 =============================================================

--- a/Realm/RLMObjectBase.mm
+++ b/Realm/RLMObjectBase.mm
@@ -188,7 +188,7 @@ id RLMCreateManagedAccessor(Class cls, __unsafe_unretained RLMRealm *realm, RLMC
 - (void)setValue:(id)value forUndefinedKey:(NSString *)key {
     RLMProperty *property = _objectSchema[key];
     if (Ivar ivar = property.swiftIvar) {
-        if (property.type == RLMPropertyTypeArray && [value conformsToProtocol:@protocol(NSFastEnumeration)]) {
+        if (property.type == RLMPropertyTypeArray && (!value || [value conformsToProtocol:@protocol(NSFastEnumeration)])) {
             RLMArray *array = [object_getIvar(self, ivar) _rlmArray];
             [array removeAllObjects];
             [array addObjects:validatedObjectForProperty(value, property, RLMSchema.partialSharedSchema)];

--- a/Realm/RLMObjectBase.mm
+++ b/Realm/RLMObjectBase.mm
@@ -188,7 +188,7 @@ id RLMCreateManagedAccessor(Class cls, __unsafe_unretained RLMRealm *realm, RLMC
 - (void)setValue:(id)value forUndefinedKey:(NSString *)key {
     RLMProperty *property = _objectSchema[key];
     if (Ivar ivar = property.swiftIvar) {
-        if (property.type == RLMPropertyTypeArray && (value || [value conformsToProtocol:@protocol(NSFastEnumeration)])) {
+        if (property.type == RLMPropertyTypeArray && (!value || [value conformsToProtocol:@protocol(NSFastEnumeration)])) {
             RLMArray *array = [object_getIvar(self, ivar) _rlmArray];
             [array removeAllObjects];
 

--- a/Realm/RLMObjectBase.mm
+++ b/Realm/RLMObjectBase.mm
@@ -186,6 +186,7 @@ id RLMCreateManagedAccessor(Class cls, __unsafe_unretained RLMRealm *realm, RLMC
 }
 
 - (void)setValue:(id)value forUndefinedKey:(NSString *)key {
+    value = RLMCoerceToNil(value);
     RLMProperty *property = _objectSchema[key];
     if (Ivar ivar = property.swiftIvar) {
         if (property.type == RLMPropertyTypeArray && (!value || [value conformsToProtocol:@protocol(NSFastEnumeration)])) {

--- a/Realm/RLMObjectBase.mm
+++ b/Realm/RLMObjectBase.mm
@@ -188,10 +188,13 @@ id RLMCreateManagedAccessor(Class cls, __unsafe_unretained RLMRealm *realm, RLMC
 - (void)setValue:(id)value forUndefinedKey:(NSString *)key {
     RLMProperty *property = _objectSchema[key];
     if (Ivar ivar = property.swiftIvar) {
-        if (property.type == RLMPropertyTypeArray && (!value || [value conformsToProtocol:@protocol(NSFastEnumeration)])) {
+        if (property.type == RLMPropertyTypeArray && (value || [value conformsToProtocol:@protocol(NSFastEnumeration)])) {
             RLMArray *array = [object_getIvar(self, ivar) _rlmArray];
             [array removeAllObjects];
-            [array addObjects:validatedObjectForProperty(value, property, RLMSchema.partialSharedSchema)];
+
+            if (value) {
+                [array addObjects:validatedObjectForProperty(value, property, RLMSchema.partialSharedSchema)];
+            }
         }
         else if (property.optional) {
             RLMOptionalBase *optional = object_getIvar(self, ivar);

--- a/RealmSwift/Tests/ObjectTests.swift
+++ b/RealmSwift/Tests/ObjectTests.swift
@@ -312,6 +312,10 @@ class ObjectTests: TestCase {
 
         setter(object, nil, "arrayCol")
         XCTAssertEqual((getter(object, "arrayCol") as! List<SwiftBoolObject>).count, 0)
+
+        setter(object, [boolObject], "arrayCol")
+        setter(object, NSNull(), "arrayCol")
+        XCTAssertEqual((getter(object, "arrayCol") as! List<SwiftBoolObject>).count, 0)
     }
 
     func dynamicSetAndTestAllTypes(_ setter: (DynamicObject, Any?, String) -> Void,

--- a/RealmSwift/Tests/ObjectTests.swift
+++ b/RealmSwift/Tests/ObjectTests.swift
@@ -309,6 +309,9 @@ class ObjectTests: TestCase {
         setter(object, [boolObject], "arrayCol")
         XCTAssertEqual((getter(object, "arrayCol") as! List<SwiftBoolObject>).count, 1)
         XCTAssertEqual((getter(object, "arrayCol") as! List<SwiftBoolObject>).first!, boolObject)
+
+        setter(object, nil, "arrayCol")
+        XCTAssertEqual((getter(object, "arrayCol") as! List<SwiftBoolObject>).count, 0)
     }
 
     func dynamicSetAndTestAllTypes(_ setter: (DynamicObject, Any?, String) -> Void,
@@ -352,6 +355,9 @@ class ObjectTests: TestCase {
         setter(object, [boolObject], "arrayCol")
         XCTAssertEqual((getter(object, "arrayCol") as! List<DynamicObject>).count, 1)
         XCTAssertEqual((getter(object, "arrayCol") as! List<DynamicObject>).first!, boolObject)
+
+        setter(object, nil, "arrayCol")
+        XCTAssertEqual((getter(object, "arrayCol") as! List<DynamicObject>).count, 0)
     }
 
     // Yields a read-write migration `SwiftObject` to the given block


### PR DESCRIPTION
to align behavior with RLMArray. This is continued from https://github.com/realm/realm-cocoa/pull/4912.