### PR TITLE
Set `NSURLIsExcludedFromBackupKey` for auxiliary files to prevent them from being backed up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ x.x.x Release notes (yyyy-MM-dd)
 
 ### Enhancements
 
-* None.
+* Auxiliary files are excluded from backup by default.
 
 ### Bugfixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ x.x.x Release notes (yyyy-MM-dd)
 
 * Fix more cases where assigning an RLMArray property to itself would clear the
   RLMArray.
+* None.
 
 2.10.0 Release notes (2017-08-21)
 =============================================================

--- a/Realm/RLMRealm.mm
+++ b/Realm/RLMRealm.mm
@@ -66,6 +66,10 @@ void RLMDisableSyncToDisk() {
     realm::disable_sync_to_disk();
 }
 
+static void RLMAddSkipBackupAttributeToItemAtPath(std::string const& path) {
+    [[NSURL fileURLWithPath:@(path.c_str())] setResourceValue:@YES forKey:NSURLIsExcludedFromBackupKey error:nil];
+}
+
 @implementation RLMRealmNotificationToken
 - (void)stop {
     [_realm verifyThread];
@@ -436,6 +440,10 @@ REALM_NOINLINE void RLMRealmTranslateException(NSError **error) {
     if (!readOnly) {
         realm->_realm->m_binding_context = RLMCreateBindingContext(realm);
         realm->_realm->m_binding_context->realm = realm->_realm;
+
+        RLMAddSkipBackupAttributeToItemAtPath(config.path + ".management");
+        RLMAddSkipBackupAttributeToItemAtPath(config.path + ".lock");
+        RLMAddSkipBackupAttributeToItemAtPath(config.path + ".note");
     }
 
     return RLMAutorelease(realm);

--- a/Realm/Tests/RealmTests.mm
+++ b/Realm/Tests/RealmTests.mm
@@ -1871,4 +1871,18 @@
     [self waitForExpectationsWithTimeout:1 handler:nil];
 }
 
+- (void)testAuxiliaryFilesAreExcludedFromBackup {
+    @autoreleasepool { [RLMRealm defaultRealm]; }
+
+    NSURL *fileURL = RLMRealmConfiguration.defaultConfiguration.fileURL;
+    for (NSString *pathExtension in @[@"management", @"lock", @"note"]) {
+        NSNumber *attribute = nil;
+        NSError *error = nil;
+        BOOL success = [[fileURL URLByAppendingPathExtension:pathExtension] getResourceValue:&attribute forKey:NSURLIsExcludedFromBackupKey error:&error];
+        XCTAssertTrue(success);
+        XCTAssertNil(error);
+        XCTAssertTrue(attribute.boolValue);
+    }
+}
+
 @end

--- a/Realm/Tests/RealmTests.mm
+++ b/Realm/Tests/RealmTests.mm
@@ -1874,8 +1874,13 @@
 - (void)testAuxiliaryFilesAreExcludedFromBackup {
     @autoreleasepool { [RLMRealm defaultRealm]; }
 
+#if TARGET_OS_TV
+    NSArray *auxiliaryFileExtensions = @[@"management", @"lock"]; // tvOS does not support named pipes
+#else
+    NSArray *auxiliaryFileExtensions = @[@"management", @"lock", @"note"];
+#endif
     NSURL *fileURL = RLMRealmConfiguration.defaultConfiguration.fileURL;
-    for (NSString *pathExtension in @[@"management", @"lock", @"note"]) {
+    for (NSString *pathExtension in auxiliaryFileExtensions) {
         NSNumber *attribute = nil;
         NSError *error = nil;
         BOOL success = [[fileURL URLByAppendingPathExtension:pathExtension] getResourceValue:&attribute forKey:NSURLIsExcludedFromBackupKey error:&error];
@@ -1883,6 +1888,38 @@
         XCTAssertNil(error);
         XCTAssertTrue(attribute.boolValue);
     }
+}
+
+- (void)testAuxiliaryFilesAreExcludedFromBackupPerformance {
+    [self measureBlock:^{
+        @autoreleasepool {
+            RLMRealm *realm = [RLMRealm defaultRealm];
+            realm = [RLMRealm defaultRealm];
+            realm = [RLMRealm defaultRealm];
+            realm = [RLMRealm defaultRealm];
+            realm = [RLMRealm defaultRealm];
+            realm = [RLMRealm defaultRealm];
+            realm = [RLMRealm defaultRealm];
+            realm = [RLMRealm defaultRealm];
+            realm = [RLMRealm defaultRealm];
+            realm = [RLMRealm defaultRealm];
+            realm = [RLMRealm defaultRealm];
+            realm = [RLMRealm defaultRealm];
+            realm = [RLMRealm defaultRealm];
+            realm = [RLMRealm defaultRealm];
+        }
+        @autoreleasepool { [RLMRealm defaultRealm]; }
+    }];
+
+//    NSURL *fileURL = RLMRealmConfiguration.defaultConfiguration.fileURL;
+//    for (NSString *pathExtension in @[@"management", @"lock", @"note"]) {
+//        NSNumber *attribute = nil;
+//        NSError *error = nil;
+//        BOOL success = [[fileURL URLByAppendingPathExtension:pathExtension] getResourceValue:&attribute forKey:NSURLIsExcludedFromBackupKey error:&error];
+//        XCTAssertTrue(success);
+//        XCTAssertNil(error);
+//        XCTAssertTrue(attribute.boolValue);
+//    }
 }
 
 @end


### PR DESCRIPTION
Fixes https://github.com/realm/realm-cocoa/issues/4189

Set `NSURLIsExcludedFromBackupKey` for `*.realm.management ` `*.realm.lock` and `*.realm.note` to prevent them from being backed up.

cc @bdash @tgoyne 
