### PR TITLE
Remove non-sync APIs marked `deprecated` and `unavailable`

### DIFF
--- a/Realm/RLMArray.h
+++ b/Realm/RLMArray.h
@@ -272,17 +272,6 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Returns a sorted `RLMResults` from the array.
 
- @param property    The property name to sort by.
- @param ascending   The direction to sort in.
-
- @return    An `RLMResults` sorted by the specified property.
- */
-- (RLMResults<RLMObjectType> *)sortedResultsUsingProperty:(NSString *)property ascending:(BOOL)ascending
-    __deprecated_msg("Use `-sortedResultsUsingKeyPath:ascending:`");
-
-/**
- Returns a sorted `RLMResults` from the array.
-
  @param properties  An array of `RLMSortDescriptor`s to sort by.
 
  @return    An `RLMResults` sorted by the specified properties.

--- a/Realm/RLMArray.mm
+++ b/Realm/RLMArray.mm
@@ -433,11 +433,6 @@ static void RLMValidateArrayBounds(__unsafe_unretained RLMArray *const ar,
     return [self sortedResultsUsingDescriptors:@[[RLMSortDescriptor sortDescriptorWithKeyPath:keyPath ascending:ascending]]];
 }
 
-- (RLMResults *)sortedResultsUsingProperty:(NSString *)property ascending:(BOOL)ascending
-{
-    return [self sortedResultsUsingKeyPath:property ascending:ascending];
-}
-
 - (RLMResults *)sortedResultsUsingDescriptors:(NSArray<RLMSortDescriptor *> *)properties
 {
     @throw RLMException(@"This method may only be called on RLMArray instances retrieved from an RLMRealm");
@@ -505,16 +500,8 @@ static void RLMValidateArrayBounds(__unsafe_unretained RLMArray *const ar,
     return desc;
 }
 
-+ (instancetype)sortDescriptorWithProperty:(NSString *)propertyName ascending:(BOOL)ascending {
-    return [RLMSortDescriptor sortDescriptorWithKeyPath:propertyName ascending:ascending];
-}
-
 - (instancetype)reversedSortDescriptor {
     return [self.class sortDescriptorWithKeyPath:_keyPath ascending:!_ascending];
-}
-
-- (NSString *)property {
-    return _keyPath;
 }
 
 @end

--- a/Realm/RLMCollection.h
+++ b/Realm/RLMCollection.h
@@ -144,17 +144,6 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Returns a sorted `RLMResults` from the collection.
 
- @param property    The property name to sort by.
- @param ascending   The direction to sort in.
-
- @return    An `RLMResults` sorted by the specified property.
- */
-- (RLMResults *)sortedResultsUsingProperty:(NSString *)property ascending:(BOOL)ascending
-    __deprecated_msg("Use `-sortedResultsUsingKeyPath:ascending:`");
-
-/**
- Returns a sorted `RLMResults` from the collection.
-
  @param properties  An array of `RLMSortDescriptor`s to sort by.
 
  @return    An `RLMResults` sorted by the specified properties.
@@ -341,19 +330,6 @@ NS_ASSUME_NONNULL_BEGIN
  Returns a copy of the receiver with the sort direction reversed.
  */
 - (instancetype)reversedSortDescriptor;
-
-#pragma mark - Deprecated
-
-/**
- The name of the property which the sort descriptor orders results by.
- */
-@property (nonatomic, readonly) NSString *property __deprecated_msg("Use `-keyPath`");
-
-/**
- Returns a new sort descriptor for the given property name and sort direction.
- */
-+ (instancetype)sortDescriptorWithProperty:(NSString *)propertyName ascending:(BOOL)ascending
-    __deprecated_msg("Use `+sortDescriptorWithKeyPath:ascending:`");
 
 @end
 

--- a/Realm/RLMRealm.h
+++ b/Realm/RLMRealm.h
@@ -598,21 +598,6 @@ NS_REFINED_FOR_SWIFT;
 
  @see                 RLMMigration
  */
