### PR TITLE
Fix self-assignment of RLMArray properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ x.x.x Release notes (yyyy-MM-dd)
 * `List.description` now reports the correct types for nested lists.
 * Fix unmanaged object initialization when a nested property type returned
   `false` from `Object.shouldIncludeInDefaultSchema()`.
+* Don't clear RLMArrays on self-assignment.
 
 2.8.3 Release notes (2017-06-20)
 =============================================================

--- a/Realm/RLMAccessor.mm
+++ b/Realm/RLMAccessor.mm
@@ -133,10 +133,14 @@ RLMArray *getArray(__unsafe_unretained RLMObjectBase *const obj, NSUInteger colI
 }
 
 void setValue(__unsafe_unretained RLMObjectBase *const obj, NSUInteger colIndex,
-                     __unsafe_unretained id<NSFastEnumeration> const value) {
+              __unsafe_unretained id<NSFastEnumeration> const value) {
     RLMVerifyInWriteTransaction(obj);
 
     realm::List list(obj->_realm->_realm, obj->_row.get_linklist(colIndex));
+    if ([(id)value respondsToSelector:@selector(isBackedByList:)] && [(id)value isBackedByList:list]) {
+        return; // self-assignment is a no-op
+    }
+
     list.remove_all();
     if (!value || (id)value == NSNull.null) {
         return;

--- a/Realm/RLMArrayLinkView.mm
+++ b/Realm/RLMArrayLinkView.mm
@@ -206,11 +206,13 @@ static void changeArray(__unsafe_unretained RLMArrayLinkView *const ar, NSKeyVal
     return _objectInfo;
 }
 
+
+- (bool)isBackedByList:(realm::List const&)list {
+    return _backingList == list;
+}
+
 - (BOOL)isEqual:(id)object {
-    if (RLMArrayLinkView *linkView = RLMDynamicCast<RLMArrayLinkView>(object)) {
-        return linkView->_backingList == _backingList;
-    }
-    return NO;
+    return [object respondsToSelector:@selector(isBackedByList:)] && [object isBackedByList:_backingList];
 }
 
 - (NSUInteger)hash {

--- a/Realm/RLMArray_Private.hpp
+++ b/Realm/RLMArray_Private.hpp
@@ -52,6 +52,8 @@ class RLMObservationInfo;
                         parentInfo:(RLMClassInfo *)parentInfo
                           property:(__unsafe_unretained RLMProperty *const)property;
 
+- (bool)isBackedByList:(realm::List const&)list;
+
 // deletes all objects in the RLMArray from their containing realms
 - (void)deleteObjectsFromRealm;
 @end


### PR DESCRIPTION
Assigning an RLMArray to itself was clearing the array.