### PR TITLE
Fix building the Realm Swift unit tests with Xcode 9 beta 6

### DIFF
--- a/RealmSwift/Tests/TestCase.swift
+++ b/RealmSwift/Tests/TestCase.swift
@@ -204,11 +204,8 @@ class TestCase: XCTestCase {
     }
 
     private func realmFilePrefix() -> String {
-#if swift(>=3.2)
-        return name.trimmingCharacters(in: CharacterSet(charactersIn: "-[]"))
-#else
+        let name: String? = self.name
         return name!.trimmingCharacters(in: CharacterSet(charactersIn: "-[]"))
-#endif
     }
 
     internal func testRealmURL() -> URL {


### PR DESCRIPTION
`XCTest.name` has changed from `String` to `String?` and back a few times during the Xcode 9 beta cycle. Use a `String?` local variable to accommodate either declaration.