-+ (nullable NSError *)migrateRealm:(RLMRealmConfiguration *)configuration
-__deprecated_msg("Use `performMigrationForConfiguration:error:`") NS_REFINED_FOR_SWIFT;
-
-/**
- Performs the given Realm configuration's migration block on a Realm at the given path.
-
- This method is called automatically when opening a Realm for the first time and does
- not need to be called explicitly. You can choose to call this method to control
- exactly when and how migrations are performed.
-
- @param configuration The Realm configuration used to open and migrate the Realm.
- @return              The error that occurred while applying the migration, if any.
-
- @see                 RLMMigration
- */
 + (BOOL)performMigrationForConfiguration:(RLMRealmConfiguration *)configuration error:(NSError **)error;
 
 #pragma mark - Unavailable Methods

--- a/Realm/RLMRealm.mm
+++ b/Realm/RLMRealm.mm
@@ -767,13 +767,6 @@ REALM_NOINLINE void RLMRealmTranslateException(NSError **error) {
     }
 }
 
-+ (nullable NSError *)migrateRealm:(RLMRealmConfiguration *)configuration {
-    // Preserves backwards compatibility
-    NSError *error;
-    [self performMigrationForConfiguration:configuration error:&error];
-    return error;
-}
-
 + (BOOL)performMigrationForConfiguration:(RLMRealmConfiguration *)configuration error:(NSError **)error {
     if (RLMGetAnyCachedRealmForPath(configuration.config.path)) {
         @throw RLMException(@"Cannot migrate Realms that are already open.");

--- a/Realm/RLMResults.h
+++ b/Realm/RLMResults.h
@@ -170,17 +170,6 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Returns a sorted `RLMResults` from an existing results collection.
 
- @param property    The property name to sort by.
- @param ascending   The direction to sort in.
-
- @return    An `RLMResults` sorted by the specified property.
- */
-- (RLMResults<RLMObjectType> *)sortedResultsUsingProperty:(NSString *)property ascending:(BOOL)ascending
-    __deprecated_msg("Use `-sortedResultsUsingKeyPath:ascending:`");
-
-/**
- Returns a sorted `RLMResults` from an existing results collection.
-
  @param properties  An array of `RLMSortDescriptor`s to sort by.
 
  @return    An `RLMResults` sorted by the specified properties.

--- a/Realm/RLMResults.mm
+++ b/Realm/RLMResults.mm
@@ -343,10 +343,6 @@ static inline void RLMResultsValidateInWriteTransaction(__unsafe_unretained RLMR
     return [self sortedResultsUsingDescriptors:@[[RLMSortDescriptor sortDescriptorWithKeyPath:keyPath ascending:ascending]]];
 }
 
-- (RLMResults *)sortedResultsUsingProperty:(NSString *)property ascending:(BOOL)ascending {
-    return [self sortedResultsUsingKeyPath:property ascending:ascending];
-}
-
 - (RLMResults *)sortedResultsUsingDescriptors:(NSArray<RLMSortDescriptor *> *)properties {
     if (properties.count == 0) {
         return self;

--- a/RealmSwift/LinkingObjects.swift
+++ b/RealmSwift/LinkingObjects.swift
@@ -234,24 +234,6 @@ public final class LinkingObjects<T: Object>: LinkingObjectsBase {
     /**
      Returns a `Results` containing all the linking objects, but sorted.
 
-     Objects are sorted based on the values of the given property. For example, to sort a collection of `Student`s from
-     youngest to oldest based on their `age` property, you might call
-     `students.sorted(byProperty: "age", ascending: true)`.
-
-     - warning: Collections may only be sorted by properties of boolean, `Date`, `NSDate`, single and double-precision
-                floating point, integer, and string types.
-
-     - parameter property:  The name of the property to sort by.
-     - parameter ascending: The direction to sort in.
-     */
-    @available(*, deprecated, renamed: "sorted(byKeyPath:ascending:)")
-    public func sorted(byProperty property: String, ascending: Bool = true) -> Results<T> {
-        return sorted(byKeyPath: property, ascending: ascending)
-    }
-
-    /**
-     Returns a `Results` containing all the linking objects, but sorted.
-
      - warning: Collections may only be sorted by properties of boolean, `Date`, `NSDate`, single and double-precision
                 floating point, integer, and string types.
 
@@ -458,32 +440,6 @@ internal enum LinkingObjectsBridgingMetadata {
 // MARK: Unavailable
 
 extension LinkingObjects {
-    @available(*, unavailable, renamed: "isInvalidated")
-    public var invalidated: Bool { fatalError() }
-
-    @available(*, unavailable, renamed: "index(matching:)")
-    public func index(of predicate: NSPredicate) -> Int? { fatalError() }
-
-    @available(*, unavailable, renamed: "index(matching:_:)")
-    public func index(of predicateFormat: String, _ args: Any...) -> Int? { fatalError() }
-
     @available(*, unavailable, renamed: "sorted(byKeyPath:ascending:)")
-    public func sorted(_ property: String, ascending: Bool = true) -> Results<T> { fatalError() }
-
-    @available(*, unavailable, renamed: "sorted(by:)")
-    public func sorted<S: Sequence>(_ sortDescriptors: S) -> Results<T> where S.Iterator.Element == SortDescriptor {
-        fatalError()
-    }
-
-    @available(*, unavailable, renamed: "min(ofProperty:)")
-    public func min<U: MinMaxType>(_ property: String) -> U? { fatalError() }
-
-    @available(*, unavailable, renamed: "max(ofProperty:)")
-    public func max<U: MinMaxType>(_ property: String) -> U? { fatalError() }
-
-    @available(*, unavailable, renamed: "sum(ofProperty:)")
-    public func sum<U: AddableType>(_ property: String) -> U { fatalError() }
-
-    @available(*, unavailable, renamed: "average(ofProperty:)")
-    public func average<U: AddableType>(_ property: String) -> U? { fatalError() }
+    public func sorted(byProperty property: String, ascending: Bool = true) -> Results<T> { fatalError() }
 }

--- a/RealmSwift/List.swift
+++ b/RealmSwift/List.swift
@@ -206,24 +206,6 @@ public final class List<T: Object>: ListBase {
     /**
      Returns a `Results` containing the objects in the list, but sorted.
 
-     Objects are sorted based on the values of the given property. For example, to sort a list of `Student`s from
-     youngest to oldest based on their `age` property, you might call
-     `students.sorted(byProperty: "age", ascending: true)`.
-
-     - warning: Lists may only be sorted by properties of boolean, `Date`, `NSDate`, single and double-precision
-                floating point, integer, and string types.
-
-     - parameter property:  The name of the property to sort by.
-     - parameter ascending: The direction to sort in.
-     */
-    @available(*, deprecated, renamed: "sorted(byKeyPath:ascending:)")
-    public func sorted(byProperty property: String, ascending: Bool = true) -> Results<T> {
-        return sorted(byKeyPath: property, ascending: ascending)
-    }
-
-    /**
-     Returns a `Results` containing the objects in the list, but sorted.
-
      - warning: Lists may only be sorted by properties of boolean, `Date`, `NSDate`, single and double-precision
                 floating point, integer, and string types.
 
@@ -546,38 +528,6 @@ extension List: AssistedObjectiveCBridgeable {
 // MARK: Unavailable
 
 extension List {
-    @available(*, unavailable, renamed: "append(objectsIn:)")
-    public func appendContentsOf<S: Sequence>(_ objects: S) where S.Iterator.Element == T { fatalError() }
-
-    @available(*, unavailable, renamed: "remove(objectAtIndex:)")
-    public func remove(at index: Int) { fatalError() }
-
-    @available(*, unavailable, renamed: "isInvalidated")
-    public var invalidated: Bool { fatalError() }
-
-    @available(*, unavailable, renamed: "index(matching:)")
-    public func index(of predicate: NSPredicate) -> Int? { fatalError() }
-
-    @available(*, unavailable, renamed: "index(matching:_:)")
-    public func index(of predicateFormat: String, _ args: Any...) -> Int? { fatalError() }
-
     @available(*, unavailable, renamed: "sorted(byKeyPath:ascending:)")
-    public func sorted(_ property: String, ascending: Bool = true) -> Results<T> { fatalError() }
-
-    @available(*, unavailable, renamed: "sorted(by:)")
-    public func sorted<S: Sequence>(_ sortDescriptors: S) -> Results<T> where S.Iterator.Element == SortDescriptor {
-        fatalError()
-    }
-
-    @available(*, unavailable, renamed: "min(ofProperty:)")
-    public func min<U: MinMaxType>(_ property: String) -> U? { fatalError() }
-
-    @available(*, unavailable, renamed: "max(ofProperty:)")
-    public func max<U: MinMaxType>(_ property: String) -> U? { fatalError() }
-
-    @available(*, unavailable, renamed: "sum(ofProperty:)")
-    public func sum<U: AddableType>(_ property: String) -> U { fatalError() }
-
-    @available(*, unavailable, renamed: "average(ofProperty:)")
-    public func average<U: AddableType>(_ property: String) -> U? { fatalError() }
+    public func sorted(byProperty property: String, ascending: Bool = true) -> Results<T> { fatalError() }
 }

--- a/RealmSwift/Migration.swift
+++ b/RealmSwift/Migration.swift
@@ -195,18 +195,3 @@ internal func accessorMigrationBlock(_ migrationBlock: @escaping MigrationBlock)
         migrationBlock(Migration(migration), oldVersion)
     }
 }
-
-// MARK: Unavailable
-
-extension Migration {
-    @available(*, unavailable, renamed: "enumerateObjects(ofType:_:)")
-    public func enumerate(_ objectClassName: String, _ block: MigrationObjectEnumerateBlock) { fatalError() }
-
-    @available(*, unavailable, renamed: "deleteData(forType:)")
-    public func deleteData(_ objectClassName: String) -> Bool {
-        fatalError()
-    }
-
-    @available(*, unavailable, renamed: "renameProperty(onType:from:to:)")
-    public func renamePropertyForClass(_ className: String, oldName: String, newName: String) { fatalError() }
-}

--- a/RealmSwift/Property.swift
+++ b/RealmSwift/Property.swift
@@ -67,13 +67,3 @@ extension Property: Equatable {
         return lhs.rlmProperty.isEqual(to: rhs.rlmProperty)
     }
 }
-
-// MARK: Unavailable
-
-extension Property {
-    @available(*, unavailable, renamed: "isIndexed")
-    public var indexed: Bool { fatalError() }
-
-    @available(*, unavailable, renamed: "isOptional")
-    public var optional: Bool { fatalError() }
-}

--- a/RealmSwift/Realm.swift
+++ b/RealmSwift/Realm.swift
@@ -709,21 +709,3 @@ extension Realm {
 
 /// The type of a block to run for notification purposes when the data in a Realm is modified.
 public typealias NotificationBlock = (_ notification: Realm.Notification, _ realm: Realm) -> Void
-
-
-// MARK: Unavailable
-
-extension Realm {
-
-    @available(*, unavailable, renamed: "isInWriteTransaction")
-    public var inWriteTransaction: Bool { fatalError() }
-
-    @available(*, unavailable, renamed: "object(ofType:forPrimaryKey:)")
-    public func objectForPrimaryKey<T: Object>(_ type: T.Type, key: AnyObject) -> T? { fatalError() }
-
-    @available(*, unavailable, renamed: "dynamicObject(ofType:forPrimaryKey:)")
-    public func dynamicObjectForPrimaryKey(_ className: String, key: AnyObject) -> DynamicObject? { fatalError() }
-
-    @available(*, unavailable, renamed: "writeCopy(toFile:encryptionKey:)")
-    public func writeCopyToURL(_ fileURL: NSURL, encryptionKey: Data? = nil) throws { fatalError() }
-}

--- a/RealmSwift/RealmCollection.swift
+++ b/RealmSwift/RealmCollection.swift
@@ -221,22 +221,6 @@ public protocol RealmCollection: RealmCollectionBase {
     /**
      Returns a `Results` containing the objects in the collection, but sorted.
 
-     Objects are sorted based on the values of the given property. For example, to sort a collection of `Student`s from
-     youngest to oldest based on their `age` property, you might call
-     `students.sorted(byProperty: "age", ascending: true)`.
-
-     - warning: Collections may only be sorted by properties of boolean, `Date`, `NSDate`, single and double-precision
-                floating point, integer, and string types.
-
-     - parameter property:  The name of the property to sort by.
-     - parameter ascending: The direction to sort in.
-     */
-    @available(*, deprecated, renamed: "sorted(byKeyPath:ascending:)")
-    func sorted(byProperty property: String, ascending: Bool) -> Results<Element>
-
-    /**
-     Returns a `Results` containing the objects in the collection, but sorted.
-
      - warning: Collections may only be sorted by properties of boolean, `Date`, `NSDate`, single and double-precision
                 floating point, integer, and string types.
 
@@ -639,24 +623,6 @@ public final class AnyRealmCollection<T: Object>: RealmCollection {
     /**
      Returns a `Results` containing the objects in the collection, but sorted.
 
-     Objects are sorted based on the values of the given property. For example, to sort a collection of `Student`s from
-     youngest to oldest based on their `age` property, you might call
-     `students.sorted(byProperty: "age", ascending: true)`.
-
-     - warning:  Collections may only be sorted by properties of boolean, `Date`, `NSDate`, single and double-precision
-                 floating point, integer, and string types.
-
-     - parameter property:  The name of the property to sort by.
-     - parameter ascending: The direction to sort in.
-     */
-    @available(*, deprecated, renamed: "sorted(byKeyPath:ascending:)")
-    public func sorted(byProperty property: String, ascending: Bool) -> Results<Element> {
-        return sorted(byKeyPath: property, ascending: ascending)
-    }
-
-    /**
-     Returns a `Results` containing the objects in the collection, but sorted.
-
      - warning:  Collections may only be sorted by properties of boolean, `Date`, `NSDate`, single and double-precision
                  floating point, integer, and string types.
 
@@ -858,32 +824,6 @@ extension AnyRealmCollection: AssistedObjectiveCBridgeable {
 // MARK: Unavailable
 
 extension AnyRealmCollection {
-    @available(*, unavailable, renamed: "isInvalidated")
-    public var invalidated: Bool { fatalError() }
-
-    @available(*, unavailable, renamed: "index(matching:)")
-    public func index(of predicate: NSPredicate) -> Int? { fatalError() }
-
-    @available(*, unavailable, renamed: "index(matching:_:)")
-    public func index(of predicateFormat: String, _ args: AnyObject...) -> Int? { fatalError() }
-
     @available(*, unavailable, renamed: "sorted(byKeyPath:ascending:)")
-    public func sorted(_ property: String, ascending: Bool = true) -> Results<T> { fatalError() }
-
-    @available(*, unavailable, renamed: "sorted(by:)")
-    public func sorted<S: Sequence>(_ sortDescriptors: S) -> Results<T> where S.Iterator.Element == SortDescriptor {
-        fatalError()
-    }
-
-    @available(*, unavailable, renamed: "min(ofProperty:)")
-    public func min<U: MinMaxType>(_ property: String) -> U? { fatalError() }
-
-    @available(*, unavailable, renamed: "max(ofProperty:)")
-    public func max<U: MinMaxType>(_ property: String) -> U? { fatalError() }
-
-    @available(*, unavailable, renamed: "sum(ofProperty:)")
-    public func sum<U: AddableType>(_ property: String) -> U { fatalError() }
-
-    @available(*, unavailable, renamed: "average(ofProperty:)")
-    public func average<U: AddableType>(_ property: String) -> U? { fatalError() }
+    func sorted(byProperty property: String, ascending: Bool) -> Results<Element> { fatalError() }
 }

--- a/RealmSwift/Results.swift
+++ b/RealmSwift/Results.swift
@@ -239,24 +239,6 @@ public final class Results<T: Object>: NSObject, NSFastEnumeration {
     /**
      Returns a `Results` containing the objects represented by the results, but sorted.
 
-     Objects are sorted based on the values of the given property. For example, to sort a collection of `Student`s from
-     youngest to oldest based on their `age` property, you might call
-     `students.sorted(byProperty: "age", ascending: true)`.
-
-     - warning: Collections may only be sorted by properties of boolean, `Date`, `NSDate`, single and double-precision
-                floating point, integer, and string types.
-
-     - parameter property:  The name of the property to sort by.
-     - parameter ascending: The direction to sort in.
-     */
-    @available(*, deprecated, renamed: "sorted(byKeyPath:ascending:)")
-    public func sorted(byProperty property: String, ascending: Bool = true) -> Results<T> {
-        return sorted(byKeyPath: property, ascending: ascending)
-    }
-
-    /**
-     Returns a `Results` containing the objects represented by the results, but sorted.
-
      - warning: Collections may only be sorted by properties of boolean, `Date`, `NSDate`, single and double-precision
                 floating point, integer, and string types.
 
@@ -425,32 +407,6 @@ extension Results: AssistedObjectiveCBridgeable {
 // MARK: Unavailable
 
 extension Results {
-    @available(*, unavailable, renamed: "isInvalidated")
-    public var invalidated: Bool { fatalError() }
-
-    @available(*, unavailable, renamed: "index(matching:)")
-    public func index(of predicate: NSPredicate) -> Int? { fatalError() }
-
-    @available(*, unavailable, renamed: "index(matching:_:)")
-    public func index(of predicateFormat: String, _ args: AnyObject...) -> Int? { fatalError() }
-
     @available(*, unavailable, renamed: "sorted(byKeyPath:ascending:)")
-    public func sorted(_ property: String, ascending: Bool = true) -> Results<T> { fatalError() }
-
-    @available(*, unavailable, renamed: "sorted(by:)")
-    public func sorted<S: Sequence>(_ sortDescriptors: S) -> Results<T> where S.Iterator.Element == SortDescriptor {
-        fatalError()
-    }
-
-    @available(*, unavailable, renamed: "min(ofProperty:)")
-    public func min<U: MinMaxType>(_ property: String) -> U? { fatalError() }
-
-    @available(*, unavailable, renamed: "max(ofProperty:)")
-    public func max<U: MinMaxType>(_ property: String) -> U? { fatalError() }
-
-    @available(*, unavailable, renamed: "sum(ofProperty:)")
-    public func sum<U: AddableType>(_ property: String) -> U { fatalError() }
-
-    @available(*, unavailable, renamed: "average(ofProperty:)")
-    public func average<U: AddableType>(_ property: String) -> U? { fatalError() }
+    public func sorted(byProperty property: String, ascending: Bool = true) -> Results<T> { fatalError() }
 }

--- a/RealmSwift/SortDescriptor.swift
+++ b/RealmSwift/SortDescriptor.swift
@@ -51,27 +51,12 @@ public struct SortDescriptor {
         self.ascending = ascending
     }
 
-    /**
-     Creates a sort descriptor with the given property and sort order values.
-
-     - parameter property:  The property which the sort descriptor orders results by.
-     - parameter ascending: Whether the descriptor sorts in ascending or descending order.
-     */
-    @available(*, deprecated, renamed: "init(keyPath:ascending:)")
-    public init(property: String, ascending: Bool = true) {
-        self.init(keyPath: property, ascending: ascending)
-    }
-
     // MARK: Functions
 
     /// Returns a copy of the sort descriptor with the sort order reversed.
     public func reversed() -> SortDescriptor {
         return SortDescriptor(keyPath: keyPath, ascending: !ascending)
     }
-
-    /// The key path which the sort descriptor orders results by.
-    @available(*, deprecated, renamed: "keyPath")
-    public var property: String { return keyPath }
 }
 
 // MARK: CustomStringConvertible
@@ -127,4 +112,14 @@ extension SortDescriptor: ExpressibleByStringLiteral {
     public init(stringLiteral value: StringLiteralType) {
         self.init(keyPath: value)
     }
+}
+
+// MARK: Unavailable
+
+extension SortDescriptor {
+    @available(*, unavailable, renamed: "init(keyPath:ascending:)")
+    public init(property: String, ascending: Bool = true) { fatalError() }
+
+    @available(*, unavailable, renamed: "keyPath")
+    public var property: String { fatalError() }
 }


### PR DESCRIPTION
TODO:
- [x] Some of the deprecated Swift APIs removed in this commit should be brought back but marked `unavailable`