### PR TITLE
Fix the biggest shellcheck issues

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 ##################################################################################
 # Custom build tool for Realm Objective-C binding.
@@ -411,7 +411,7 @@ case "$COMMAND" in
     # Clean
     ######################################
     "clean")
-        find . -type d -name build -exec rm -r "{}" +\;
+        find . -type d -name build -exec rm -r "{}" +
         exit 0
         ;;
 
@@ -967,7 +967,7 @@ case "$COMMAND" in
         archs="$(lipo -info "$BINARY" | rev | cut -d ':' -f1 | rev)"
 
         archs_array=( $archs )
-        if [[ ${#archs_array[@]} < 2 ]]; then
+        if [[ ${#archs_array[@]} -lt 2 ]]; then
             exit 1 # Early exit if not a fat binary
         fi
 
@@ -1413,7 +1413,7 @@ EOF
         ;;
 
     "add-empty-changelog")
-        empty_section=$(cat <<EOS
+        read -r -d '' empty_section << EOS
 x.x.x Release notes (yyyy-MM-dd)
 =============================================================
 
@@ -1428,7 +1428,7 @@ x.x.x Release notes (yyyy-MM-dd)
 ### Bugfixes
 
 * None.
-EOS)
+EOS
         changelog=$(cat CHANGELOG.md)
         echo "$empty_section" > CHANGELOG.md
         echo >> CHANGELOG.md


### PR DESCRIPTION
* so many `bash` specific features are being used that I see no point in keeping using `/bin/sh` as a shebang
* in `find -exec` either `+` or `\;` should be used
* `<` should only be used to compare strings. When comparing numbers `-lt` is needed.
* Using a subshell to assign a multiline string to a variable is considered bad practice and was breaking the shellcheck parser.

There are still more than a hundred medium and minor issues found, but I thought it would be nice to at least fix the biggest offenders.