### PR TITLE
Exploring a partial sync API

### DIFF
--- a/Realm.xcodeproj/project.pbxproj
+++ b/Realm.xcodeproj/project.pbxproj
@@ -455,6 +455,10 @@
 		E8F992BE1F1401C100F634B5 /* RLMObjectBase_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = E8F992BD1F1401C100F634B5 /* RLMObjectBase_Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E8F992BF1F1401C100F634B5 /* RLMObjectBase_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = E8F992BD1F1401C100F634B5 /* RLMObjectBase_Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E8FD2E381D93345100569F10 /* keychain_helper.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1A64CA891D8763B400BC0F9B /* keychain_helper.cpp */; };
+		F98AC6A51F576F6500E811A5 /* RLMResults+RLMResults_Sync.h in Headers */ = {isa = PBXBuildFile; fileRef = F98AC6A31F576F6500E811A5 /* RLMResults+RLMResults_Sync.h */; };
+		F98AC6A61F576F6500E811A5 /* RLMResults+RLMResults_Sync.h in Headers */ = {isa = PBXBuildFile; fileRef = F98AC6A31F576F6500E811A5 /* RLMResults+RLMResults_Sync.h */; };
+		F98AC6A71F576F6500E811A5 /* RLMResults+RLMResults_Sync.m in Sources */ = {isa = PBXBuildFile; fileRef = F98AC6A41F576F6500E811A5 /* RLMResults+RLMResults_Sync.m */; };
+		F98AC6A81F576F6500E811A5 /* RLMResults+RLMResults_Sync.m in Sources */ = {isa = PBXBuildFile; fileRef = F98AC6A41F576F6500E811A5 /* RLMResults+RLMResults_Sync.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -930,6 +934,8 @@
 		E8DA16F71E81210D0055141C /* CompactionTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CompactionTests.m; sourceTree = "<group>"; };
 		E8F8D90B196CB8DD00475368 /* SwiftTestObjects.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwiftTestObjects.swift; sourceTree = "<group>"; };
 		E8F992BD1F1401C100F634B5 /* RLMObjectBase_Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RLMObjectBase_Private.h; sourceTree = "<group>"; };
+		F98AC6A31F576F6500E811A5 /* RLMResults+RLMResults_Sync.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "RLMResults+RLMResults_Sync.h"; sourceTree = "<group>"; };
+		F98AC6A41F576F6500E811A5 /* RLMResults+RLMResults_Sync.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "RLMResults+RLMResults_Sync.m"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1142,6 +1148,8 @@
 				1A84132E1D4BCCE600C5326F /* RLMSyncUtil.mm */,
 				1A1C6E241D3FFCF70077B6E7 /* RLMSyncUtil_Private.h */,
 				1A0512731D87413000806AEC /* RLMSyncUtil_Private.hpp */,
+				F98AC6A31F576F6500E811A5 /* RLMResults+RLMResults_Sync.h */,
+				F98AC6A41F576F6500E811A5 /* RLMResults+RLMResults_Sync.m */,
 			);
 			name = Sync;
 			sourceTree = "<group>";
@@ -1591,6 +1599,7 @@
 				5D659EA71BE04556006515A0 /* RLMAccessor.h in Headers */,
 				5D659EA91BE04556006515A0 /* RLMArray.h in Headers */,
 				5D659EAA1BE04556006515A0 /* RLMArray_Private.h in Headers */,
+				F98AC6A51F576F6500E811A5 /* RLMResults+RLMResults_Sync.h in Headers */,
 				5D659EAB1BE04556006515A0 /* RLMCollection.h in Headers */,
 				5D1BF1FF1EF987AD00B7DC87 /* RLMCollection_Private.h in Headers */,
 				5D659EAC1BE04556006515A0 /* RLMConstants.h in Headers */,
@@ -1695,6 +1704,7 @@
 				1ADE093F1E897EF0008AB1D3 /* RLMSyncPermission.h in Headers */,
 				1A7003111D5270FF00FD9EE3 /* RLMSyncSession.h in Headers */,
 				1ABDCDB11D793012003489E3 /* RLMSyncUser.h in Headers */,
