### PR TITLE
Fix sorting collections on iOS 7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ x.x.x Release notes (yyyy-MM-dd)
 
 ### Bugfixes
 
-* None.
+* Sorting Realm collection types no longer throws an exception on iOS 7.
 
 2.9.1 Release notes (2017-08-01)
 =============================================================

--- a/Configuration/Base.xcconfig
+++ b/Configuration/Base.xcconfig
@@ -42,7 +42,7 @@ GCC_WARN_UNUSED_PARAMETER = YES;
 GCC_WARN_UNUSED_VARIABLE = YES;
 SWIFT_OPTIMIZATION_LEVEL = -Owholemodule;
 SWIFT_WHOLE_MODULE_OPTIMIZATION = YES;
-WARNING_CFLAGS = -Wmismatched-tags -Wunused-private-field;
+WARNING_CFLAGS = -Wmismatched-tags -Wunused-private-field -Wpartial-availability;
 OTHER_CFLAGS = -fvisibility-inlines-hidden;
 
 OTHER_CPLUSPLUSFLAGS = $(inherited) -isystem core/include;

--- a/Realm/RLMCollection.mm
+++ b/Realm/RLMCollection.mm
@@ -268,7 +268,7 @@ std::vector<std::pair<std::string, bool>> RLMSortDescriptorsToKeypathArray(NSArr
     std::vector<std::pair<std::string, bool>> keypaths;
     keypaths.reserve(properties.count);
     for (RLMSortDescriptor *desc in properties) {
-        if ([desc.keyPath containsString:@"@"]) {
+        if ([desc.keyPath rangeOfString:@"@"].location != NSNotFound) {
             @throw RLMException(@"Cannot sort on key path '%@': KVC collection operators are not supported.", desc.keyPath);
         }
         keypaths.push_back({desc.keyPath.UTF8String, desc.ascending});

--- a/Realm/RLMPredicateUtil.mm
+++ b/Realm/RLMPredicateUtil.mm
@@ -90,7 +90,10 @@ NSExpression *PredicateExpressionTransformer::visit(NSExpression *expression) co
         }
 
         case NSConditionalExpressionType:
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wpartial-availability"
             return [NSExpression expressionForConditional:visit(expression.predicate) trueExpression:visit(expression.trueExpression) falseExpression:visit(expression.falseExpression)];
+#pragma clang diagnostic pop
 
         default:
             // The remaining expression types do not contain nested expressions or predicates.

--- a/Realm/Tests/RLMAssertions.h
+++ b/Realm/Tests/RLMAssertions.h
@@ -90,12 +90,12 @@
     if (macro_dsc.length) {                                                                              \
         NSString *macro_dscActual = [macro_castErr.userInfo[NSLocalizedDescriptionKey] lowercaseString]; \
         XCTAssertNotNil(macro_dscActual);                                                                \
-        XCTAssert([macro_dscActual containsString:macro_dsc], @"Did not find the expected string '%@' in the description string '%@'", macro_dsc, macro_dscActual); \
+        XCTAssert([macro_dscActual rangeOfString:macro_dsc].location != NSNotFound, @"Did not find the expected string '%@' in the description string '%@'", macro_dsc, macro_dscActual); \
     }                                                                                                    \
     if (macro_usl.length) {                                                                              \
         NSString *macro_uslActual = [macro_castErr.userInfo[@"Underlying"] lowercaseString];             \
         XCTAssertNotNil(macro_uslActual);                                                                \
-        XCTAssert([macro_uslActual containsString:macro_usl], @"Did not find the expected string '%@' in the underlying info string '%@'", macro_usl, macro_uslActual); \
+        XCTAssert([macro_uslActual rangeOfString:macro_usl].location != NSNotFound, @"Did not find the expected string '%@' in the underlying info string '%@'", macro_usl, macro_uslActual); \
     }                                                                                                    \
 })
 


### PR DESCRIPTION
`-[NSString containsString:]` wasn't added until iOS 8, so attempting to use it on iOS 7 would throw an unrecognized selector exception. Switch to using `-[NSString rangeOfString:]` for compatibility with iOS 7.

This also enables `-Wpartial-availability`, which results in warnings when using symbols that are not available in all OS versions that we're building for. It revealed a similar issue with our use of `-containsString:` in unit tests, and a false-positive within RLMPredicateUtil.mm.

I've not been able to run the tests on iOS 7 as I don't have any devices with such an old version of iOS. The iOS 7 simulator is only supported back on macOS 10.10, and no version of Xcode that will build Realm from source runs on that version of macOS either.

Fixes #5194.