### PR TITLE
Fix package-test-examples's extraction of version numbers from the zip file names

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1114,8 +1114,8 @@ EOM
         ;;
 
     "package-test-examples")
-        if ! VERSION=$(echo realm-objc-*.zip | grep -o '\d*\.\d*\.\d*-[a-z]*'); then
-            VERSION=$(echo realm-objc-*.zip | grep -o '\d*\.\d*\.\d*')
+        if ! VERSION=$(echo realm-objc-*.zip | egrep -o '\d*\.\d*\.\d*-[a-z]*(\.\d*)?'); then
+            VERSION=$(echo realm-objc-*.zip | egrep -o '\d*\.\d*\.\d*')
         fi
         OBJC="realm-objc-${VERSION}"
         SWIFT="realm-swift-${VERSION}"


### PR DESCRIPTION
It didn't accommodate an extra version component after the beta label. Now it does.