+				F98AC6A61F576F6500E811A5 /* RLMResults+RLMResults_Sync.h in Headers */,
 				1A7DE70B1D3847670029F0AE /* RLMSyncUtil.h in Headers */,
 				E8C6EAF41DD66C0C00EC1A03 /* RLMSyncUtil_Private.h in Headers */,
 				3F67DB401E26D6A20024533D /* RLMThreadSafeReference.h in Headers */,
@@ -2264,6 +2274,7 @@
 				5D659E9D1BE04556006515A0 /* shared_realm.cpp in Sources */,
 				1A1536721DB0464800C0EC93 /* sync_file.cpp in Sources */,
 				1A1536581DB045B500C0EC93 /* sync_manager.cpp in Sources */,
+				F98AC6A71F576F6500E811A5 /* RLMResults+RLMResults_Sync.m in Sources */,
 				1A1536741DB0464800C0EC93 /* sync_metadata.cpp in Sources */,
 				1ADE09371E897BCA008AB1D3 /* sync_permission.cpp in Sources */,
 				1A15365C1DB045B500C0EC93 /* sync_session.cpp in Sources */,
@@ -2401,6 +2412,7 @@
 				5DD7559B1BE056DE002800DA /* shared_realm.cpp in Sources */,
 				1A1536761DB0464F00C0EC93 /* sync_file.cpp in Sources */,
 				1A1536631DB045CB00C0EC93 /* sync_manager.cpp in Sources */,
+				F98AC6A81F576F6500E811A5 /* RLMResults+RLMResults_Sync.m in Sources */,
 				1A1536771DB0465400C0EC93 /* sync_metadata.cpp in Sources */,
 				1ADE09391E897BEF008AB1D3 /* sync_permission.cpp in Sources */,
 				1A1536671DB045D200C0EC93 /* sync_session.cpp in Sources */,

--- a/Realm/RLMResults+RLMResults_Sync.h
+++ b/Realm/RLMResults+RLMResults_Sync.h
@@ -1,0 +1,24 @@
+//
+//  RLMResults+RLMResults_Sync.h
+//  Realm
+//
+//  Created by Adam Fish on 8/30/17.
+//  Copyright © 2017 Realm. All rights reserved.
+//
+
+#import <Realm/Realm.h>
+#import <Realm/RLMCollection.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@class RLMObject, RLMRealm, RLMNotificationToken;
+
+@interface RLMResults<RLMObjectType> (RLMResults_Sync)
+
+- (RLMNotificationToken *)addNotificationBlock:(void (^)(RLMResults<RLMObjectType> *__nullable results,
+                                                         RLMCollectionChange *__nullable change,
+                                                         NSError *__nullable error))block __attribute__((warn_unused_result));
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Realm/RLMResults+RLMResults_Sync.m
+++ b/Realm/RLMResults+RLMResults_Sync.m
@@ -1,0 +1,63 @@
+//
+//  RLMResults+RLMResults_Sync.m
+//  Realm
+//
+//  Created by Adam Fish on 8/30/17.
+//  Copyright © 2017 Realm. All rights reserved.
+//
+
+#import "RLMResults+RLMResults_Sync.h"
+
+@implementation RLMResults (RLMResults_Sync)
+
+- (RLMNotificationToken *)addNotificationBlock:(void (^)(RLMResults<RLMObjectType> *__nullable results,
+                                                         RLMCollectionChange *__nullable change,
+                                                         NSError *__nullable error))block __attribute__((warn_unused_result)) {
+    // Pseudo-code
+    
+    /*
+     1. Check if existing `ResultSets` object exists
+     1a. If NO, create or update the `ResultSets` table in the Realm
+     
+     @interface ResultSets : RLMObject
+     
+     // The name of the matches property to be used for the query associated
+     // with this result set (`'car_matches'` for instance).
+     @property NSString *matches_property;
+     
+     // The query (usual predicate syntax) to be executed against
+     // the class associated with the selected matches property
+     // (see `matches_property`).
+     @property NSString *query;
+     
+     // Status    meaning
+     // -------------------------------
+     //   0       uninitialized
+     //   1       initialized
+     //  -1       query parsing failed
+     //
+     // Application should leave the status at zero for new result
+     // sets. Server will set to 1 after each successful execution, and -1 on
+     // failure to parse the query. While the status remains -1, the server
+     // will ignore that result set. The application may reset the status
+     // back to 0 at any time.
+     @property NSInteger status;
+     
+     // When the server fails to parse the specified query, it
+     // stores the associated error message here. Expect a multi
+     // lined message with a line terminator on the final line.
+     @property NSString *error_message;
+     
+     // Custom matches properties. One for each class that needs to be
+     // queryable.
+     @property RLMArray<RLMObjectType *><RLMObjectType> *matches;
+     @end
+     1b. If YES, skip to step 3
+     2. Create a `ResultSets` object for the query
+     3. Obtain the session and use `wait_for_download_completion` to then fire the first callback
+     
+     */
+    
+}
+
+@end

