### PR TITLE
Work around a hang seen when building Realm using Xcode 9b5 with Carthage

### DIFF
--- a/examples/tvos/swift-3.0/RealmExamples.xcodeproj/project.pbxproj
+++ b/examples/tvos/swift-3.0/RealmExamples.xcodeproj/project.pbxproj
@@ -219,7 +219,6 @@
 					};
 					14AACA851BFE7B740046BD85 = {
 						CreatedOnToolsVersion = 7.2;
-						DevelopmentTeam = QX5CR2FTN2;
 					};
 				};
 			};
@@ -444,7 +443,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = "App Icon & Top Shelf Image";
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
-				DEVELOPMENT_TEAM = QX5CR2FTN2;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = PreloadedData/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = io.realm.PreloadedData;
@@ -458,7 +457,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = "App Icon & Top Shelf Image";
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
-				DEVELOPMENT_TEAM = QX5CR2FTN2;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = PreloadedData/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = io.realm.PreloadedData;


### PR DESCRIPTION
Xcode 9 beta 5 appears to hang when computing the build settings for the PreloadedData scheme in the tvOS examples project. At the point of the hang, `xcodebuild` is initializing some portion of the code signing subsystem. The only thing interesting about the PreloadedData target is that it has a development team specified, unlike all of the other targets in our example projects. Removing the development team prevents the hang. There's no reason for a development team to be specified for that target anyway.

Fixes #5207 (works around the issue, really).