### PR TITLE
Fix the type name mentioned in the description of nested `List` types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ x.x.x Release notes (yyyy-MM-dd)
 
 ### Bugfixes
 
-* None.
+* `List.description` now reports the correct types for nested lists.
 
 2.8.3 Release notes (2017-06-20)
 =============================================================

--- a/Realm.xcodeproj/project.pbxproj
+++ b/Realm.xcodeproj/project.pbxproj
@@ -251,6 +251,8 @@
 		5D03FB201E0DAFBA007D53EA /* PredicateUtilTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5D03FB1E1E0DAFBA007D53EA /* PredicateUtilTests.mm */; };
 		5D128F2A1BE984E5001F4FBF /* Realm.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 5D659ED91BE04556006515A0 /* Realm.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		5D1534B81CCFF545008976D7 /* LinkingObjects.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D1534B71CCFF545008976D7 /* LinkingObjects.swift */; };
+		5D1BF1FF1EF987AD00B7DC87 /* RLMCollection_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 5D1BF1FE1EF9875300B7DC87 /* RLMCollection_Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		5D1BF2001EF987AE00B7DC87 /* RLMCollection_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 5D1BF1FE1EF9875300B7DC87 /* RLMCollection_Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		5D274C4D1D6D15D2006FEBB1 /* weak_realm_notifier.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5D274C4C1D6D15D2006FEBB1 /* weak_realm_notifier.cpp */; };
 		5D274C4E1D6D15FD006FEBB1 /* weak_realm_notifier.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5D274C4C1D6D15D2006FEBB1 /* weak_realm_notifier.cpp */; };
 		5D3E1A2F1C1FC6D5002913BA /* RLMPredicateUtil.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5D3E1A2D1C1FC6D5002913BA /* RLMPredicateUtil.mm */; };
@@ -801,6 +803,7 @@
 		5BC537151DD5B8D70055C524 /* ObjectiveCSupportTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ObjectiveCSupportTests.swift; sourceTree = "<group>"; };
 		5D03FB1E1E0DAFBA007D53EA /* PredicateUtilTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = PredicateUtilTests.mm; sourceTree = "<group>"; };
 		5D1534B71CCFF545008976D7 /* LinkingObjects.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LinkingObjects.swift; sourceTree = "<group>"; };
+		5D1BF1FE1EF9875300B7DC87 /* RLMCollection_Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RLMCollection_Private.h; sourceTree = "<group>"; };
 		5D274C4C1D6D15D2006FEBB1 /* weak_realm_notifier.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = weak_realm_notifier.cpp; sourceTree = "<group>"; };
 		5D274C4F1D6D16A8006FEBB1 /* event_loop_signal.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = event_loop_signal.hpp; sourceTree = "<group>"; };
 		5D274C521D6D16BA006FEBB1 /* event_loop_signal.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = event_loop_signal.hpp; sourceTree = "<group>"; };
@@ -1504,6 +1507,7 @@
 				3F9863B91D36876B00641C98 /* RLMClassInfo.mm */,
 				02B8EF5B19E7048D0045A93D /* RLMCollection.h */,
 				3FBEF6791C63D66100F6935B /* RLMCollection.mm */,
+				5D1BF1FE1EF9875300B7DC87 /* RLMCollection_Private.h */,
 				3FBEF6781C63D66100F6935B /* RLMCollection_Private.hpp */,
 				E81A1F6B1955FC9300FDED82 /* RLMConstants.h */,
 				E81A1F6C1955FC9300FDED82 /* RLMConstants.m */,
@@ -1629,6 +1633,7 @@
 				5D659EB51BE04556006515A0 /* RLMObjectSchema.h in Headers */,
 				5D659EB61BE04556006515A0 /* RLMObjectSchema_Private.h in Headers */,
 				5D659EB81BE04556006515A0 /* RLMObjectStore.h in Headers */,
+				5D1BF1FF1EF987AD00B7DC87 /* RLMCollection_Private.h in Headers */,
 				5D659EBA1BE04556006515A0 /* RLMOptionalBase.h in Headers */,
 				5D659EBC1BE04556006515A0 /* RLMProperty.h in Headers */,
 				5D659EBD1BE04556006515A0 /* RLMProperty_Private.h in Headers */,
@@ -1708,6 +1713,7 @@
 				5DD755C41BE056DE002800DA /* RLMResults_Private.h in Headers */,
 				5DD755C51BE056DE002800DA /* RLMSchema.h in Headers */,
 				5DD755C61BE056DE002800DA /* RLMSchema_Private.h in Headers */,
+				5D1BF2001EF987AE00B7DC87 /* RLMCollection_Private.h in Headers */,
 				5DD755C71BE056DE002800DA /* RLMSwiftSupport.h in Headers */,
 				1A0512761D8746CD00806AEC /* RLMSyncConfiguration.h in Headers */,
 				3F336E8A1DA2FA14006CB5A0 /* RLMSyncConfiguration_Private.h in Headers */,

