### PR TITLE
Remove workarounds for incorrect `create(_:, value:, update:)` behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,11 @@ Synchronized Realms require a server running Realm Object Server v2.0 or higher.
   `SortDescriptor.property`.
   These APIs have been superseded by equivalent APIs that take
   or return key paths instead of property names.
-  
+* The Objective-C and Swift `create(_:, value: update:)` APIs now
+  correctly nil out nullable properties when updating an existing
+  object when the `value` argument specifies nil or `NSNull` for
+  the property value.
+
 ### Enhancements
 
 * Add a new error code to denote 'permission denied' errors when working

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,10 +25,6 @@ Synchronized Realms require a server running Realm Object Server v2.0 or higher.
   `SortDescriptor.property`.
   These APIs have been superseded by equivalent APIs that take
   or return key paths instead of property names.
-* The Objective-C and Swift `create(_:, value: update:)` APIs now
-  correctly nil out nullable properties when updating an existing
-  object when the `value` argument specifies nil or `NSNull` for
-  the property value.
 
 ### Enhancements
 
@@ -51,6 +47,10 @@ Synchronized Realms require a server running Realm Object Server v2.0 or higher.
 * Fix unmanaged object initialization when a nested property type returned
   `false` from `Object.shouldIncludeInDefaultSchema()`.
 * Don't clear RLMArrays on self-assignment.
+* The Objective-C and Swift `create(_:, value: update:)` APIs now
+  correctly nil out nullable properties when updating an existing
+  object when the `value` argument specifies nil or `NSNull` for
+  the property value.
 
 2.8.3 Release notes (2017-06-20)
 =============================================================

--- a/Realm/RLMAccessor.hpp
+++ b/Realm/RLMAccessor.hpp
@@ -106,11 +106,6 @@ private:
     // for every property
     NSDictionary *_defaultValues;
 
-    // A temporary hack to preserve the existing behavior for
-    // https://github.com/realm/realm-cocoa/issues/4926
-    // FIXME: remove in 3.0
-    bool _nilHack = false;
-
     RLMObservationInfo *_observationInfo = nullptr;
     NSString *_kvoPropertyName = nil;
 

--- a/Realm/RLMRealm.h
+++ b/Realm/RLMRealm.h
@@ -507,6 +507,10 @@ NS_REFINED_FOR_SWIFT;
  As with `addObject:`, the object cannot already be managed by a different
  Realm. Use `-[RLMObject createOrUpdateInRealm:withValue:]` to copy values to
  a different Realm.
+ 
+ If there is a property or KVC value on `object` whose value is nil, and it corresponds
+ to a nullable property on an existing object being updated, that nullable property will
+ be set to nil.
 
  @warning This method may only be called during a write transaction.
 

--- a/Realm/Tests/ObjectCreationTests.mm
+++ b/Realm/Tests/ObjectCreationTests.mm
@@ -918,14 +918,13 @@
     auto obj = [AllOptionalTypesPK createInRealm:realm withValue:nonnull];
     [AllOptionalTypesPK createOrUpdateInRealm:realm withValue:null];
 
-    // FIXME: these should actually all be nil
-    XCTAssertNotNil(obj.intObj);
-    XCTAssertNotNil(obj.floatObj);
-    XCTAssertNotNil(obj.doubleObj);
-    XCTAssertNotNil(obj.boolObj);
-    XCTAssertNotNil(obj.string);
-    XCTAssertNotNil(obj.data);
-    XCTAssertNotNil(obj.date);
+    XCTAssertNil(obj.intObj);
+    XCTAssertNil(obj.floatObj);
+    XCTAssertNil(obj.doubleObj);
+    XCTAssertNil(obj.boolObj);
+    XCTAssertNil(obj.string);
+    XCTAssertNil(obj.data);
+    XCTAssertNil(obj.date);
 
     [AllOptionalTypesPK createOrUpdateInRealm:realm withValue:nonnull];
     [AllOptionalTypesPK createOrUpdateInRealm:realm withValue:@[@0]];

--- a/RealmSwift/Realm.swift
+++ b/RealmSwift/Realm.swift
@@ -322,7 +322,9 @@ public final class Realm {
      If the object is being updated, all properties defined in its schema will be set by copying
      from `value` using key-value coding. If the `value` argument does not respond to `value(forKey:)`
      for a given property name (or getter name, if defined), that value will remain untouched.
-     Nullable properties on the object can be set to nil by using `NSNull` as the updated value.
+     Nullable properties on the object can be set to nil by using `NSNull` as the updated value,
+     or (if you are passing in an instance of an `Object` subclass) setting the corresponding
+     property on `value` to nil.
 
      If the `value` argument is an array, all properties must be present, valid and in the same
      order as the properties defined in the model.

--- a/RealmSwift/Tests/ObjectCreationTests.swift
+++ b/RealmSwift/Tests/ObjectCreationTests.swift
@@ -543,20 +543,19 @@ class ObjectCreationTests: TestCase {
 
         XCTAssertNil(object.id.value)
 
-        // FIXME: these should all be nil but that's a breaking change
-        XCTAssertNotNil(object.optIntCol.value)
-        XCTAssertNotNil(object.optInt8Col.value)
-        XCTAssertNotNil(object.optInt16Col.value)
-        XCTAssertNotNil(object.optInt32Col.value)
-        XCTAssertNotNil(object.optInt64Col.value)
-        XCTAssertNotNil(object.optBoolCol.value)
-        XCTAssertNotNil(object.optFloatCol.value)
-        XCTAssertNotNil(object.optDoubleCol.value)
-        XCTAssertNotNil(object.optDateCol)
-        XCTAssertNotNil(object.optStringCol)
-        XCTAssertNotNil(object.optNSStringCol)
-        XCTAssertNotNil(object.optBinaryCol)
-        XCTAssertNotNil(object.optObjectCol)
+        XCTAssertNil(object.optIntCol.value)
+        XCTAssertNil(object.optInt8Col.value)
+        XCTAssertNil(object.optInt16Col.value)
+        XCTAssertNil(object.optInt32Col.value)
+        XCTAssertNil(object.optInt64Col.value)
+        XCTAssertNil(object.optBoolCol.value)
+        XCTAssertNil(object.optFloatCol.value)
+        XCTAssertNil(object.optDoubleCol.value)
+        XCTAssertNil(object.optDateCol)
+        XCTAssertNil(object.optStringCol)
+        XCTAssertNil(object.optNSStringCol)
+        XCTAssertNil(object.optBinaryCol)
+        XCTAssertNil(object.optObjectCol)
 
         realm.cancelWrite()
     }


### PR DESCRIPTION
Closes #4926.

This PR is nothing more than deleting some code marked by FIXMEs as to be removed for 3.0, and expanding on the documentation for the affected methods.