### PR TITLE
Align notification APIs with new KVO APIs

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -7,7 +7,7 @@ identifier_name:
     warning: 0
     error: 0
   excluded:
-    - _addNotificationBlock(_:)
+    - _observe(_:)
     - _nsError
     - _nsErrorDomain
     - _realmObjectName()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,8 +42,8 @@ x.x.x Release notes (yyyy-MM-dd)
   now runs on the main queue by default, or can be explicitly specified
   by a new `callbackQueue` parameter on the `{RLM}SyncUser.logIn(...)` API.
 * Rename `{RLM}NotificationToken.stop()` to `invalidate()` and
-  `RealmCollection.addNotificationBlock(_:)` to `observe(_:)` to mirror the new
-  KVO Swift APIs.
+  `{RealmCollection,SyncPermissionResults}.addNotificationBlock(_:)` to
+  `observe(_:)` to mirror Foundation's new KVO APIs.
 
 ### Enhancements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,9 @@ x.x.x Release notes (yyyy-MM-dd)
 * The callback which runs when a sync user login succeeds or fails
   now runs on the main queue by default, or can be explicitly specified
   by a new `callbackQueue` parameter on the `{RLM}SyncUser.logIn(...)` API.
+* Rename `{RLM}NotificationToken.stop()` to `invalidate()` and
+  `RealmCollection.addNotificationBlock(_:)` to `observe(_:)` to mirror the new
+  KVO Swift APIs.
 
 ### Enhancements
 

--- a/Realm/ObjectServerTests/RLMObjectServerTests.mm
+++ b/Realm/ObjectServerTests/RLMObjectServerTests.mm
@@ -1189,7 +1189,7 @@
         // Wait for the child process to upload everything.
         RLMRunChildAndWait();
         [self waitForExpectationsWithTimeout:10.0 handler:nil];
-        [token stop];
+        [token invalidate];
         // The notifier should have been called at least twice: once at the beginning and at least once
         // to report progress.
         XCTAssert(callCount > 1);
@@ -1252,7 +1252,7 @@
     [realm commitWriteTransaction];
     // Wait for upload to begin and finish
     [self waitForExpectationsWithTimeout:10.0 handler:nil];
-    [token stop];
+    [token invalidate];
     // The notifier should have been called at least twice: once at the beginning and at least once
     // to report progress.
     XCTAssert(callCount > 1);

--- a/Realm/ObjectServerTests/RLMPermissionsAPITests.m
+++ b/Realm/ObjectServerTests/RLMPermissionsAPITests.m
@@ -655,7 +655,7 @@ static RLMSyncPermission *makeExpectedPermission(RLMSyncPermission *original, RL
 
     // Wait for the notification to be fired.
     [self waitForExpectations:@[noteEx] timeout:2.0];
-    [token stop];
+    [token invalidate];
     id expectedPermission = makeExpectedPermission(p, self.userA, NSStringFromSelector(_cmd));
     CHECK_PERMISSION_PRESENT(results, expectedPermission);
 }
@@ -907,7 +907,7 @@ static RLMSyncPermission *makeExpectedPermission(RLMSyncPermission *original, RL
 
     [self waitForExpectationsWithTimeout:2.0 handler:nil];
 
-    [token stop];
+    [token invalidate];
 }
 
 /// Failed to process a permission offer object due to the offer expired
@@ -956,7 +956,7 @@ static RLMSyncPermission *makeExpectedPermission(RLMSyncPermission *original, RL
 
     [self waitForExpectationsWithTimeout:2.0 handler:nil];
 
-    [token stop];
+    [token invalidate];
 }
 
 /// Get a permission offer token, then permission offer response will be processed, then open another user's Realm file
@@ -1010,7 +1010,7 @@ static RLMSyncPermission *makeExpectedPermission(RLMSyncPermission *original, RL
 
     [self waitForExpectationsWithTimeout:2.0 handler:nil];
 
-    [token stop];
+    [token invalidate];
 
     NSString *userNameB = [NSStringFromSelector(_cmd) stringByAppendingString:@"_B"];
     RLMSyncUser *userB = [self logInUserForCredentials:[RLMSyncTestCase basicCredentialsWithName:userNameB
@@ -1055,7 +1055,7 @@ static RLMSyncPermission *makeExpectedPermission(RLMSyncPermission *original, RL
 
     [self waitForExpectationsWithTimeout:2.0 handler:nil];
 
-    [token stop];
+    [token invalidate];
 
     XCTAssertNotNil([self openRealmForURL:[NSURL URLWithString:responseRealmUrl] user:userB]);
 }
@@ -1099,7 +1099,7 @@ static RLMSyncPermission *makeExpectedPermission(RLMSyncPermission *original, RL
 
     [self waitForExpectationsWithTimeout:2.0 handler:nil];
 
-    [token stop];
+    [token invalidate];
 }
 
 /// Failed to process a permission offer response object due to `token` does not exist
@@ -1142,7 +1142,7 @@ static RLMSyncPermission *makeExpectedPermission(RLMSyncPermission *original, RL
     
     [self waitForExpectationsWithTimeout:2.0 handler:nil];
     
-    [token stop];
+    [token invalidate];
 }
 
 #pragma mark - Delete Realm upon permission denied

--- a/Realm/ObjectServerTests/RLMSyncTestCase.mm
+++ b/Realm/ObjectServerTests/RLMSyncTestCase.mm
@@ -265,7 +265,7 @@ static NSURL *syncDirectoryForChildProcess() {
                 }
             }];
             [self waitForExpectations:@[findAdminEx] timeout:10.0];
-            [token stop];
+            [token invalidate];
             [realm transactionWithBlock:^{
                 [userObject setValue:@YES forKey:@"isAdmin"];
             }];

--- a/Realm/ObjectServerTests/SwiftObjectServerTests.swift
+++ b/Realm/ObjectServerTests/SwiftObjectServerTests.swift
@@ -188,7 +188,7 @@ class SwiftObjectServerTests: SwiftSyncTestCase {
                 // Wait for the child process to upload all the data.
                 executeChild()
                 waitForExpectations(timeout: 10.0, handler: nil)
-                token!.stop()
+                token!.invalidate()
                 XCTAssert(callCount > 1)
                 XCTAssert(transferred >= transferrable)
             } else {
@@ -234,7 +234,7 @@ class SwiftObjectServerTests: SwiftSyncTestCase {
                 }
             }
             waitForExpectations(timeout: 10.0, handler: nil)
-            token!.stop()
+            token!.invalidate()
             XCTAssert(callCount > 1)
             XCTAssert(transferred >= transferrable)
         } catch {
@@ -349,7 +349,7 @@ class SwiftObjectServerTests: SwiftSyncTestCase {
             }
 
             waitForExpectations(timeout: 2)
-            notificationToken.stop()
+            notificationToken.invalidate()
         } catch {
             XCTFail("Got an error: \(error) (process: \(isParent ? "parent" : "child"))")
         }
@@ -386,7 +386,7 @@ class SwiftObjectServerTests: SwiftSyncTestCase {
             }
 
             waitForExpectations(timeout: 2)
-            permissionOfferNotificationToken.stop()
+            permissionOfferNotificationToken.invalidate()
 
             let userB = try synchronouslyLogInUser(for: basicCredentials(register: isParent, usernameSuffix: "_B"), server: authURL)
             _ = try synchronouslyOpenRealm(url: realmURL, user: userB)
@@ -421,7 +421,7 @@ class SwiftObjectServerTests: SwiftSyncTestCase {
             }
 
             waitForExpectations(timeout: 2)
