### PR TITLE
Have the GitHub release notes include only changes since the last beta

### DIFF
--- a/scripts/github_release.rb
+++ b/scripts/github_release.rb
@@ -30,7 +30,7 @@ def release_notes(version)
   end
   current_version_index += 2
   previous_version_lines = changelog[(current_version_index+1)...-1]
-  previous_version_index = current_version_index + (previous_version_lines.find_index { |line| line =~ /^\d+\.\d+\.\d+\s+/ } || changelog.count)
+  previous_version_index = current_version_index + (previous_version_lines.find_index { |line| line =~ /^\d+\.\d+\.\d+(-(alpha|beta|rc)(\.\d+)?)?\s+/ } || changelog.count)
 
   relevant = changelog[current_version_index..previous_version_index]
 


### PR DESCRIPTION
Previously the script attempted to include all changes since the last non-beta release, which resulted in wonky formatting in most cases.