--- a/Realm/RLMCollection_Private.h
+++ b/Realm/RLMCollection_Private.h
@@ -1,0 +1,27 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2016 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+#import <Realm/RLMCollection.h>
+
+#import <Realm/RLMRealm.h>
+
+@protocol RLMFastEnumerable;
+
+NSArray *RLMCollectionValueForKey(id<RLMFastEnumerable> collection, NSString *key);
+void RLMCollectionSetValueForKey(id<RLMFastEnumerable> collection, NSString *key, id value);
+FOUNDATION_EXTERN NSString *RLMDescriptionWithMaxDepth(NSString *name, id<RLMCollection> collection, NSUInteger depth);

--- a/Realm/RLMCollection_Private.hpp
+++ b/Realm/RLMCollection_Private.hpp
@@ -16,9 +16,7 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-#import <Realm/RLMCollection.h>
-
-#import <Realm/RLMRealm.h>
+#import <Realm/RLMCollection_Private.h>
 
 namespace realm {
     class List;
@@ -72,6 +70,3 @@ RLMNotificationToken *RLMAddNotificationBlock(id objcCollection,
                                               void (^block)(id, RLMCollectionChange *, NSError *),
                                               bool suppressInitialChange=false);
 
-NSArray *RLMCollectionValueForKey(id<RLMFastEnumerable> collection, NSString *key);
-void RLMCollectionSetValueForKey(id<RLMFastEnumerable> collection, NSString *key, id value);
-NSString *RLMDescriptionWithMaxDepth(NSString *name, id<RLMCollection> collection, NSUInteger depth);

--- a/Realm/Realm.modulemap
+++ b/Realm/Realm.modulemap
@@ -7,6 +7,7 @@ framework module Realm {
     explicit module Private {
         header "RLMAccessor.h"
         header "RLMArray_Private.h"
+        header "RLMCollection_Private.h"
         header "RLMListBase.h"
         header "RLMObjectBase_Dynamic.h"
         header "RLMObjectSchema_Private.h"

--- a/RealmSwift/LinkingObjects.swift
+++ b/RealmSwift/LinkingObjects.swift
@@ -106,8 +106,7 @@ public final class LinkingObjects<T: Object>: LinkingObjectsBase {
 
     /// A human-readable description of the objects represented by the linking objects.
     public override var description: String {
-        let type = "LinkingObjects<\(rlmResults.objectClassName)>"
-        return gsub(pattern: "RLMResults <0x[a-z0-9]+>", template: type, string: rlmResults.description) ?? type
+        return RLMDescriptionWithMaxDepth("LinkingObjects<\(rlmResults.objectClassName)>", rlmResults, RLMDescriptionMaxDepth)
     }
 
     // MARK: Index Retrieval

--- a/RealmSwift/List.swift
+++ b/RealmSwift/List.swift
@@ -32,8 +32,7 @@ public class ListBase: RLMListBase {
     }
 
     @objc private func descriptionWithMaxDepth(_ depth: UInt) -> String {
-        let type = "List<\(_rlmArray.objectClassName)>"
-        return gsub(pattern: "RLMArray <0x[a-z0-9]+>", template: type, string: _rlmArray.description(withMaxDepth: depth)) ?? type
+        return RLMDescriptionWithMaxDepth("List<\(_rlmArray.objectClassName)>", _rlmArray, depth)
     }
 
     /// Returns the number of objects in this List.

--- a/RealmSwift/Results.swift
+++ b/RealmSwift/Results.swift
@@ -81,8 +81,7 @@ public final class Results<T: Object>: NSObject, NSFastEnumeration {
 
     /// A human-readable description of the objects represented by the results.
     public override var description: String {
-        let type = "Results<\(rlmResults.objectClassName)>"
-        return gsub(pattern: "RLMResults <0x[a-z0-9]+>", template: type, string: rlmResults.description) ?? type
+        return RLMDescriptionWithMaxDepth("Results<\(rlmResults.objectClassName)>", rlmResults, RLMDescriptionMaxDepth)
     }
 
     // MARK: Fast Enumeration

--- a/RealmSwift/Tests/ObjectTests.swift
+++ b/RealmSwift/Tests/ObjectTests.swift
@@ -115,11 +115,11 @@ class ObjectTests: TestCase {
     func testDescription() {
         let object = SwiftObject()
         // swiftlint:disable line_length
-        XCTAssertEqual(object.description, "SwiftObject {\n\tboolCol = 0;\n\tintCol = 123;\n\tfloatCol = 1.23;\n\tdoubleCol = 12.3;\n\tstringCol = a;\n\tbinaryCol = <61 — 1 total bytes>;\n\tdateCol = 1970-01-01 00:00:01 +0000;\n\tobjectCol = SwiftBoolObject {\n\t\tboolCol = 0;\n\t};\n\tarrayCol = List<SwiftBoolObject> (\n\t\n\t);\n}")
+        assertMatches(object.description, "SwiftObject \\{\n\tboolCol = 0;\n\tintCol = 123;\n\tfloatCol = 1\\.23;\n\tdoubleCol = 12\\.3;\n\tstringCol = a;\n\tbinaryCol = <61 — 1 total bytes>;\n\tdateCol = 1970-01-01 00:00:01 \\+0000;\n\tobjectCol = SwiftBoolObject \\{\n\t\tboolCol = 0;\n\t\\};\n\tarrayCol = List<SwiftBoolObject> <0x[0-9a-f]+> \\(\n\t\n\t\\);\n\\}")
 
         let recursiveObject = SwiftRecursiveObject()
         recursiveObject.objects.append(recursiveObject)
-        XCTAssertEqual(recursiveObject.description, "SwiftRecursiveObject {\n\tobjects = List<SwiftRecursiveObject> (\n\t\t[0] SwiftRecursiveObject {\n\t\t\tobjects = List<SwiftRecursiveObject> (\n\t\t\t\t[0] SwiftRecursiveObject {\n\t\t\t\t\tobjects = <Maximum depth exceeded>;\n\t\t\t\t}\n\t\t\t);\n\t\t}\n\t);\n}")
+        assertMatches(recursiveObject.description, "SwiftRecursiveObject \\{\n\tobjects = List<SwiftRecursiveObject> <0x[0-9a-f]+> \\(\n\t\t\\[0\\] SwiftRecursiveObject \\{\n\t\t\tobjects = List<SwiftRecursiveObject> <0x[0-9a-f]+> \\(\n\t\t\t\t\\[0\\] SwiftRecursiveObject \\{\n\t\t\t\t\tobjects = <Maximum depth exceeded>;\n\t\t\t\t\\}\n\t\t\t\\);\n\t\t\\}\n\t\\);\n\\}")
         // swiftlint:enable line_length
     }
 

--- a/RealmSwift/Tests/RealmCollectionTypeTests.swift
+++ b/RealmSwift/Tests/RealmCollectionTypeTests.swift
@@ -170,7 +170,7 @@ class RealmCollectionTypeTests: TestCase {
             fatalError("Test precondition failed")
         }
         // swiftlint:disable:next line_length
-        XCTAssertEqual(collection.description, "Results<CTTStringObjectWithLink> (\n\t[0] CTTStringObjectWithLink {\n\t\tstringCol = 1;\n\t\tlinkCol = (null);\n\t},\n\t[1] CTTStringObjectWithLink {\n\t\tstringCol = 2;\n\t\tlinkCol = (null);\n\t}\n)")
+        assertMatches(collection.description, "Results<CTTStringObjectWithLink> <0x[0-9a-f]+> \\(\n\t\\[0\\] CTTStringObjectWithLink \\{\n\t\tstringCol = 1;\n\t\tlinkCol = \\(null\\);\n\t\\},\n\t\\[1\\] CTTStringObjectWithLink \\{\n\t\tstringCol = 2;\n\t\tlinkCol = \\(null\\);\n\t\\}\n\\)")
     }
 
     func testCount() {
@@ -794,7 +794,7 @@ class ListRealmCollectionTypeTests: RealmCollectionTypeTests {
             fatalError("Test precondition failed")
         }
         // swiftlint:disable:next line_length
-        XCTAssertEqual(collection.description, "List<CTTStringObjectWithLink> (\n\t[0] CTTStringObjectWithLink {\n\t\tstringCol = 1;\n\t\tlinkCol = (null);\n\t},\n\t[1] CTTStringObjectWithLink {\n\t\tstringCol = 2;\n\t\tlinkCol = (null);\n\t}\n)")
+        assertMatches(collection.description, "List<CTTStringObjectWithLink> <0x[0-9a-f]+> \\(\n\t\\[0\\] CTTStringObjectWithLink \\{\n\t\tstringCol = 1;\n\t\tlinkCol = \\(null\\);\n\t\\},\n\t\\[1\\] CTTStringObjectWithLink \\{\n\t\tstringCol = 2;\n\t\tlinkCol = \\(null\\);\n\t\\}\n\\)")
     }
 
     func testAddNotificationBlockDirect() {
@@ -1045,7 +1045,7 @@ class LinkingObjectsCollectionTypeTests: RealmCollectionTypeTests {
             fatalError("Test precondition failure - a property was unexpectedly nil")
         }
         // swiftlint:disable:next line_length
-        XCTAssertEqual(collection.description, "LinkingObjects<CTTStringObjectWithLink> (\n\t[0] CTTStringObjectWithLink {\n\t\tstringCol = 1;\n\t\tlinkCol = CTTLinkTarget {\n\t\t\tid = 0;\n\t\t};\n\t},\n\t[1] CTTStringObjectWithLink {\n\t\tstringCol = 2;\n\t\tlinkCol = CTTLinkTarget {\n\t\t\tid = 0;\n\t\t};\n\t}\n)")
+        assertMatches(collection.description, "LinkingObjects<CTTStringObjectWithLink> <0x[0-9a-f]+> \\(\n\t\\[0\\] CTTStringObjectWithLink \\{\n\t\tstringCol = 1;\n\t\tlinkCol = CTTLinkTarget \\{\n\t\t\tid = 0;\n\t\t\\};\n\t\\},\n\t\\[1\\] CTTStringObjectWithLink \\{\n\t\tstringCol = 2;\n\t\tlinkCol = CTTLinkTarget \\{\n\t\t\tid = 0;\n\t\t\\};\n\t\\}\n\\)")
     }
 
     override func testAssignListProperty() {

--- a/RealmSwift/Tests/TestCase.swift
+++ b/RealmSwift/Tests/TestCase.swift
@@ -170,6 +170,11 @@ class TestCase: XCTestCase {
         XCTAssert(block() == nil, message ?? "", file: fileName, line: lineNumber)
     }
 
+    func assertMatches(_ block: @autoclosure () -> String, _ regexString: String, _ message: String? = nil,
+                       fileName: String = #file, lineNumber: UInt = #line) {
+        RLMAssertMatches(self, block, regexString, message, fileName, lineNumber)
+    }
+
     private func realmFilePrefix() -> String {
         return name!.trimmingCharacters(in: CharacterSet(charactersIn: "-[]"))
     }

--- a/RealmSwift/Tests/TestUtils.h
+++ b/RealmSwift/Tests/TestUtils.h
@@ -19,15 +19,18 @@
 #import <Foundation/Foundation.h>
 #import <XCTest/XCTestCase.h>
 
-FOUNDATION_EXTERN void RLMAssertThrowsWithName(XCTestCase *self,
-                                       __attribute__((noescape)) dispatch_block_t block,
-                                       NSString *name, NSString *message,
-                                       NSString *fileName, NSUInteger lineNumber);
+FOUNDATION_EXTERN void RLMAssertThrowsWithName(XCTestCase *self, __attribute__((noescape)) dispatch_block_t block,
+                                               NSString *name, NSString *message, NSString *fileName,
+                                               NSUInteger lineNumber);
 
 
 FOUNDATION_EXTERN void RLMAssertThrowsWithReasonMatching(XCTestCase *self,
-                                      __attribute__((noescape)) dispatch_block_t block,
-                                      NSString *regexString, NSString *message,
-                                      NSString *fileName, NSUInteger lineNumber);
+                                                         __attribute__((noescape)) dispatch_block_t block,
+                                                         NSString *regexString, NSString *message,
+                                                         NSString *fileName, NSUInteger lineNumber);
+
+FOUNDATION_EXTERN void RLMAssertMatches(XCTestCase *self, __attribute__((noescape)) NSString *(^block)(),
+                                        NSString *regexString, NSString *message, NSString *fileName,
+                                        NSUInteger lineNumber);
 
 FOUNDATION_EXTERN bool RLMHasCachedRealmForPath(NSString *path);

--- a/RealmSwift/Tests/TestUtils.mm
+++ b/RealmSwift/Tests/TestUtils.mm
@@ -73,6 +73,17 @@ void RLMAssertThrowsWithReasonMatching(XCTestCase *self, dispatch_block_t block,
     }
 }
 
+
+void RLMAssertMatches(XCTestCase *self, NSString *(^block)(), NSString *regexString, NSString *message, NSString *fileName, NSUInteger lineNumber) {
+    NSString *result = block();
+    NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:regexString options:(NSRegularExpressionOptions)0 error:nil];
+    if ([regex numberOfMatchesInString:result options:(NSMatchingOptions)0 range:NSMakeRange(0, result.length)] == 0) {
+        NSString *msg = [NSString stringWithFormat:@"The given expression '%@' did not match '%@'%@",
+                         result, regexString, message ? [NSString stringWithFormat:@": %@", message] : @""];
+        [self recordFailureWithDescription:msg inFile:fileName atLine:lineNumber expected:NO];
+    }
+}
+
 bool RLMHasCachedRealmForPath(NSString *path) {
     return RLMGetAnyCachedRealmForPath(path.UTF8String);
 }


### PR DESCRIPTION
Have the collection's `description` properties delegate directly to `RLMDescriptionWithMaxDepth` rather than trying to munge the output of their Objective-C counterpart's `-description` methods.

Fixes #5049.