### PR TITLE
Change how synced Realm permission errors are handled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@ x.x.x Release notes (yyyy-MM-dd)
 
 ### Enhancements
 
-* None.
+* Add a new error code to denote permission denied errors when working with
+  synchronized Realms, as well as an accompanying block that can be called
+  to inform the binding that the offending Realm's files should be kept or
+  deleted immediately. This allows recovering from permission denied errors
+  in a more robust manner.
 
 ### Bugfixes
 

--- a/Realm.xcodeproj/project.pbxproj
+++ b/Realm.xcodeproj/project.pbxproj
@@ -115,7 +115,7 @@
 		1A90FCBB1D3D37F50086A57F /* RLMSyncManager.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1AF7EA951D340AF70001A9B5 /* RLMSyncManager.mm */; };
 		1A90FCBC1D3D37F70086A57F /* RLMNetworkClient.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1AF7EA9A1D340E700001A9B5 /* RLMNetworkClient.mm */; };
 		1AA5AE981D989BE400ED8C27 /* SwiftSyncTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AA5AE961D989BE000ED8C27 /* SwiftSyncTestCase.swift */; };
-		1AA5AE9C1D98A68E00ED8C27 /* RLMSyncTestCase.m in Sources */ = {isa = PBXBuildFile; fileRef = 1AA5AE9B1D98A68E00ED8C27 /* RLMSyncTestCase.m */; };
+		1AA5AE9C1D98A68E00ED8C27 /* RLMSyncTestCase.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1AA5AE9B1D98A68E00ED8C27 /* RLMSyncTestCase.mm */; };
 		1AA5AEA11D98C99800ED8C27 /* SwiftObjectServerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AA5AE9F1D98C99500ED8C27 /* SwiftObjectServerTests.swift */; };
 		1AA5AEA31D98DF1000ED8C27 /* RealmSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5D660FCC1BE98C560021E04F /* RealmSwift.framework */; };
 		1AA5AEA41D98DF1500ED8C27 /* RealmSwift.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 5D660FCC1BE98C560021E04F /* RealmSwift.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -664,7 +664,7 @@
 		1A877BEE1EAE9F79001BEC40 /* SwiftPermissionsAPITests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SwiftPermissionsAPITests.swift; path = Realm/ObjectServerTests/SwiftPermissionsAPITests.swift; sourceTree = "<group>"; };
 		1AA5AE961D989BE000ED8C27 /* SwiftSyncTestCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; name = SwiftSyncTestCase.swift; path = Realm/ObjectServerTests/SwiftSyncTestCase.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		1AA5AE9A1D98A1B000ED8C27 /* Object-Server-Tests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "Object-Server-Tests-Bridging-Header.h"; path = "Realm/ObjectServerTests/Object-Server-Tests-Bridging-Header.h"; sourceTree = "<group>"; };
-		1AA5AE9B1D98A68E00ED8C27 /* RLMSyncTestCase.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RLMSyncTestCase.m; path = Realm/ObjectServerTests/RLMSyncTestCase.m; sourceTree = "<group>"; };
+		1AA5AE9B1D98A68E00ED8C27 /* RLMSyncTestCase.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = RLMSyncTestCase.mm; path = Realm/ObjectServerTests/RLMSyncTestCase.mm; sourceTree = "<group>"; };
 		1AA5AE9D1D98A6D800ED8C27 /* RLMSyncTestCase.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = RLMSyncTestCase.h; path = Realm/ObjectServerTests/RLMSyncTestCase.h; sourceTree = "<group>"; };
 		1AA5AE9F1D98C99500ED8C27 /* SwiftObjectServerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SwiftObjectServerTests.swift; path = Realm/ObjectServerTests/SwiftObjectServerTests.swift; sourceTree = "<group>"; };
 		1AABD4001E9552BA00115A75 /* uuid.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = uuid.cpp; sourceTree = "<group>"; };
@@ -1431,7 +1431,7 @@
 				3F73BC881E3A876600FE80B6 /* RLMSyncSessionRefreshHandle+ObjectServerTests.h */,
 				3F73BC891E3A876600FE80B6 /* RLMSyncSessionRefreshHandle+ObjectServerTests.m */,
 				1AA5AE9D1D98A6D800ED8C27 /* RLMSyncTestCase.h */,
-				1AA5AE9B1D98A68E00ED8C27 /* RLMSyncTestCase.m */,
+				1AA5AE9B1D98A68E00ED8C27 /* RLMSyncTestCase.mm */,
 				3F73BC8A1E3A876600FE80B6 /* RLMTestUtils.h */,
 				3F73BC8B1E3A876600FE80B6 /* RLMTestUtils.m */,
 				1AA5AE9F1D98C99500ED8C27 /* SwiftObjectServerTests.swift */,
@@ -2459,7 +2459,7 @@
 				1AD6E7A61E8C2BDF00D4C8B4 /* RLMPermissionsAPITests.m in Sources */,
 				1AF64DCF1DA3042B0081EB15 /* RLMSyncManager+ObjectServerTests.m in Sources */,
 				3F73BC911E3A877300FE80B6 /* RLMSyncSessionRefreshHandle+ObjectServerTests.m in Sources */,
