### PR TITLE
Change `SyncUser.logIn()` to invoke its callback on the main thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,9 @@ x.x.x Release notes (yyyy-MM-dd)
   removed.
 * The class methods `Object.className()`, `Object.objectUtilClass()`, and
   the property `Object.isInvalidated` can no longer be overriden.
+* The callback which runs when a sync user login succeeds or fails
+  now runs on the main queue by default, or can be explicitly specified
+  by a new `callbackQueue` parameter on the `{RLM}SyncUser.logIn(...)` API.
 
 ### Enhancements
 

--- a/Realm/ObjectServerTests/RLMSyncTestCase.mm
+++ b/Realm/ObjectServerTests/RLMSyncTestCase.mm
@@ -207,6 +207,7 @@ static NSURL *syncDirectoryForChildProcess() {
     [RLMSyncUser logInWithCredentials:credentials
                         authServerURL:url
                          onCompletion:^(RLMSyncUser *user, NSError *error) {
+                             XCTAssertTrue(NSThread.isMainThread);
                              XCTAssertNil(error,
                                           @"Error when trying to log in a user: %@ (process: %@)",
                                           error, process);

--- a/Realm/RLMSyncUser.h
+++ b/Realm/RLMSyncUser.h
@@ -103,18 +103,31 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark - Lifecycle
 
 /**
- Create, log in, and asynchronously return a new user object, specifying a custom timeout for the network request.
- Credentials identifying the user must be passed in. The user becomes available in the completion block, at which point
- it is ready for use.
+ Create, log in, and asynchronously return a new user object, specifying a custom
+ timeout for the network request and a custom queue to run the callback upon.
+ Credentials identifying the user must be passed in. The user becomes available in
+ the completion block, at which point it is ready for use.
  */
 + (void)logInWithCredentials:(RLMSyncCredentials *)credentials
                authServerURL:(NSURL *)authServerURL
                      timeout:(NSTimeInterval)timeout
+               callbackQueue:(dispatch_queue_t)callbackQueue
                 onCompletion:(RLMUserCompletionBlock)completion NS_REFINED_FOR_SWIFT;
 
 /**
- Create, log in, and asynchronously return a new user object. Credentials identifying the user must be passed in. The
- user becomes available in the completion block, at which point it is ready for use.
+ Create, log in, and asynchronously return a new user object.
+
+ If the login completes successfully, the completion block will invoked with
+ a `RLMSyncUser` object representing the logged-in user. This object can be
+ used to open synchronized Realms. If the login fails, the completion block
+ will be invoked with an error.
+
+ The completion block always runs on the main queue.
+
+ @param credentials     A credentials value identifying the user to be logged in.
+ @param authServerURL   The URL of the authentication server (e.g. "http://realm.example.org:9080").
+ @param completion      A callback block that returns a user object or an error,
+                        indicating the completion of the login operation.
  */
 + (void)logInWithCredentials:(RLMSyncCredentials *)credentials
                authServerURL:(NSURL *)authServerURL

--- a/RealmSwift/Sync.swift
+++ b/RealmSwift/Sync.swift
@@ -300,16 +300,28 @@ extension RLMSyncCredentials {
 
 extension SyncUser {
     /**
-     Given credentials and a server URL, log in a user and asynchronously return a `SyncUser`
-     object which can be used to open `Realm`s and retrieve `SyncSession`s.
+     Log in a user and asynchronously retrieve a user object.
+
+     If the log in completes successfully, the completion block will be called, and a
+     `SyncUser` representing the logged-in user will be passed to it. This user object
+     can be used to open `Realm`s and retrieve `SyncSession`s. Otherwise, the
+     completion block will be called with an error.
+
+     - parameter credentials: A `SyncCredentials` object representing the user to log in.
+     - parameter authServerURL: The URL of the authentication server (e.g. "http://realm.example.org:9080").
+     - parameter timeout: How long the network client should wait, in seconds, before timing out.
+     - parameter callbackQueue: The dispatch queue upon which the callback should run. Defaults to the main queue.
+     - parameter completion: A callback block to be invoked once the log in completes.
      */
     public static func logIn(with credentials: SyncCredentials,
                              server authServerURL: URL,
                              timeout: TimeInterval = 30,
+                             callbackQueue queue: DispatchQueue = DispatchQueue.main,
                              onCompletion completion: @escaping UserCompletionBlock) {
         return SyncUser.__logIn(with: RLMSyncCredentials(credentials),
                                 authServerURL: authServerURL,
                                 timeout: timeout,
+                                callbackQueue: queue,
                                 onCompletion: completion)
     }
 


### PR DESCRIPTION
Also rewrote the documentation to be clearer.

Fixes #4338. Breaking change.

I'm quite against offering the option of a queue to be specified as an argument. This would increase our API surface for negligible gain.