### PR TITLE
Rename generic type parameter on collections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ x.x.x Release notes (yyyy-MM-dd)
   using a `RLMResults`. This results collection supports all normal collection
   operations except for setting values using KVO (since `RLMSyncPermission`s are
   immutable) and the property aggregation operations.
+* `RealmCollection`'s associated type `Element` has been renamed `ElementType`.
+* Realm Swift collection types (`List`, `Results`, `AnyRealmCollection`, and
+  `LinkingObjects` have had their generic type parameter changed from `T` to
+  `Element`).
+* `RealmOptional`'s generic type parameter has been changed from `T` to `Value`.
 
 ### Enhancements
 

--- a/RealmSwift/LinkingObjects.swift
+++ b/RealmSwift/LinkingObjects.swift
@@ -257,7 +257,7 @@ public final class LinkingObjects<Element: Object>: LinkingObjectsBase {
 
      - parameter property: The name of a property whose minimum value is desired.
      */
-    public func min<U: MinMaxType>(ofProperty property: String) -> U? {
+    public func min<T: MinMaxType>(ofProperty property: String) -> T? {
         return rlmResults.min(ofProperty: property).map(dynamicBridgeCast)
     }
 
@@ -269,7 +269,7 @@ public final class LinkingObjects<Element: Object>: LinkingObjectsBase {
 
      - parameter property: The name of a property whose minimum value is desired.
      */
-    public func max<U: MinMaxType>(ofProperty property: String) -> U? {
+    public func max<T: MinMaxType>(ofProperty property: String) -> T? {
         return rlmResults.max(ofProperty: property).map(dynamicBridgeCast)
     }
 
@@ -280,7 +280,7 @@ public final class LinkingObjects<Element: Object>: LinkingObjectsBase {
 
      - parameter property: The name of a property whose values should be summed.
      */
-    public func sum<U: AddableType>(ofProperty property: String) -> U {
+    public func sum<T: AddableType>(ofProperty property: String) -> T {
         return dynamicBridgeCast(fromObjectiveC: rlmResults.sum(ofProperty: property))
     }
 
@@ -292,7 +292,7 @@ public final class LinkingObjects<Element: Object>: LinkingObjectsBase {
 
      - parameter property: The name of a property whose average value should be calculated.
      */
-    public func average<U: AddableType>(ofProperty property: String) -> U? {
+    public func average<T: AddableType>(ofProperty property: String) -> T? {
         return rlmResults.average(ofProperty: property).map(dynamicBridgeCast)
     }
 

--- a/RealmSwift/LinkingObjects.swift
+++ b/RealmSwift/LinkingObjects.swift
@@ -61,7 +61,7 @@ public class LinkingObjectsBase: NSObject, NSFastEnumeration {
  `LinkingObjects` is an auto-updating container type. It represents zero or more objects that are linked to its owning
  model object through a property relationship.
 
- `LinkingObjects` can be queried with the same predicates as `List<T>` and `Results<T>`.
+ `LinkingObjects` can be queried with the same predicates as `List<Element>` and `Results<Element>`.
 
  `LinkingObjects` always reflects the current state of the Realm on the current thread, including during write
  transactions on the current thread. The one exception to this is when using `for...in` enumeration, which will always
@@ -71,9 +71,9 @@ public class LinkingObjectsBase: NSObject, NSFastEnumeration {
  `LinkingObjects` can only be used as a property on `Object` models. Properties of this type must be declared as `let`
  and cannot be `dynamic`.
  */
-public final class LinkingObjects<T: Object>: LinkingObjectsBase {
+public final class LinkingObjects<Element: Object>: LinkingObjectsBase {
     /// The type of the objects represented by the linking objects.
-    public typealias Element = T
+    public typealias ElementType = Element
 
     // MARK: Properties
 
@@ -99,8 +99,8 @@ public final class LinkingObjects<T: Object>: LinkingObjectsBase {
      - parameter type:         The type of the object owning the property the linking objects should refer to.
      - parameter propertyName: The property name of the property the linking objects should refer to.
      */
-    public init(fromType type: T.Type, property propertyName: String) {
-        let className = (T.self as Object.Type).className()
+    public init(fromType type: Element.Type, property propertyName: String) {
+        let className = (Element.self as Object.Type).className()
         super.init(fromClassName: className, property: propertyName)
     }
 
@@ -116,7 +116,7 @@ public final class LinkingObjects<T: Object>: LinkingObjectsBase {
 
      - parameter object: The object whose index is being queried.
      */
-    public func index(of object: T) -> Int? {
+    public func index(of object: Element) -> Int? {
         return notFoundToNil(index: rlmResults.index(of: object.unsafeCastToRLMObject()))
     }
 
@@ -146,18 +146,18 @@ public final class LinkingObjects<T: Object>: LinkingObjectsBase {
 
      - parameter index: The index.
      */
-    public subscript(index: Int) -> T {
+    public subscript(index: Int) -> Element {
         get {
             throwForNegativeIndex(index)
-            return unsafeBitCast(rlmResults[UInt(index)], to: T.self)
+            return unsafeBitCast(rlmResults[UInt(index)], to: Element.self)
         }
     }
 
     /// Returns the first object in the linking objects, or `nil` if the linking objects are empty.
-    public var first: T? { return unsafeBitCast(rlmResults.firstObject(), to: Optional<T>.self) }
+    public var first: Element? { return unsafeBitCast(rlmResults.firstObject(), to: Optional<Element>.self) }
 
     /// Returns the last object in the linking objects, or `nil` if the linking objects are empty.
-    public var last: T? { return unsafeBitCast(rlmResults.lastObject(), to: Optional<T>.self) }
+    public var last: Element? { return unsafeBitCast(rlmResults.lastObject(), to: Optional<Element>.self) }
 
     // MARK: KVC
 
@@ -199,9 +199,9 @@ public final class LinkingObjects<T: Object>: LinkingObjectsBase {
 
      - parameter predicateFormat: A predicate format string, optionally followed by a variable number of arguments.
      */
-    public func filter(_ predicateFormat: String, _ args: Any...) -> Results<T> {
-        return Results<T>(rlmResults.objects(with: NSPredicate(format: predicateFormat,
-                                                               argumentArray: unwrapOptionals(in: args))))
+    public func filter(_ predicateFormat: String, _ args: Any...) -> Results<Element> {
+        return Results(rlmResults.objects(with: NSPredicate(format: predicateFormat,
+                                                            argumentArray: unwrapOptionals(in: args))))
     }
 
     /**
@@ -209,8 +209,8 @@ public final class LinkingObjects<T: Object>: LinkingObjectsBase {
 
      - parameter predicate: The predicate with which to filter the objects.
      */
-    public func filter(_ predicate: NSPredicate) -> Results<T> {
-        return Results<T>(rlmResults.objects(with: predicate))
+    public func filter(_ predicate: NSPredicate) -> Results<Element> {
+        return Results(rlmResults.objects(with: predicate))
     }
 
     // MARK: Sorting
@@ -228,7 +228,7 @@ public final class LinkingObjects<T: Object>: LinkingObjectsBase {
      - parameter keyPath:  The key path to sort by.
      - parameter ascending: The direction to sort in.
      */
-    public func sorted(byKeyPath keyPath: String, ascending: Bool = true) -> Results<T> {
+    public func sorted(byKeyPath keyPath: String, ascending: Bool = true) -> Results<Element> {
         return sorted(by: [SortDescriptor(keyPath: keyPath, ascending: ascending)])
     }
 
@@ -242,8 +242,9 @@ public final class LinkingObjects<T: Object>: LinkingObjectsBase {
 
      - parameter sortDescriptors: A sequence of `SortDescriptor`s to sort by.
      */
-    public func sorted<S: Sequence>(by sortDescriptors: S) -> Results<T> where S.Iterator.Element == SortDescriptor {
-        return Results<T>(rlmResults.sortedResults(using: sortDescriptors.map { $0.rlmSortDescriptorValue }))
+    public func sorted<S: Sequence>(by sortDescriptors: S) -> Results<Element>
+        where S.Iterator.Element == SortDescriptor {
+            return Results(rlmResults.sortedResults(using: sortDescriptors.map { $0.rlmSortDescriptorValue }))
     }
 
     // MARK: Aggregate Operations
@@ -363,7 +364,7 @@ extension LinkingObjects : RealmCollection {
     // MARK: Sequence Support
 
     /// Returns an iterator that yields successive elements in the linking objects.
-    public func makeIterator() -> RLMIterator<T> {
+    public func makeIterator() -> RLMIterator<Element> {
         return RLMIterator(collection: rlmResults)
     }
 
@@ -387,7 +388,7 @@ extension LinkingObjects : RealmCollection {
     }
 
     /// :nodoc:
-    public func _observe(_ block: @escaping (RealmCollectionChange<AnyRealmCollection<T>>) -> Void) ->
+    public func _observe(_ block: @escaping (RealmCollectionChange<AnyRealmCollection<Element>>) -> Void) ->
         NotificationToken {
             let anyCollection = AnyRealmCollection(self)
             return rlmResults.addNotificationBlock { _, change, error in
@@ -402,7 +403,7 @@ extension LinkingObjects: AssistedObjectiveCBridgeable {
     internal static func bridging(from objectiveCValue: Any, with metadata: Any?) -> LinkingObjects {
         guard let metadata = metadata as? LinkingObjectsBridgingMetadata else { preconditionFailure() }
 
-        let swiftValue = LinkingObjects(fromType: T.self, property: metadata.propertyName)
+        let swiftValue = LinkingObjects(fromType: Element.self, property: metadata.propertyName)
         switch (objectiveCValue, metadata) {
         case (let object as RLMObjectBase, .uncached(let property)):
             swiftValue.object = RLMWeakObjectHandle(object: object)

--- a/RealmSwift/List.swift
+++ b/RealmSwift/List.swift
@@ -489,7 +489,7 @@ extension List: RealmCollection, RangeReplaceableCollection {
                 insert(x, at: subrange.lowerBound)
             }
     }
-    
+
     // This should be inferred, but Xcode 8.1 is unable to
     /// :nodoc:
     public typealias Indices = DefaultRandomAccessIndices<List>

--- a/RealmSwift/List.swift
+++ b/RealmSwift/List.swift
@@ -224,7 +224,7 @@ public final class List<Element: RealmCollectionValue>: ListBase {
 
      - parameter property: The name of a property whose minimum value is desired.
      */
-    public func min<U: MinMaxType>(ofProperty property: String) -> U? {
+    public func min<T: MinMaxType>(ofProperty property: String) -> T? {
         return _rlmArray.min(ofProperty: property).map(dynamicBridgeCast)
     }
 
@@ -236,7 +236,7 @@ public final class List<Element: RealmCollectionValue>: ListBase {
 
      - parameter property: The name of a property whose maximum value is desired.
      */
-    public func max<U: MinMaxType>(ofProperty property: String) -> U? {
+    public func max<T: MinMaxType>(ofProperty property: String) -> T? {
         return _rlmArray.max(ofProperty: property).map(dynamicBridgeCast)
     }
 
@@ -247,7 +247,7 @@ public final class List<Element: RealmCollectionValue>: ListBase {
 
      - parameter property: The name of a property whose values should be summed.
      */
-    public func sum<U: AddableType>(ofProperty property: String) -> U {
+    public func sum<T: AddableType>(ofProperty property: String) -> T {
         return dynamicBridgeCast(fromObjectiveC: _rlmArray.sum(ofProperty: property))
     }
 
@@ -258,7 +258,7 @@ public final class List<Element: RealmCollectionValue>: ListBase {
 
      - parameter property: The name of a property whose average value should be calculated.
      */
-    public func average<U: AddableType>(ofProperty property: String) -> U? {
+    public func average<T: AddableType>(ofProperty property: String) -> T? {
         return _rlmArray.average(ofProperty: property).map(dynamicBridgeCast)
     }
 

--- a/RealmSwift/List.swift
+++ b/RealmSwift/List.swift
@@ -47,14 +47,11 @@ public class ListBase: RLMListBase {
  Unlike Swift's native collections, `List`s are reference types, and are only immutable if the Realm that manages them
  is opened as read-only.
 
- Lists can be filtered and sorted with the same predicates as `Results<T>`.
+ Lists can be filtered and sorted with the same predicates as `Results<Element>`.
 
  Properties of `List` type defined on `Object` subclasses must be declared as `let` and cannot be `dynamic`.
  */
-public final class List<T: RealmCollectionValue>: ListBase {
-
-    /// The type of the elements contained within the collection.
-    public typealias Element = T
+public final class List<Element: RealmCollectionValue>: ListBase {
 
     // MARK: Properties
 
@@ -68,9 +65,9 @@ public final class List<T: RealmCollectionValue>: ListBase {
 
     // MARK: Initializers
 
-    /// Creates a `List` that holds Realm model objects of type `T`.
+    /// Creates a `List` that holds Realm model objects of type `Element`.
     public override init() {
-        super.init(array: RLMArray(objectClassName: T.className()))
+        super.init(array: RLMArray(objectClassName: Element.className()))
     }
 
     internal init(rlmArray: RLMArray<AnyObject>) {
@@ -84,7 +81,7 @@ public final class List<T: RealmCollectionValue>: ListBase {
 
      - parameter object: An object to find.
      */
-    public func index(of object: T) -> Int? {
+    public func index(of object: Element) -> Int? {
         return notFoundToNil(index: _rlmArray.index(of: object as AnyObject))
     }
 
@@ -115,10 +112,10 @@ public final class List<T: RealmCollectionValue>: ListBase {
 
      - parameter index: The index of the object to retrieve or replace.
      */
-    public subscript(position: Int) -> T {
+    public subscript(position: Int) -> Element {
         get {
             throwForNegativeIndex(position)
-            return cast(_rlmArray.object(at: UInt(position)), to: T.self)
+            return cast(_rlmArray.object(at: UInt(position)), to: Element.self)
         }
         set {
             throwForNegativeIndex(position)
@@ -127,10 +124,10 @@ public final class List<T: RealmCollectionValue>: ListBase {
     }
 
     /// Returns the first object in the list, or `nil` if the list is empty.
-    public var first: T? { return cast(_rlmArray.firstObject(), to: Optional<T>.self) }
+    public var first: Element? { return cast(_rlmArray.firstObject(), to: Optional<Element>.self) }
 
     /// Returns the last object in the list, or `nil` if the list is empty.
-    public var last: T? { return cast(_rlmArray.lastObject(), to: Optional<T>.self) }
+    public var last: Element? { return cast(_rlmArray.lastObject(), to: Optional<Element>.self) }
 
     // MARK: KVC
 
@@ -171,8 +168,8 @@ public final class List<T: RealmCollectionValue>: ListBase {
 
      - parameter predicateFormat: A predicate format string, optionally followed by a variable number of arguments.
     */
-    public func filter(_ predicateFormat: String, _ args: Any...) -> Results<T> {
-        return Results<T>(_rlmArray.objects(with: NSPredicate(format: predicateFormat,
+    public func filter(_ predicateFormat: String, _ args: Any...) -> Results<Element> {
+        return Results<Element>(_rlmArray.objects(with: NSPredicate(format: predicateFormat,
                                                               argumentArray: unwrapOptionals(in: args))))
     }
 
@@ -181,8 +178,8 @@ public final class List<T: RealmCollectionValue>: ListBase {
 
      - parameter predicate: The predicate with which to filter the objects.
      */
-    public func filter(_ predicate: NSPredicate) -> Results<T> {
-        return Results<T>(_rlmArray.objects(with: predicate))
+    public func filter(_ predicate: NSPredicate) -> Results<Element> {
+        return Results<Element>(_rlmArray.objects(with: predicate))
     }
 
     // MARK: Sorting
@@ -200,7 +197,7 @@ public final class List<T: RealmCollectionValue>: ListBase {
      - parameter keyPath:  The key path to sort by.
      - parameter ascending: The direction to sort in.
      */
-    public func sorted(byKeyPath keyPath: String, ascending: Bool = true) -> Results<T> {
+    public func sorted(byKeyPath keyPath: String, ascending: Bool = true) -> Results<Element> {
         return sorted(by: [SortDescriptor(keyPath: keyPath, ascending: ascending)])
     }
 
@@ -212,8 +209,9 @@ public final class List<T: RealmCollectionValue>: ListBase {
 
      - see: `sorted(byKeyPath:ascending:)`
     */
-    public func sorted<S: Sequence>(by sortDescriptors: S) -> Results<T> where S.Iterator.Element == SortDescriptor {
-        return Results<T>(_rlmArray.sortedResults(using: sortDescriptors.map { $0.rlmSortDescriptorValue }))
+    public func sorted<S: Sequence>(by sortDescriptors: S) -> Results<Element>
+        where S.Iterator.Element == SortDescriptor {
+            return Results<Element>(_rlmArray.sortedResults(using: sortDescriptors.map { $0.rlmSortDescriptorValue }))
     }
 
     // MARK: Aggregate Operations
@@ -276,7 +274,7 @@ public final class List<T: RealmCollectionValue>: ListBase {
 
      - parameter object: An object.
      */
-    public func append(_ object: T) {
+    public func append(_ object: Element) {
         _rlmArray.add(object as AnyObject)
     }
 
@@ -285,7 +283,7 @@ public final class List<T: RealmCollectionValue>: ListBase {
 
      - warning: This method may only be called during a write transaction.
     */
-    public func append<S: Sequence>(objectsIn objects: S) where S.Iterator.Element == T {
+    public func append<S: Sequence>(objectsIn objects: S) where S.Iterator.Element == Element {
         for obj in objects {
             _rlmArray.add(obj as AnyObject)
         }
@@ -301,7 +299,7 @@ public final class List<T: RealmCollectionValue>: ListBase {
      - parameter object: An object.
      - parameter index:  The index at which to insert the object.
      */
-    public func insert(_ object: T, at index: Int) {
+    public func insert(_ object: Element, at index: Int) {
         throwForNegativeIndex(index)
         _rlmArray.insert(object as AnyObject, at: UInt(index))
     }
@@ -350,7 +348,7 @@ public final class List<T: RealmCollectionValue>: ListBase {
      - parameter index:  The index of the object to be replaced.
      - parameter object: An object.
      */
-    public func replace(index: Int, object: T) {
+    public func replace(index: Int, object: Element) {
         throwForNegativeIndex(index)
         _rlmArray.replaceObject(at: UInt(index), with: object as AnyObject)
     }
@@ -452,10 +450,13 @@ public final class List<T: RealmCollectionValue>: ListBase {
 }
 
 extension List: RealmCollection, RangeReplaceableCollection {
+    /// The type of the objects stored within the list.
+    public typealias ElementType = Element
+
     // MARK: Sequence Support
 
     /// Returns a `RLMIterator` that yields successive elements in the `List`.
-    public func makeIterator() -> RLMIterator<T> {
+    public func makeIterator() -> RLMIterator<Element> {
         return RLMIterator(collection: _rlmArray)
     }
 
@@ -476,19 +477,19 @@ extension List: RealmCollection, RangeReplaceableCollection {
     /**
      Replace the given `subRange` of elements with `newElements`.
 
-    - parameter subrange:    The range of elements to be replaced.
-    - parameter newElements: The new elements to be inserted into the List.
-    */
+     - parameter subrange:    The range of elements to be replaced.
+     - parameter newElements: The new elements to be inserted into the List.
+     */
     public func replaceSubrange<C: Collection>(_ subrange: Range<Int>, with newElements: C)
-        where C.Iterator.Element == T {
-        for _ in subrange.lowerBound..<subrange.upperBound {
-            remove(at: subrange.lowerBound)
-        }
-        for x in newElements.reversed() {
-            insert(x, at: subrange.lowerBound)
-        }
+        where C.Iterator.Element == Element {
+            for _ in subrange.lowerBound..<subrange.upperBound {
+                remove(at: subrange.lowerBound)
+            }
+            for x in newElements.reversed() {
+                insert(x, at: subrange.lowerBound)
+            }
     }
-
+    
     // This should be inferred, but Xcode 8.1 is unable to
     /// :nodoc:
     public typealias Indices = DefaultRandomAccessIndices<List>
@@ -506,7 +507,7 @@ extension List: RealmCollection, RangeReplaceableCollection {
     public func index(before i: Int) -> Int { return i - 1 }
 
     /// :nodoc:
-    public func _observe(_ block: @escaping (RealmCollectionChange<AnyRealmCollection<T>>) -> Void) ->
+    public func _observe(_ block: @escaping (RealmCollectionChange<AnyRealmCollection<Element>>) -> Void) ->
         NotificationToken {
         let anyCollection = AnyRealmCollection(self)
         return _rlmArray.addNotificationBlock { _, change, error in

--- a/RealmSwift/Object.swift
+++ b/RealmSwift/Object.swift
@@ -44,9 +44,9 @@ import Realm.Private
  - `Bool`
  - `Date`, `NSDate`
  - `Data`, `NSData`
- - `RealmOptional<T>` for optional numeric properties
+ - `RealmOptional<Value>` for optional numeric properties
  - `Object` subclasses, to model many-to-one relationships
- - `List<T>`, to model many-to-many relationships
+ - `List<Element>`, to model many-to-many relationships
 
  `String`, `NSString`, `Date`, `NSDate`, `Data`, `NSData` and `Object` subclass properties can be declared as optional.
  `Int`, `Int8`, `Int16`, `Int32`, `Int64`, `Float`, `Double`, `Bool`, and `List` properties cannot. To store an optional

--- a/RealmSwift/Optional.swift
+++ b/RealmSwift/Optional.swift
@@ -35,9 +35,9 @@ extension Bool: RealmOptionalType {}
 
  To change the underlying value stored by a `RealmOptional` instance, mutate the instance's `value` property.
  */
-public final class RealmOptional<T: RealmOptionalType>: RLMOptionalBase {
+public final class RealmOptional<Value: RealmOptionalType>: RLMOptionalBase {
     /// The value the optional represents.
-    public var value: T? {
+    public var value: Value? {
         get {
             return underlyingValue.map(dynamicBridgeCast)
         }
@@ -51,7 +51,7 @@ public final class RealmOptional<T: RealmOptionalType>: RLMOptionalBase {
 
      - parameter value: The value to store in the optional, or `nil` if not specified.
      */
-    public init(_ value: T? = nil) {
+    public init(_ value: Value? = nil) {
         super.init()
         self.value = value
     }

--- a/RealmSwift/Realm.swift
+++ b/RealmSwift/Realm.swift
@@ -438,7 +438,7 @@ public final class Realm {
 
      :nodoc:
      */
-    public func delete<T: Object>(_ objects: List<T>) {
+    public func delete<Element: Object>(_ objects: List<Element>) {
         rlmRealm.deleteObjects(objects._rlmArray)
     }
 
@@ -451,7 +451,7 @@ public final class Realm {
 
      :nodoc:
      */
-    public func delete<T: Object>(_ objects: Results<T>) {
+    public func delete<Element: Object>(_ objects: Results<Element>) {
         rlmRealm.deleteObjects(objects.rlmResults)
     }
 
@@ -473,8 +473,8 @@ public final class Realm {
 
      - returns: A `Results` containing the objects.
      */
-    public func objects<T: Object>(_ type: T.Type) -> Results<T> {
-        return Results<T>(RLMGetObjects(rlmRealm, type.className(), nil))
+    public func objects<Element: Object>(_ type: Element.Type) -> Results<Element> {
+        return Results(RLMGetObjects(rlmRealm, type.className(), nil))
     }
 
     /**
@@ -505,10 +505,10 @@ public final class Realm {
 
      - returns: An object of type `type`, or `nil` if no instance with the given primary key exists.
      */
-    public func object<T: Object, K>(ofType type: T.Type, forPrimaryKey key: K) -> T? {
+    public func object<Element: Object, KeyType>(ofType type: Element.Type, forPrimaryKey key: KeyType) -> Element? {
         return unsafeBitCast(RLMGetObject(rlmRealm, (type as Object.Type).className(),
                                           dynamicBridgeCast(fromSwift: key)) as! RLMObjectBase?,
-                             to: Optional<T>.self)
+                             to: Optional<Element>.self)
     }
 
     /**

--- a/RealmSwift/RealmCollection.swift
+++ b/RealmSwift/RealmCollection.swift
@@ -252,7 +252,7 @@ public protocol RealmCollection: RealmCollectionBase {
 
      - parameter property: The name of a property whose minimum value is desired.
      */
-    func min<U: MinMaxType>(ofProperty property: String) -> U?
+    func min<T: MinMaxType>(ofProperty property: String) -> T?
 
     /**
      Returns the maximum (highest) value of the given property among all the objects in the collection, or `nil` if the
@@ -262,7 +262,7 @@ public protocol RealmCollection: RealmCollectionBase {
 
      - parameter property: The name of a property whose minimum value is desired.
      */
-    func max<U: MinMaxType>(ofProperty property: String) -> U?
+    func max<T: MinMaxType>(ofProperty property: String) -> T?
 
     /**
     Returns the sum of the given property for objects in the collection, or `nil` if the collection is empty.
@@ -271,7 +271,7 @@ public protocol RealmCollection: RealmCollectionBase {
 
     - parameter property: The name of a property conforming to `AddableType` to calculate sum on.
     */
-    func sum<U: AddableType>(ofProperty property: String) -> U
+    func sum<T: AddableType>(ofProperty property: String) -> T
 
     /**
      Returns the sum of the values of a given property over all the objects in the collection.
@@ -280,7 +280,7 @@ public protocol RealmCollection: RealmCollectionBase {
 
      - parameter property: The name of a property whose values should be summed.
      */
-    func average<U: AddableType>(ofProperty property: String) -> U?
+    func average<T: AddableType>(ofProperty property: String) -> T?
 
 
     // MARK: Key-Value Coding
@@ -390,10 +390,10 @@ private class _AnyRealmCollectionBase<T: RealmCollectionValue>: AssistedObjectiv
     func sorted<S: Sequence>(by sortDescriptors: S) -> Results<Element> where S.Iterator.Element == SortDescriptor {
         fatalError()
     }
-    func min<U: MinMaxType>(ofProperty property: String) -> U? { fatalError() }
-    func max<U: MinMaxType>(ofProperty property: String) -> U? { fatalError() }
-    func sum<U: AddableType>(ofProperty property: String) -> U { fatalError() }
-    func average<U: AddableType>(ofProperty property: String) -> U? { fatalError() }
+    func min<T: MinMaxType>(ofProperty property: String) -> T? { fatalError() }
+    func max<T: MinMaxType>(ofProperty property: String) -> T? { fatalError() }
+    func sum<T: AddableType>(ofProperty property: String) -> T { fatalError() }
+    func average<T: AddableType>(ofProperty property: String) -> T? { fatalError() }
     subscript(position: Int) -> Element { fatalError() }
     func makeIterator() -> RLMIterator<T> { fatalError() }
     var startIndex: Int { fatalError() }
@@ -453,19 +453,19 @@ private final class _AnyRealmCollection<C: RealmCollection>: _AnyRealmCollection
 
     // MARK: Aggregate Operations
 
-    override func min<U: MinMaxType>(ofProperty property: String) -> U? {
+    override func min<T: MinMaxType>(ofProperty property: String) -> T? {
         return base.min(ofProperty: property)
     }
 
-    override func max<U: MinMaxType>(ofProperty property: String) -> U? {
+    override func max<T: MinMaxType>(ofProperty property: String) -> T? {
         return base.max(ofProperty: property)
     }
 
-    override func sum<U: AddableType>(ofProperty property: String) -> U {
+    override func sum<T: AddableType>(ofProperty property: String) -> T {
         return base.sum(ofProperty: property)
     }
 
-    override func average<U: AddableType>(ofProperty property: String) -> U? {
+    override func average<T: AddableType>(ofProperty property: String) -> T? {
         return base.average(ofProperty: property)
     }
 
@@ -660,7 +660,7 @@ public final class AnyRealmCollection<Element: RealmCollectionValue>: RealmColle
 
      - parameter property: The name of a property whose minimum value is desired.
      */
-    public func min<U: MinMaxType>(ofProperty property: String) -> U? {
+    public func min<T: MinMaxType>(ofProperty property: String) -> T? {
         return base.min(ofProperty: property)
     }
 
@@ -672,7 +672,7 @@ public final class AnyRealmCollection<Element: RealmCollectionValue>: RealmColle
 
      - parameter property: The name of a property whose minimum value is desired.
      */
-    public func max<U: MinMaxType>(ofProperty property: String) -> U? {
+    public func max<T: MinMaxType>(ofProperty property: String) -> T? {
         return base.max(ofProperty: property)
     }
 
@@ -683,7 +683,7 @@ public final class AnyRealmCollection<Element: RealmCollectionValue>: RealmColle
 
      - parameter property: The name of a property whose values should be summed.
      */
-    public func sum<U: AddableType>(ofProperty property: String) -> U { return base.sum(ofProperty: property) }
+    public func sum<T: AddableType>(ofProperty property: String) -> T { return base.sum(ofProperty: property) }
 
     /**
      Returns the average value of a given property over all the objects in the collection, or `nil` if the collection is
@@ -693,7 +693,7 @@ public final class AnyRealmCollection<Element: RealmCollectionValue>: RealmColle
 
      - parameter property: The name of a property whose average value should be calculated.
      */
-    public func average<U: AddableType>(ofProperty property: String) -> U? { return base.average(ofProperty: property) }
+    public func average<T: AddableType>(ofProperty property: String) -> T? { return base.average(ofProperty: property) }
 
 
     // MARK: Sequence Support

--- a/RealmSwift/RealmCollection.swift
+++ b/RealmSwift/RealmCollection.swift
@@ -22,7 +22,7 @@ import Realm
 /**
  An iterator for a `RealmCollection` instance.
  */
-public struct RLMIterator<T: RealmCollectionValue>: IteratorProtocol {
+public struct RLMIterator<Element: RealmCollectionValue>: IteratorProtocol {
     private var generatorBase: NSFastEnumerationIterator
 
     init(collection: RLMCollection) {
@@ -30,12 +30,12 @@ public struct RLMIterator<T: RealmCollectionValue>: IteratorProtocol {
     }
 
     /// Advance to the next element and return it, or `nil` if no next element exists.
-    public mutating func next() -> T? {
+    public mutating func next() -> Element? {
         let next = generatorBase.next()
         if let next = next as? Object? {
-            return unsafeBitCast(next, to: Optional<T>.self)
+            return unsafeBitCast(next, to: Optional<Element>.self)
         }
-        return next as! T?
+        return next as! Element?
     }
 }
 
@@ -78,13 +78,13 @@ public struct RLMIterator<T: RealmCollectionValue>: IteratorProtocol {
  }
  ```
  */
-public enum RealmCollectionChange<T> {
+public enum RealmCollectionChange<CollectionType> {
     /**
      `.initial` indicates that the initial run of the query has completed (if
      applicable), and the collection can now be used without performing any
      blocking work.
      */
-    case initial(T)
+    case initial(CollectionType)
 
     /**
      `.update` indicates that a write transaction has been committed which
@@ -97,7 +97,7 @@ public enum RealmCollectionChange<T> {
      - parameter insertions:    The indices in the new collection which were added in this version.
      - parameter modifications: The indices of the objects in the new collection which were modified in this version.
      */
-    case update(T, deletions: [Int], insertions: [Int], modifications: [Int])
+    case update(CollectionType, deletions: [Int], insertions: [Int], modifications: [Int])
 
     /**
      If an error occurs, notification blocks are called one time with a `.error`
@@ -108,7 +108,7 @@ public enum RealmCollectionChange<T> {
      */
     case error(Error)
 
-    static func fromObjc(value: T, change: RLMCollectionChange?, error: Error?) -> RealmCollectionChange {
+    static func fromObjc(value: CollectionType, change: RLMCollectionChange?, error: Error?) -> RealmCollectionChange {
         if let error = error {
             return .error(error)
         }
@@ -143,7 +143,7 @@ public protocol RealmCollectionBase: RandomAccessCollection, LazyCollectionProto
 /// :nodoc:
 public protocol RealmCollectionBase: RandomAccessCollection, LazyCollectionProtocol, CustomStringConvertible, ThreadConfined {
     /// The type of the objects contained in the collection.
-    associatedtype Element: RealmCollectionValue
+    associatedtype ElementType: RealmCollectionValue
 }
 #endif
 
@@ -179,7 +179,7 @@ public protocol RealmCollection: RealmCollectionBase {
 
      - parameter object: An object.
      */
-    func index(of object: Element) -> Int?
+    func index(of object: ElementType) -> Int?
 
     /**
      Returns the index of the first object matching the predicate, or `nil` if no objects match.
@@ -203,14 +203,14 @@ public protocol RealmCollection: RealmCollectionBase {
 
      - parameter predicateFormat: A predicate format string, optionally followed by a variable number of arguments.
      */
-    func filter(_ predicateFormat: String, _ args: Any...) -> Results<Element>
+    func filter(_ predicateFormat: String, _ args: Any...) -> Results<ElementType>
 
     /**
      Returns a `Results` containing all objects matching the given predicate in the collection.
 
      - parameter predicate: The predicate to use to filter the objects.
      */
-    func filter(_ predicate: NSPredicate) -> Results<Element>
+    func filter(_ predicate: NSPredicate) -> Results<ElementType>
 
 
     // MARK: Sorting
@@ -228,7 +228,7 @@ public protocol RealmCollection: RealmCollectionBase {
      - parameter keyPath:   The key path to sort by.
      - parameter ascending: The direction to sort in.
      */
-    func sorted(byKeyPath keyPath: String, ascending: Bool) -> Results<Element>
+    func sorted(byKeyPath keyPath: String, ascending: Bool) -> Results<ElementType>
 
     /**
      Returns a `Results` containing the objects in the collection, but sorted.
@@ -240,7 +240,7 @@ public protocol RealmCollection: RealmCollectionBase {
 
      - parameter sortDescriptors: A sequence of `SortDescriptor`s to sort by.
      */
-    func sorted<S: Sequence>(by sortDescriptors: S) -> Results<Element> where S.Iterator.Element == SortDescriptor
+    func sorted<S: Sequence>(by sortDescriptors: S) -> Results<ElementType> where S.Iterator.Element == SortDescriptor
 
     // MARK: Aggregate Operations
 
@@ -371,7 +371,7 @@ public protocol RealmCollection: RealmCollectionBase {
     func observe(_ block: @escaping (RealmCollectionChange<Self>) -> Void) -> NotificationToken
 
     /// :nodoc:
-    func _observe(_ block: @escaping (RealmCollectionChange<AnyRealmCollection<Element>>) -> Void) -> NotificationToken
+    func _observe(_ block: @escaping (RealmCollectionChange<AnyRealmCollection<ElementType>>) -> Void) -> NotificationToken
 }
 
 private class _AnyRealmCollectionBase<T: RealmCollectionValue>: AssistedObjectiveCBridgeable {
@@ -407,7 +407,7 @@ private class _AnyRealmCollectionBase<T: RealmCollectionValue>: AssistedObjectiv
     var bridged: (objectiveCValue: Any, metadata: Any?) { fatalError() }
 }
 
-private final class _AnyRealmCollection<C: RealmCollection>: _AnyRealmCollectionBase<C.Element> {
+private final class _AnyRealmCollection<C: RealmCollection>: _AnyRealmCollectionBase<C.ElementType> {
     let base: C
     init(base: C) {
         self.base = base
@@ -423,7 +423,7 @@ private final class _AnyRealmCollection<C: RealmCollection>: _AnyRealmCollection
 
     // MARK: Index Retrieval
 
-    override func index(of object: C.Element) -> Int? { return base.index(of: object) }
+    override func index(of object: C.ElementType) -> Int? { return base.index(of: object) }
 
     override func index(matching predicate: NSPredicate) -> Int? { return base.index(matching: predicate) }
 
@@ -433,20 +433,20 @@ private final class _AnyRealmCollection<C: RealmCollection>: _AnyRealmCollection
 
     // MARK: Filtering
 
-    override func filter(_ predicateFormat: String, _ args: Any...) -> Results<C.Element> {
+    override func filter(_ predicateFormat: String, _ args: Any...) -> Results<C.ElementType> {
         return base.filter(NSPredicate(format: predicateFormat, argumentArray: unwrapOptionals(in: args)))
     }
 
-    override func filter(_ predicate: NSPredicate) -> Results<C.Element> { return base.filter(predicate) }
+    override func filter(_ predicate: NSPredicate) -> Results<C.ElementType> { return base.filter(predicate) }
 
     // MARK: Sorting
 
-    override func sorted(byKeyPath keyPath: String, ascending: Bool) -> Results<C.Element> {
+    override func sorted(byKeyPath keyPath: String, ascending: Bool) -> Results<C.ElementType> {
         return base.sorted(byKeyPath: keyPath, ascending: ascending)
     }
 
     override func sorted<S: Sequence>
-        (by sortDescriptors: S) -> Results<C.Element> where S.Iterator.Element == SortDescriptor {
+        (by sortDescriptors: S) -> Results<C.ElementType> where S.Iterator.Element == SortDescriptor {
         return base.sorted(by: sortDescriptors)
     }
 
@@ -472,11 +472,11 @@ private final class _AnyRealmCollection<C: RealmCollection>: _AnyRealmCollection
 
     // MARK: Sequence Support
 
-    override subscript(position: Int) -> C.Element {
+    override subscript(position: Int) -> C.ElementType {
         #if swift(>=3.2)
             return base[position as! C.Index]
         #else
-            return base[position as! C.Index] as! C.Element
+            return base[position as! C.Index] as! C.ElementType
         #endif
     }
 
@@ -530,21 +530,23 @@ private final class _AnyRealmCollection<C: RealmCollection>: _AnyRealmCollection
 
  Instances of `RealmCollection` forward operations to an opaque underlying collection having the same `Element` type.
  */
-public final class AnyRealmCollection<T: RealmCollectionValue>: RealmCollection {
+public final class AnyRealmCollection<Element: RealmCollectionValue>: RealmCollection {
+
+    /// The type of the objects contained within the collection.
+    public typealias ElementType = Element
 
     public func index(after i: Int) -> Int { return i + 1 }
     public func index(before i: Int) -> Int { return i - 1 }
 
     /// The type of the objects contained in the collection.
-    public typealias Element = T
-    fileprivate let base: _AnyRealmCollectionBase<T>
+    fileprivate let base: _AnyRealmCollectionBase<Element>
 
-    fileprivate init(base: _AnyRealmCollectionBase<T>) {
+    fileprivate init(base: _AnyRealmCollectionBase<Element>) {
         self.base = base
     }
 
     /// Creates an `AnyRealmCollection` wrapping `base`.
-    public init<C: RealmCollection>(_ base: C) where C.Element == T {
+    public init<C: RealmCollection>(_ base: C) where C.ElementType == Element {
         self.base = _AnyRealmCollection(base: base)
     }
 
@@ -701,10 +703,10 @@ public final class AnyRealmCollection<T: RealmCollectionValue>: RealmCollection 
 
      - parameter index: The index.
      */
-    public subscript(position: Int) -> T { return base[position] }
+    public subscript(position: Int) -> Element { return base[position] }
 
     /// Returns a `RLMIterator` that yields successive elements in the collection.
-    public func makeIterator() -> RLMIterator<T> { return base.makeIterator() }
+    public func makeIterator() -> RLMIterator<Element> { return base.makeIterator() }
 
 
     // MARK: Collection Support
@@ -821,7 +823,7 @@ private struct AnyRealmCollectionBridgingMetadata<T: RealmCollectionValue> {
 
 extension AnyRealmCollection: AssistedObjectiveCBridgeable {
     static func bridging(from objectiveCValue: Any, with metadata: Any?) -> AnyRealmCollection {
-        guard let metadata = metadata as? AnyRealmCollectionBridgingMetadata<T> else { preconditionFailure() }
+        guard let metadata = metadata as? AnyRealmCollectionBridgingMetadata<Element> else { preconditionFailure() }
         return AnyRealmCollection(base: metadata.baseType.bridging(from: objectiveCValue, with: metadata.baseMetadata))
     }
 
@@ -837,7 +839,7 @@ extension AnyRealmCollection: AssistedObjectiveCBridgeable {
 
 extension RealmCollection {
     @available(*, unavailable, renamed: "sorted(byKeyPath:ascending:)")
-    func sorted(byProperty property: String, ascending: Bool) -> Results<Element> { fatalError() }
+    func sorted(byProperty property: String, ascending: Bool) -> Results<ElementType> { fatalError() }
 
     @available(*, unavailable, renamed: "observe(_:)")
     public func addNotificationBlock(_ block: @escaping (RealmCollectionChange<Self>) -> Void) -> NotificationToken {

--- a/RealmSwift/Results.swift
+++ b/RealmSwift/Results.swift
@@ -261,7 +261,7 @@ public final class Results<Element: RealmCollectionValue>: NSObject, NSFastEnume
 
      - parameter property: The name of a property whose minimum value is desired.
      */
-    public func min<U: MinMaxType>(ofProperty property: String) -> U? {
+    public func min<T: MinMaxType>(ofProperty property: String) -> T? {
         return rlmResults.min(ofProperty: property).map(dynamicBridgeCast)
     }
 
@@ -272,7 +272,7 @@ public final class Results<Element: RealmCollectionValue>: NSObject, NSFastEnume
 
      - parameter property: The name of a property whose minimum value is desired.
      */
-    public func max<U: MinMaxType>(ofProperty property: String) -> U? {
+    public func max<T: MinMaxType>(ofProperty property: String) -> T? {
         return rlmResults.max(ofProperty: property).map(dynamicBridgeCast)
     }
 
@@ -283,7 +283,7 @@ public final class Results<Element: RealmCollectionValue>: NSObject, NSFastEnume
 
      - parameter property: The name of a property whose values should be summed.
      */
-    public func sum<U: AddableType>(ofProperty property: String) -> U {
+    public func sum<T: AddableType>(ofProperty property: String) -> T {
         return dynamicBridgeCast(fromObjectiveC: rlmResults.sum(ofProperty: property))
     }
 
@@ -294,7 +294,7 @@ public final class Results<Element: RealmCollectionValue>: NSObject, NSFastEnume
 
      - parameter property: The name of a property whose average value should be calculated.
      */
-    public func average<U: AddableType>(ofProperty property: String) -> U? {
+    public func average<T: AddableType>(ofProperty property: String) -> T? {
         return rlmResults.average(ofProperty: property).map(dynamicBridgeCast)
     }
 

--- a/RealmSwift/Results.swift
+++ b/RealmSwift/Results.swift
@@ -58,8 +58,8 @@ extension Int64: AddableType {}
 /**
  `Results` is an auto-updating container type in Realm returned from object queries.
 
- `Results` can be queried with the same predicates as `List<T>`, and you can chain queries to further filter query
- results.
+ `Results` can be queried with the same predicates as `List<Element>`, and you can
+ chain queries to further filter query results.
 
  `Results` always reflect the current state of the Realm on the current thread, including during write transactions on
  the current thread. The one exception to this is when using `for...in` enumeration, which will always enumerate over
@@ -75,7 +75,7 @@ extension Int64: AddableType {}
 
  Results instances cannot be directly instantiated.
  */
-public final class Results<T: RealmCollectionValue>: NSObject, NSFastEnumeration {
+public final class Results<Element: RealmCollectionValue>: NSObject, NSFastEnumeration {
 
     internal let rlmResults: RLMResults<AnyObject>
 
@@ -94,7 +94,7 @@ public final class Results<T: RealmCollectionValue>: NSObject, NSFastEnumeration
     }
 
     /// The type of the objects described by the results.
-    public typealias Element = T
+    public typealias ElementType = Element
 
     // MARK: Properties
 
@@ -123,7 +123,7 @@ public final class Results<T: RealmCollectionValue>: NSObject, NSFastEnumeration
     /**
      Returns the index of the given object in the results, or `nil` if the object is not present.
      */
-    public func index(of object: T) -> Int? {
+    public func index(of object: Element) -> Int? {
         return notFoundToNil(index: rlmResults.index(of: object as AnyObject))
     }
 
@@ -153,16 +153,16 @@ public final class Results<T: RealmCollectionValue>: NSObject, NSFastEnumeration
 
      - parameter index: The index.
      */
-    public subscript(position: Int) -> T {
+    public subscript(position: Int) -> Element {
         throwForNegativeIndex(position)
-        return cast(rlmResults.object(at: UInt(position)), to: T.self)
+        return cast(rlmResults.object(at: UInt(position)), to: Element.self)
     }
 
     /// Returns the first object in the results, or `nil` if the results are empty.
-    public var first: T? { return unsafeBitCast(rlmResults.firstObject(), to: Optional<T>.self) }
+    public var first: Element? { return unsafeBitCast(rlmResults.firstObject(), to: Optional<Element>.self) }
 
     /// Returns the last object in the results, or `nil` if the results are empty.
-    public var last: T? { return unsafeBitCast(rlmResults.lastObject(), to: Optional<T>.self) }
+    public var last: Element? { return unsafeBitCast(rlmResults.lastObject(), to: Optional<Element>.self) }
 
     // MARK: KVC
 
@@ -204,9 +204,9 @@ public final class Results<T: RealmCollectionValue>: NSObject, NSFastEnumeration
 
      - parameter predicateFormat: A predicate format string, optionally followed by a variable number of arguments.
      */
-    public func filter(_ predicateFormat: String, _ args: Any...) -> Results<T> {
-        return Results<T>(rlmResults.objects(with: NSPredicate(format: predicateFormat,
-                                                               argumentArray: unwrapOptionals(in: args))))
+    public func filter(_ predicateFormat: String, _ args: Any...) -> Results<Element> {
+        return Results<Element>(rlmResults.objects(with: NSPredicate(format: predicateFormat,
+                                                                     argumentArray: unwrapOptionals(in: args))))
     }
 
     /**
@@ -214,8 +214,8 @@ public final class Results<T: RealmCollectionValue>: NSObject, NSFastEnumeration
 
      - parameter predicate: The predicate with which to filter the objects.
      */
-    public func filter(_ predicate: NSPredicate) -> Results<T> {
-        return Results<T>(rlmResults.objects(with: predicate))
+    public func filter(_ predicate: NSPredicate) -> Results<Element> {
+        return Results<Element>(rlmResults.objects(with: predicate))
     }
 
     // MARK: Sorting
@@ -233,7 +233,7 @@ public final class Results<T: RealmCollectionValue>: NSObject, NSFastEnumeration
      - parameter keyPath:   The key path to sort by.
      - parameter ascending: The direction to sort in.
      */
-    public func sorted(byKeyPath keyPath: String, ascending: Bool = true) -> Results<T> {
+    public func sorted(byKeyPath keyPath: String, ascending: Bool = true) -> Results<Element> {
         return sorted(by: [SortDescriptor(keyPath: keyPath, ascending: ascending)])
     }
 
@@ -247,8 +247,9 @@ public final class Results<T: RealmCollectionValue>: NSObject, NSFastEnumeration
 
      - parameter sortDescriptors: A sequence of `SortDescriptor`s to sort by.
      */
-    public func sorted<S: Sequence>(by sortDescriptors: S) -> Results<T> where S.Iterator.Element == SortDescriptor {
-        return Results<T>(rlmResults.sortedResults(using: sortDescriptors.map { $0.rlmSortDescriptorValue }))
+    public func sorted<S: Sequence>(by sortDescriptors: S) -> Results<Element>
+        where S.Iterator.Element == SortDescriptor {
+            return Results<Element>(rlmResults.sortedResults(using: sortDescriptors.map { $0.rlmSortDescriptorValue }))
     }
 
     // MARK: Aggregate Operations
@@ -365,7 +366,7 @@ extension Results: RealmCollection {
     // MARK: Sequence Support
 
     /// Returns a `RLMIterator` that yields successive elements in the results.
-    public func makeIterator() -> RLMIterator<T> {
+    public func makeIterator() -> RLMIterator<Element> {
         return RLMIterator(collection: rlmResults)
     }
 
@@ -384,7 +385,7 @@ extension Results: RealmCollection {
     public func index(before i: Int) -> Int { return i - 1 }
 
     /// :nodoc:
-    public func _observe(_ block: @escaping (RealmCollectionChange<AnyRealmCollection<T>>) -> Void) ->
+    public func _observe(_ block: @escaping (RealmCollectionChange<AnyRealmCollection<Element>>) -> Void) ->
         NotificationToken {
         let anyCollection = AnyRealmCollection(self)
         return rlmResults.addNotificationBlock { _, change, error in

--- a/RealmSwift/Sync.swift
+++ b/RealmSwift/Sync.swift
@@ -737,14 +737,15 @@ extension SortDescriptor {
 }
 
 #if swift(>=3.1)
-extension Results where T == SyncPermission {
+extension Results where Element == SyncPermission {
     /**
      Return a `Results<SyncPermissionValue>` containing the objects represented
      by the results, but sorted on the specified property.
 
      - see: `sorted(byKeyPath:, ascending:)`
      */
-    public func sorted(bySortProperty sortProperty: SyncPermissionSortProperty, ascending: Bool = true) -> Results<T> {
+    public func sorted(bySortProperty sortProperty: SyncPermissionSortProperty,
+                       ascending: Bool = true) -> Results<Element> {
         return sorted(by: [SortDescriptor(sortProperty: sortProperty, ascending: ascending)])
     }
 }


### PR DESCRIPTION
The generic type parameter `T` on collection-like Realm types has been renamed `Element`, to better match the Swift stdlib's naming conventions. As such, the associated type `Element` on `RealmCollection` has been renamed `ElementType`.

I didn't rename the type parameters `S: Sequence` on some of the methods, ~or `U` on the aggregate methods (max, min, etc)~ since what they mean is clear in context and giving them a full name just made the type signature look more confusing. (_ed_: Renamed `U` to `T`, since there are no longer `T` parameters.)

I also renamed the param on `RealmOptional`.

Fixes #3991.