-            permissionOfferResponseNotificationToken.stop()
+            permissionOfferResponseNotificationToken.invalidate()
 
             _ = try synchronouslyOpenRealm(url: URL(string: responseRealmUrl!)!, user: userB)
         } catch {

--- a/Realm/ObjectServerTests/SwiftObjectServerTests.swift
+++ b/Realm/ObjectServerTests/SwiftObjectServerTests.swift
@@ -335,7 +335,7 @@ class SwiftObjectServerTests: SwiftSyncTestCase {
             let exp = expectation(description: "A new permission offer will be processed by the server")
 
             let results = managementRealm.objects(SyncPermissionOffer.self).filter("id = %@", permissionOffer.id)
-            let notificationToken = results.addNotificationBlock { (changes) in
+            let notificationToken = results.observe { (changes) in
                 if case .update(let change, _, _, _) = changes, let statusCode = change[0].statusCode.value {
                     XCTAssertEqual(statusCode, 0)
                     XCTAssertEqual(change[0].status, .success)
@@ -370,7 +370,7 @@ class SwiftObjectServerTests: SwiftSyncTestCase {
             let permissionOfferNotificationToken = managementRealm
                 .objects(SyncPermissionOffer.self)
                 .filter("id = %@", permissionOffer.id)
-                .addNotificationBlock { (changes) in
+                .observe { (changes) in
                 if case .update(let change, _, _, _) = changes, let statusCode = change[0].statusCode.value {
                     XCTAssertEqual(statusCode, 0)
                     XCTAssertEqual(change[0].status, .success)
@@ -403,7 +403,7 @@ class SwiftObjectServerTests: SwiftSyncTestCase {
             let permissionOfferResponseNotificationToken = managementRealm
                 .objects(SyncPermissionOfferResponse.self)
                 .filter("id = %@", permissionOfferResponse.id)
-                .addNotificationBlock { (changes) in
+                .observe { (changes) in
                 if case .update(let change, _, _, _) = changes, let statusCode = change[0].statusCode.value {
                     XCTAssertEqual(statusCode, 0)
                     XCTAssertEqual(change[0].status, .success)

--- a/Realm/ObjectServerTests/SwiftPermissionsAPITests.swift
+++ b/Realm/ObjectServerTests/SwiftPermissionsAPITests.swift
@@ -54,7 +54,7 @@ class SwiftPermissionsAPITests: SwiftSyncTestCase {
             }
         }
         waitForExpectations(timeout: 2.0, handler: nil)
-        token.stop()
+        token.invalidate()
     }
 
     private func get(permission: SyncPermission,
@@ -72,7 +72,7 @@ class SwiftPermissionsAPITests: SwiftSyncTestCase {
             }
         }
         waitForExpectations(timeout: 2.0, handler: nil)
-        token.stop()
+        token.invalidate()
         return finalValue
     }
 
@@ -94,7 +94,7 @@ class SwiftPermissionsAPITests: SwiftSyncTestCase {
             ex.fulfill()
         }
         waitForExpectations(timeout: wait + 1.0, handler: nil)
-        token.stop()
+        token.invalidate()
         XCTAssertFalse(isPresent, "Permission '\(permission)' was spuriously present (\(file):\(line))")
     }
 
@@ -196,7 +196,7 @@ class SwiftPermissionsAPITests: SwiftSyncTestCase {
 
         // Wait for the notification to be fired.
         wait(for: [noteEx], timeout: 2.0)
-        token.stop()
+        token.invalidate()
         let expectedPermission = SwiftPermissionsAPITests.makeExpected(from: p, owner: userA, name: uuid)
         let finalValue = get(permission: expectedPermission, from: results)
         XCTAssertNotNil(finalValue, "Did not find the permission \(expectedPermission)")

--- a/Realm/ObjectServerTests/SwiftPermissionsAPITests.swift
+++ b/Realm/ObjectServerTests/SwiftPermissionsAPITests.swift
@@ -47,7 +47,7 @@ class SwiftPermissionsAPITests: SwiftSyncTestCase {
                                       file: StaticString = #file,
                                       line: UInt = #line) {
         let ex = expectation(description: "Checking permission count")
-        let token = results.addNotificationBlock { (error) in
+        let token = results.observe { (error) in
             XCTAssertNil(error, "Notification returned error '\(error!)' when running test at \(file):\(line)")
             if results.count == expected {
                 ex.fulfill()
@@ -63,7 +63,7 @@ class SwiftPermissionsAPITests: SwiftSyncTestCase {
                      line: UInt = #line) -> SyncPermission? {
         let ex = expectation(description: "Retrieving permission")
         var finalValue: SyncPermission?
-        let token = results.addNotificationBlock { (error) in
+        let token = results.observe { (error) in
             XCTAssertNil(error, "Notification returned error '\(error!)' when running test at \(file):\(line)")
             for result in results where result == permission {
                 finalValue = result
@@ -86,7 +86,7 @@ class SwiftPermissionsAPITests: SwiftSyncTestCase {
                                line: UInt = #line) {
         let ex = expectation(description: "Looking for permission")
         var isPresent = false
-        let token = results.addNotificationBlock { (error) in
+        let token = results.observe { (error) in
             XCTAssertNil(error, "Notification returned error '\(error!)' when running test at \(file):\(line)")
             isPresent = results.contains(permission)
         }
@@ -176,7 +176,7 @@ class SwiftPermissionsAPITests: SwiftSyncTestCase {
 
         // Register notifications.
         let noteEx = expectation(description: "Notification should fire")
-        let token = results.addNotificationBlock { (error) in
+        let token = results.observe { (error) in
             XCTAssertNil(error)
             if results.count > 0 {
                 noteEx.fulfill()

--- a/Realm/RLMArray.h
+++ b/Realm/RLMArray.h
@@ -331,7 +331,7 @@ NS_ASSUME_NONNULL_BEGIN
      // end of run loop execution context
 
  You must retain the returned token for as long as you want updates to continue
- to be sent to the block. To stop receiving updates, call `-stop` on the token.
+ to be sent to the block. To stop receiving updates, call `-invalidate` on the token.
 
  @warning This method cannot be called during a write transaction, or when the
           containing Realm is read-only.

--- a/Realm/RLMCollection.h
+++ b/Realm/RLMCollection.h
@@ -223,7 +223,7 @@ NS_ASSUME_NONNULL_BEGIN
      // end of run loop execution context
 
  You must retain the returned token for as long as you want updates to continue
- to be sent to the block. To stop receiving updates, call `-stop` on the token.
+ to be sent to the block. To stop receiving updates, call `-invalidate` on the token.
 
  @warning This method cannot be called during a write transaction, or when the
           containing Realm is read-only.

--- a/Realm/RLMCollection.mm
+++ b/Realm/RLMCollection.mm
@@ -297,7 +297,7 @@ std::vector<std::pair<std::string, bool>> RLMSortDescriptorsToKeypathArray(NSArr
     _token.suppress_next();
 }
 
-- (void)stop {
+- (void)invalidate {
     _token = {};
 }
 

--- a/Realm/RLMObject.h
+++ b/Realm/RLMObject.h
@@ -469,7 +469,7 @@ typedef void (^RLMObjectChangeBlock)(BOOL deleted,
 
  Only objects which are managed by a Realm can be observed in this way. You
  must retain the returned token for as long as you want updates to be sent to
- the block. To stop receiving updates, call `stop` on the token.
+ the block. To stop receiving updates, call `-invalidate` on the token.
 
  It is safe to capture a strong reference to the observed object within the
  callback block. There is no retain cycle due to that the callback is retained

--- a/Realm/RLMRealm.h
+++ b/Realm/RLMRealm.h
@@ -643,6 +643,9 @@ NS_REFINED_FOR_SWIFT;
 @interface RLMNotificationToken : NSObject
 /// Stops notifications for the change subscription that returned this token.
 - (void)invalidate;
+
+/// Stops notifications for the change subscription that returned this token.
+- (void)stop __attribute__((unavailable("Renamed to -invalidate.")));;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Realm/RLMRealm.h
+++ b/Realm/RLMRealm.h
@@ -637,12 +637,12 @@ NS_REFINED_FOR_SWIFT;
  Change subscriptions in Realm return an `RLMNotificationToken` instance,
  which can be used to unsubscribe from the changes. You must store a strong
  reference to the token for as long as you want to continue to receive notifications.
- When you wish to stop, call the `-stop` method. Notifications are also stopped if
+ When you wish to stop, call the `-invalidate` method. Notifications are also stopped if
  the token is deallocated.
  */
 @interface RLMNotificationToken : NSObject
 /// Stops notifications for the change subscription that returned this token.
-- (void)stop;
+- (void)invalidate;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Realm/RLMRealm.mm
+++ b/Realm/RLMRealm.mm
@@ -67,7 +67,7 @@ void RLMDisableSyncToDisk() {
 }
 
 @implementation RLMRealmNotificationToken
-- (void)stop {
+- (void)invalidate {
     [_realm verifyThread];
     [_realm.notificationHandlers removeObject:self];
     _realm = nil;
@@ -93,7 +93,7 @@ void RLMDisableSyncToDisk() {
     if (_realm || _block) {
         NSLog(@"RLMNotificationToken released without unregistering a notification. You must hold "
               @"on to the RLMNotificationToken returned from addNotificationBlock and call "
-              @"-[RLMNotificationToken stop] when you no longer wish to receive RLMRealm notifications.");
+              @"-[RLMNotificationToken invalidate] when you no longer wish to receive RLMRealm notifications.");
     }
 }
 @end

--- a/Realm/RLMResults.h
+++ b/Realm/RLMResults.h
@@ -228,7 +228,7 @@ NS_ASSUME_NONNULL_BEGIN
      // end of run loop execution context
 
  You must retain the returned token for as long as you want updates to continue
- to be sent to the block. To stop receiving updates, call `-stop` on the token.
+ to be sent to the block. To stop receiving updates, call `-invalidate` on the token.
 
  @warning This method cannot be called during a write transaction, or when the
           containing Realm is read-only.

--- a/Realm/RLMSyncPermissionResults.h
+++ b/Realm/RLMSyncPermissionResults.h
@@ -80,7 +80,7 @@ typedef NS_ENUM(NSUInteger, RLMSyncPermissionResultsSortProperty) {
  are desired. Call `-invalidate` on the token to stop notifications, and before
  deallocating the token.
  */
-- (RLMNotificationToken *)addNotificationBlock:(RLMPermissionStatusBlock)block;
+- (RLMNotificationToken *)addNotificationBlock:(RLMPermissionStatusBlock)block NS_REFINED_FOR_SWIFT;
 
 #pragma mark - Queries
 

--- a/Realm/RLMSyncPermissionResults.h
+++ b/Realm/RLMSyncPermissionResults.h
@@ -77,7 +77,7 @@ typedef NS_ENUM(NSUInteger, RLMSyncPermissionResultsSortProperty) {
  Register to be notified when the contents of the results object change.
 
  This method returns a token. Hold on to the token for as long as notifications
- are desired. Call `-stop` on the token to stop notifications, and before
+ are desired. Call `-invalidate` on the token to stop notifications, and before
  deallocating the token.
  */
 - (RLMNotificationToken *)addNotificationBlock:(RLMPermissionStatusBlock)block;

--- a/Realm/RLMSyncSession.h
+++ b/Realm/RLMSyncSession.h
@@ -54,7 +54,7 @@ typedef NS_ENUM(NSUInteger, RLMSyncProgressDirection) {
 typedef NS_ENUM(NSUInteger, RLMSyncProgress) {
     /**
      The block will be called indefinitely, or until it is unregistered by calling
-     `-[RLMProgressNotificationToken stop]`.
+     `-[RLMProgressNotificationToken invalidate]`.
 
      Notifications will always report the latest number of transferred bytes, and the
      most up-to-date number of total transferrable bytes.
@@ -87,7 +87,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  A token object corresponding to a progress notification block on a session object.
 
- To stop notifications manually, call `-stop` on it. Notifications should be stopped before
+ To stop notifications manually, call `-invalidate` on it. Notifications should be stopped before
  the token goes out of scope or is destroyed.
  */
 @interface RLMProgressNotificationToken : RLMNotificationToken
@@ -130,7 +130,7 @@ NS_ASSUME_NONNULL_BEGIN
  will be called as soon as progress information becomes available.
 
  The token returned by this method must be retained as long as progress
- notifications are desired, and the `-stop` method should be called on it
+ notifications are desired, and the `-invalidate` method should be called on it
  when notifications are no longer needed and before the token is destroyed.
 
  If no token is returned, the notification block will never be called again.

--- a/Realm/RLMSyncSession.mm
+++ b/Realm/RLMSyncSession.mm
@@ -45,7 +45,7 @@ using namespace realm;
     // `-[RLMRealm commitWriteTransactionWithoutNotifying:]`.
 }
 
-- (void)stop {
+- (void)invalidate {
     if (auto session = _session.lock()) {
         session->unregister_progress_notifier(_token);
         _session.reset();
@@ -57,7 +57,7 @@ using namespace realm;
     if (_token != 0) {
         NSLog(@"RLMProgressNotificationToken released without unregistering a notification. "
               @"You must hold on to the RLMProgressNotificationToken and call "
-              @"-[RLMProgressNotificationToken stop] when you no longer wish to receive "
+              @"-[RLMProgressNotificationToken invalidate] when you no longer wish to receive "
               @"progress update notifications.");
     }
 }

--- a/Realm/Swift/RLMSupport.swift
+++ b/Realm/Swift/RLMSupport.swift
@@ -85,6 +85,12 @@ extension RLMCollection {
     }
 }
 
+extension RLMSyncPermissionResults {
+    @nonobjc open func addNotificationBlock(_ block: @escaping RLMPermissionStatusBlock) -> RLMNotificationToken {
+        return __addNotificationBlock(block)
+    }
+}
+
 #if swift(>=3.1)
 // Collection conformance for RLMSyncPermissionResults.
 extension RLMSyncPermissionResults: RandomAccessCollection {

--- a/Realm/Tests/ArrayPropertyTests.m
+++ b/Realm/Tests/ArrayPropertyTests.m
@@ -1101,7 +1101,7 @@
     }];
 
     [self waitForExpectationsWithTimeout:2.0 handler:nil];
-    [(RLMNotificationToken *)token stop];
+    [(RLMNotificationToken *)token invalidate];
 }
 
 - (void)testNotificationSentAfterCommit {
@@ -1131,7 +1131,7 @@
     }];
     [self waitForExpectationsWithTimeout:2.0 handler:nil];
 
-    [(RLMNotificationToken *)token stop];
+    [(RLMNotificationToken *)token invalidate];
 }
 
 - (void)testNotificationNotSentForUnrelatedChange {
@@ -1158,7 +1158,7 @@
             }];
         }];
     }];
-    [(RLMNotificationToken *)token stop];
+    [(RLMNotificationToken *)token invalidate];
 }
 
 - (void)testNotificationSentOnlyForActualRefresh {
@@ -1196,7 +1196,7 @@
     [realm refresh];
     [self waitForExpectationsWithTimeout:2.0 handler:nil];
 
-    [(RLMNotificationToken *)token stop];
+    [(RLMNotificationToken *)token invalidate];
 }
 
 - (void)testDeletingObjectWithNotificationsRegistered {
@@ -1217,7 +1217,7 @@
     [realm deleteObject:array];
     [realm commitWriteTransaction];
 
-    [(RLMNotificationToken *)token stop];
+    [(RLMNotificationToken *)token invalidate];
 }
 
 - (void)testAllMethodsCheckThread {

--- a/Realm/Tests/InterprocessTests.m
+++ b/Realm/Tests/InterprocessTests.m
@@ -212,7 +212,7 @@
         XCTAssertEqual(0U, [IntObject allObjectsInRealm:realm].count);
     }
 
-    [token stop];
+    [token invalidate];
 }
 
 // FIXME: Re-enable this test when it can be made to pass reliably.
@@ -272,7 +272,7 @@
         }
     }
 
-    [token stop];
+    [token invalidate];
 }
 
 - (void)testManyWriters {
@@ -304,7 +304,7 @@
             CFRunLoopStop(CFRunLoopGetCurrent());
         }];
         CFRunLoopRun();
-        [token stop];
+        [token invalidate];
     };
 
     IntObject *obj = [IntObject allObjects].firstObject;

--- a/Realm/Tests/LinkingObjectsTests.mm
+++ b/Realm/Tests/LinkingObjectsTests.mm
@@ -129,7 +129,7 @@
     }];
 
     [self waitForExpectationsWithTimeout:2.0 handler:nil];
-    [token stop];
+    [token invalidate];
 }
 
 - (void)testNotificationSentAfterCommit {
@@ -158,7 +158,7 @@
     }];
     [self waitForExpectationsWithTimeout:2.0 handler:nil];
 
-    [token stop];
+    [token invalidate];
 }
 
 - (void)testNotificationNotSentForUnrelatedChange {
@@ -182,7 +182,7 @@
             [self.realmWithTestPath transactionWithBlock:^{ }];
         }];
     }];
-    [token stop];
+    [token invalidate];
 }
 
 - (void)testNotificationSentOnlyForActualRefresh {
@@ -219,7 +219,7 @@
     [realm refresh];
     [self waitForExpectationsWithTimeout:2.0 handler:nil];
 
-    [token stop];
+    [token invalidate];
 }
 
 - (void)testDeletingObjectWithNotificationsRegistered {
@@ -241,7 +241,7 @@
     [realm deleteObject:mark];
     [realm commitWriteTransaction];
 
-    [token stop];
+    [token invalidate];
 }
 
 @end

--- a/Realm/Tests/NotificationTests.m
+++ b/Realm/Tests/NotificationTests.m
@@ -45,7 +45,7 @@
 }
 
 - (void)tearDown {
-    [_token stop];
+    [_token invalidate];
     [super tearDown];
 }
 
@@ -149,7 +149,7 @@
         CFRunLoopStop(CFRunLoopGetCurrent());
     }];
     CFRunLoopRun();
-    [token stop];
+    [token invalidate];
 
     XCTAssertFalse(_called);
 }
@@ -165,7 +165,7 @@
     [realm commitWriteTransactionWithoutNotifying:@[token] error:nil];
 
     // local realm notifications are called synchronously so no need to wait for anything
-    [token stop];
+    [token invalidate];
 }
 
 - (void)testSuppressRealmNotificationForWrongRealm {
@@ -178,7 +178,7 @@
     [realm beginWriteTransaction];
     XCTAssertThrows([realm commitWriteTransactionWithoutNotifying:@[token] error:nil]);
     [realm cancelWriteTransaction];
-    [token stop];
+    [token invalidate];
 }
 
 - (void)testSuppressCollectionNotificationForWrongRealm {
@@ -271,7 +271,7 @@ static RLMCollectionChange *getChange(RLMTestCase<ChangesetTestCase> *self, void
         }];
     }];
 
