### PR TITLE
Add support for email permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,16 @@ x.x.x Release notes (yyyy-MM-dd)
 
 ### Enhancements
 
-* Add a new error code to denote permission denied errors when working with
-  synchronized Realms, as well as an accompanying block that can be called
-  to inform the binding that the offending Realm's files should be kept or
-  deleted immediately. This allows recovering from permission denied errors
-  in a more robust manner.
+* Add a new error code to denote 'permission denied' errors when working
+  with synchronized Realms, as well as an accompanying block that can be
+  called to inform the binding that the offending Realm's files should be
+  deleted immediately. This allows recovering from 'permission denied'
+  errors in a more robust manner. See the documentation for
+  `RLMSyncErrorPermissionDeniedError` for more information.
+* Add `-[RLMSyncPermissionValue initWithRealmPath:username:accessLevel:]`
+  API allowing permissions to be applied to a user based on their username
+  (usually, an email address). Requires any edition of the Realm Object
+  Server 1.6.0 or later.
 
 ### Bugfixes
 
@@ -123,10 +128,7 @@ Add support for building with Xcode 9 Beta 1.
 
 ### Enhancements
 
-* Add `-[RLMSyncPermissionValue initWithRealmPath:username:accessLevel:]`
-  API allowing permissions to be applied to a user based on their username
-  (usually, an email address). Requires any edition of the Realm Object
-  Server 1.6.0 or later.
+* None.
 
 ### Bugfixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,7 +123,10 @@ Add support for building with Xcode 9 Beta 1.
 
 ### Enhancements
 
-* None.
+* Add `-[RLMSyncPermissionValue initWithRealmPath:username:accessLevel:]`
+  API allowing permissions to be applied to a user based on their username
+  (usually, an email address). Requires any edition of the Realm Object
+  Server 1.6.0 or later.
 
 ### Bugfixes
 

--- a/Realm/RLMSyncPermissionValue.h
+++ b/Realm/RLMSyncPermissionValue.h
@@ -82,7 +82,7 @@ NS_ASSUME_NONNULL_BEGIN
  Create a new sync permission value, for use with permission APIs.
 
  @param path        The Realm Object Server path to the Realm whose permission should be modified
-                    (e.g. "/path/to/realm"). Pass "*" to apply to all Realms managed by the server.
+                    (e.g. "/path/to/realm"). Pass "*" to apply to all Realms managed by the user.
  @param userID      The identity of the user who should be granted access to the Realm at `path`.
                     Pass "*" to apply to all users managed by the server.
  @param accessLevel The access level to grant.
@@ -95,7 +95,7 @@ NS_ASSUME_NONNULL_BEGIN
  Create a new sync permission value, for use with permission APIs.
 
  @param path        The Realm Object Server path to the Realm whose permission should be modified
-                    (e.g. "/path/to/realm"). Pass "*" to apply to all Realms managed by the server.
+                    (e.g. "/path/to/realm"). Pass "*" to apply to all Realms managed by the user.
  @param username    The username (often an email address) of the user who should be granted access
                     to the Realm at `path`.
  @param accessLevel The access level to grant.

--- a/Realm/RLMSyncPermissionValue.h
+++ b/Realm/RLMSyncPermissionValue.h
@@ -92,10 +92,38 @@ NS_ASSUME_NONNULL_BEGIN
                       accessLevel:(RLMSyncAccessLevel)accessLevel;
 
 /**
+ Create a new sync permission value, for use with permission APIs.
+
+ @param path        The Realm Object Server path to the Realm whose permission should be modified
+                    (e.g. "/path/to/realm"). Pass "*" to apply to all Realms managed by the server.
+ @param username    The username (often an email address) of the user who should be granted access
+                    to the Realm at `path`.
+ @param accessLevel The access level to grant.
+ */
+- (instancetype)initWithRealmPath:(NSString *)path
+                         username:(NSString *)username
+                      accessLevel:(RLMSyncAccessLevel)accessLevel;
+
+/**
  The identity of the user to whom this permission is granted, or "*"
- if all users are granted this permission.
+ if all users are granted this permission. Nil if the permission is
+ defined in terms of a key-value pair.
  */
 @property (nullable, nonatomic, readonly) NSString *userId;
