### PR TITLE
point podspec documentation URL to '/latest'

### DIFF
--- a/Realm.podspec
+++ b/Realm.podspec
@@ -13,7 +13,8 @@ Pod::Spec.new do |s|
   s.library                 = 'c++', 'z'
   s.requires_arc            = true
   s.social_media_url        = 'https://twitter.com/realm'
-  s.documentation_url       = "https://realm.io/docs/objc/latest"
+  has_versioned_docs        = !(s.version =~ /alpha|beta|rc/)
+  s.documentation_url       = "https://realm.io/docs/objc/#{has_versioned_docs ? s.version : 'latest'}"
   s.license                 = { :type => 'Apache 2.0', :file => 'LICENSE' }
 
   public_header_files       = 'include/**/RLMArray.h',

--- a/Realm.podspec
+++ b/Realm.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.library                 = 'c++', 'z'
   s.requires_arc            = true
   s.social_media_url        = 'https://twitter.com/realm'
-  s.documentation_url       = "https://realm.io/docs/objc/#{s.version}"
+  s.documentation_url       = "https://realm.io/docs/objc/latest"
   s.license                 = { :type => 'Apache 2.0', :file => 'LICENSE' }
 
   public_header_files       = 'include/**/RLMArray.h',

--- a/RealmSwift.podspec
+++ b/RealmSwift.podspec
@@ -12,7 +12,8 @@ Pod::Spec.new do |s|
   s.author                    = { 'Realm' => 'help@realm.io' }
   s.requires_arc              = true
   s.social_media_url          = 'https://twitter.com/realm'
-  s.documentation_url         = "https://realm.io/docs/swift/latest"
+  has_versioned_docs          = !(s.version =~ /alpha|beta|rc/)
+  s.documentation_url         = "https://realm.io/docs/swift/#{has_versioned_docs ? s.version : 'latest'}"
   s.license                   = { :type => 'Apache 2.0', :file => 'LICENSE' }
 
   s.dependency 'Realm', "= #{s.version}"

--- a/RealmSwift.podspec
+++ b/RealmSwift.podspec
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.author                    = { 'Realm' => 'help@realm.io' }
   s.requires_arc              = true
   s.social_media_url          = 'https://twitter.com/realm'
-  s.documentation_url         = "https://realm.io/docs/swift/#{s.version}"
+  s.documentation_url         = "https://realm.io/docs/swift/latest"
   s.license                   = { :type => 'Apache 2.0', :file => 'LICENSE' }
 
   s.dependency 'Realm', "= #{s.version}"


### PR DESCRIPTION
since we're not publishing dedicated docs for 3.0 pre-releases. I did this manually for the release of `3.0.0-beta` a few minutes ago (https://github.com/CocoaPods/Specs/commit/350f917949eb80336f100bf37634fec6f159fab5 & https://github.com/CocoaPods/Specs/commit/a8526da512820edb459e2590b5d5b6039a30f381)