### PR TITLE
Try to fix sporadic CI test failure

### DIFF
--- a/Realm/ObjectServerTests/RLMObjectServerTests.mm
+++ b/Realm/ObjectServerTests/RLMObjectServerTests.mm
@@ -1280,7 +1280,7 @@
         NSUInteger sizeBefore = fileSize(c.pathOnDisk);
         XCTAssertGreaterThan(sizeBefore, 0U);
         XCTAssertNotNil(RLMGetAnyCachedRealmForPath(c.pathOnDisk.UTF8String));
-        [self waitForExpectationsWithTimeout:15.0 handler:nil];
+        [self waitForExpectationsWithTimeout:10.0 handler:nil];
         XCTAssertGreaterThan(fileSize(c.pathOnDisk), sizeBefore);
         XCTAssertNotNil(RLMGetAnyCachedRealmForPath(c.pathOnDisk.UTF8String));
         CHECK_COUNT(NUMBER_OF_BIG_OBJECTS, HugeSyncObject, realm);

--- a/Realm/ObjectServerTests/RLMObjectServerTests.mm
+++ b/Realm/ObjectServerTests/RLMObjectServerTests.mm
@@ -1254,6 +1254,7 @@
         // Wait for the child process to upload everything.
         RLMRunChildAndWait();
         XCTestExpectation *ex = [self expectationWithDescription:@"download-realm"];
+        XCTestExpectation *ex2 = [self expectationWithDescription:@"wait for downloads after asyncOpen"];
         RLMRealmConfiguration *c = [RLMRealmConfiguration defaultConfiguration];
         RLMSyncConfiguration *syncConfig = [[RLMSyncConfiguration alloc] initWithUser:user realmURL:url];
         c.syncConfiguration = syncConfig;