+
+/**
+ If the permission is defined in terms of a key-value pair, the key
+ describing the type of criterion used to determine what users the
+ permission applies to. Otherwise, nil.
+ */
+@property (nullable, nonatomic, readonly) NSString *key;
+
+/**
+ If the permission is defined in terms of a key-value pair, a string
+ describing the criterion value used to determine what users the
+ permission applies to. Otherwise, nil.
+ */
+@property (nullable, nonatomic, readonly) NSString *value;
 
 /**
  When this permission object was last updated.

--- a/Realm/RLMSyncPermissionValue.mm
+++ b/Realm/RLMSyncPermissionValue.mm
@@ -60,6 +60,8 @@ RLMSyncAccessLevel objCAccessLevelForAccessLevel(Permission::AccessLevel level) 
 @interface RLMSyncPermissionValue () {
 @private
     NSString *_userID;
+    NSString *_key;
+    NSString *_value;
     util::Optional<Permission> _underlying;
     RLMSyncAccessLevel _accessLevel;
     NSString *_path;
@@ -76,25 +78,39 @@ RLMSyncAccessLevel objCAccessLevelForAccessLevel(Permission::AccessLevel level) 
         _accessLevel = accessLevel;
         _path = path;
         _userID = userID;
+        if (!_userID) {
+            @throw RLMException(@"A permission value cannot be created without a valid user ID");
+        }
+        _updatedAt = [NSDate date];
+    }
+    return self;
+}
+
+- (instancetype)initWithRealmPath:(NSString *)path
+                         username:(NSString *)username
+                      accessLevel:(RLMSyncAccessLevel)accessLevel {
+    if (self = [super init]) {
+        _accessLevel = accessLevel;
+        _path = path;
+        _userID = nil;
+        // This is correct; we internally call this key 'email' even though it doesn't have to be...
+        _key = @"email";
+        // FIXME: this should be done on the server, not the client.
+        _value = [username lowercaseString];
+        if (!_value) {
+            @throw RLMException(@"A permission value cannot be created without a valid username");
+        }
         _updatedAt = [NSDate date];
     }
     return self;
 }
 
 - (instancetype)initWithPermission:(Permission)permission {
-    switch (permission.condition.type) {
-        case ConditionType::UserId:
-            self = [super init];
-            break;
-        case ConditionType::KeyValue:
-            @throw RLMException(@"Key-value permissions are not yet supported in Realm Objective-C or Realm Swift.");
-            break;
+    if (self = [super init]) {
+        _underlying = util::make_optional<Permission>(std::move(permission));
+        return self;
     }
-    if (!self) {
-        return nil;
-    }
-    _underlying = util::make_optional<Permission>(std::move(permission));
-    return self;
+    return nil;
 }
 
 - (NSString *)path {
@@ -128,8 +144,30 @@ RLMSyncAccessLevel objCAccessLevelForAccessLevel(Permission::AccessLevel level) 
     if (!_underlying) {
         return _userID;
     }
-    REALM_ASSERT(_underlying->condition.type == ConditionType::UserId);
-    return @(_underlying->condition.user_id.c_str());
+    if (_underlying->condition.type == ConditionType::UserId) {
+        return @(_underlying->condition.user_id.c_str());
+    }
+    return nil;
+}
+
+- (NSString *)key {
+    if (!_underlying) {
+        return _key;
+    }
+    if (_underlying->condition.type == ConditionType::KeyValue) {
+        return @(_underlying->condition.key_value.first.c_str());
+    }
+    return nil;
+}
+
+- (NSString *)value {
+    if (!_underlying) {
+        return _value;
+    }
+    if (_underlying->condition.type == ConditionType::KeyValue) {
+        return @(_underlying->condition.key_value.second.c_str());
+    }
+    return nil;
 }
 
 - (NSDate *)updatedAt {
@@ -143,10 +181,13 @@ RLMSyncAccessLevel objCAccessLevelForAccessLevel(Permission::AccessLevel level) 
     if (_underlying) {
         return *_underlying;
     }
+    auto condition = (_userID
+                      ? Permission::Condition([_userID UTF8String])
+                      : Permission::Condition([_key UTF8String], [_value UTF8String]));
     return Permission{
         [_path UTF8String],
         accessLevelForObjcAccessLevel(_accessLevel),
-        Permission::Condition([_userID UTF8String])
+        std::move(condition)
     };
 }
 
@@ -169,8 +210,14 @@ RLMSyncAccessLevel objCAccessLevelForAccessLevel(Permission::AccessLevel level) 
 }
 
 - (NSString *)description {
-    return [NSString stringWithFormat:@"<RLMSyncPermissionValue> user ID: %@, path: %@, access level: %@",
-            self.userId,
+    NSString *typeDescription = nil;
+    if (self.userId) {
+        typeDescription = [NSString stringWithFormat:@"user ID: %@", self.userId];
+    } else {
+        typeDescription = [NSString stringWithFormat:@"key: %@, value: %@", self.key, self.value];
+    }
+    return [NSString stringWithFormat:@"<RLMSyncPermissionValue> %@, path: %@, access level: %@",
+            typeDescription,
             self.path,
             @(Permission::description_for_access_level(accessLevelForObjcAccessLevel(self.accessLevel)).c_str())];
 }

--- a/Realm/RLMSyncPermissionValue.mm
+++ b/Realm/RLMSyncPermissionValue.mm
@@ -97,9 +97,6 @@ RLMSyncAccessLevel objCAccessLevelForAccessLevel(Permission::AccessLevel level) 
         _key = @"email";
         // FIXME: this should be done on the server, not the client.
         _value = [username lowercaseString];
-        if (!_value) {
-            @throw RLMException(@"A permission value cannot be created without a valid username");
-        }
         _updatedAt = [NSDate date];
     }
     return self;


### PR DESCRIPTION
cc @alazier 

I'm actually not sure any other work needs to be done, besides pulling in the correct object store dependency. I need to figure out how to test this, which is equivalent to figuring out how to build a version of ROS that supports this new feature.

Also, ideas for email validation welcome. I figure I'll just add in a very lenient regex check and have the initializer throw an exception if the provided email fails even that.