### PR TITLE
Fix add(update: true) for nil RealmOptional properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+x.x.x Release notes (yyyy-MM-dd)
+=============================================================
+
+### API Breaking Changes
+
+* None.
+
+### Enhancements
+
+* None.
+
+### Bugfixes
+
+* None.
+
 2.8.2 Release notes (2017-06-16)
 =============================================================
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ x.x.x Release notes (yyyy-MM-dd)
 
 ### Bugfixes
 
-* None.
+* Properly update RealmOptional properties when adding an object with `add(update: true)`.
 
 2.8.2 Release notes (2017-06-16)
 =============================================================

--- a/Realm/RLMAccessor.mm
+++ b/Realm/RLMAccessor.mm
@@ -640,18 +640,20 @@ id RLMAccessorContext::propertyValue(__unsafe_unretained id const obj, size_t pr
     }
 
     // Property value from an instance of this object type
+    id value;
     if ([obj isKindOfClass:_info.rlmObjectSchema.objectClass] && prop.swiftIvar) {
         if (prop.type == RLMPropertyTypeArray) {
             return static_cast<RLMListBase *>(object_getIvar(obj, prop.swiftIvar))._rlmArray;
         }
         else { // optional
-            return static_cast<RLMOptionalBase *>(object_getIvar(obj, prop.swiftIvar)).underlyingValue;
+            value = static_cast<RLMOptionalBase *>(object_getIvar(obj, prop.swiftIvar)).underlyingValue;
         }
     }
-
+    else {
     // Property value from some object that's KVC-compatible
-    id value = RLMValidatedValueForProperty(obj, [obj respondsToSelector:prop.getterSel] ? prop.getterName : prop.name,
-                                            _info.rlmObjectSchema.className);
+        value = RLMValidatedValueForProperty(obj, [obj respondsToSelector:prop.getterSel] ? prop.getterName : prop.name,
+                                             _info.rlmObjectSchema.className);
+    }
     // return value ?: NSNull.null;
 
     // FIXME: for compatiblity with existing code this does bad things to make

--- a/RealmSwift/Tests/ObjectCreationTests.swift
+++ b/RealmSwift/Tests/ObjectCreationTests.swift
@@ -484,6 +484,83 @@ class ObjectCreationTests: TestCase {
         }
     }
 
+    func testCreateOrUpdateNil() {
+        let realm = try! Realm()
+        realm.beginWrite()
+
+        // Create with all fields nil
+        let object = realm.create(SwiftOptionalPrimaryObject.self, value: SwiftOptionalPrimaryObject(), update: true)
+
+        XCTAssertNil(object.id.value)
+        XCTAssertNil(object.optIntCol.value)
+        XCTAssertNil(object.optInt8Col.value)
+        XCTAssertNil(object.optInt16Col.value)
+        XCTAssertNil(object.optInt32Col.value)
+        XCTAssertNil(object.optInt64Col.value)
+        XCTAssertNil(object.optBoolCol.value)
+        XCTAssertNil(object.optFloatCol.value)
+        XCTAssertNil(object.optDoubleCol.value)
+        XCTAssertNil(object.optDateCol)
+        XCTAssertNil(object.optStringCol)
+        XCTAssertNil(object.optNSStringCol)
+        XCTAssertNil(object.optBinaryCol)
+        XCTAssertNil(object.optObjectCol)
+
+        // Try to switch to non-nil
+        let object2 = SwiftOptionalPrimaryObject()
+        object2.optIntCol.value = 1
+        object2.optInt8Col.value = 1
+        object2.optInt16Col.value = 1
+        object2.optInt32Col.value = 1
+        object2.optInt64Col.value = 1
+        object2.optFloatCol.value = 1
+        object2.optDoubleCol.value = 1
+        object2.optBoolCol.value = true
+        object2.optDateCol = Date()
+        object2.optStringCol = ""
+        object2.optNSStringCol = ""
+        object2.optBinaryCol = Data()
+        object2.optObjectCol = SwiftBoolObject()
+        realm.create(SwiftOptionalPrimaryObject.self, value: object2, update: true)
+
+        XCTAssertNil(object.id.value)
+        XCTAssertNotNil(object.optIntCol.value)
+        XCTAssertNotNil(object.optInt8Col.value)
+        XCTAssertNotNil(object.optInt16Col.value)
+        XCTAssertNotNil(object.optInt32Col.value)
+        XCTAssertNotNil(object.optInt64Col.value)
+        XCTAssertNotNil(object.optBoolCol.value)
+        XCTAssertNotNil(object.optFloatCol.value)
+        XCTAssertNotNil(object.optDoubleCol.value)
+        XCTAssertNotNil(object.optDateCol)
+        XCTAssertNotNil(object.optStringCol)
+        XCTAssertNotNil(object.optNSStringCol)
+        XCTAssertNotNil(object.optBinaryCol)
+        XCTAssertNotNil(object.optObjectCol)
+
+        // Try to switch back to nil
+        realm.create(SwiftOptionalPrimaryObject.self, value: SwiftOptionalPrimaryObject(), update: true)
+
+        XCTAssertNil(object.id.value)
+
+        // FIXME: these should all be nil but that's a breaking change
+        XCTAssertNotNil(object.optIntCol.value)
+        XCTAssertNotNil(object.optInt8Col.value)
+        XCTAssertNotNil(object.optInt16Col.value)
+        XCTAssertNotNil(object.optInt32Col.value)
+        XCTAssertNotNil(object.optInt64Col.value)
+        XCTAssertNotNil(object.optBoolCol.value)
+        XCTAssertNotNil(object.optFloatCol.value)
+        XCTAssertNotNil(object.optDoubleCol.value)
+        XCTAssertNotNil(object.optDateCol)
+        XCTAssertNotNil(object.optStringCol)
+        XCTAssertNotNil(object.optNSStringCol)
+        XCTAssertNotNil(object.optBinaryCol)
+        XCTAssertNotNil(object.optObjectCol)
+
+        realm.cancelWrite()
+    }
+
     // test null object
     // test null list
 
