### PR TITLE
Restore support for modifying primary keys in migrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ x.x.x Release notes (yyyy-MM-dd)
 * Fix an issue where synchronized Realms would eventually disconnect from the
   remote server if the user object used to define their sync configuration
   was destroyed.
+* Restore support for changing primary keys in migrations (broken in 2.8.0).
 
 2.8.1 Release notes (2017-06-12)
 =============================================================


### PR DESCRIPTION
Pulls in https://github.com/realm/realm-object-store/pull/471 and https://github.com/realm/realm-object-store/pull/466 (which probably doesn't merit a changelog entry due to being future-proofing).