### PR TITLE
Detect and automatically ignore computed properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@
   correctly nil out nullable properties when updating an existing
   object when the `value` argument specifies nil or `NSNull` for
   the property value.
+* Computed properties on Realm object types are detected and no
+  longer added to the automatically generated schema.
 
 ### Enhancements
 

--- a/Realm/RLMObjectSchema.mm
+++ b/Realm/RLMObjectSchema.mm
@@ -216,7 +216,7 @@ using namespace realm;
 
         if (prop) {
             [propArray addObject:prop];
-         }
+        }
     }
 
     auto existingPropertyIndex = [=](NSString *name) -> NSUInteger {

--- a/Realm/Tests/ObjectTests.m
+++ b/Realm/Tests/ObjectTests.m
@@ -581,6 +581,7 @@ static void testDatesInRange(NSTimeInterval from, NSTimeInterval to, void (^chec
 static void addProperty(Class cls, const char *name, const char *type, size_t size, size_t align, id getter) {
     objc_property_attribute_t objectColAttrs[] = {
         {"T", type},
+        {"V", name},
     };
     class_addIvar(cls, name, size, align, type);
     class_addProperty(cls, name, objectColAttrs, sizeof(objectColAttrs) / sizeof(objc_property_attribute_t));

--- a/Realm/Tests/RLMTestObjects.h
+++ b/Realm/Tests/RLMTestObjects.h
@@ -397,6 +397,13 @@ RLM_ARRAY_TYPE(PrimaryCompanyObject);
 @property RLM_GENERIC_ARRAY(PrimaryCompanyObject) *companies;
 @end
 
+#pragma mark ComputedPropertyNotExplicitlyIgnoredObject
+
+@interface ComputedPropertyNotExplicitlyIgnoredObject : RLMObject
+@property NSString *_URLBacking;
+@property NSURL *URL;
+@end
+
 #pragma mark FakeObject
 
 @interface FakeObject : NSObject

--- a/Realm/Tests/RLMTestObjects.m
+++ b/Realm/Tests/RLMTestObjects.m
@@ -329,3 +329,17 @@
 + (BOOL)shouldIncludeInDefaultSchema { return NO; }
 + (NSString *)_realmObjectName { return nil; }
 @end
+
+#pragma mark ComputedPropertyNotExplicitlyIgnoredObject
+
+@implementation ComputedPropertyNotExplicitlyIgnoredObject
+
+- (NSURL *)URL {
+    return [NSURL URLWithString:self._URLBacking];
+}
+
+- (void)setURL:(NSURL *)URL {
+    self._URLBacking = URL.absoluteString;
+}
+
+@end

--- a/Realm/Tests/SchemaTests.mm
+++ b/Realm/Tests/SchemaTests.mm
@@ -626,8 +626,11 @@ RLM_ARRAY_TYPE(NotARealClass)
 
 - (void)testClassWithDuplicateProperties
 {
-    RLMAssertThrowsWithReasonMatching([RLMObjectSchema schemaForObjectClass:SchemaTestClassWithSingleDuplicateProperty.class], @"'string' .* multiple times .* 'SchemaTestClassWithSingleDuplicateProperty'");
-    RLMAssertThrowsWithReasonMatching([RLMObjectSchema schemaForObjectClass:SchemaTestClassWithMultipleDuplicateProperties.class], @"'SchemaTestClassWithMultipleDuplicateProperties' .* declared multiple times");
+    // If a property is overriden in a child class it should not be picked up more than once.
+    RLMObjectSchema *firstSchema = [RLMObjectSchema schemaForObjectClass:SchemaTestClassWithSingleDuplicateProperty.class];
+    XCTAssertEqual((int)firstSchema.properties.count, 1);
+    RLMObjectSchema *secondSchema = [RLMObjectSchema schemaForObjectClass:SchemaTestClassWithMultipleDuplicateProperties.class];
+    XCTAssertEqual((int)secondSchema.properties.count, 2);
 }
 
 - (void)testClassWithInvalidPrimaryKey {

--- a/RealmSwift/Tests/ObjectSchemaInitializationTests.swift
+++ b/RealmSwift/Tests/ObjectSchemaInitializationTests.swift
@@ -204,6 +204,13 @@ class ObjectSchemaInitializationTests: TestCase {
     func testNonRealmOptionalTypesDeclaredAsRealmOptional() {
         assertThrows(RLMObjectSchema(forObjectClass: SwiftObjectWithNonRealmOptionalType.self))
     }
+
+    func testNotExplicitlyIgnoredComputedProperties() {
+        let schema = SwiftComputedPropertyNotExplicitlyIgnoredObject().objectSchema
+        // The two computed properties should not appear on the schema.
+        XCTAssertEqual(schema.properties.count, 1)
+        XCTAssertNotNil(schema["_urlBacking"])
+    }
 }
 
 class SwiftFakeObject: NSObject {

--- a/RealmSwift/Tests/ObjectSchemaInitializationTests.swift
+++ b/RealmSwift/Tests/ObjectSchemaInitializationTests.swift
@@ -206,7 +206,7 @@ class ObjectSchemaInitializationTests: TestCase {
     }
 
     func testNotExplicitlyIgnoredComputedProperties() {
-        let schema = SwiftComputedPropertyNotExplicitlyIgnoredObject().objectSchema
+        let schema = SwiftComputedPropertyNotIgnoredObject().objectSchema
         // The two computed properties should not appear on the schema.
         XCTAssertEqual(schema.properties.count, 1)
         XCTAssertNotNil(schema["_urlBacking"])

--- a/RealmSwift/Tests/SwiftTestObjects.swift
+++ b/RealmSwift/Tests/SwiftTestObjects.swift
@@ -442,6 +442,18 @@ class SwiftObjectiveCTypesObject: Object {
     @objc dynamic var numCol: NSNumber? = 0
 }
 
+class SwiftComputedPropertyNotExplicitlyIgnoredObject: Object {
+    dynamic var _urlBacking = ""
+    var url: URL? {
+        get {
+            return URL(string: _urlBacking)
+        }
+        set {
+            _urlBacking = newValue?.absoluteString ?? ""
+        }
+    }
+}
+
 @objc(SwiftObjcRenamedObject)
 class SwiftObjcRenamedObject: Object {
     @objc dynamic var stringCol = ""

--- a/RealmSwift/Tests/SwiftTestObjects.swift
+++ b/RealmSwift/Tests/SwiftTestObjects.swift
@@ -444,6 +444,18 @@ class SwiftObjectiveCTypesObject: Object {
 
 class SwiftComputedPropertyNotExplicitlyIgnoredObject: Object {
     dynamic var _urlBacking = ""
+
+    // Dynamic; no ivar
+    dynamic var dynamicURL: URL? {
+        get {
+            return URL(string: _urlBacking)
+        }
+        set {
+            _urlBacking = newValue?.absoluteString ?? ""
+        }
+    }
+
+    // Non-dynamic; no ivar
     var url: URL? {
         get {
             return URL(string: _urlBacking)

--- a/RealmSwift/Tests/SwiftTestObjects.swift
+++ b/RealmSwift/Tests/SwiftTestObjects.swift
@@ -442,7 +442,8 @@ class SwiftObjectiveCTypesObject: Object {
     @objc dynamic var numCol: NSNumber? = 0
 }
 
-class SwiftComputedPropertyNotExplicitlyIgnoredObject: Object {
+class SwiftComputedPropertyNotIgnoredObject: Object {
+    // swiftlint:disable:next identifier_name
     dynamic var _urlBacking = ""
 
     // Dynamic; no ivar


### PR DESCRIPTION
Replaces #3870. Is that PR, but manually refactored to work with our latest code and to accommodate lazy Swift properties.

I've left that PR alone so that the changes in this PR can be compared more easily against the original changes.

Fixes #2840.