@@ -541,6 +618,83 @@ class ObjectCreationTests: TestCase {
 
         XCTAssertNil(weakObj1)
         XCTAssertNil(weakObj2)
+    }
+
+    func testAddOrUpdateNil() {
+        let realm = try! Realm()
+        realm.beginWrite()
+
+        // Create with all fields nil
+        let object = SwiftOptionalPrimaryObject()
+        realm.add(object)
+
+        XCTAssertNil(object.id.value)
+        XCTAssertNil(object.optIntCol.value)
+        XCTAssertNil(object.optInt8Col.value)
+        XCTAssertNil(object.optInt16Col.value)
+        XCTAssertNil(object.optInt32Col.value)
+        XCTAssertNil(object.optInt64Col.value)
+        XCTAssertNil(object.optBoolCol.value)
+        XCTAssertNil(object.optFloatCol.value)
+        XCTAssertNil(object.optDoubleCol.value)
+        XCTAssertNil(object.optDateCol)
+        XCTAssertNil(object.optStringCol)
+        XCTAssertNil(object.optNSStringCol)
+        XCTAssertNil(object.optBinaryCol)
+        XCTAssertNil(object.optObjectCol)
+
+        // Try to switch to non-nil
+        let object2 = SwiftOptionalPrimaryObject()
+        object2.optIntCol.value = 1
+        object2.optInt8Col.value = 1
+        object2.optInt16Col.value = 1
+        object2.optInt32Col.value = 1
+        object2.optInt64Col.value = 1
+        object2.optFloatCol.value = 1
+        object2.optDoubleCol.value = 1
+        object2.optBoolCol.value = true
+        object2.optDateCol = Date()
+        object2.optStringCol = ""
+        object2.optNSStringCol = ""
+        object2.optBinaryCol = Data()
+        object2.optObjectCol = SwiftBoolObject()
+        realm.add(object2, update: true)
+
+        XCTAssertNil(object.id.value)
+        XCTAssertNotNil(object.optIntCol.value)
+        XCTAssertNotNil(object.optInt8Col.value)
+        XCTAssertNotNil(object.optInt16Col.value)
+        XCTAssertNotNil(object.optInt32Col.value)
+        XCTAssertNotNil(object.optInt64Col.value)
+        XCTAssertNotNil(object.optBoolCol.value)
+        XCTAssertNotNil(object.optFloatCol.value)
+        XCTAssertNotNil(object.optDoubleCol.value)
+        XCTAssertNotNil(object.optDateCol)
+        XCTAssertNotNil(object.optStringCol)
+        XCTAssertNotNil(object.optNSStringCol)
+        XCTAssertNotNil(object.optBinaryCol)
+        XCTAssertNotNil(object.optObjectCol)
+
+        // Try to switch back to nil
+        let object3 = SwiftOptionalPrimaryObject()
+        realm.add(object3, update: true)
+
+        XCTAssertNil(object.id.value)
+        XCTAssertNil(object.optIntCol.value)
+        XCTAssertNil(object.optInt8Col.value)
+        XCTAssertNil(object.optInt16Col.value)
+        XCTAssertNil(object.optInt32Col.value)
+        XCTAssertNil(object.optInt64Col.value)
+        XCTAssertNil(object.optBoolCol.value)
+        XCTAssertNil(object.optFloatCol.value)
+        XCTAssertNil(object.optDoubleCol.value)
+        XCTAssertNil(object.optDateCol)
+        XCTAssertNil(object.optStringCol)
+        XCTAssertNil(object.optNSStringCol)
+        XCTAssertNil(object.optBinaryCol)
+        XCTAssertNil(object.optObjectCol)
+
+        realm.cancelWrite()
     }
 
     // MARK: Private utilities

--- a/RealmSwift/Tests/SwiftTestObjects.swift
+++ b/RealmSwift/Tests/SwiftTestObjects.swift
@@ -78,6 +78,12 @@ class SwiftOptionalObject: Object {
     @objc dynamic var optObjectCol: SwiftBoolObject?
 }
 
+class SwiftOptionalPrimaryObject: SwiftOptionalObject {
+    let id = RealmOptional<Int>()
+
+    override class func primaryKey() -> String? { return "id" }
+}
+
 class SwiftImplicitlyUnwrappedOptionalObject: Object {
     @objc dynamic var optNSStringCol: NSString!
     @objc dynamic var optStringCol: String!


### PR DESCRIPTION
This also needs the `?: NSNull.null` so that existing values are actually set
to null, along with the hack to not do this for create() until 3.0.

Fixes another case of #5000.