-    [(RLMNotificationToken *)token stop];
+    [(RLMNotificationToken *)token invalidate];
     token = nil;
 
     return changes;
@@ -491,7 +491,7 @@ static void ExpectChange(id self, NSArray *deletions, NSArray *insertions, NSArr
         }];
     }];
 
-    [token stop];
+    [token invalidate];
     token = nil;
 
     XCTAssertNotNil(changes);
@@ -920,7 +920,7 @@ static void ExpectChange(id self, NSArray *deletions, NSArray *insertions, NSArr
     [realm commitWriteTransaction];
 
     [self waitForExpectationsWithTimeout:2.0 handler:nil];
-    [token stop];
+    [token invalidate];
 }
 
 - (void)testChangeAllPropertyTypes {
@@ -953,7 +953,7 @@ static void ExpectChange(id self, NSArray *deletions, NSArray *insertions, NSArr
 
         [self waitForExpectationsWithTimeout:2.0 handler:nil];
     }
-    [token stop];
+    [token invalidate];
 }
 
 - (void)testChangeAllPropertyTypesFromBackground {
@@ -984,7 +984,7 @@ static void ExpectChange(id self, NSArray *deletions, NSArray *insertions, NSArr
         }];
         [_obj.realm refresh];
     }
-    [token stop];
+    [token invalidate];
 }
 
 - (void)testChangeAllPropertyTypesInSingleTransaction {
@@ -1015,7 +1015,7 @@ static void ExpectChange(id self, NSArray *deletions, NSArray *insertions, NSArr
     [_obj.realm commitWriteTransaction];
 
     [self waitForExpectationsWithTimeout:2.0 handler:nil];
-    [token stop];
+    [token invalidate];
 }
 
 - (void)testMultipleObjectNotifiers {
@@ -1053,9 +1053,9 @@ static void ExpectChange(id self, NSArray *deletions, NSArray *insertions, NSArr
     }];
 
     [self waitForExpectationsWithTimeout:2.0 handler:nil];
-    [token1 stop];
-    [token2 stop];
-    [token3 stop];
+    [token1 invalidate];
+    [token2 invalidate];
+    [token3 invalidate];
 }
 
 - (void)testArrayPropertiesMerelyReportModification {
@@ -1084,7 +1084,7 @@ static void ExpectChange(id self, NSArray *deletions, NSArray *insertions, NSArr
     }];
 
     [self waitForExpectationsWithTimeout:2.0 handler:nil];
-    [token stop];
+    [token invalidate];
 }
 
 @end

--- a/Realm/Tests/PerformanceTests.m
+++ b/Realm/Tests/PerformanceTests.m
@@ -441,7 +441,7 @@ static RLMRealm *s_smallRealm, *s_mediumRealm, *s_largeRealm;
             }];
         }
         [self stopMeasuring];
-        [token stop];
+        [token invalidate];
     }];
 }
 
@@ -470,7 +470,7 @@ static RLMRealm *s_smallRealm, *s_mediumRealm, *s_largeRealm;
             });
             CFRunLoopRun();
 
-            [token stop];
+            [token invalidate];
         }];
 
         dispatch_semaphore_wait(sema, DISPATCH_TIME_FOREVER);
@@ -501,7 +501,7 @@ static RLMRealm *s_smallRealm, *s_mediumRealm, *s_largeRealm;
 
         [self startMeasuring];
         CFRunLoopRun();
-        [token stop];
+        [token invalidate];
     }];
 }
 
@@ -523,7 +523,7 @@ static RLMRealm *s_smallRealm, *s_mediumRealm, *s_largeRealm;
 
         [self startMeasuring];
         CFRunLoopRun();
-        [token stop];
+        [token invalidate];
     }];
 }
 
@@ -559,7 +559,7 @@ static RLMRealm *s_smallRealm, *s_mediumRealm, *s_largeRealm;
             });
             CFRunLoopRun();
 
-            [token stop];
+            [token invalidate];
         }];
 
         RLMNotificationToken *token = [realm addNotificationBlock:^(__unused NSString *note, __unused RLMRealm *realm) {
@@ -582,7 +582,7 @@ static RLMRealm *s_smallRealm, *s_mediumRealm, *s_largeRealm;
         [self dispatchAsyncAndWait:^{}];
         [self stopMeasuring];
 
-        [token stop];
+        [token invalidate];
     }];
 }
 

--- a/Realm/Tests/QueryTests.m
+++ b/Realm/Tests/QueryTests.m
@@ -2696,7 +2696,7 @@ struct NullTestData {
         CFRunLoopStop(CFRunLoopGetCurrent());
     }];
     CFRunLoopRun();
-    [(RLMNotificationToken *)token stop];
+    [(RLMNotificationToken *)token invalidate];
     return results;
 }
 @end

--- a/Realm/Tests/RLMTestCase.m
+++ b/Realm/Tests/RLMTestCase.m
@@ -195,7 +195,7 @@ static BOOL encryptTests() {
     // wait for queue to finish
     dispatch_sync(queue, ^{});
 
-    [token stop];
+    [token invalidate];
 }
 
 - (void)dispatchAsync:(dispatch_block_t)block {

--- a/Realm/Tests/RealmTests.mm
+++ b/Realm/Tests/RealmTests.mm
@@ -876,7 +876,7 @@
     [realm beginWriteTransaction];
     [realm commitWriteTransaction];
 
-    [token stop];
+    [token invalidate];
     XCTAssertTrue(notificationFired);
 }
 
