### PR TITLE
Set properties to `nil` when addOrUpdating a RLMObject

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ x.x.x Release notes (yyyy-MM-dd)
   remote server if the user object used to define their sync configuration
   was destroyed.
 * Restore support for changing primary keys in migrations (broken in 2.8.0).
+* Revert handling of adding objects with nil properties to a Realm to the
+  pre-2.8.0 behavior.
 
 2.8.1 Release notes (2017-06-12)
 =============================================================

--- a/Realm/RLMAccessor.mm
+++ b/Realm/RLMAccessor.mm
@@ -659,7 +659,7 @@ id RLMAccessorContext::propertyValue(__unsafe_unretained id const obj, size_t pr
     // unless using the dictionary/array code path. Remove this in 3.0.
     if (!value) {
         validateValueForProperty(NSNull.null, prop, _info);
-        if (prop.isPrimary)
+        if (prop.isPrimary || _promote_existing)
             return NSNull.null;
         _nilHack = true;
     }

--- a/Realm/Tests/ObjectCreationTests.mm
+++ b/Realm/Tests/ObjectCreationTests.mm
@@ -1296,4 +1296,28 @@
     [realm2 cancelWriteTransaction];
 }
 
+- (void)testAddOrUpdateWithNilValues {
+    auto now = [NSDate date];
+    auto bytes = [NSData dataWithBytes:"a" length:1];
+    auto nonnull = [[AllOptionalTypesPK alloc] initWithValue:@[@0, @1, @2.2f, @3.3, @YES, @"a", bytes, now]];
+    auto null = [[AllOptionalTypesPK alloc] initWithValue:@[@0]];
+
+    auto realm = [RLMRealm defaultRealm];
+    [realm beginWriteTransaction];
+
+    auto obj = [AllOptionalTypesPK createInRealm:realm withValue:nonnull];
+    auto nullobj = [[AllOptionalTypesPK alloc] initWithValue:null];
+    [realm addOrUpdateObject:nullobj];
+
+    XCTAssertNil(obj.intObj);
+    XCTAssertNil(obj.floatObj);
+    XCTAssertNil(obj.doubleObj);
+    XCTAssertNil(obj.boolObj);
+    XCTAssertNil(obj.string);
+    XCTAssertNil(obj.data);
+    XCTAssertNil(obj.date);
+
+    [realm cancelWriteTransaction];
+}
+
 @end


### PR DESCRIPTION
The hack to preserve existing behavior for createOrUpdate was overly broad and also affected addOrUpdate. The newly added test passes in 2.7.0 and fails in 2.8.0.

Fixes #5000.