### PR TITLE
Extend the retry time to longer than `refreshBuffer`

### DIFF
--- a/Realm/RLMSyncSessionRefreshHandle.mm
+++ b/Realm/RLMSyncSessionRefreshHandle.mm
@@ -40,6 +40,8 @@ void unregisterRefreshHandle(const std::weak_ptr<SyncUser>& user, const std::str
 
 }
 
+static const NSTimeInterval RefreshBuffer = 10;
+
 @interface RLMSyncSessionRefreshHandle () {
     std::weak_ptr<SyncUser> _user;
     std::string _path;
@@ -91,8 +93,7 @@ void unregisterRefreshHandle(const std::weak_ptr<SyncUser>& user, const std::str
 }
 
 + (NSDate *)fireDateForTokenExpirationDate:(NSDate *)date nowDate:(NSDate *)nowDate {
-    static const NSTimeInterval refreshBuffer = 10;
-    NSDate *fireDate = [date dateByAddingTimeInterval:-refreshBuffer];
+    NSDate *fireDate = [date dateByAddingTimeInterval:-RefreshBuffer];
     // Only fire times in the future are valid.
     return ([fireDate compare:nowDate] == NSOrderedDescending ? fireDate : nil);
 }
@@ -190,7 +191,7 @@ void unregisterRefreshHandle(const std::weak_ptr<SyncUser>& user, const std::str
             case NSURLErrorDNSLookupFailed:
             case NSURLErrorCannotFindHost:
                 // FIXME: 10 seconds is an arbitrarily chosen value, consider rationalizing it.
-                nextTryDate = [NSDate dateWithTimeIntervalSinceNow:10];
+                nextTryDate = [NSDate dateWithTimeIntervalSinceNow:RefreshBuffer + 10];
                 break;
             default:
                 break;

--- a/Realm/RLMSyncSessionRefreshHandle.mm
+++ b/Realm/RLMSyncSessionRefreshHandle.mm
@@ -40,7 +40,7 @@ void unregisterRefreshHandle(const std::weak_ptr<SyncUser>& user, const std::str
 
 }
 
-static const NSTimeInterval RefreshBuffer = 10;
+static const NSTimeInterval RLMRefreshBuffer = 10;
 
 @interface RLMSyncSessionRefreshHandle () {
     std::weak_ptr<SyncUser> _user;
@@ -93,7 +93,7 @@ static const NSTimeInterval RefreshBuffer = 10;
 }
 
 + (NSDate *)fireDateForTokenExpirationDate:(NSDate *)date nowDate:(NSDate *)nowDate {
-    NSDate *fireDate = [date dateByAddingTimeInterval:-RefreshBuffer];
+    NSDate *fireDate = [date dateByAddingTimeInterval:-RLMRefreshBuffer];
     // Only fire times in the future are valid.
     return ([fireDate compare:nowDate] == NSOrderedDescending ? fireDate : nil);
 }
@@ -191,7 +191,7 @@ static const NSTimeInterval RefreshBuffer = 10;
             case NSURLErrorDNSLookupFailed:
             case NSURLErrorCannotFindHost:
                 // FIXME: 10 seconds is an arbitrarily chosen value, consider rationalizing it.
-                nextTryDate = [NSDate dateWithTimeIntervalSinceNow:RefreshBuffer + 10];
+                nextTryDate = [NSDate dateWithTimeIntervalSinceNow:RLMRefreshBuffer + 10];
                 break;
             default:
                 break;


### PR DESCRIPTION
Fixes https://github.com/realm/realm-cocoa/issues/5104

Fix an issue that reconnection does not happen if initial session binding fails.
If initial session binding fails, retry time will be offset by `refreshBuffer`. Retry will not be registered in the timer.  In that case, there is no session, no error handler will be called anymore, so reconnecting will not happen again.

Extend the retry time to longer than `refreshBuffer`.

CC: @austinzheng @bdash 