-				1AA5AE9C1D98A68E00ED8C27 /* RLMSyncTestCase.m in Sources */,
+				1AA5AE9C1D98A68E00ED8C27 /* RLMSyncTestCase.mm in Sources */,
 				1A1536481DB0408A00C0EC93 /* RLMSyncUser+ObjectServerTests.mm in Sources */,
 				E86E61241D91E4E200DC2419 /* RLMTestCase.m in Sources */,
 				3F73BC921E3A877300FE80B6 /* RLMTestUtils.m in Sources */,

--- a/Realm/NSError+RLMSync.h
+++ b/Realm/NSError+RLMSync.h
@@ -32,6 +32,13 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable void(^)(void))rlmSync_clientResetBlock NS_REFINED_FOR_SWIFT;
 
 /**
+ Given a Realm Object Server permission denied error, return the block that
+ can be called to manually initiate or cancel the Realm file deletion process,
+ or nil if the error isn't a permission denied error.
+ */
+- (nullable void(^)(BOOL))rlmSync_deleteRealmBlock NS_REFINED_FOR_SWIFT;
+
+/**
  Given a Realm Object Server client reset error, return the path where the
  backup copy of the Realm will be placed once the client reset process is
  complete.

--- a/Realm/NSError+RLMSync.h
+++ b/Realm/NSError+RLMSync.h
@@ -35,6 +35,13 @@ NS_ASSUME_NONNULL_BEGIN
  Given a Realm Object Server permission denied error, return the block that
  can be called to manually initiate or cancel the Realm file deletion process,
  or nil if the error isn't a permission denied error.
+
+ The block itself takes a single boolean argument. Pass in YES to immediately
+ delete the files on disk (after all references to the Realm and objects in
+ the Realm have been invalidated). Pass in NO to never delete the Realm files.
+ The block can only be called once. If the block isn't called at all, the
+ Realm files will be deleted the next time your application is launched and the
+ sync subsystem is initialized.
  */
 - (nullable void(^)(BOOL))rlmSync_deleteRealmBlock NS_REFINED_FOR_SWIFT;
 

--- a/Realm/NSError+RLMSync.m
+++ b/Realm/NSError+RLMSync.m
@@ -29,6 +29,13 @@
     return nil;
 }
 
