### PR TITLE
Specify Realm type using an enum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,9 @@ x.x.x Release notes (yyyy-MM-dd)
   properties after generic Realm properties (like `List<T>`), the schema
   would be constructed incorrectly. Fixes an issue where creating such
   models from an array could fail.
+* `Realm.Configuration` is now constructed using a `Realm.Kind` enum case,
+  rather than a separate file URL, in-memory identifier, or sync configuration
+  value.
 
 ### Enhancements
 

--- a/Realm/ObjectServerTests/SwiftObjectServerTests.swift
+++ b/Realm/ObjectServerTests/SwiftObjectServerTests.swift
@@ -240,7 +240,7 @@ class SwiftObjectServerTests: SwiftSyncTestCase {
                 // Wait for the child process to upload everything.
                 executeChild()
                 let ex = expectation(description: "download-realm")
-                let config = Realm.Configuration(syncConfiguration: SyncConfiguration(user: user, realmURL: realmURL))
+                let config = Realm.Configuration(kind: .synced(SyncConfiguration(user: user, realmURL: realmURL)))
                 let pathOnDisk = ObjectiveCSupport.convert(object: config).pathOnDisk
                 XCTAssertFalse(FileManager.default.fileExists(atPath: pathOnDisk))
                 Realm.asyncOpen(configuration: config) { realm, error in

--- a/Realm/ObjectServerTests/SwiftSyncTestCase.swift
+++ b/Realm/ObjectServerTests/SwiftSyncTestCase.swift
@@ -78,7 +78,7 @@ class SwiftSyncTestCase: RLMSyncTestCase {
             semaphore.signal()
         }
         SyncManager.shared.setSessionCompletionNotifier(basicBlock)
-        let config = Realm.Configuration(syncConfiguration: SyncConfiguration(user: user, realmURL: url))
+        let config = Realm.Configuration(kind: .synced(SyncConfiguration(user: user, realmURL: url)))
         let realm = try Realm(configuration: config)
         // FIXME: Perhaps we should have a reasonable timeout here, instead of allowing bad code to stall forever.
         _ = semaphore.wait(timeout: .distantFuture)
@@ -86,7 +86,7 @@ class SwiftSyncTestCase: RLMSyncTestCase {
     }
 
     func immediatelyOpenRealm(url: URL, user: SyncUser) throws -> Realm {
-        return try Realm(configuration: Realm.Configuration(syncConfiguration: SyncConfiguration(user: user, realmURL: url)))
+        return try Realm(configuration: Realm.Configuration(kind: .synced(SyncConfiguration(user: user, realmURL: url))))
     }
 
     func synchronouslyLogInUser(for credentials: SyncCredentials,

--- a/RealmSwift/Realm.swift
+++ b/RealmSwift/Realm.swift
@@ -89,7 +89,7 @@ public final class Realm {
      */
     public convenience init(fileURL: URL) throws {
         var configuration = Configuration.defaultConfiguration
-        configuration.fileURL = fileURL
+        configuration.kind = .file(fileURL)
         try self.init(configuration: configuration)
     }
 

--- a/RealmSwift/Sync.swift
+++ b/RealmSwift/Sync.swift
@@ -181,7 +181,7 @@ public typealias Provider = RLMIdentityProvider
  A `SyncConfiguration` represents configuration parameters for Realms intended to sync with
  a Realm Object Server.
  */
-public struct SyncConfiguration {
+public struct SyncConfiguration: Equatable {
     /// The `SyncUser` who owns the Realm that this configuration should open.
     public let user: SyncUser
 
@@ -237,6 +237,11 @@ public struct SyncConfiguration {
         self.realmURL = realmURL
         self.stopPolicy = .afterChangesUploaded
         self.enableSSLValidation = enableSSLValidation
+    }
+
+    /// :nodoc:
+    public static func == (lhs: SyncConfiguration, rhs: SyncConfiguration) -> Bool {
+        return lhs.realmURL == rhs.realmURL && lhs.user == rhs.user
     }
 }
 

--- a/RealmSwift/Tests/CompactionTests.swift
+++ b/RealmSwift/Tests/CompactionTests.swift
@@ -54,7 +54,7 @@ class CompactionTests: TestCase {
 
     func testSuccessfulCompactOnLaunch() {
         // Configure the Realm to compact on launch
-        let config = Realm.Configuration(fileURL: testRealmURL(),
+        let config = Realm.Configuration(kind: .file(testRealmURL()),
                                          shouldCompactOnLaunch: { totalBytes, usedBytes in
             // Confirm expected sizes
             XCTAssertEqual(totalBytes, expectedTotalBytesBefore)
@@ -67,9 +67,13 @@ class CompactionTests: TestCase {
         })
 
         // Confirm expected sizes before and after opening the Realm
-        XCTAssertEqual(fileSize(path: config.fileURL!.path), expectedTotalBytesBefore)
+        var configPath: String!
+        if case let .file(url) = config.kind {
+            configPath = url.path
+        }
+        XCTAssertEqual(fileSize(path: configPath), expectedTotalBytesBefore)
         let realm = try! Realm(configuration: config)
-        XCTAssertLessThan(fileSize(path: config.fileURL!.path), expectedTotalBytesBefore)
+        XCTAssertLessThan(fileSize(path: configPath), expectedTotalBytesBefore)
 
         // Validate that the file still contains what it should
         XCTAssertEqual(realm.objects(SwiftStringObject.self).count, count + 2)

--- a/RealmSwift/Tests/MigrationTests.swift
+++ b/RealmSwift/Tests/MigrationTests.swift
@@ -58,7 +58,7 @@ class MigrationTests: TestCase {
     private func migrateAndTestRealm(_ fileURL: URL, shouldRun: Bool = true, schemaVersion: UInt64 = 1,
                                      autoMigration: Bool = false, block: MigrationBlock? = nil) {
         var didRun = false
-        let config = Realm.Configuration(fileURL: fileURL, schemaVersion: schemaVersion,
+        let config = Realm.Configuration(kind: .file(fileURL), schemaVersion: schemaVersion,
             migrationBlock: { migration, oldSchemaVersion in
                 if let block = block {
                     block(migration, oldSchemaVersion)
@@ -80,7 +80,7 @@ class MigrationTests: TestCase {
 
     private func migrateAndTestDefaultRealm(_ schemaVersion: UInt64 = 1, block: @escaping MigrationBlock) {
         migrateAndTestRealm(defaultRealmURL(), schemaVersion: schemaVersion, block: block)
-        let config = Realm.Configuration(fileURL: defaultRealmURL(),
+        let config = Realm.Configuration(kind: .file(defaultRealmURL()),
                                          schemaVersion: schemaVersion)
         Realm.Configuration.defaultConfiguration = config
     }
@@ -91,7 +91,7 @@ class MigrationTests: TestCase {
         createAndTestRealmAtURL(defaultRealmURL())
 
         var didRun = false
-        let config = Realm.Configuration(fileURL: defaultRealmURL(), schemaVersion: 1,
+        let config = Realm.Configuration(kind: .file(defaultRealmURL()), schemaVersion: 1,
                                          migrationBlock: { _, _ in didRun = true })
         Realm.Configuration.defaultConfiguration = config
 
@@ -561,7 +561,7 @@ class MigrationTests: TestCase {
             realmWithSingleClassProperties(defaultRealmURL(), className: "SwiftEmployeeObject", properties: [prop])
         }
 
-        let config = Realm.Configuration(fileURL: defaultRealmURL(), objectTypes: [SwiftEmployeeObject.self])
+        let config = Realm.Configuration(kind: .file(defaultRealmURL()), objectTypes: [SwiftEmployeeObject.self])
         autoreleasepool {
             assertFails(.schemaMismatch) {
                 try Realm(configuration: config)
@@ -576,7 +576,7 @@ class MigrationTests: TestCase {
             realmWithSingleClassProperties(defaultRealmURL(), className: "SwiftEmployeeObject", properties: [prop])
         }
 
-        var config = Realm.Configuration(fileURL: defaultRealmURL(), objectTypes: [SwiftEmployeeObject.self])
+        var config = Realm.Configuration(kind: .file(defaultRealmURL()), objectTypes: [SwiftEmployeeObject.self])
         config.migrationBlock = { _, _ in
             XCTFail("Migration block should not be called")
         }
@@ -590,7 +590,7 @@ class MigrationTests: TestCase {
     }
 
     func testDeleteRealmIfMigrationNeeded() {
-        autoreleasepool { _ = try! Realm(configuration: Realm.Configuration(fileURL: defaultRealmURL())) }
+        autoreleasepool { _ = try! Realm(configuration: Realm.Configuration(kind: .file(defaultRealmURL()))) }
 
         let objectSchema = RLMObjectSchema(forObjectClass: SwiftEmployeeObject.self)
         objectSchema.properties = Array(objectSchema.properties[0..<1])
@@ -614,7 +614,7 @@ class MigrationTests: TestCase {
         let migrationBlock: MigrationBlock = { _, _ in
             XCTFail("Migration block should not be called")
         }
-        let config = Realm.Configuration(fileURL: defaultRealmURL(),
+        let config = Realm.Configuration(kind: .file(defaultRealmURL()),
                                          migrationBlock: migrationBlock,
                                          deleteRealmIfMigrationNeeded: true)
 

--- a/RealmSwift/Tests/ObjectiveCSupportTests.swift
+++ b/RealmSwift/Tests/ObjectiveCSupportTests.swift
@@ -67,15 +67,27 @@ class ObjectiveCSupportTests: TestCase {
             return
         }
 
-        XCTAssertEqual(realm.configuration.fileURL,
+        var fileURL: URL!
+        if case let .file(url) = realm.configuration.kind {
+            fileURL = url
+        }
+        XCTAssertEqual(fileURL,
                        ObjectiveCSupport.convert(object: realm.configuration).fileURL,
                        "Configuration.fileURL must be equal to RLMConfiguration.fileURL")
 
-        XCTAssertEqual(realm.configuration.inMemoryIdentifier,
+        var inMemoryIdentifier: String!
+        if case let .inMemory(identifier) = realm.configuration.kind {
+            inMemoryIdentifier = identifier
+        }
+        XCTAssertEqual(inMemoryIdentifier,
                        ObjectiveCSupport.convert(object: realm.configuration).inMemoryIdentifier,
                        "Configuration.inMemoryIdentifier must be equal to RLMConfiguration.inMemoryIdentifier")
 
-        XCTAssertEqual(realm.configuration.syncConfiguration?.realmURL,
+        var syncConfiguration: SyncConfiguration!
+        if case let .synced(config) = realm.configuration.kind {
+            syncConfiguration = config
+        }
+        XCTAssertEqual(syncConfiguration?.realmURL,
                        ObjectiveCSupport.convert(object: realm.configuration).syncConfiguration?.realmURL,
                        "Configuration.syncConfiguration must be equal to RLMConfiguration.syncConfiguration")
 

--- a/RealmSwift/Tests/RealmCollectionTypeTests.swift
+++ b/RealmSwift/Tests/RealmCollectionTypeTests.swift
@@ -162,7 +162,7 @@ class RealmCollectionTypeTests: TestCase {
         guard let collection = collection else {
             fatalError("Test precondition failed")
         }
-        XCTAssertEqual(collection.realm!.configuration.fileURL, realmWithTestPath().configuration.fileURL)
+        XCTAssertEqual(collection.realm!.configuration.kind, realmWithTestPath().configuration.kind)
     }
 
     func testDescription() {

--- a/RealmSwift/Tests/RealmConfigurationTests.swift
+++ b/RealmSwift/Tests/RealmConfigurationTests.swift
@@ -24,8 +24,7 @@ class RealmConfigurationTests: TestCase {
     func testDefaultConfiguration() {
         let defaultConfiguration = Realm.Configuration.defaultConfiguration
 
-        XCTAssertEqual(defaultConfiguration.fileURL, try! Realm().configuration.fileURL)
-        XCTAssertNil(defaultConfiguration.inMemoryIdentifier)
+        XCTAssertEqual(defaultConfiguration.kind, try! Realm().configuration.kind)
         XCTAssertNil(defaultConfiguration.encryptionKey)
         XCTAssertFalse(defaultConfiguration.readOnly)
         XCTAssertEqual(defaultConfiguration.schemaVersion, 0)
@@ -33,11 +32,17 @@ class RealmConfigurationTests: TestCase {
     }
 
     func testSetDefaultConfiguration() {
-        let fileURL = Realm.Configuration.defaultConfiguration.fileURL
-        let configuration = Realm.Configuration(fileURL: URL(fileURLWithPath: "/dev/null"))
+        let kind = Realm.Configuration.defaultConfiguration.kind
+        let configuration = Realm.Configuration(kind: .file(URL(fileURLWithPath: "/dev/null")))
         Realm.Configuration.defaultConfiguration = configuration
-        XCTAssertEqual(Realm.Configuration.defaultConfiguration.fileURL, URL(fileURLWithPath: "/dev/null"))
-        Realm.Configuration.defaultConfiguration.fileURL = fileURL
+        var newURL: URL?
+        if case let .file(url) = Realm.Configuration.defaultConfiguration.kind {
+            newURL = url
+        } else {
+            XCTFail("Setting the default configuration's kind should work properly.")
+        }
+        XCTAssertEqual(newURL, URL(fileURLWithPath: "/dev/null"))
+        Realm.Configuration.defaultConfiguration.kind = kind
     }
 
     func testCannotSetMutuallyExclusiveProperties() {
@@ -46,5 +51,35 @@ class RealmConfigurationTests: TestCase {
         configuration.deleteRealmIfMigrationNeeded = true
         assertThrows(try! Realm(configuration: configuration),
                      reason: "Cannot set `deleteRealmIfMigrationNeeded` when `readOnly` is set.")
+    }
+
+    func testConfigurationCreationWithPath() {
+        let fileURL = URL(fileURLWithPath: "/tmp/1234")
+        let configuration1 = Realm.Configuration(kind: .file(fileURL))
+        if case let .file(url) = configuration1.kind {
+            XCTAssertEqual(url, fileURL)
+        } else {
+            XCTFail("A configuration was created with kind 'file', but the kind was stored incorrectly")
+        }
+        // Check equality
+        let configuration2 = Realm.Configuration(kind: .file(fileURL))
+        XCTAssertEqual(configuration1.kind, configuration2.kind)
+        let badConfig = Realm.Configuration(kind: .file(URL(fileURLWithPath: "/tmp/5678")))
+        XCTAssertNotEqual(configuration1.kind, badConfig.kind)
+    }
+
+    func testConfigurationCreationWithIdentifier() {
+        let expectedIdentifier = "123456"
+        let configuration1 = Realm.Configuration(kind: .inMemory(expectedIdentifier))
+        if case let .inMemory(identifier) = configuration1.kind {
+            XCTAssertEqual(identifier, expectedIdentifier)
+        } else {
+            XCTFail("A configuration was created with kind 'inMemory', but the kind was stored incorrectly")
+        }
+        // Check equality
+        let configuration2 = Realm.Configuration(kind: .inMemory(expectedIdentifier))
+        XCTAssertEqual(configuration1.kind, configuration2.kind)
+        let badConfig = Realm.Configuration(kind: .inMemory("7890"))
+        XCTAssertNotEqual(configuration1.kind, badConfig.kind)
     }
 }

--- a/RealmSwift/Tests/RealmTests.swift
+++ b/RealmSwift/Tests/RealmTests.swift
@@ -30,8 +30,11 @@ class RealmTests: TestCase {
     }
 
     func testFileURL() {
-        XCTAssertEqual(try! Realm(fileURL: testRealmURL()).configuration.fileURL,
-                       testRealmURL())
+        var fileURL: URL!
+        if case let .file(url) = try! Realm(fileURL: testRealmURL()).configuration.kind {
+            fileURL = url
+        }
+        XCTAssertEqual(fileURL, testRealmURL())
     }
 
     func testReadOnly() {
@@ -42,7 +45,7 @@ class RealmTests: TestCase {
                 try! Realm().create(SwiftIntObject.self, value: [100])
             }
         }
-        let config = Realm.Configuration(fileURL: defaultRealmURL(), readOnly: true)
+        let config = Realm.Configuration(kind: .file(defaultRealmURL()), readOnly: true)
         let readOnlyRealm = try! Realm(configuration: config)
         XCTAssertEqual(true, readOnlyRealm.configuration.readOnly)
         XCTAssertEqual(1, readOnlyRealm.objects(SwiftIntObject.self).count)
@@ -52,7 +55,7 @@ class RealmTests: TestCase {
 
     func testOpeningInvalidPathThrows() {
         assertFails(.fileAccess) {
-            try Realm(configuration: Realm.Configuration(fileURL: URL(fileURLWithPath: "/dev/null/foo")))
+            try Realm(configuration: Realm.Configuration(kind: .file(URL(fileURLWithPath: "/dev/null/foo"))))
         }
     }
 
@@ -74,7 +77,7 @@ class RealmTests: TestCase {
 
         assertSucceeds {
             let realm = try Realm(configuration:
-                Realm.Configuration(fileURL: testRealmURL(), readOnly: true))
+                Realm.Configuration(kind: .file(testRealmURL()), readOnly: true))
             XCTAssertEqual(1, realm.objects(SwiftStringObject.self).count)
         }
 
@@ -84,7 +87,7 @@ class RealmTests: TestCase {
     func testReadOnlyRealmMustExist() {
         assertFails(.fileNotFound) {
             try Realm(configuration:
-                Realm.Configuration(fileURL: defaultRealmURL(), readOnly: true))
+                Realm.Configuration(kind: .file(defaultRealmURL()), readOnly: true))
         }
     }
 
@@ -145,8 +148,11 @@ class RealmTests: TestCase {
     }
 
     func testInit() {
-        XCTAssertEqual(try! Realm(fileURL: testRealmURL()).configuration.fileURL,
-                       testRealmURL())
+        var fileURL: URL!
+        if case let .file(url) = try! Realm(fileURL: testRealmURL()).configuration.kind {
+            fileURL = url
+        }
+        XCTAssertEqual(fileURL, testRealmURL())
     }
 
     func testInitFailable() {
@@ -188,7 +194,7 @@ class RealmTests: TestCase {
     }
 
     func testInitCustomClassList() {
-        let configuration = Realm.Configuration(fileURL: Realm.Configuration.defaultConfiguration.fileURL,
+        let configuration = Realm.Configuration(kind: Realm.Configuration.defaultConfiguration.kind,
             objectTypes: [SwiftStringObject.self])
         XCTAssert(configuration.objectTypes! is [SwiftStringObject.Type])
         let realm = try! Realm(configuration: configuration)
@@ -679,7 +685,11 @@ class RealmTests: TestCase {
         let realm = try! Realm()
         var notificationCalled = false
         let token = realm.observe { _, realm in
-            XCTAssertEqual(realm.configuration.fileURL, self.defaultRealmURL())
+            var fileURL: URL!
+            if case let .file(url) = realm.configuration.kind {
+                fileURL = url
+            }
+            XCTAssertEqual(fileURL, self.defaultRealmURL())
             notificationCalled = true
         }
         XCTAssertFalse(notificationCalled)
@@ -692,7 +702,11 @@ class RealmTests: TestCase {
         let realm = try! Realm()
         var notificationCalled = false
         let token = realm.observe { (_, realm) -> Void in
-            XCTAssertEqual(realm.configuration.fileURL, self.defaultRealmURL())
+            var fileURL: URL!
+            if case let .file(url) = realm.configuration.kind {
+                fileURL = url
+            }
+            XCTAssertEqual(fileURL, self.defaultRealmURL())
             notificationCalled = true
         }
         token.invalidate()
@@ -815,7 +829,7 @@ class RealmTests: TestCase {
 
     func testCatchSpecificErrors() {
         do {
-            _ = try Realm(configuration: Realm.Configuration(fileURL: URL(fileURLWithPath: "/dev/null/foo")))
+            _ = try Realm(configuration: Realm.Configuration(kind: .file(URL(fileURLWithPath: "/dev/null/foo"))))
             XCTFail("Error should be thrown")
         } catch Realm.Error.fileAccess {
             // Success to catch the error
@@ -823,7 +837,7 @@ class RealmTests: TestCase {
             XCTFail("Failed to brigde RLMError to Realm.Error")
         }
         do {
-            _ = try Realm(configuration: Realm.Configuration(fileURL: defaultRealmURL(), readOnly: true))
+            _ = try Realm(configuration: Realm.Configuration(kind: .file(defaultRealmURL()), readOnly: true))
             XCTFail("Error should be thrown")
         } catch Realm.Error.fileNotFound {
             // Success to catch the error

--- a/RealmSwift/Tests/TestCase.swift
+++ b/RealmSwift/Tests/TestCase.swift
@@ -24,7 +24,7 @@ import RealmSwift
 import XCTest
 
 func inMemoryRealm(_ inMememoryIdentifier: String) -> Realm {
-    return try! Realm(configuration: Realm.Configuration(inMemoryIdentifier: inMememoryIdentifier))
+    return try! Realm(configuration: Realm.Configuration(kind: .inMemory(inMememoryIdentifier)))
 }
 
 class TestCase: XCTestCase {
@@ -36,7 +36,7 @@ class TestCase: XCTestCase {
     @discardableResult
     func realmWithTestPath(configuration: Realm.Configuration = Realm.Configuration()) -> Realm {
         var configuration = configuration
-        configuration.fileURL = testRealmURL()
+        configuration.kind = .file(testRealmURL())
         return try! Realm(configuration: configuration)
     }
 
@@ -72,7 +72,7 @@ class TestCase: XCTestCase {
         try! FileManager.default.createDirectory(at: URL(fileURLWithPath: testDir, isDirectory: true),
                                                      withIntermediateDirectories: true, attributes: nil)
 
-        let config = Realm.Configuration(fileURL: defaultRealmURL())
+        let config = Realm.Configuration(kind: .file(defaultRealmURL()))
         Realm.Configuration.defaultConfiguration = config
 
         exceptionThrown = false

--- a/examples/ios/swift-3.0/Backlink/AppDelegate.swift
+++ b/examples/ios/swift-3.0/Backlink/AppDelegate.swift
@@ -43,7 +43,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         window?.makeKeyAndVisible()
 
         do {
-            try FileManager.default.removeItem(at: Realm.Configuration.defaultConfiguration.fileURL!)
+            if case let .file(url) = Realm.Configuration.defaultConfiguration.kind {
+                try FileManager.default.removeItem(at: url)
+            }
         } catch {}
 
         let realm = try! Realm()

--- a/examples/ios/swift-3.0/Migration/AppDelegate.swift
+++ b/examples/ios/swift-3.0/Migration/AppDelegate.swift
@@ -62,7 +62,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         window?.makeKeyAndVisible()
 
         // copy over old data files for migration
-        let defaultURL = Realm.Configuration.defaultConfiguration.fileURL!
+        var defaultURL: URL!
+        if case let .file(url) = Realm.Configuration.defaultConfiguration.kind {
+            defaultURL = url
+        }
         let defaultParentURL = defaultURL.deletingLastPathComponent()
 
         if let v0URL = bundleURL("default-v0") {
@@ -112,8 +115,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             let realmv1URL = defaultParentURL.appendingPathComponent("default-v1.realm")
             let realmv2URL = defaultParentURL.appendingPathComponent("default-v2.realm")
 
-            let realmv1Configuration = Realm.Configuration(fileURL: realmv1URL, schemaVersion: 2, migrationBlock: migrationBlock)
-            let realmv2Configuration = Realm.Configuration(fileURL: realmv2URL, schemaVersion: 3, migrationBlock: migrationBlock)
+            let realmv1Configuration = Realm.Configuration(kind: .file(realmv1URL), schemaVersion: 2, migrationBlock: migrationBlock)
+            let realmv2Configuration = Realm.Configuration(kind: .file(realmv2URL), schemaVersion: 3, migrationBlock: migrationBlock)
 
             do {
                 try FileManager.default.removeItem(at: realmv1URL)

--- a/examples/ios/swift-3.0/Simple/AppDelegate.swift
+++ b/examples/ios/swift-3.0/Simple/AppDelegate.swift
@@ -40,7 +40,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         window?.makeKeyAndVisible()
 
         do {
-            try FileManager.default.removeItem(at: Realm.Configuration.defaultConfiguration.fileURL!)
+            if case let .file(url) = Realm.Configuration.defaultConfiguration.kind {
+                try FileManager.default.removeItem(at: url)
+            }
         } catch {}
 
         // Create a standalone object

--- a/examples/tvos/swift-3.0/PreloadedData/PlacesViewController.swift
+++ b/examples/tvos/swift-3.0/PreloadedData/PlacesViewController.swift
@@ -28,7 +28,7 @@ class PlacesViewController: UITableViewController, UITextFieldDelegate {
         super.viewDidLoad()
 
         let seedFileURL = Bundle.main.url(forResource: "Places", withExtension: "realm")
-        let config = Realm.Configuration(fileURL: seedFileURL, readOnly: true)
+        let config = Realm.Configuration(kind: .file(seedFileURL!), readOnly: true)
         Realm.Configuration.defaultConfiguration = config
 
         reloadData()


### PR DESCRIPTION
Also make `SyncConfiguration` struct `Equatable`.

Fixes #4852.