### PR TITLE
don't test "compact on launch" if the Realm is open on another thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ x.x.x Release notes (yyyy-MM-dd)
 
 ### Bugfixes
 
-* None.
+* The `shouldCompactOnLaunch` block is no longer invoked if the Realm at that
+  path is already open on other threads.
 
 2.9.0 Release notes (2017-07-26)
 =============================================================


### PR DESCRIPTION
Fixes #5010. Depends on realm/realm-object-store#496.