### PR TITLE
Remove a redundant call to RLMInitializeSwiftAccessorGenerics()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ x.x.x Release notes (yyyy-MM-dd)
   API allowing permissions to be applied to a user based on their username
   (usually, an email address). Requires any edition of the Realm Object
   Server 1.6.0 or later.
+* Improve performance of creating Swift objects which contain at least one List
+  property.
 
 ### Bugfixes
 

--- a/RealmSwift/RealmCollection.swift
+++ b/RealmSwift/RealmCollection.swift
@@ -32,11 +32,7 @@ public final class RLMIterator<T: Object>: IteratorProtocol {
 
     /// Advance to the next element and return it, or `nil` if no next element exists.
     public func next() -> T? {
-        let accessor = unsafeBitCast(generatorBase.next() as! Object?, to: Optional<T>.self)
-        if let accessor = accessor {
-            RLMInitializeSwiftAccessorGenerics(accessor)
-        }
-        return accessor
+        return unsafeBitCast(generatorBase.next() as! Object?, to: Optional<T>.self)
     }
 }
 


### PR DESCRIPTION
This was originally added way back in 2faa3beae4c50c5d9cec0aa21ac5d09a3d271186 in the Swift iteration code to avoid adding any extra overhead to obj-c fast enumeration, but then it turned out that the swift generics needed to be initialized even when enumerating from obj-c (#2905) and the obj-c fast enumeration code was changed to do it without removing it from the Swift code.

Greatly speeds up enumerating over Swift objects with at least one List property as initializing even just one of those is roughly half of the time spent initializing the accessor object.