### PR TITLE
Fix the bundle version of our frameworks in our beta releases

### DIFF
--- a/Realm/Realm-Info.plist
+++ b/Realm/Realm-Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>3.0.0-beta.2</string>
+	<string>3.0.0</string>
 	<key>NSHumanReadableCopyright</key>
 	<string>Copyright © 2014 Realm. All rights reserved.</string>
 	<key>NSPrincipalClass</key>

--- a/build.sh
+++ b/build.sh
@@ -931,8 +931,11 @@ case "$COMMAND" in
             echo "You must specify a version."
             exit 1
         fi
+        # The bundle version can contain only three groups of digits separated by periods,
+        # so strip off any -beta.x tag from the end of the version string.
+        bundle_version=$(echo "$realm_version" | cut -d - -f 1)
         for version_file in $version_files; do
-            PlistBuddy -c "Set :CFBundleVersion $realm_version" "$version_file"
+            PlistBuddy -c "Set :CFBundleVersion $bundle_version" "$version_file"
             PlistBuddy -c "Set :CFBundleShortVersionString $realm_version" "$version_file"
         done
         sed -i '' "s/^VERSION=.*/VERSION=$realm_version/" dependencies.list


### PR DESCRIPTION
iTunes Connect rejects `CFBundleVersion` fields that contain anything besides three groups of digits separated by periods. Strip our `-beta.x` suffix so that we conform to that convention.

Fixes #5249.