### PR TITLE
Rename `addOrUpdateObjectsInArray:`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,12 @@ x.x.x Release notes (yyyy-MM-dd)
   the property value.
 * Computed properties on Realm object types are detected and no
   longer added to the automatically generated schema.
+* `-[RLMRealm addOrUpdateObjectsInArray:]` has been renamed to
+  `-[RLMRealm addOrUpdateObjects:]` for consistency with similar methods
+  that add or delete objects.
+* `-[RLMRealm addOrUpdateObjects:]` and `-[RLMRealm deleteObjects:]` now
+  require their argument to conform to `NSFastEnumeration`, to match similar
+  APIs that also take collections.
 
 ### Enhancements
 

--- a/Realm/RLMRealm.h
+++ b/Realm/RLMRealm.h
@@ -490,12 +490,12 @@ NS_REFINED_FOR_SWIFT;
 
  @warning This method may only be called during a write transaction.
 
- @param array   An enumerable object such as `NSArray` or `RLMResults` which contains objects to be added to
-                the Realm.
+ @param objects   An enumerable collection such as `NSArray`, `RLMArray`, or `RLMResults`,
+                  containing Realm objects to be added to the Realm.
 
  @see   `addObject:`
  */
-- (void)addObjects:(id<NSFastEnumeration>)array;
+- (void)addObjects:(id<NSFastEnumeration>)objects;
 
 /**
  Adds or updates an existing object into the Realm.
@@ -525,11 +525,12 @@ NS_REFINED_FOR_SWIFT;
 
  @warning This method may only be called during a write transaction.
 
- @param array  An `NSArray`, `RLMArray`, or `RLMResults` of `RLMObject`s (or subclasses) to be added to the Realm.
+ @param objects  An enumerable collection such as `NSArray`, `RLMArray`, or `RLMResults`,
+                 containing Realm objects to be added to or updated within the Realm.
 
  @see   `addOrUpdateObject:`
  */
-- (void)addOrUpdateObjectsFromArray:(id)array;
+- (void)addOrUpdateObjects:(id<NSFastEnumeration>)objects;
 
 /**
  Deletes an object from the Realm. Once the object is deleted it is considered invalidated.
@@ -547,11 +548,12 @@ NS_REFINED_FOR_SWIFT;
 
  @warning This method may only be called during a write transaction.
 
- @param array  An `RLMArray`, `NSArray`, or `RLMResults` of `RLMObject`s (or subclasses) to be deleted.
+ @param objects  An enumerable collection such as `NSArray`, `RLMArray`, or `RLMResults`,
+                 containing objects to be deleted from the Realm.
 
  @see `deleteObject:`
  */
-- (void)deleteObjects:(id)array;
+- (void)deleteObjects:(id<NSFastEnumeration>)objects;
 
 /**
  Deletes all objects from the Realm.
@@ -622,7 +624,12 @@ NS_REFINED_FOR_SWIFT;
  */
 + (instancetype)new __attribute__((unavailable("Use +defaultRealm, +realmWithConfiguration: or +realmWithURL:.")));
 
+/// :nodoc:
+- (void)addOrUpdateObjectsFromArray:(id)array __attribute__((unavailable("Renamed to -addOrUpdateObjects:.")));
+
 @end
+
+// MARK: - RLMNotificationToken
 
 /**
  A token which is returned from methods which subscribe to changes to a Realm.

--- a/Realm/RLMRealm.mm
+++ b/Realm/RLMRealm.mm
@@ -675,7 +675,7 @@ REALM_NOINLINE void RLMRealmTranslateException(NSError **error) {
 
 - (void)addObjects:(id<NSFastEnumeration>)objects {
     for (RLMObject *obj in objects) {
-        if (![obj isKindOfClass:[RLMObject class]]) {
+        if (![obj isKindOfClass:RLMObjectBase.class]) {
             @throw RLMException(@"Cannot insert objects of type %@ with addObjects:. Only RLMObjects are supported.",
                                 NSStringFromClass(obj.class));
         }
@@ -694,7 +694,7 @@ REALM_NOINLINE void RLMRealmTranslateException(NSError **error) {
 
 - (void)addOrUpdateObjects:(id<NSFastEnumeration>)objects {
     for (RLMObject *obj in objects) {
-        if (![obj isKindOfClass:[RLMObject class]]) {
+        if (![obj isKindOfClass:RLMObjectBase.class]) {
             @throw RLMException(@"Cannot add or update objects of type %@ with addOrUpdateObjects:. Only RLMObjects are"
                                 " supported.",
                                 NSStringFromClass(obj.class));
@@ -708,16 +708,16 @@ REALM_NOINLINE void RLMRealmTranslateException(NSError **error) {
 }
 
 - (void)deleteObjects:(id<NSFastEnumeration>)objects {
-    NSObject *collection = (NSObject *)objects;
-    if ([collection respondsToSelector:@selector(realm)]
-        && [collection respondsToSelector:@selector(deleteObjectsFromRealm)]) {
-        if (self != (RLMRealm *)[collection performSelector:@selector(realm)]) {
+    id idObjects = objects;
+    if ([idObjects respondsToSelector:@selector(realm)]
+        && [idObjects respondsToSelector:@selector(deleteObjectsFromRealm)]) {
+        if (self != (RLMRealm *)[idObjects realm]) {
             @throw RLMException(@"Can only delete objects from the Realm they belong to.");
         }
-        [collection performSelector:@selector(deleteObjectsFromRealm)];
+        [idObjects deleteObjectsFromRealm];
     }
     for (RLMObject *obj in objects) {
-        if (![obj isKindOfClass:[RLMObject class]]) {
+        if (![obj isKindOfClass:RLMObjectBase.class]) {
             @throw RLMException(@"Cannot delete objects of type %@ with deleteObjects:. Only RLMObjects are supported.",
                                 NSStringFromClass(obj.class));
         }

--- a/Realm/Tests/RealmTests.mm
+++ b/Realm/Tests/RealmTests.mm
@@ -677,7 +677,7 @@
     // upsert with array of 2 objects. One is to update the existing value, another is added
     NSArray *array = @[[[PrimaryStringObject alloc] initWithValue:@[@"string2", @4]],
                        [[PrimaryStringObject alloc] initWithValue:@[@"string4", @5]]];
-    [realm addOrUpdateObjectsFromArray:array];
+    [realm addOrUpdateObjects:array];
     XCTAssertEqual([objects count], 4U, @"Should have 4 objects");
     XCTAssertEqual([(PrimaryStringObject *)objects[0] intCol], 1, @"Value should be 1");
     XCTAssertEqual([(PrimaryStringObject *)objects[1] intCol], 4, @"Value should be 4");


### PR DESCRIPTION
Changes:
- Renamed `-[RLMRealm addOrUpdateObjectsInArray:]` to just `addOrUpdateObjects:` to match other APIs
- The three add/update/delete methods now actually check their collection elements to avoid unsafe memory access

Supersedes #3836.