### PR TITLE
Make `Object` comparison behavior match `RLMObject` comparison behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,8 @@ x.x.x Release notes (yyyy-MM-dd)
 * Swift `Object` comparison and hashing behavior now works the same way as
   that of `RLMObject` (objects are now only considered equatable if their
   model class defines a primary key).
+* Fix the way the hash property works on `Object` when the object model has
+  no primary key.
 
 ### Enhancements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,10 +51,14 @@ x.x.x Release notes (yyyy-MM-dd)
 * Fix empty strings, binary data, and null on the right side of `BEGINSWITH`,
   `ENDSWITH` and `CONTAINS` operators in predicates to match Foundation's
   semantics of never matching any strings or data.
+* Swift `Object` comparison and hashing behavior now works the same way as
+  that of `RLMObject` (objects are now only considered equatable if their
+  model class defines a primary key).
 
 ### Enhancements
 
-* None.
+* Add Swift `Object.isSameObject(as:_)` API to perform the same function as
+  the existing Objective-C API `-[RLMObject isEqualToObject:]`.
 
 ### Bugfixes
 

--- a/Realm/RLMObject.h
+++ b/Realm/RLMObject.h
@@ -489,8 +489,8 @@ typedef void (^RLMObjectChangeBlock)(BOOL deleted,
  Returns YES if another Realm object instance points to the same object as the receiver in the Realm managing
  the receiver.
 
- For object types with a primary, key, `isEqual:` is overridden to use this method (along with a corresponding
- implementation for `hash`).
+ For object types with a primary, key, `isEqual:` is overridden to use the same logic as this
+ method (along with a corresponding implementation for `hash`).
 
  @param object  The object to compare the receiver to.
 

--- a/RealmSwift/Object.swift
+++ b/RealmSwift/Object.swift
@@ -266,17 +266,22 @@ open class Object: RLMObjectBase, ThreadConfined {
                                    to: List<DynamicObject>.self)
     }
 
-    // MARK: Equatable
-
+    // MARK: Comparison
     /**
-     Returns whether two Realm objects are equal.
+     Returns whether two Realm objects are the same.
 
-     Objects are considered equal if and only if they are both managed by the same Realm and point to the same
-     underlying object in the database.
+     Objects are considered the same if and only if they are both managed by the same
+     Realm and point to the same underlying object in the database.
+     
+     - note: Equality comparison is implemented by `isEqual(_:)`, but objects are only
+             considered equatable using `==` or `isEqual(_:)` if a primary key is
+             defined for the model type. This method can be used to carry out the same
+             underlying comparison regardless of whether the object types are defined
+             with primary keys or not.
 
      - parameter object: The object to compare the receiver to.
      */
-    open override func isEqual(_ object: Any?) -> Bool {
+    public func isSameObject(as object: Any?) -> Bool {
         return RLMObjectBaseAreEqual(self as RLMObjectBase?, object as? RLMObjectBase)
     }
 
@@ -492,3 +497,15 @@ extension Object: AssistedObjectiveCBridgeable {
         return (objectiveCValue: unsafeCastToRLMObject(), metadata: nil)
     }
 }
+
+// MARK: - Migration assistance
+
+#if os(OSX)
+#else
+extension Object {
+    /// :nodoc:
+    @available(*, unavailable, renamed: "isSameObject(as:)") public func isEqual(to object: Any?) -> Bool {
+        fatalError()
+    }
+}
+#endif

