### PR TITLE
Make non-breaking changes to support arrays of primitives

### DIFF
--- a/Realm.xcodeproj/project.pbxproj
+++ b/Realm.xcodeproj/project.pbxproj
@@ -269,7 +269,7 @@
 		5D659E851BE04556006515A0 /* RLMAccessor.mm in Sources */ = {isa = PBXBuildFile; fileRef = E81A1F641955FC9300FDED82 /* RLMAccessor.mm */; };
 		5D659E861BE04556006515A0 /* RLMAnalytics.mm in Sources */ = {isa = PBXBuildFile; fileRef = E83591931B3DF05C0035F2F3 /* RLMAnalytics.mm */; };
 		5D659E871BE04556006515A0 /* RLMArray.mm in Sources */ = {isa = PBXBuildFile; fileRef = E81A1F671955FC9300FDED82 /* RLMArray.mm */; };
-		5D659E881BE04556006515A0 /* RLMArrayLinkView.mm in Sources */ = {isa = PBXBuildFile; fileRef = E81A1F691955FC9300FDED82 /* RLMArrayLinkView.mm */; };
+		5D659E881BE04556006515A0 /* RLMManagedArray.mm in Sources */ = {isa = PBXBuildFile; fileRef = E81A1F691955FC9300FDED82 /* RLMManagedArray.mm */; };
 		5D659E891BE04556006515A0 /* RLMConstants.m in Sources */ = {isa = PBXBuildFile; fileRef = E81A1F6C1955FC9300FDED82 /* RLMConstants.m */; };
 		5D659E8A1BE04556006515A0 /* RLMListBase.mm in Sources */ = {isa = PBXBuildFile; fileRef = 023B19561A3BA90D0067FB81 /* RLMListBase.mm */; };
 		5D659E8B1BE04556006515A0 /* RLMMigration.mm in Sources */ = {isa = PBXBuildFile; fileRef = 0207AB7E195DF9FB007EFB12 /* RLMMigration.mm */; };
@@ -369,7 +369,7 @@
 		5DD755831BE056DE002800DA /* RLMAccessor.mm in Sources */ = {isa = PBXBuildFile; fileRef = E81A1F641955FC9300FDED82 /* RLMAccessor.mm */; };
 		5DD755841BE056DE002800DA /* RLMAnalytics.mm in Sources */ = {isa = PBXBuildFile; fileRef = E83591931B3DF05C0035F2F3 /* RLMAnalytics.mm */; };
 		5DD755851BE056DE002800DA /* RLMArray.mm in Sources */ = {isa = PBXBuildFile; fileRef = E81A1F671955FC9300FDED82 /* RLMArray.mm */; };
-		5DD755861BE056DE002800DA /* RLMArrayLinkView.mm in Sources */ = {isa = PBXBuildFile; fileRef = E81A1F691955FC9300FDED82 /* RLMArrayLinkView.mm */; };
+		5DD755861BE056DE002800DA /* RLMManagedArray.mm in Sources */ = {isa = PBXBuildFile; fileRef = E81A1F691955FC9300FDED82 /* RLMManagedArray.mm */; };
 		5DD755871BE056DE002800DA /* RLMConstants.m in Sources */ = {isa = PBXBuildFile; fileRef = E81A1F6C1955FC9300FDED82 /* RLMConstants.m */; };
 		5DD755881BE056DE002800DA /* RLMListBase.mm in Sources */ = {isa = PBXBuildFile; fileRef = 023B19561A3BA90D0067FB81 /* RLMListBase.mm */; };
 		5DD755891BE056DE002800DA /* RLMMigration.mm in Sources */ = {isa = PBXBuildFile; fileRef = 0207AB7E195DF9FB007EFB12 /* RLMMigration.mm */; };
@@ -889,7 +889,7 @@
 		E81A1F651955FC9300FDED82 /* RLMArray_Private.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = RLMArray_Private.hpp; sourceTree = "<group>"; };
 		E81A1F661955FC9300FDED82 /* RLMArray.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RLMArray.h; sourceTree = "<group>"; };
 		E81A1F671955FC9300FDED82 /* RLMArray.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = RLMArray.mm; sourceTree = "<group>"; };
-		E81A1F691955FC9300FDED82 /* RLMArrayLinkView.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; lineEnding = 0; path = RLMArrayLinkView.mm; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
+		E81A1F691955FC9300FDED82 /* RLMManagedArray.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; lineEnding = 0; path = RLMManagedArray.mm; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
 		E81A1F6A1955FC9300FDED82 /* RLMResults.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; lineEnding = 0; path = RLMResults.mm; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
 		E81A1F6B1955FC9300FDED82 /* RLMConstants.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RLMConstants.h; sourceTree = "<group>"; };
 		E81A1F6C1955FC9300FDED82 /* RLMConstants.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RLMConstants.m; sourceTree = "<group>"; };
@@ -1505,7 +1505,6 @@
 				E81A1F671955FC9300FDED82 /* RLMArray.mm */,
 				0237B5421A856F06004ACD57 /* RLMArray_Private.h */,
 				E81A1F651955FC9300FDED82 /* RLMArray_Private.hpp */,
-				E81A1F691955FC9300FDED82 /* RLMArrayLinkView.mm */,
 				3F9863BA1D36876B00641C98 /* RLMClassInfo.hpp */,
 				3F9863B91D36876B00641C98 /* RLMClassInfo.mm */,
 				02B8EF5B19E7048D0045A93D /* RLMCollection.h */,
@@ -1516,6 +1515,7 @@
 				E81A1F6C1955FC9300FDED82 /* RLMConstants.m */,
 				023B19551A3BA90D0067FB81 /* RLMListBase.h */,
 				023B19561A3BA90D0067FB81 /* RLMListBase.mm */,
+				E81A1F691955FC9300FDED82 /* RLMManagedArray.mm */,
 				0207AB7D195DF9FB007EFB12 /* RLMMigration.h */,
 				0207AB7E195DF9FB007EFB12 /* RLMMigration.mm */,
 				0207AB7C195DF9FB007EFB12 /* RLMMigration_Private.h */,
@@ -1626,6 +1626,7 @@
 				5D659EA91BE04556006515A0 /* RLMArray.h in Headers */,
 				5D659EAA1BE04556006515A0 /* RLMArray_Private.h in Headers */,
 				5D659EAB1BE04556006515A0 /* RLMCollection.h in Headers */,
+				5D1BF1FF1EF987AD00B7DC87 /* RLMCollection_Private.h in Headers */,
 				5D659EAC1BE04556006515A0 /* RLMConstants.h in Headers */,
 				5D659EAE1BE04556006515A0 /* RLMListBase.h in Headers */,
 				5D659EAF1BE04556006515A0 /* RLMMigration.h in Headers */,
@@ -1637,7 +1638,6 @@
 				5D659EB51BE04556006515A0 /* RLMObjectSchema.h in Headers */,
 				5D659EB61BE04556006515A0 /* RLMObjectSchema_Private.h in Headers */,
 				5D659EB81BE04556006515A0 /* RLMObjectStore.h in Headers */,
-				5D1BF1FF1EF987AD00B7DC87 /* RLMCollection_Private.h in Headers */,
 				5D659EBA1BE04556006515A0 /* RLMOptionalBase.h in Headers */,
 				5D659EBC1BE04556006515A0 /* RLMProperty.h in Headers */,
 				E8F992BE1F1401C100F634B5 /* RLMObjectBase_Private.h in Headers */,
@@ -1694,6 +1694,7 @@
 				5DD755A71BE056DE002800DA /* RLMArray.h in Headers */,
 				5DD755A81BE056DE002800DA /* RLMArray_Private.h in Headers */,
 				5DD755A91BE056DE002800DA /* RLMCollection.h in Headers */,
+				5D1BF2001EF987AE00B7DC87 /* RLMCollection_Private.h in Headers */,
 				5DD755AA1BE056DE002800DA /* RLMConstants.h in Headers */,
 				5DD755AC1BE056DE002800DA /* RLMListBase.h in Headers */,
 				5DD755AD1BE056DE002800DA /* RLMMigration.h in Headers */,
@@ -1719,7 +1720,6 @@
 				5DD755C41BE056DE002800DA /* RLMResults_Private.h in Headers */,
 				5DD755C51BE056DE002800DA /* RLMSchema.h in Headers */,
 				5DD755C61BE056DE002800DA /* RLMSchema_Private.h in Headers */,
-				5D1BF2001EF987AE00B7DC87 /* RLMCollection_Private.h in Headers */,
 				5DD755C71BE056DE002800DA /* RLMSwiftSupport.h in Headers */,
 				1A0512761D8746CD00806AEC /* RLMSyncConfiguration.h in Headers */,
 				3F336E8A1DA2FA14006CB5A0 /* RLMSyncConfiguration_Private.h in Headers */,
@@ -2264,12 +2264,12 @@
 				5D659E851BE04556006515A0 /* RLMAccessor.mm in Sources */,
 				5D659E861BE04556006515A0 /* RLMAnalytics.mm in Sources */,
 				5D659E871BE04556006515A0 /* RLMArray.mm in Sources */,
-				5D659E881BE04556006515A0 /* RLMArrayLinkView.mm in Sources */,
 				1AF6EA481D36B1850014EB85 /* RLMAuthResponseModel.m in Sources */,
 				3F9863BB1D36876B00641C98 /* RLMClassInfo.mm in Sources */,
 				3FBEF67B1C63D66100F6935B /* RLMCollection.mm in Sources */,
 				5D659E891BE04556006515A0 /* RLMConstants.m in Sources */,
 				5D659E8A1BE04556006515A0 /* RLMListBase.mm in Sources */,
+				5D659E881BE04556006515A0 /* RLMManagedArray.mm in Sources */,
 				5D659E8B1BE04556006515A0 /* RLMMigration.mm in Sources */,
 				1AF7EA9C1D340E700001A9B5 /* RLMNetworkClient.mm in Sources */,
 				5D659E8C1BE04556006515A0 /* RLMObject.mm in Sources */,
@@ -2405,12 +2405,12 @@
 				5DD755831BE056DE002800DA /* RLMAccessor.mm in Sources */,
 				5DD755841BE056DE002800DA /* RLMAnalytics.mm in Sources */,
 				5DD755851BE056DE002800DA /* RLMArray.mm in Sources */,
-				5DD755861BE056DE002800DA /* RLMArrayLinkView.mm in Sources */,
 				1A70030A1D5270CF00FD9EE3 /* RLMAuthResponseModel.m in Sources */,
 				3F9863BC1D36876B00641C98 /* RLMClassInfo.mm in Sources */,
 				3FBEF67C1C63D66400F6935B /* RLMCollection.mm in Sources */,
 				5DD755871BE056DE002800DA /* RLMConstants.m in Sources */,
 				5DD755881BE056DE002800DA /* RLMListBase.mm in Sources */,
+				5DD755861BE056DE002800DA /* RLMManagedArray.mm in Sources */,
 				5DD755891BE056DE002800DA /* RLMMigration.mm in Sources */,
 				1A90FCBC1D3D37F70086A57F /* RLMNetworkClient.mm in Sources */,
 				5DD7558A1BE056DE002800DA /* RLMObject.mm in Sources */,

--- a/Realm.xcodeproj/project.pbxproj
+++ b/Realm.xcodeproj/project.pbxproj
@@ -176,6 +176,8 @@
 		3F2E66651CA0BA12004761D5 /* NotificationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 3F2E66611CA0B9D5004761D5 /* NotificationTests.m */; };
 		3F336E8A1DA2FA14006CB5A0 /* RLMSyncConfiguration_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 1A36236A1D83868F00945A54 /* RLMSyncConfiguration_Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		3F336E8B1DA2FA15006CB5A0 /* RLMSyncConfiguration_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 1A36236A1D83868F00945A54 /* RLMSyncConfiguration_Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		3F4657371F27F2EF00456B07 /* RLMTestCaseUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 297FBEFA1C19F696009D1118 /* RLMTestCaseUtils.swift */; };
+		3F4657381F27F35600456B07 /* TestUtils.mm in Sources */ = {isa = PBXBuildFile; fileRef = 297FBEFE1C19F844009D1118 /* TestUtils.mm */; };
 		3F5B5D301E84230B00953B33 /* binding_callback_thread_observer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3F5B5D2E1E84230B00953B33 /* binding_callback_thread_observer.cpp */; };
 		3F5B5D321E84230E00953B33 /* binding_callback_thread_observer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3F5B5D2E1E84230B00953B33 /* binding_callback_thread_observer.cpp */; };
 		3F643BED1CEA655800F6D0C8 /* mixed-column.realm in Resources */ = {isa = PBXBuildFile; fileRef = 3F643BEB1CEA654D00F6D0C8 /* mixed-column.realm */; };
@@ -1635,12 +1637,12 @@
 				5D659EB21BE04556006515A0 /* RLMObject_Private.h in Headers */,
 				5D659EB31BE04556006515A0 /* RLMObjectBase.h in Headers */,
 				5D659EB41BE04556006515A0 /* RLMObjectBase_Dynamic.h in Headers */,
+				E8F992BE1F1401C100F634B5 /* RLMObjectBase_Private.h in Headers */,
 				5D659EB51BE04556006515A0 /* RLMObjectSchema.h in Headers */,
 				5D659EB61BE04556006515A0 /* RLMObjectSchema_Private.h in Headers */,
 				5D659EB81BE04556006515A0 /* RLMObjectStore.h in Headers */,
 				5D659EBA1BE04556006515A0 /* RLMOptionalBase.h in Headers */,
 				5D659EBC1BE04556006515A0 /* RLMProperty.h in Headers */,
-				E8F992BE1F1401C100F634B5 /* RLMObjectBase_Private.h in Headers */,
 				5D659EBD1BE04556006515A0 /* RLMProperty_Private.h in Headers */,
 				5D659EBF1BE04556006515A0 /* RLMRealm.h in Headers */,
 				5D659EC01BE04556006515A0 /* RLMRealm_Dynamic.h in Headers */,
@@ -1703,6 +1705,7 @@
 				5DD755B01BE056DE002800DA /* RLMObject_Private.h in Headers */,
 				5DD755B11BE056DE002800DA /* RLMObjectBase.h in Headers */,
 				5DD755B21BE056DE002800DA /* RLMObjectBase_Dynamic.h in Headers */,
+				E8F992BF1F1401C100F634B5 /* RLMObjectBase_Private.h in Headers */,
 				5DD755B31BE056DE002800DA /* RLMObjectSchema.h in Headers */,
 				5DD755B41BE056DE002800DA /* RLMObjectSchema_Private.h in Headers */,
 				5DD755B61BE056DE002800DA /* RLMObjectStore.h in Headers */,