+- (nullable void(^)(BOOL))rlmSync_deleteRealmBlock {
+    if (self.domain == RLMSyncErrorDomain && self.code == RLMSyncErrorPermissionDeniedError) {
+        return self.userInfo[kRLMSyncInitiateDeleteRealmBlockKey];
+    }
+    return nil;
+}
+
 - (NSString *)rlmSync_clientResetBackedUpRealmPath {
     if (self.domain == RLMSyncErrorDomain && self.code == RLMSyncErrorClientResetError) {
         return self.userInfo[kRLMSyncPathOfRealmBackupCopyKey];

--- a/Realm/ObjectServerTests/RLMSyncTestCase.h
+++ b/Realm/ObjectServerTests/RLMSyncTestCase.h
@@ -46,6 +46,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (RLMSyncCredentials *)basicCredentialsWithName:(NSString *)name register:(BOOL)shouldRegister;
 
++ (NSURL *)onDiskPathForSyncedRealm:(RLMRealm *)realm;
+
 /// Synchronously open a synced Realm and wait until the binding process has completed or failed.
 - (RLMRealm *)openRealmForURL:(NSURL *)url user:(RLMSyncUser *)user;
 

--- a/Realm/RLMSyncConfiguration.mm
+++ b/Realm/RLMSyncConfiguration.mm
@@ -37,6 +37,8 @@ using ProtocolError = realm::sync::ProtocolError;
 RLMSyncSystemErrorKind errorKindForSyncError(SyncError error) {
     if (error.is_client_reset_requested()) {
         return RLMSyncSystemErrorKindClientReset;
+    } else if (error.error_code == ProtocolError::permission_denied) {
+        return RLMSyncSystemErrorKindPermissionDenied;
     } else if (error.error_code == ProtocolError::bad_authentication) {
         return RLMSyncSystemErrorKindUser;
     } else if (error.is_session_level_protocol_error()) {

--- a/Realm/RLMSyncManager.mm
+++ b/Realm/RLMSyncManager.mm
@@ -193,7 +193,6 @@ static dispatch_once_t s_onceToken;
                 calledAlready = YES;
                 std::string original_path = [originalPath UTF8String];
                 if (deleteRealm) {
-                    NSLog(@"Deleting Realm...");
                     SyncManager::shared().immediately_run_file_actions(original_path);
                 } else {
                     SyncManager::shared().perform_metadata_update([&](const auto& manager) {

--- a/Realm/RLMSyncUtil.h
+++ b/Realm/RLMSyncUtil.h
@@ -29,6 +29,9 @@ extern NSString *const kRLMSyncPathOfRealmBackupCopyKey;
 /// A user info key for use with `RLMSyncErrorClientResetError`.
 extern NSString *const kRLMSyncInitiateClientResetBlockKey;
 
+/// A user info key for use with `RLMSyncErrorPermissionDeniedError`.
+extern NSString *const kRLMSyncInitiateDeleteRealmBlockKey;
+
 /**
  The error domain string for all SDK errors related to errors reported
  by the synchronization manager error handler, as well as general sync
@@ -118,6 +121,30 @@ typedef RLM_ERROR_ENUM(NSInteger, RLMSyncError, RLMSyncErrorDomain) {
      error domain.
      */
     RLMSyncErrorUnderlyingAuthError     = 8,
+
+    /**
+     An error that indicates the user does not have permission to perform an operation
+     upon a synced Realm. For example, a user may receive this error if they attempt to
+     open a Realm they do not have at least read access to, or write to a Realm they only
+     have read access to.
+     
+     This error may also occur if a user incorrectly opens a Realm they have read-only
+     permissions to without using the `asyncOpen()` APIs.
+
+     A Realm that suffers a permission denied error is, by default, flagged so that its
+     local copy will be deleted the next time the application starts.
+     
+     The `userInfo` dictionary contains a block under the key
+     `kRLMSyncInitiateDeleteRealmBlockKey`. This block can be called with a single argument:
+     `YES` to immediately delete the Realm file, `NO` to not delete the file at all (either
+     now or upon restart). This block should only be called with `YES` if and when your app
+     closes and invalidates every instance of the offending Realm on all threads (note that
+     autorelease pools may make this difficult to guarantee).
+
+     @warning It is strongly recommended that, if a Realm has encountered a permission denied
+              error, its files be deleted before attempting to re-open it.
+     */
+    RLMSyncErrorPermissionDeniedError   = 9,
 };
 
 /// An error which is related to authentication to a Realm Object Server.

--- a/Realm/RLMSyncUtil.mm
+++ b/Realm/RLMSyncUtil.mm
@@ -72,6 +72,7 @@ NSString *const RLMSyncPermissionErrorDomain = @"io.realm.sync.permission";
 
 NSString *const kRLMSyncPathOfRealmBackupCopyKey            = @"recovered_realm_location_path";
 NSString *const kRLMSyncInitiateClientResetBlockKey         = @"initiate_client_reset_block";
+NSString *const kRLMSyncInitiateDeleteRealmBlockKey         = @"initiate_delete_realm_block";
 
 NSString *const kRLMSyncAppIDKey                = @"app_id";
 NSString *const kRLMSyncDataKey                 = @"data";
@@ -174,10 +175,12 @@ NSError *make_sync_error(RLMSyncSystemErrorKind kind, NSString *description, NSI
 
     RLMSyncError errorCode;
     switch (kind) {
-        case RLMSyncSystemErrorKindClientReset: {
+        case RLMSyncSystemErrorKindClientReset:
             errorCode = RLMSyncErrorClientResetError;
             break;
-        }
+        case RLMSyncSystemErrorKindPermissionDenied:
+            errorCode = RLMSyncErrorPermissionDeniedError;
+            break;
         case RLMSyncSystemErrorKindUser:
             errorCode = RLMSyncErrorClientUserError;
             break;

--- a/Realm/RLMSyncUtil_Private.h
+++ b/Realm/RLMSyncUtil_Private.h
@@ -25,6 +25,7 @@
 typedef NS_ENUM(NSUInteger, RLMSyncSystemErrorKind) {
     // Specific
     RLMSyncSystemErrorKindClientReset,
+    RLMSyncSystemErrorKindPermissionDenied,
     // General
     RLMSyncSystemErrorKindClient,
     RLMSyncSystemErrorKindConnection,

--- a/RealmSwift/Sync.swift
+++ b/RealmSwift/Sync.swift
@@ -122,6 +122,15 @@ public extension SyncError {
         }
         return nil
     }
+
+    /// Given a permission denied error, extract and return the reset closure.
+    public func deleteRealmUserInfo() -> ((Bool) -> Void)? {
+        if code == SyncError.permissionDeniedError,
+            let block = _nsError.__rlmSync_deleteRealmBlock() {
+            return block
+        }
+        return nil
+    }
 }
 
 /**

--- a/RealmSwift/Sync.swift
+++ b/RealmSwift/Sync.swift
@@ -125,11 +125,7 @@ public extension SyncError {
 
     /// Given a permission denied error, extract and return the reset closure.
     public func deleteRealmUserInfo() -> ((Bool) -> Void)? {
-        if code == SyncError.permissionDeniedError,
-            let block = _nsError.__rlmSync_deleteRealmBlock() {
-            return block
-        }
-        return nil
+        return _nsError.__rlmSync_deleteRealmBlock()
     }
 }
 


### PR DESCRIPTION
Fixes #5043
Requires https://github.com/realm/realm-object-store/pull/476

Changes:
- Permission denied errors now have their own code, as well as a block for recovery purposes
- Sessions that encounter a permission denied error are now closed immediately