### PR TITLE
Add integration tests for wildcard permissions

### DIFF
--- a/Realm/ObjectServerTests/RLMObjectServerTests.mm
+++ b/Realm/ObjectServerTests/RLMObjectServerTests.mm
@@ -302,13 +302,14 @@
 /// A sync user should be able to successfully change their own password.
 - (void)testOtherUserChangePassword {
     // Create admin user.
+    NSString *adminUsername = [[NSUUID UUID] UUIDString];
     {
         NSURL *url = [RLMObjectServerTests authServerURL];
-        RLMSyncUser *adminUser = [self makeAdminUser:@"admin" password:@"admin" server:url];
+        RLMSyncUser *adminUser = [self makeAdminUser:adminUsername password:@"admin" server:url];
         [adminUser logOut];
 
-        // Confirm that admin/admin user has admin privileges.
-        RLMSyncCredentials *creds = [RLMSyncCredentials credentialsWithUsername:@"admin"
+        // Confirm that admin user has admin privileges.
+        RLMSyncCredentials *creds = [RLMSyncCredentials credentialsWithUsername:adminUsername
                                                                        password:@"admin"
                                                                        register:NO];
         adminUser = [self logInUserForCredentials:creds server:url];
@@ -330,7 +331,9 @@
     }
     // Attempt change password from regular user.
     {
-        RLMSyncCredentials *creds = [RLMSyncCredentials credentialsWithUsername:@"user2" password:@"password"
+        NSString *regularUsername = [[NSUUID UUID] UUIDString];
+        RLMSyncCredentials *creds = [RLMSyncCredentials credentialsWithUsername:regularUsername
+                                                                       password:@"password"
                                                                        register:YES];
         RLMSyncUser *user = [self logInUserForCredentials:creds server:[RLMObjectServerTests authServerURL]];
         XCTestExpectation *ex = [self expectationWithDescription:@"change password callback invoked"];
@@ -343,7 +346,9 @@
     }
     // Change password from admin user.
     {
-        RLMSyncCredentials *creds = [RLMSyncCredentials credentialsWithUsername:@"admin" password:@"admin" register:NO];
+        RLMSyncCredentials *creds = [RLMSyncCredentials credentialsWithUsername:adminUsername
+                                                                       password:@"admin"
+                                                                       register:NO];
         RLMSyncUser *user = [self logInUserForCredentials:creds server:[RLMObjectServerTests authServerURL]];
         XCTestExpectation *ex = [self expectationWithDescription:@"change password callback invoked"];
         [user changePassword:secondPassword forUserID:userID completion:^(NSError * _Nullable error) {
@@ -355,7 +360,8 @@
     }
     // Fail to log in with original password.
     {
-        RLMSyncCredentials *creds = [RLMSyncCredentials credentialsWithUsername:username password:firstPassword
+        RLMSyncCredentials *creds = [RLMSyncCredentials credentialsWithUsername:username
+                                                                       password:firstPassword
                                                                        register:NO];
 
         XCTestExpectation *ex = [self expectationWithDescription:@"login callback invoked"];

--- a/Realm/ObjectServerTests/RLMObjectServerTests.mm
+++ b/Realm/ObjectServerTests/RLMObjectServerTests.mm
@@ -709,10 +709,6 @@
                                                                                    register:NO]
                                       server:[RLMObjectServerTests authServerURL]];
         [self addSyncObjectsToRealm:realm descriptions:@[@"parent-2", @"parent-3"]];
-
-        // FIXME: calling wait_for_upload_complete() before receiving BIND does
-        // not actually wait
-        sleep(1);
         [self waitForUploadsForUser:user url:url];
         CHECK_COUNT(3, SyncObject, realm);
         RLMRunChildAndWait();
@@ -747,10 +743,6 @@
     } else {
         [self waitForDownloadsForUser:user url:url];
         [self addSyncObjectsToRealm:realm descriptions:@[@"child-1", @"child-2"]];
-
-        // FIXME: calling wait_for_upload_complete() before receiving BIND does
-        // not actually wait
-        sleep(1);
         [self waitForUploadsForUser:user url:url];
         CHECK_COUNT(3, SyncObject, realm);
     }
@@ -914,10 +906,6 @@
         realm = [self immediatelyOpenRealmForURL:url user:user];
         [self addSyncObjectsToRealm:realm descriptions:@[@"child-1", @"child-2", @"child-3", @"child-4"]];
         CHECK_COUNT(5, SyncObject, realm);
-
-        // FIXME: calling wait_for_upload_complete() before receiving BIND does
-        // not actually wait
-        sleep(1);
         [self waitForUploadsForUser:user url:url];
         RLMRunChildAndWait();
     } else {

--- a/Realm/ObjectServerTests/RLMPermissionsAPITests.m
+++ b/Realm/ObjectServerTests/RLMPermissionsAPITests.m
@@ -31,7 +31,12 @@
             [ex fulfill];                                                                                              \
         }                                                                                                              \
     }];                                                                                                                \
-    [self waitForExpectationsWithTimeout:2.0 handler:nil];                                                             \
+    [self waitForExpectationsWithTimeout:10.0 handler:^(NSError *err) {                                                \
+        if (err) {                                                                                                     \
+            NSLog(@"Checking permission count failed!\nError: %@\nResults: %@\nResults count: %@",                     \
+                  err, weakResults, @([weakResults count]));                                                           \
+        }                                                                                                              \
+    }];                                                                                                                \
 }
 
 #define CHECK_PERMISSION_COUNT(ma_results, ma_count) CHECK_PERMISSION_COUNT_PREDICATE(ma_results, ma_count, ==)

--- a/Realm/ObjectServerTests/RLMSyncTestCase.h
+++ b/Realm/ObjectServerTests/RLMSyncTestCase.h
@@ -77,6 +77,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (RLMSyncUser *)logInUserForCredentials:(RLMSyncCredentials *)credentials
                                   server:(NSURL *)url;
 
+- (RLMSyncUser *)makeAdminUser:(NSString *)userName password:(NSString *)password server:(NSURL *)url;
+
 /// Add a number of objects to a Realm.
 - (void)addSyncObjectsToRealm:(RLMRealm *)realm descriptions:(NSArray<NSString *> *)descriptions;
 

--- a/Realm/ObjectServerTests/RLMSyncTestCase.mm
+++ b/Realm/ObjectServerTests/RLMSyncTestCase.mm
@@ -262,7 +262,7 @@ static NSURL *syncDirectoryForChildProcess() {
             }];
             [setAdminEx fulfill];
         }];
-        [self waitForExpectations:@[findAdminEx] timeout:20.0];
+        [self waitForExpectations:@[setAdminEx] timeout:20.0];
     }
 
     // Refresh this Realm's token until it becomes an admin user. (We don't have any other

--- a/Realm/ObjectServerTests/RLMSyncTestCase.mm
+++ b/Realm/ObjectServerTests/RLMSyncTestCase.mm
@@ -22,6 +22,7 @@
 #import <Realm/Realm.h>
 
 #import "RLMRealm_Dynamic.h"
+#import "RLMRealmConfiguration_Private.h"
 #import "RLMSyncManager+ObjectServerTests.h"
 #import "RLMSyncSessionRefreshHandle+ObjectServerTests.h"
 #import "RLMSyncConfiguration_Private.h"


### PR DESCRIPTION
Add tests for wildcard permissions, including a test suite for a global Realm. Also, break out the code JP wrote earlier to create an admin user into its own helper method.

~This requires a working OS X version of ROS with the appropriate fix before it can be merged.~