### PR TITLE
Fix sh build.sh get-version

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -919,7 +919,7 @@ case "$COMMAND" in
     ######################################
     "get-version")
         version_file="Realm/Realm-Info.plist"
-        echo "$(PlistBuddy -c "Print :CFBundleVersion" "$version_file")"
+        echo "$(PlistBuddy -c "Print :CFBundleShortVersionString" "$version_file")"
         exit 0
         ;;
 


### PR DESCRIPTION
In #5256 I changed `CFBundleVersion` in the framework's Info.plist file to omit any `-beta.x` suffix. I overlooked the fact that this key is what `sh build.sh get-version` reads from. It now reads from `CFBundleShortVersionString` instead, which contains the complete version string.