### PR TITLE
Change `RLMSyncPermissionResults` notification blocks to match other …

### DIFF
--- a/Realm/ObjectServerTests/RLMPermissionsAPITests.m
+++ b/Realm/ObjectServerTests/RLMPermissionsAPITests.m
@@ -25,7 +25,9 @@
 #define CHECK_PERMISSION_COUNT_PREDICATE(ma_results, ma_count, ma_op) {                                                \
     XCTestExpectation *ex = [self expectationWithDescription:@"Checking permission count"];                            \
     __weak typeof(ma_results) weakResults = ma_results;                                                                \
-    __attribute__((objc_precise_lifetime))id token = [ma_results addNotificationBlock:^(NSError *err) {                \
+    __attribute__((objc_precise_lifetime)) id token = [ma_results addNotificationBlock:^(__unused id collection,       \
+                                                                                         __unused id changes,          \
+                                                                                         NSError *err) {               \
         XCTAssertNil(err);                                                                                             \
         if (weakResults.count ma_op ma_count) {                                                                        \
             [ex fulfill];                                                                                              \
@@ -44,7 +46,9 @@
 #define CHECK_PERMISSION_PRESENT(ma_results, ma_permission) {                                                          \
     XCTestExpectation *ex = [self expectationWithDescription:@"Checking permission presence"];                         \
     __weak typeof(ma_results) weakResults = ma_results;                                                                \
-    __attribute__((objc_precise_lifetime)) id token = [ma_results addNotificationBlock:^(NSError *err) {               \
+    __attribute__((objc_precise_lifetime)) id token = [ma_results addNotificationBlock:^(__unused id collection,       \
+                                                                                         __unused id changes,          \
+                                                                                         NSError *err) {               \
         XCTAssertNil(err);                                                                                             \
         for (NSInteger i=0; i<weakResults.count; i++) {                                                                \
             if ([[weakResults objectAtIndex:i] isEqual:ma_permission]) {                                               \
@@ -62,7 +66,9 @@
 #define CHECK_PERMISSION_ABSENT(ma_results, ma_permission) {                                                           \
     XCTestExpectation *ex = [self expectationWithDescription:@"Checking permission absence"];                          \
     __weak typeof(ma_results) weakResults = ma_results;                                                                \
-    __attribute__((objc_precise_lifetime)) id token = [ma_results addNotificationBlock:^(NSError *err) {               \
+    __attribute__((objc_precise_lifetime)) id token = [ma_results addNotificationBlock:^(__unused id collection,       \
+                                                                                         __unused id changes,          \
+                                                                                         NSError *err) {               \
         XCTAssertNil(err);                                                                                             \
         BOOL isPresent = NO;                                                                                           \
         for (NSInteger i=0; i<weakResults.count; i++) {                                                                \
@@ -82,7 +88,9 @@
     XCTestExpectation *ex = [self expectationWithDescription:@"Retrieving permission..."];                             \
     __block RLMSyncPermissionValue *value = nil;                                                                       \
     __weak typeof(ma_results) weakResults = ma_results;                                                                \
-    __attribute__((objc_precise_lifetime)) id token = [ma_results addNotificationBlock:^(NSError *err) {               \
+    __attribute__((objc_precise_lifetime)) id token = [ma_results addNotificationBlock:^(__unused id collection,       \
+                                                                                         __unused id changes,          \
+                                                                                         NSError *err) {               \
         XCTAssertNil(err);                                                                                             \
         for (NSInteger i=0; i<weakResults.count; i++) {                                                                \
             if ([[weakResults objectAtIndex:i] isEqual:ma_permission]) {                                               \
@@ -639,7 +647,9 @@ static RLMSyncPermissionValue *makeExpectedPermission(RLMSyncPermissionValue *or
 
     // Register notifications.
     XCTestExpectation *noteEx = [self expectationWithDescription:@"Notification should fire."];
-    RLMNotificationToken *token = [results addNotificationBlock:^(NSError *error) {
+    RLMNotificationToken *token = [results addNotificationBlock:^(__unused id collection,
+                                                                  __unused id changes,
+                                                                  NSError *error) {
         XCTAssertNil(error);
         if (results.count > 0) {
             [noteEx fulfill];

--- a/Realm/ObjectServerTests/SwiftPermissionsAPITests.swift
+++ b/Realm/ObjectServerTests/SwiftPermissionsAPITests.swift
@@ -47,7 +47,7 @@ class SwiftPermissionsAPITests: SwiftSyncTestCase {
                                       file: StaticString = #file,
                                       line: UInt = #line) {
         let ex = expectation(description: "Checking permission count")
-        let token = results.addNotificationBlock { (error) in
+        let token = results.addNotificationBlock { (_, _, error) in
             XCTAssertNil(error, "Notification returned error '\(error!)' when running test at \(file):\(line)")
             if results.count == expected {
                 ex.fulfill()
@@ -63,7 +63,7 @@ class SwiftPermissionsAPITests: SwiftSyncTestCase {
                      line: UInt = #line) -> SyncPermissionValue? {
         let ex = expectation(description: "Retrieving permission")
         var finalValue: SyncPermissionValue?
-        let token = results.addNotificationBlock { (error) in
+        let token = results.addNotificationBlock { (_, _, error) in
             XCTAssertNil(error, "Notification returned error '\(error!)' when running test at \(file):\(line)")
             for result in results where result == permission {
                 finalValue = result
@@ -86,7 +86,7 @@ class SwiftPermissionsAPITests: SwiftSyncTestCase {
                                line: UInt = #line) {
         let ex = expectation(description: "Looking for permission")
         var isPresent = false
-        let token = results.addNotificationBlock { (error) in
+        let token = results.addNotificationBlock { (_, _, error) in
             XCTAssertNil(error, "Notification returned error '\(error!)' when running test at \(file):\(line)")
             isPresent = results.contains(permission)
         }
@@ -176,7 +176,7 @@ class SwiftPermissionsAPITests: SwiftSyncTestCase {
 
         // Register notifications.
         let noteEx = expectation(description: "Notification should fire")
-        let token = results.addNotificationBlock { (error) in
+        let token = results.addNotificationBlock { (_, _, error) in
             XCTAssertNil(error)
             if results.count > 0 {
                 noteEx.fulfill()

--- a/Realm/RLMSyncPermissionResults.h
+++ b/Realm/RLMSyncPermissionResults.h
@@ -80,7 +80,7 @@ typedef NS_ENUM(NSUInteger, RLMSyncPermissionResultsSortProperty) {
  are desired. Call `-stop` on the token to stop notifications, and before
  deallocating the token.
  */
-- (RLMNotificationToken *)addNotificationBlock:(RLMPermissionStatusBlock)block;
+- (RLMNotificationToken *)addNotificationBlock:(RLMPermissionResultsNotificationBlock)block;
 
 #pragma mark - Queries
 

--- a/Realm/RLMSyncUser.h
+++ b/Realm/RLMSyncUser.h
@@ -18,7 +18,7 @@
 
 #import <Foundation/Foundation.h>
 
-@class RLMSyncUser, RLMSyncCredentials, RLMSyncPermissionValue, RLMSyncPermissionResults, RLMSyncSession, RLMRealm;
+@class RLMCollectionChange, RLMSyncUser, RLMSyncCredentials, RLMSyncPermissionValue, RLMSyncPermissionResults, RLMSyncSession, RLMRealm;
 
 /**
  The state of the user object.
@@ -42,6 +42,11 @@ typedef void(^RLMPasswordChangeStatusBlock)(NSError * _Nullable);
 /// A block type used to report the status of a permission apply or revoke operation.
 /// If the `NSError` argument is nil, the operation succeeded.
 typedef void(^RLMPermissionStatusBlock)(NSError * _Nullable);
+
+/// A block type used to report changes made to a permission results collection.
+/// This block will always pass back either the `RLMSyncPermissionResults` object
+/// and a `RLMCollectionChange` describing the changes, or an `NSError` otherwise.
+typedef void(^RLMPermissionResultsNotificationBlock)(RLMSyncPermissionResults * _Nullable, RLMCollectionChange * _Nullable, NSError * _Nullable);
 
 /// A block type used to asynchronously report results of a permissions get operation.
 /// Exactly one of the two arguments will be populated.

--- a/Realm/RLMSyncUser_Private.hpp
+++ b/Realm/RLMSyncUser_Private.hpp
@@ -63,6 +63,7 @@ private:
 
 using PermissionChangeCallback = std::function<void(std::exception_ptr)>;
 
+NSError *RLMTranslatePermissionExceptionPtrToError(std::exception_ptr ptr, bool get);
 PermissionChangeCallback RLMWrapPermissionStatusCallback(RLMPermissionStatusBlock callback);
 
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION
…collection notifications

Breaking change.
Requires https://github.com/realm/realm-object-store/pull/483
Fixes https://github.com/realm/realm-cocoa/issues/5076

Not sure yet how to test this. None of our existing permissions tests rely on the ordering of permissions or how they're inserted into the collection, and the underlying APIs make no guarantees about this.