@@ -909,7 +909,7 @@
     XCTAssertTrue(notificationFired);
 
     [realm cancelWriteTransaction];
-    [token stop];
+    [token invalidate];
 }
 
 - (void)testBeginWriteTransactionFromWithinRefreshRequiredNotification {
@@ -934,7 +934,7 @@
     }];
 
     [self waitForExpectationsWithTimeout:2.0 handler:nil];
-    [token stop];
+    [token invalidate];
 }
 
 - (void)testBeginWriteTransactionFromWithinRealmChangedNotification {
@@ -971,7 +971,7 @@
     createObject();
 
     [self waitForExpectationsWithTimeout:2.0 handler:nil];
-    [token stop];
+    [token invalidate];
 
     // Test with the triggering transaction on the same thread
     __block bool first = true;
@@ -1018,7 +1018,7 @@
         XCTAssertEqual(2U, results.count);
         [realm cancelWriteTransaction];
         [expectation fulfill];
-        [token stop];
+        [token invalidate];
     };
     token = [StringObject.allObjects addNotificationBlock:block];
     [self waitForExpectationsWithTimeout:2.0 handler:nil];
@@ -1321,7 +1321,7 @@
     [realm beginWriteTransaction];
     XCTAssertTrue(called);
     [realm cancelWriteTransaction];
-    [token stop];
+    [token invalidate];
 }
 
 - (void)testThrowingFromDidChangeNotificationFromBeginWriteCancelsTransaction {
@@ -1343,7 +1343,7 @@
         XCTFail(@"should have thrown");
     }
     catch (int) { }
-    [token stop];
+    [token invalidate];
 
     XCTAssertFalse(realm.inWriteTransaction);
     XCTAssertNoThrow([realm beginWriteTransaction]);
@@ -1366,7 +1366,7 @@
         XCTFail(@"should have thrown");
     }
     catch (int) { }
-    [token stop];
+    [token invalidate];
 
     XCTAssertFalse(realm.inWriteTransaction);
     XCTAssertNoThrow([realm beginWriteTransaction]);
@@ -1388,7 +1388,7 @@
         [RLMRealm.defaultRealm transactionWithBlock:^{ }];
     }];
     [self waitForExpectationsWithTimeout:2.0 handler:nil];
-    [token stop];
+    [token invalidate];
 }
 
 - (void)testNotificationBlockMustNotBeNil {
@@ -1447,7 +1447,7 @@
                 XCTAssertEqual(note, RLMRealmDidChangeNotification);
                 XCTAssertEqual(1U, [StringObject allObjectsInRealm:realm].count);
                 fulfilled = true;
-                [token stop];
+                [token invalidate];
             }];
 
             // notify main thread that we're ready for it to commit
@@ -1483,7 +1483,7 @@
         CFRunLoopPerformBlock(CFRunLoopGetCurrent(), kCFRunLoopDefaultMode, ^{
             RLMNotificationToken *token;
             XCTAssertNoThrow(token = [realm addNotificationBlock:^(NSString *, RLMRealm *) { }]);
-            [token stop];
+            [token invalidate];
             CFRunLoopStop(CFRunLoopGetCurrent());
         });
 

--- a/Realm/Tests/SchemaTests.mm
+++ b/Realm/Tests/SchemaTests.mm
@@ -851,7 +851,7 @@ RLM_ARRAY_TYPE(NotARealClass)
         }
     }];
     [self waitForExpectationsWithTimeout:10.0 handler:nil];
-    [token stop];
+    [token invalidate];
 
     // Release the write transaction and let them run
     [realm cancelWriteTransaction];

--- a/Realm/Tests/Swift/SwiftRealmTests.swift
+++ b/Realm/Tests/Swift/SwiftRealmTests.swift
@@ -79,7 +79,7 @@ class SwiftRealmTests: RLMTestCase {
             try! realm.commitWriteTransaction()
         }
         waitForExpectations(timeout: 2.0, handler: nil)
-        token.stop()
+        token.invalidate()
 
         // get object
         let objects = SwiftStringObject.allObjects(in: realm)
@@ -137,7 +137,7 @@ class SwiftRealmTests: RLMTestCase {
         }
 
         waitForExpectations(timeout: 2.0, handler: nil)
