### PR TITLE
fix `-Wdocumentation` warnings introduced in Xcode 8.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ x.x.x Release notes (yyyy-MM-dd)
 
 ### Bugfixes
 
-* None.
+* Suppress `-Wdocumentation` warnings in Realm C++ headers when using CocoaPods
+  with Xcode 8.3.2.
 
 2.7.0 Release notes (2017-05-03)
 =============================================================

--- a/Realm.podspec
+++ b/Realm.podspec
@@ -77,7 +77,7 @@ Pod::Spec.new do |s|
   s.header_mappings_dir     = 'include'
   s.pod_target_xcconfig     = { 'APPLICATION_EXTENSION_API_ONLY' => 'YES',
                                 'CLANG_CXX_LANGUAGE_STANDARD' => 'c++14',
-                                'HEADER_SEARCH_PATHS' => '"${PODS_ROOT}/Realm/include/core"',
+                                'OTHER_CPLUSPLUSFLAGS' => '-isystem "${PODS_ROOT}/Realm/include/core"',
                                 'USER_HEADER_SEARCH_PATHS' => '"${PODS_ROOT}/Realm/include" "${PODS_ROOT}/Realm/include/Realm"' }
   s.preserve_paths          = %w(build.sh include)
 


### PR DESCRIPTION
when using CocoaPods by treating the core+sync headers as system headers.

Fixes #4853.