--- a/Realm/RLMSyncConfiguration.h
+++ b/Realm/RLMSyncConfiguration.h
@@ -48,6 +48,18 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic) BOOL enableSSLValidation;
 
 /**
+ Whether to open the Realm in partial synchronization mode.
+ 
+ In this mode, the Realm will only synchronize a subset of data from the server.
+ 
+ On first open, the Realm will contain no data. Instead, data will synchronize
+ from the server after registration of a query.
+ 
+ To register a query see RLMResults
+ */
+@property (nonatomic, readonly) BOOL partial;
+
+/**
  Create a sync configuration instance.
 
  @param user    A `RLMSyncUser` that owns the Realm at the given URL.
@@ -57,6 +69,19 @@ NS_ASSUME_NONNULL_BEGIN
                 the user identity by the Realm Object Server.
  */
 - (instancetype)initWithUser:(RLMSyncUser *)user realmURL:(NSURL *)url;
+
+/**
+ Create a sync configuration instance.
+ 
+ @param user    A `RLMSyncUser` that owns the Realm at the given URL.
+ @param url     The unresolved absolute URL to the Realm on the Realm Object Server, e.g.
+                `realm://example.org/~/path/to/realm`. "Unresolved" means the path should
+                contain the wildcard marker `~`, which will automatically be filled in with
+                the user identity by the Realm Object Server.
+ @param partial Whether to open the Realm in partial synchronization mode
+ */
+
+- (instancetype)initWithUser:(RLMSyncUser *)user realmURL:(NSURL *)url partial:(BOOL)partial;
 
 /// :nodoc:
 - (instancetype)init __attribute__((unavailable("This type cannot be created directly")));