-        token.stop()
+        token.invalidate()
     }
 
     func testRealmIsUpdatedImmediatelyAfterBackgroundUpdate() {
@@ -162,7 +162,7 @@ class SwiftRealmTests: RLMTestCase {
         }
 
         waitForExpectations(timeout: 2.0, handler: nil)
-        token.stop()
+        token.invalidate()
 
         // get object
         let objects = SwiftStringObject.allObjects(in: realm)
@@ -216,7 +216,7 @@ class SwiftRealmTests: RLMTestCase {
             try! realm.commitWriteTransaction()
         }
         waitForExpectations(timeout: 2.0, handler: nil)
-        token.stop()
+        token.invalidate()
 
         // get object
         let objects = StringObject.allObjects(in: realm)
@@ -247,7 +247,7 @@ class SwiftRealmTests: RLMTestCase {
         }
 
         waitForExpectations(timeout: 2.0, handler: nil)
-        token.stop()
+        token.invalidate()
 
         // get object
         let objects = StringObject.allObjects(in: realm)

--- a/RealmSwift/Aliases.swift
+++ b/RealmSwift/Aliases.swift
@@ -52,6 +52,6 @@ public typealias PropertyType = RLMPropertyType
 /**
  An opaque token which is returned from methods which subscribe to changes to a Realm.
 
- - see: `addNotificationBlock(_:)`
+ - see: `Realm.observe(_:)`
  */
 public typealias NotificationToken = RLMNotificationToken

--- a/RealmSwift/LinkingObjects.swift
+++ b/RealmSwift/LinkingObjects.swift
@@ -322,7 +322,7 @@ public final class LinkingObjects<T: Object>: LinkingObjectsBase {
      ```swift
      let results = realm.objects(Dog.self)
      print("dogs.count: \(dogs?.count)") // => 0
-     let token = dogs.addNotificationBlock { changes in
+     let token = dogs.observe { changes in
          switch changes {
          case .initial(let dogs):
              // Will print "dogs.count: 1"
@@ -351,7 +351,7 @@ public final class LinkingObjects<T: Object>: LinkingObjectsBase {
      - parameter block: The block to be called whenever a change occurs.
      - returns: A token which must be held for as long as you want updates to be delivered.
      */
-    public func addNotificationBlock(_ block: @escaping (RealmCollectionChange<LinkingObjects>) -> Void) -> NotificationToken {
+    public func observe(_ block: @escaping (RealmCollectionChange<LinkingObjects>) -> Void) -> NotificationToken {
         return rlmResults.addNotificationBlock { _, change, error in
             block(RealmCollectionChange.fromObjc(value: self, change: change, error: error))
         }
@@ -386,7 +386,7 @@ extension LinkingObjects : RealmCollection {
     }
 
     /// :nodoc:
-    public func _addNotificationBlock(_ block: @escaping (RealmCollectionChange<AnyRealmCollection<T>>) -> Void) ->
+    public func _observe(_ block: @escaping (RealmCollectionChange<AnyRealmCollection<T>>) -> Void) ->
         NotificationToken {
             let anyCollection = AnyRealmCollection(self)
             return rlmResults.addNotificationBlock { _, change, error in

--- a/RealmSwift/LinkingObjects.swift
+++ b/RealmSwift/LinkingObjects.swift
@@ -436,10 +436,3 @@ internal enum LinkingObjectsBridgingMetadata {
         }
     }
 }
-
-// MARK: Unavailable
-
-extension LinkingObjects {
-    @available(*, unavailable, renamed: "sorted(byKeyPath:ascending:)")
-    public func sorted(byProperty property: String, ascending: Bool = true) -> Results<T> { fatalError() }
-}

--- a/RealmSwift/LinkingObjects.swift
+++ b/RealmSwift/LinkingObjects.swift
@@ -344,7 +344,7 @@ public final class LinkingObjects<T: Object>: LinkingObjectsBase {
      ```
 
      You must retain the returned token for as long as you want updates to be sent to the block. To stop receiving
-     updates, call `stop()` on the token.
+     updates, call `invalidate()` on the token.
 
      - warning: This method cannot be called during a write transaction, or when the containing Realm is read-only.
 

--- a/RealmSwift/List.swift
+++ b/RealmSwift/List.swift
@@ -524,10 +524,3 @@ extension List: AssistedObjectiveCBridgeable {
         return (objectiveCValue: _rlmArray, metadata: nil)
     }
 }
-
-// MARK: Unavailable
-
-extension List {
-    @available(*, unavailable, renamed: "sorted(byKeyPath:ascending:)")
-    public func sorted(byProperty property: String, ascending: Bool = true) -> Results<T> { fatalError() }
-}

--- a/RealmSwift/List.swift
+++ b/RealmSwift/List.swift
@@ -434,7 +434,7 @@ public final class List<T: Object>: ListBase {
      ```
 
      You must retain the returned token for as long as you want updates to be sent to the block. To stop receiving
-     updates, call `stop()` on the token.
+     updates, call `invalidate()` on the token.
 
      - warning: This method cannot be called during a write transaction, or when the containing Realm is read-only.
 

--- a/RealmSwift/List.swift
+++ b/RealmSwift/List.swift
@@ -412,7 +412,7 @@ public final class List<T: Object>: ListBase {
      ```swift
      let results = realm.objects(Dog.self)
      print("dogs.count: \(dogs?.count)") // => 0
-     let token = dogs.addNotificationBlock { changes in
+     let token = dogs.observe { changes in
          switch changes {
          case .initial(let dogs):
              // Will print "dogs.count: 1"
@@ -441,7 +441,7 @@ public final class List<T: Object>: ListBase {
      - parameter block: The block to be called whenever a change occurs.
      - returns: A token which must be held for as long as you want updates to be delivered.
      */
-    public func addNotificationBlock(_ block: @escaping (RealmCollectionChange<List>) -> Void) -> NotificationToken {
+    public func observe(_ block: @escaping (RealmCollectionChange<List>) -> Void) -> NotificationToken {
         return _rlmArray.addNotificationBlock { _, change, error in
             block(RealmCollectionChange.fromObjc(value: self, change: change, error: error))
         }
@@ -503,7 +503,7 @@ extension List: RealmCollection, RangeReplaceableCollection {
     public func index(before i: Int) -> Int { return i - 1 }
 
     /// :nodoc:
-    public func _addNotificationBlock(_ block: @escaping (RealmCollectionChange<AnyRealmCollection<T>>) -> Void) ->
+    public func _observe(_ block: @escaping (RealmCollectionChange<AnyRealmCollection<T>>) -> Void) ->
         NotificationToken {
         let anyCollection = AnyRealmCollection(self)
         return _rlmArray.addNotificationBlock { _, change, error in

--- a/RealmSwift/Object.swift
+++ b/RealmSwift/Object.swift
@@ -217,7 +217,7 @@ open class Object: RLMObjectBase, ThreadConfined {
 
      Only objects which are managed by a Realm can be observed in this way. You
      must retain the returned token for as long as you want updates to be sent
-     to the block. To stop receiving updates, call `stop()` on the token.
+     to the block. To stop receiving updates, call `invalidate()` on the token.
 
      It is safe to capture a strong reference to the observed object within the
      callback block. There is no retain cycle due to that the callback is

--- a/RealmSwift/Object.swift
+++ b/RealmSwift/Object.swift
@@ -229,7 +229,7 @@ open class Object: RLMObjectBase, ThreadConfined {
      - parameter block: The block to call with information about changes to the object.
      - returns: A token which must be held for as long as you want updates to be delivered.
      */
-    public func addNotificationBlock(_ block: @escaping (ObjectChange) -> Void) -> NotificationToken {
+    public func observe(_ block: @escaping (ObjectChange) -> Void) -> NotificationToken {
         return RLMObjectAddNotificationBlock(self, { names, oldValues, newValues, error in
             if let error = error {
                 block(.error(error as NSError))

--- a/RealmSwift/Realm.swift
+++ b/RealmSwift/Realm.swift
@@ -552,7 +552,7 @@ public final class Realm {
      delivered instantly, multiple notifications may be coalesced.
 
      You must retain the returned token for as long as you want updates to be sent to the block. To stop receiving
-     updates, call `stop()` on the token.
+     updates, call `invalidate()` on the token.
 
      - parameter block: A block which is called to process Realm notifications. It receives the following parameters:
                         `notification`: the incoming notification; `realm`: the Realm for which the notification

--- a/RealmSwift/Realm.swift
+++ b/RealmSwift/Realm.swift
@@ -560,7 +560,7 @@ public final class Realm {
 
      - returns: A token which must be held for as long as you wish to continue receiving change notifications.
      */
-    public func addNotificationBlock(_ block: @escaping NotificationBlock) -> NotificationToken {
+    public func observe(_ block: @escaping NotificationBlock) -> NotificationToken {
         return rlmRealm.addNotificationBlock { rlmNotification, _ in
             switch rlmNotification {
             case RLMNotification.DidChange:

--- a/RealmSwift/RealmCollection.swift
+++ b/RealmSwift/RealmCollection.swift
@@ -50,7 +50,7 @@ public final class RLMIterator<T: Object>: IteratorProtocol {
  For example, for a simple one-section table view, you can do the following:
 
  ```swift
- self.notificationToken = results.addNotificationBlock { changes in
+ self.notificationToken = results.observe { changes in
      switch changes {
      case .initial:
          // Results are now populated and can be accessed without blocking the UI
@@ -327,7 +327,7 @@ public protocol RealmCollection: RealmCollectionBase {
      ```swift
      let results = realm.objects(Dog.self)
      print("dogs.count: \(dogs?.count)") // => 0
-     let token = dogs.addNotificationBlock { changes in
+     let token = dogs.observe { changes in
      switch changes {
          case .initial(let dogs):
              // Will print "dogs.count: 1"
@@ -356,10 +356,10 @@ public protocol RealmCollection: RealmCollectionBase {
      - parameter block: The block to be called whenever a change occurs.
      - returns: A token which must be held for as long as you want updates to be delivered.
      */
-    func addNotificationBlock(_ block: @escaping (RealmCollectionChange<Self>) -> Void) -> NotificationToken
+    func observe(_ block: @escaping (RealmCollectionChange<Self>) -> Void) -> NotificationToken
 
     /// :nodoc:
-    func _addNotificationBlock(_ block: @escaping (RealmCollectionChange<AnyRealmCollection<Element>>) -> Void) -> NotificationToken
+    func _observe(_ block: @escaping (RealmCollectionChange<AnyRealmCollection<Element>>) -> Void) -> NotificationToken
 }
 
 private class _AnyRealmCollectionBase<T: Object>: AssistedObjectiveCBridgeable {
@@ -389,7 +389,7 @@ private class _AnyRealmCollectionBase<T: Object>: AssistedObjectiveCBridgeable {
     func value(forKey key: String) -> Any? { fatalError() }
     func value(forKeyPath keyPath: String) -> Any? { fatalError() }
     func setValue(_ value: Any?, forKey key: String) { fatalError() }
-    func _addNotificationBlock(_ block: @escaping (RealmCollectionChange<Wrapper>) -> Void)
+    func _observe(_ block: @escaping (RealmCollectionChange<Wrapper>) -> Void)
         -> NotificationToken { fatalError() }
     class func bridging(from objectiveCValue: Any, with metadata: Any?) -> Self { fatalError() }
     var bridged: (objectiveCValue: Any, metadata: Any?) { fatalError() }
@@ -498,8 +498,8 @@ private final class _AnyRealmCollection<C: RealmCollection>: _AnyRealmCollection
     // MARK: Notifications
 
     /// :nodoc:
-    override func _addNotificationBlock(_ block: @escaping (RealmCollectionChange<Wrapper>) -> Void)
-        -> NotificationToken { return base._addNotificationBlock(block) }
+    override func _observe(_ block: @escaping (RealmCollectionChange<Wrapper>) -> Void)
+        -> NotificationToken { return base._observe(block) }
 
     // MARK: AssistedObjectiveCBridgeable
 
@@ -763,7 +763,7 @@ public final class AnyRealmCollection<T: Object>: RealmCollection {
      ```swift
      let results = realm.objects(Dog.self)
      print("dogs.count: \(dogs?.count)") // => 0
-     let token = dogs.addNotificationBlock { changes in
+     let token = dogs.observe { changes in
          switch changes {
          case .initial(let dogs):
              // Will print "dogs.count: 1"
@@ -792,12 +792,12 @@ public final class AnyRealmCollection<T: Object>: RealmCollection {
      - parameter block: The block to be called whenever a change occurs.
      - returns: A token which must be held for as long as you want updates to be delivered.
      */
-    public func addNotificationBlock(_ block: @escaping (RealmCollectionChange<AnyRealmCollection>) -> Void)
-        -> NotificationToken { return base._addNotificationBlock(block) }
+    public func observe(_ block: @escaping (RealmCollectionChange<AnyRealmCollection>) -> Void)
+        -> NotificationToken { return base._observe(block) }
 
     /// :nodoc:
-    public func _addNotificationBlock(_ block: @escaping (RealmCollectionChange<AnyRealmCollection>) -> Void)
-        -> NotificationToken { return base._addNotificationBlock(block) }
+    public func _observe(_ block: @escaping (RealmCollectionChange<AnyRealmCollection>) -> Void)
+        -> NotificationToken { return base._observe(block) }
 }
 
 // MARK: AssistedObjectiveCBridgeable

--- a/RealmSwift/RealmCollection.swift
+++ b/RealmSwift/RealmCollection.swift
@@ -823,7 +823,12 @@ extension AnyRealmCollection: AssistedObjectiveCBridgeable {
 
 // MARK: Unavailable
 
-extension AnyRealmCollection {
+extension RealmCollection {
     @available(*, unavailable, renamed: "sorted(byKeyPath:ascending:)")
     func sorted(byProperty property: String, ascending: Bool) -> Results<Element> { fatalError() }
+
+    @available(*, unavailable, renamed: "observe(_:)")
+    public func addNotificationBlock(_ block: @escaping (RealmCollectionChange<Self>) -> Void) -> NotificationToken {
+        fatalError()
+    }
 }

--- a/RealmSwift/RealmCollection.swift
+++ b/RealmSwift/RealmCollection.swift
@@ -349,7 +349,7 @@ public protocol RealmCollection: RealmCollectionBase {
      ```
 
      You must retain the returned token for as long as you want updates to be sent to the block. To stop receiving
-     updates, call `stop()` on the token.
+     updates, call `invalidate()` on the token.
 
      - warning: This method cannot be called during a write transaction, or when the containing Realm is read-only.
 
@@ -785,7 +785,7 @@ public final class AnyRealmCollection<T: Object>: RealmCollection {
      ```
 
      You must retain the returned token for as long as you want updates to be sent to the block. To stop receiving
-     updates, call `stop()` on the token.
+     updates, call `invalidate()` on the token.
 
      - warning: This method cannot be called during a write transaction, or when the containing Realm is read-only.
 

--- a/RealmSwift/Results.swift
+++ b/RealmSwift/Results.swift
@@ -403,10 +403,3 @@ extension Results: AssistedObjectiveCBridgeable {
         return (objectiveCValue: rlmResults, metadata: nil)
     }
 }
-
-// MARK: Unavailable
-
-extension Results {
-    @available(*, unavailable, renamed: "sorted(byKeyPath:ascending:)")
-    public func sorted(byProperty property: String, ascending: Bool = true) -> Results<T> { fatalError() }
-}

--- a/RealmSwift/Results.swift
+++ b/RealmSwift/Results.swift
@@ -324,7 +324,7 @@ public final class Results<T: Object>: NSObject, NSFastEnumeration {
      ```swift
      let results = realm.objects(Dog.self)
      print("dogs.count: \(dogs?.count)") // => 0
-     let token = dogs.addNotificationBlock { changes in
+     let token = dogs.observe { changes in
          switch changes {
          case .initial(let dogs):
              // Will print "dogs.count: 1"
@@ -353,7 +353,7 @@ public final class Results<T: Object>: NSObject, NSFastEnumeration {
      - parameter block: The block to be called whenever a change occurs.
      - returns: A token which must be held for as long as you want updates to be delivered.
      */
-    public func addNotificationBlock(_ block: @escaping (RealmCollectionChange<Results>) -> Void) -> NotificationToken {
+    public func observe(_ block: @escaping (RealmCollectionChange<Results>) -> Void) -> NotificationToken {
         return rlmResults.addNotificationBlock { _, change, error in
             block(RealmCollectionChange.fromObjc(value: self, change: change, error: error))
         }
@@ -383,7 +383,7 @@ extension Results: RealmCollection {
     public func index(before i: Int) -> Int { return i - 1 }
 
     /// :nodoc:
-    public func _addNotificationBlock(_ block: @escaping (RealmCollectionChange<AnyRealmCollection<T>>) -> Void) ->
+    public func _observe(_ block: @escaping (RealmCollectionChange<AnyRealmCollection<T>>) -> Void) ->
         NotificationToken {
         let anyCollection = AnyRealmCollection(self)
         return rlmResults.addNotificationBlock { _, change, error in

--- a/RealmSwift/Results.swift
+++ b/RealmSwift/Results.swift
@@ -346,7 +346,7 @@ public final class Results<T: Object>: NSObject, NSFastEnumeration {
      ```
 
      You must retain the returned token for as long as you want updates to be sent to the block. To stop receiving
-     updates, call `stop()` on the token.
+     updates, call `invalidate()` on the token.
 
      - warning: This method cannot be called during a write transaction, or when the containing Realm is read-only.
 

--- a/RealmSwift/Sync.swift
+++ b/RealmSwift/Sync.swift
@@ -608,7 +608,7 @@ public extension SyncSession {
     public enum ProgressMode {
         /**
          The block will be called forever, or until it is unregistered by calling
-         `ProgressNotificationToken.stop()`.
+         `ProgressNotificationToken.invalidate()`.
 
          Notifications will always report the latest number of transferred bytes, and the
          most up-to-date number of total transferrable bytes.
@@ -628,8 +628,8 @@ public extension SyncSession {
     /**
      A token corresponding to a progress notification block.
 
-     Call `stop()` on the token to stop notifications. If the notification block has already
-     been automatically stopped, calling `stop()` does nothing. `stop()` should be called
+     Call `invalidate()` on the token to stop notifications. If the notification block has already
+     been automatically stopped, calling `invalidate()` does nothing. `invalidate()` should be called
      before the token is destroyed.
      */
     public typealias ProgressNotificationToken = RLMProgressNotificationToken
@@ -685,7 +685,7 @@ public extension SyncSession {
      will be invoked on a side queue devoted to progress notifications.
 
      The token returned by this method must be retained as long as progress
-     notifications are desired, and the `stop()` method should be called on it
+     notifications are desired, and the `invalidate()` method should be called on it
      when notifications are no longer needed and before the token is destroyed.
 
      If no token is returned, the notification block will never be called again.

--- a/RealmSwift/Sync.swift
+++ b/RealmSwift/Sync.swift
@@ -377,6 +377,17 @@ public typealias SyncAccessLevel = RLMSyncAccessLevel
  */
 public typealias SyncPermissionResults = RLMSyncPermissionResults
 
+extension SyncPermissionResults {
+    public func observe(_ block: @escaping RLMPermissionStatusBlock) -> RLMNotificationToken {
+        return __addNotificationBlock(block)
+    }
+
+    @available(*, unavailable, renamed: "observe(_:)")
+    @nonobjc public func addNotificationBlock(_ block: @escaping RLMPermissionStatusBlock) -> RLMNotificationToken {
+        fatalError()
+    }
+}
+
 #if swift(>=3.1)
 extension SyncPermissionResults: RandomAccessCollection {
     public subscript(index: Int) -> SyncPermission {

--- a/RealmSwift/Sync.swift
+++ b/RealmSwift/Sync.swift
@@ -378,6 +378,13 @@ public typealias SyncAccessLevel = RLMSyncAccessLevel
 public typealias SyncPermissionResults = RLMSyncPermissionResults
 
 extension SyncPermissionResults {
+    /**
+     Register to be notified when the contents of the results object change.
+
+     This method returns a token. Hold on to the token for as long as notifications
+     are desired. Call `invalidate()` on the token to stop notifications, and before
+     deallocating the token.
+     */
     public func observe(_ block: @escaping RLMPermissionStatusBlock) -> RLMNotificationToken {
         return __addNotificationBlock(block)
     }

--- a/RealmSwift/Tests/KVOTests.swift
+++ b/RealmSwift/Tests/KVOTests.swift
@@ -165,10 +165,17 @@ class KVOTests: TestCase {
     func testAllPropertyTypesStandalone() {
         let obj = KVOObject()
         observeChange(obj, "boolCol", false, true) { obj.boolCol = true }
+#if swift(>=3.2)
         observeChange(obj, "int8Col", 1 as Int8, 10) { obj.int8Col = 10 }
         observeChange(obj, "int16Col", 2 as Int16, 10) { obj.int16Col = 10 }
         observeChange(obj, "int32Col", 3 as Int32, 10) { obj.int32Col = 10 }
         observeChange(obj, "int64Col", 4 as Int64, 10) { obj.int64Col = 10 }
+#else
+        observeChange(obj, "int8Col", 1, 10) { obj.int8Col = 10 }
+        observeChange(obj, "int16Col", 2, 10) { obj.int16Col = 10 }
+        observeChange(obj, "int32Col", 3, 10) { obj.int32Col = 10 }
+        observeChange(obj, "int64Col", 4, 10) { obj.int64Col = 10 }
+#endif
         observeChange(obj, "floatCol", 5 as Float, 10) { obj.floatCol = 10 }
         observeChange(obj, "doubleCol", 6 as Double, 10) { obj.doubleCol = 10 }
         observeChange(obj, "stringCol", "", "abc") { obj.stringCol = "abc" }
@@ -209,10 +216,17 @@ class KVOTests: TestCase {
         realm.add(obj)
 
         observeChange(obj, "boolCol", false, true) { obj.boolCol = true }
+#if swift(>=3.2)
         observeChange(obj, "int8Col", 1 as Int8, 10) { obj.int8Col = 10 }
         observeChange(obj, "int16Col", 2 as Int16, 10) { obj.int16Col = 10 }
         observeChange(obj, "int32Col", 3 as Int32, 10) { obj.int32Col = 10 }
         observeChange(obj, "int64Col", 4 as Int64, 10) { obj.int64Col = 10 }
+#else
+        observeChange(obj, "int8Col", 1, 10) { obj.int8Col = 10 }
+        observeChange(obj, "int16Col", 2, 10) { obj.int16Col = 10 }
+        observeChange(obj, "int32Col", 3, 10) { obj.int32Col = 10 }
+        observeChange(obj, "int64Col", 4, 10) { obj.int64Col = 10 }
+#endif
         observeChange(obj, "floatCol", 5 as Float, 10) { obj.floatCol = 10 }
         observeChange(obj, "doubleCol", 6 as Double, 10) { obj.doubleCol = 10 }
         observeChange(obj, "stringCol", "", "abc") { obj.stringCol = "abc" }
@@ -264,10 +278,17 @@ class KVOTests: TestCase {
         let obs = realm.object(ofType: KVOObject.self, forPrimaryKey: obj.pk)!
 
         observeChange(obs, "boolCol", false, true) { obj.boolCol = true }
+#if swift(>=3.2)
         observeChange(obs, "int8Col", 1 as Int8, 10) { obj.int8Col = 10 }
         observeChange(obs, "int16Col", 2 as Int16, 10) { obj.int16Col = 10 }
         observeChange(obs, "int32Col", 3 as Int32, 10) { obj.int32Col = 10 }
         observeChange(obs, "int64Col", 4 as Int64, 10) { obj.int64Col = 10 }
+#else
+        observeChange(obs, "int8Col", 1, 10) { obj.int8Col = 10 }
+        observeChange(obs, "int16Col", 2, 10) { obj.int16Col = 10 }
+        observeChange(obs, "int32Col", 3, 10) { obj.int32Col = 10 }
+        observeChange(obs, "int64Col", 4, 10) { obj.int64Col = 10 }
+#endif
         observeChange(obs, "floatCol", 5 as Float, 10) { obj.floatCol = 10 }
         observeChange(obs, "doubleCol", 6 as Double, 10) { obj.doubleCol = 10 }
         observeChange(obs, "stringCol", "", "abc") { obj.stringCol = "abc" }

--- a/RealmSwift/Tests/ObjectTests.swift
+++ b/RealmSwift/Tests/ObjectTests.swift
@@ -474,7 +474,7 @@ class ObjectTests: TestCase {
         try! realm.commitWrite()
 
         let exp = expectation(description: "")
-        let token = object.addNotificationBlock { change in
+        let token = object.observe { change in
             if case .deleted = change {
             } else {
                 XCTFail("expected .deleted, got \(change)")
@@ -513,7 +513,7 @@ class ObjectTests: TestCase {
         let object = realm.create(SwiftIntObject.self, value: [1])
         try! realm.commitWrite()
 
-        let token = object.addNotificationBlock(expectChange("intCol", Int?.none, 2))
+        let token = object.observe(expectChange("intCol", Int?.none, 2))
         try! realm.write {
             object.intCol = 2
         }
@@ -528,7 +528,7 @@ class ObjectTests: TestCase {
         let object = realm.create(SwiftIntObject.self, value: [1])
         try! realm.commitWrite()
 
-        let token = object.addNotificationBlock(expectChange("intCol", 1, 2))
+        let token = object.observe(expectChange("intCol", 1, 2))
         dispatchSyncNewThread {
             let realm = try! Realm()
             try! realm.write {
@@ -546,7 +546,7 @@ class ObjectTests: TestCase {
         let object = realm.create(SwiftRecursiveObject.self, value: [[]])
         try! realm.commitWrite()
 
-        let token = object.addNotificationBlock(expectChange("objects", Int?.none, Int?.none))
+        let token = object.observe(expectChange("objects", Int?.none, Int?.none))
         dispatchSyncNewThread {
             let realm = try! Realm()
             try! realm.write {
@@ -566,7 +566,7 @@ class ObjectTests: TestCase {
             realm.add(object)
         }
 
-        var token = object.addNotificationBlock(expectChange("optIntCol", 1, 2))
+        var token = object.observe(expectChange("optIntCol", 1, 2))
         dispatchSyncNewThread {
             let realm = try! Realm()
             try! realm.write {
@@ -576,7 +576,7 @@ class ObjectTests: TestCase {
         waitForExpectations(timeout: 2)
         token.stop()
 
-        token = object.addNotificationBlock(expectChange("optIntCol", 2, Int?.none))
+        token = object.observe(expectChange("optIntCol", 2, Int?.none))
         dispatchSyncNewThread {
             let realm = try! Realm()
             try! realm.write {
@@ -586,7 +586,7 @@ class ObjectTests: TestCase {
         waitForExpectations(timeout: 2)
         token.stop()
 
-        token = object.addNotificationBlock(expectChange("optIntCol", Int?.none, 3))
+        token = object.observe(expectChange("optIntCol", Int?.none, 3))
         dispatchSyncNewThread {
             let realm = try! Realm()
             try! realm.write {

--- a/RealmSwift/Tests/ObjectTests.swift
+++ b/RealmSwift/Tests/ObjectTests.swift
@@ -487,7 +487,7 @@ class ObjectTests: TestCase {
         try! realm.commitWrite()
 
         waitForExpectations(timeout: 2)
-        token.stop()
+        token.invalidate()
     }
 
     func expectChange<T: Equatable, U: Equatable>(_ name: String, _ old: T?, _ new: U?) -> ((ObjectChange) -> Void) {
@@ -519,7 +519,7 @@ class ObjectTests: TestCase {
         }
 
         waitForExpectations(timeout: 2)
-        token.stop()
+        token.invalidate()
     }
 
     func testModifyObservedObjectRemotely() {
@@ -537,7 +537,7 @@ class ObjectTests: TestCase {
         }
 
         waitForExpectations(timeout: 2)
-        token.stop()
+        token.invalidate()
     }
 
     func testListPropertyNotifications() {
@@ -556,7 +556,7 @@ class ObjectTests: TestCase {
         }
 
         waitForExpectations(timeout: 2)
-        token.stop()
+        token.invalidate()
     }
 
     func testOptionalPropertyNotifications() {
@@ -574,7 +574,7 @@ class ObjectTests: TestCase {
             }
         }
         waitForExpectations(timeout: 2)
-        token.stop()
+        token.invalidate()
 
         token = object.observe(expectChange("optIntCol", 2, Int?.none))
         dispatchSyncNewThread {
@@ -584,7 +584,7 @@ class ObjectTests: TestCase {
             }
         }
         waitForExpectations(timeout: 2)
-        token.stop()
+        token.invalidate()
 
         token = object.observe(expectChange("optIntCol", Int?.none, 3))
         dispatchSyncNewThread {
@@ -594,6 +594,6 @@ class ObjectTests: TestCase {
             }
         }
         waitForExpectations(timeout: 2)
-        token.stop()
+        token.invalidate()
     }
 }

--- a/RealmSwift/Tests/PerformanceTests.swift
+++ b/RealmSwift/Tests/PerformanceTests.swift
@@ -426,7 +426,7 @@ class SwiftPerformanceTests: TestCase {
                 try! realm.write { object.intCol += 1 }
             }
             self.stopMeasuring()
-            token.stop()
+            token.invalidate()
         }
     }
 
@@ -454,7 +454,7 @@ class SwiftPerformanceTests: TestCase {
                         semaphore.signal()
                     }
                     CFRunLoopRun()
-                    token.stop()
+                    token.invalidate()
                 }
             }
 
@@ -495,7 +495,7 @@ class SwiftPerformanceTests: TestCase {
                         semaphore.signal()
                     }
                     CFRunLoopRun()
-                    token.stop()
+                    token.invalidate()
                 }
             }
 
@@ -514,7 +514,7 @@ class SwiftPerformanceTests: TestCase {
             }
             queue.sync {}
             self.stopMeasuring()
-            token.stop()
+            token.invalidate()
         }
     }
 

--- a/RealmSwift/Tests/PerformanceTests.swift
+++ b/RealmSwift/Tests/PerformanceTests.swift
@@ -420,7 +420,7 @@ class SwiftPerformanceTests: TestCase {
             let object = realm.create(SwiftIntObject.self)
             try! realm.commitWrite()
 
-            let token = realm.addNotificationBlock { _, _ in }
+            let token = realm.observe { _, _ in }
             self.startMeasuring()
             while object.intCol < 100 {
                 try! realm.write { object.intCol += 1 }
@@ -446,7 +446,7 @@ class SwiftPerformanceTests: TestCase {
                     let object = realm.objects(SwiftIntObject.self).first!
                     var token: NotificationToken! = nil
                     CFRunLoopPerformBlock(CFRunLoopGetCurrent(), CFRunLoopMode.defaultMode.rawValue) {
-                        token = realm.addNotificationBlock { _, _ in
+                        token = realm.observe { _, _ in
                             if object.intCol == stopValue {
                                 CFRunLoopStop(CFRunLoopGetCurrent())
                             }
@@ -485,7 +485,7 @@ class SwiftPerformanceTests: TestCase {
                     let object = realm.objects(SwiftIntObject.self).first!
                     var token: NotificationToken! = nil
                     CFRunLoopPerformBlock(CFRunLoopGetCurrent(), CFRunLoopMode.defaultMode.rawValue) {
-                        token = realm.addNotificationBlock { _, _ in
+                        token = realm.observe { _, _ in
                             if object.intCol == stopValue {
                                 CFRunLoopStop(CFRunLoopGetCurrent())
                             } else if object.intCol % 2 == 0 {
@@ -499,7 +499,7 @@ class SwiftPerformanceTests: TestCase {
                 }
             }
 
-            let token = realm.addNotificationBlock { _, _ in
+            let token = realm.observe { _, _ in
                 if object.intCol % 2 == 1 && object.intCol < stopValue {
                     try! realm.write { object.intCol += 1 }
                 }

--- a/RealmSwift/Tests/RealmCollectionTypeTests.swift
+++ b/RealmSwift/Tests/RealmCollectionTypeTests.swift
@@ -490,13 +490,13 @@ class RealmCollectionTypeTests: TestCase {
         _ = collection.filter("ANY stringListCol == %@", CTTStringObjectWithLink())
     }
 
-    func testAddNotificationBlock() {
+    func testObserve() {
         guard let collection = collection else {
             fatalError("Test precondition failed")
         }
 
         var theExpectation = expectation(description: "")
-        let token = collection.addNotificationBlock { (changes: RealmCollectionChange) in
+        let token = collection.observe { (changes: RealmCollectionChange) in
             switch changes {
             case .initial(let collection):
                 XCTAssertEqual(collection.count, 2)
@@ -515,7 +515,7 @@ class RealmCollectionTypeTests: TestCase {
 
         // add a second notification and wait for it
         theExpectation = expectation(description: "")
-        let token2 = collection.addNotificationBlock { _ in
+        let token2 = collection.observe { _ in
             theExpectation.fulfill()
         }
         waitForExpectations(timeout: 1, handler: nil)
@@ -616,7 +616,7 @@ class ResultsTests: RealmCollectionTypeTests {
 
         var theExpectation = expectation(description: "")
         var calls = 0
-        let token = collection.addNotificationBlock { (changes: RealmCollectionChange) in
+        let token = collection.observe { (changes: RealmCollectionChange) in
             switch changes {
             case .initial(let results):
                 XCTAssertEqual(results.count, calls + 2)
@@ -647,7 +647,7 @@ class ResultsTests: RealmCollectionTypeTests {
 
         var theExpectation = expectation(description: "")
         var calls = 0
-        let token = collection.addNotificationBlock { (change: RealmCollectionChange) in
+        let token = collection.observe { (change: RealmCollectionChange) in
             switch change {
             case .initial(let results):
                 XCTAssertEqual(calls, 0)
@@ -799,11 +799,11 @@ class ListRealmCollectionTypeTests: RealmCollectionTypeTests {
         assertMatches(collection.description, "List<CTTStringObjectWithLink> <0x[0-9a-f]+> \\(\n\t\\[0\\] CTTStringObjectWithLink \\{\n\t\tstringCol = 1;\n\t\tlinkCol = \\(null\\);\n\t\\},\n\t\\[1\\] CTTStringObjectWithLink \\{\n\t\tstringCol = 2;\n\t\tlinkCol = \\(null\\);\n\t\\}\n\\)")
     }
 
-    func testAddNotificationBlockDirect() {
+    func testObserveDirect() {
         let collection = collectionBase()
 
         var theExpectation = expectation(description: "")
-        let token = collection.addNotificationBlock { (changes: RealmCollectionChange) in
+        let token = collection.observe { (changes: RealmCollectionChange) in
             switch changes {
             case .initial(let collection):
                 XCTAssertEqual(collection.count, 2)
@@ -822,7 +822,7 @@ class ListRealmCollectionTypeTests: RealmCollectionTypeTests {
 
         // add a second notification and wait for it
         theExpectation = expectation(description: "")
-        let token2 = collection.addNotificationBlock { _ in
+        let token2 = collection.observe { _ in
             theExpectation.fulfill()
         }
         waitForExpectations(timeout: 1, handler: nil)
@@ -936,16 +936,16 @@ class ListStandaloneRealmCollectionTypeTests: ListRealmCollectionTypeTests {
         assertThrows(collection.filter("ANY stringListCol == %@", CTTStringObjectWithLink()))
     }
 
-    override func testAddNotificationBlock() {
+    override func testObserve() {
         guard let collection = collection else {
             fatalError("Test precondition failed")
         }
-        assertThrows(collection.addNotificationBlock { _ in })
+        assertThrows(collection.observe { _ in })
     }
 
-    override func testAddNotificationBlockDirect() {
+    override func testObserveDirect() {
         let collection = collectionBase()
-        assertThrows(collection.addNotificationBlock { _ in })
+        assertThrows(collection.observe { _ in })
     }
 }
 

--- a/RealmSwift/Tests/RealmCollectionTypeTests.swift
+++ b/RealmSwift/Tests/RealmCollectionTypeTests.swift
@@ -529,8 +529,8 @@ class RealmCollectionTypeTests: TestCase {
         try! realm.commitWrite(withoutNotifying: [token])
         waitForExpectations(timeout: 1, handler: nil)
 
-        token.stop()
-        token2.stop()
+        token.invalidate()
+        token2.invalidate()
     }
 
     func testValueForKeyPath() {
@@ -639,7 +639,7 @@ class ResultsTests: RealmCollectionTypeTests {
         addObjectToResults()
         waitForExpectations(timeout: 1, handler: nil)
 
-        token.stop()
+        token.invalidate()
     }
 
     func testNotificationBlockChangeIndices() {
@@ -674,7 +674,7 @@ class ResultsTests: RealmCollectionTypeTests {
         addObjectToResults()
         waitForExpectations(timeout: 1, handler: nil)
 
-        token.stop()
+        token.invalidate()
     }
 }
 
@@ -836,8 +836,8 @@ class ListRealmCollectionTypeTests: RealmCollectionTypeTests {
         try! realm.commitWrite(withoutNotifying: [token])
         waitForExpectations(timeout: 1, handler: nil)
 
-        token.stop()
-        token2.stop()
+        token.invalidate()
+        token2.invalidate()
     }
 }
 

--- a/RealmSwift/Tests/RealmTests.swift
+++ b/RealmSwift/Tests/RealmTests.swift
@@ -675,10 +675,10 @@ class RealmTests: TestCase {
         XCTAssertEqual(stringVal, "a", "Object Subscripting Failed!")
     }
 
-    func testAddNotificationBlock() {
+    func testObserve() {
         let realm = try! Realm()
         var notificationCalled = false
-        let token = realm.addNotificationBlock { _, realm in
+        let token = realm.observe { _, realm in
             XCTAssertEqual(realm.configuration.fileURL, self.defaultRealmURL())
             notificationCalled = true
         }
@@ -691,7 +691,7 @@ class RealmTests: TestCase {
     func testRemoveNotification() {
         let realm = try! Realm()
         var notificationCalled = false
-        let token = realm.addNotificationBlock { (_, realm) -> Void in
+        let token = realm.observe { (_, realm) -> Void in
             XCTAssertEqual(realm.configuration.fileURL, self.defaultRealmURL())
             notificationCalled = true
         }
@@ -711,7 +711,7 @@ class RealmTests: TestCase {
         // test that autoreresh is applied
         // we have two notifications, one for opening the realm, and a second when performing our transaction
         let notificationFired = expectation(description: "notification fired")
-        let token = realm.addNotificationBlock { _, realm in
+        let token = realm.observe { _, realm in
             XCTAssertNotNil(realm, "Realm should not be nil")
             notificationFired.fulfill()
         }
@@ -738,7 +738,7 @@ class RealmTests: TestCase {
         // test that autoreresh is not applied
         // we have two notifications, one for opening the realm, and a second when performing our transaction
         let notificationFired = expectation(description: "notification fired")
-        let token = realm.addNotificationBlock { _, realm in
+        let token = realm.observe { _, realm in
             XCTAssertNotNil(realm, "Realm should not be nil")
             notificationFired.fulfill()
         }

--- a/RealmSwift/Tests/RealmTests.swift
+++ b/RealmSwift/Tests/RealmTests.swift
@@ -685,7 +685,7 @@ class RealmTests: TestCase {
         XCTAssertFalse(notificationCalled)
         try! realm.write {}
         XCTAssertTrue(notificationCalled)
-        token.stop()
+        token.invalidate()
     }
 
     func testRemoveNotification() {
@@ -695,7 +695,7 @@ class RealmTests: TestCase {
             XCTAssertEqual(realm.configuration.fileURL, self.defaultRealmURL())
             notificationCalled = true
         }
-        token.stop()
+        token.invalidate()
         try! realm.write {}
         XCTAssertFalse(notificationCalled)
     }
@@ -723,7 +723,7 @@ class RealmTests: TestCase {
             }
         }
         waitForExpectations(timeout: 1, handler: nil)
-        token.stop()
+        token.invalidate()
 
         // get object
         let results = realm.objects(SwiftStringObject.self)
@@ -753,7 +753,7 @@ class RealmTests: TestCase {
             }
         }
         waitForExpectations(timeout: 1, handler: nil)
-        token.stop()
+        token.invalidate()
 
         XCTAssertEqual(results.count, Int(0), "There should be 1 object of type StringObject")
 

--- a/RealmSwift/Tests/SwiftTestObjects.swift
+++ b/RealmSwift/Tests/SwiftTestObjects.swift
@@ -444,10 +444,10 @@ class SwiftObjectiveCTypesObject: Object {
 
 class SwiftComputedPropertyNotIgnoredObject: Object {
     // swiftlint:disable:next identifier_name
-    dynamic var _urlBacking = ""
+    @objc dynamic var _urlBacking = ""
 
     // Dynamic; no ivar
-    dynamic var dynamicURL: URL? {
+    @objc dynamic var dynamicURL: URL? {
         get {
             return URL(string: _urlBacking)
         }

--- a/examples/installation/watchos/objc/CarthageExample/CarthageExample WatchKit Extension/InterfaceController.m
+++ b/examples/installation/watchos/objc/CarthageExample/CarthageExample WatchKit Extension/InterfaceController.m
@@ -60,7 +60,7 @@
 }
 
 - (void)didDeactivate {
-    [self.token stop];
+    [self.token invalidate];
     [super didDeactivate];
 }
 

--- a/examples/installation/watchos/objc/CocoaPodsExample/CocoaPodsExample WatchKit Extension/InterfaceController.m
+++ b/examples/installation/watchos/objc/CocoaPodsExample/CocoaPodsExample WatchKit Extension/InterfaceController.m
@@ -60,7 +60,7 @@
 }
 
 - (void)didDeactivate {
-    [self.token stop];
+    [self.token invalidate];
     [super didDeactivate];
 }
 

--- a/examples/installation/watchos/objc/DynamicExample/DynamicExample WatchKit Extension/InterfaceController.m
+++ b/examples/installation/watchos/objc/DynamicExample/DynamicExample WatchKit Extension/InterfaceController.m
@@ -60,7 +60,7 @@
 }
 
 - (void)didDeactivate {
-    [self.token stop];
+    [self.token invalidate];
     [super didDeactivate];
 }
 

--- a/examples/installation/watchos/swift-3.0/CarthageExample/CarthageExample WatchKit Extension/InterfaceController.swift
+++ b/examples/installation/watchos/swift-3.0/CarthageExample/CarthageExample WatchKit Extension/InterfaceController.swift
@@ -44,7 +44,7 @@ class InterfaceController: WKInterfaceController {
 
     override func willActivate() {
         super.willActivate()
-        token = counter.realm!.addNotificationBlock { [unowned self] _, _ in
+        token = counter.realm!.observe { [unowned self] _, _ in
             self.button.setTitle("\(self.counter.count)")
         }
     }

--- a/examples/installation/watchos/swift-3.0/CarthageExample/CarthageExample WatchKit Extension/InterfaceController.swift
+++ b/examples/installation/watchos/swift-3.0/CarthageExample/CarthageExample WatchKit Extension/InterfaceController.swift
@@ -50,7 +50,7 @@ class InterfaceController: WKInterfaceController {
     }
 
     override func didDeactivate() {
-        token.stop()
+        token.invalidate()
         super.didDeactivate()
     }
 }

--- a/examples/installation/watchos/swift-3.0/CocoaPodsExample/CocoaPodsExample WatchKit Extension/InterfaceController.swift
+++ b/examples/installation/watchos/swift-3.0/CocoaPodsExample/CocoaPodsExample WatchKit Extension/InterfaceController.swift
@@ -44,7 +44,7 @@ class InterfaceController: WKInterfaceController {
 
     override func willActivate() {
         super.willActivate()
-        token = counter.realm!.addNotificationBlock { [unowned self] _, _ in
+        token = counter.realm!.observe { [unowned self] _, _ in
             self.button.setTitle("\(self.counter.count)")
         }
     }

--- a/examples/installation/watchos/swift-3.0/CocoaPodsExample/CocoaPodsExample WatchKit Extension/InterfaceController.swift
+++ b/examples/installation/watchos/swift-3.0/CocoaPodsExample/CocoaPodsExample WatchKit Extension/InterfaceController.swift
@@ -50,7 +50,7 @@ class InterfaceController: WKInterfaceController {
     }
 
     override func didDeactivate() {
-        token.stop()
+        token.invalidate()
         super.didDeactivate()
     }
 }

--- a/examples/installation/watchos/swift-3.0/DynamicExample/DynamicExample WatchKit Extension/InterfaceController.swift
+++ b/examples/installation/watchos/swift-3.0/DynamicExample/DynamicExample WatchKit Extension/InterfaceController.swift
@@ -44,7 +44,7 @@ class InterfaceController: WKInterfaceController {
 
     override func willActivate() {
         super.willActivate()
-        token = counter.realm!.addNotificationBlock { [unowned self] _, _ in
+        token = counter.realm!.observe { [unowned self] _, _ in
             self.button.setTitle("\(self.counter.count)")
         }
     }

--- a/examples/installation/watchos/swift-3.0/DynamicExample/DynamicExample WatchKit Extension/InterfaceController.swift
+++ b/examples/installation/watchos/swift-3.0/DynamicExample/DynamicExample WatchKit Extension/InterfaceController.swift
@@ -50,7 +50,7 @@ class InterfaceController: WKInterfaceController {
     }
 
     override func didDeactivate() {
-        token.stop()
+        token.invalidate()
         super.didDeactivate()
     }
 }

--- a/examples/ios/swift-3.0/GroupedTableView/TableViewController.swift
+++ b/examples/ios/swift-3.0/GroupedTableView/TableViewController.swift
@@ -50,7 +50,7 @@ class TableViewController: UITableViewController {
         realm = try! Realm()
 
         // Set realm notification block
-        notificationToken = realm.addNotificationBlock { [unowned self] note, realm in
+        notificationToken = realm.observe { [unowned self] note, realm in
             self.tableView.reloadData()
         }
         for section in sectionTitles {

--- a/examples/ios/swift-3.0/TableView/TableViewController.swift
+++ b/examples/ios/swift-3.0/TableView/TableViewController.swift
@@ -46,7 +46,7 @@ class TableViewController: UITableViewController {
         setupUI()
 
         // Set results notification block
-        self.notificationToken = results.addNotificationBlock { (changes: RealmCollectionChange) in
+        self.notificationToken = results.observe { (changes: RealmCollectionChange) in
             switch changes {
             case .initial:
                 // Results are now populated and can be accessed without blocking the UI

--- a/examples/tvos/objc/DownloadCache/RepositoriesViewController.m
+++ b/examples/tvos/objc/DownloadCache/RepositoriesViewController.m
@@ -33,7 +33,7 @@
 @implementation RepositoriesViewController
 
 - (void)dealloc {
-    [self.token stop];
+    [self.token invalidate];
 }
 
 - (void)viewDidLoad {

--- a/examples/tvos/swift-3.0/DownloadCache/RepositoriesViewController.swift
+++ b/examples/tvos/swift-3.0/DownloadCache/RepositoriesViewController.swift
@@ -34,7 +34,7 @@ class RepositoriesViewController: UICollectionViewController, UITextFieldDelegat
         super.viewDidLoad()
 
         let realm = try! Realm()
-        token = realm.addNotificationBlock { [weak self] notification, realm in
+        token = realm.observe { [weak self] notification, realm in
             self?.reloadData()
         }
 

--- a/examples/tvos/swift-3.0/DownloadCache/RepositoriesViewController.swift
+++ b/examples/tvos/swift-3.0/DownloadCache/RepositoriesViewController.swift
@@ -27,7 +27,7 @@ class RepositoriesViewController: UICollectionViewController, UITextFieldDelegat
     var token: NotificationToken?
 
     deinit {
-        token?.stop()
+        token?.invalidate()
     }
 
     override func viewDidLoad() {


### PR DESCRIPTION
Addresses #5025. I opted to leave the Objective-C `addNotificationBlock` API as-is, because `observe` isn't a very idiomatic ObjC method name. However, the ObjC API _is_ affected by this (i.e. `-[RLMNotificationToken invalidate]`) in order to keep our terminology aligned between Swift & ObjC and the first argument of idiomatic naming doesn't apply here.