### PR TITLE
Move ownership of refresh handles to `SyncUser`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,9 @@ x.x.x Release notes (yyyy-MM-dd)
 
 ### Bugfixes
 
-* None.
+* Fix an issue where synchronized Realms would eventually disconnect from the
+  remote server if the user object used to define their sync configuration
+  was destroyed.
 
 2.8.1 Release notes (2017-06-12)
 =============================================================

--- a/Realm/RLMSyncManager.mm
+++ b/Realm/RLMSyncManager.mm
@@ -102,6 +102,8 @@ static dispatch_once_t s_onceToken;
 
 - (instancetype)initWithCustomRootDirectory:(NSURL *)rootDirectory {
     if (self = [super init]) {
+        [RLMSyncUser _setupBindingContextFactory];
+
         // Initialize the sync engine.
         SyncManager::shared().set_logger_factory(s_syncLoggerFactory);
         bool should_encrypt = !getenv("REALM_DISABLE_METADATA_ENCRYPTION") && !RLMIsRunningInPlayground();

--- a/Realm/RLMSyncManager.mm
+++ b/Realm/RLMSyncManager.mm
@@ -102,7 +102,7 @@ static dispatch_once_t s_onceToken;
 
 - (instancetype)initWithCustomRootDirectory:(NSURL *)rootDirectory {
     if (self = [super init]) {
-        [RLMSyncUser _setupBindingContextFactory];
+        [RLMSyncUser _setUpBindingContextFactory];
 
         // Initialize the sync engine.
         SyncManager::shared().set_logger_factory(s_syncLoggerFactory);

--- a/Realm/RLMSyncSessionRefreshHandle.mm
+++ b/Realm/RLMSyncSessionRefreshHandle.mm
@@ -30,16 +30,30 @@
 
 using namespace realm;
 
+namespace {
+void runBlockForUserContext(const std::weak_ptr<SyncUser>& user,
+                                const std::string& path,
+                                std::function<void(CocoaSyncUserContext&, const std::string&)> block) {
+    if (auto strong_user = user.lock()) {
+        strong_user->run_block_with_context<CocoaSyncUserContext>([block=std::move(block), path](auto& context) {
+            block(context, path);
+        });
+    }
+}
+}
+
 @interface RLMSyncSessionRefreshHandle () {
+    std::weak_ptr<SyncUser> _user;
+    std::string _path;
     std::weak_ptr<SyncSession> _session;
     std::shared_ptr<SyncSession> _strongSession;
 }
 
-@property (nonatomic, weak) RLMSyncUser *user;
-@property (nonatomic, strong) NSString *pathToRealm;
 @property (nonatomic) NSTimer *timer;
+@property (nonatomic) NSString *identity;
 
 @property (nonatomic) NSURL *realmURL;
+@property (nonatomic) NSURL *authServerURL;
 @property (nonatomic, copy) RLMSyncBasicErrorReportingBlock completionBlock;
 
 @end
@@ -52,13 +66,18 @@ using namespace realm;
                  completionBlock:(RLMSyncBasicErrorReportingBlock)completionBlock {
     if (self = [super init]) {
         NSString *path = [realmURL path];
-        self.pathToRealm = path;
-        self.user = user;
+        _path = [path UTF8String];
+        self.identity = user.identity;
+        if (!self.identity) {
+            @throw RLMException(@"Refresh handles cannot be created for users without a valid identity.");
+        }
+        self.authServerURL = user.authenticationServer;
         self.completionBlock = completionBlock;
         self.realmURL = realmURL;
         // For the initial bind, we want to prolong the session's lifetime.
         _strongSession = std::move(session);
         _session = _strongSession;
+        _user = [user _syncUser];
         // Immediately fire off the network request.
         [self _timerFired:nil];
         return self;
@@ -93,7 +112,9 @@ using namespace realm;
         NSDate *fireDate = [RLMSyncSessionRefreshHandle fireDateForTokenExpirationDate:dateWhenTokenExpires
                                                                                nowDate:[NSDate date]];
         if (!fireDate) {
-            [self.user _unregisterRefreshHandleForURLPath:self.pathToRealm];
+            runBlockForUserContext(_user, _path, [](auto& context, auto& path) {
+                context.unregister_refresh_handle(path);
+            });
             return;
         }
         self.timer = [[NSTimer alloc] initWithFireDate:fireDate
@@ -107,12 +128,14 @@ using namespace realm;
 }
 
 /// Handler for network requests whose responses successfully parse into an auth response model.
-- (BOOL)_handleSuccessfulRequest:(RLMAuthResponseModel *)model strongUser:(RLMSyncUser *)user {
+- (BOOL)_handleSuccessfulRequest:(RLMAuthResponseModel *)model {
     // Success
     std::shared_ptr<SyncSession> session = _session.lock();
     if (!session) {
         // The session is dead or in a fatal error state.
-        [user _unregisterRefreshHandleForURLPath:self.pathToRealm];
+        runBlockForUserContext(_user, _path, [](auto& context, auto& path) {
+            context.unregister_refresh_handle(path);
+        });
         [self invalidate];
         return NO;
     }
@@ -140,7 +163,9 @@ using namespace realm;
             [self scheduleRefreshTimer:expires];
         } else {
             // The session is dead or in a fatal error state.
-            [user _unregisterRefreshHandleForURLPath:self.pathToRealm];
+            runBlockForUserContext(_user, _path, [](auto& context, auto& path) {
+                context.unregister_refresh_handle(path);
+            });
             [self invalidate];
         }
     }
@@ -151,7 +176,7 @@ using namespace realm;
 }
 
 /// Handler for network requests that failed before the JSON parsing stage.
-- (BOOL)_handleFailedRequest:(NSError *)error strongUser:(RLMSyncUser *)user {
+- (BOOL)_handleFailedRequest:(NSError *)error {
     NSError *authError;
     if ([error.domain isEqualToString:RLMSyncAuthErrorDomain]) {
         // Network client may return sync related error
@@ -183,7 +208,9 @@ using namespace realm;
     }
     if (!nextTryDate) {
         // This error isn't a network failure error. Just invalidate the refresh handle and stop.
-        [user _unregisterRefreshHandleForURLPath:self.pathToRealm];
+        runBlockForUserContext(_user, _path, [](auto& context, auto& path) {
+            context.unregister_refresh_handle(path);
+        });
         [self invalidate];
         return NO;
     }
@@ -197,19 +224,17 @@ using namespace realm;
 
 /// Callback handler for network requests.
 - (BOOL)_onRefreshCompletionWithError:(NSError *)error json:(NSDictionary *)json {
-    RLMSyncUser *user = self.user;
-    if (!user) {
-        return NO;
-    }
     if (json && !error) {
         RLMAuthResponseModel *model = [[RLMAuthResponseModel alloc] initWithDictionary:json
                                                                     requireAccessToken:YES
                                                                    requireRefreshToken:NO];
         if (model) {
-            return [self _handleSuccessfulRequest:model strongUser:user];
+            return [self _handleSuccessfulRequest:model];
         }
         // Otherwise, malformed JSON
-        [user _unregisterRefreshHandleForURLPath:self.pathToRealm];
+        runBlockForUserContext(_user, _path, [](auto& context, auto& path) {
+            context.unregister_refresh_handle(path);
+        });
         [self.timer invalidate];
         if (self.completionBlock) {
             self.completionBlock(error);
@@ -218,25 +243,26 @@ using namespace realm;
         return NO;
     } else {
         REALM_ASSERT(error);
-        return [self _handleFailedRequest:error strongUser:user];
+        return [self _handleFailedRequest:error];
     }
 }
 
 - (void)_timerFired:(__unused NSTimer *)timer {
-    RLMSyncUser *user = self.user;
-    if (!user) {
-        return;
+    RLMServerToken refreshToken = nil;
+    if (auto user = _user.lock()) {
+        refreshToken = @(user->refresh_token().c_str());
     }
-    RLMServerToken refreshToken = user._refreshToken;
     if (!refreshToken) {
-        [user _unregisterRefreshHandleForURLPath:self.pathToRealm];
+        runBlockForUserContext(_user, _path, [](auto& context, auto& path) {
+            context.unregister_refresh_handle(path);
+        });
         [self.timer invalidate];
         return;
     }
 
     NSDictionary *json = @{
                            kRLMSyncProviderKey: @"realm",
-                           kRLMSyncPathKey: self.pathToRealm,
+                           kRLMSyncPathKey: @(_path.c_str()),
                            kRLMSyncDataKey: refreshToken,
                            kRLMSyncAppIDKey: [RLMSyncManager sharedManager].appID,
                            };
@@ -246,7 +272,7 @@ using namespace realm;
         [weakSelf _onRefreshCompletionWithError:error json:json];
     };
     [RLMNetworkClient postRequestToEndpoint:RLMServerEndpointAuth
-                                     server:user.authenticationServer
+                                     server:self.authServerURL
                                        JSON:json
                                  completion:handler];
 }

--- a/Realm/RLMSyncSessionRefreshHandle.mm
+++ b/Realm/RLMSyncSessionRefreshHandle.mm
@@ -32,12 +32,10 @@ using namespace realm;
 
 namespace {
 void runBlockForUserContext(const std::weak_ptr<SyncUser>& user,
-                                const std::string& path,
-                                std::function<void(CocoaSyncUserContext&, const std::string&)> block) {
+                            const std::string& path,
+                            std::function<void(CocoaSyncUserContext&, const std::string&)> block) {
     if (auto strong_user = user.lock()) {
-        strong_user->run_block_with_context<CocoaSyncUserContext>([block=std::move(block), path](auto& context) {
-            block(context, path);
-        });
+        block(static_cast<CocoaSyncUserContext&>(*strong_user->binding_context.load()), path);
     }
 }
 }

--- a/Realm/RLMSyncSessionRefreshHandle.mm
+++ b/Realm/RLMSyncSessionRefreshHandle.mm
@@ -35,7 +35,7 @@ void runBlockForUserContext(const std::weak_ptr<SyncUser>& user,
                             const std::string& path,
                             std::function<void(CocoaSyncUserContext&, const std::string&)> block) {
     if (auto strong_user = user.lock()) {
-        block(static_cast<CocoaSyncUserContext&>(*strong_user->binding_context.load()), path);
+        block(static_cast<CocoaSyncUserContext&>(*strong_user->binding_context()), path);
     }
 }
 }

--- a/Realm/RLMSyncUser.mm
+++ b/Realm/RLMSyncUser.mm
@@ -79,6 +79,7 @@ std::shared_ptr<CocoaSyncUserContext> contextForUser(const std::shared_ptr<SyncU
 void CocoaSyncUserContext::register_refresh_handle(const std::string& path, RLMSyncSessionRefreshHandle *handle)
 {
     REALM_ASSERT(handle);
+    std::lock_guard<std::mutex> lock(m_mutex);
     auto it = m_refresh_handles.find(path);
     if (it != m_refresh_handles.end()) {
         [it->second invalidate];
@@ -89,11 +90,13 @@ void CocoaSyncUserContext::register_refresh_handle(const std::string& path, RLMS
 
 void CocoaSyncUserContext::unregister_refresh_handle(const std::string& path)
 {
+    std::lock_guard<std::mutex> lock(m_mutex);
     m_refresh_handles.erase(path);
 }
 
 void CocoaSyncUserContext::invalidate_all_handles()
 {
+    std::lock_guard<std::mutex> lock(m_mutex);
     for (auto& it : m_refresh_handles) {
         [it.second invalidate];
     }

--- a/Realm/RLMSyncUser_Private.hpp
+++ b/Realm/RLMSyncUser_Private.hpp
@@ -21,16 +21,34 @@
 #import "RLMSyncConfiguration.h"
 #import "RLMSyncUtil_Private.h"
 
-#include "sync/sync_config.hpp"
-#include "sync/impl/sync_metadata.hpp"
+#import "sync/sync_config.hpp"
+#import "sync/sync_user.hpp"
+#import "sync/impl/sync_metadata.hpp"
 
-@class RLMSyncConfiguration;
+@class RLMSyncConfiguration, RLMSyncSessionRefreshHandle;
 
 using namespace realm;
 
 typedef void(^RLMFetchedRealmCompletionBlock)(NSError * _Nullable, RLMRealm * _Nullable, BOOL * _Nonnull);
 
 NS_ASSUME_NONNULL_BEGIN
+
+class CocoaSyncUserContext : public SyncUserContext {
+public:
+    void register_refresh_handle(const std::string& path, RLMSyncSessionRefreshHandle *handle);
+    void unregister_refresh_handle(const std::string& path);
+    void invalidate_all_handles();
+
+private:
+    /**
+     A map of paths to 'refresh handles'.
+
+     A refresh handle is an object that encapsulates the concept of periodically
+     refreshing the Realm's access token before it expires. Tokens are indexed by their
+     paths (e.g. `/~/path/to/realm`).
+     */
+    std::unordered_map<std::string, RLMSyncSessionRefreshHandle *> m_refresh_handles;
+};
 
 @interface RLMSyncUser ()
 
@@ -41,8 +59,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithSyncUser:(std::shared_ptr<SyncUser>)user;
 - (std::shared_ptr<SyncUser>)_syncUser;
 - (nullable NSString *)_refreshToken;
-
-- (void)_unregisterRefreshHandleForURLPath:(NSString *)path;
 
 @end
 

--- a/Realm/RLMSyncUser_Private.hpp
+++ b/Realm/RLMSyncUser_Private.hpp
@@ -59,6 +59,7 @@ private:
 - (instancetype)initWithSyncUser:(std::shared_ptr<SyncUser>)user;
 - (std::shared_ptr<SyncUser>)_syncUser;
 - (nullable NSString *)_refreshToken;
++ (void)_setupBindingContextFactory;
 
 @end
 

--- a/Realm/RLMSyncUser_Private.hpp
+++ b/Realm/RLMSyncUser_Private.hpp
@@ -48,6 +48,8 @@ private:
      paths (e.g. `/~/path/to/realm`).
      */
     std::unordered_map<std::string, RLMSyncSessionRefreshHandle *> m_refresh_handles;
+
+    mutable std::mutex m_mutex;
 };
 
 @interface RLMSyncUser ()

--- a/Realm/RLMSyncUser_Private.hpp
+++ b/Realm/RLMSyncUser_Private.hpp
@@ -59,7 +59,7 @@ private:
 - (instancetype)initWithSyncUser:(std::shared_ptr<SyncUser>)user;
 - (std::shared_ptr<SyncUser>)_syncUser;
 - (nullable NSString *)_refreshToken;
-+ (void)_setupBindingContextFactory;
++ (void)_setUpBindingContextFactory;
 
 @end
 

--- a/Realm/RLMSyncUser_Private.hpp
+++ b/Realm/RLMSyncUser_Private.hpp
@@ -49,7 +49,7 @@ private:
      */
     std::unordered_map<std::string, RLMSyncSessionRefreshHandle *> m_refresh_handles;
 
-    mutable std::mutex m_mutex;
+    std::mutex m_mutex;
 };
 
 @interface RLMSyncUser ()


### PR DESCRIPTION
This fixes a potential issue where, if a `RLMSyncUser` representing a given user is instantiated (whether by logging in or getting the current user), used to open Realms, and then destroyed, the refresh handles for those Realms are destroyed along with it, even if other `RLMSyncUser` instances representing the same user are still around (and the Realms are still open).