--- a/RealmSwift/Object.swift
+++ b/RealmSwift/Object.swift
@@ -273,11 +273,12 @@ open class Object: RLMObjectBase, ThreadConfined {
      Objects are considered the same if and only if they are both managed by the same
      Realm and point to the same underlying object in the database.
      
-     - note: Equality comparison is implemented by `isEqual(_:)`, but objects are only
-             considered equatable using `==` or `isEqual(_:)` if a primary key is
-             defined for the model type. This method can be used to carry out the same
-             underlying comparison regardless of whether the object types are defined
-             with primary keys or not.
+     - note: Equality comparison is implemented by `isEqual(_:)`. If the object type
+             is defined with a primary key, `isEqual(_:)` behaves identically to this
+             method. If the object type is not defined with a primary key,
+             `isEqual(_:)` uses the `NSObject` behavior of comparing object identity.
+             This method can be used to compare two objects for database equality
+             whether or not their object type defines a primary key.
 
      - parameter object: The object to compare the receiver to.
      */

--- a/RealmSwift/Object.swift
+++ b/RealmSwift/Object.swift
@@ -282,8 +282,8 @@ open class Object: RLMObjectBase, ThreadConfined {
 
      - parameter object: The object to compare the receiver to.
      */
-    public func isSameObject(as object: Any?) -> Bool {
-        return RLMObjectBaseAreEqual(self as RLMObjectBase?, object as? RLMObjectBase)
+    public func isSameObject(as object: Object?) -> Bool {
+        return RLMObjectBaseAreEqual(self, object)
     }
 
     // MARK: Private functions

--- a/RealmSwift/Tests/ListTests.swift
+++ b/RealmSwift/Tests/ListTests.swift
@@ -121,9 +121,9 @@ class ListTests: TestCase {
             array.append(str)
         }
         XCTAssertEqual(Int(3), array.count)
-        XCTAssertEqual(str1, array[0])
-        XCTAssertEqual(str2, array[1])
-        XCTAssertEqual(str1, array[2])
+        assertEqual(str1, array[0])
+        assertEqual(str2, array[1])
+        assertEqual(str1, array[2])
     }
 
     func testAppendArray() {
@@ -132,9 +132,9 @@ class ListTests: TestCase {
         }
         array.append(objectsIn: [str1, str2, str1])
         XCTAssertEqual(Int(3), array.count)
-        XCTAssertEqual(str1, array[0])
-        XCTAssertEqual(str2, array[1])
-        XCTAssertEqual(str1, array[2])
+        assertEqual(str1, array[0])
+        assertEqual(str2, array[1])
+        assertEqual(str1, array[2])
     }
 
     func testAppendResults() {
@@ -143,8 +143,8 @@ class ListTests: TestCase {
         }
         array.append(objectsIn: realmWithTestPath().objects(SwiftStringObject.self))
         XCTAssertEqual(Int(2), array.count)
-        XCTAssertEqual(str1, array[0])
-        XCTAssertEqual(str2, array[1])
+        assertEqual(str1, array[0])
+        assertEqual(str2, array[1])
     }
 
     func testInsert() {
@@ -156,12 +156,12 @@ class ListTests: TestCase {
 
         array.insert(str1, at: 0)
         XCTAssertEqual(Int(1), array.count)
-        XCTAssertEqual(str1, array[0])
+        assertEqual(str1, array[0])
 
         array.insert(str2, at: 0)
         XCTAssertEqual(Int(2), array.count)
-        XCTAssertEqual(str2, array[0])
-        XCTAssertEqual(str1, array[1])
+        assertEqual(str2, array[0])
+        assertEqual(str1, array[1])
 
         assertThrows(_ = array.insert(str2, at: 200))
         assertThrows(_ = array.insert(str2, at: -200))
@@ -175,8 +175,8 @@ class ListTests: TestCase {
         array.append(objectsIn: [str1, str2, str1])
 
         array.remove(objectAtIndex: 1)
-        XCTAssertEqual(str1, array[0])
-        XCTAssertEqual(str1, array[1])
+        assertEqual(str1, array[0])
+        assertEqual(str1, array[1])
 
         assertThrows(array.remove(objectAtIndex: 200))
         assertThrows(array.remove(objectAtIndex: -200))
@@ -191,7 +191,7 @@ class ListTests: TestCase {
 
         array.removeLast()
         XCTAssertEqual(Int(1), array.count)
-        XCTAssertEqual(str1, array[0])
+        assertEqual(str1, array[0])
 
         array.removeLast()
         XCTAssertEqual(Int(0), array.count)
@@ -223,13 +223,13 @@ class ListTests: TestCase {
 
         array.replace(index: 0, object: str2)
         XCTAssertEqual(Int(2), array.count)
-        XCTAssertEqual(str2, array[0])
-        XCTAssertEqual(str1, array[1])
+        assertEqual(str2, array[0])
+        assertEqual(str1, array[1])
 
         array.replace(index: 1, object: str2)
         XCTAssertEqual(Int(2), array.count)
-        XCTAssertEqual(str2, array[0])
-        XCTAssertEqual(str2, array[1])
+        assertEqual(str2, array[0])
+        assertEqual(str2, array[1])
 
         assertThrows(array.replace(index: 200, object: str2))
         assertThrows(array.replace(index: -200, object: str2))
@@ -270,19 +270,19 @@ class ListTests: TestCase {
 
         array.replaceSubrange(0..<1, with: [str2])
         XCTAssertEqual(Int(2), array.count)
-        XCTAssertEqual(str2, array[0])
-        XCTAssertEqual(str1, array[1])
+        assertEqual(str2, array[0])
+        assertEqual(str1, array[1])
 
         array.replaceSubrange(1..<2, with: [str2])
         XCTAssertEqual(Int(2), array.count)
-        XCTAssertEqual(str2, array[0])
-        XCTAssertEqual(str2, array[1])
+        assertEqual(str2, array[0])
+        assertEqual(str2, array[1])
 
         array.replaceSubrange(0..<0, with: [str2])
         XCTAssertEqual(Int(3), array.count)
-        XCTAssertEqual(str2, array[0])
-        XCTAssertEqual(str2, array[1])
-        XCTAssertEqual(str2, array[2])
+        assertEqual(str2, array[0])
+        assertEqual(str2, array[1])
+        assertEqual(str2, array[2])
 
         array.replaceSubrange(0..<3, with: [])
         XCTAssertEqual(Int(0), array.count)
@@ -301,13 +301,13 @@ class ListTests: TestCase {
 
         array.swap(index1: 0, 1)
         XCTAssertEqual(Int(2), array.count)
-        XCTAssertEqual(str2, array[0])
-        XCTAssertEqual(str1, array[1])
+        assertEqual(str2, array[0])
+        assertEqual(str1, array[1])
 
         array.swap(index1: 1, 1)
         XCTAssertEqual(Int(2), array.count)
-        XCTAssertEqual(str2, array[0])
-        XCTAssertEqual(str1, array[1])
+        assertEqual(str2, array[0])
+        assertEqual(str1, array[1])
 
         assertThrows(array.swap(index1: -1, 0))
         assertThrows(array.swap(index1: 0, -1))

--- a/RealmSwift/Tests/ObjectCreationTests.swift
+++ b/RealmSwift/Tests/ObjectCreationTests.swift
@@ -576,7 +576,7 @@ class ObjectCreationTests: TestCase {
 
         XCTAssertNotNil(object.realm)
 
-        XCTAssertEqual(object.objectCol, existingObject)
+        assertEqual(object.objectCol, existingObject)
     }
 
     func testAddAndUpdateWithExisingNestedObjects() {

--- a/RealmSwift/Tests/RealmCollectionTypeTests.swift
+++ b/RealmSwift/Tests/RealmCollectionTypeTests.swift
@@ -222,8 +222,8 @@ class RealmCollectionTypeTests: TestCase {
         guard let collection = collection else {
             fatalError("Test precondition failed")
         }
-        XCTAssertEqual(str1, collection[0])
-        XCTAssertEqual(str2, collection[1])
+        assertEqual(str1, collection[0])
+        assertEqual(str2, collection[1])
 
         assertThrows(collection[200])
         assertThrows(collection[-200])
@@ -233,8 +233,8 @@ class RealmCollectionTypeTests: TestCase {
         guard let collection = collection else {
             fatalError("Test precondition failed")
         }
-        XCTAssertEqual(str1, collection.first!)
-        XCTAssertEqual(str2, collection.filter("stringCol = '2'").first!)
+        assertEqual(str1, collection.first!)
+        assertEqual(str2, collection.filter("stringCol = '2'").first!)
         XCTAssertNil(collection.filter("stringCol = '3'").first)
     }
 
@@ -242,8 +242,8 @@ class RealmCollectionTypeTests: TestCase {
         guard let collection = collection else {
             fatalError("Test precondition failed")
         }
-        XCTAssertEqual(str2, collection.last!)
-        XCTAssertEqual(str2, collection.filter("stringCol = '2'").last!)
+        assertEqual(str2, collection.last!)
+        assertEqual(str2, collection.filter("stringCol = '2'").last!)
         XCTAssertNil(collection.filter("stringCol = '3'").last)
     }
 
@@ -255,7 +255,7 @@ class RealmCollectionTypeTests: TestCase {
         let actual = collection.value(forKey: "stringCol") as! [String]!
         XCTAssertEqual(expected, actual!)
 
-        XCTAssertEqual(collection.map { $0 }, collection.value(forKey: "self") as! [CTTStringObjectWithLink])
+        assertEqualObjectCollections(collection.map { $0 }, collection.value(forKey: "self") as! [CTTStringObjectWithLink])
     }
 
     func testSetValueForKey() {
@@ -339,8 +339,8 @@ class RealmCollectionTypeTests: TestCase {
         let collection = getAggregateableCollection()
 
         let notActuallySorted = collection.sorted(by: [])
-        XCTAssertEqual(collection[0], notActuallySorted[0])
-        XCTAssertEqual(collection[1], notActuallySorted[1])
+        assertEqual(collection[0], notActuallySorted[0])
+        assertEqual(collection[1], notActuallySorted[1])
 
         var sorted = collection.sorted(by: [SortDescriptor(keyPath: "intCol", ascending: true)])
         XCTAssertEqual(1, sorted[0].intCol)
@@ -689,7 +689,7 @@ class ResultsWithCustomInitializerTest: TestCase {
         let expected = Array(collection.map { $0.stringCol })
         let actual = collection.value(forKey: "stringCol") as! [String]!
         XCTAssertEqual(expected, actual!)
-        XCTAssertEqual(collection.map { $0 }, collection.value(forKey: "self") as! [CTTStringObjectWithLink])
+        assertEqualObjectCollections(collection.map { $0 }, collection.value(forKey: "self") as! [SwiftCustomInitializerObject])
     }
 }
 

--- a/RealmSwift/Tests/RealmCollectionTypeTests.swift
+++ b/RealmSwift/Tests/RealmCollectionTypeTests.swift
@@ -255,7 +255,7 @@ class RealmCollectionTypeTests: TestCase {
         let actual = collection.value(forKey: "stringCol") as! [String]!
         XCTAssertEqual(expected, actual!)
 
-        assertEqualObjectCollections(collection.map { $0 }, collection.value(forKey: "self") as! [CTTStringObjectWithLink])
+        assertEqual(collection.map { $0 }, collection.value(forKey: "self") as! [CTTStringObjectWithLink])
     }
 
     func testSetValueForKey() {
@@ -689,7 +689,7 @@ class ResultsWithCustomInitializerTests: TestCase {
         let expected = Array(collection.map { $0.stringCol })
         let actual = collection.value(forKey: "stringCol") as! [String]!
         XCTAssertEqual(expected, actual!)
-        assertEqualObjectCollections(collection.map { $0 }, collection.value(forKey: "self") as! [SwiftCustomInitializerObject])
+        assertEqual(collection.map { $0 }, collection.value(forKey: "self") as! [SwiftCustomInitializerObject])
     }
 }
 

--- a/RealmSwift/Tests/RealmCollectionTypeTests.swift
+++ b/RealmSwift/Tests/RealmCollectionTypeTests.swift
@@ -678,7 +678,7 @@ class ResultsTests: RealmCollectionTypeTests {
     }
 }
 
-class ResultsWithCustomInitializerTest: TestCase {
+class ResultsWithCustomInitializerTests: TestCase {
     func testValueForKey() {
         let realm = realmWithTestPath()
         try! realm.write {

--- a/RealmSwift/Tests/SwiftUnicodeTests.swift
+++ b/RealmSwift/Tests/SwiftUnicodeTests.swift
@@ -34,7 +34,7 @@ class SwiftUnicodeTests: TestCase {
         XCTAssertEqual(obj1.stringCol, utf8TestString)
 
         let obj2 = realm.objects(SwiftStringObject.self).filter("stringCol == %@", utf8TestString).first!
-        XCTAssertEqual(obj1, obj2)
+        assertEqual(obj1, obj2)
         XCTAssertEqual(obj2.stringCol, utf8TestString)
 
         XCTAssertEqual(Int(0), realm.objects(SwiftStringObject.self).filter("stringCol != %@", utf8TestString).count)
@@ -52,6 +52,6 @@ class SwiftUnicodeTests: TestCase {
             "Storing and retrieving a string with UTF8 content should work")
 
         let obj2 = realm.objects(SwiftUTF8Object.self).filter("%K == %@", "柱колоéнǢкƱаم👍", utf8TestString).first!
-        XCTAssertEqual(obj1, obj2, "Querying a realm searching for a string with UTF8 content should work")
+        assertEqual(obj1, obj2)
     }
 }

--- a/RealmSwift/Tests/TestCase.swift
+++ b/RealmSwift/Tests/TestCase.swift
@@ -113,6 +113,32 @@ class TestCase: XCTestCase {
         queue.sync { }
     }
 
+    /// Check whether two test objects are equal (refer to the same row in the same Realm), even if their models
+    /// don't define a primary key.
+    func assertEqual(_ o1: Object?, _ o2: Object?, fileName: StaticString = #file, lineNumber: UInt = #line) {
+        if o1 == nil && o2 == nil {
+            return
+        }
+        if let o1 = o1, let o2 = o2, o1.isSameObject(as: o2) {
+            return
+        }
+        recordFailure(withDescription: "Objects expected to be equal, but weren't. First: \(o1?.description ?? "nil"), "
+            + "second: \(o2?.description ?? "nil")",
+            inFile: String(describing: fileName), atLine: lineNumber, expected: false)
+    }
+
+    /// Check whether two collections containing Realm objects are equal.
+    func assertEqualObjectCollections<T: Collection, U: Collection>(_ c1: T, _ c2: U, fileName: StaticString = #file, lineNumber: UInt = #line)
+        where T.Iterator.Element : Object,
+        U.Iterator.Element : Object,
+        T.IndexDistance : Equatable,
+        T.IndexDistance == U.IndexDistance {
+            XCTAssertEqual(c1.count, c2.count, "Collection counts were incorrect", file: fileName, line: lineNumber)
+            for (o1, o2) in zip(c1, c2) {
+                assertEqual(o1, o2, fileName: fileName, lineNumber: lineNumber)
+            }
+    }
+
     func assertThrows<T>(_ block: @autoclosure @escaping() -> T, named: String? = RLMExceptionName,
                          _ message: String? = nil, fileName: String = #file, lineNumber: UInt = #line) {
         exceptionThrown = true

--- a/RealmSwift/Tests/TestCase.swift
+++ b/RealmSwift/Tests/TestCase.swift
@@ -115,24 +115,20 @@ class TestCase: XCTestCase {
 
     /// Check whether two test objects are equal (refer to the same row in the same Realm), even if their models
     /// don't define a primary key.
-    func assertEqual(_ o1: Object?, _ o2: Object?, fileName: StaticString = #file, lineNumber: UInt = #line) {
+    func assertEqual<O: Object>(_ o1: O?, _ o2: O?, fileName: StaticString = #file, lineNumber: UInt = #line) {
         if o1 == nil && o2 == nil {
             return
         }
         if let o1 = o1, let o2 = o2, o1.isSameObject(as: o2) {
             return
         }
-        recordFailure(withDescription: "Objects expected to be equal, but weren't. First: \(o1?.description ?? "nil"), "
-            + "second: \(o2?.description ?? "nil")",
-            inFile: String(describing: fileName), atLine: lineNumber, expected: false)
+        XCTFail("Objects expected to be equal, but weren't. First: \(String(describing: o1)), "
+            + "second: \(String(describing: o2))", file: fileName, line: lineNumber)
     }
 
     /// Check whether two collections containing Realm objects are equal.
-    func assertEqualObjectCollections<T: Collection, U: Collection>(_ c1: T, _ c2: U, fileName: StaticString = #file, lineNumber: UInt = #line)
-        where T.Iterator.Element : Object,
-        U.Iterator.Element : Object,
-        T.IndexDistance : Equatable,
-        T.IndexDistance == U.IndexDistance {
+    func assertEqual<C: Collection>(_ c1: C, _ c2: C, fileName: StaticString = #file, lineNumber: UInt = #line)
+        where C.Iterator.Element: Object {
             XCTAssertEqual(c1.count, c2.count, "Collection counts were incorrect", file: fileName, line: lineNumber)
             for (o1, o2) in zip(c1, c2) {
                 assertEqual(o1, o2, fileName: fileName, lineNumber: lineNumber)


### PR DESCRIPTION
Breaking change for 3.0
Fixes #4705