@@ -1264,7 +1265,9 @@
                                callbackQueue:dispatch_get_main_queue()
                                     callback:^(RLMRealm * _Nullable realm, NSError * _Nullable error) {
             XCTAssertNil(error);
-            CHECK_COUNT(NUMBER_OF_BIG_OBJECTS, HugeSyncObject, realm);
+            // The big objects might take some time for the server to process,
+            // so we may need to ask it a few times before it's ready.
+            CHECK_COUNT_PENDING_DOWNLOAD_CUSTOM_EXPECTATION(NUMBER_OF_BIG_OBJECTS, HugeSyncObject, realm, ex2);
             [ex fulfill];
         }];
         NSUInteger (^fileSize)(NSString *) = ^NSUInteger(NSString *path) {
@@ -1277,7 +1280,7 @@
         NSUInteger sizeBefore = fileSize(c.pathOnDisk);
         XCTAssertGreaterThan(sizeBefore, 0U);
         XCTAssertNotNil(RLMGetAnyCachedRealmForPath(c.pathOnDisk.UTF8String));
-        [self waitForExpectationsWithTimeout:10.0 handler:nil];
+        [self waitForExpectationsWithTimeout:15.0 handler:nil];
         XCTAssertGreaterThan(fileSize(c.pathOnDisk), sizeBefore);
         XCTAssertNotNil(RLMGetAnyCachedRealmForPath(c.pathOnDisk.UTF8String));
         CHECK_COUNT(NUMBER_OF_BIG_OBJECTS, HugeSyncObject, realm);

--- a/Realm/ObjectServerTests/RLMPermissionsAPITests.m
+++ b/Realm/ObjectServerTests/RLMPermissionsAPITests.m
@@ -248,8 +248,7 @@ static RLMSyncPermissionValue *makeExpectedPermission(RLMSyncPermissionValue *or
     // TODO: if we can get the session itself we can check to see if it's been errored out (as expected).
 
     // Perhaps obviously, there should be no new objects.
-    [self waitForDownloadsForUser:self.userA url:userAURL];
-    CHECK_COUNT(3, SyncObject, userARealm);
+    CHECK_COUNT_PENDING_DOWNLOAD(3, SyncObject, userARealm);
 
     // Administering the Realm should fail.
     RLMSyncPermissionValue *p2 = [[RLMSyncPermissionValue alloc] initWithRealmPath:[userBURL path]
@@ -295,15 +294,13 @@ static RLMSyncPermissionValue *makeExpectedPermission(RLMSyncPermissionValue *or
     // Open the Realm for user B. Since user B has write privileges, they should be able to open it 'normally'.
     NSURL *userBURL = makeTestURL(testName, self.userA);
     RLMRealm *userBRealm = [self openRealmForURL:userBURL user:self.userB];
-    [self waitForDownloadsForUser:self.userB url:userBURL];
-    CHECK_COUNT(3, SyncObject, userBRealm);
+    CHECK_COUNT_PENDING_DOWNLOAD(3, SyncObject, userBRealm);
 
     // Add some objects using user B.
     [self addSyncObjectsToRealm:userBRealm descriptions:@[@"child-4", @"child-5"]];
     [self waitForUploadsForUser:self.userB url:userBURL];
     CHECK_COUNT(5, SyncObject, userBRealm);
-    [self waitForUploadsForUser:self.userA url:userAURL];
-    CHECK_COUNT(5, SyncObject, userARealm);
+    CHECK_COUNT_PENDING_DOWNLOAD(5, SyncObject, userARealm);
 
     // Administering the Realm should fail.
     RLMSyncPermissionValue *p2 = [[RLMSyncPermissionValue alloc] initWithRealmPath:[userBURL path]
@@ -352,15 +349,13 @@ static RLMSyncPermissionValue *makeExpectedPermission(RLMSyncPermissionValue *or
 
     // Open the Realm for user B. Since user B has admin privileges, they should be able to open it 'normally'.
     RLMRealm *userBRealm = [self openRealmForURL:userAURLResolved user:self.userB];
-    [self waitForDownloadsForUser:self.userB url:userAURLResolved];
-    CHECK_COUNT(3, SyncObject, userBRealm);
+    CHECK_COUNT_PENDING_DOWNLOAD(3, SyncObject, userBRealm);
 
     // Add some objects using user B.
     [self addSyncObjectsToRealm:userBRealm descriptions:@[@"child-4", @"child-5"]];
     [self waitForUploadsForUser:self.userB url:userAURLResolved];
     CHECK_COUNT(5, SyncObject, userBRealm);
-    [self waitForDownloadsForUser:self.userA url:userAURLUnresolved];
-    CHECK_COUNT(5, SyncObject, userARealm);
+    CHECK_COUNT_PENDING_DOWNLOAD(5, SyncObject, userARealm);
 
     // User B should be able to give user C write permissions to user A's Realm.
     RLMSyncPermissionValue *p2 = [[RLMSyncPermissionValue alloc] initWithRealmPath:[userAURLResolved path]
@@ -370,15 +365,12 @@ static RLMSyncPermissionValue *makeExpectedPermission(RLMSyncPermissionValue *or
 
     // User C should be able to write to the Realm.
     RLMRealm *userCRealm = [self openRealmForURL:userAURLResolved user:self.userC];
-    [self waitForDownloadsForUser:self.userC url:userAURLResolved];
-    CHECK_COUNT(5, SyncObject, userCRealm);
+    CHECK_COUNT_PENDING_DOWNLOAD(5, SyncObject, userCRealm);
     [self addSyncObjectsToRealm:userCRealm descriptions:@[@"child-6", @"child-7", @"child-8"]];
     [self waitForUploadsForUser:self.userC url:userAURLResolved];
     CHECK_COUNT(8, SyncObject, userCRealm);
-    [self waitForDownloadsForUser:self.userA url:userAURLUnresolved];
-    CHECK_COUNT(8, SyncObject, userARealm);
-    [self waitForDownloadsForUser:self.userB url:userAURLResolved];
-    CHECK_COUNT(8, SyncObject, userBRealm);
+    CHECK_COUNT_PENDING_DOWNLOAD(8, SyncObject, userARealm);
+    CHECK_COUNT_PENDING_DOWNLOAD(8, SyncObject, userBRealm);
 }
 
 /// If user A grants user B write access to a Realm via username, user B should be able to write to it.
@@ -413,15 +405,13 @@ static RLMSyncPermissionValue *makeExpectedPermission(RLMSyncPermissionValue *or
     // Open the Realm for user B. Since user B has write privileges, they should be able to open it 'normally'.
     NSURL *userBURL = makeTestURL(testName, self.userA);
     RLMRealm *userBRealm = [self openRealmForURL:userBURL user:self.userB];
-    [self waitForDownloadsForUser:self.userB url:userBURL];
-    CHECK_COUNT(3, SyncObject, userBRealm);
+    CHECK_COUNT_PENDING_DOWNLOAD(3, SyncObject, userBRealm);
 
     // Add some objects using user B.
     [self addSyncObjectsToRealm:userBRealm descriptions:@[@"child-4", @"child-5"]];
     [self waitForUploadsForUser:self.userB url:userBURL];
     CHECK_COUNT(5, SyncObject, userBRealm);
-    [self waitForUploadsForUser:self.userA url:userAURL];
-    CHECK_COUNT(5, SyncObject, userARealm);
+    CHECK_COUNT_PENDING_DOWNLOAD(5, SyncObject, userARealm);
 }
 
 /// Setting a permission for all users should work.
@@ -447,14 +437,14 @@ static RLMSyncPermissionValue *makeExpectedPermission(RLMSyncPermissionValue *or
 
     // User B should be able to write to the Realm.
     RLMRealm *userBRealm = [self openRealmForURL:guestURL user:self.userB];
-    [self waitForDownloadsForUser:self.userB url:guestURL];
+    CHECK_COUNT_PENDING_DOWNLOAD(3, SyncObject, userBRealm);
     [self addSyncObjectsToRealm:userBRealm descriptions:@[@"child-4", @"child-5"]];
     [self waitForUploadsForUser:self.userB url:guestURL];
     CHECK_COUNT(5, SyncObject, userBRealm);
 
     // User C should be able to write to the Realm.
     RLMRealm *userCRealm = [self openRealmForURL:guestURL user:self.userC];
-    [self waitForDownloadsForUser:self.userC url:guestURL];
+    CHECK_COUNT_PENDING_DOWNLOAD(5, SyncObject, userCRealm);
     [self addSyncObjectsToRealm:userCRealm descriptions:@[@"child-6", @"child-7", @"child-8", @"child-9"]];
     [self waitForUploadsForUser:self.userC url:guestURL];
     CHECK_COUNT(9, SyncObject, userCRealm);
@@ -543,14 +533,14 @@ static RLMSyncPermissionValue *makeExpectedPermission(RLMSyncPermissionValue *or
 
     // User B should be able to write to the Realm.
     RLMRealm *userBRealm = [self openRealmForURL:globalRealmURL user:self.userB];
-    [self waitForDownloadsForUser:self.userB url:globalRealmURL];
+    CHECK_COUNT_PENDING_DOWNLOAD(3, SyncObject, userBRealm);
     [self addSyncObjectsToRealm:userBRealm descriptions:@[@"child-4", @"child-5"]];
     [self waitForUploadsForUser:self.userB url:globalRealmURL];
     CHECK_COUNT(5, SyncObject, userBRealm);
 
     // User C should be able to write to the Realm.
     RLMRealm *userCRealm = [self openRealmForURL:globalRealmURL user:self.userC];
-    [self waitForDownloadsForUser:self.userC url:globalRealmURL];
+    CHECK_COUNT_PENDING_DOWNLOAD(5, SyncObject, userCRealm);
     [self addSyncObjectsToRealm:userCRealm descriptions:@[@"child-6", @"child-7", @"child-8", @"child-9"]];
     [self waitForUploadsForUser:self.userC url:globalRealmURL];
     CHECK_COUNT(9, SyncObject, userCRealm);

--- a/Realm/ObjectServerTests/RLMSyncTestCase.h
+++ b/Realm/ObjectServerTests/RLMSyncTestCase.h
@@ -99,7 +99,10 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)waitForUploadsForUser:(RLMSyncUser *)user url:(NSURL *)url;
 
 /// Wait for downloads to complete while spinning the runloop. This method uses expectations.
-- (void)waitForDownloadsForUser:(RLMSyncUser *)user url:(NSURL *)url error:(NSError **)error;
+- (void)waitForDownloadsForUser:(RLMSyncUser *)user
+                            url:(NSURL *)url
+                    expectation:(nullable XCTestExpectation *)expectation
+                          error:(NSError **)error;
 
 /// Wait for uploads to complete while spinning the runloop. This method uses expectations.
 - (void)waitForUploadsForUser:(RLMSyncUser *)user url:(NSURL *)url error:(NSError **)error;
@@ -117,7 +120,30 @@ NS_ASSUME_NONNULL_END
 
 #define CHECK_COUNT(d_count, macro_object_type, macro_realm) \
 {                                                                                                       \
+    [macro_realm refresh];                                                                              \
     NSInteger c = [macro_object_type allObjectsInRealm:macro_realm].count;                              \
     NSString *w = self.isParent ? @"parent" : @"child";                                                 \
     XCTAssert(d_count == c, @"Expected %@ items, but actually got %@ (%@)", @(d_count), @(c), w);       \
+}
+
+#define CHECK_COUNT_PENDING_DOWNLOAD(expected_count, m_type, m_realm) \
+CHECK_COUNT_PENDING_DOWNLOAD_CUSTOM_EXPECTATION(expected_count, m_type, m_realm, nil)
+
+/// This macro tries ten times to wait for downloads and then check for object count.
+/// If the object count does not match, it waits 0.1 second before trying again.
+/// It is most useful in cases where the test ROS might be expected to take some
+/// non-negligible amount of time performing an operation whose completion is required
+/// for the test on the client side to proceed.
+#define CHECK_COUNT_PENDING_DOWNLOAD_CUSTOM_EXPECTATION(expected_count, m_type, m_realm, m_exp)                        \
+{                                                                                                                      \
+    RLMSyncConfiguration *m_config = m_realm.configuration.syncConfiguration;                                          \
+    XCTAssertNotNil(m_config, @"Realm passed to CHECK_COUNT_PENDING_DOWNLOAD() doesn't have a sync config!");          \
+    RLMSyncUser *m_user = m_config.user;                                                                               \
+    NSURL *m_url = m_config.realmURL;                                                                                  \
+    for (int i=0; i<10; i++) {                                                                                         \
+        [self waitForDownloadsForUser:m_user url:m_url expectation:m_exp error:nil];                                   \
+        if (expected_count == [m_type allObjectsInRealm:m_realm].count) { break; }                                     \
+        [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.1]];                           \
+    }                                                                                                                  \
+    CHECK_COUNT(expected_count, m_type, m_realm);                                                                      \
 }

--- a/Realm/ObjectServerTests/RLMSyncTestCase.mm
+++ b/Realm/ObjectServerTests/RLMSyncTestCase.mm
@@ -138,7 +138,7 @@ static NSURL *syncDirectoryForChildProcess() {
     NSAssert(realms.count == counts.count && realms.count == realmURLs.count,
              @"Test logic error: all array arguments must be the same size.");
     for (NSUInteger i = 0; i < realms.count; i++) {
-        [self waitForDownloadsForUser:user url:realmURLs[i] error:nil];
+        [self waitForDownloadsForUser:user url:realmURLs[i] expectation:nil error:nil];
         [realms[i] refresh];
         CHECK_COUNT([counts[i] integerValue], SyncObject, realms[i]);
     }
@@ -294,20 +294,27 @@ static NSURL *syncDirectoryForChildProcess() {
 }
 
 - (void)waitForDownloadsForUser:(RLMSyncUser *)user url:(NSURL *)url {
-    [self waitForDownloadsForUser:user url:url error:nil];
+    [self waitForDownloadsForUser:user url:url expectation:nil error:nil];
 }
 
-- (void)waitForDownloadsForUser:(RLMSyncUser *)user url:(NSURL *)url error:(NSError **)error {
+- (void)waitForDownloadsForUser:(RLMSyncUser *)user
+                            url:(NSURL *)url
+                    expectation:(XCTestExpectation *)expectation
+                          error:(NSError **)error {
     RLMSyncSession *session = [user sessionForURL:url];
     NSAssert(session, @"Cannot call with invalid URL");
-    XCTestExpectation *ex = [self expectationWithDescription:@"Download waiter expectation"];
+    XCTestExpectation *ex = expectation ?: [self expectationWithDescription:@"Download waiter expectation"];
     __block NSError *theError = nil;
-    [session waitForDownloadCompletionOnQueue:dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_LOW, 0)
-                                     callback:^(NSError *err){
-                                         theError = err;
-                                         [ex fulfill];
-                                     }];
-    [self waitForExpectationsWithTimeout:10.0 handler:nil];
+    BOOL queued = [session waitForDownloadCompletionOnQueue:dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_LOW, 0)
+                                                   callback:^(NSError *err){
+                                                       theError = err;
+                                                       [ex fulfill];
+                                                   }];
+    if (!queued) {
+        XCTFail(@"Download waiter did not queue; session was invalid or errored out.");
+        return;
+    }
+    [self waitForExpectations:@[ex] timeout:20.0];
     if (error) {
         *error = theError;
     }
@@ -322,12 +329,16 @@ static NSURL *syncDirectoryForChildProcess() {
     NSAssert(session, @"Cannot call with invalid URL");
     XCTestExpectation *ex = [self expectationWithDescription:@"Upload waiter expectation"];
     __block NSError *theError = nil;
-    [session waitForUploadCompletionOnQueue:dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_LOW, 0)
-                                   callback:^(NSError *err){
-                                       theError = err;
-                                       [ex fulfill];
-                                   }];
-    [self waitForExpectationsWithTimeout:10.0 handler:nil];
+    BOOL queued = [session waitForUploadCompletionOnQueue:dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_LOW, 0)
+                                                 callback:^(NSError *err){
+                                                     theError = err;
+                                                     [ex fulfill];
+                                                 }];
+    if (!queued) {
+        XCTFail(@"Upload waiter did not queue; session was invalid or errored out.");
+        return;
+    }
+    [self waitForExpectations:@[ex] timeout:20.0];
     if (error) {
         *error = theError;
     }

--- a/Realm/ObjectServerTests/RLMSyncTestCase.mm
+++ b/Realm/ObjectServerTests/RLMSyncTestCase.mm
@@ -338,6 +338,8 @@ static NSURL *syncDirectoryForChildProcess() {
         XCTFail(@"Upload waiter did not queue; session was invalid or errored out.");
         return;
     }
+    // FIXME: If tests involving `HugeSyncObject` are more reliable after July 2017, file an issue against sync
+    // regarding performance of ROS.
     [self waitForExpectations:@[ex] timeout:20.0];
     if (error) {
         *error = theError;


### PR DESCRIPTION
There is a family of CI object server test failures that all look something like this:

```
RLMRealm *realm = // ...open a Realm
doSomething();
CHECK_COUNT(3, MyTestObject, realm);   // this passes
doSomethingElse();
waitForDownloads();
CHECK_COUNT(5, MyTestObject, realm);   // this fails; count is still 3
```

They are all impossible to reproduce, happen in different tests, but all take that same basic structure.

My hypothesis is that, since Realms are not refreshed until the current runloop iteration is complete, that there exists a possibility where `waitForDownloads()` completes quickly enough the second `CHECK_COUNT()` call is made before the runloop has had a chance to complete and the Realm has a chance to refresh.