@@ -1713,7 +1716,6 @@
 				5DD755BE1BE056DE002800DA /* RLMRealm_Dynamic.h in Headers */,
 				5DD755BF1BE056DE002800DA /* RLMRealm_Private.h in Headers */,
 				1AFEF8421D52CD8F00495005 /* RLMRealmConfiguration+Sync.h in Headers */,
-				E8F992BF1F1401C100F634B5 /* RLMObjectBase_Private.h in Headers */,
 				5DD755C01BE056DE002800DA /* RLMRealmConfiguration.h in Headers */,
 				5DD755C11BE056DE002800DA /* RLMRealmConfiguration_Private.h in Headers */,
 				5DD755C31BE056DE002800DA /* RLMResults.h in Headers */,
@@ -2512,6 +2514,7 @@
 				3FC767071BB9FE7500FE0AFC /* RLMMultiProcessTestCase.m in Sources */,
 				3FDE338D19C39A87003B7DBA /* RLMSupport.swift in Sources */,
 				E856D21F195615B100FB2FCF /* RLMTestCase.m in Sources */,
+				3F4657371F27F2EF00456B07 /* RLMTestCaseUtils.swift in Sources */,
 				028481CB19CCFC9C0097A416 /* RLMTestObjects.m in Sources */,
 				0207AB8A195DFA15007EFB12 /* SchemaTests.mm in Sources */,
 				3F8DCA7619930FCB0008BD7F /* SwiftArrayPropertyTests.swift in Sources */,
@@ -2523,6 +2526,7 @@
 				3F8DCA7D19930FCB0008BD7F /* SwiftRealmTests.swift in Sources */,
 				3F8DCA7519930FCB0008BD7F /* SwiftTestObjects.swift in Sources */,
 				3F8DCA7E19930FCB0008BD7F /* SwiftUnicodeTests.swift in Sources */,
+				3F4657381F27F35600456B07 /* TestUtils.mm in Sources */,
 				E856D213195615A900FB2FCF /* TransactionTests.m in Sources */,
 				E8917599197A1B350068ACC6 /* UnicodeTests.m in Sources */,
 				C0CDC0831B38DABB00C5716D /* UtilTests.mm in Sources */,

--- a/Realm/ObjectServerTests/RLMPermissionsAPITests.m
+++ b/Realm/ObjectServerTests/RLMPermissionsAPITests.m
@@ -786,7 +786,7 @@ static RLMSyncPermissionValue *makeExpectedPermission(RLMSyncPermissionValue *or
                                                                   ascending:YES];
     // Wait for changes to propagate
     CHECK_PERMISSION_COUNT(sorted, 3);
-    
+
     RLMSyncPermissionValue *n1 = nil;
     RLMSyncPermissionValue *n2 = nil;
     RLMSyncPermissionValue *n3 = nil;

