### PR TITLE
fix how the podspec determines if the version is prerelease or not

### DIFF
--- a/Realm.podspec
+++ b/Realm.podspec
@@ -1,6 +1,7 @@
 Pod::Spec.new do |s|
   s.name                    = 'Realm'
-  s.version                 = `sh build.sh get-version`
+  version                   = `sh build.sh get-version`
+  s.version                 = version
   s.summary                 = 'Realm is a modern data framework & database for iOS, macOS, tvOS & watchOS.'
   s.description             = <<-DESC
                               The Realm Mobile Database, for Objective-C. (If you want to use Realm from Swift, see the “RealmSwift” pod.)
@@ -13,7 +14,7 @@ Pod::Spec.new do |s|
   s.library                 = 'c++', 'z'
   s.requires_arc            = true
   s.social_media_url        = 'https://twitter.com/realm'
-  has_versioned_docs        = !(s.version =~ /alpha|beta|rc/)
+  has_versioned_docs        = !(version =~ /alpha|beta|rc/)
   s.documentation_url       = "https://realm.io/docs/objc/#{has_versioned_docs ? s.version : 'latest'}"
   s.license                 = { :type => 'Apache 2.0', :file => 'LICENSE' }
 

--- a/RealmSwift.podspec
+++ b/RealmSwift.podspec
@@ -1,6 +1,7 @@
 Pod::Spec.new do |s|
   s.name                      = 'RealmSwift'
-  s.version                   = `sh build.sh get-version`
+  version                     = `sh build.sh get-version`
+  s.version                   = version
   s.summary                   = 'Realm is a modern data framework & database for iOS, macOS, tvOS & watchOS.'
   s.description               = <<-DESC
                                 The Realm Mobile Database, for Swift. (If you want to use Realm from Objective-C, see the “Realm” pod.)
@@ -12,7 +13,7 @@ Pod::Spec.new do |s|
   s.author                    = { 'Realm' => 'help@realm.io' }
   s.requires_arc              = true
   s.social_media_url          = 'https://twitter.com/realm'
-  has_versioned_docs          = !(s.version =~ /alpha|beta|rc/)
+  has_versioned_docs          = !(version =~ /alpha|beta|rc/)
   s.documentation_url         = "https://realm.io/docs/swift/#{has_versioned_docs ? s.version : 'latest'}"
   s.license                   = { :type => 'Apache 2.0', :file => 'LICENSE' }
 


### PR DESCRIPTION
due to the way podspecs are evaluated, member values are only set after non-member values, which meant that `s.version` was always `nil` at the time `has_versioned_docs` was evaluated, leading the regex match to always fail, leading `has_versioned_docs` to always be true.

I've now confirmed that this works:

```bash
$ # before
$ ./build.sh set-version 3.0.0-beta.2
$ pod lib lint Realm.podspec | grep "not reachable"
    - WARN  | url: The URL (https://realm.io/docs/objc/3.0.0-beta.2) is not reachable.
$ ./build.sh set-version 3.0.0
$ pod lib lint Realm.podspec | grep "not reachable"
    - WARN  | url: The URL (https://realm.io/docs/objc/3.0.0) is not reachable.
$
$ # after
$ ./build.sh set-version 3.0.0-beta.2
$ pod lib lint Realm.podspec | grep "not reachable"
$ ./build.sh set-version 3.0.0
$ pod lib lint Realm.podspec | grep "not reachable"
    - WARN  | url: The URL (https://realm.io/docs/objc/3.0.0) is not reachable.
```