### PR TITLE
Fix an issue causing permissions tests to fail

### DIFF
--- a/Realm/RLMSyncPermissionResults.mm
+++ b/Realm/RLMSyncPermissionResults.mm
@@ -149,6 +149,10 @@ using namespace realm;
     }
 }
 
+- (NSString *)objectClassName {
+    return @"RLMSyncPermission";
+}
+
 - (NSString *)description {
     // FIXME: rather than force-casting to a protocol we don't formally implement,
     // we should change RLMDescriptionWithMaxDepth to take a less restrictive


### PR DESCRIPTION
I overlooked the fact that #5264 caused the object server tests to break. The culprit was `RLMSyncPermissionResults`'s misuse of a protocol. (#5168 will get rid of this entire issue in Realm 3 by refactoring how results work.)