--- a/Realm/RLMAccessor.mm
+++ b/Realm/RLMAccessor.mm
@@ -129,7 +129,7 @@ void setValue(__unsafe_unretained RLMObjectBase *const obj, NSUInteger colIndex,
 RLMArray *getArray(__unsafe_unretained RLMObjectBase *const obj, NSUInteger colIndex) {
     RLMVerifyAttached(obj);
     auto prop = obj->_info->rlmObjectSchema.properties[colIndex];
-    return [[RLMArrayLinkView alloc] initWithParent:obj property:prop];
+    return [[RLMManagedArray alloc] initWithParent:obj property:prop];
 }
 
 void setValue(__unsafe_unretained RLMObjectBase *const obj, NSUInteger colIndex,
@@ -675,9 +675,9 @@ id RLMAccessorContext::propertyValue(__unsafe_unretained id const obj, size_t pr
 id RLMAccessorContext::box(realm::List&& l) {
     REALM_ASSERT(_parentObject);
     REALM_ASSERT(currentProperty);
-    return [[RLMArrayLinkView alloc] initWithList:std::move(l) realm:_realm
-                                       parentInfo:_parentObject->_info
-                                         property:currentProperty];
+    return [[RLMManagedArray alloc] initWithList:std::move(l) realm:_realm
+                                      parentInfo:_parentObject->_info
+                                        property:currentProperty];
 }
 
 id RLMAccessorContext::box(realm::Object&& o) {

--- a/Realm/RLMAccessor.mm
+++ b/Realm/RLMAccessor.mm
@@ -682,11 +682,11 @@ id RLMAccessorContext::box(realm::List&& l) {
 
 id RLMAccessorContext::box(realm::Object&& o) {
     REALM_ASSERT(currentProperty);
-    return RLMCreateObjectAccessor(_realm, _info.linkTargetType(currentProperty.index), o.row().get_index());
+    return RLMCreateObjectAccessor(_realm, _info.linkTargetType(currentProperty.index), o.row());
 }
 
 id RLMAccessorContext::box(realm::RowExpr r) {
-    return RLMCreateObjectAccessor(_realm, _info, r.get_index());
+    return RLMCreateObjectAccessor(_realm, _info, r);
 }
 
 id RLMAccessorContext::box(realm::Results&& r) {

--- a/Realm/RLMAccessor.mm
+++ b/Realm/RLMAccessor.mm
@@ -582,7 +582,7 @@ RLMAccessorContext::RLMAccessorContext(RLMRealm *realm, RLMClassInfo& info, bool
 RLMAccessorContext::RLMAccessorContext(__unsafe_unretained RLMObjectBase *const parent,
                                        const realm::Property *prop)
 : _realm(parent->_realm)
-, _info(prop && (prop->type == realm::PropertyType::Object || prop->type == realm::PropertyType::Array)
+, _info(prop && (prop->type == realm::PropertyType::Object)
         ? parent->_info->linkTargetType(*prop)
         : *parent->_info)
 , _parentObject(parent)

--- a/Realm/RLMAnalytics.hpp
+++ b/Realm/RLMAnalytics.hpp
@@ -48,7 +48,7 @@
 // - What version of OS X it's running on (in case Xcode aggressively drops
 //   support for older versions again, we need to know what we need to support).
 // - The minimum iOS/OS X version that the application is targeting (again, to
-//   help us decide what versions we need to support). 
+//   help us decide what versions we need to support).
 // - An anonymous MAC address and bundle ID to aggregate the other information on.
 // - What version of Swift is being used (if applicable).
 

--- a/Realm/RLMAnalytics.mm
+++ b/Realm/RLMAnalytics.mm
@@ -48,7 +48,7 @@
 // - What version of OS X it's running on (in case Xcode aggressively drops
 //   support for older versions again, we need to know what we need to support).
 // - The minimum iOS/OS X version that the application is targeting (again, to
-//   help us decide what versions we need to support). 
+//   help us decide what versions we need to support).
 // - An anonymous MAC address and bundle ID to aggregate the other information on.
 // - What version of Swift is being used (if applicable).
 

--- a/Realm/RLMArray.h
+++ b/Realm/RLMArray.h
@@ -418,13 +418,13 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  `-[RLMArray init]` is not available because `RLMArray`s cannot be created directly.
- `RLMArray` properties on `RLMObject`s are lazily created when accessed, or can be obtained by querying a Realm.
+ `RLMArray` properties on `RLMObject`s are lazily created when accessed.
  */
 - (instancetype)init __attribute__((unavailable("RLMArrays cannot be created directly")));
 
 /**
  `+[RLMArray new]` is not available because `RLMArray`s cannot be created directly.
- `RLMArray` properties on `RLMObject`s are lazily created when accessed, or can be obtained by querying a Realm.
+ `RLMArray` properties on `RLMObject`s are lazily created when accessed.
  */
 + (instancetype)new __attribute__((unavailable("RLMArrays cannot be created directly")));
 

--- a/Realm/RLMArrayLinkView.mm
+++ b/Realm/RLMArrayLinkView.mm
@@ -402,14 +402,10 @@ static void RLMInsertObject(RLMArrayLinkView *ar, id object, NSUInteger index) {
 }
 
 - (RLMResults *)sortedResultsUsingDescriptors:(NSArray<RLMSortDescriptor *> *)properties {
-    if (properties.count == 0) {
-        auto results = translateErrors([&] { return _backingList.filter({}); });
-        return [RLMResults resultsWithObjectInfo:*_objectInfo results:std::move(results)];
-    }
-
-    auto order = RLMSortDescriptorFromDescriptors(*_objectInfo, properties);
-    auto results = translateErrors([&] { return _backingList.sort(std::move(order)); });
-    return [RLMResults resultsWithObjectInfo:*_objectInfo results:std::move(results)];
+    return translateErrors([&] {
+        return [RLMResults resultsWithObjectInfo:*_objectInfo
+                                         results:_backingList.sort(RLMSortDescriptorsToKeypathArray(properties))];
+    });
 }
 
 - (RLMResults *)objectsWithPredicate:(NSPredicate *)predicate {

--- a/Realm/RLMArray_Private.hpp
+++ b/Realm/RLMArray_Private.hpp
@@ -45,12 +45,12 @@ class RLMObservationInfo;
 //
 // LinkView backed RLMArray subclass
 //
-@interface RLMArrayLinkView : RLMArray <RLMFastEnumerable>
+@interface RLMManagedArray : RLMArray <RLMFastEnumerable>
 - (instancetype)initWithParent:(RLMObjectBase *)parentObject property:(RLMProperty *)property;
-- (RLMArrayLinkView *)initWithList:(realm::List)list
-                             realm:(__unsafe_unretained RLMRealm *const)realm
-                        parentInfo:(RLMClassInfo *)parentInfo
-                          property:(__unsafe_unretained RLMProperty *const)property;
+- (RLMManagedArray *)initWithList:(realm::List)list
+                            realm:(__unsafe_unretained RLMRealm *const)realm
+                       parentInfo:(RLMClassInfo *)parentInfo
+                         property:(__unsafe_unretained RLMProperty *const)property;
 
 - (bool)isBackedByList:(realm::List const&)list;
 

--- a/Realm/RLMAuthResponseModel.h
+++ b/Realm/RLMAuthResponseModel.h
@@ -20,7 +20,7 @@
 
 /**
  An internal class representing a valid JSON response to an auth request.
- 
+
  ```
  {
      "access_token": { ... } // (optional),

--- a/Realm/RLMClassInfo.mm
+++ b/Realm/RLMClassInfo.mm
@@ -79,7 +79,7 @@ RLMClassInfo &RLMClassInfo::linkTargetType(size_t propertyIndex) {
 }
 
 RLMClassInfo &RLMClassInfo::linkTargetType(realm::Property const& property) {
-    REALM_ASSERT(property.type == PropertyType::Object || property.type == PropertyType::Array);
+    REALM_ASSERT(property.type == PropertyType::Object);
     return linkTargetType(&property - &objectSchema->persisted_properties[0]);
 }
 

--- a/Realm/RLMCollection.h
+++ b/Realm/RLMCollection.h
@@ -18,7 +18,7 @@
 
 #import <Foundation/Foundation.h>
 
-#import "RLMThreadSafeReference.h"
+#import <Realm/RLMThreadSafeReference.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Realm/RLMCollection.h
+++ b/Realm/RLMCollection.h
@@ -313,7 +313,7 @@ NS_ASSUME_NONNULL_BEGIN
  `sortedResultsUsingDescriptors:`. It is similar to `NSSortDescriptor`, but supports
  only the subset of functionality which can be efficiently run by Realm's query
  engine.
- 
+
  `RLMSortDescriptor` instances are immutable.
  */
 @interface RLMSortDescriptor : NSObject
@@ -388,11 +388,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  The indices in the new version of the collection which were modified.
- 
+
  For `RLMResults`, this means that one or more of the properties of the object at
  that index were modified (or an object linked to by that object was
  modified).
- 
+
  For `RLMArray`, the array itself being modified to contain a
  different object at that index will also be reported as a modification.
  */

--- a/Realm/RLMCollection.mm
+++ b/Realm/RLMCollection.mm
@@ -229,6 +229,18 @@ NSString *RLMDescriptionWithMaxDepth(NSString *name,
     return str;
 }
 
+std::vector<std::pair<std::string, bool>> RLMSortDescriptorsToKeypathArray(NSArray<RLMSortDescriptor *> *properties) {
+    std::vector<std::pair<std::string, bool>> keypaths;
+    keypaths.reserve(properties.count);
+    for (RLMSortDescriptor *desc in properties) {
+        if ([desc.keyPath containsString:@"@"]) {
+            @throw RLMException(@"Cannot sort on key path '%@': KVC collection operators are not supported.", desc.keyPath);
+        }
+        keypaths.push_back({desc.keyPath.UTF8String, desc.ascending});
+    }
+    return keypaths;
+}
+
 @implementation RLMCancellationToken {
     realm::NotificationToken _token;
     __unsafe_unretained RLMRealm *_realm;

--- a/Realm/RLMCollection.mm
+++ b/Realm/RLMCollection.mm
@@ -18,7 +18,9 @@
 
 #import "RLMCollection_Private.hpp"
 
-#import "RLMArray_Private.h"
+#import "RLMAccessor.hpp"
+#import "RLMArray_Private.hpp"
+#import "RLMListBase.h"
 #import "RLMObjectSchema_Private.hpp"
 #import "RLMObjectStore.h"
 #import "RLMObject_Private.hpp"
@@ -27,8 +29,6 @@
 #import "collection_notifications.hpp"
 #import "list.hpp"
 #import "results.hpp"
-
-#import <realm/table_view.hpp>
 
 static const int RLMEnumerationBufferSize = 16;
 
@@ -42,27 +42,56 @@ static const int RLMEnumerationBufferSize = 16;
     RLMRealm *_realm;
     RLMClassInfo *_info;
 
-    // Collection being enumerated. Only one of these two will be valid: when
-    // possible we enumerate the collection directly, but when in a write
-    // transaction we instead create a frozen TableView and enumerate that
-    // instead so that mutating the collection during enumeration works.
-    id<RLMFastEnumerable> _collection;
-    realm::TableView _tableView;
+    // A pointer to either _snapshot or a Results from the source collection,
+    // to avoid having to copy the Results when not in a write transaction
+    realm::Results *_results;
+    realm::Results _snapshot;
+
+    // A strong reference to the collection being enumerated to ensure it stays
+    // alive when we're holding a pointer to a member in it
+    id _collection;
 }
 
-- (instancetype)initWithCollection:(id<RLMFastEnumerable>)collection objectSchema:(RLMClassInfo&)info {
+- (instancetype)initWithList:(realm::List&)list
+                  collection:(id)collection
+                       realm:(RLMRealm *)realm
+                   classInfo:(RLMClassInfo&)info
+{
     self = [super init];
     if (self) {
-        _realm = collection.realm;
-        _info = &info;
-
-        if (_realm.inWriteTransaction) {
-            _tableView = [collection tableView];
+        if (realm.inWriteTransaction) {
+            _snapshot = list.snapshot();
         }
         else {
+            _snapshot = list.as_results();
             _collection = collection;
-            [_realm registerEnumerator:self];
+            [realm registerEnumerator:self];
         }
+        _results = &_snapshot;
+        _realm = realm;
+        _info = &info;
+    }
+    return self;
+}
+
+- (instancetype)initWithResults:(realm::Results&)results
+                     collection:(id)collection
+                          realm:(RLMRealm *)realm
+                      classInfo:(RLMClassInfo&)info
+{
+    self = [super init];
+    if (self) {
+        if (realm.inWriteTransaction) {
+            _snapshot = results.snapshot();
+            _results = &_snapshot;
+        }
+        else {
+            _results = &results;
+            _collection = collection;
+            [realm registerEnumerator:self];
+        }
+        _realm = realm;
+        _info = &info;
     }
     return self;
 }
@@ -74,14 +103,15 @@ static const int RLMEnumerationBufferSize = 16;
 }
 
 - (void)detach {
-    _tableView = [_collection tableView];
+    _snapshot = _results->snapshot();
+    _results = &_snapshot;
     _collection = nil;
 }
 
 - (NSUInteger)countByEnumeratingWithState:(NSFastEnumerationState *)state
                                     count:(NSUInteger)len {
     [_realm verifyThread];
-    if (!_tableView.is_attached() && !_collection) {
+    if (!_results->is_valid()) {
         @throw RLMException(@"Collection is no longer valid");
     }
     // The fast enumeration buffer size is currently a hardcoded number in the
@@ -93,18 +123,12 @@ static const int RLMEnumerationBufferSize = 16;
 
     NSUInteger batchCount = 0, count = state->extra[1];
 
-    Class accessorClass = _info->rlmObjectSchema.accessorClass;
-    for (NSUInteger index = state->state; index < count && batchCount < len; ++index) {
-        RLMObject *accessor = RLMCreateManagedAccessor(accessorClass, _realm, _info);
-        if (_collection) {
-            accessor->_row = (*_info->table())[[_collection indexInSource:index]];
+    @autoreleasepool {
+        RLMAccessorContext ctx(_realm, *_info);
+        for (NSUInteger index = state->state; index < count && batchCount < len; ++index) {
+            _strongBuffer[batchCount] = _results->get(ctx, index);
+            batchCount++;
         }
-        else if (_tableView.is_row_attached(index)) {
-            accessor->_row = (*_info->table())[_tableView.get_source_ndx(index)];
-        }
-        RLMInitializeSwiftAccessorGenerics(accessor);
-        _strongBuffer[batchCount] = accessor;
-        batchCount++;
     }
 
     for (NSUInteger i = batchCount; i < len; ++i) {
@@ -114,13 +138,11 @@ static const int RLMEnumerationBufferSize = 16;
     if (batchCount == 0) {
         // Release our data if we're done, as we're autoreleased and so may
         // stick around for a while
-        _collection = nil;
-        if (_tableView.is_attached()) {
-            _tableView = {};
-        }
-        else {
+        if (_collection) {
+            _collection = nil;
             [_realm unregisterEnumerator:self];
         }
+        _snapshot = {};
     }
 
     state->itemsPtr = (__unsafe_unretained id *)(void *)_strongBuffer;
@@ -131,6 +153,19 @@ static const int RLMEnumerationBufferSize = 16;
 }
 @end
 
+NSUInteger RLMFastEnumerate(NSFastEnumerationState *state, NSUInteger len, id<RLMFastEnumerable> collection) {
+    __autoreleasing RLMFastEnumerator *enumerator;
+    if (state->state == 0) {
+        enumerator = collection.fastEnumerator;
+        state->extra[0] = (long)enumerator;
+        state->extra[1] = collection.count;
+    }
+    else {
+        enumerator = (__bridge id)(void *)state->extra[0];
+    }
+
+    return [enumerator countByEnumeratingWithState:state count:len];
+}
 
 NSArray *RLMCollectionValueForKey(id<RLMFastEnumerable> collection, NSString *key) {
     size_t count = collection.count;

--- a/Realm/RLMCollection_Private.hpp
+++ b/Realm/RLMCollection_Private.hpp
@@ -28,6 +28,7 @@ namespace realm {
     struct NotificationToken;
 }
 class RLMClassInfo;
+@class RLMFastEnumerator;
 
 @protocol RLMFastEnumerable
 @property (nonatomic, readonly) RLMRealm *realm;
@@ -36,14 +37,21 @@ class RLMClassInfo;
 
 - (NSUInteger)indexInSource:(NSUInteger)index;
 - (realm::TableView)tableView;
+- (RLMFastEnumerator *)fastEnumerator;
 @end
 
 // An object which encapulates the shared logic for fast-enumerating RLMArray
 // and RLMResults, and has a buffer to store strong references to the current
 // set of enumerated items
 @interface RLMFastEnumerator : NSObject
-- (instancetype)initWithCollection:(id<RLMFastEnumerable>)collection
-                      objectSchema:(RLMClassInfo&)objectSchema;
+- (instancetype)initWithList:(realm::List&)list
+                  collection:(id)collection
+                       realm:(RLMRealm *)realm
+                   classInfo:(RLMClassInfo&)info;
+- (instancetype)initWithResults:(realm::Results&)results
+                     collection:(id)collection
+                          realm:(RLMRealm *)realm
+                      classInfo:(RLMClassInfo&)info;
 
 // Detach this enumerator from the source collection. Must be called before the
 // source collection is changed.
@@ -52,6 +60,7 @@ class RLMClassInfo;
 - (NSUInteger)countByEnumeratingWithState:(NSFastEnumerationState *)state
                                     count:(NSUInteger)len;
 @end
+NSUInteger RLMFastEnumerate(NSFastEnumerationState *state, NSUInteger len, id<RLMFastEnumerable> collection);
 
 @interface RLMNotificationToken ()
 - (void)suppressNextNotification;

--- a/Realm/RLMCollection_Private.hpp
+++ b/Realm/RLMCollection_Private.hpp
@@ -18,6 +18,8 @@
 
 #import <Realm/RLMCollection_Private.h>
 
+#import <vector>
+
 namespace realm {
     class List;
     class Results;
@@ -70,3 +72,4 @@ RLMNotificationToken *RLMAddNotificationBlock(id objcCollection,
                                               void (^block)(id, RLMCollectionChange *, NSError *),
                                               bool suppressInitialChange=false);
 
+std::vector<std::pair<std::string, bool>> RLMSortDescriptorsToKeypathArray(NSArray<RLMSortDescriptor *> *properties);

--- a/Realm/RLMConstants.h
+++ b/Realm/RLMConstants.h
@@ -66,9 +66,9 @@ typedef NS_ENUM(int32_t, RLMPropertyType) {
     RLMPropertyTypeString = 2,
     /** Binary data: `NSData` */
     RLMPropertyTypeData   = 3,
-    /** 
+    /**
      Any object: `id`.
-     
+
      This property type is no longer supported for new models. However, old models with any-typed properties are still
      supported for migration purposes.
      */
@@ -103,9 +103,9 @@ typedef RLM_ERROR_ENUM(NSInteger, RLMError, RLMErrorDomain) {
     /** Denotes a file I/O error that occurred when trying to open a Realm. */
     RLMErrorFileAccess            = 2,
 
-    /** 
+    /**
      Denotes a file permission error that ocurred when trying to open a Realm.
-     
+
      This error can occur if the user does not have permission to open or create
      the specified file in the specified access mode when opening a Realm.
      */
@@ -116,24 +116,24 @@ typedef RLM_ERROR_ENUM(NSInteger, RLMError, RLMErrorDomain) {
 
     /**
      Denotes an error that occurs if a file could not be found.
-     
+
      This error may occur if a Realm file could not be found on disk when trying to open a
      Realm as read-only, or if the directory part of the specified path was not found when
      trying to write a copy.
      */
     RLMErrorFileNotFound          = 5,
 
-    /** 
+    /**
      Denotes an error that occurs if a file format upgrade is required to open the file,
      but upgrades were explicitly disabled.
      */
     RLMErrorFileFormatUpgradeRequired = 6,
 
-    /** 
+    /**
      Denotes an error that occurs if the database file is currently open in another
      process which cannot share with the current process due to an
      architecture mismatch.
-     
+
      This error may occur if trying to share a Realm file between an i386 (32-bit) iOS
      Simulator and the Realm Browser application. In this case, please use the 64-bit
      version of the iOS Simulator.

--- a/Realm/RLMConstants.h
+++ b/Realm/RLMConstants.h
@@ -47,7 +47,6 @@ NS_ASSUME_NONNULL_BEGIN
 
  For more information, see [Realm Models](https://realm.io/docs/objc/latest/#models).
  */
-// Make sure numbers match those in <realm/data_type.hpp>
 typedef NS_ENUM(int32_t, RLMPropertyType) {
 
 #pragma mark - Primitive types
@@ -57,34 +56,34 @@ typedef NS_ENUM(int32_t, RLMPropertyType) {
     /** Booleans: `BOOL`, `bool`, `Bool` (Swift) */
     RLMPropertyTypeBool   = 1,
     /** Floating-point numbers: `float`, `Float` (Swift) */
-    RLMPropertyTypeFloat  = 9,
+    RLMPropertyTypeFloat  = 5,
     /** Double-precision floating-point numbers: `double`, `Double` (Swift) */
-    RLMPropertyTypeDouble = 10,
+    RLMPropertyTypeDouble = 6,
 
 #pragma mark - Object types
 
     /** Strings: `NSString`, `String` (Swift) */
     RLMPropertyTypeString = 2,
     /** Binary data: `NSData` */
-    RLMPropertyTypeData   = 4,
+    RLMPropertyTypeData   = 3,
     /** 
      Any object: `id`.
      
      This property type is no longer supported for new models. However, old models with any-typed properties are still
      supported for migration purposes.
      */
-    RLMPropertyTypeAny    = 6,
+    RLMPropertyTypeAny    = 9,
     /** Dates: `NSDate` */
-    RLMPropertyTypeDate   = 8,
+    RLMPropertyTypeDate   = 4,
 
 #pragma mark - Array/Linked object types
 
     /** Realm model objects. See [Realm Models](https://realm.io/docs/objc/latest/#models) for more information. */
-    RLMPropertyTypeObject = 12,
+    RLMPropertyTypeObject = 7,
     /** Realm arrays. See [Realm Models](https://realm.io/docs/objc/latest/#models) for more information. */
-    RLMPropertyTypeArray  = 13,
+    RLMPropertyTypeArray  = 128,
     /** Realm linking objects. See [Realm Models](https://realm.io/docs/objc/latest/#models) for more information. */
-    RLMPropertyTypeLinkingObjects = 14,
+    RLMPropertyTypeLinkingObjects = 8,
 };
 
 /** An error domain identifying Realm-specific errors. */

--- a/Realm/RLMMigration.h
+++ b/Realm/RLMMigration.h
@@ -25,11 +25,11 @@ NS_ASSUME_NONNULL_BEGIN
 @class RLMObject;
 
 /**
- A block type which provides both the old and new versions of an object in the Realm. Object 
+ A block type which provides both the old and new versions of an object in the Realm. Object
  properties can only be accessed using keyed subscripting.
- 
+
  @see `-[RLMMigration enumerateObjects:block:]`
- 
+
  @param oldObject The object from the original Realm (read-only).
  @param newObject The object from the migrated Realm (read-write).
 */
@@ -37,7 +37,7 @@ typedef void (^RLMObjectMigrationBlock)(RLMObject * __nullable oldObject, RLMObj
 
 /**
  `RLMMigration` instances encapsulate information intended to facilitate a schema migration.
- 
+
  A `RLMMigration` instance is passed into a user-defined `RLMMigrationBlock` block when updating
  the version of a Realm. This instance provides access to the old and new database schemas, the
  objects in the Realm, and provides functionality for modifying the Realm during the migration.
@@ -75,8 +75,8 @@ typedef void (^RLMObjectMigrationBlock)(RLMObject * __nullable oldObject, RLMObj
 
 /**
  Creates and returns an `RLMObject` instance of type `className` in the Realm being migrated.
- 
- The `value` argument is used to populate the object. It can be a key-value coding compliant object, an array or 
+
+ The `value` argument is used to populate the object. It can be a key-value coding compliant object, an array or
  dictionary returned from the methods in `NSJSONSerialization`, or an array containing one element for each managed
  property. An exception will be thrown if any required properties are not present and those properties were not defined
  with default values.

--- a/Realm/RLMObject.h
+++ b/Realm/RLMObject.h
@@ -138,7 +138,7 @@ NS_ASSUME_NONNULL_BEGIN
 
  The `value` argument can be a key-value coding compliant object, an array or dictionary returned from the methods in
  `NSJSONSerialization`, or an array containing one element for each managed property.
- 
+
  An exception will be thrown if any required properties are not present and those properties
  were not defined with default values.
 
@@ -159,7 +159,7 @@ NS_ASSUME_NONNULL_BEGIN
 
  The `value` argument can be a key-value coding compliant object, an array or dictionary returned from the methods in
  `NSJSONSerialization`, or an array containing one element for each managed property.
- 
+
  An exception will be thrown if any required properties are not present and those properties
  were not defined with default values.
 
@@ -189,7 +189,7 @@ NS_ASSUME_NONNULL_BEGIN
 
  If the object is being created, an exception will be thrown if any required properties
  are not present and those properties were not defined with default values.
- 
+
  If the `value` argument is a Realm object already managed by the default Realm, the
  argument's type is the same as the receiver, and the objects have identical values for
  their managed properties, this method does nothing.

--- a/Realm/RLMObject.mm
+++ b/Realm/RLMObject.mm
@@ -264,6 +264,39 @@
 
 @end
 
+static bool treatFakeObjectAsRLMObject = false;
+void RLMSetTreatFakeObjectAsRLMObject(BOOL flag) {
+    treatFakeObjectAsRLMObject = flag;
+}
+
+BOOL RLMIsObjectOrSubclass(Class klass) {
+    if (RLMIsKindOfClass(klass, RLMObjectBase.class)) {
+        return YES;
+    }
+
+    if (treatFakeObjectAsRLMObject) {
+        static Class FakeObjectClass = NSClassFromString(@"FakeObject");
+        return RLMIsKindOfClass(klass, FakeObjectClass);
+    }
+    return NO;
+}
+
+BOOL RLMIsObjectSubclass(Class klass) {
+    auto isSubclass = [](Class class1, Class class2) {
+        class1 = class_getSuperclass(class1);
+        return RLMIsKindOfClass(class1, class2);
+    };
+    if (isSubclass(class_getSuperclass(klass), RLMObjectBase.class)) {
+        return YES;
+    }
+
+    if (treatFakeObjectAsRLMObject) {
+        static Class FakeObjectClass = NSClassFromString(@"FakeObject");
+        return isSubclass(klass, FakeObjectClass);
+    }
+    return NO;
+}
+
 @interface RLMObjectNotificationToken : RLMCancellationToken
 @end
 @implementation RLMObjectNotificationToken {

--- a/Realm/RLMObjectBase_Dynamic.h
+++ b/Realm/RLMObjectBase_Dynamic.h
@@ -24,26 +24,26 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  Returns the Realm that manages the object, if one exists.
- 
+
  @warning  This function is useful only in specialized circumstances, for example, when building components
            that integrate with Realm. If you are simply building an app on Realm, it is
            recommended to retrieve the Realm that manages the object via `RLMObject`.
 
  @param object	An `RLMObjectBase` obtained via a Swift `Object` or `RLMObject`.
- 
+
  @return The Realm which manages this object. Returns `nil `for unmanaged objects.
  */
 FOUNDATION_EXTERN RLMRealm * _Nullable RLMObjectBaseRealm(RLMObjectBase * _Nullable object);
 
 /**
  Returns an `RLMObjectSchema` which describes the managed properties of the object.
- 
+
  @warning  This function is useful only in specialized circumstances, for example, when building components
            that integrate with Realm. If you are simply building an app on Realm, it is
            recommended to retrieve `objectSchema` via `RLMObject`.
 
  @param object	An `RLMObjectBase` obtained via a Swift `Object` or `RLMObject`.
- 
+
  @return The object schema which lists the managed properties for the object.
  */
 FOUNDATION_EXTERN RLMObjectSchema * _Nullable RLMObjectBaseObjectSchema(RLMObjectBase * _Nullable object);
@@ -56,23 +56,23 @@ FOUNDATION_EXTERN RLMObjectSchema * _Nullable RLMObjectBaseObjectSchema(RLMObjec
            recommended to retrieve key values via `RLMObject`.
 
  @warning Will throw an `NSUndefinedKeyException` if `key` is not present on the object.
- 
+
  @param object	An `RLMObjectBase` obtained via a Swift `Object` or `RLMObject`.
  @param key		The name of the property.
- 
+
  @return The object for the property requested.
  */
 FOUNDATION_EXTERN id _Nullable RLMObjectBaseObjectForKeyedSubscript(RLMObjectBase * _Nullable object, NSString *key);
 
 /**
  Sets a value for a key on the object.
- 
+
  @warning  This function is useful only in specialized circumstances, for example, when building components
            that integrate with Realm. If you are simply building an app on Realm, it is
            recommended to set key values via `RLMObject`.
 
  @warning Will throw an `NSUndefinedKeyException` if `key` is not present on the object.
- 
+
  @param object	An `RLMObjectBase` obtained via a Swift `Object` or `RLMObject`.
  @param key		The name of the property.
  @param obj		The object to set as the value of the key.

--- a/Realm/RLMObjectSchema.h
+++ b/Realm/RLMObjectSchema.h
@@ -36,7 +36,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  An array of `RLMProperty` instances representing the managed properties of a class described by the schema.
- 
+
  @see `RLMProperty`
  */
 @property (nonatomic, readonly, copy) NSArray<RLMProperty *> *properties;
@@ -55,9 +55,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  Retrieves an `RLMProperty` object by the property name.
- 
+
  @param propertyName The property's name.
- 
+
  @return An `RLMProperty` object, or `nil` if there is no property with the given name.
  */
 - (nullable RLMProperty *)objectForKeyedSubscript:(NSString *)propertyName;

--- a/Realm/RLMObjectSchema.mm
+++ b/Realm/RLMObjectSchema.mm
@@ -114,7 +114,8 @@ using namespace realm;
     Class superClass = class_getSuperclass(cls);
     NSArray *allProperties = @[];
     while (superClass && superClass != RLMObjectBase.class) {
-        allProperties = [[RLMObjectSchema propertiesForClass:cls isSwift:isSwift] arrayByAddingObjectsFromArray:allProperties];
+        allProperties = [[RLMObjectSchema propertiesForClass:cls isSwift:isSwift]
+                         arrayByAddingObjectsFromArray:allProperties];
         cls = superClass;
         superClass = class_getSuperclass(superClass);
     }
@@ -131,14 +132,14 @@ using namespace realm;
     // verify that we didn't add any properties twice due to inheritance
     if (allProperties.count != [NSSet setWithArray:[allProperties valueForKey:@"name"]].count) {
         NSCountedSet *countedPropertyNames = [NSCountedSet setWithArray:[allProperties valueForKey:@"name"]];
-        NSSet *duplicatePropertyNames = [countedPropertyNames filteredSetUsingPredicate:[NSPredicate predicateWithBlock:^BOOL(id object, NSDictionary *) {
+        NSArray *duplicatePropertyNames = [countedPropertyNames filteredSetUsingPredicate:[NSPredicate predicateWithBlock:^BOOL(id object, NSDictionary *) {
             return [countedPropertyNames countForObject:object] > 1;
-        }]];
+        }]].allObjects;
 
         if (duplicatePropertyNames.count == 1) {
-            @throw RLMException(@"Property '%@' is declared multiple times in the class hierarchy of '%@'", duplicatePropertyNames.allObjects.firstObject, className);
+            @throw RLMException(@"Property '%@' is declared multiple times in the class hierarchy of '%@'", duplicatePropertyNames.firstObject, className);
         } else {
-            @throw RLMException(@"Object '%@' has properties that are declared multiple times in its class hierarchy: '%@'", className, [duplicatePropertyNames.allObjects componentsJoinedByString:@"', '"]);
+            @throw RLMException(@"Object '%@' has properties that are declared multiple times in its class hierarchy: '%@'", className, [duplicatePropertyNames componentsJoinedByString:@"', '"]);
         }
     }
 
@@ -161,7 +162,7 @@ using namespace realm;
     }
 
     for (RLMProperty *prop in schema.properties) {
-        if (prop.optional && !RLMPropertyTypeIsNullable(prop.type)) {
+        if (prop.optional && (prop.type == RLMPropertyTypeArray || prop.type == RLMPropertyTypeLinkingObjects)) {
             @throw RLMException(@"Property '%@.%@' cannot be made optional because optional '%@' properties are not supported.",
                                 className, prop.name, RLMTypeToString(prop.type));
         }
@@ -189,7 +190,7 @@ using namespace realm;
     id swiftObjectInstance = isSwiftClass ? [[objectClass alloc] init] : nil;
 
     unsigned int count;
-    objc_property_t *props = class_copyPropertyList(objectClass, &count);
+    std::unique_ptr<objc_property_t[], decltype(&free)> props(class_copyPropertyList(objectClass, &count), &free);
     NSMutableArray *propArray = [NSMutableArray arrayWithCapacity:count];
     NSSet *indexed = [[NSSet alloc] initWithArray:[objectUtil indexedPropertiesForClass:objectClass]];
     for (unsigned int i = 0; i < count; i++) {
@@ -217,87 +218,81 @@ using namespace realm;
             [propArray addObject:prop];
          }
     }
-    free(props);
+
+    auto existingPropertyIndex = [=](NSString *name) -> NSUInteger {
+        return [propArray indexOfObjectPassingTest:^BOOL(RLMProperty *obj, NSUInteger, BOOL *) {
+            return [obj.name isEqualToString:name];
+        }];
+    };
+    auto addProperty = [=](RLMProperty *prop) {
+        NSUInteger existing = existingPropertyIndex(prop.name);
+        if (existing != NSNotFound) {
+            propArray[existing] = prop;
+        }
+        else {
+            [propArray addObject:prop];
+        }
+    };
 
     if (isSwiftClass) {
         // List<> properties don't show up as objective-C properties due to
         // being generic, so use Swift reflection to get a list of them, and
         // then access their ivars directly
         for (NSString *propName in [objectUtil getGenericListPropertyNames:swiftObjectInstance]) {
-            Ivar ivar = class_getInstanceVariable(objectClass, propName.UTF8String);
-            id value = object_getIvar(swiftObjectInstance, ivar);
-            NSString *className = [value _rlmArray].objectClassName;
-            NSUInteger existing = [propArray indexOfObjectPassingTest:^BOOL(RLMProperty *obj, __unused NSUInteger idx, __unused BOOL *stop) {
-                return [obj.name isEqualToString:propName];
-            }];
-            if (existing != NSNotFound) {
-                [propArray removeObjectAtIndex:existing];
-            }
-            [propArray addObject:[[RLMProperty alloc] initSwiftListPropertyWithName:propName
-                                                                               ivar:ivar
-                                                                    objectClassName:className]];
+            addProperty([[RLMProperty alloc] initSwiftListPropertyWithName:propName instance:swiftObjectInstance]);
         }
 
         // Ditto for LinkingObjects<> properties.
-        NSDictionary *linkingObjectsProperties = [objectUtil getLinkingObjectsProperties:swiftObjectInstance];
-        for (NSString *propName in linkingObjectsProperties) {
-            NSDictionary *info = linkingObjectsProperties[propName];
-            Ivar ivar = class_getInstanceVariable(objectClass, propName.UTF8String);
-
-            NSUInteger existing = [propArray indexOfObjectPassingTest:^BOOL(RLMProperty *obj, __unused NSUInteger idx, __unused BOOL *stop) {
-                return [obj.name isEqualToString:propName];
-            }];
-            if (existing != NSNotFound) {
-                [propArray removeObjectAtIndex:existing];
-            }
-
-            [propArray addObject:[[RLMProperty alloc] initSwiftLinkingObjectsPropertyWithName:propName
-                                                                                         ivar:ivar
-                                                                              objectClassName:info[@"class"]
-                                                                       linkOriginPropertyName:info[@"property"]]];
-        }
+        [[objectUtil getLinkingObjectsProperties:swiftObjectInstance]
+         enumerateKeysAndObjectsUsingBlock:^(NSString *propName, NSDictionary *info, BOOL *) {
+             Ivar ivar = class_getInstanceVariable(objectClass, propName.UTF8String);
+             addProperty([[RLMProperty alloc] initSwiftLinkingObjectsPropertyWithName:propName
+                                                                                 ivar:ivar
+                                                                      objectClassName:info[@"class"]
+                                                               linkOriginPropertyName:info[@"property"]]);
+         }];
     }
 
     if (auto optionalProperties = [objectUtil getOptionalProperties:swiftObjectInstance]) {
         for (RLMProperty *property in propArray) {
             property.optional = false;
         }
-        [optionalProperties enumerateKeysAndObjectsUsingBlock:^(NSString *propertyName, NSNumber *propertyType, __unused BOOL *stop) {
+        [optionalProperties enumerateKeysAndObjectsUsingBlock:^(NSString *propertyName, NSNumber *propertyType, BOOL *) {
             if ([ignoredProperties containsObject:propertyName]) {
                 return;
             }
-            NSUInteger existing = [propArray indexOfObjectPassingTest:^BOOL(RLMProperty *obj, __unused NSUInteger idx, __unused BOOL *stop) {
-                return [obj.name isEqualToString:propertyName];
-            }];
+
+            NSUInteger existing = existingPropertyIndex(propertyName);
             RLMProperty *property;
             if (existing != NSNotFound) {
                 property = propArray[existing];
                 property.optional = true;
             }
-            if (auto type = RLMCoerceToNil(propertyType)) {
-                if (existing == NSNotFound) {
-                    // Check to see if this optional property is an underlying storage property for a Swift lazy var.
-                    // Managed lazy vars are't allowed.
-                    // NOTE: Revisit this once property behaviors are implemented in Swift.
-                    if (NSString *lazyPropertyBaseName = [self baseNameForLazySwiftProperty:propertyName]) {
-                        if ([ignoredProperties containsObject:lazyPropertyBaseName]) {
-                            // This property is the storage property for a ignored lazy Swift property. Just continue.
-                            return;
-                        } else {
-                            @throw RLMException(@"Lazy managed property '%@' is not allowed on a Realm Swift object class. Either add the property to the ignored properties list or make it non-lazy.", lazyPropertyBaseName);
-                        }
-                    }
-                    // The current property isn't a storage property for a lazy Swift property.
-                    property = [[RLMProperty alloc] initSwiftOptionalPropertyWithName:propertyName
-                                                                              indexed:[indexed containsObject:propertyName]
-                                                                                 ivar:class_getInstanceVariable(objectClass, propertyName.UTF8String)
-                                                                         propertyType:RLMPropertyType(type.intValue)];
-                    [propArray addObject:property];
-                }
-                else {
-                    property.type = RLMPropertyType(type.intValue);
-                }
+            auto type = RLMCoerceToNil(propertyType);
+            if (!type) {
+                return;
             }
+            if (property) {
+                property.type = RLMPropertyType(type.intValue);
+                return;
+            }
+
+            // Check to see if this optional property is an underlying storage property for a Swift lazy var.
+            // Managed lazy vars are't allowed.
+            // NOTE: Revisit this once property behaviors are implemented in Swift.
+            if (NSString *lazyPropertyBaseName = [self baseNameForLazySwiftProperty:propertyName]) {
+                if ([ignoredProperties containsObject:lazyPropertyBaseName]) {
+                    // This property is the storage property for a ignored lazy Swift property. Just continue.
+                    return;
+                }
+                @throw RLMException(@"Lazy managed property '%@' is not allowed on a Realm Swift object class. Either add the property to the ignored properties list or make it non-lazy.", lazyPropertyBaseName);
+            }
+            // The current property isn't a storage property for a lazy Swift property.
+            property = [[RLMProperty alloc] initSwiftOptionalPropertyWithName:propertyName
+                                                                      indexed:[indexed containsObject:propertyName]
+                                                                         ivar:class_getInstanceVariable(objectClass, propertyName.UTF8String)
+                                                                 propertyType:RLMPropertyType(type.intValue)];
+            [propArray addObject:property];
         }];
     }
     if (auto requiredProperties = [objectUtil requiredPropertiesForClass:objectClass]) {
@@ -312,8 +307,9 @@ using namespace realm;
     }
 
     for (RLMProperty *property in propArray) {
-        if (!property.optional && property.type == RLMPropertyTypeObject) { // remove if/when core supports required link columns
-            @throw RLMException(@"The `%@.%@` property must be marked as being optional.", [objectClass className], property.name);
+        if (!property.optional && property.type == RLMPropertyTypeObject) {
+            @throw RLMException(@"The `%@.%@` property must be marked as being optional.",
+                                [objectClass className], property.name);
         }
     }
 

--- a/Realm/RLMObjectSchema.mm
+++ b/Realm/RLMObjectSchema.mm
@@ -100,10 +100,10 @@ using namespace realm;
     if (hasSwiftName) {
         className = [RLMSwiftSupport demangleClassName:className];
     }
-    
+
     static Class s_swiftObjectClass = NSClassFromString(@"RealmSwiftObject");
     bool isSwift = hasSwiftName || [objectClass isSubclassOfClass:s_swiftObjectClass];
-    
+
     schema.className = className;
     schema.objectClass = objectClass;
     schema.accessorClass = objectClass;
@@ -413,7 +413,7 @@ using namespace realm;
     schema.objectClass = RLMObject.class;
     schema.accessorClass = RLMDynamicObject.class;
     schema.unmanagedClass = RLMObject.class;
-    
+
     return schema;
 }
 

--- a/Realm/RLMObjectSchema.mm
+++ b/Realm/RLMObjectSchema.mm
@@ -278,7 +278,7 @@ using namespace realm;
             }
 
             // Check to see if this optional property is an underlying storage property for a Swift lazy var.
-            // Managed lazy vars are't allowed.
+            // Managed lazy vars aren't allowed.
             // NOTE: Revisit this once property behaviors are implemented in Swift.
             if (NSString *lazyPropertyBaseName = [self baseNameForLazySwiftProperty:propertyName]) {
                 if ([ignoredProperties containsObject:lazyPropertyBaseName]) {

--- a/Realm/RLMObjectSchema_Private.h
+++ b/Realm/RLMObjectSchema_Private.h
@@ -54,15 +54,15 @@ NS_ASSUME_NONNULL_BEGIN
  This method is useful only in specialized circumstances, for example, when accessing objects
  in a Realm produced externally. If you are simply building an app on Realm, it is not recommended
  to use this method as an [RLMObjectSchema](RLMObjectSchema) is generated automatically for every [RLMObject](RLMObject) subclass.
- 
+
  Initialize an RLMObjectSchema with classname, objectClass, and an array of properties
- 
+
  @warning This method is useful only in specialized circumstances.
- 
+
  @param objectClassName     The name of the class used to refer to objects of this type.
  @param objectClass         The Objective-C class used when creating instances of this type.
  @param properties          An array of RLMProperty instances describing the managed properties for this type.
- 
+
  @return    An initialized instance of RLMObjectSchema.
  */
 - (instancetype)initWithClassName:(NSString *)objectClassName objectClass:(Class)objectClass properties:(NSArray *)properties;

--- a/Realm/RLMObjectStore.h
+++ b/Realm/RLMObjectStore.h
@@ -65,7 +65,7 @@ NS_RETURNS_RETAINED;
 //
 
 
-// switch List<> properties from being backed by unmanaged RLMArrays to RLMArrayLinkView
+// switch List<> properties from being backed by unmanaged RLMArrays to RLMManagedArray
 void RLMInitializeSwiftAccessorGenerics(RLMObjectBase *object);
 
 #ifdef __cplusplus

--- a/Realm/RLMObjectStore.h
+++ b/Realm/RLMObjectStore.h
@@ -58,7 +58,7 @@ id _Nullable RLMGetObject(RLMRealm *realm, NSString *objectClassName, id _Nullab
 RLMObjectBase *RLMCreateObjectInRealmWithValue(RLMRealm *realm, NSString *className,
                                                id _Nullable value, bool createOrUpdate)
 NS_RETURNS_RETAINED;
-    
+
 
 //
 // Accessor Creation

--- a/Realm/RLMObjectStore.mm
+++ b/Realm/RLMObjectStore.mm
@@ -86,7 +86,7 @@ void RLMInitializeSwiftAccessorGenerics(__unsafe_unretained RLMObjectBase *const
 
     for (RLMProperty *prop in object->_objectSchema.swiftGenericProperties) {
         if (prop.type == RLMPropertyTypeArray) {
-            RLMArray *array = [[RLMArrayLinkView alloc] initWithParent:object property:prop];
+            RLMArray *array = [[RLMManagedArray alloc] initWithParent:object property:prop];
             [object_getIvar(object, prop.swiftIvar) set_rlmArray:array];
         }
         else if (prop.type == RLMPropertyTypeLinkingObjects) {

--- a/Realm/RLMObject_Private.h
+++ b/Realm/RLMObject_Private.h
@@ -94,7 +94,7 @@ FOUNDATION_EXTERN const NSUInteger RLMDescriptionMaxDepth;
 + (nullable NSDictionary<NSString *, NSDictionary<NSString *, NSString *> *> *)linkingObjectsPropertiesForClass:(Class)cls;
 
 + (nullable NSArray<NSString *> *)getGenericListPropertyNames:(id)obj;
-+ (nullable NSDictionary<NSString *, NSString *> *)getLinkingObjectsProperties:(id)object;
++ (nullable NSDictionary<NSString *, NSDictionary<NSString *, NSString *> *> *)getLinkingObjectsProperties:(id)object;
 
 + (nullable NSDictionary<NSString *, NSNumber *> *)getOptionalProperties:(id)obj;
 + (nullable NSArray<NSString *> *)requiredPropertiesForClass:(Class)cls;

--- a/Realm/RLMObject_Private.h
+++ b/Realm/RLMObject_Private.h
@@ -81,6 +81,16 @@ typedef void (^RLMObjectNotificationCallback)(NSArray<NSString *> *_Nullable pro
                                               NSError *_Nullable error);
 FOUNDATION_EXTERN RLMNotificationToken *RLMObjectAddNotificationBlock(RLMObjectBase *obj, RLMObjectNotificationCallback block);
 
+// Returns whether the class is a descendent of RLMObjectBase
+FOUNDATION_EXTERN BOOL RLMIsObjectOrSubclass(Class klass);
+
+// Returns whether the class is an indirect descendant of RLMObjectBase
+FOUNDATION_EXTERN BOOL RLMIsObjectSubclass(Class klass);
+
+// For unit testing purposes, allow an Objective-C class named FakeObject to also be used
+// as the base class of managed objects. This allows for testing invalid schemas.
+FOUNDATION_EXTERN void RLMSetTreatFakeObjectAsRLMObject(BOOL flag);
+
 // Get ObjectUil class for objc or swift
 FOUNDATION_EXTERN Class RLMObjectUtilClass(BOOL isSwift);
 

--- a/Realm/RLMProperty.h
+++ b/Realm/RLMProperty.h
@@ -44,9 +44,9 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  `RLMProperty` instances represent properties managed by a Realm in the context of an object schema. Such properties may
  be persisted to a Realm file or computed from other data from the Realm.
- 
+
  When using Realm, `RLMProperty` instances allow performing migrations and introspecting the database's schema.
- 
+
  These property instances map to columns in the core database.
  */
 @interface RLMProperty : NSObject
@@ -60,14 +60,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  The type of the property.
- 
+
  @see `RLMPropertyType`
  */
 @property (nonatomic, readonly) RLMPropertyType type;
 
 /**
  Indicates whether this property is indexed.
- 
+
  @see `RLMObject`
  */
 @property (nonatomic, readonly) BOOL indexed;

--- a/Realm/RLMProperty.h
+++ b/Realm/RLMProperty.h
@@ -16,36 +16,36 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-#import <Foundation/Foundation.h>
 #import <Realm/RLMConstants.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
 /// :nodoc:
-@protocol RLMInt
-@end
-
+@protocol RLMInt @end
 /// :nodoc:
-@protocol RLMBool
-@end
-
+@protocol RLMBool @end
 /// :nodoc:
-@protocol RLMDouble
-@end
-
+@protocol RLMDouble @end
 /// :nodoc:
-@protocol RLMFloat
-@end
+@protocol RLMFloat @end
+/// :nodoc:
+@protocol RLMString @end
+/// :nodoc:
+@protocol RLMDate @end
+/// :nodoc:
+@protocol RLMData @end
 
 /// :nodoc:
 @interface NSNumber ()<RLMInt, RLMBool, RLMDouble, RLMFloat>
 @end
 
 /**
- `RLMProperty` instances represent properties managed by a Realm in the context of an object schema. Such properties may
- be persisted to a Realm file or computed from other data from the Realm.
+ `RLMProperty` instances represent properties managed by a Realm in the context
+ of an object schema. Such properties may be persisted to a Realm file or
+ computed from other data from the Realm.
 
- When using Realm, `RLMProperty` instances allow performing migrations and introspecting the database's schema.
+ When using Realm, `RLMProperty` instances allow performing migrations and
+ introspecting the database's schema.
 
  These property instances map to columns in the core database.
  */

--- a/Realm/RLMProperty.mm
+++ b/Realm/RLMProperty.mm
@@ -376,8 +376,10 @@ static realm::util::Optional<RLMPropertyType> typeFromProtocolString(const char 
         RLMArray *value = propertyValue;
         _type = RLMPropertyTypeArray;
         _objectClassName = value.objectClassName;
-        if (_objectClassName) {
-            // FIXME: validate
+        if (![RLMSchema classForString:_objectClassName]) {
+            @throw RLMException(@"Property '%@' is of type 'RLMArray<%@>' which is not a supported RLMArray object type. "
+                                @"RLMArrays can only contain instances of RLMObject subclasses. "
+                                @"See https://realm.io/docs/objc/latest/#to-many for more information.", _name, _objectClassName);
         }
     }
     else if ([rawType isEqualToString:@"@\"NSNumber\""]) {

--- a/Realm/RLMProperty_Private.h
+++ b/Realm/RLMProperty_Private.h
@@ -116,11 +116,11 @@ static inline NSString *RLMTypeToString(RLMPropertyType type) {
  This method is useful only in specialized circumstances, for example, in conjunction with
  +[RLMObjectSchema initWithClassName:objectClass:properties:]. If you are simply building an
  app on Realm, it is not recommened to use this method.
- 
+
  Initialize an RLMProperty
- 
+
  @warning This method is useful only in specialized circumstances.
- 
+
  @param name            The property name.
  @param type            The property type.
  @param objectClassName The object type used for Object and Array types.

--- a/Realm/RLMProperty_Private.h
+++ b/Realm/RLMProperty_Private.h
@@ -24,7 +24,6 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-BOOL RLMPropertyTypeIsNullable(RLMPropertyType propertyType);
 BOOL RLMPropertyTypeIsComputed(RLMPropertyType propertyType);
 FOUNDATION_EXTERN void RLMValidateSwiftPropertyName(NSString *name);
 
@@ -76,8 +75,7 @@ static inline NSString *RLMTypeToString(RLMPropertyType type) {
                                  instance:(RLMObjectBase *)objectInstance;
 
 - (instancetype)initSwiftListPropertyWithName:(NSString *)name
-                                         ivar:(Ivar)ivar
-                              objectClassName:(nullable NSString *)objectClassName;
+                                     instance:(id)object;
 
 - (instancetype)initSwiftOptionalPropertyWithName:(NSString *)name
                                           indexed:(BOOL)indexed

--- a/Realm/RLMQueryUtil.hpp
+++ b/Realm/RLMQueryUtil.hpp
@@ -37,6 +37,3 @@ realm::Query RLMPredicateToQuery(NSPredicate *predicate, RLMObjectSchema *object
 
 // return property - throw for invalid column name
 RLMProperty *RLMValidatedProperty(RLMObjectSchema *objectSchema, NSString *columnName);
-
-// validate the array of RLMSortDescriptors and convert it to a realm::SortDescriptor
-realm::SortDescriptor RLMSortDescriptorFromDescriptors(RLMClassInfo& classInfo, NSArray<RLMSortDescriptor *> *descriptors);

--- a/Realm/RLMRealmConfiguration+Sync.h
+++ b/Realm/RLMRealmConfiguration+Sync.h
@@ -30,10 +30,10 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  A configuration object representing configuration state for Realms intended
  to sync with a Realm Object Server.
- 
+
  This property is mutually exclusive with both `inMemoryIdentifier` and `fileURL`;
  setting any one of the three properties will automatically nil out the other two.
- 
+
  @see `RLMSyncConfiguration`
  */
 @property (nullable, nonatomic) RLMSyncConfiguration *syncConfiguration;

--- a/Realm/RLMRealmConfiguration.h
+++ b/Realm/RLMRealmConfiguration.h
@@ -39,10 +39,10 @@ typedef BOOL (^RLMShouldCompactOnLaunchBlock)(NSUInteger totalBytes, NSUInteger 
  `RLMRealmConfiguration` instances are just plain `NSObject`s. Unlike `RLMRealm`s
  and `RLMObject`s, they can be freely shared between threads as long as you do not
  mutate them.
- 
+
  Creating configuration objects for class subsets (by setting the
  `objectClasses` property) can be expensive. Because of this, you will normally want to
- cache and reuse a single configuration object for each distinct configuration rather than 
+ cache and reuse a single configuration object for each distinct configuration rather than
  creating a new object each time you open a Realm.
  */
 @interface RLMRealmConfiguration : NSObject<NSCopying>

--- a/Realm/RLMRealm_Dynamic.h
+++ b/Realm/RLMRealm_Dynamic.h
@@ -79,22 +79,22 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Returns the object of the given type with the given primary key from the Realm.
 
- @warning This method is useful only in specialized circumstances, for example, when building components 
+ @warning This method is useful only in specialized circumstances, for example, when building components
           that integrate with Realm. The preferred way to get an object of a single class is to use the class
           methods on `RLMObject`.
- 
+
  @param className   The class name for the object you are looking for.
  @param primaryKey  The primary key value for the object you are looking for.
- 
+
  @return    An object, or `nil` if an object with the given primary key does not exist.
- 
+
  @see       `+[RLMObject objectForPrimaryKey:]`
  */
 - (nullable RLMObject *)objectWithClassName:(NSString *)className forPrimaryKey:(id)primaryKey;
 
 /**
  Creates an `RLMObject` instance of type `className` in the Realm, and populates it using a given object.
- 
+
  The `value` argument is used to populate the object. It can be a key-value coding compliant object, an array or
  dictionary returned from the methods in `NSJSONSerialization`, or an array containing one element for each managed
  property. An exception will be thrown if any required properties are not present and those properties were not defined

--- a/Realm/RLMResults.h
+++ b/Realm/RLMResults.h
@@ -38,8 +38,8 @@ NS_ASSUME_NONNULL_BEGIN
  enumeration.
 
  `RLMResults` are lazily evaluated the first time they are accessed; they only
- run queries when the result of the query is requested. This means that 
- chaining several temporary `RLMResults` to sort and filter your data does not 
+ run queries when the result of the query is requested. This means that
+ chaining several temporary `RLMResults` to sort and filter your data does not
  perform any extra work processing the intermediate state.
 
  Once the results have been evaluated or a notification block has been added,
@@ -201,7 +201,7 @@ NS_ASSUME_NONNULL_BEGIN
  which rows in the results collection were added, removed or modified. If a
  write transaction did not modify any objects in the results collection,
  the block is not called at all. See the `RLMCollectionChange` documentation for
- information on how the changes are reported and an example of updating a 
+ information on how the changes are reported and an example of updating a
  `UITableView`.
 
  If an error occurs the block will be called with `nil` for the results
@@ -275,7 +275,7 @@ NS_ASSUME_NONNULL_BEGIN
 
  @warning You cannot use this method on `RLMObject`, `RLMArray`, and `NSData` properties.
 
- @param property The property whose maximum value is desired. Only properties of types `int`, `float`, `double`, and 
+ @param property The property whose maximum value is desired. Only properties of types `int`, `float`, `double`, and
                  `NSDate` are supported.
 
  @return The maximum value of the property, or `nil` if the Results are empty.
@@ -332,7 +332,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  `RLMLinkingObjects` is an auto-updating container type. It represents a collection of objects that link to its
  parent object.
- 
+
  For more information, please see the "Inverse Relationships" section in the
  [documentation](https://realm.io/docs/objc/latest/#relationships).
  */

--- a/Realm/RLMResults.mm
+++ b/Realm/RLMResults.mm
@@ -101,6 +101,9 @@ static void throwError(NSString *aggregateMethod) {
                             RLMTypeToString((RLMPropertyType)e.column_type),
                             e.column_name.data());
     }
+    catch (std::exception const& e) {
+        @throw RLMException(e);
+    }
 }
 
 template<typename Function>
@@ -355,8 +358,8 @@ static inline void RLMResultsValidateInWriteTransaction(__unsafe_unretained RLMR
         if (_results.get_mode() == Results::Mode::Empty) {
             return self;
         }
-
-        return [RLMResults resultsWithObjectInfo:*_info results:_results.sort(RLMSortDescriptorFromDescriptors(*_info, properties))];
+        return [RLMResults resultsWithObjectInfo:*_info
+                                         results:_results.sort(RLMSortDescriptorsToKeypathArray(properties))];
     });
 }
 

--- a/Realm/RLMResults.mm
+++ b/Realm/RLMResults.mm
@@ -156,18 +156,7 @@ static inline void RLMResultsValidateInWriteTransaction(__unsafe_unretained RLMR
     if (!_info) {
         return 0;
     }
-
-    __autoreleasing RLMFastEnumerator *enumerator;
-    if (state->state == 0) {
-        enumerator = [[RLMFastEnumerator alloc] initWithCollection:self objectSchema:*_info];
-        state->extra[0] = (long)enumerator;
-        state->extra[1] = self.count;
-    }
-    else {
-        enumerator = (__bridge id)(void *)state->extra[0];
-    }
-
-    return [enumerator countByEnumeratingWithState:state count:len];
+    return RLMFastEnumerate(state, len, self);
 }
 
 - (NSUInteger)indexOfObjectWhere:(NSString *)predicateFormat, ... {
@@ -418,6 +407,13 @@ static inline void RLMResultsValidateInWriteTransaction(__unsafe_unretained RLMR
 
 - (realm::TableView)tableView {
     return translateErrors([&] { return _results.get_tableview(); });
+}
+
+- (RLMFastEnumerator *)fastEnumerator {
+    return translateErrors([&] {
+        return [[RLMFastEnumerator alloc] initWithResults:_results collection:self
+                                                    realm:_realm classInfo:*_info];
+    });
 }
 
 // The compiler complains about the method's argument type not matching due to

--- a/Realm/RLMSchema.h
+++ b/Realm/RLMSchema.h
@@ -36,7 +36,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  An `NSArray` containing `RLMObjectSchema`s for all object types in the Realm.
- 
+
  This property is intended to be used during migrations for dynamic introspection.
 
  @see `RLMObjectSchema`
@@ -57,7 +57,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  Looks up and returns an `RLMObjectSchema` for the given class name in the Realm.
- 
+
  If there is no object of type `className` in the schema, an exception will be thrown.
 
  @param className   The object class name.

--- a/Realm/RLMSyncConfiguration.h
+++ b/Realm/RLMSyncConfiguration.h
@@ -33,7 +33,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  The URL of the remote Realm upon the Realm Object Server.
- 
+
  @warning The URL cannot end with `.realm`, `.realm.lock` or `.realm.management`.
  */
 @property (nonatomic, readonly) NSURL *realmURL;

--- a/Realm/RLMSyncErrorResponseModel.m
+++ b/Realm/RLMSyncErrorResponseModel.m
@@ -44,5 +44,5 @@ static const NSString *const kRLMSyncErrorHintKey       = @"hint";
     }
     return nil;
 }
-    
+
 @end

--- a/Realm/RLMSyncManager.h
+++ b/Realm/RLMSyncManager.h
@@ -83,7 +83,7 @@ typedef void(^RLMSyncErrorReportingBlock)(NSError *, RLMSyncSession * _Nullable)
 
 /**
  Whether SSL certificate validation should be disabled.
- 
+
  Once this value is set (either way), it will be used as the default value for SSL
  validation when initializing new sync configuration values. A given configuration's
  SSL validation setting can still be overriden from the global default by setting it

--- a/Realm/RLMSyncPermissionValue.h
+++ b/Realm/RLMSyncPermissionValue.h
@@ -32,7 +32,7 @@ typedef NS_ENUM(NSUInteger, RLMSyncAccessLevel) {
     RLMSyncAccessLevelNone          = 0,
     /**
      User can only read the contents of the Realm.
-     
+
      @warning Users who have read-only access to a Realm should open the
               Realm using `+[RLMRealm asyncOpenWithConfiguration:callbackQueue:callback:]`.
               Attempting to directly open the Realm is an error; in this
@@ -52,7 +52,7 @@ NS_ASSUME_NONNULL_BEGIN
  A value representing a permission granted to the specified user(s) to access the specified Realm(s).
 
  `RLMSyncPermissionValue` is immutable and can be accessed from any thread.
- 
+
  See https://realm.io/docs/realm-object-server/#permissions for general documentation.
  */
 @interface RLMSyncPermissionValue : NSObject

--- a/Realm/RLMSyncSession.h
+++ b/Realm/RLMSyncSession.h
@@ -124,7 +124,7 @@ NS_ASSUME_NONNULL_BEGIN
 
  Multiple blocks can be registered with the same session at once. Each block
  will be invoked on a side queue devoted to progress notifications.
- 
+
  If the session has already received progress information from the
  synchronization subsystem, the block will be called immediately. Otherwise, it
  will be called as soon as progress information becomes available.

--- a/Realm/RLMSyncUtil.h
+++ b/Realm/RLMSyncUtil.h
@@ -59,7 +59,7 @@ typedef RLM_ERROR_ENUM(NSInteger, RLMSyncError, RLMSyncErrorDomain) {
     /**
      An error that indicates that the response received from the
      authentication server was malformed.
-     
+
      @warning This error is deprecated, and has been replaced by
               `RLMSyncAuthErrorBadResponse`.
      */
@@ -71,7 +71,7 @@ typedef RLM_ERROR_ENUM(NSInteger, RLMSyncError, RLMSyncErrorDomain) {
     /// An error that indicates a problem with a specific user.
     RLMSyncErrorClientUserError         = 5,
 
-    /** 
+    /**
      An error that indicates an internal, unrecoverable problem
      with the underlying synchronization engine.
      */

--- a/Realm/RLMUtil.hpp
+++ b/Realm/RLMUtil.hpp
@@ -70,12 +70,6 @@ static inline BOOL RLMIsKindOfClass(Class class1, Class class2) {
     return NO;
 }
 
-// Returns whether the class is a descendent of RLMObjectBase
-BOOL RLMIsObjectOrSubclass(Class klass);
-
-// Returns whether the class is an indirect descendant of RLMObjectBase
-BOOL RLMIsObjectSubclass(Class klass);
-
 template<typename T>
 static inline T *RLMDynamicCast(__unsafe_unretained id obj) {
     if ([obj isKindOfClass:[T class]]) {
@@ -167,10 +161,6 @@ static inline NSUInteger RLMConvertNotFound(size_t index) {
 }
 
 id RLMMixedToObjc(realm::Mixed const& value);
-
-// For unit testing purposes, allow an Objective-C class named FakeObject to also be used
-// as the base class of managed objects. This allows for testing invalid schemas.
-void RLMSetTreatFakeObjectAsRLMObject(BOOL flag);
 
 // Given a bundle identifier, return the base directory on the disk within which Realm database and support files should
 // be stored.

--- a/Realm/RLMUtil.mm
+++ b/Realm/RLMUtil.mm
@@ -301,42 +301,6 @@ void RLMSetErrorOrThrow(NSError *error, NSError **outError) {
     }
 }
 
-// Determines if class1 descends from class2
-static inline BOOL RLMIsSubclass(Class class1, Class class2) {
-    class1 = class_getSuperclass(class1);
-    return RLMIsKindOfClass(class1, class2);
-}
-
-static bool treatFakeObjectAsRLMObject = false;
-
-void RLMSetTreatFakeObjectAsRLMObject(BOOL flag) {
-    treatFakeObjectAsRLMObject = flag;
-}
-
-BOOL RLMIsObjectOrSubclass(Class klass) {
-    if (RLMIsKindOfClass(klass, RLMObjectBase.class)) {
-        return YES;
-    }
-
-    if (treatFakeObjectAsRLMObject) {
-        static Class FakeObjectClass = NSClassFromString(@"FakeObject");
-        return RLMIsKindOfClass(klass, FakeObjectClass);
-    }
-    return NO;
-}
-
-BOOL RLMIsObjectSubclass(Class klass) {
-    if (RLMIsSubclass(class_getSuperclass(klass), RLMObjectBase.class)) {
-        return YES;
-    }
-
-    if (treatFakeObjectAsRLMObject) {
-        static Class FakeObjectClass = NSClassFromString(@"FakeObject");
-        return RLMIsSubclass(klass, FakeObjectClass);
-    }
-    return NO;
-}
-
 BOOL RLMIsDebuggerAttached()
 {
     int name[] = {

--- a/Realm/Swift/RLMSupport.swift
+++ b/Realm/Swift/RLMSupport.swift
@@ -22,9 +22,7 @@ extension RLMRealm {
     @nonobjc public class func schemaVersion(at url: URL, usingEncryptionKey key: Data? = nil) throws -> UInt64 {
         var error: NSError?
         let version = __schemaVersion(at: url, encryptionKey: key, error: &error)
-        guard version != RLMNotVersioned else {
-            throw error!
-        }
+        guard version != RLMNotVersioned else { throw error! }
         return version
     }
 
@@ -52,15 +50,15 @@ extension RLMObject {
     }
 }
 
-public final class RLMIterator: IteratorProtocol {
+public struct RLMIterator<T>: IteratorProtocol {
     private var iteratorBase: NSFastEnumerationIterator
 
     internal init(collection: RLMCollection) {
         iteratorBase = NSFastEnumerationIterator(collection)
     }
 
-    public func next() -> RLMObject? {
-        return iteratorBase.next() as! RLMObject?
+    public func next() -> T? {
+        return iteratorBase.next() as! T?
     }
 }
 
@@ -71,7 +69,7 @@ extension RLMResults: Sequence {}
 
 extension RLMCollection {
     // Support Sequence-style enumeration
-    public func makeIterator() -> RLMIterator {
+    public func makeIterator() -> RLMIterator<RLMObject> {
         return RLMIterator(collection: self)
     }
 }

--- a/Realm/Tests/DynamicTests.m
+++ b/Realm/Tests/DynamicTests.m
@@ -161,7 +161,7 @@
 
     // verify properties
     RLMRealm *dyrealm = [self realmWithTestPathAndSchema:nil];
-    RLMResults *results = [dyrealm allObjects:AllTypesObject.className];
+    RLMResults<RLMObject *> *results = [dyrealm allObjects:AllTypesObject.className];
     XCTAssertEqual(results.count, (NSUInteger)2, @"Should have 2 objects");
 
     RLMObjectSchema *schema = dyrealm.schema[AllTypesObject.className];
@@ -233,10 +233,10 @@
     RLMObject *stringObject1 = [dyrealm createObject:StringObject.className withValue:@[@"string1"]];
     [dyrealm createObject:ArrayPropertyObject.className withValue:@[@"name", @[stringObject, stringObject1], @[]]];
 
-    RLMResults *results = [dyrealm allObjects:ArrayPropertyObject.className];
+    RLMResults<RLMObject *> *results = [dyrealm allObjects:ArrayPropertyObject.className];
     XCTAssertEqual(1U, results.count);
     RLMObject *arrayObj = results.firstObject;
-    RLMArray *array = arrayObj[@"array"];
+    RLMArray<RLMObject *> *array = arrayObj[@"array"];
     XCTAssertEqual(2U, array.count);
     XCTAssertEqualObjects(array[0][@"stringCol"], stringObject[@"stringCol"]);
 

--- a/Realm/Tests/EnumeratorTests.m
+++ b/Realm/Tests/EnumeratorTests.m
@@ -28,19 +28,19 @@
     RLMRealm *realm = [RLMRealm defaultRealm];
 
     RLMResults *emptyPeople = [EmployeeObject allObjects];
-    
+
     // Enum for zero rows added
     for (EmployeeObject *row in emptyPeople) {
         XCTFail(@"No objects should have been added %@", row);
     }
-    
+
     NSArray *rowsArray = @[@{@"name": @"John", @"age": @20, @"hired": @YES},
                            @{@"name": @"Mary", @"age": @21, @"hired": @NO},
                            @{@"name": @"Lars", @"age": @21, @"hired": @YES},
                            @{@"name": @"Phil", @"age": @43, @"hired": @NO},
                            @{@"name": @"Anni", @"age": @54, @"hired": @YES}];
-    
-    
+
+
     // Add objects
     [realm beginWriteTransaction];
     for (NSArray *rowArray in rowsArray) {
@@ -50,7 +50,7 @@
 
     // Get all objects
     RLMResults *people = [EmployeeObject allObjects];
-    
+
     // Iterate using for...in
     NSUInteger index = 0;
     for (EmployeeObject *row in people) {
@@ -62,10 +62,10 @@
 
     NSPredicate *pred = [NSPredicate predicateWithFormat:@"hired = YES && age BETWEEN {20, 30}"];
     NSArray *filteredArray = [rowsArray filteredArrayUsingPredicate:pred];
-    
+
     // Do a query, and get all matches as RLMResults
     RLMResults *res = [EmployeeObject objectsWithPredicate:pred];
-    
+
     // Iterate over the resulting RLMResults
     index = 0;
     for (EmployeeObject *row in res) {

--- a/Realm/Tests/LinkTests.m
+++ b/Realm/Tests/LinkTests.m
@@ -120,7 +120,7 @@ RLM_ARRAY_TYPE(CircularArrayObject)
     XCTAssertThrows(dog.dogName, @"Dog object should be invalid after being deleted from the realm");
 
     // refresh owner and check
-    owner = [realm allObjects:[OwnerObject className]].firstObject;
+    owner = [OwnerObject allObjectsInRealm:realm].firstObject;
     XCTAssertNotNil(owner, @"Should have 1 owner");
     XCTAssertNil(owner.dog, @"Dog should be nullified when deleted");
     XCTAssertEqual([DogObject objectsInRealm:realm withPredicate:nil].count, 0U);

--- a/Realm/Tests/QueryTests.m
+++ b/Realm/Tests/QueryTests.m
@@ -525,12 +525,12 @@
 - (void)verifySort:(RLMRealm *)realm column:(NSString *)column ascending:(BOOL)ascending expected:(id)val {
     RLMResults *results = [[AllTypesObject allObjectsInRealm:realm] sortedResultsUsingKeyPath:column ascending:ascending];
     AllTypesObject *obj = results[0];
-    XCTAssertEqualObjects(obj[column], val, @"Array not sorted as expected - %@ != %@", obj[column], val);
+    XCTAssertEqualObjects(obj[column], val);
 
     RLMArray *ar = (RLMArray *)[[[ArrayOfAllTypesObject allObjectsInRealm:realm] firstObject] array];
     results = [ar sortedResultsUsingKeyPath:column ascending:ascending];
     obj = results[0];
-    XCTAssertEqualObjects(obj[column], val, @"Array not sorted as expected - %@ != %@", obj[column], val);
+    XCTAssertEqualObjects(obj[column], val);
 }
 
 - (void)verifySortWithAccuracy:(RLMRealm *)realm column:(NSString *)column ascending:(BOOL)ascending getter:(double(^)(id))getter expected:(double)val accuracy:(double)accuracy {

--- a/Realm/Tests/QueryTests.m
+++ b/Realm/Tests/QueryTests.m
@@ -594,8 +594,10 @@
     [self verifySort:realm column:@"stringCol" ascending:NO expected:@"cc"];
 
     // sort invalid name
-    RLMAssertThrowsWithReasonMatching([[AllTypesObject allObjects] sortedResultsUsingKeyPath:@"invalidCol" ascending:YES], @"'invalidCol'.* not found .*'AllTypesObject'");
-    XCTAssertThrows([arrayOfAll.array sortedResultsUsingKeyPath:@"invalidCol" ascending:NO]);
+    RLMAssertThrowsWithReason([[AllTypesObject allObjects] sortedResultsUsingKeyPath:@"invalidCol" ascending:YES],
+                              @"Cannot sort on key path 'invalidCol': property 'AllTypesObject.invalidCol' does not exist.");
+    RLMAssertThrowsWithReason([arrayOfAll.array sortedResultsUsingKeyPath:@"invalidCol" ascending:NO],
+                              @"Cannot sort on key path 'invalidCol': property 'AllTypesObject.invalidCol' does not exist.");
 }
 
 - (void)testSortByNoColumns {
@@ -685,16 +687,16 @@
 
 - (void)testSortByUnspportedKeyPath {
     // Array property
-    RLMAssertThrowsWithReasonMatching([DogArrayObject.allObjects sortedResultsUsingKeyPath:@"dogs.age" ascending:YES],
-                                      @"to-many relationship is not supported");
+    RLMAssertThrowsWithReason([DogArrayObject.allObjects sortedResultsUsingKeyPath:@"dogs.age" ascending:YES],
+                              @"Cannot sort on key path 'dogs.age': property 'DogArrayObject.dogs' is of unsupported type 'array'.");
 
     // Backlinks property
-    RLMAssertThrowsWithReasonMatching([DogObject.allObjects sortedResultsUsingKeyPath:@"owners.name" ascending:YES],
-                                      @"to-many relationship is not supported");
+    RLMAssertThrowsWithReason([DogObject.allObjects sortedResultsUsingKeyPath:@"owners.name" ascending:YES],
+                              @"Cannot sort on key path 'owners.name': property 'DogObject.owners' is of unsupported type 'linking objects'.");
 
     // Collection operator
-    RLMAssertThrowsWithReasonMatching([DogArrayObject.allObjects sortedResultsUsingKeyPath:@"dogs.@count" ascending:YES],
-                                      @"collection operators is not supported");
+    RLMAssertThrowsWithReason([DogArrayObject.allObjects sortedResultsUsingKeyPath:@"dogs.@count" ascending:YES],
+                              @"Cannot sort on key path 'dogs.@count': KVC collection operators are not supported.");
 }
 
 - (void)testSortedLinkViewWithDeletion {

--- a/Realm/Tests/QueryTests.m
+++ b/Realm/Tests/QueryTests.m
@@ -535,7 +535,8 @@
 
 - (void)verifySortWithAccuracy:(RLMRealm *)realm column:(NSString *)column ascending:(BOOL)ascending getter:(double(^)(id))getter expected:(double)val accuracy:(double)accuracy {
     // test TableView query
-    RLMResults *results = [[AllTypesObject allObjectsInRealm:realm] sortedResultsUsingKeyPath:column ascending:ascending];
+    RLMResults<AllTypesObject *> *results = [[AllTypesObject allObjectsInRealm:realm]
+                                             sortedResultsUsingKeyPath:column ascending:ascending];
     XCTAssertEqualWithAccuracy(getter(results[0][column]), val, accuracy, @"Array not sorted as expected");
 
     // test LinkView query
@@ -1779,7 +1780,7 @@
     [EmployeeObject createInRealm:realm withValue:@{@"name": @"Joe",  @"age": @40, @"hired": @YES}];
     [realm commitWriteTransaction];
 
-    RLMResults *subarray = nil;
+    RLMResults<EmployeeObject *> *subarray = nil;
     @autoreleasepool {
         __attribute((objc_precise_lifetime)) CompanyObject *co = [CompanyObject allObjects][0];
         subarray = [co.employees objectsWhere:@"age = 40"];

--- a/Realm/Tests/ResultsTests.m
+++ b/Realm/Tests/ResultsTests.m
@@ -516,7 +516,7 @@
     [EmployeeObject createInRealm:realm withValue:@{@"name": @"Jill",  @"age": @50, @"hired": @YES}];
     [realm commitWriteTransaction];
 
-    RLMResults *subarray = nil;
+    RLMResults<EmployeeObject *> *subarray = nil;
     {
         __attribute((objc_precise_lifetime)) RLMResults *results = [EmployeeObject objectsWhere:@"hired = YES"];
         subarray = [results objectsWhere:@"age = 40"];
@@ -538,7 +538,7 @@
     [EmployeeObject createInRealm:realm withValue:@{@"name": @"Jill",  @"age": @50, @"hired": @YES}];
     [realm commitWriteTransaction];
 
-    RLMResults *subarray = nil;
+    RLMResults<EmployeeObject *> *subarray = nil;
     {
         __attribute((objc_precise_lifetime)) RLMResults *results = [[EmployeeObject allObjects] sortedResultsUsingKeyPath:@"age" ascending:YES];
         subarray = [results sortedResultsUsingKeyPath:@"age" ascending:NO];

--- a/Realm/Tests/SchemaTests.mm
+++ b/Realm/Tests/SchemaTests.mm
@@ -654,7 +654,7 @@ RLM_ARRAY_TYPE(NotARealClass)
 
 - (void)testClassWithInvalidNSNumberProtocolProperty {
     RLMAssertThrowsWithReasonMatching([RLMObjectSchema schemaForObjectClass:InvalidNSNumberProtocolObject.class],
-                                      @"Property 'number' is of type 'NSNumber<NSFastEnumeration>' which is not a supported NSNumber object type.");
+                                      @"Property 'number' is of type \"NSNumber<NSFastEnumeration>\" which is not a supported NSNumber object type.");
 }
 
 - (void)testClassWithInvalidNSNumberNoProtocolProperty {

--- a/Realm/Tests/SchemaTests.mm
+++ b/Realm/Tests/SchemaTests.mm
@@ -426,14 +426,14 @@ RLM_ARRAY_TYPE(NotARealClass)
     // types and ignores any other types that may be included in the realm's type catalogue.
     // If a more fine-grained control with the realm's type inclusion mechanism is introduced later
     // on, these tests should be altered to verify all types.
-    
+
     NSArray *expectedTypes = @[@"AllTypesObject",
                                @"LinkToAllTypesObject",
                                @"StringObject",
                                @"IntObject"];
-    
+
     NSString *unexpectedType = @"__$ThisTypeShouldNotOccur$__";
-    
+
     // Getting the test realm
     NSMutableArray *objectSchema = [NSMutableArray array];
     for (NSString *className in expectedTypes) {
@@ -452,22 +452,22 @@ RLM_ARRAY_TYPE(NotARealClass)
 
     // Test 1: Does the objectSchema return the right number of object schemas?
     NSArray *objectSchemas = schema.objectSchema;
-    
+
     XCTAssertTrue(objectSchemas.count >= expectedTypes.count, @"Expecting %lu object schemas in database found %lu", (unsigned long)expectedTypes.count, (unsigned long)objectSchemas.count);
-    
+
     // Test 2: Does the object schema array contain the expected schemas?
     NSUInteger identifiedTypesCount = 0;
     for (NSString *expectedType in expectedTypes) {
         NSUInteger occurrenceCount = 0;
-        
+
         for (RLMObjectSchema *objectSchema in objectSchemas) {
             if ([objectSchema.className isEqualToString:expectedType]) {
                 occurrenceCount++;
             }
         }
-        
+
         XCTAssertEqual(occurrenceCount, (NSUInteger)1, @"Expecting single occurrence of object schema for type %@ found %lu", expectedType, (unsigned long)occurrenceCount);
-        
+
         if (occurrenceCount > 0) {
             identifiedTypesCount++;
         }
@@ -475,7 +475,7 @@ RLM_ARRAY_TYPE(NotARealClass)
 
     // Test 3: Does the object schema array contains at least the expected classes
     XCTAssertTrue(identifiedTypesCount >= expectedTypes.count, @"Unexpected object schemas in database. Found %lu out of %lu expected", (unsigned long)identifiedTypesCount, (unsigned long)expectedTypes.count);
-    
+
     // Test 4: Test querying object schemas using schemaForClassName: for expected types
     for (NSString *expectedType in expectedTypes) {
         XCTAssertNotNil([schema schemaForClassName:expectedType], @"Expecting to find object schema for type %@ in realm using query, found none", expectedType);
@@ -483,12 +483,12 @@ RLM_ARRAY_TYPE(NotARealClass)
 
     // Test 5: Test querying object schemas using schemaForClassName: for unexpected types
     XCTAssertNil([schema schemaForClassName:unexpectedType], @"Expecting not to find object schema for type %@ in realm using query, did find", unexpectedType);
-    
+
     // Test 6: Test querying object schemas using subscription for unexpected types
     for (NSString *expectedType in expectedTypes) {
         XCTAssertNotNil(schema[expectedType], @"Expecting to find object schema for type %@ in realm using subscription, found none", expectedType);
     }
-    
+
     // Test 7: Test querying object schemas using subscription for unexpected types
     XCTAssertThrows(schema[unexpectedType], @"Expecting asking schema for type %@ in realm using subscription to throw", unexpectedType);
 

--- a/Realm/Tests/Swift/SwiftArrayPropertyTests.swift
+++ b/Realm/Tests/Swift/SwiftArrayPropertyTests.swift
@@ -38,7 +38,7 @@ class SwiftArrayPropertyTests: RLMTestCase {
         array.name = "arrayObject"
         array.array.add(string)
         XCTAssertEqual(array.array.count, UInt(1))
-        XCTAssertEqual((array.array.firstObject() as! SwiftStringObject).stringCol, "string")
+        XCTAssertEqual(array.array.firstObject()!.stringCol, "string")
 
         realm.beginWriteTransaction()
         realm.add(array)
@@ -48,7 +48,7 @@ class SwiftArrayPropertyTests: RLMTestCase {
         let arrayObjects = SwiftArrayPropertyObject.allObjects(in: realm)
 
         XCTAssertEqual(arrayObjects.count, UInt(1), "There should be a single SwiftStringObject in the realm")
-        let cmp = (arrayObjects.firstObject() as! SwiftArrayPropertyObject).array.firstObject() as! SwiftStringObject
+        let cmp = (arrayObjects.firstObject() as! SwiftArrayPropertyObject).array.firstObject()!
         XCTAssertTrue(string.isEqual(to: cmp), "First array object should be the string object we added")
     }
 
@@ -68,9 +68,9 @@ class SwiftArrayPropertyTests: RLMTestCase {
         try! realm.commitWriteTransaction()
 
         XCTAssertEqual(array.array.count, UInt(3), "Should have three elements in array")
-        XCTAssertEqual((array.array[0] as! SwiftStringObject).stringCol, "a", "First element should have property value 'a'")
-        XCTAssertEqual((array.array[1] as! SwiftStringObject).stringCol, "b", "Second element should have property value 'b'")
-        XCTAssertEqual((array.array[2] as! SwiftStringObject).stringCol, "a", "Third element should have property value 'a'")
+        XCTAssertEqual(array.array[0].stringCol, "a", "First element should have property value 'a'")
+        XCTAssertEqual(array.array[1].stringCol, "b", "Second element should have property value 'b'")
+        XCTAssertEqual(array.array[2].stringCol, "a", "Third element should have property value 'a'")
 
         for obj in array.array {
             XCTAssertFalse(obj.description.isEmpty, "Object should have description")
@@ -92,8 +92,8 @@ class SwiftArrayPropertyTests: RLMTestCase {
         try! realm.commitWriteTransaction()
 
         XCTAssertEqual(array.count, UInt(2), "Should have two elements in array")
-        XCTAssertEqual((array[0] as! SwiftStringObject).stringCol, "a", "First element should have property value 'a'")
-        XCTAssertEqual((array[1] as! SwiftStringObject).stringCol, "b", "Second element should have property value 'b'")
+        XCTAssertEqual(array[0].stringCol, "a", "First element should have property value 'a'")
+        XCTAssertEqual(array[1].stringCol, "b", "Second element should have property value 'b'")
     }
 
     func testInsertMultiple() {

--- a/Realm/Tests/Swift/SwiftArrayTests.swift
+++ b/Realm/Tests/Swift/SwiftArrayTests.swift
@@ -225,13 +225,13 @@ class SwiftArrayTests: RLMTestCase {
 
         XCTAssertEqual(peopleInCompany.count, UInt(2), "link deleted when accessing via links")
 
-        var test = peopleInCompany[0] as! SwiftEmployeeObject
+        var test = peopleInCompany[0]
         XCTAssertEqual(test.age, po1.age, "Should be equal")
         XCTAssertEqual(test.name, po1.name, "Should be equal")
         XCTAssertEqual(test.hired, po1.hired, "Should be equal")
         // XCTAssertEqual(test, po1, "Should be equal") //FIXME, should work. Asana : https://app.asana.com/0/861870036984/13123030433568
 
-        test = peopleInCompany[1] as! SwiftEmployeeObject
+        test = peopleInCompany[1]
         XCTAssertEqual(test.age, po3.age, "Should be equal")
         XCTAssertEqual(test.name, po3.name, "Should be equal")
         XCTAssertEqual(test.hired, po3.hired, "Should be equal")

--- a/Realm/Tests/Swift/SwiftObjectInterfaceTests.swift
+++ b/Realm/Tests/Swift/SwiftObjectInterfaceTests.swift
@@ -31,7 +31,7 @@ class SwiftStringObjectSubclass : SwiftStringObject {
 }
 
 class SwiftSelfRefrencingSubclass: SwiftStringObject {
-    @objc dynamic var objects = RLMArray(objectClassName: SwiftSelfRefrencingSubclass.className())
+    @objc dynamic var objects = RLMArray<SwiftSelfRefrencingSubclass>(objectClassName: SwiftSelfRefrencingSubclass.className())
 }
 
 
@@ -86,7 +86,7 @@ class SwiftObjectInterfaceTests: RLMTestCase {
         XCTAssertEqual(firstObj.dateCol, Date(timeIntervalSince1970: 123), "should be epoch + 123")
         XCTAssertEqual(firstObj.objectCol.boolCol, true, "should be true")
         XCTAssertEqual(obj.arrayCol.count, UInt(1), "array count should be 1")
-        XCTAssertEqual((obj.arrayCol.firstObject() as? SwiftBoolObject)!.boolCol, true, "should be true")
+        XCTAssertEqual(obj.arrayCol.firstObject()!.boolCol, true, "should be true")
     }
 
     func testDefaultValueSwiftObject() {

--- a/Realm/Tests/Swift/SwiftSchemaTests.swift
+++ b/Realm/Tests/Swift/SwiftSchemaTests.swift
@@ -82,13 +82,13 @@ class SwiftRecursingSchemaTestObject : RLMObject {
 }
 
 class InitAppendsToArrayProperty : RLMObject {
-    @objc dynamic var propertyWithIllegalDefaultValue: RLMArray = {
+    @objc dynamic var propertyWithIllegalDefaultValue: RLMArray<SwiftIntObject> = {
         if mayAppend {
-            let array = RLMArray(objectClassName: SwiftIntObject.className())
+            let array = RLMArray<SwiftIntObject>(objectClassName: SwiftIntObject.className())
             array.add(SwiftIntObject())
             return array
         } else {
-            return RLMArray(objectClassName: SwiftIntObject.className())
+            return RLMArray<SwiftIntObject>(objectClassName: SwiftIntObject.className())
         }
     }()
 

--- a/Realm/Tests/Swift/SwiftSchemaTests.swift
+++ b/Realm/Tests/Swift/SwiftSchemaTests.swift
@@ -81,6 +81,10 @@ class SwiftRecursingSchemaTestObject : RLMObject {
     static var mayAccessSchema = false
 }
 
+class InvalidArrayType: FakeObject {
+    @objc dynamic var array = RLMArray<SwiftIntObject>(objectClassName: "invalid class")
+}
+
 class InitAppendsToArrayProperty : RLMObject {
     @objc dynamic var propertyWithIllegalDefaultValue: RLMArray<SwiftIntObject> = {
         if mayAppend {
@@ -198,4 +202,10 @@ class SwiftSchemaTests: RLMMultiProcessTestCase {
         assertThrowsWithReasonMatching(RLMSchema.shared(), ".*unless the schema is initialized.*")
     }
 
+    func testInvalidObjectTypeForRLMArray() {
+        RLMSetTreatFakeObjectAsRLMObject(true)
+        assertThrowsWithReasonMatching(RLMObjectSchema(forObjectClass: InvalidArrayType.self),
+                                       "RLMArray\\<invalid class\\>")
+        RLMSetTreatFakeObjectAsRLMObject(false)
+    }
 }

--- a/Realm/Tests/Swift/SwiftTestObjects.swift
+++ b/Realm/Tests/Swift/SwiftTestObjects.swift
@@ -43,15 +43,10 @@ class SwiftObject: RLMObject {
     @objc dynamic var binaryCol = "a".data(using: String.Encoding.utf8)
     @objc dynamic var dateCol = Date(timeIntervalSince1970: 1)
     @objc dynamic var objectCol = SwiftBoolObject()
-    @objc dynamic var arrayCol = RLMArray(objectClassName: SwiftBoolObject.className())
+    @objc dynamic var arrayCol = RLMArray<SwiftBoolObject>(objectClassName: SwiftBoolObject.className())
 }
 
 class SwiftOptionalObject: RLMObject {
-    // FIXME: Support all optional property types
-//    @objc dynamic var optBoolCol: Bool?
-//    @objc dynamic var optIntCol: Int?
-//    @objc dynamic var optFloatCol: Float?
-//    @objc dynamic var optDoubleCol: Double?
     @objc dynamic var optStringCol: String?
     @objc dynamic var optNSStringCol: NSString?
     @objc dynamic var optBinaryCol: Data?
@@ -90,13 +85,13 @@ class SwiftEmployeeObject: RLMObject {
 }
 
 class SwiftCompanyObject: RLMObject {
-    @objc dynamic var employees = RLMArray(objectClassName: SwiftEmployeeObject.className())
+    @objc dynamic var employees = RLMArray<SwiftEmployeeObject>(objectClassName: SwiftEmployeeObject.className())
 }
 
 class SwiftArrayPropertyObject: RLMObject {
     @objc dynamic var name = ""
-    @objc dynamic var array = RLMArray(objectClassName: SwiftStringObject.className())
-    @objc dynamic var intArray = RLMArray(objectClassName: SwiftIntObject.className())
+    @objc dynamic var array = RLMArray<SwiftStringObject>(objectClassName: SwiftStringObject.className())
+    @objc dynamic var intArray = RLMArray<SwiftIntObject>(objectClassName: SwiftIntObject.className())
 }
 
 class SwiftDynamicObject: RLMObject {

--- a/Realm/Tests/TransactionTests.m
+++ b/Realm/Tests/TransactionTests.m
@@ -29,26 +29,26 @@
     [realm beginWriteTransaction];
     StringObject *obj = [StringObject createInRealm:realm withValue:@[@"a"]];
     [realm commitWriteTransaction];
-    
+
     XCTAssertThrows([obj setStringCol:@"throw"], @"Setter should throw when called outside of transaction.");
 }
 
 - (void)testTransactionMisuse
 {
     RLMRealm *realm = [RLMRealm defaultRealm];
-    
+
     // Insert an object
     [realm beginWriteTransaction];
     StringObject *obj = [StringObject createInRealm:realm withValue:@[@"a"]];
     [realm commitWriteTransaction];
-    
+
     XCTAssertThrows([StringObject createInRealm:realm withValue:@[@"a"]], @"Outside write transaction");
     XCTAssertThrows([realm commitWriteTransaction], @"No write transaction to close");
-    
+
     [realm beginWriteTransaction];
     XCTAssertThrows([realm beginWriteTransaction], @"Write transaction already in place");
     [realm commitWriteTransaction];
-    
+
     XCTAssertThrows([realm deleteObject:obj], @"Outside writetransaction");
 }
 

--- a/RealmSwift/Migration.swift
+++ b/RealmSwift/Migration.swift
@@ -80,7 +80,7 @@ extension Realm {
  instance provides access to the old and new database schemas, the objects in the Realm, and provides functionality for
  modifying the Realm during the migration.
  */
-public final class Migration {
+public struct Migration {
 
     // MARK: Properties
 

--- a/RealmSwift/ObjectSchema.swift
+++ b/RealmSwift/ObjectSchema.swift
@@ -26,7 +26,7 @@ import Realm
 
  Object schemas map to tables in the core database.
  */
-public final class ObjectSchema: CustomStringConvertible {
+public struct ObjectSchema: CustomStringConvertible {
 
     // MARK: Properties
 

--- a/RealmSwift/Property.swift
+++ b/RealmSwift/Property.swift
@@ -27,7 +27,7 @@ import Realm
 
  Property instances map to columns in the core database.
  */
-public final class Property: CustomStringConvertible {
+public struct Property: CustomStringConvertible {
 
     // MARK: Properties
 

--- a/RealmSwift/Schema.swift
+++ b/RealmSwift/Schema.swift
@@ -26,7 +26,7 @@ import Realm
 
  Schemas map to collections of tables in the core database.
  */
-public final class Schema: CustomStringConvertible {
+public struct Schema: CustomStringConvertible {
 
     // MARK: Properties
 

--- a/RealmSwift/Sync.swift
+++ b/RealmSwift/Sync.swift
@@ -175,13 +175,13 @@ public struct SyncConfiguration {
 
      Additional settings can be optionally specified. Descriptions of these
      settings follow.
-     
+
      `enableSSLValidation` is true by default. It can be disabled for debugging
      purposes.
 
      - warning: The URL must be absolute (e.g. `realms://example.com/~/foo`), and cannot end with
                 `.realm`, `.realm.lock` or `.realm.management`.
-     
+
      - warning: NEVER disable SSL validation for a system running in production.
      */
     public init(user: SyncUser, realmURL: URL, enableSSLValidation: Bool = true) {

--- a/RealmSwift/Tests/ObjectTests.swift
+++ b/RealmSwift/Tests/ObjectTests.swift
@@ -152,19 +152,19 @@ class ObjectTests: TestCase {
 
         try! realm.write {
             realm.add(intObj)
-            assertThrows(intObj.intCol = 2, reason: primaryKeyReason)
-            assertThrows(intObj["intCol"] = 2, reason: primaryKeyReason)
-            assertThrows(intObj.setValue(2, forKey: "intCol"), reason: primaryKeyReason)
+            assertThrows(intObj.intCol = 2, reasonMatching: primaryKeyReason)
+            assertThrows(intObj["intCol"] = 2, reasonMatching: primaryKeyReason)
+            assertThrows(intObj.setValue(2, forKey: "intCol"), reasonMatching: primaryKeyReason)
 
             realm.add(optionalIntObj)
-            assertThrows(optionalIntObj.intCol.value = 2, reason: primaryKeyReason)
-            assertThrows(optionalIntObj["intCol"] = 2, reason: primaryKeyReason)
-            assertThrows(optionalIntObj.setValue(2, forKey: "intCol"), reason: primaryKeyReason)
+            assertThrows(optionalIntObj.intCol.value = 2, reasonMatching: primaryKeyReason)
+            assertThrows(optionalIntObj["intCol"] = 2, reasonMatching: primaryKeyReason)
+            assertThrows(optionalIntObj.setValue(2, forKey: "intCol"), reasonMatching: primaryKeyReason)
 
             realm.add(stringObj)
-            assertThrows(stringObj.stringCol = "c", reason: primaryKeyReason)
-            assertThrows(stringObj["stringCol"] = "c", reason: primaryKeyReason)
-            assertThrows(stringObj.setValue("c", forKey: "stringCol"), reason: primaryKeyReason)
+            assertThrows(stringObj.stringCol = "c", reasonMatching: primaryKeyReason)
+            assertThrows(stringObj["stringCol"] = "c", reasonMatching: primaryKeyReason)
+            assertThrows(stringObj.setValue("c", forKey: "stringCol"), reasonMatching: primaryKeyReason)
         }
     }
 

--- a/RealmSwift/Tests/RealmCollectionTypeTests.swift
+++ b/RealmSwift/Tests/RealmCollectionTypeTests.swift
@@ -331,7 +331,8 @@ class RealmCollectionTypeTests: TestCase {
         XCTAssertEqual("1", sorted[0].stringCol)
         XCTAssertEqual("2", sorted[1].stringCol)
 
-        assertThrows(collection.sorted(byKeyPath: "noSuchCol", ascending: true), named: "Invalid property name")
+        assertThrows(collection.sorted(byKeyPath: "noSuchCol", ascending: true),
+                     reason: "Cannot sort on key path 'noSuchCol': property 'CTTStringObjectWithLink.noSuchCol' does not exist")
     }
 
     func testSortWithDescriptor() {
@@ -353,7 +354,8 @@ class RealmCollectionTypeTests: TestCase {
         XCTAssertEqual(2, sorted[1].intCol)
         XCTAssertEqual(1.11, sorted[2].doubleCol)
 
-        assertThrows(collection.sorted(by: [SortDescriptor(keyPath: "noSuchCol")]), named: "Invalid property name")
+        assertThrows(collection.sorted(by: [SortDescriptor(keyPath: "noSuchCol")]),
+                     reason: "Cannot sort on key path 'noSuchCol': property 'CTTAggregateObject.noSuchCol' does not exist")
     }
 
     func testMin() {

--- a/RealmSwift/Tests/TestCase.swift
+++ b/RealmSwift/Tests/TestCase.swift
@@ -119,7 +119,13 @@ class TestCase: XCTestCase {
         RLMAssertThrowsWithName(self, { _ = block() }, named, message, fileName, lineNumber)
     }
 
-    func assertThrows<T>(_ block: @autoclosure @escaping () -> T, reason regexString: String,
+    func assertThrows<T>(_ block: @autoclosure () -> T, reason: String,
+                         _ message: String? = nil, fileName: String = #file, lineNumber: UInt = #line) {
+        exceptionThrown = true
+        RLMAssertThrowsWithReason(self, { _ = block() }, reason, message, fileName, lineNumber)
+    }
+
+    func assertThrows<T>(_ block: @autoclosure () -> T, reasonMatching regexString: String,
                          _ message: String? = nil, fileName: String = #file, lineNumber: UInt = #line) {
         exceptionThrown = true
         RLMAssertThrowsWithReasonMatching(self, { _ = block() }, regexString, message, fileName, lineNumber)

--- a/RealmSwift/Tests/TestUtils.h
+++ b/RealmSwift/Tests/TestUtils.h
@@ -33,4 +33,9 @@ FOUNDATION_EXTERN void RLMAssertMatches(XCTestCase *self, __attribute__((noescap
                                         NSString *regexString, NSString *message, NSString *fileName,
                                         NSUInteger lineNumber);
 
+FOUNDATION_EXTERN void RLMAssertThrowsWithReason(XCTestCase *self,
+                                      __attribute__((noescape)) dispatch_block_t block,
+                                      NSString *regexString, NSString *message,
+                                      NSString *fileName, NSUInteger lineNumber);
+
 FOUNDATION_EXTERN bool RLMHasCachedRealmForPath(NSString *path);


### PR DESCRIPTION
A bunch of individually not very interesting changes made to support arrays of primitives. Should have no functional changes other than some error messages being a bit different.

Pulls in https://github.com/realm/realm-object-store/pull/464 (and so depends on that getting merged).