### PR TITLE
Refine `SyncPermissionResults` APIs to match other Realm collections

### DIFF
--- a/Realm/ObjectServerTests/SwiftPermissionsAPITests.swift
+++ b/Realm/ObjectServerTests/SwiftPermissionsAPITests.swift
@@ -151,9 +151,9 @@ class SwiftPermissionsAPITests: SwiftSyncTestCase {
         XCTAssertNotNil(finalValue, "Did not find the permission \(expectedPermission)")
 
         // Check getting permission by its index.
-        let index = results.index(ofObject: expectedPermission)
-        XCTAssertNotEqual(index, NSNotFound)
-        XCTAssertTrue(expectedPermission == results.object(at: index))
+        let index = results.index(of: expectedPermission)
+        XCTAssertNotNil(index)
+        XCTAssertTrue(expectedPermission == results[index!])
     }
 
     /// Observing permission changes should work.

--- a/Realm/RLMSyncPermissionResults.h
+++ b/Realm/RLMSyncPermissionResults.h
@@ -65,13 +65,13 @@ typedef NS_ENUM(NSUInteger, RLMSyncPermissionResultsSortProperty) {
  Retrieve the permission value at the given index. Throws an exception if the index
  is out of bounds.
  */
-- (RLMSyncPermissionValue *)objectAtIndex:(NSInteger)index;
+- (RLMSyncPermissionValue *)objectAtIndex:(NSInteger)index NS_REFINED_FOR_SWIFT;
 
 /**
  Returns the index of the permission in the collection, or `NSNotFound` if the permission
  is not found in the collection.
  */
-- (NSInteger)indexOfObject:(RLMSyncPermissionValue *)object;
+- (NSInteger)indexOfObject:(RLMSyncPermissionValue *)object NS_REFINED_FOR_SWIFT;
 
 /**
  Register to be notified when the contents of the results object change.
@@ -90,14 +90,14 @@ typedef NS_ENUM(NSUInteger, RLMSyncPermissionResultsSortProperty) {
  @note Valid properties to filter on are `path` and `userId`, as well as
        the boolean properties `mayRead`, `mayWrite`, and `mayManage`.
  */
-- (RLMSyncPermissionResults *)objectsWithPredicate:(NSPredicate *)predicate;
+- (RLMSyncPermissionResults *)objectsWithPredicate:(NSPredicate *)predicate NS_REFINED_FOR_SWIFT;
 
 /**
  Return a sorted `RLMSyncPermissionResults` from the collection, sorted based on
  the given property.
  */
 - (RLMSyncPermissionResults *)sortedResultsUsingProperty:(RLMSyncPermissionResultsSortProperty)property
-                                               ascending:(BOOL)ascending;
+                                               ascending:(BOOL)ascending NS_REFINED_FOR_SWIFT;
 
 #pragma mark - Misc
 

--- a/RealmSwift/Sync.swift
+++ b/RealmSwift/Sync.swift
@@ -336,12 +336,50 @@ public typealias SyncAccessLevel = RLMSyncAccessLevel
  */
 public typealias SyncPermissionResults = RLMSyncPermissionResults
 
-#if swift(>=3.1)
-extension SyncPermissionResults: RandomAccessCollection {
-    public subscript(index: Int) -> SyncPermissionValue {
-        return object(at: index)
+// Refined APIs for Swift
+extension SyncPermissionResults {
+    /**
+     An enum describing any of the properties that a permission results
+     can be sorted on.
+     */
+    public typealias SortProperty = RLMSyncPermissionResultsSortProperty
+
+    /**
+     Return the permission value at the given position in the collection.
+     */
+    public subscript(position: Int) -> SyncPermissionValue {
+        throwForNegativeIndex(position)
+        return __object(at: position)
     }
 
+    /**
+     Return the index of the given permission value in the collection, or
+     nil if the collection contains no such permission value.
+     */
+    public func index(of object: SyncPermissionValue) -> Int? {
+        let idx = __index(ofObject: object)
+        return (idx == NSNotFound) ? nil : idx
+    }
+
+    /**
+     Return a new `SyncPermissionResults` consisting of the receiver after
+     it has been filtered according to the given predicate.
+     */
+    public func filter(_ predicate: NSPredicate) -> SyncPermissionResults {
+        return __objects(with: predicate)
+    }
+
+    /**
+     Return a new `SyncPermissionResults` consisting of the receiver after
+     it has been sorted according to the given sortable property.
+     */
+    public func sorted(by property: SortProperty, ascending: Bool = true) -> SyncPermissionResults {
+        return __sortedResults(using: property, ascending: ascending)
+    }
+}
+
+#if swift(>=3.1)
+extension SyncPermissionResults: RandomAccessCollection {
     public func index(after i: Int) -> Int {
         return i + 1
     }

--- a/RealmSwift/Sync.swift
+++ b/RealmSwift/Sync.swift
@@ -397,13 +397,13 @@ extension SyncPermissionResults {
     /// Return the first permission value in the results, or `nil` if
     /// the results are empty.
     public var first: SyncPermissionValue? {
-        return count > 0 ? object(at: 0) : nil
+        return count > 0 ? self[0] : nil
     }
 
     /// Return the last permission value in the results, or `nil` if
     /// the results are empty.
     public var last: SyncPermissionValue? {
-        return count > 0 ? object(at: count - 1) : nil
+        return count > 0 ? self[count - 1] : nil
     }
 }
 


### PR DESCRIPTION
Fixes #5075 
Breaking change

TODO:
- [ ] Any affordances needed for migration? This feature has only been around for a short while, and it's not clear whether there exists a way to provide a fixit for a non-refined API that becomes refined for Swift.