### PR TITLE
Remove the workaround for realm/realm-core#2724

### DIFF
--- a/Realm/ObjectServerTests/RLMPermissionsAPITests.m
+++ b/Realm/ObjectServerTests/RLMPermissionsAPITests.m
@@ -164,19 +164,6 @@ static RLMSyncPermission *makeExpectedPermission(RLMSyncPermission *original, RL
 
 #pragma mark - Helper methods
 
-- (void)workAroundCoreIssue2724
-{
-    // As described in https://github.com/realm/realm-core/issues/2724, with realm-core v3.0.0-rc3 we're
-    // seeing occasional deadlocks in these tests due to core thinking that the history schema needs to
-    // be upgraded when it doesn't. This leads to it taking a write transaction as part of opening a file.
-    // Since this can happen on the notification listener thread while another thread both has an existing
-    // write transaction and is waiting for the notification listener thread to process notifications,
-    // we deadlock.
-    // We work around this by delaying slightly between registering for notifications on a given Realm and
-    // opening a write transaction on the same Realm.
-    [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.1]];
-}
-
 - (RLMSyncPermissionResults *)getPermissionResultsFor:(RLMSyncUser *)user {
     return [self getPermissionResultsFor:user message:@"Get permission results"];
 }
@@ -899,7 +886,6 @@ static RLMSyncPermission *makeExpectedPermission(RLMSyncPermission *original, RL
         }
     }];
 
-    [self workAroundCoreIssue2724];
     [managementRealm transactionWithBlock:^{
         [managementRealm addObject:permissionOffer];
     } error:&error];
@@ -948,7 +934,6 @@ static RLMSyncPermission *makeExpectedPermission(RLMSyncPermission *original, RL
         }
     }];
 
-    [self workAroundCoreIssue2724];
     [managementRealm transactionWithBlock:^{
         [managementRealm addObject:permissionOffer];
     } error:&error];
@@ -1002,7 +987,6 @@ static RLMSyncPermission *makeExpectedPermission(RLMSyncPermission *original, RL
         }
     }];
 
-    [self workAroundCoreIssue2724];
     [managementRealm transactionWithBlock:^{
         [managementRealm addObject:permissionOffer];
     } error:&error];
@@ -1047,7 +1031,6 @@ static RLMSyncPermission *makeExpectedPermission(RLMSyncPermission *original, RL
         }
     }];
 
-    [self workAroundCoreIssue2724];
     [managementRealm transactionWithBlock:^{
         [managementRealm addObject:permissionOfferResponse];
     } error:&error];
@@ -1091,7 +1074,6 @@ static RLMSyncPermission *makeExpectedPermission(RLMSyncPermission *original, RL
         }
     }];
 
-    [self workAroundCoreIssue2724];
     [managementRealm transactionWithBlock:^{
         [managementRealm addObject:permissionOfferResponse];
     } error:&error];
@@ -1134,7 +1116,6 @@ static RLMSyncPermission *makeExpectedPermission(RLMSyncPermission *original, RL
         }
     }];
 
-    [self workAroundCoreIssue2724];
     [managementRealm transactionWithBlock:^{
         [managementRealm addObject:permissionOfferResponse];
     } error:&error];

--- a/Realm/ObjectServerTests/SwiftObjectServerTests.swift
+++ b/Realm/ObjectServerTests/SwiftObjectServerTests.swift
@@ -387,7 +387,6 @@ class SwiftObjectServerTests: SwiftSyncTestCase {
                 }
             }
 
-            workAroundCoreIssue2724()
             try managementRealm.write {
                 managementRealm.add(permissionOffer)
             }
@@ -424,7 +423,6 @@ class SwiftObjectServerTests: SwiftSyncTestCase {
                 }
             }
 
-            workAroundCoreIssue2724()
             try managementRealm.write {
                 managementRealm.add(permissionOffer)
             }
@@ -459,7 +457,6 @@ class SwiftObjectServerTests: SwiftSyncTestCase {
                 }
             }
 
-            workAroundCoreIssue2724()
             try managementRealm.write {
                 managementRealm.add(permissionOfferResponse)
             }


### PR DESCRIPTION
The fix for realm/realm-core#2724 was included in realm-core v3.0.0-rc4, and we're now using v3.0.0-rc5.