### PR TITLE
disable update checker on master-3.0 branch

### DIFF
--- a/Realm/RLMUpdateChecker.mm
+++ b/Realm/RLMUpdateChecker.mm
@@ -26,8 +26,20 @@
 #endif
 
 void RLMCheckForUpdates() {
-#if 0
+#if TARGET_IPHONE_SIMULATOR
     if (getenv("REALM_DISABLE_UPDATE_CHECKER") || RLMIsRunningInPlayground()) {
+        return;
+    }
+
+    NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:@"alpha|beta|rc"
+                                                                           options:(NSRegularExpressionOptions)0
+                                                                             error:nil];
+    NSUInteger numberOfMatches = [regex numberOfMatchesInString:REALM_COCOA_VERSION
+                                                        options:(NSMatchingOptions)0
+                                                          range:NSMakeRange(0, REALM_COCOA_VERSION.length)];
+
+    if (numberOfMatches > 0) {
+        // pre-release version, skip update checking
         return;
     }
 

--- a/Realm/RLMUpdateChecker.mm
+++ b/Realm/RLMUpdateChecker.mm
@@ -26,7 +26,7 @@
 #endif
 
 void RLMCheckForUpdates() {
-#if TARGET_IPHONE_SIMULATOR
+#if 0
     if (getenv("REALM_DISABLE_UPDATE_CHECKER") || RLMIsRunningInPlayground()) {
         return;
     }


### PR DESCRIPTION
since we won't be updating the contents of `static.realm.io/update/cocoa` with 3.0 pre-releases, and we don't want to constantly prompt users of those pre-releases for updates.