### PR TITLE
Fix the way generic Swift properties are added to schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,10 @@ x.x.x Release notes (yyyy-MM-dd)
   model class defines a primary key).
 * Fix the way the hash property works on `Object` when the object model has
   no primary key.
+* Fix an issue where if a Swift model class defined non-generic managed
+  properties after generic Realm properties (like `List<T>`), the schema
+  would be constructed incorrectly. Fixes an issue where creating such
+  models from an array could fail.
 
 ### Enhancements
 

--- a/Realm/RLMObjectBase.mm
+++ b/Realm/RLMObjectBase.mm
@@ -485,11 +485,7 @@ Class RLMObjectUtilClass(BOOL isSwift) {
     return nil;
 }
 
-+ (NSArray *)getListProperties:(__unused id)obj {
-    return nil;
-}
-
-+ (NSArray *)getLinkingObjectsProperties:(__unused id)obj {
++ (NSArray *)getSwiftGenericProperties:(__unused id)obj {
     return nil;
 }
 
@@ -503,28 +499,43 @@ Class RLMObjectUtilClass(BOOL isSwift) {
 
 @end
 
-@implementation RLMListPropertyMetadata
+@implementation RLMGenericPropertyMetadata
 
-+ (instancetype)listPropertyMetadataWithPropertyName:(NSString *)propertyName index:(NSInteger)index {
-    RLMListPropertyMetadata *md = [RLMListPropertyMetadata new];
++ (instancetype)metadataForListProperty:(NSString *)propertyName index:(NSInteger)index {
+    RLMGenericPropertyMetadata *md = [RLMGenericPropertyMetadata new];
     md.propertyName = propertyName;
     md.index = index;
+    md.kind = RLMGenericPropertyKindList;
     return md;
 }
 
-@end
-
-@implementation RLMLinkingObjectsPropertyMetadata
-
-+ (instancetype)linkingObjectsPropertyMetadataWithPropertyName:(NSString *)propertyName
-                                                     className:(NSString *)className
-                                            linkedPropertyName:(NSString *)linkedPropertyName
-                                                         index:(NSInteger)index {
-    RLMLinkingObjectsPropertyMetadata *md = [RLMLinkingObjectsPropertyMetadata new];
++ (instancetype)metadataForLinkingObjectsProperty:(NSString *)propertyName
+                                        className:(NSString *)className
+                               linkedPropertyName:(NSString *)linkedPropertyName
+                                            index:(NSInteger)index {
+    RLMGenericPropertyMetadata *md = [RLMGenericPropertyMetadata new];
     md.propertyName = propertyName;
     md.className = className;
     md.linkedPropertyName = linkedPropertyName;
     md.index = index;
+    md.kind = RLMGenericPropertyKindLinkingObjects;
+    return md;
+}
+
++ (instancetype)metadataForOptionalProperty:(NSString *)propertyName type:(NSInteger)type index:(NSInteger)index {
+    RLMGenericPropertyMetadata *md = [RLMGenericPropertyMetadata new];
+    md.propertyName = propertyName;
+    md.propertyType = type;
+    md.index = index;
+    md.kind = RLMGenericPropertyKindOptional;
+    return md;
+}
+
++ (instancetype)metadataForNilLiteralOptionalProperty:(NSString *)propertyName index:(NSInteger)index {
+    RLMGenericPropertyMetadata *md = [RLMGenericPropertyMetadata new];
+    md.propertyName = propertyName;
+    md.index = index;
+    md.kind = RLMGenericPropertyKindNilLiteralOptional;
     return md;
 }
 

--- a/Realm/RLMObjectBase.mm
+++ b/Realm/RLMObjectBase.mm
@@ -489,7 +489,11 @@ Class RLMObjectUtilClass(BOOL isSwift) {
     return nil;
 }
 
-+ (NSDictionary *)getLinkingObjectsProperties:(__unused id)obj {
++ (NSArray *)getGenericListPropertyIndices:(__unused id)obj {
+    return nil;
+}
+
++ (NSArray *)getLinkingObjectsProperties:(__unused id)obj {
     return nil;
 }
 
@@ -499,6 +503,22 @@ Class RLMObjectUtilClass(BOOL isSwift) {
 
 + (NSArray *)requiredPropertiesForClass:(Class)cls {
     return [cls requiredProperties];
+}
+
+@end
+
+@implementation RLMLinkingObjectsPropertyMetadata
+
++ (instancetype)linkingObjectsPropertyMetadataWithPropertyName:(NSString *)propertyName
+                                                     className:(NSString *)className
+                                            linkedPropertyName:(NSString *)linkedPropertyName
+                                                         index:(NSInteger)index {
+    RLMLinkingObjectsPropertyMetadata *md = [RLMLinkingObjectsPropertyMetadata new];
+    md.propertyName = propertyName;
+    md.className = className;
+    md.linkedPropertyName = linkedPropertyName;
+    md.index = index;
+    return md;
 }
 
 @end

--- a/Realm/RLMObjectBase.mm
+++ b/Realm/RLMObjectBase.mm
@@ -485,11 +485,7 @@ Class RLMObjectUtilClass(BOOL isSwift) {
     return nil;
 }
 
-+ (NSArray *)getGenericListPropertyNames:(__unused id)obj {
-    return nil;
-}
-
-+ (NSArray *)getGenericListPropertyIndices:(__unused id)obj {
++ (NSArray *)getListProperties:(__unused id)obj {
     return nil;
 }
 
@@ -503,6 +499,17 @@ Class RLMObjectUtilClass(BOOL isSwift) {
 
 + (NSArray *)requiredPropertiesForClass:(Class)cls {
     return [cls requiredProperties];
+}
+
+@end
+
+@implementation RLMListPropertyMetadata
+
++ (instancetype)listPropertyMetadataWithPropertyName:(NSString *)propertyName index:(NSInteger)index {
+    RLMListPropertyMetadata *md = [RLMListPropertyMetadata new];
+    md.propertyName = propertyName;
+    md.index = index;
+    return md;
 }
 
 @end

--- a/Realm/RLMObjectSchema.mm
+++ b/Realm/RLMObjectSchema.mm
@@ -238,16 +238,12 @@ using namespace realm;
         // List<> properties don't show up as objective-C properties due to
         // being generic, so use Swift reflection to get a list of them, and
         // then access their ivars directly
-        NSArray<NSString *> *listPropNames = [objectUtil getGenericListPropertyNames:swiftObjectInstance] ?: @[];
-        NSArray<NSNumber *> *listPropIndices = [objectUtil getGenericListPropertyIndices:swiftObjectInstance] ?: @[];
-        if ([listPropNames count] != [listPropIndices count]) {
-            @throw RLMException(@"List property name count and index count did not match up. This may be due to "
-                                "misuse of Realm property types.");
-        }
-        for (NSUInteger i = 0; i < listPropNames.count; i++) {
-            addProperty([[RLMProperty alloc] initSwiftListPropertyWithName:listPropNames[i]
+        NSArray<RLMListPropertyMetadata *> *listProps = [objectUtil getListProperties:swiftObjectInstance];
+        for (RLMListPropertyMetadata *metadata in listProps) {
+            addProperty([[RLMProperty alloc] initSwiftListPropertyWithName:metadata.propertyName
                                                                   instance:swiftObjectInstance],
-                        [listPropIndices[i] integerValue]);
+                        metadata.index);
+
         }
 
         // Ditto for LinkingObjects<> properties.

--- a/Realm/RLMObject_Private.h
+++ b/Realm/RLMObject_Private.h
@@ -96,7 +96,7 @@ FOUNDATION_EXTERN Class RLMObjectUtilClass(BOOL isSwift);
 
 FOUNDATION_EXTERN const NSUInteger RLMDescriptionMaxDepth;
 
-@class RLMProperty, RLMArray, RLMLinkingObjectsPropertyMetadata;
+@class RLMProperty, RLMArray, RLMListPropertyMetadata, RLMLinkingObjectsPropertyMetadata;
 @interface RLMObjectUtil : NSObject
 
 + (nullable NSArray<NSString *> *)ignoredPropertiesForClass:(Class)cls;
@@ -104,13 +104,21 @@ FOUNDATION_EXTERN const NSUInteger RLMDescriptionMaxDepth;
 + (nullable NSDictionary<NSString *, NSDictionary<NSString *, NSString *> *> *)linkingObjectsPropertiesForClass:(Class)cls;
 
 // Precondition: these must be returned in ascending order.
-+ (nullable NSArray<NSString *> *)getGenericListPropertyNames:(id)obj;
-+ (nullable NSArray<NSNumber *> *)getGenericListPropertyIndices:(id)obj;
++ (nullable NSArray<RLMListPropertyMetadata *> *)getListProperties:(id)obj;
 // Precondition: these must be returned in ascending order.
-+ (nullable NSArray<RLMLinkingObjectsPropertyMetadata *> *)getLinkingObjectsProperties:(id)object;
++ (nullable NSArray<RLMLinkingObjectsPropertyMetadata *> *)getLinkingObjectsProperties:(id)obj;
 
 + (nullable NSDictionary<NSString *, NSNumber *> *)getOptionalProperties:(id)obj;
 + (nullable NSArray<NSString *> *)requiredPropertiesForClass:(Class)cls;
+
+@end
+
+@interface RLMListPropertyMetadata : NSObject
+
+@property (nonatomic, strong) NSString *propertyName;
+@property (nonatomic) NSInteger index;
+
++ (instancetype)listPropertyMetadataWithPropertyName:(NSString *)propertyName index:(NSInteger)index;
 
 @end
 

--- a/Realm/RLMObject_Private.h
+++ b/Realm/RLMObject_Private.h
@@ -96,18 +96,35 @@ FOUNDATION_EXTERN Class RLMObjectUtilClass(BOOL isSwift);
 
 FOUNDATION_EXTERN const NSUInteger RLMDescriptionMaxDepth;
 
-@class RLMProperty, RLMArray;
+@class RLMProperty, RLMArray, RLMLinkingObjectsPropertyMetadata;
 @interface RLMObjectUtil : NSObject
 
 + (nullable NSArray<NSString *> *)ignoredPropertiesForClass:(Class)cls;
 + (nullable NSArray<NSString *> *)indexedPropertiesForClass:(Class)cls;
 + (nullable NSDictionary<NSString *, NSDictionary<NSString *, NSString *> *> *)linkingObjectsPropertiesForClass:(Class)cls;
 
+// Precondition: these must be returned in ascending order.
 + (nullable NSArray<NSString *> *)getGenericListPropertyNames:(id)obj;
-+ (nullable NSDictionary<NSString *, NSDictionary<NSString *, NSString *> *> *)getLinkingObjectsProperties:(id)object;
++ (nullable NSArray<NSNumber *> *)getGenericListPropertyIndices:(id)obj;
+// Precondition: these must be returned in ascending order.
++ (nullable NSArray<RLMLinkingObjectsPropertyMetadata *> *)getLinkingObjectsProperties:(id)object;
 
 + (nullable NSDictionary<NSString *, NSNumber *> *)getOptionalProperties:(id)obj;
 + (nullable NSArray<NSString *> *)requiredPropertiesForClass:(Class)cls;
+
+@end
+
+@interface RLMLinkingObjectsPropertyMetadata : NSObject
+
+@property (nonatomic, strong) NSString *propertyName;
+@property (nonatomic, strong) NSString *className;
+@property (nonatomic, strong) NSString *linkedPropertyName;
+@property (nonatomic) NSInteger index;
+
++ (instancetype)linkingObjectsPropertyMetadataWithPropertyName:(NSString *)propertyName
+                                                     className:(NSString *)className
+                                            linkedPropertyName:(NSString *)linkedPropertyName
+                                                         index:(NSInteger)index;
 
 @end
 

--- a/Realm/RLMObject_Private.h
+++ b/Realm/RLMObject_Private.h
@@ -96,7 +96,7 @@ FOUNDATION_EXTERN Class RLMObjectUtilClass(BOOL isSwift);
 
 FOUNDATION_EXTERN const NSUInteger RLMDescriptionMaxDepth;
 
-@class RLMProperty, RLMArray, RLMListPropertyMetadata, RLMLinkingObjectsPropertyMetadata;
+@class RLMProperty, RLMArray, RLMGenericPropertyMetadata;
 @interface RLMObjectUtil : NSObject
 
 + (nullable NSArray<NSString *> *)ignoredPropertiesForClass:(Class)cls;
@@ -104,35 +104,40 @@ FOUNDATION_EXTERN const NSUInteger RLMDescriptionMaxDepth;
 + (nullable NSDictionary<NSString *, NSDictionary<NSString *, NSString *> *> *)linkingObjectsPropertiesForClass:(Class)cls;
 
 // Precondition: these must be returned in ascending order.
-+ (nullable NSArray<RLMListPropertyMetadata *> *)getListProperties:(id)obj;
-// Precondition: these must be returned in ascending order.
-+ (nullable NSArray<RLMLinkingObjectsPropertyMetadata *> *)getLinkingObjectsProperties:(id)obj;
++ (nullable NSArray<RLMGenericPropertyMetadata *> *)getSwiftGenericProperties:(id)obj;
 
 + (nullable NSDictionary<NSString *, NSNumber *> *)getOptionalProperties:(id)obj;
 + (nullable NSArray<NSString *> *)requiredPropertiesForClass:(Class)cls;
 
 @end
 
-@interface RLMListPropertyMetadata : NSObject
+typedef NS_ENUM(NSUInteger, RLMGenericPropertyKind) {
+    RLMGenericPropertyKindList,
+    RLMGenericPropertyKindLinkingObjects,
+    RLMGenericPropertyKindOptional,
+    RLMGenericPropertyKindNilLiteralOptional,   // For Swift optional properties that reflect as nil
+};
+
+// Metadata that describes a Swift generic property.
+@interface RLMGenericPropertyMetadata : NSObject
 
 @property (nonatomic, strong) NSString *propertyName;
+@property (nullable, nonatomic, strong) NSString *className;
+@property (nullable, nonatomic, strong) NSString *linkedPropertyName;
 @property (nonatomic) NSInteger index;
+@property (nonatomic) NSInteger propertyType;
+@property (nonatomic) RLMGenericPropertyKind kind;
 
-+ (instancetype)listPropertyMetadataWithPropertyName:(NSString *)propertyName index:(NSInteger)index;
++ (instancetype)metadataForListProperty:(NSString *)propertyName index:(NSInteger)index;
 
-@end
++ (instancetype)metadataForLinkingObjectsProperty:(NSString *)propertyName
+                                        className:(NSString *)className
+                               linkedPropertyName:(NSString *)linkedPropertyName
+                                            index:(NSInteger)index;
 
-@interface RLMLinkingObjectsPropertyMetadata : NSObject
++ (instancetype)metadataForOptionalProperty:(NSString *)propertyName type:(NSInteger)type index:(NSInteger)index;
 
-@property (nonatomic, strong) NSString *propertyName;
-@property (nonatomic, strong) NSString *className;
-@property (nonatomic, strong) NSString *linkedPropertyName;
-@property (nonatomic) NSInteger index;
-
-+ (instancetype)linkingObjectsPropertyMetadataWithPropertyName:(NSString *)propertyName
-                                                     className:(NSString *)className
-                                            linkedPropertyName:(NSString *)linkedPropertyName
-                                                         index:(NSInteger)index;
++ (instancetype)metadataForNilLiteralOptionalProperty:(NSString *)propertyName index:(NSInteger)index;
 
 @end
 

--- a/RealmSwift/Object.swift
+++ b/RealmSwift/Object.swift
@@ -416,8 +416,19 @@ public class ObjectUtil: NSObject {
         return nil
     }
 
-    // Reflect an object, and remove all the ignored stored properties from the
-    // children collection.
+    // If the property is a storage property for a lazy Swift property, return
+    // the base property name (e.g. `foo.storage` becomes `foo`). Otherwise, nil.
+    private static func baseName(forLazySwiftProperty name: String) -> String? {
+        let storageSuffix = ".storage"
+        if let storageRange = name.range(of: storageSuffix, options: [.anchored, .backwards]) {
+            var baseName = name
+            baseName.removeSubrange(storageRange)
+            return baseName
+        }
+        return nil
+    }
+
+    // Reflect an object, returning only children representing managed Realm properties.
     private static func getNonIgnoredMirrorChildren(for object: Any) -> [Mirror.Child] {
         guard let realmObject = object as? Object else {
             return Array(Mirror(reflecting: object).children)
@@ -428,68 +439,78 @@ public class ObjectUtil: NSObject {
             guard let label = prop.label else {
                 return false
             }
-            return !ignoredPropNames.contains(label)
-        }
-    }
-
-    @objc private class func getListProperties(_ object: Any) -> [RLMListPropertyMetadata] {
-        var props: [RLMListPropertyMetadata] = []
-        for (idx, prop) in getNonIgnoredMirrorChildren(for: object).enumerated() {
-            if let value = prop.value as? RLMListBase {
-                props.append(RLMListPropertyMetadata(propertyName: prop.label!, index: idx))
+            if ignoredPropNames.contains(label) {
+                // Ignored property.
+                return false
             }
+            if let lazyBaseName = baseName(forLazySwiftProperty: label) {
+                if ignoredPropNames.contains(lazyBaseName) {
+                    // Ignored lazy property.
+                    return false
+                }
+                // Managed lazy property; not currently supported.
+                // FIXME: revisit this once Swift gets property behaviors/property macros.
+                throwRealmException("Lazy managed property '\(lazyBaseName)' is not allowed on a Realm Swift object"
+                    + " class. Either add the property to the ignored properties list or make it non-lazy.")
+            }
+            return true
         }
-        return props
     }
 
-    @objc private class func getLinkingObjectsProperties(_ object: Any) -> [RLMLinkingObjectsPropertyMetadata] {
-        var props: [RLMLinkingObjectsPropertyMetadata] = []
+    // Build optional property metadata for a given property.
+    private static func buildMetadata(for child: Mirror.Child, at index: Int) -> RLMGenericPropertyMetadata? {
+        guard let name = child.label else {
+            return nil
+        }
+        let mirror = Mirror(reflecting: child.value)
+        let type = mirror.subjectType
+        let code: PropertyType
+        if type is Optional<String>.Type || type is Optional<NSString>.Type {
+            code = .string
+        } else if type is Optional<Date>.Type {
+            code = .date
+        } else if type is Optional<Data>.Type {
+            code = .data
+        } else if type is Optional<Object>.Type {
+            code = .object
+        } else if type is RealmOptional<Int>.Type ||
+            type is RealmOptional<Int8>.Type ||
+            type is RealmOptional<Int16>.Type ||
+            type is RealmOptional<Int32>.Type ||
+            type is RealmOptional<Int64>.Type {
+            code = .int
+        } else if type is RealmOptional<Float>.Type {
+            code = .float
+        } else if type is RealmOptional<Double>.Type {
+            code = .double
+        } else if type is RealmOptional<Bool>.Type {
+            code = .bool
+        } else if child.value as? RLMOptionalBase != nil {
+            throwRealmException("'\(type)' is not a valid RealmOptional type.")
+            code = .int // ignored
+        } else if mirror.displayStyle == .optional || type is ExpressibleByNilLiteral.Type {
+            return RLMGenericPropertyMetadata(forNilLiteralOptionalProperty: name, index: index)
+        } else {
+            return nil
+        }
+        return RLMGenericPropertyMetadata(forOptionalProperty: name, type: Int(code.rawValue), index: index)
+    }
+
+    @objc private class func getSwiftGenericProperties(_ object: Any) -> [RLMGenericPropertyMetadata] {
+        var props: [RLMGenericPropertyMetadata] = []
         for (idx, prop) in getNonIgnoredMirrorChildren(for: object).enumerated() {
             if let value = prop.value as? LinkingObjectsBase {
-                props.append(RLMLinkingObjectsPropertyMetadata(propertyName: prop.label!,
-                                                               className: value.objectClassName,
-                                                               linkedPropertyName: value.propertyName,
-                                                               index: idx))
+                props.append(.init(forLinkingObjectsProperty: prop.label!,
+                                   className: value.objectClassName,
+                                   linkedPropertyName: value.propertyName,
+                                   index: idx))
+            } else if prop.value is RLMListBase {
+                props.append(.init(forListProperty: prop.label!, index: idx))
+            } else if let optional = buildMetadata(for: prop, at: idx) {
+                props.append(optional)
             }
         }
         return props
-    }
-
-    // swiftlint:disable:next cyclomatic_complexity
-    @objc private class func getOptionalProperties(_ object: Any) -> [String: Any] {
-        let children = Mirror(reflecting: object).children
-        return children.reduce([:]) { (properties: [String: Any], prop: Mirror.Child) in
-            guard let name = prop.label else { return properties }
-            let mirror = Mirror(reflecting: prop.value)
-            let type = mirror.subjectType
-            var properties = properties
-            if type is Optional<String>.Type || type is Optional<NSString>.Type {
-                properties[name] = NSNumber(value: PropertyType.string.rawValue)
-            } else if type is Optional<Date>.Type {
-                properties[name] = NSNumber(value: PropertyType.date.rawValue)
-            } else if type is Optional<Data>.Type {
-                properties[name] = NSNumber(value: PropertyType.data.rawValue)
-            } else if type is Optional<Object>.Type {
-                properties[name] = NSNumber(value: PropertyType.object.rawValue)
-            } else if type is RealmOptional<Int>.Type ||
-                      type is RealmOptional<Int8>.Type ||
-                      type is RealmOptional<Int16>.Type ||
-                      type is RealmOptional<Int32>.Type ||
-                      type is RealmOptional<Int64>.Type {
-                properties[name] = NSNumber(value: PropertyType.int.rawValue)
-            } else if type is RealmOptional<Float>.Type {
-                properties[name] = NSNumber(value: PropertyType.float.rawValue)
-            } else if type is RealmOptional<Double>.Type {
-                properties[name] = NSNumber(value: PropertyType.double.rawValue)
-            } else if type is RealmOptional<Bool>.Type {
-                properties[name] = NSNumber(value: PropertyType.bool.rawValue)
-            } else if prop.value as? RLMOptionalBase != nil {
-                throwRealmException("'\(type)' is not a valid RealmOptional type.")
-            } else if mirror.displayStyle == .optional || type is ExpressibleByNilLiteral.Type {
-                properties[name] = NSNull()
-            }
-            return properties
-        }
     }
 
     @objc private class func requiredPropertiesForClass(_: Any) -> [String] {

--- a/RealmSwift/Tests/ObjectCreationTests.swift
+++ b/RealmSwift/Tests/ObjectCreationTests.swift
@@ -723,6 +723,8 @@ class ObjectCreationTests: TestCase {
         XCTAssertEqual(object.secondArray[0].stringCol, "goodbye")
         XCTAssertEqual(object.secondArray[1].stringCol, "cruel")
         XCTAssertEqual(object.secondArray[2].stringCol, "world")
+        XCTAssertEqual(object.firstOptionalNumber.value, nil)
+        XCTAssertEqual(object.secondOptionalNumber.value, 300)
         XCTAssertTrue(object.parentFirstList.count == 2)
         XCTAssertEqual(object.parentFirstList[0].intCol, 42)
         XCTAssertEqual(object.parentFirstList[1].intCol, 9001)

--- a/RealmSwift/Tests/ObjectCreationTests.swift
+++ b/RealmSwift/Tests/ObjectCreationTests.swift
@@ -709,7 +709,9 @@ class ObjectCreationTests: TestCase {
             [["stringCol": "hello"], ["stringCol": "world"]],
             2,
             [["stringCol": "goodbye"], ["stringCol": "cruel"], ["stringCol": "world"]],
-            3]
+            NSNull(),
+            3,
+            300]
         let object = SwiftGenericPropsOrderingObject(value: v)
         XCTAssertEqual(object.firstNumber, 1)
         XCTAssertEqual(object.secondNumber, 2)

--- a/RealmSwift/Tests/ObjectCreationTests.swift
+++ b/RealmSwift/Tests/ObjectCreationTests.swift
@@ -699,9 +699,18 @@ class ObjectCreationTests: TestCase {
     /// If a Swift class declares generic properties before non-generic ones, the properties
     /// should be registered in order and creation from an array of values should work.
     func testProperOrderingOfProperties() {
-        let sc = "stringCol"
-        let v: [Any] = [1, [[sc: "hello"], [sc: "world"]], 2, [[sc: "goodbye"], [sc: "cruel"], [sc: "world"]], 3]
-        let object = SwiftGenericPropsNotLastObject(value: v)
+        let v: [Any] = [
+            // Superclass's columns
+            [["intCol": 42], ["intCol": 9001]],
+            100,
+            200,
+            // Class's columns
+            1,
+            [["stringCol": "hello"], ["stringCol": "world"]],
+            2,
+            [["stringCol": "goodbye"], ["stringCol": "cruel"], ["stringCol": "world"]],
+            3]
+        let object = SwiftGenericPropsOrderingObject(value: v)
         XCTAssertEqual(object.firstNumber, 1)
         XCTAssertEqual(object.secondNumber, 2)
         XCTAssertEqual(object.thirdNumber, 3)
@@ -712,6 +721,11 @@ class ObjectCreationTests: TestCase {
         XCTAssertEqual(object.secondArray[0].stringCol, "goodbye")
         XCTAssertEqual(object.secondArray[1].stringCol, "cruel")
         XCTAssertEqual(object.secondArray[2].stringCol, "world")
+        XCTAssertTrue(object.parentFirstList.count == 2)
+        XCTAssertEqual(object.parentFirstList[0].intCol, 42)
+        XCTAssertEqual(object.parentFirstList[1].intCol, 9001)
+        XCTAssertEqual(object.parentFirstNumber, 100)
+        XCTAssertEqual(object.parentSecondNumber, 200)
         XCTAssertTrue(object.firstLinking.count == 0)
         XCTAssertTrue(object.secondLinking.count == 0)
     }

--- a/RealmSwift/Tests/ObjectCreationTests.swift
+++ b/RealmSwift/Tests/ObjectCreationTests.swift
@@ -696,6 +696,26 @@ class ObjectCreationTests: TestCase {
         realm.cancelWrite()
     }
 
+    /// If a Swift class declares generic properties before non-generic ones, the properties
+    /// should be registered in order and creation from an array of values should work.
+    func testProperOrderingOfProperties() {
+        let sc = "stringCol"
+        let v: [Any] = [1, [[sc: "hello"], [sc: "world"]], 2, [[sc: "goodbye"], [sc: "cruel"], [sc: "world"]], 3]
+        let object = SwiftGenericPropsNotLastObject(value: v)
+        XCTAssertEqual(object.firstNumber, 1)
+        XCTAssertEqual(object.secondNumber, 2)
+        XCTAssertEqual(object.thirdNumber, 3)
+        XCTAssertTrue(object.firstArray.count == 2)
+        XCTAssertEqual(object.firstArray[0].stringCol, "hello")
+        XCTAssertEqual(object.firstArray[1].stringCol, "world")
+        XCTAssertTrue(object.secondArray.count == 3)
+        XCTAssertEqual(object.secondArray[0].stringCol, "goodbye")
+        XCTAssertEqual(object.secondArray[1].stringCol, "cruel")
+        XCTAssertEqual(object.secondArray[2].stringCol, "world")
+        XCTAssertTrue(object.firstLinking.count == 0)
+        XCTAssertTrue(object.secondLinking.count == 0)
+    }
+
     // MARK: Private utilities
     private func verifySwiftObjectWithArrayLiteral(_ object: SwiftObject, array: [Any], boolObjectValue: Bool,
                                                    boolObjectListValues: [Bool]) {

--- a/RealmSwift/Tests/ObjectSchemaInitializationTests.swift
+++ b/RealmSwift/Tests/ObjectSchemaInitializationTests.swift
@@ -124,6 +124,10 @@ class ObjectSchemaInitializationTests: TestCase {
                      "Should throw when not ignoring a property of a type we can't persist")
         assertThrows(RLMObjectSchema(forObjectClass: SwiftObjectWithBadPropertyName.self),
                      "Should throw when not ignoring a property with a name we don't support")
+        assertThrows(RLMObjectSchema(forObjectClass: SwiftObjectWithManagedLazyProperty.self),
+                     "Should throw when not ignoring a lazy property")
+        assertThrows(RLMObjectSchema(forObjectClass: SwiftObjectWithDynamicManagedLazyProperty.self),
+                     "Should throw when not ignoring a lazy property")
 
         // Shouldn't throw when not ignoring a property of a type we can't persist if it's not dynamic
         _ = RLMObjectSchema(forObjectClass: SwiftObjectWithEnum.self)
@@ -302,4 +306,13 @@ class SwiftObjectWithNonRealmOptionalType: SwiftFakeObject {
 
 class SwiftObjectWithBadPropertyName: SwiftFakeObject {
     @objc dynamic var newValue = false
+}
+
+class SwiftObjectWithManagedLazyProperty: SwiftFakeObject {
+    lazy var foobar: String = "foo"
+}
+
+// swiftlint:disable:next type_name
+class SwiftObjectWithDynamicManagedLazyProperty: SwiftFakeObject {
+    @objc dynamic lazy var foobar: String = "foo"
 }

--- a/RealmSwift/Tests/SwiftTestObjects.swift
+++ b/RealmSwift/Tests/SwiftTestObjects.swift
@@ -491,14 +491,19 @@ class SwiftGenericPropsOrderingParent: Object {
 }
 
 class SwiftGenericPropsOrderingObject: SwiftGenericPropsOrderingParent {
-
     func myFunction() -> Int { return firstNumber + secondNumber + thirdNumber }
+    var firstIgnored = 1
     @objc dynamic var firstNumber = 0
     class func myClassFunction(x: Int, y: Int) -> Int { return x + y }
+    var secondIgnored = 10
     let firstArray = List<SwiftStringObject>()
     @objc dynamic var secondNumber = 0
     var computedProp: String { return "\(firstNumber), \(secondNumber), and \(thirdNumber)" }
     let secondArray = List<SwiftStringObject>()
+    override class func ignoredProperties() -> [String] {
+        return ["firstIgnored", "secondIgnored", "thirdIgnored"]
+    }
+    var thirdIgnored = 100
     let firstLinking = LinkingObjects(fromType: SwiftGenericPropsOrderingHelper.self, property: "first")
     let secondLinking = LinkingObjects(fromType: SwiftGenericPropsOrderingHelper.self, property: "second")
     @objc dynamic var thirdNumber = 0

--- a/RealmSwift/Tests/SwiftTestObjects.swift
+++ b/RealmSwift/Tests/SwiftTestObjects.swift
@@ -481,3 +481,19 @@ class SwiftCircleObject: Object {
     @objc dynamic var obj: SwiftCircleObject?
     let array = List<SwiftCircleObject>()
 }
+
+class SwiftGenericPropsNotLastObject: Object {
+    @objc dynamic var firstNumber = 0
+    let firstArray = List<SwiftStringObject>()
+    @objc dynamic var secondNumber = 0
+    let secondArray = List<SwiftStringObject>()
+    let firstLinking = LinkingObjects(fromType: SwiftGenericPropsNotLastHelper.self, property: "first")
+    let secondLinking = LinkingObjects(fromType: SwiftGenericPropsNotLastHelper.self, property: "second")
+    @objc dynamic var thirdNumber = 0
+}
+
+// Only exists to allow linking object properties on `SwiftGenericPropsNotLastObject`.
+class SwiftGenericPropsNotLastHelper: Object {
+    @objc dynamic var first: SwiftGenericPropsNotLastObject?
+    @objc dynamic var second: SwiftGenericPropsNotLastObject?
+}

--- a/RealmSwift/Tests/SwiftTestObjects.swift
+++ b/RealmSwift/Tests/SwiftTestObjects.swift
@@ -482,18 +482,30 @@ class SwiftCircleObject: Object {
     let array = List<SwiftCircleObject>()
 }
 
-class SwiftGenericPropsNotLastObject: Object {
+class SwiftGenericPropsOrderingParent: Object {
+    let parentFirstList = List<SwiftIntObject>()
+    @objc dynamic var parentFirstNumber = 0
+    func parentFunction() -> Int { return parentFirstNumber + 1 }
+    @objc dynamic var parentSecondNumber = 1
+    var parentComputedProp: String { return "hello world" }
+}
+
+class SwiftGenericPropsOrderingObject: SwiftGenericPropsOrderingParent {
+
+    func myFunction() -> Int { return firstNumber + secondNumber + thirdNumber }
     @objc dynamic var firstNumber = 0
+    class func myClassFunction(x: Int, y: Int) -> Int { return x + y }
     let firstArray = List<SwiftStringObject>()
     @objc dynamic var secondNumber = 0
+    var computedProp: String { return "\(firstNumber), \(secondNumber), and \(thirdNumber)" }
     let secondArray = List<SwiftStringObject>()
-    let firstLinking = LinkingObjects(fromType: SwiftGenericPropsNotLastHelper.self, property: "first")
-    let secondLinking = LinkingObjects(fromType: SwiftGenericPropsNotLastHelper.self, property: "second")
+    let firstLinking = LinkingObjects(fromType: SwiftGenericPropsOrderingHelper.self, property: "first")
+    let secondLinking = LinkingObjects(fromType: SwiftGenericPropsOrderingHelper.self, property: "second")
     @objc dynamic var thirdNumber = 0
 }
 
 // Only exists to allow linking object properties on `SwiftGenericPropsNotLastObject`.
-class SwiftGenericPropsNotLastHelper: Object {
-    @objc dynamic var first: SwiftGenericPropsNotLastObject?
-    @objc dynamic var second: SwiftGenericPropsNotLastObject?
+class SwiftGenericPropsOrderingHelper: Object {
+    @objc dynamic var first: SwiftGenericPropsOrderingObject?
+    @objc dynamic var second: SwiftGenericPropsOrderingObject?
 }

--- a/RealmSwift/Tests/SwiftTestObjects.swift
+++ b/RealmSwift/Tests/SwiftTestObjects.swift
@@ -482,6 +482,7 @@ class SwiftCircleObject: Object {
     let array = List<SwiftCircleObject>()
 }
 
+// Exists to serve as a superclass to `SwiftGenericPropsOrderingObject`
 class SwiftGenericPropsOrderingParent: Object {
     let parentFirstList = List<SwiftIntObject>()
     @objc dynamic var parentFirstNumber = 0
@@ -490,23 +491,31 @@ class SwiftGenericPropsOrderingParent: Object {
     var parentComputedProp: String { return "hello world" }
 }
 
+// Used to verify that Swift properties (generic and otherwise) are detected properly and
+// added to the schema in the correct order.
 class SwiftGenericPropsOrderingObject: SwiftGenericPropsOrderingParent {
     func myFunction() -> Int { return firstNumber + secondNumber + thirdNumber }
-    var firstIgnored = 1
-    @objc dynamic var firstNumber = 0
+    @objc dynamic var dynamicComputed: Int { return 999 }
+    var firstIgnored = 999
+    @objc dynamic var dynamicIgnored = 999
+    @objc dynamic var firstNumber = 0                   // Managed property
     class func myClassFunction(x: Int, y: Int) -> Int { return x + y }
-    var secondIgnored = 10
-    let firstArray = List<SwiftStringObject>()
-    @objc dynamic var secondNumber = 0
+    var secondIgnored = 999
+    lazy var lazyIgnored = 999
+    let firstArray = List<SwiftStringObject>()          // Managed property
+    @objc dynamic var secondNumber = 0                  // Managed property
     var computedProp: String { return "\(firstNumber), \(secondNumber), and \(thirdNumber)" }
-    let secondArray = List<SwiftStringObject>()
+    let secondArray = List<SwiftStringObject>()         // Managed property
     override class func ignoredProperties() -> [String] {
-        return ["firstIgnored", "secondIgnored", "thirdIgnored"]
+        return ["firstIgnored", "dynamicIgnored", "secondIgnored", "thirdIgnored", "lazyIgnored", "dynamicLazyIgnored"]
     }
-    var thirdIgnored = 100
+    let firstOptionalNumber = RealmOptional<Int>()      // Managed property
+    var thirdIgnored = 999
+    @objc dynamic lazy var dynamicLazyIgnored = 999
     let firstLinking = LinkingObjects(fromType: SwiftGenericPropsOrderingHelper.self, property: "first")
     let secondLinking = LinkingObjects(fromType: SwiftGenericPropsOrderingHelper.self, property: "second")
-    @objc dynamic var thirdNumber = 0
+    @objc dynamic var thirdNumber = 0                   // Managed property
+    let secondOptionalNumber = RealmOptional<Int>()     // Managed property
 }
 
 // Only exists to allow linking object properties on `SwiftGenericPropsNotLastObject`.


### PR DESCRIPTION
Changes:
- Generic Swift properties should now be added to schema in the order they are defined

Fixes #5102