### PR TITLE
Revert "only apply swift_objc_members attribute if available"

### DIFF
--- a/Realm/Tests/RLMMultiProcessTestCase.h
+++ b/Realm/Tests/RLMMultiProcessTestCase.h
@@ -20,7 +20,6 @@
 
 @class NSTask;
 
-__attribute__((swift_objc_members)) // workaround for rdar://33514802
 @interface RLMMultiProcessTestCase : RLMTestCase
 // if true, this is running the main test process
 @property (nonatomic, readonly) bool isParent;

--- a/Realm/Tests/RLMMultiProcessTestCase.h
+++ b/Realm/Tests/RLMMultiProcessTestCase.h
@@ -20,7 +20,7 @@
 
 @class NSTask;
 
-REALM_SWIFT_OBJC_MEMBERS // workaround for rdar://33514802
+__attribute__((swift_objc_members)) // workaround for rdar://33514802
 @interface RLMMultiProcessTestCase : RLMTestCase
 // if true, this is running the main test process
 @property (nonatomic, readonly) bool isParent;

--- a/Realm/Tests/RLMTestCase.h
+++ b/Realm/Tests/RLMTestCase.h
@@ -33,7 +33,6 @@ NSData *RLMGenerateKey(void);
 }
 #endif
 
-__attribute__((swift_objc_members)) // workaround for rdar://33514802
 @interface RLMTestCase : XCTestCase
 
 - (RLMRealm *)realmWithTestPath;

--- a/Realm/Tests/RLMTestCase.h
+++ b/Realm/Tests/RLMTestCase.h
@@ -33,13 +33,7 @@ NSData *RLMGenerateKey(void);
 }
 #endif
 
-#if __has_attribute(swift_objc_members)
-#define REALM_SWIFT_OBJC_MEMBERS __attribute__((swift_objc_members))
-#else
-#define REALM_SWIFT_OBJC_MEMBERS
-#endif
-
-REALM_SWIFT_OBJC_MEMBERS // workaround for rdar://33514802
+__attribute__((swift_objc_members)) // workaround for rdar://33514802
 @interface RLMTestCase : XCTestCase
 
 - (RLMRealm *)realmWithTestPath;


### PR DESCRIPTION
This reverts commit 17cf8e88e679d25e4a8b1a234791d2db88567f5a.

This was initially applied to work around [rdar://33514802](http://www.openradar.me/33514802), but that's fixed as of Xcode 9 beta 5.