### PR TITLE
Fix compilation error in Swift 4

### DIFF
--- a/Realm/ObjectServerTests/SwiftObjectServerTests.swift
+++ b/Realm/ObjectServerTests/SwiftObjectServerTests.swift
@@ -124,7 +124,7 @@ class SwiftObjectServerTests: SwiftSyncTestCase {
             let user = try synchronouslyLogInUser(for: basicCredentials(register: isParent), server: authURL)
             var theError: SyncError?
 
-            try autoreleasepool { _ in
+            try autoreleasepool {
                 let realm = try synchronouslyOpenRealm(url: realmURL, user: user)
                 let ex = expectation(description: "Waiting for error handler to be called...")
                 SyncManager.shared.errorHandler = { (error, session) in


### PR DESCRIPTION
Object Server Tests fail in Swift 4 due to compilation error. This doesn't affect Swift 3

```
error: contextual closure type '() -> _' expects 0 arguments, but 1 was used in closure body
            try autoreleasepool { (_) in
                                  ^~~~~~
```

CC @austinzheng @bdash 