### PR TITLE
Add swift_objc_members attribute to RLMObjectBase

### DIFF
--- a/Realm/ObjectServerTests/SwiftSyncTestCase.swift
+++ b/Realm/ObjectServerTests/SwiftSyncTestCase.swift
@@ -20,11 +20,11 @@ import XCTest
 import RealmSwift
 
 class SwiftSyncObject: Object {
-    @objc dynamic var stringProp: String = ""
+    dynamic var stringProp: String = ""
 }
 
 class SwiftHugeSyncObject: Object {
-    @objc dynamic var dataProp: NSData?
+    dynamic var dataProp: NSData?
 
     required init() {
         super.init()

--- a/Realm/RLMConstants.h
+++ b/Realm/RLMConstants.h
@@ -39,6 +39,11 @@ NS_ASSUME_NONNULL_BEGIN
 #define RLM_ERROR_ENUM(type, name, domain) NS_ENUM(type, name)
 #endif
 
+#if __has_attribute(swift_objc_members)
+#define REALM_SWIFT_OBJC_MEMBERS __attribute__((swift_objc_members))
+#else
+#define REALM_SWIFT_OBJC_MEMBERS
+#endif
 
 #pragma mark - Enums
 

--- a/Realm/RLMObjectBase.h
+++ b/Realm/RLMObjectBase.h
@@ -17,6 +17,7 @@
 ////////////////////////////////////////////////////////////////////////////
 
 #import <Foundation/Foundation.h>
+#import <Realm/RLMConstants.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -25,6 +26,7 @@ NS_ASSUME_NONNULL_BEGIN
 @class RLMObjectSchema;
 
 /// :nodoc:
+REALM_SWIFT_OBJC_MEMBERS
 @interface RLMObjectBase : NSObject
 
 @property (nonatomic, readonly, getter = isInvalidated) BOOL invalidated;

--- a/Realm/Tests/RLMMultiProcessTestCase.h
+++ b/Realm/Tests/RLMMultiProcessTestCase.h
@@ -20,7 +20,6 @@
 
 @class NSTask;
 
-__attribute__((swift_objc_members)) // workaround for rdar://33514802
 @interface RLMMultiProcessTestCase : RLMTestCase
 // if true, this is running the main test process
 @property (nonatomic, readonly) bool isParent;

--- a/Realm/Tests/RLMMultiProcessTestCase.h
+++ b/Realm/Tests/RLMMultiProcessTestCase.h
@@ -20,7 +20,7 @@
 
 @class NSTask;
 
-REALM_SWIFT_OBJC_MEMBERS // workaround for rdar://33514802
+__attribute__((swift_objc_members)) // workaround for rdar://33514802
 @interface RLMMultiProcessTestCase : RLMTestCase
 // if true, this is running the main test process
 @property (nonatomic, readonly) bool isParent;

--- a/Realm/Tests/RLMTestCase.h
+++ b/Realm/Tests/RLMTestCase.h
@@ -33,7 +33,6 @@ NSData *RLMGenerateKey(void);
 }
 #endif
 
-__attribute__((swift_objc_members)) // workaround for rdar://33514802
 @interface RLMTestCase : XCTestCase
 
 - (RLMRealm *)realmWithTestPath;

--- a/Realm/Tests/RLMTestCase.h
+++ b/Realm/Tests/RLMTestCase.h
@@ -33,13 +33,7 @@ NSData *RLMGenerateKey(void);
 }
 #endif
 
-#if __has_attribute(swift_objc_members)
-#define REALM_SWIFT_OBJC_MEMBERS __attribute__((swift_objc_members))
-#else
-#define REALM_SWIFT_OBJC_MEMBERS
-#endif
-
-REALM_SWIFT_OBJC_MEMBERS // workaround for rdar://33514802
+__attribute__((swift_objc_members)) // workaround for rdar://33514802
 @interface RLMTestCase : XCTestCase
 
 - (RLMRealm *)realmWithTestPath;

