### PR TITLE
Minor cleanup changes for sync APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,10 @@ x.x.x Release notes (yyyy-MM-dd)
 * Rename `{RLM}NotificationToken.stop()` to `invalidate()` and
   `{RealmCollection,SyncPermissionResults}.addNotificationBlock(_:)` to
   `observe(_:)` to mirror Foundation's new KVO APIs.
+* The `RLMSyncProgress` enum has been renamed `RLMSyncProgressMode`.
+* Remove deprecated `{RLM}SyncManager.disableSSLValidation` property. Disable
+  SSL validation on a per-Realm basis by setting the `enableSSLValidation`
+  property on `{RLM}SyncConfiguration` instead.
 
 ### Enhancements
 

--- a/Realm/ObjectServerTests/RLMObjectServerTests.mm
+++ b/Realm/ObjectServerTests/RLMObjectServerTests.mm
@@ -1173,7 +1173,7 @@
         XCTAssertNotNil(session);
         XCTestExpectation *ex = [self expectationWithDescription:@"streaming-download-notifier"];
         RLMProgressNotificationToken *token = [session addProgressNotificationForDirection:RLMSyncProgressDirectionDownload
-                                                                                      mode:RLMSyncProgressReportIndefinitely
+                                                                                      mode:RLMSyncProgressModeReportIndefinitely
                                                                                      block:^(NSUInteger xfr, NSUInteger xfb) {
             // Make sure the values are increasing, and update our stored copies.
             XCTAssert(xfr >= transferred);
@@ -1227,7 +1227,7 @@
     XCTAssertNotNil(session);
     XCTestExpectation *ex = [self expectationWithDescription:@"streaming-upload-expectation"];
     RLMProgressNotificationToken *token = [session addProgressNotificationForDirection:RLMSyncProgressDirectionUpload
-                                                                                  mode:RLMSyncProgressReportIndefinitely
+                                                                                  mode:RLMSyncProgressModeReportIndefinitely
                                                                                  block:^(NSUInteger xfr, NSUInteger xfb) {
                                                                                      // Make sure the values are
                                                                                      // increasing, and update our

--- a/Realm/RLMSyncConfiguration.mm
+++ b/Realm/RLMSyncConfiguration.mm
@@ -178,9 +178,6 @@ static BOOL isValidRealmURL(NSURL *url) {
             std::move(bindHandler),
             std::move(errorHandler)
         });
-        if (NSNumber *disabled = [[RLMSyncManager sharedManager] globalSSLValidationDisabled]) {
-            _config->client_validate_ssl = ![disabled boolValue];
-        }
         self.customFileURL = customFileURL;
         return self;
     }

--- a/Realm/RLMSyncManager.h
+++ b/Realm/RLMSyncManager.h
@@ -82,18 +82,6 @@ typedef void(^RLMSyncErrorReportingBlock)(NSError *, RLMSyncSession * _Nullable)
 @property (nonatomic, copy) NSString *appID;
 
 /**
- Whether SSL certificate validation should be disabled.
-
- Once this value is set (either way), it will be used as the default value for SSL
- validation when initializing new sync configuration values. A given configuration's
- SSL validation setting can still be overriden from the global default by setting it
- explicitly.
-
- @warning NEVER disable certificate validation for clients and servers in production.
- */
-@property (nonatomic) BOOL disableSSLValidation __deprecated_msg("Set `enableSSLValidation` on individual configurations instead.");
-
-/**
  The logging threshold which newly opened synced Realms will use. Defaults to
  `RLMSyncLogLevelInfo`.
 

--- a/Realm/RLMSyncManager.mm
+++ b/Realm/RLMSyncManager.mm
@@ -82,13 +82,9 @@ struct CocoaSyncLoggerFactory : public realm::SyncLoggerFactory {
 
 @interface RLMSyncManager ()
 - (instancetype)initWithCustomRootDirectory:(nullable NSURL *)rootDirectory NS_DESIGNATED_INITIALIZER;
-
-@property (nonatomic, nullable, strong) NSNumber *globalSSLValidationDisabled;
 @end
 
 @implementation RLMSyncManager
-
-@synthesize globalSSLValidationDisabled = _globalSSLValidationDisabled;
 
 static RLMSyncManager *s_sharedManager = nil;
 static dispatch_once_t s_onceToken;
@@ -120,26 +116,6 @@ static dispatch_once_t s_onceToken;
         _appID = [[NSBundle mainBundle] bundleIdentifier] ?: @"(none)";
     }
     return _appID;
-}
-
-- (NSNumber *)globalSSLValidationDisabled {
-    @synchronized (self) {
-        return _globalSSLValidationDisabled;
-    }
-}
-
-- (void)setGlobalSSLValidationDisabled:(NSNumber *)globalSSLValidationDisabled {
-    @synchronized (self) {
-        _globalSSLValidationDisabled = globalSSLValidationDisabled;
-    }
-}
-
-- (void)setDisableSSLValidation:(BOOL)disableSSLValidation {
-    self.globalSSLValidationDisabled = @(disableSSLValidation);
-}
-
-- (BOOL)disableSSLValidation {
-    return [self.globalSSLValidationDisabled boolValue];
 }
 
 #pragma mark - Passthrough properties

--- a/Realm/RLMSyncManager_Private.h
+++ b/Realm/RLMSyncManager_Private.h
@@ -31,8 +31,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nullable, nonatomic, copy) RLMSyncBasicErrorReportingBlock sessionCompletionNotifier;
 
-- (nullable NSNumber *)globalSSLValidationDisabled;
-
 - (void)_fireError:(NSError *)error;
 
 - (void)_fireErrorWithCode:(int)errorCode

--- a/Realm/RLMSyncSession.h
+++ b/Realm/RLMSyncSession.h
@@ -51,7 +51,7 @@ typedef NS_ENUM(NSUInteger, RLMSyncProgressDirection) {
  Progress notification blocks can be registered on sessions if your app wishes to be informed
  how many bytes have been uploaded or downloaded, for example to show progress indicator UIs.
  */
-typedef NS_ENUM(NSUInteger, RLMSyncProgress) {
+typedef NS_ENUM(NSUInteger, RLMSyncProgressMode) {
     /**
      The block will be called indefinitely, or until it is unregistered by calling
      `-[RLMProgressNotificationToken invalidate]`.
@@ -59,7 +59,7 @@ typedef NS_ENUM(NSUInteger, RLMSyncProgress) {
      Notifications will always report the latest number of transferred bytes, and the
      most up-to-date number of total transferrable bytes.
      */
-    RLMSyncProgressReportIndefinitely,
+    RLMSyncProgressModeReportIndefinitely,
     /**
      The block will, upon registration, store the total number of bytes
      to be transferred. When invoked, it will always report the most up-to-date number
@@ -68,7 +68,7 @@ typedef NS_ENUM(NSUInteger, RLMSyncProgress) {
      When the number of transferred bytes reaches or exceeds the
      number of transferrable bytes, the block will be unregistered.
      */
-    RLMSyncProgressForCurrentlyOutstandingWork,
+    RLMSyncProgressModeForCurrentlyOutstandingWork,
 };
 
 @class RLMSyncUser, RLMSyncConfiguration, RLMSyncErrorActionToken;
@@ -150,7 +150,7 @@ NS_ASSUME_NONNULL_BEGIN
  @see `RLMSyncProgressDirection`, `RLMSyncProgress`, `RLMProgressNotificationBlock`, `RLMProgressNotificationToken`
  */
 - (nullable RLMProgressNotificationToken *)addProgressNotificationForDirection:(RLMSyncProgressDirection)direction
-                                                                          mode:(RLMSyncProgress)mode
+                                                                          mode:(RLMSyncProgressMode)mode
                                                                          block:(RLMProgressNotificationBlock)block
 NS_REFINED_FOR_SWIFT;
 

--- a/Realm/RLMSyncSession.mm
+++ b/Realm/RLMSyncSession.mm
@@ -174,7 +174,7 @@ using namespace realm;
 }
 
 - (RLMProgressNotificationToken *)addProgressNotificationForDirection:(RLMSyncProgressDirection)direction
-                                                                 mode:(RLMSyncProgress)mode
+                                                                 mode:(RLMSyncProgressMode)mode
                                                                 block:(RLMProgressNotificationBlock)block {
     if (auto session = _session.lock()) {
         if (session->state() == SyncSession::PublicState::Error) {
@@ -184,7 +184,7 @@ using namespace realm;
         auto notifier_direction = (direction == RLMSyncProgressDirectionUpload
                                    ? SyncSession::NotifierType::upload
                                    : SyncSession::NotifierType::download);
-        bool is_streaming = (mode == RLMSyncProgressReportIndefinitely);
+        bool is_streaming = (mode == RLMSyncProgressModeReportIndefinitely);
         uint64_t token = session->register_progress_notifier([=](uint64_t transferred, uint64_t transferrable) {
             dispatch_async(queue, ^{
                 block((NSUInteger)transferred, (NSUInteger)transferrable);


### PR DESCRIPTION
Changes:
- Remove a deprecated API on `SyncManager`
- Rename an enum for consistency