--- a/Realm/RLMSyncConfiguration.mm
+++ b/Realm/RLMSyncConfiguration.mm
@@ -68,6 +68,7 @@ static BOOL isValidRealmURL(NSURL *url) {
 
 - (instancetype)initWithUser:(RLMSyncUser *)user
                     realmURL:(NSURL *)url
+                     partial:(BOOL)partial
                customFileURL:(nullable NSURL *)customFileURL
                   stopPolicy:(RLMSyncStopPolicy)stopPolicy
                 errorHandler:(std::function<realm::SyncSessionErrorHandler>)errorHandler;
@@ -126,6 +127,16 @@ static BOOL isValidRealmURL(NSURL *url) {
 - (instancetype)initWithUser:(RLMSyncUser *)user realmURL:(NSURL *)url {
     return [self initWithUser:user
                      realmURL:url
+                      partial:NO
+                customFileURL:nil
+                   stopPolicy:RLMSyncStopPolicyAfterChangesUploaded
+                 errorHandler:nullptr];
+}
+
+- (instancetype)initWithUser:(RLMSyncUser *)user realmURL:(NSURL *)url partial:(BOOL)partial {
+    return [self initWithUser:user
+                     realmURL:url
+                      partial:partial
                 customFileURL:nil
                    stopPolicy:RLMSyncStopPolicyAfterChangesUploaded
                  errorHandler:nullptr];
@@ -133,6 +144,7 @@ static BOOL isValidRealmURL(NSURL *url) {
 
 - (instancetype)initWithUser:(RLMSyncUser *)user
                     realmURL:(NSURL *)url
+                     partial:(BOOL)partial
                customFileURL:(nullable NSURL *)customFileURL
                   stopPolicy:(RLMSyncStopPolicy)stopPolicy
                 errorHandler:(std::function<realm::SyncSessionErrorHandler>)errorHandler {
@@ -147,6 +159,12 @@ static BOOL isValidRealmURL(NSURL *url) {
             NSURL *realmURL = [NSURL URLWithString:@(config.realm_url.c_str())];
             NSString *path = [realmURL path];
             REALM_ASSERT(realmURL && path);
+            
+            // Setup partial sync
+            if (partial) {
+                path = [NSString stringWithFormat:@"%@/__partial/%s", path, user->identity().c_str()];
+            }
+            
             RLMSyncSessionRefreshHandle *handle = [[RLMSyncSessionRefreshHandle alloc] initWithRealmURL:realmURL
                                                                                                    user:user
                                                                                                 session:std::move(session)

--- a/Realm/RLMSyncManager.h
+++ b/Realm/RLMSyncManager.h
@@ -20,7 +20,7 @@
 
 #import "RLMSyncUtil.h"
 
-@class RLMSyncSession;
+@class RLMSyncSession, RLMResults;
 
 /// An enum representing different levels of sync-related logging that can be configured.
 typedef NS_ENUM(NSUInteger, RLMSyncLogLevel) {
@@ -92,8 +92,27 @@ typedef void(^RLMSyncErrorReportingBlock)(NSError *, RLMSyncSession * _Nullable)
  */
 @property (nonatomic) RLMSyncLogLevel logLevel;
 
+/**
+ Retrieve a list of all registered remote queries.
+ 
+ Only works with partial synced Realms
+ 
+ Returns a list of ResultSet objects, where only the `query` and `status` are public
+*/
+@property (nonatomic, readonly) RLMResults<ResultSet> *remoteQueries;
+
 /// The sole instance of the singleton.
 + (instancetype)sharedManager NS_REFINED_FOR_SWIFT;
+
+/**
+ Deletes all the `ResultSet` objects to unregister the remote queries
+ 
+ Must be done in a write transaction
+ 
+ 
+ // `unregister()` method is available on an individual `ResultSets` to remove a single one.
+ */
+- (void)unregisterAllRemoteQueries;
 
 /// :nodoc:
 - (instancetype)init __attribute__((unavailable("RLMSyncManager cannot be created directly")));


### PR DESCRIPTION
I haven't been able to get too far with an actual implementation of the partial sync API, but started exploring how it could hook into the Cocoa API. Currently I see the API broken into three pieces:

1. SyncConfiguration support to configure the Realm to be a partially synced Realm - implemented as just an additional boolean
2. Registration of a remote query - I explored how this could hook into the existing query and notification system, however, I am starting to doubt this approach (details below)
3. De-registration and querying of registered remote queries - explored this on the SyncManager

Thoughts on registration:

My initial exploration on this PR was to tap into the existing Cocoa functionality where you can perform a local query and add a notification block which would be the registration of a remote query:
```objc
RLMNotificationToken *token = [[Person objectsWhere:@"age > 5"] addNotificationBlock:^(RLMResults<Person *> *results, RLMCollectionChange *changes, NSError *error) {
    // Handle results
}];
```
```swift
let token = Realm().objects(Person.self).filter("age > 5").addNotificationBlock { [weak self] (changes: RealmCollectionChange) in
    // Handle results
}
```
However, while this is nice in that it reuses existing patterns, it has the following problems:

1. Without `addNotificationBlock` the local query returns nothing and its not obvious why adding a notification block would register a remote query
2. The `token` is confusing in this sense because it controls the lifetime of the callback but not the lifetime of the remote query registration
3. This reusing of existing APIs won't work with Java and .Net because they don't even have a string-based query API.

Creating this PR to track a discussion.