--- a/Realm/Tests/Swift/SwiftObjectInterfaceTests.swift
+++ b/Realm/Tests/Swift/SwiftObjectInterfaceTests.swift
@@ -27,17 +27,17 @@ class OuterClass {
 }
 
 class SwiftStringObjectSubclass : SwiftStringObject {
-    @objc dynamic var stringCol2 = ""
+    dynamic var stringCol2 = ""
 }
 
 class SwiftSelfRefrencingSubclass: SwiftStringObject {
-    @objc dynamic var objects = RLMArray<SwiftSelfRefrencingSubclass>(objectClassName: SwiftSelfRefrencingSubclass.className())
+    dynamic var objects = RLMArray<SwiftSelfRefrencingSubclass>(objectClassName: SwiftSelfRefrencingSubclass.className())
 }
 
 
 class SwiftDefaultObject: RLMObject {
-    @objc dynamic var intCol = 1
-    @objc dynamic var boolCol = true
+    dynamic var intCol = 1
+    dynamic var boolCol = true
 
     override class func defaultPropertyValues() -> [AnyHashable : Any]? {
         return ["intCol": 2]
@@ -45,10 +45,10 @@ class SwiftDefaultObject: RLMObject {
 }
 
 class SwiftOptionalNumberObject: RLMObject {
-    @objc dynamic var intCol: NSNumber? = 1
-    @objc dynamic var floatCol: NSNumber? = 2.2 as Float as NSNumber
-    @objc dynamic var doubleCol: NSNumber? = 3.3
-    @objc dynamic var boolCol: NSNumber? = true
+    dynamic var intCol: NSNumber? = 1
+    dynamic var floatCol: NSNumber? = 2.2 as Float as NSNumber
+    dynamic var doubleCol: NSNumber? = 3.3
+    dynamic var boolCol: NSNumber? = true
 }
 
 class SwiftObjectInterfaceTests: RLMTestCase {

--- a/Realm/Tests/Swift/SwiftSchemaTests.swift
+++ b/Realm/Tests/Swift/SwiftSchemaTests.swift
@@ -21,46 +21,46 @@ import Realm
 import Realm.Private
 
 class InitLinkedToClass: RLMObject {
-    @objc dynamic var value = SwiftIntObject(value: [0])
+    dynamic var value = SwiftIntObject(value: [0])
 }
 
 class SwiftNonDefaultObject: RLMObject {
-    @objc dynamic var value = 0
+    dynamic var value = 0
     public override class func shouldIncludeInDefaultSchema() -> Bool {
         return false
     }
 }
 
 class SwiftLinkedNonDefaultObject: RLMObject {
-    @objc dynamic var obj: SwiftNonDefaultObject?
+    dynamic var obj: SwiftNonDefaultObject?
     public override class func shouldIncludeInDefaultSchema() -> Bool {
         return false
     }
 }
 
 class SwiftNonDefaultArrayObject: RLMObject {
-    @objc dynamic var array = RLMArray(objectClassName: SwiftNonDefaultObject.className())
+    dynamic var array = RLMArray(objectClassName: SwiftNonDefaultObject.className())
     public override class func shouldIncludeInDefaultSchema() -> Bool {
         return false
     }
 }
 
 class SwiftMutualLink1Object: RLMObject {
-    @objc dynamic var object: SwiftMutualLink2Object?
+    dynamic var object: SwiftMutualLink2Object?
     public override class func shouldIncludeInDefaultSchema() -> Bool {
         return false
     }
 }
 
 class SwiftMutualLink2Object: RLMObject {
-    @objc dynamic var object: SwiftMutualLink1Object?
+    dynamic var object: SwiftMutualLink1Object?
     public override class func shouldIncludeInDefaultSchema() -> Bool {
         return false
     }
 }
 
 class IgnoredLinkPropertyObject : RLMObject {
-    @objc dynamic var value = 0
+    dynamic var value = 0
     var obj = SwiftIntObject()
 
     override class func ignoredProperties() -> [String] {
@@ -69,7 +69,7 @@ class IgnoredLinkPropertyObject : RLMObject {
 }
 
 class SwiftRecursingSchemaTestObject : RLMObject {
-    @objc dynamic var propertyWithIllegalDefaultValue: SwiftIntObject? = {
+    dynamic var propertyWithIllegalDefaultValue: SwiftIntObject? = {
         if mayAccessSchema {
             let realm = RLMRealm.default()
             return SwiftIntObject.allObjects().firstObject() as! SwiftIntObject?
@@ -82,11 +82,11 @@ class SwiftRecursingSchemaTestObject : RLMObject {
 }
 
 class InvalidArrayType: FakeObject {
-    @objc dynamic var array = RLMArray<SwiftIntObject>(objectClassName: "invalid class")
+    dynamic var array = RLMArray<SwiftIntObject>(objectClassName: "invalid class")
 }
 
 class InitAppendsToArrayProperty : RLMObject {
-    @objc dynamic var propertyWithIllegalDefaultValue: RLMArray<SwiftIntObject> = {
+    dynamic var propertyWithIllegalDefaultValue: RLMArray<SwiftIntObject> = {
         if mayAppend {
             let array = RLMArray<SwiftIntObject>(objectClassName: SwiftIntObject.className())
             array.add(SwiftIntObject())

--- a/Realm/Tests/Swift/SwiftTestObjects.swift
+++ b/Realm/Tests/Swift/SwiftTestObjects.swift
@@ -19,95 +19,95 @@
 import Realm
 
 class SwiftStringObject: RLMObject {
-    @objc dynamic var stringCol = ""
+    dynamic var stringCol = ""
 }
 
 class SwiftBoolObject: RLMObject {
-    @objc dynamic var boolCol = false
+    dynamic var boolCol = false
 }
 
 class SwiftIntObject: RLMObject {
-    @objc dynamic var intCol = 0
+    dynamic var intCol = 0
 }
 
 class SwiftLongObject: RLMObject {
-    @objc dynamic var longCol: Int64 = 0
+    dynamic var longCol: Int64 = 0
 }
 
 class SwiftObject: RLMObject {
-    @objc dynamic var boolCol = false
-    @objc dynamic var intCol = 123
-    @objc dynamic var floatCol = 1.23 as Float
-    @objc dynamic var doubleCol = 12.3
-    @objc dynamic var stringCol = "a"
-    @objc dynamic var binaryCol = "a".data(using: String.Encoding.utf8)
-    @objc dynamic var dateCol = Date(timeIntervalSince1970: 1)
-    @objc dynamic var objectCol = SwiftBoolObject()
-    @objc dynamic var arrayCol = RLMArray<SwiftBoolObject>(objectClassName: SwiftBoolObject.className())
+    dynamic var boolCol = false
+    dynamic var intCol = 123
+    dynamic var floatCol = 1.23 as Float
+    dynamic var doubleCol = 12.3
+    dynamic var stringCol = "a"
+    dynamic var binaryCol = "a".data(using: String.Encoding.utf8)
+    dynamic var dateCol = Date(timeIntervalSince1970: 1)
+    dynamic var objectCol = SwiftBoolObject()
+    dynamic var arrayCol = RLMArray<SwiftBoolObject>(objectClassName: SwiftBoolObject.className())
 }
 
 class SwiftOptionalObject: RLMObject {
-    @objc dynamic var optStringCol: String?
-    @objc dynamic var optNSStringCol: NSString?
-    @objc dynamic var optBinaryCol: Data?
-    @objc dynamic var optDateCol: Date?
-    @objc dynamic var optObjectCol: SwiftBoolObject?
+    dynamic var optStringCol: String?
+    dynamic var optNSStringCol: NSString?
+    dynamic var optBinaryCol: Data?
+    dynamic var optDateCol: Date?
+    dynamic var optObjectCol: SwiftBoolObject?
 }
 
 class SwiftDogObject: RLMObject {
-    @objc dynamic var dogName = ""
+    dynamic var dogName = ""
 }
 
 class SwiftOwnerObject: RLMObject {
-    @objc dynamic var name = ""
-    @objc dynamic var dog: SwiftDogObject? = SwiftDogObject()
+    dynamic var name = ""
+    dynamic var dog: SwiftDogObject? = SwiftDogObject()
 }
 
 class SwiftAggregateObject: RLMObject {
-    @objc dynamic var intCol = 0
-    @objc dynamic var floatCol = 0 as Float
-    @objc dynamic var doubleCol = 0.0
-    @objc dynamic var boolCol = false
-    @objc dynamic var dateCol = Date()
+    dynamic var intCol = 0
+    dynamic var floatCol = 0 as Float
+    dynamic var doubleCol = 0.0
+    dynamic var boolCol = false
+    dynamic var dateCol = Date()
 }
 
 class SwiftAllIntSizesObject: RLMObject {
-    @objc dynamic var int8  : Int8  = 0
-    @objc dynamic var int16 : Int16 = 0
-    @objc dynamic var int32 : Int32 = 0
-    @objc dynamic var int64 : Int64 = 0
+    dynamic var int8  : Int8  = 0
+    dynamic var int16 : Int16 = 0
+    dynamic var int32 : Int32 = 0
+    dynamic var int64 : Int64 = 0
 }
 
 class SwiftEmployeeObject: RLMObject {
-    @objc dynamic var name = ""
-    @objc dynamic var age = 0
-    @objc dynamic var hired = false
+    dynamic var name = ""
+    dynamic var age = 0
+    dynamic var hired = false
 }
 
 class SwiftCompanyObject: RLMObject {
-    @objc dynamic var employees = RLMArray<SwiftEmployeeObject>(objectClassName: SwiftEmployeeObject.className())
+    dynamic var employees = RLMArray<SwiftEmployeeObject>(objectClassName: SwiftEmployeeObject.className())
 }
 
 class SwiftArrayPropertyObject: RLMObject {
-    @objc dynamic var name = ""
-    @objc dynamic var array = RLMArray<SwiftStringObject>(objectClassName: SwiftStringObject.className())
-    @objc dynamic var intArray = RLMArray<SwiftIntObject>(objectClassName: SwiftIntObject.className())
+    dynamic var name = ""
+    dynamic var array = RLMArray<SwiftStringObject>(objectClassName: SwiftStringObject.className())
+    dynamic var intArray = RLMArray<SwiftIntObject>(objectClassName: SwiftIntObject.className())
 }
 
 class SwiftDynamicObject: RLMObject {
-    @objc dynamic var stringCol = "a"
-    @objc dynamic var intCol = 0
+    dynamic var stringCol = "a"
+    dynamic var intCol = 0
 }
 
 class SwiftUTF8Object: RLMObject {
-    @objc dynamic var 柱колоéнǢкƱаم👍 = "值значен™👍☞⎠‱௹♣︎☐▼❒∑⨌⧭иеمرحبا"
+    dynamic var 柱колоéнǢкƱаم👍 = "值значен™👍☞⎠‱௹♣︎☐▼❒∑⨌⧭иеمرحبا"
 }
 
 class SwiftIgnoredPropertiesObject: RLMObject {
-    @objc dynamic var name = ""
-    @objc dynamic var age = 0
-    @objc dynamic var runtimeProperty: AnyObject?
-    @objc dynamic var readOnlyProperty: Int { return 0 }
+    dynamic var name = ""
+    dynamic var age = 0
+    dynamic var runtimeProperty: AnyObject?
+    dynamic var readOnlyProperty: Int { return 0 }
 
     override class func ignoredProperties() -> [String]? {
         return ["runtimeProperty"]
@@ -115,8 +115,8 @@ class SwiftIgnoredPropertiesObject: RLMObject {
 }
 
 class SwiftPrimaryStringObject: RLMObject {
-    @objc dynamic var stringCol = ""
-    @objc dynamic var intCol = 0
+    dynamic var stringCol = ""
+    dynamic var intCol = 0
 
     override class func primaryKey() -> String {
         return "stringCol"
@@ -124,13 +124,13 @@ class SwiftPrimaryStringObject: RLMObject {
 }
 
 class SwiftLinkSourceObject: RLMObject {
-    @objc dynamic var id = 0
-    @objc dynamic var link: SwiftLinkTargetObject?
+    dynamic var id = 0
+    dynamic var link: SwiftLinkTargetObject?
 }
 
 class SwiftLinkTargetObject: RLMObject {
-    @objc dynamic var id = 0
-    @objc dynamic var backlinks: RLMLinkingObjects<SwiftLinkSourceObject>?
+    dynamic var id = 0
+    dynamic var backlinks: RLMLinkingObjects<SwiftLinkSourceObject>?
 
     override class func linkingObjectsProperties() -> [String : RLMPropertyDescriptor] {
         return ["backlinks": RLMPropertyDescriptor(with: SwiftLinkSourceObject.self, propertyName: "link")]
@@ -138,18 +138,18 @@ class SwiftLinkTargetObject: RLMObject {
 }
 
 class SwiftLazyVarObject : RLMObject {
-    @objc dynamic lazy var lazyProperty : String = "hello world"
+    dynamic lazy var lazyProperty : String = "hello world"
 }
 
 class SwiftIgnoredLazyVarObject : RLMObject {
-    @objc dynamic var id = 0
-    @objc dynamic lazy var ignoredVar : String = "hello world"
+    dynamic var id = 0
+    dynamic lazy var ignoredVar : String = "hello world"
     override class func ignoredProperties() -> [String] { return ["ignoredVar"] }
 }
 
 class SwiftObjectiveCTypesObject: RLMObject {
-    @objc dynamic var stringCol: NSString?
-    @objc dynamic var dateCol: NSDate?
-    @objc dynamic var dataCol: NSData?
-    @objc dynamic var numCol: NSNumber? = 0
+    dynamic var stringCol: NSString?
+    dynamic var dateCol: NSDate?
+    dynamic var dataCol: NSData?
+    dynamic var numCol: NSNumber? = 0
 }

--- a/RealmSwift/Object.swift
+++ b/RealmSwift/Object.swift
@@ -28,8 +28,8 @@ import Realm.Private
 
  ```swift
  class Dog: Object {
-     @objc dynamic var name: String = ""
-     @objc dynamic var adopted: Bool = false
+     dynamic var name: String = ""
+     dynamic var adopted: Bool = false
      let siblings = List<Dog>()
  }
  ```
@@ -53,7 +53,7 @@ import Realm.Private
  number, use `RealmOptional<Int>`, `RealmOptional<Float>`, `RealmOptional<Double>`, or `RealmOptional<Bool>` instead,
  which wraps an optional numeric value.
 
- All property types except for `List` and `RealmOptional` *must* be declared as `@objc dynamic var`. `List` and
+ All property types except for `List` and `RealmOptional` *must* be declared as `dynamic var`. `List` and
  `RealmOptional` properties must be declared as non-dynamic `let` properties. Swift `lazy` properties are not allowed.
 
  Note that none of the restrictions listed above apply to properties that are configured to be ignored by Realm.

--- a/RealmSwift/Tests/KVOTests.swift
+++ b/RealmSwift/Tests/KVOTests.swift
@@ -26,28 +26,28 @@ func nextPrimaryKey() -> Int {
 }
 
 class KVOObject: Object {
-    @objc dynamic var pk = nextPrimaryKey() // primary key for equality
-    @objc dynamic var ignored: Int = 0
+    dynamic var pk = nextPrimaryKey() // primary key for equality
+    dynamic var ignored: Int = 0
 
-    @objc dynamic var boolCol: Bool = false
-    @objc dynamic var int8Col: Int8 = 1
-    @objc dynamic var int16Col: Int16 = 2
-    @objc dynamic var int32Col: Int32 = 3
-    @objc dynamic var int64Col: Int64 = 4
-    @objc dynamic var floatCol: Float = 5
-    @objc dynamic var doubleCol: Double = 6
-    @objc dynamic var stringCol: String = ""
-    @objc dynamic var binaryCol: Data = Data()
-    @objc dynamic var dateCol: Date = Date(timeIntervalSince1970: 0)
-    @objc dynamic var objectCol: KVOObject?
+    dynamic var boolCol: Bool = false
+    dynamic var int8Col: Int8 = 1
+    dynamic var int16Col: Int16 = 2
+    dynamic var int32Col: Int32 = 3
+    dynamic var int64Col: Int64 = 4
+    dynamic var floatCol: Float = 5
+    dynamic var doubleCol: Double = 6
+    dynamic var stringCol: String = ""
+    dynamic var binaryCol: Data = Data()
+    dynamic var dateCol: Date = Date(timeIntervalSince1970: 0)
+    dynamic var objectCol: KVOObject?
     let arrayCol = List<KVOObject>()
     let optIntCol = RealmOptional<Int>()
     let optFloatCol = RealmOptional<Float>()
     let optDoubleCol = RealmOptional<Double>()
     let optBoolCol = RealmOptional<Bool>()
-    @objc dynamic var optStringCol: String?
-    @objc dynamic var optBinaryCol: Data?
-    @objc dynamic var optDateCol: Date?
+    dynamic var optStringCol: String?
+    dynamic var optBinaryCol: Data?
+    dynamic var optDateCol: Date?
 
     override class func primaryKey() -> String { return "pk" }
     override class func ignoredProperties() -> [String] { return ["ignored"] }

--- a/RealmSwift/Tests/ObjectSchemaInitializationTests.swift
+++ b/RealmSwift/Tests/ObjectSchemaInitializationTests.swift
@@ -206,7 +206,13 @@ class ObjectSchemaInitializationTests: TestCase {
     }
 }
 
-class SwiftFakeObject: NSObject {
+#if swift(>=3.2)
+@objcMembers class SwiftFakeObject: NSObject {}
+#else
+class SwiftFakeObject: NSObject {}
+#endif
+
+extension SwiftFakeObject {
     @objc class func objectUtilClass(_ isSwift: Bool) -> AnyClass { return ObjectUtil.self }
     @objc class func primaryKey() -> String? { return nil }
     @objc class func ignoredProperties() -> [String] { return [] }
@@ -215,19 +221,19 @@ class SwiftFakeObject: NSObject {
 }
 
 class SwiftObjectWithNSURL: SwiftFakeObject {
-    @objc dynamic var url = NSURL(string: "http://realm.io")!
+    dynamic var url = NSURL(string: "http://realm.io")!
 }
 
 class SwiftObjectWithAnyObject: SwiftFakeObject {
-    @objc dynamic var anyObject: AnyObject = NSObject()
+    dynamic var anyObject: AnyObject = NSObject()
 }
 
 class SwiftObjectWithStringArray: SwiftFakeObject {
-    @objc dynamic var stringArray = [String]()
+    dynamic var stringArray = [String]()
 }
 
 class SwiftObjectWithOptionalStringArray: SwiftFakeObject {
-    @objc dynamic var stringArray: [String]?
+    dynamic var stringArray: [String]?
 }
 
 enum SwiftEnum {
@@ -244,7 +250,7 @@ class SwiftObjectWithStruct: SwiftFakeObject {
 }
 
 class SwiftObjectWithDatePrimaryKey: SwiftFakeObject {
-    @objc dynamic var date = Date()
+    dynamic var date = Date()
 
     override class func primaryKey() -> String? {
         return "date"
@@ -252,25 +258,25 @@ class SwiftObjectWithDatePrimaryKey: SwiftFakeObject {
 }
 
 class SwiftObjectWithNSNumber: SwiftFakeObject {
-    @objc dynamic var number = NSNumber()
+    dynamic var number = NSNumber()
 }
 
 class SwiftObjectWithOptionalNSNumber: SwiftFakeObject {
-    @objc dynamic var number: NSNumber? = NSNumber()
+    dynamic var number: NSNumber? = NSNumber()
 }
 
 class SwiftFakeObjectSubclass: SwiftFakeObject {
-    @objc dynamic var dateCol = Date()
+    dynamic var dateCol = Date()
 }
 
 class SwiftObjectWithUnindexibleProperties: SwiftFakeObject {
-    @objc dynamic var boolCol = false
-    @objc dynamic var intCol = 123
-    @objc dynamic var floatCol = 1.23 as Float
-    @objc dynamic var doubleCol = 12.3
-    @objc dynamic var binaryCol = "a".data(using: String.Encoding.utf8)!
-    @objc dynamic var dateCol = Date(timeIntervalSince1970: 1)
-    @objc dynamic var objectCol: SwiftBoolObject? = SwiftBoolObject()
+    dynamic var boolCol = false
+    dynamic var intCol = 123
+    dynamic var floatCol = 1.23 as Float
+    dynamic var doubleCol = 12.3
+    dynamic var binaryCol = "a".data(using: String.Encoding.utf8)!
+    dynamic var dateCol = Date(timeIntervalSince1970: 1)
+    dynamic var objectCol: SwiftBoolObject? = SwiftBoolObject()
     let arrayCol = List<SwiftBoolObject>()
 
     dynamic override class func indexedProperties() -> [String] {
@@ -280,11 +286,11 @@ class SwiftObjectWithUnindexibleProperties: SwiftFakeObject {
 
 // swiftlint:disable:next type_name
 class SwiftObjectWithNonNullableOptionalProperties: SwiftFakeObject {
-    @objc dynamic var optDateCol: Date?
+    dynamic var optDateCol: Date?
 }
 
 class SwiftObjectWithNonOptionalLinkProperty: SwiftFakeObject {
-    @objc dynamic var objectCol = SwiftBoolObject()
+    dynamic var objectCol = SwiftBoolObject()
 }
 
 extension Set: RealmOptionalType { }
@@ -294,5 +300,5 @@ class SwiftObjectWithNonRealmOptionalType: SwiftFakeObject {
 }
 
 class SwiftObjectWithBadPropertyName: SwiftFakeObject {
-    @objc dynamic var newValue = false
+    dynamic var newValue = false
 }

--- a/RealmSwift/Tests/ObjectTests.swift
+++ b/RealmSwift/Tests/ObjectTests.swift
@@ -26,12 +26,12 @@ private func nextDynamicDefaultSeed() -> Int {
     return dynamicDefaultSeed
 }
 class DynamicDefaultObject: Object {
-    @objc dynamic var intCol = nextDynamicDefaultSeed()
-    @objc dynamic var floatCol = Float(nextDynamicDefaultSeed())
-    @objc dynamic var doubleCol = Double(nextDynamicDefaultSeed())
-    @objc dynamic var dateCol = Date(timeIntervalSinceReferenceDate: TimeInterval(nextDynamicDefaultSeed()))
-    @objc dynamic var stringCol = UUID().uuidString
-    @objc dynamic var binaryCol = UUID().uuidString.data(using: .utf8)
+    dynamic var intCol = nextDynamicDefaultSeed()
+    dynamic var floatCol = Float(nextDynamicDefaultSeed())
+    dynamic var doubleCol = Double(nextDynamicDefaultSeed())
+    dynamic var dateCol = Date(timeIntervalSinceReferenceDate: TimeInterval(nextDynamicDefaultSeed()))
+    dynamic var stringCol = UUID().uuidString
+    dynamic var binaryCol = UUID().uuidString.data(using: .utf8)
 
     override static func primaryKey() -> String? {
         return "intCol"

--- a/RealmSwift/Tests/RealmCollectionTypeTests.swift
+++ b/RealmSwift/Tests/RealmCollectionTypeTests.swift
@@ -20,18 +20,18 @@ import XCTest
 import RealmSwift
 
 class CTTAggregateObject: Object {
-    @objc dynamic var intCol = 0
-    @objc dynamic var int8Col = 0
-    @objc dynamic var int16Col = 0
-    @objc dynamic var int32Col = 0
-    @objc dynamic var int64Col = 0
-    @objc dynamic var floatCol = 0 as Float
-    @objc dynamic var doubleCol = 0.0
-    @objc dynamic var boolCol = false
-    @objc dynamic var dateCol = Date()
-    @objc dynamic var trueCol = true
+    dynamic var intCol = 0
+    dynamic var int8Col = 0
+    dynamic var int16Col = 0
+    dynamic var int32Col = 0
+    dynamic var int64Col = 0
+    dynamic var floatCol = 0 as Float
+    dynamic var doubleCol = 0.0
+    dynamic var boolCol = false
+    dynamic var dateCol = Date()
+    dynamic var trueCol = true
     let stringListCol = List<CTTStringObjectWithLink>()
-    @objc dynamic var linkCol: CTTLinkTarget?
+    dynamic var linkCol: CTTLinkTarget?
 }
 
 class CTTAggregateObjectList: Object {
@@ -39,12 +39,12 @@ class CTTAggregateObjectList: Object {
 }
 
 class CTTStringObjectWithLink: Object {
-    @objc dynamic var stringCol = ""
-    @objc dynamic var linkCol: CTTLinkTarget?
+    dynamic var stringCol = ""
+    dynamic var linkCol: CTTLinkTarget?
 }
 
 class CTTLinkTarget: Object {
-    @objc dynamic var id = 0
+    dynamic var id = 0
     let stringObjects = LinkingObjects(fromType: CTTStringObjectWithLink.self, property: "linkCol")
     let aggregateObjects = LinkingObjects(fromType: CTTAggregateObject.self, property: "linkCol")
 }

--- a/RealmSwift/Tests/SwiftTestObjects.swift
+++ b/RealmSwift/Tests/SwiftTestObjects.swift
@@ -21,30 +21,30 @@ import RealmSwift
 import Realm
 
 class SwiftStringObject: Object {
-    @objc dynamic var stringCol = ""
+    dynamic var stringCol = ""
 }
 
 class SwiftBoolObject: Object {
-    @objc dynamic var boolCol = false
+    dynamic var boolCol = false
 }
 
 class SwiftIntObject: Object {
-    @objc dynamic var intCol = 0
+    dynamic var intCol = 0
 }
 
 class SwiftLongObject: Object {
-    @objc dynamic var longCol: Int64 = 0
+    dynamic var longCol: Int64 = 0
 }
 
 class SwiftObject: Object {
-    @objc dynamic var boolCol = false
-    @objc dynamic var intCol = 123
-    @objc dynamic var floatCol = 1.23 as Float
-    @objc dynamic var doubleCol = 12.3
-    @objc dynamic var stringCol = "a"
-    @objc dynamic var binaryCol = "a".data(using: String.Encoding.utf8)!
-    @objc dynamic var dateCol = Date(timeIntervalSince1970: 1)
-    @objc dynamic var objectCol: SwiftBoolObject? = SwiftBoolObject()
+    dynamic var boolCol = false
+    dynamic var intCol = 123
+    dynamic var floatCol = 1.23 as Float
+    dynamic var doubleCol = 12.3
+    dynamic var stringCol = "a"
+    dynamic var binaryCol = "a".data(using: String.Encoding.utf8)!
+    dynamic var dateCol = Date(timeIntervalSince1970: 1)
+    dynamic var objectCol: SwiftBoolObject? = SwiftBoolObject()
     let arrayCol = List<SwiftBoolObject>()
 
     class func defaultValues() -> [String: Any] {
@@ -63,10 +63,10 @@ class SwiftObject: Object {
 }
 
 class SwiftOptionalObject: Object {
-    @objc dynamic var optNSStringCol: NSString?
-    @objc dynamic var optStringCol: String?
-    @objc dynamic var optBinaryCol: Data?
-    @objc dynamic var optDateCol: Date?
+    dynamic var optNSStringCol: NSString?
+    dynamic var optStringCol: String?
+    dynamic var optBinaryCol: Data?
+    dynamic var optDateCol: Date?
     let optIntCol = RealmOptional<Int>()
     let optInt8Col = RealmOptional<Int8>()
     let optInt16Col = RealmOptional<Int16>()
@@ -75,7 +75,7 @@ class SwiftOptionalObject: Object {
     let optFloatCol = RealmOptional<Float>()
     let optDoubleCol = RealmOptional<Double>()
     let optBoolCol = RealmOptional<Bool>()
-    @objc dynamic var optObjectCol: SwiftBoolObject?
+    dynamic var optObjectCol: SwiftBoolObject?
 }
 
 class SwiftOptionalPrimaryObject: SwiftOptionalObject {
@@ -85,18 +85,18 @@ class SwiftOptionalPrimaryObject: SwiftOptionalObject {
 }
 
 class SwiftImplicitlyUnwrappedOptionalObject: Object {
-    @objc dynamic var optNSStringCol: NSString!
-    @objc dynamic var optStringCol: String!
-    @objc dynamic var optBinaryCol: Data!
-    @objc dynamic var optDateCol: Date!
-    @objc dynamic var optObjectCol: SwiftBoolObject!
+    dynamic var optNSStringCol: NSString!
+    dynamic var optStringCol: String!
+    dynamic var optBinaryCol: Data!
+    dynamic var optDateCol: Date!
+    dynamic var optObjectCol: SwiftBoolObject!
 }
 
 class SwiftOptionalDefaultValuesObject: Object {
-    @objc dynamic var optNSStringCol: NSString? = "A"
-    @objc dynamic var optStringCol: String? = "B"
-    @objc dynamic var optBinaryCol: Data? = "C".data(using: String.Encoding.utf8)! as Data
-    @objc dynamic var optDateCol: Date? = Date(timeIntervalSince1970: 10)
+    dynamic var optNSStringCol: NSString? = "A"
+    dynamic var optStringCol: String? = "B"
+    dynamic var optBinaryCol: Data? = "C".data(using: String.Encoding.utf8)! as Data
+    dynamic var optDateCol: Date? = Date(timeIntervalSince1970: 10)
     let optIntCol = RealmOptional<Int>(1)
     let optInt8Col = RealmOptional<Int8>(1)
     let optInt16Col = RealmOptional<Int16>(1)
@@ -105,7 +105,7 @@ class SwiftOptionalDefaultValuesObject: Object {
     let optFloatCol = RealmOptional<Float>(2.2)
     let optDoubleCol = RealmOptional<Double>(3.3)
     let optBoolCol = RealmOptional<Bool>(true)
-    @objc dynamic var optObjectCol: SwiftBoolObject? = SwiftBoolObject(value: [true])
+    dynamic var optObjectCol: SwiftBoolObject? = SwiftBoolObject(value: [true])
     //    let arrayCol = List<SwiftBoolObject?>()
 
     class func defaultValues() -> [String: Any] {
@@ -127,13 +127,13 @@ class SwiftOptionalDefaultValuesObject: Object {
 }
 
 class SwiftOptionalIgnoredPropertiesObject: Object {
-    @objc dynamic var id = 0
+    dynamic var id = 0
 
-    @objc dynamic var optNSStringCol: NSString? = "A"
-    @objc dynamic var optStringCol: String? = "B"
-    @objc dynamic var optBinaryCol: Data? = "C".data(using: String.Encoding.utf8)! as Data
-    @objc dynamic var optDateCol: Date? = Date(timeIntervalSince1970: 10)
-    @objc dynamic var optObjectCol: SwiftBoolObject? = SwiftBoolObject(value: [true])
+    dynamic var optNSStringCol: NSString? = "A"
+    dynamic var optStringCol: String? = "B"
+    dynamic var optBinaryCol: Data? = "C".data(using: String.Encoding.utf8)! as Data
+    dynamic var optDateCol: Date? = Date(timeIntervalSince1970: 10)
+    dynamic var optObjectCol: SwiftBoolObject? = SwiftBoolObject(value: [true])
 
     override class func ignoredProperties() -> [String] {
         return [
@@ -149,36 +149,36 @@ class SwiftOptionalIgnoredPropertiesObject: Object {
 
 
 class SwiftDogObject: Object {
-    @objc dynamic var dogName = ""
+    dynamic var dogName = ""
     let owners = LinkingObjects(fromType: SwiftOwnerObject.self, property: "dog")
 }
 
 class SwiftOwnerObject: Object {
-    @objc dynamic var name = ""
-    @objc dynamic var dog: SwiftDogObject? = SwiftDogObject()
+    dynamic var name = ""
+    dynamic var dog: SwiftDogObject? = SwiftDogObject()
 }
 
 class SwiftAggregateObject: Object {
-    @objc dynamic var intCol = 0
-    @objc dynamic var floatCol = 0 as Float
-    @objc dynamic var doubleCol = 0.0
-    @objc dynamic var boolCol = false
-    @objc dynamic var dateCol = Date()
-    @objc dynamic var trueCol = true
+    dynamic var intCol = 0
+    dynamic var floatCol = 0 as Float
+    dynamic var doubleCol = 0.0
+    dynamic var boolCol = false
+    dynamic var dateCol = Date()
+    dynamic var trueCol = true
     let stringListCol = List<SwiftStringObject>()
 }
 
 class SwiftAllIntSizesObject: Object {
-    @objc dynamic var int8: Int8  = 0
-    @objc dynamic var int16: Int16 = 0
-    @objc dynamic var int32: Int32 = 0
-    @objc dynamic var int64: Int64 = 0
+    dynamic var int8: Int8  = 0
+    dynamic var int16: Int16 = 0
+    dynamic var int32: Int32 = 0
+    dynamic var int64: Int64 = 0
 }
 
 class SwiftEmployeeObject: Object {
-    @objc dynamic var name = ""
-    @objc dynamic var age = 0
-    @objc dynamic var hired = false
+    dynamic var name = ""
+    dynamic var age = 0
+    dynamic var hired = false
 }
 
 class SwiftCompanyObject: Object {
@@ -186,7 +186,7 @@ class SwiftCompanyObject: Object {
 }
 
 class SwiftArrayPropertyObject: Object {
-    @objc dynamic var name = ""
+    dynamic var name = ""
     let array = List<SwiftStringObject>()
     let intArray = List<SwiftIntObject>()
 }
@@ -208,8 +208,8 @@ class SwiftArrayPropertySubclassObject: SwiftArrayPropertyObject {
 }
 
 class SwiftLinkToPrimaryStringObject: Object {
-    @objc dynamic var pk = ""
-    @objc dynamic var object: SwiftPrimaryStringObject?
+    dynamic var pk = ""
+    dynamic var object: SwiftPrimaryStringObject?
     let objects = List<SwiftPrimaryStringObject>()
 
     override class func primaryKey() -> String? {
@@ -219,15 +219,15 @@ class SwiftLinkToPrimaryStringObject: Object {
 
 class SwiftUTF8Object: Object {
     // swiftlint:disable:next identifier_name
-    @objc dynamic var 柱колоéнǢкƱаم👍 = "值значен™👍☞⎠‱௹♣︎☐▼❒∑⨌⧭иеمرحبا"
+    dynamic var 柱колоéнǢкƱаم👍 = "值значен™👍☞⎠‱௹♣︎☐▼❒∑⨌⧭иеمرحبا"
 }
 
 class SwiftIgnoredPropertiesObject: Object {
-    @objc dynamic var name = ""
-    @objc dynamic var age = 0
-    @objc dynamic var runtimeProperty: AnyObject?
-    @objc dynamic var runtimeDefaultProperty = "property"
-    @objc dynamic var readOnlyProperty: Int { return 0 }
+    dynamic var name = ""
+    dynamic var age = 0
+    dynamic var runtimeProperty: AnyObject?
+    dynamic var runtimeDefaultProperty = "property"
+    dynamic var readOnlyProperty: Int { return 0 }
 
     override class func ignoredProperties() -> [String] {
         return ["runtimeProperty", "runtimeDefaultProperty"]
@@ -244,8 +244,8 @@ protocol SwiftPrimaryKeyObjectType {
 }
 
 class SwiftPrimaryStringObject: Object, SwiftPrimaryKeyObjectType {
-    @objc dynamic var stringCol = ""
-    @objc dynamic var intCol = 0
+    dynamic var stringCol = ""
+    dynamic var intCol = 0
 
     typealias PrimaryKey = String
     override class func primaryKey() -> String? {
@@ -254,8 +254,8 @@ class SwiftPrimaryStringObject: Object, SwiftPrimaryKeyObjectType {
 }
 
 class SwiftPrimaryOptionalStringObject: Object, SwiftPrimaryKeyObjectType {
-    @objc dynamic var stringCol: String? = ""
-    @objc dynamic var intCol = 0
+    dynamic var stringCol: String? = ""
+    dynamic var intCol = 0
 
     typealias PrimaryKey = String?
     override class func primaryKey() -> String? {
@@ -264,8 +264,8 @@ class SwiftPrimaryOptionalStringObject: Object, SwiftPrimaryKeyObjectType {
 }
 
 class SwiftPrimaryIntObject: Object, SwiftPrimaryKeyObjectType {
-    @objc dynamic var stringCol = ""
-    @objc dynamic var intCol = 0
+    dynamic var stringCol = ""
+    dynamic var intCol = 0
 
     typealias PrimaryKey = Int
     override class func primaryKey() -> String? {
@@ -274,7 +274,7 @@ class SwiftPrimaryIntObject: Object, SwiftPrimaryKeyObjectType {
 }
 
 class SwiftPrimaryOptionalIntObject: Object, SwiftPrimaryKeyObjectType {
-    @objc dynamic var stringCol = ""
+    dynamic var stringCol = ""
     let intCol = RealmOptional<Int>()
 
     typealias PrimaryKey = RealmOptional<Int>
@@ -284,8 +284,8 @@ class SwiftPrimaryOptionalIntObject: Object, SwiftPrimaryKeyObjectType {
 }
 
 class SwiftPrimaryInt8Object: Object, SwiftPrimaryKeyObjectType {
-    @objc dynamic var stringCol = ""
-    @objc dynamic var int8Col: Int8 = 0
+    dynamic var stringCol = ""
+    dynamic var int8Col: Int8 = 0
 
     typealias PrimaryKey = Int8
     override class func primaryKey() -> String? {
@@ -294,7 +294,7 @@ class SwiftPrimaryInt8Object: Object, SwiftPrimaryKeyObjectType {
 }
 
 class SwiftPrimaryOptionalInt8Object: Object, SwiftPrimaryKeyObjectType {
-    @objc dynamic var stringCol = ""
+    dynamic var stringCol = ""
     let int8Col = RealmOptional<Int8>()
 
     typealias PrimaryKey = RealmOptional<Int8>
@@ -304,8 +304,8 @@ class SwiftPrimaryOptionalInt8Object: Object, SwiftPrimaryKeyObjectType {
 }
 
 class SwiftPrimaryInt16Object: Object, SwiftPrimaryKeyObjectType {
-    @objc dynamic var stringCol = ""
-    @objc dynamic var int16Col: Int16 = 0
+    dynamic var stringCol = ""
+    dynamic var int16Col: Int16 = 0
 
     typealias PrimaryKey = Int16
     override class func primaryKey() -> String? {
@@ -314,7 +314,7 @@ class SwiftPrimaryInt16Object: Object, SwiftPrimaryKeyObjectType {
 }
 
 class SwiftPrimaryOptionalInt16Object: Object, SwiftPrimaryKeyObjectType {
-    @objc dynamic var stringCol = ""
+    dynamic var stringCol = ""
     let int16Col = RealmOptional<Int16>()
 
     typealias PrimaryKey = RealmOptional<Int16>
@@ -324,8 +324,8 @@ class SwiftPrimaryOptionalInt16Object: Object, SwiftPrimaryKeyObjectType {
 }
 
 class SwiftPrimaryInt32Object: Object, SwiftPrimaryKeyObjectType {
-    @objc dynamic var stringCol = ""
-    @objc dynamic var int32Col: Int32 = 0
+    dynamic var stringCol = ""
+    dynamic var int32Col: Int32 = 0
 
     typealias PrimaryKey = Int32
     override class func primaryKey() -> String? {
@@ -334,7 +334,7 @@ class SwiftPrimaryInt32Object: Object, SwiftPrimaryKeyObjectType {
 }
 
 class SwiftPrimaryOptionalInt32Object: Object, SwiftPrimaryKeyObjectType {
-    @objc dynamic var stringCol = ""
+    dynamic var stringCol = ""
     let int32Col = RealmOptional<Int32>()
 
     typealias PrimaryKey = RealmOptional<Int32>
@@ -344,8 +344,8 @@ class SwiftPrimaryOptionalInt32Object: Object, SwiftPrimaryKeyObjectType {
 }
 
 class SwiftPrimaryInt64Object: Object, SwiftPrimaryKeyObjectType {
-    @objc dynamic var stringCol = ""
-    @objc dynamic var int64Col: Int64 = 0
+    dynamic var stringCol = ""
+    dynamic var int64Col: Int64 = 0
 
     typealias PrimaryKey = Int64
     override class func primaryKey() -> String? {
@@ -354,7 +354,7 @@ class SwiftPrimaryInt64Object: Object, SwiftPrimaryKeyObjectType {
 }
 
 class SwiftPrimaryOptionalInt64Object: Object, SwiftPrimaryKeyObjectType {
-    @objc dynamic var stringCol = ""
+    dynamic var stringCol = ""
     let int64Col = RealmOptional<Int64>()
 
     typealias PrimaryKey = RealmOptional<Int64>
@@ -364,18 +364,18 @@ class SwiftPrimaryOptionalInt64Object: Object, SwiftPrimaryKeyObjectType {
 }
 
 class SwiftIndexedPropertiesObject: Object {
-    @objc dynamic var stringCol = ""
-    @objc dynamic var intCol = 0
-    @objc dynamic var int8Col: Int8 = 0
-    @objc dynamic var int16Col: Int16 = 0
-    @objc dynamic var int32Col: Int32 = 0
-    @objc dynamic var int64Col: Int64 = 0
-    @objc dynamic var boolCol = false
-    @objc dynamic var dateCol = Date()
+    dynamic var stringCol = ""
+    dynamic var intCol = 0
+    dynamic var int8Col: Int8 = 0
+    dynamic var int16Col: Int16 = 0
+    dynamic var int32Col: Int32 = 0
+    dynamic var int64Col: Int64 = 0
+    dynamic var boolCol = false
+    dynamic var dateCol = Date()
 
-    @objc dynamic var floatCol: Float = 0.0
-    @objc dynamic var doubleCol: Double = 0.0
-    @objc dynamic var dataCol = Data()
+    dynamic var floatCol: Float = 0.0
+    dynamic var doubleCol: Double = 0.0
+    dynamic var dataCol = Data()
 
     override class func indexedProperties() -> [String] {
         return ["stringCol", "intCol", "int8Col", "int16Col", "int32Col", "int64Col", "boolCol", "dateCol"]
@@ -383,18 +383,18 @@ class SwiftIndexedPropertiesObject: Object {
 }
 
 class SwiftIndexedOptionalPropertiesObject: Object {
-    @objc dynamic var optionalStringCol: String? = ""
+    dynamic var optionalStringCol: String? = ""
     let optionalIntCol = RealmOptional<Int>()
     let optionalInt8Col = RealmOptional<Int8>()
     let optionalInt16Col = RealmOptional<Int16>()
     let optionalInt32Col = RealmOptional<Int32>()
     let optionalInt64Col = RealmOptional<Int64>()
     let optionalBoolCol = RealmOptional<Bool>()
-    @objc dynamic var optionalDateCol: Date? = Date()
+    dynamic var optionalDateCol: Date? = Date()
 
     let optionalFloatCol = RealmOptional<Float>()
     let optionalDoubleCol = RealmOptional<Double>()
-    @objc dynamic var optionalDataCol: Data? = Data()
+    dynamic var optionalDataCol: Data? = Data()
 
     override class func indexedProperties() -> [String] {
         return ["optionalStringCol", "optionalIntCol", "optionalInt8Col", "optionalInt16Col",
@@ -403,7 +403,7 @@ class SwiftIndexedOptionalPropertiesObject: Object {
 }
 
 class SwiftCustomInitializerObject: Object {
-    @objc dynamic var stringCol: String
+    dynamic var stringCol: String
 
     init(stringVal: String) {
         stringCol = stringVal
@@ -427,7 +427,7 @@ class SwiftCustomInitializerObject: Object {
 }
 
 class SwiftConvenienceInitializerObject: Object {
-    @objc dynamic var stringCol = ""
+    dynamic var stringCol = ""
 
     convenience init(stringCol: String) {
         self.init()
@@ -436,23 +436,23 @@ class SwiftConvenienceInitializerObject: Object {
 }
 
 class SwiftObjectiveCTypesObject: Object {
-    @objc dynamic var stringCol: NSString?
-    @objc dynamic var dateCol: NSDate?
-    @objc dynamic var dataCol: NSData?
-    @objc dynamic var numCol: NSNumber? = 0
+    dynamic var stringCol: NSString?
+    dynamic var dateCol: NSDate?
+    dynamic var dataCol: NSData?
+    dynamic var numCol: NSNumber? = 0
 }
 
 @objc(SwiftObjcRenamedObject)
 class SwiftObjcRenamedObject: Object {
-    @objc dynamic var stringCol = ""
+    dynamic var stringCol = ""
 }
 
 @objc(SwiftObjcRenamedObjectWithTotallyDifferentName)
 class SwiftObjcArbitrarilyRenamedObject: Object {
-    @objc dynamic var boolCol = false
+    dynamic var boolCol = false
 }
 
 class SwiftCircleObject: Object {
-    @objc dynamic var obj: SwiftCircleObject?
+    dynamic var obj: SwiftCircleObject?
     let array = List<SwiftCircleObject>()
 }

--- a/examples/ios/swift-3.0/Backlink/AppDelegate.swift
+++ b/examples/ios/swift-3.0/Backlink/AppDelegate.swift
@@ -21,14 +21,14 @@ import RealmSwift
 
 
 class Dog: Object {
-    @objc dynamic var name = ""
-    @objc dynamic var age = 0
+    dynamic var name = ""
+    dynamic var age = 0
     // Define "owners" as the inverse relationship to Person.dogs
     let owners = LinkingObjects(fromType: Person.self, property: "dogs")
 }
 
 class Person: Object {
-    @objc dynamic var name = ""
+    dynamic var name = ""
     let dogs = List<Dog>()
 }
 

--- a/examples/ios/swift-3.0/Encryption/ViewController.swift
+++ b/examples/ios/swift-3.0/Encryption/ViewController.swift
@@ -23,7 +23,7 @@ import UIKit
 
 // Model definition
 class EncryptionObject: Object {
-    @objc dynamic var stringProp = ""
+    dynamic var stringProp = ""
 }
 
 class ViewController: UIViewController {

--- a/examples/ios/swift-3.0/GroupedTableView/TableViewController.swift
+++ b/examples/ios/swift-3.0/GroupedTableView/TableViewController.swift
@@ -20,9 +20,9 @@ import UIKit
 import RealmSwift
 
 class DemoObject: Object {
-    @objc dynamic var title = ""
-    @objc dynamic var date = NSDate()
-    @objc dynamic var sectionTitle = ""
+    dynamic var title = ""
+    dynamic var date = NSDate()
+    dynamic var sectionTitle = ""
 }
 
 class Cell: UITableViewCell {

--- a/examples/ios/swift-3.0/Migration/AppDelegate.swift
+++ b/examples/ios/swift-3.0/Migration/AppDelegate.swift
@@ -22,28 +22,28 @@ import RealmSwift
 // Old data models
 /* V0
 class Person: Object {
-    @objc dynamic var firstName = ""
-    @objc dynamic var lastName = ""
-    @objc dynamic var age = 0
+    dynamic var firstName = ""
+    dynamic var lastName = ""
+    dynamic var age = 0
 }
 */
 
 /* V1
 class Person: Object {
-    @objc dynamic var fullName = ""        // combine firstName and lastName into single field
-    @objc dynamic var age = 0
+    dynamic var fullName = ""        // combine firstName and lastName into single field
+    dynamic var age = 0
 }
 */
 
 /* V2 */
 class Pet: Object {
-    @objc dynamic var name = ""
-    @objc dynamic var type = ""
+    dynamic var name = ""
+    dynamic var type = ""
 }
 
 class Person: Object {
-    @objc dynamic var fullName = ""
-    @objc dynamic var age = 0
+    dynamic var fullName = ""
+    dynamic var age = 0
     let pets = List<Pet>() // Add pets field
 }
 

--- a/examples/ios/swift-3.0/Simple/AppDelegate.swift
+++ b/examples/ios/swift-3.0/Simple/AppDelegate.swift
@@ -20,12 +20,12 @@ import UIKit
 import RealmSwift
 
 class Dog: Object {
-    @objc dynamic var name = ""
-    @objc dynamic var age = 0
+    dynamic var name = ""
+    dynamic var age = 0
 }
 
 class Person: Object {
-    @objc dynamic var name = ""
+    dynamic var name = ""
     let dogs = List<Dog>()
 }
 

--- a/examples/ios/swift-3.0/TableView/TableViewController.swift
+++ b/examples/ios/swift-3.0/TableView/TableViewController.swift
@@ -20,8 +20,8 @@ import UIKit
 import RealmSwift
 
 class DemoObject: Object {
-    @objc dynamic var title = ""
-    @objc dynamic var date = NSDate()
+    dynamic var title = ""
+    dynamic var date = NSDate()
 }
 
 class Cell: UITableViewCell {

--- a/examples/tvos/swift-3.0/DownloadCache/Repository.swift
+++ b/examples/tvos/swift-3.0/DownloadCache/Repository.swift
@@ -20,9 +20,9 @@ import UIKit
 import RealmSwift
 
 class Repository: Object {
-    @objc dynamic var identifier = ""
-    @objc dynamic var name: String?
-    @objc dynamic var avatarURL: String?
+    dynamic var identifier = ""
+    dynamic var name: String?
+    dynamic var avatarURL: String?
 
     override static func primaryKey() -> String? {
         return "identifier"

--- a/examples/tvos/swift-3.0/PreloadedData/Place.swift
+++ b/examples/tvos/swift-3.0/PreloadedData/Place.swift
@@ -20,11 +20,11 @@ import UIKit
 import RealmSwift
 
 class Place: Object {
-    @objc dynamic var postalCode: String?
-    @objc dynamic var placeName: String?
-    @objc dynamic var state: String?
-    @objc dynamic var stateAbbreviation: String?
-    @objc dynamic var county: String?
-    @objc dynamic var latitude = 0.0
-    @objc dynamic var longitude = 0.0
+    dynamic var postalCode: String?
+    dynamic var placeName: String?
+    dynamic var state: String?
+    dynamic var stateAbbreviation: String?
+    dynamic var county: String?
+    dynamic var latitude = 0.0
+    dynamic var longitude = 0.0
 }


### PR DESCRIPTION
which will allow Swift 3.x syntax RLMObject/Object subclasses to continue working in Swift 4.x (i.e. without marking `dynamic` properties as also being `@objc`).

Depends on #5218.