### PR TITLE
fix Swift 4 compilation error with Xcode 9 beta 3

### DIFF
--- a/RealmSwift/RealmConfiguration.swift
+++ b/RealmSwift/RealmConfiguration.swift
@@ -223,7 +223,11 @@ extension Realm {
             configuration.schemaVersion = self.schemaVersion
             configuration.migrationBlock = self.migrationBlock.map { accessorMigrationBlock($0) }
             configuration.deleteRealmIfMigrationNeeded = self.deleteRealmIfMigrationNeeded
-            configuration.shouldCompactOnLaunch = self.shouldCompactOnLaunch.map(ObjectiveCSupport.convert)
+            if let shouldCompactOnLaunch = self.shouldCompactOnLaunch {
+                configuration.shouldCompactOnLaunch = ObjectiveCSupport.convert(object: shouldCompactOnLaunch)
+            } else {
+                configuration.shouldCompactOnLaunch = nil
+            }
             configuration.customSchema = self.customSchema
             configuration.disableFormatUpgrade = self.disableFormatUpgrade
             return configuration


### PR DESCRIPTION
*Actually* addresses #5105. Turns out I only addressed Xcode 9b3 warnings with `SWIFT_VERSION` set to `3.0`.

When changing its value in `Base.xcconfig` to `4.0`, I could reproduce the same error reported in #5105. This fixes it.

```
RealmSwift/RealmConfiguration.swift:226:78: generic parameter 'U' could not be inferred

  configuration.shouldCompactOnLaunch = self.shouldCompactOnLaunch.map(ObjectiveCSupport.convert)
                                                                   ^
```