### PR TITLE
Update object store to avoid making non-additive schema changes to synced Realms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,8 @@ x.x.x Release notes (yyyy-MM-dd)
 
 ### Bugfixes
 
-* None.
+* Realm no longer throws an "unsupported instruction" exception in some cases
+  when opening a synced Realm asynchronously.
 
 3.0.0-beta Release notes (2017-07-14)
 =============================================================


### PR DESCRIPTION
This pulls in the fix from realm/realm-object-store#504.