### PR TITLE
Add Xcode 9 to CI's test matrix

### DIFF
--- a/.jenkins.yml
+++ b/.jenkins.yml
@@ -6,6 +6,7 @@ xcode_version:
   - 8.1
   - 8.2
   - 8.3.3
+  - 9.0
 target:
   - osx
   - docs
@@ -46,6 +47,9 @@ configuration:
 # | -------------------- | --- | ---- | ---------- | ----------- | --------- | --------- | ------- | --------- | --------- | ---- | -------------- | ----------------- | -------------------- | --------------------- | --------------------- | ---------------------- | ----------- |
 # | 8.3.3 | Debug        | X   |      |            | X           | X         | X         | X       |           |           | X    |                |                   |                      |                       |                       |                        |             |
 # | 8.3.3 | Release      | X   | X    |            | X           | X         | X         | X       | X         | X         | X    | X              | X                 | X                    |                       | X                     |                        | X           |
+# | -------------------- | --- | ---- | ---------- | ----------- | --------- | --------- | ------- | --------- | --------- | ---- | -------------- | ----------------- | -------------------- | --------------------- | --------------------- | ---------------------- | ----------- |
+# | 9.0   | Debug        | X   |      |            | X           | X         | X         | X       |           |           | X    |                |                   |                      |                       |                       |                        |             |
+# | 9.0   | Release      | X   |      |            | X           | X         | X         | X       | X         | X         | X    | X              | X                 | X                    |                       | X                     |                        | X           |
 # +----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 
 exclude:
@@ -59,6 +63,8 @@ exclude:
     target: docs
   - xcode_version: 8.2
     target: docs
+  - xcode_version: 9.0
+    target: docs
   - target: docs
     configuration: Debug
 
@@ -66,7 +72,7 @@ exclude:
   # ios-static
   ################
   # Skip on 8.0/8.1 Debug
-  # Skip 8.3.3 altogether since it doesn't support the iOS 7 deployment target
+  # Skip 8.3.3/9.0 altogether since it doesn't support the iOS 7 deployment target
   - xcode_version: 8.0
     target: ios-static
     configuration: Debug
@@ -74,6 +80,8 @@ exclude:
     target: ios-static
     configuration: Debug
   - xcode_version: 8.3.3
+    target: ios-static
+  - xcode_version: 9.0
     target: ios-static
 
   ################
@@ -142,7 +150,7 @@ exclude:
   ################
   # swiftlint
   ################
-  # Just run on 8.3.3 Release
+  # Just run on 8.3.3/9.0 Release
   - xcode_version: 8.0
     target: swiftlint
   - xcode_version: 8.1
@@ -169,7 +177,7 @@ exclude:
   ################
   # osx-encryption
   ################
-  # Just run on 8.3.3 Release
+  # Just run on 8.3.3/9.0 Release
   - xcode_version: 8.0
     target: osx-encryption
   - xcode_version: 8.1
@@ -182,7 +190,7 @@ exclude:
   ################
   # osx-object-server
   ################
-  # Just run on 8.3.3 Release
+  # Just run on 8.3.3/9.0 Release
   - xcode_version: 8.0
     target: osx-object-server
   - xcode_version: 8.1
@@ -195,7 +203,7 @@ exclude:
   ################
   # ios-device-objc-ios8
   ################
-  # Just run on 8.3.3 Release
+  # Just run on 8.3.3/9.0 Release
   - xcode_version: 8.0
     target: ios-device-objc-ios8
   - xcode_version: 8.1
@@ -208,7 +216,7 @@ exclude:
   ################
   # ios-device-swift-ios8
   ################
-  # Just run on 8.3.3 Release
+  # Just run on 8.3.3/9.0 Release
   - xcode_version: 8.0
     target: ios-device-swift-ios8
   - xcode_version: 8.1
@@ -221,7 +229,7 @@ exclude:
   ################
   # ios-device-objc-ios10
   ################
-  # Just run on 8.3.3 Release
+  # Just run on 8.3.3/9.0 Release
   - xcode_version: 8.0
     target: ios-device-objc-ios10
   - xcode_version: 8.1
@@ -234,7 +242,7 @@ exclude:
   ################
   # ios-device-swift-ios10
   ################
-  # Just run on 8.3.3 Release
+  # Just run on 8.3.3/9.0 Release
   - xcode_version: 8.0
     target: ios-device-swift-ios10
   - xcode_version: 8.1
@@ -247,7 +255,7 @@ exclude:
   ################
   # tvos-device
   ################
-  # Just run on 8.3.3 Release
+  # Just run on 8.3.3/9.0 Release
   - xcode_version: 8.0
     target: tvos-device
   - xcode_version: 8.1

