### PR TITLE
Rename config `readOnly` property to `immutable`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ x.x.x Release notes (yyyy-MM-dd)
   using a `RLMResults`. This results collection supports all normal collection
   operations except for setting values using KVO (since `RLMSyncPermission`s are
   immutable) and the property aggregation operations.
+* Rename `RLMRealmConfiguration.readOnly` (and its Swift equivalent) to
+  `immutable`.
 
 ### Enhancements
 

--- a/Realm/RLMRealm.mm
+++ b/Realm/RLMRealm.mm
@@ -325,7 +325,7 @@ REALM_NOINLINE void RLMRealmTranslateException(NSError **error) {
 + (instancetype)realmWithConfiguration:(RLMRealmConfiguration *)configuration error:(NSError **)error {
     bool dynamic = configuration.dynamic;
     bool cache = configuration.cache;
-    bool readOnly = configuration.readOnly;
+    bool immutable = configuration.immutable;
 
     {
         Realm::Config& config = configuration.config;
@@ -423,7 +423,7 @@ REALM_NOINLINE void RLMRealmTranslateException(NSError **error) {
         realm->_info = RLMSchemaInfo(realm);
         RLMRealmCreateAccessors(realm.schema);
 
-        if (!readOnly) {
+        if (!immutable) {
             // initializing the schema started a read transaction, so end it
             [realm invalidate];
         }
@@ -433,7 +433,7 @@ REALM_NOINLINE void RLMRealmTranslateException(NSError **error) {
         RLMCacheRealm(config.path, realm);
     }
 
-    if (!readOnly) {
+    if (!immutable) {
         realm->_realm->m_binding_context = RLMCreateBindingContext(realm);
         realm->_realm->m_binding_context->realm = realm->_realm;
     }

--- a/Realm/RLMRealmConfiguration.h
+++ b/Realm/RLMRealmConfiguration.h
@@ -77,16 +77,16 @@ typedef BOOL (^RLMShouldCompactOnLaunchBlock)(NSUInteger totalBytes, NSUInteger 
 /// A 64-byte key to use to encrypt the data, or `nil` if encryption is not enabled.
 @property (nonatomic, copy, nullable) NSData *encryptionKey;
 
-/// Whether to open the Realm in read-only mode.
+/// Whether to open the Realm in immutable mode.
 ///
 /// This is required to be able to open Realm files which are not writeable or
 /// are in a directory which is not writeable. This should only be used on files
 /// which will not be modified by anyone while they are open, and not just to
 /// get a read-only view of a file which may be written to by another thread or
-/// process. Opening in read-only mode requires disabling Realm's reader/writer
+/// process. Opening in immutable mode requires disabling Realm's reader/writer
 /// coordination, so committing a write transaction from another process will
 /// result in crashes.
-@property (nonatomic) BOOL readOnly;
+@property (nonatomic) BOOL immutable;
 
 /// The current schema version.
 @property (nonatomic) uint64_t schemaVersion;

--- a/Realm/RLMRealmConfiguration.mm
+++ b/Realm/RLMRealmConfiguration.mm
@@ -201,20 +201,20 @@ static void RLMNSStringToStdString(std::string &out, NSString *in) {
     }
 }
 
-- (BOOL)readOnly {
+- (BOOL)immutable {
     return _config.immutable();
 }
 
-- (void)setReadOnly:(BOOL)readOnly {
-    if (readOnly) {
+- (void)setImmutable:(BOOL)immutable {
+    if (immutable) {
         if (self.deleteRealmIfMigrationNeeded) {
-            @throw RLMException(@"Cannot set `readOnly` when `deleteRealmIfMigrationNeeded` is set.");
+            @throw RLMException(@"Cannot set `immutable` when `deleteRealmIfMigrationNeeded` is set.");
         } else if (self.shouldCompactOnLaunch) {
-            @throw RLMException(@"Cannot set `readOnly` when `shouldCompactOnLaunch` is set.");
+            @throw RLMException(@"Cannot set `immutable` when `shouldCompactOnLaunch` is set.");
         }
         _config.schema_mode = realm::SchemaMode::Immutable;
     }
-    else if (self.readOnly) {
+    else if (self.immutable) {
         _config.schema_mode = realm::SchemaMode::Automatic;
     }
 }
@@ -236,8 +236,8 @@ static void RLMNSStringToStdString(std::string &out, NSString *in) {
 
 - (void)setDeleteRealmIfMigrationNeeded:(BOOL)deleteRealmIfMigrationNeeded {
     if (deleteRealmIfMigrationNeeded) {
-        if (self.readOnly) {
-            @throw RLMException(@"Cannot set `deleteRealmIfMigrationNeeded` when `readOnly` is set.");
+        if (self.immutable) {
+            @throw RLMException(@"Cannot set `deleteRealmIfMigrationNeeded` when `immutable` is set.");
         }
         _config.schema_mode = realm::SchemaMode::ResetFile;
     }
@@ -281,8 +281,8 @@ static void RLMNSStringToStdString(std::string &out, NSString *in) {
 
 - (void)setShouldCompactOnLaunch:(RLMShouldCompactOnLaunchBlock)shouldCompactOnLaunch {
     if (shouldCompactOnLaunch) {
-        if (self.readOnly) {
-            @throw RLMException(@"Cannot set `shouldCompactOnLaunch` when `readOnly` is set.");
+        if (self.immutable) {
+            @throw RLMException(@"Cannot set `shouldCompactOnLaunch` when `immutable` is set.");
         } else if (_config.sync_config) {
             @throw RLMException(@"Cannot set `shouldCompactOnLaunch` when `syncConfiguration` is set.");
         }

--- a/Realm/Tests/AsyncTests.mm
+++ b/Realm/Tests/AsyncTests.mm
@@ -506,7 +506,7 @@
     [self waitForExpectationsWithTimeout:2.0 handler:nil];
 
     RLMRealmConfiguration *config = [RLMRealmConfiguration defaultConfiguration];
-    config.readOnly = true;
+    config.immutable = true;
     @autoreleasepool {
         XCTAssertThrows([RLMRealm realmWithConfiguration:config error:nil]);
     }
@@ -891,11 +891,11 @@
     CFRunLoopRun();
 }
 
-- (void)testAsyncNotSupportedForReadOnlyRealms {
+- (void)testAsyncNotSupportedForImmutableRealms {
     @autoreleasepool { [RLMRealm defaultRealm]; }
 
     RLMRealmConfiguration *config = [RLMRealmConfiguration defaultConfiguration];
-    config.readOnly = true;
+    config.immutable = true;
     RLMRealm *realm = [RLMRealm realmWithConfiguration:config error:nil];
 
     XCTAssertThrows([[IntObject allObjectsInRealm:realm] addNotificationBlock:^(RLMResults *results, RLMCollectionChange *change, NSError *error) {

--- a/Realm/Tests/CompactionTests.m
+++ b/Realm/Tests/CompactionTests.m
@@ -240,18 +240,18 @@ NSUInteger count = 1000;
 
 - (void)testCompactOnLaunchValidation {
     RLMRealmConfiguration *configuration = [RLMRealmConfiguration defaultConfiguration];
-    configuration.readOnly = YES;
+    configuration.immutable = YES;
 
     BOOL (^compactBlock)(NSUInteger, NSUInteger) = ^BOOL(__unused NSUInteger totalBytes, __unused NSUInteger usedBytes){
         return NO;
     };
     RLMAssertThrowsWithReasonMatching(configuration.shouldCompactOnLaunch = compactBlock,
-                                      @"Cannot set `shouldCompactOnLaunch` when `readOnly` is set.");
+                                      @"Cannot set `shouldCompactOnLaunch` when `immutable` is set.");
 
-    configuration.readOnly = NO;
+    configuration.immutable = NO;
     configuration.shouldCompactOnLaunch = compactBlock;
-    RLMAssertThrowsWithReasonMatching(configuration.readOnly = YES,
-                                      @"Cannot set `readOnly` when `shouldCompactOnLaunch` is set.");
+    RLMAssertThrowsWithReasonMatching(configuration.immutable = YES,
+                                      @"Cannot set `immutable` when `shouldCompactOnLaunch` is set.");
 }
 
 @end

--- a/Realm/Tests/MigrationTests.mm
+++ b/Realm/Tests/MigrationTests.mm
@@ -553,15 +553,15 @@ RLM_ARRAY_TYPE(MigrationObject);
 
 #pragma mark - Allowed schema mismatches
 
-- (void)testMismatchedIndexAllowedForReadOnly {
+- (void)testMismatchedIndexAllowedForImmutable {
     RLMObjectSchema *objectSchema = [RLMObjectSchema schemaForObjectClass:StringObject.class];
     [objectSchema.properties[0] setIndexed:YES];
 
     [self createTestRealmWithSchema:@[objectSchema] block:^(RLMRealm *) { }];
 
-    // should be able to open readonly with mismatched index schema
+    // should be able to open immutable with mismatched index schema
     RLMRealmConfiguration *config = [self config];
-    config.readOnly = true;
+    config.immutable = true;
     RLMRealm *realm = [RLMRealm realmWithConfiguration:config error:nil];
     auto& info = realm->_info[@"StringObject"];
     XCTAssertTrue(info.table()->has_search_index(info.tableColumn(objectSchema.properties[0].name)));

--- a/Realm/Tests/RLMTestCase.h
+++ b/Realm/Tests/RLMTestCase.h
@@ -39,7 +39,7 @@ NSData *RLMGenerateKey(void);
 - (RLMRealm *)realmWithTestPathAndSchema:(nullable RLMSchema *)schema;
 
 - (RLMRealm *)inMemoryRealmWithIdentifier:(NSString *)identifier;
-- (RLMRealm *)readOnlyRealmWithURL:(NSURL *)fileURL error:(NSError **)error;
+- (RLMRealm *)immutableRealmWithURL:(NSURL *)fileURL error:(NSError **)error;
 
 - (void)deleteFiles;
 - (void)deleteRealmFileAtURL:(NSURL *)fileURL;

--- a/Realm/Tests/RLMTestCase.m
+++ b/Realm/Tests/RLMTestCase.m
@@ -166,10 +166,10 @@ static BOOL encryptTests() {
     return [RLMRealm realmWithConfiguration:configuration error:nil];
 }
 
-- (RLMRealm *)readOnlyRealmWithURL:(NSURL *)fileURL error:(NSError **)error {
+- (RLMRealm *)immutableRealmWithURL:(NSURL *)fileURL error:(NSError **)error {
     RLMRealmConfiguration *configuration = [RLMRealmConfiguration defaultConfiguration];
     configuration.fileURL = fileURL;
-    configuration.readOnly = true;
+    configuration.immutable = true;
     return [RLMRealm realmWithConfiguration:configuration error:error];
 }
 

--- a/Realm/Tests/RealmConfigurationTests.mm
+++ b/Realm/Tests/RealmConfigurationTests.mm
@@ -81,13 +81,13 @@
 
 - (void)testCannotSetMutuallyExclusiveProperties {
     RLMRealmConfiguration *configuration = [[RLMRealmConfiguration alloc] init];
-    XCTAssertNoThrow(configuration.readOnly = YES);
+    XCTAssertNoThrow(configuration.immutable = YES);
     XCTAssertNoThrow(configuration.deleteRealmIfMigrationNeeded = NO);
     XCTAssertThrows(configuration.deleteRealmIfMigrationNeeded = YES);
-    XCTAssertNoThrow(configuration.readOnly = NO);
+    XCTAssertNoThrow(configuration.immutable = NO);
     XCTAssertNoThrow(configuration.deleteRealmIfMigrationNeeded = YES);
-    XCTAssertNoThrow(configuration.readOnly = NO);
-    XCTAssertThrows(configuration.readOnly = YES);
+    XCTAssertNoThrow(configuration.immutable = NO);
+    XCTAssertThrows(configuration.immutable = YES);
 }
 
 #pragma mark - Default Configuration
@@ -97,7 +97,7 @@
     XCTAssertEqualObjects(defaultConfiguration.fileURL, RLMDefaultRealmURL());
     XCTAssertNil(defaultConfiguration.inMemoryIdentifier);
     XCTAssertNil(defaultConfiguration.encryptionKey);
-    XCTAssertFalse(defaultConfiguration.readOnly);
+    XCTAssertFalse(defaultConfiguration.immutable);
     XCTAssertEqual(defaultConfiguration.schemaVersion, 0U);
     XCTAssertNil(defaultConfiguration.migrationBlock);
 

--- a/RealmSwift/RealmConfiguration.swift
+++ b/RealmSwift/RealmConfiguration.swift
@@ -60,7 +60,7 @@ extension Realm {
          - parameter inMemoryIdentifier: A string used to identify a particular in-memory Realm.
          - parameter syncConfiguration:  For Realms intended to sync with the Realm Object Server, a sync configuration.
          - parameter encryptionKey:      An optional 64-byte key to use to encrypt the data.
-         - parameter readOnly:           Whether the Realm is read-only (must be true for read-only files).
+         - parameter immutable:          Whether the Realm is immutable (must be true for read-only files).
          - parameter schemaVersion:      The current schema version.
          - parameter migrationBlock:     The block which migrates the Realm to the current version.
          - parameter deleteRealmIfMigrationNeeded: If `true`, recreate the Realm file with the provided
@@ -78,7 +78,7 @@ extension Realm {
                     inMemoryIdentifier: String? = nil,
                     syncConfiguration: SyncConfiguration? = nil,
                     encryptionKey: Data? = nil,
-                    readOnly: Bool = false,
+                    immutable: Bool = false,
                     schemaVersion: UInt64 = 0,
                     migrationBlock: MigrationBlock? = nil,
                     deleteRealmIfMigrationNeeded: Bool = false,
@@ -92,7 +92,7 @@ extension Realm {
                     self.syncConfiguration = syncConfiguration
                 }
                 self.encryptionKey = encryptionKey
-                self.readOnly = readOnly
+                self.immutable = immutable
                 self.schemaVersion = schemaVersion
                 self.migrationBlock = migrationBlock
                 self.deleteRealmIfMigrationNeeded = deleteRealmIfMigrationNeeded
@@ -152,15 +152,15 @@ extension Realm {
         public var encryptionKey: Data?
 
         /**
-         Whether to open the Realm in read-only mode.
+         Whether to open the Realm in immutable mode.
 
          This is required to be able to open Realm files which are not writeable or are in a directory which is not
          writeable. This should only be used on files which will not be modified by anyone while they are open, and not
          just to get a read-only view of a file which may be written to by another thread or process. Opening in
-         read-only mode requires disabling Realm's reader/writer coordination, so committing a write transaction from
+         immutable mode requires disabling Realm's reader/writer coordination, so committing a write transaction from
          another process will result in crashes.
          */
-        public var readOnly: Bool = false
+        public var immutable: Bool = false
 
         /// The current schema version.
         public var schemaVersion: UInt64 = 0
@@ -219,7 +219,7 @@ extension Realm {
                 fatalError("A Realm Configuration must specify a path or an in-memory identifier.")
             }
             configuration.encryptionKey = self.encryptionKey
-            configuration.readOnly = self.readOnly
+            configuration.immutable = self.immutable
             configuration.schemaVersion = self.schemaVersion
             configuration.migrationBlock = self.migrationBlock.map { accessorMigrationBlock($0) }
             configuration.deleteRealmIfMigrationNeeded = self.deleteRealmIfMigrationNeeded
@@ -243,7 +243,7 @@ extension Realm {
                 configuration._syncConfiguration = nil
             }
             configuration.encryptionKey = rlmConfiguration.encryptionKey
-            configuration.readOnly = rlmConfiguration.readOnly
+            configuration.immutable = rlmConfiguration.immutable
             configuration.schemaVersion = rlmConfiguration.schemaVersion
             configuration.migrationBlock = rlmConfiguration.migrationBlock.map { rlmMigration in
                 return { migration, schemaVersion in
@@ -267,5 +267,15 @@ extension Realm.Configuration: CustomStringConvertible {
         return gsub(pattern: "\\ARLMRealmConfiguration",
                     template: "Realm.Configuration",
                     string: rlmConfiguration.description) ?? ""
+    }
+}
+
+// MARK: Migration assistance
+
+/// :nodoc:
+extension Realm.Configuration {
+    @available(*, unavailable, renamed: "immutable") public var readOnly: Bool {
+        get { fatalError() }
+        set { fatalError() }
     }
 }

--- a/RealmSwift/Tests/ObjectiveCSupportTests.swift
+++ b/RealmSwift/Tests/ObjectiveCSupportTests.swift
@@ -83,9 +83,9 @@ class ObjectiveCSupportTests: TestCase {
                        ObjectiveCSupport.convert(object: realm.configuration).encryptionKey,
                        "Configuration.encryptionKey must be equal to RLMConfiguration.encryptionKey")
 
-        XCTAssertEqual(realm.configuration.readOnly,
-                       ObjectiveCSupport.convert(object: realm.configuration).readOnly,
-                       "Configuration.readOnly must be equal to RLMConfiguration.readOnly")
+        XCTAssertEqual(realm.configuration.immutable,
+                       ObjectiveCSupport.convert(object: realm.configuration).immutable,
+                       "Configuration.immutable must be equal to RLMConfiguration.immutable")
 
         XCTAssertEqual(realm.configuration.schemaVersion,
                        ObjectiveCSupport.convert(object: realm.configuration).schemaVersion,

--- a/RealmSwift/Tests/RealmConfigurationTests.swift
+++ b/RealmSwift/Tests/RealmConfigurationTests.swift
@@ -27,7 +27,7 @@ class RealmConfigurationTests: TestCase {
         XCTAssertEqual(defaultConfiguration.fileURL, try! Realm().configuration.fileURL)
         XCTAssertNil(defaultConfiguration.inMemoryIdentifier)
         XCTAssertNil(defaultConfiguration.encryptionKey)
-        XCTAssertFalse(defaultConfiguration.readOnly)
+        XCTAssertFalse(defaultConfiguration.immutable)
         XCTAssertEqual(defaultConfiguration.schemaVersion, 0)
         XCTAssert(defaultConfiguration.migrationBlock == nil)
     }
@@ -42,9 +42,9 @@ class RealmConfigurationTests: TestCase {
 
     func testCannotSetMutuallyExclusiveProperties() {
         var configuration = Realm.Configuration()
-        configuration.readOnly = true
+        configuration.immutable = true
         configuration.deleteRealmIfMigrationNeeded = true
         assertThrows(try! Realm(configuration: configuration),
-                     reason: "Cannot set `deleteRealmIfMigrationNeeded` when `readOnly` is set.")
+                     reason: "Cannot set `deleteRealmIfMigrationNeeded` when `immutable` is set.")
     }
 }

--- a/RealmSwift/Tests/RealmTests.swift
+++ b/RealmSwift/Tests/RealmTests.swift
@@ -34,17 +34,17 @@ class RealmTests: TestCase {
                        testRealmURL())
     }
 
-    func testReadOnly() {
+    func testImmutable() {
         autoreleasepool {
-            XCTAssertEqual(try! Realm().configuration.readOnly, false)
+            XCTAssertEqual(try! Realm().configuration.immutable, false)
 
             try! Realm().write {
                 try! Realm().create(SwiftIntObject.self, value: [100])
             }
         }
-        let config = Realm.Configuration(fileURL: defaultRealmURL(), readOnly: true)
+        let config = Realm.Configuration(fileURL: defaultRealmURL(), immutable: true)
         let readOnlyRealm = try! Realm(configuration: config)
-        XCTAssertEqual(true, readOnlyRealm.configuration.readOnly)
+        XCTAssertEqual(true, readOnlyRealm.configuration.immutable)
         XCTAssertEqual(1, readOnlyRealm.objects(SwiftIntObject.self).count)
 
         assertThrows(try! Realm(), "Realm has different readOnly settings")
@@ -74,7 +74,7 @@ class RealmTests: TestCase {
 
         assertSucceeds {
             let realm = try Realm(configuration:
-                Realm.Configuration(fileURL: testRealmURL(), readOnly: true))
+                Realm.Configuration(fileURL: testRealmURL(), immutable: true))
             XCTAssertEqual(1, realm.objects(SwiftStringObject.self).count)
         }
 
@@ -84,7 +84,7 @@ class RealmTests: TestCase {
     func testReadOnlyRealmMustExist() {
         assertFails(.fileNotFound) {
             try Realm(configuration:
-                Realm.Configuration(fileURL: defaultRealmURL(), readOnly: true))
+                Realm.Configuration(fileURL: defaultRealmURL(), immutable: true))
         }
     }
 
@@ -823,7 +823,7 @@ class RealmTests: TestCase {
             XCTFail("Failed to brigde RLMError to Realm.Error")
         }
         do {
-            _ = try Realm(configuration: Realm.Configuration(fileURL: defaultRealmURL(), readOnly: true))
+            _ = try Realm(configuration: Realm.Configuration(fileURL: defaultRealmURL(), immutable: true))
             XCTFail("Error should be thrown")
         } catch Realm.Error.fileNotFound {
             // Success to catch the error

--- a/RealmSwift/Tests/TestUtils.mm
+++ b/RealmSwift/Tests/TestUtils.mm
@@ -61,7 +61,7 @@ void RLMAssertThrowsWithName(XCTestCase *self, dispatch_block_t block, NSString 
 void RLMAssertThrowsWithReason(XCTestCase *self, dispatch_block_t block, NSString *expected,
                                NSString *message, NSString *fileName, NSUInteger lineNumber) {
     assertThrows(self, block, message, fileName, lineNumber, ^NSString *(NSException *e) {
-        if ([e.reason containsString:expected]) {
+        if ([e.reason rangeOfString:expected].location != NSNotFound) {
             return nil;
         }
         return [NSString stringWithFormat:@"The given expression threw an exception with reason '%@', but expected '%@'",

--- a/examples/tvos/objc/PreloadedData/PlacesViewController.m
+++ b/examples/tvos/objc/PreloadedData/PlacesViewController.m
@@ -32,7 +32,7 @@
     [super viewDidLoad];
 
     RLMRealmConfiguration *config = [RLMRealmConfiguration defaultConfiguration];
-    config.readOnly = YES;
+    config.immutable = YES;
     config.fileURL = [[NSBundle mainBundle] URLForResource:@"Places" withExtension:@"realm"];
     [RLMRealmConfiguration setDefaultConfiguration:config];
 

--- a/examples/tvos/swift-3.0/PreloadedData/PlacesViewController.swift
+++ b/examples/tvos/swift-3.0/PreloadedData/PlacesViewController.swift
@@ -28,7 +28,7 @@ class PlacesViewController: UITableViewController, UITextFieldDelegate {
         super.viewDidLoad()
 
         let seedFileURL = Bundle.main.url(forResource: "Places", withExtension: "realm")
-        let config = Realm.Configuration(fileURL: seedFileURL, readOnly: true)
+        let config = Realm.Configuration(fileURL: seedFileURL, immutable: true)
         Realm.Configuration.defaultConfiguration = config
 
         reloadData()


### PR DESCRIPTION
Fixes #5248.

I have a migration helper for the `Realm.Configuration` Swift initializer in #5227, so I figure I'll just update the one in that PR once this one's merged. I can add it into this PR too if you want.