### PR TITLE
Further improve `RLMSyncUser`

### DIFF
--- a/Realm/RLMSyncConfiguration.mm
+++ b/Realm/RLMSyncConfiguration.mm
@@ -20,6 +20,7 @@
 
 #import "RLMSyncManager_Private.h"
 #import "RLMSyncSession_Private.hpp"
+#import "RLMSyncSessionRefreshHandle.hpp"
 #import "RLMSyncUser_Private.hpp"
 #import "RLMSyncUtil_Private.hpp"
 #import "RLMUtil.hpp"
@@ -140,9 +141,15 @@ static BOOL isValidRealmURL(NSURL *url) {
         auto bindHandler = [=](auto&,
                                const SyncConfig& config,
                                const std::shared_ptr<SyncSession>& session) {
-            [user _bindSessionWithConfig:config
-                                 session:session
-                              completion:[RLMSyncManager sharedManager].sessionCompletionNotifier];
+            const std::shared_ptr<SyncUser>& user = config.user;
+            NSURL *realmURL = [NSURL URLWithString:@(config.realm_url.c_str())];
+            NSString *path = [realmURL path];
+            REALM_ASSERT(realmURL && path);
+            RLMSyncSessionRefreshHandle *handle = [[RLMSyncSessionRefreshHandle alloc] initWithRealmURL:realmURL
+                                                                                                   user:user
+                                                                                                session:std::move(session)
+                                                                                        completionBlock:[RLMSyncManager sharedManager].sessionCompletionNotifier];
+            std::static_pointer_cast<CocoaSyncUserContext>(user->binding_context())->register_refresh_handle([path UTF8String], handle);
         };
         if (!errorHandler) {
             errorHandler = [=](std::shared_ptr<SyncSession> errored_session,

--- a/Realm/RLMSyncSessionRefreshHandle.hpp
+++ b/Realm/RLMSyncSessionRefreshHandle.hpp
@@ -24,6 +24,7 @@
 
 namespace realm {
 class SyncSession;
+class SyncUser;
 }
 
 @class RLMSyncUser;
@@ -33,7 +34,7 @@ class SyncSession;
 NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)initWithRealmURL:(NSURL *)realmURL
-                            user:(RLMSyncUser *)user
+                            user:(std::shared_ptr<realm::SyncUser>)user
                          session:(std::shared_ptr<realm::SyncSession>)session
                  completionBlock:(nullable RLMSyncBasicErrorReportingBlock)completionBlock;
 

--- a/Realm/RLMSyncUser_Private.hpp
+++ b/Realm/RLMSyncUser_Private.hpp
@@ -54,10 +54,6 @@ private:
 
 @interface RLMSyncUser ()
 
-- (void)_bindSessionWithConfig:(const SyncConfig&)config
-                       session:(std::shared_ptr<SyncSession>)session
-                    completion:(RLMSyncBasicErrorReportingBlock)completion;
-
 - (instancetype)initWithSyncUser:(std::shared_ptr<SyncUser>)user;
 - (std::shared_ptr<SyncUser>)_syncUser;
 - (nullable NSString *)_refreshToken;


### PR DESCRIPTION
Changes:
- Removed reference to an `RLMSyncUser` object in the login callback. This prevents the object from being kept alive unnecessarily long and simplifies the code
- Removed the server URL state stored within the `RLMSyncUser` object, since it is already stored on the underlying `SyncUser` and duplicating it achieves nothing

Tests: all object server tests pass. Also used this build in a sample app to manually ensure that refreshing works.