--- a/RealmSwift/Tests/KVOTests.swift
+++ b/RealmSwift/Tests/KVOTests.swift
@@ -72,6 +72,7 @@ class KVOTests: TestCase {
 
     var changeDictionary: [NSKeyValueChangeKey: Any]?
 
+    // swiftlint:disable:next block_based_kvo
     override func observeValue(forKeyPath keyPath: String?, of object: Any?,
                                change: [NSKeyValueChangeKey : Any]?, context: UnsafeMutableRawPointer?) {
         changeDictionary = change

--- a/build.sh
+++ b/build.sh
@@ -145,7 +145,11 @@ build_combined() {
         destination="Apple Watch - 42mm"
     elif [[ "$os" == "appletvos"  ]]; then
         os_name="tvos"
-        destination="Apple TV 1080p"
+        if (( $(xcode_version_major) >= 9 )); then
+            destination="Apple TV"
+        else
+            destination="Apple TV 1080p"
+        fi
     fi
 
     # Derive build paths
@@ -685,12 +689,22 @@ case "$COMMAND" in
         ;;
 
     "test-tvos")
-        xc "-scheme Realm -configuration $CONFIGURATION -sdk appletvsimulator -destination 'name=Apple TV 1080p' test"
+        if (( $(xcode_version_major) >= 9 )); then
+            destination="Apple TV"
+        else
+            destination="Apple TV 1080p"
+        fi
+        xc "-scheme Realm -configuration $CONFIGURATION -sdk appletvsimulator -destination 'name=$destination' test"
         exit $?
         ;;
 
     "test-tvos-swift")
-        xc "-scheme RealmSwift -configuration $CONFIGURATION -sdk appletvsimulator -destination 'name=Apple TV 1080p' test"
+        if (( $(xcode_version_major) >= 9 )); then
+            destination="Apple TV"
+        else
+            destination="Apple TV 1080p"
+        fi
+        xc "-scheme RealmSwift -configuration $CONFIGURATION -sdk appletvsimulator -destination 'name=$destination' test"
         exit $?
         ;;
 
@@ -923,15 +937,27 @@ case "$COMMAND" in
 
     "examples-tvos")
         workspace="examples/tvos/objc/RealmExamples.xcworkspace"
-        xc "-workspace $workspace -scheme DownloadCache -configuration $CONFIGURATION -destination 'name=Apple TV 1080p' build ${CODESIGN_PARAMS}"
-        xc "-workspace $workspace -scheme PreloadedData -configuration $CONFIGURATION -destination 'name=Apple TV 1080p' build ${CODESIGN_PARAMS}"
+        if (( $(xcode_version_major) >= 9 )); then
+            destination="Apple TV"
+        else
+            destination="Apple TV 1080p"
+        fi
+
+        xc "-workspace $workspace -scheme DownloadCache -configuration $CONFIGURATION -destination 'name=$destination' build ${CODESIGN_PARAMS}"
+        xc "-workspace $workspace -scheme PreloadedData -configuration $CONFIGURATION -destination 'name=$destination' build ${CODESIGN_PARAMS}"
         exit 0
         ;;
 
     "examples-tvos-swift")
         workspace="examples/tvos/swift/RealmExamples.xcworkspace"
-        xc "-workspace $workspace -scheme DownloadCache -configuration $CONFIGURATION -destination 'name=Apple TV 1080p' build ${CODESIGN_PARAMS}"
-        xc "-workspace $workspace -scheme PreloadedData -configuration $CONFIGURATION -destination 'name=Apple TV 1080p' build ${CODESIGN_PARAMS}"
+        if (( $(xcode_version_major) >= 9 )); then
+            destination="Apple TV"
+        else
+            destination="Apple TV 1080p"
+        fi
+
+        xc "-workspace $workspace -scheme DownloadCache -configuration $CONFIGURATION -destination 'name=$destination' build ${CODESIGN_PARAMS}"
+        xc "-workspace $workspace -scheme PreloadedData -configuration $CONFIGURATION -destination 'name=$destination' build ${CODESIGN_PARAMS}"
         exit 0
         ;;
 

--- a/scripts/reset-simulators.rb
+++ b/scripts/reset-simulators.rb
@@ -88,9 +88,9 @@ begin
       output = `xcrun simctl create '#{device_type['name']}' '#{device_type['identifier']}' '#{runtime['identifier']}' 2>&1`
       next if $? == 0
 
-      # Error code 161 indicates that the given device is not supported by the runtime, such as the iPad 2 and
+      # Error code 161 and 162 indicate that the given device is not supported by the runtime, such as the iPad 2 and
       # iPhone 4s not being supported by the iOS 10 simulator runtime.
-      next if output =~ /(domain=com.apple.CoreSimulator.SimError, code=161)/
+      next if output =~ /(domain=com.apple.CoreSimulator.SimError, code=16[12])/
 
       puts "Failed to create device of type #{device_type['identifier']} with runtime #{runtime['identifier']}:"
       output.each_line do |line|

--- a/scripts/swift-version.sh
+++ b/scripts/swift-version.sh
@@ -116,6 +116,7 @@ set_xcode_and_swift_versions() {
         DEVELOPER_DIR="$(xcode-select -p)"
     fi
     export DEVELOPER_DIR
+    REALM_XCODE_VERSION=$(get_xcode_version "$DEVELOPER_DIR/usr/bin/xcodebuild")
     export REALM_XCODE_VERSION
     
     if [ -z "$REALM_SWIFT_VERSION" ]; then


### PR DESCRIPTION
For now I've just had it copy the Xcode 8.3.3 configuration. We can likely remove some of the duplication after confirming that things work with Xcode 9.