### PR TITLE
Build and package for Swift 3.2 and 4.0.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1210,7 +1210,7 @@ EOM
 
     "package-ios-swift")
         cd tightdb_objc
-        for version in 8.0 8.1 8.2 8.3.3; do
+        for version in 8.0 8.1 8.2 8.3.3 9.0; do
             REALM_XCODE_VERSION=$version
             REALM_SWIFT_VERSION=
             set_xcode_and_swift_versions
@@ -1219,12 +1219,13 @@ EOM
         done
 
         cd build/ios
-        zip --symlinks -r realm-swift-framework-ios.zip swift-3.0 swift-3.0.1 swift-3.0.2 swift-3.1
+        ln -s swift-4.0 swift-3.2
+        zip --symlinks -r realm-swift-framework-ios.zip swift-3.0 swift-3.0.1 swift-3.0.2 swift-3.1 swift-3.2 swift-4.0
         ;;
 
     "package-osx-swift")
         cd tightdb_objc
-        for version in 8.0 8.1 8.2 8.3.3; do
+        for version in 8.0 8.1 8.2 8.3.3 9.0; do
             REALM_XCODE_VERSION=$version
             REALM_SWIFT_VERSION=
             set_xcode_and_swift_versions
@@ -1233,7 +1234,8 @@ EOM
         done
 
         cd build/osx
-        zip --symlinks -r realm-swift-framework-osx.zip swift-3.0 swift-3.0.1 swift-3.0.2 swift-3.1
+        ln -s swift-4.0 swift-3.2
+        zip --symlinks -r realm-swift-framework-osx.zip swift-3.0 swift-3.0.1 swift-3.0.2 swift-3.1 swift-3.2 swift-4.0
         ;;
 
     "package-watchos")
@@ -1247,7 +1249,7 @@ EOM
 
     "package-watchos-swift")
         cd tightdb_objc
-        for version in 8.0 8.1 8.2 8.3.3; do
+        for version in 8.0 8.1 8.2 8.3.3 9.0; do
             REALM_XCODE_VERSION=$version
             REALM_SWIFT_VERSION=
             set_xcode_and_swift_versions
@@ -1256,7 +1258,8 @@ EOM
         done
 
         cd build/watchos
-        zip --symlinks -r realm-swift-framework-watchos.zip swift-3.0 swift-3.0.1 swift-3.0.2 swift-3.1
+        ln -s swift-4.0 swift-3.2
+        zip --symlinks -r realm-swift-framework-watchos.zip swift-3.0 swift-3.0.1 swift-3.0.2 swift-3.1 swift-3.2 swift-4.0
         ;;
 
     "package-tvos")
@@ -1270,7 +1273,7 @@ EOM
 
     "package-tvos-swift")
         cd tightdb_objc
-        for version in 8.0 8.1 8.2 8.3.3; do
+        for version in 8.0 8.1 8.2 8.3.3 9.0; do
             REALM_XCODE_VERSION=$version
             REALM_SWIFT_VERSION=
             set_xcode_and_swift_versions
@@ -1279,7 +1282,8 @@ EOM
         done
 
         cd build/tvos
-        zip --symlinks -r realm-swift-framework-tvos.zip swift-3.0 swift-3.0.1 swift-3.0.2 swift-3.1
+        ln -s swift-4.0 swift-3.2
+        zip --symlinks -r realm-swift-framework-tvos.zip swift-3.0 swift-3.0.1 swift-3.0.2 swift-3.1 swift-3.2 swift-4.0
         ;;
 
     "package-release")

--- a/build.sh
+++ b/build.sh
@@ -922,6 +922,10 @@ case "$COMMAND" in
     "examples-ios-swift")
         sh build.sh prelaunch-simulator
         workspace="examples/ios/swift/RealmExamples.xcworkspace"
+        if [[ ! -d "$workspace" ]]; then
+            workspace="${workspace/swift/swift-$REALM_SWIFT_VERSION}"
+        fi
+
         xc "-workspace $workspace -scheme Simple -configuration $CONFIGURATION -destination 'name=iPhone 6' build ${CODESIGN_PARAMS}"
         xc "-workspace $workspace -scheme TableView -configuration $CONFIGURATION -destination 'name=iPhone 6' build ${CODESIGN_PARAMS}"
         xc "-workspace $workspace -scheme Migration -configuration $CONFIGURATION -destination 'name=iPhone 6' build ${CODESIGN_PARAMS}"
@@ -950,6 +954,10 @@ case "$COMMAND" in
 
     "examples-tvos-swift")
         workspace="examples/tvos/swift/RealmExamples.xcworkspace"
+        if [[ ! -d "$workspace" ]]; then
+            workspace="${workspace/swift/swift-$REALM_SWIFT_VERSION}"
+        fi
+
         if (( $(xcode_version_major) >= 9 )); then
             destination="Apple TV"
         else

--- a/examples/installation/build.sh
+++ b/examples/installation/build.sh
@@ -53,6 +53,9 @@ xctest() {
     LANG="$2"
     NAME="$3"
     DIRECTORY="$PLATFORM/$LANG/$NAME"
+    if [[ ! -d "$DIRECTORY" ]]; then
+        DIRECTORY="${DIRECTORY/swift/swift-$REALM_SWIFT_VERSION}"
+    fi
     PROJECT="$DIRECTORY/$NAME.xcodeproj"
     WORKSPACE="$DIRECTORY/$NAME.xcworkspace"
     if [[ $PLATFORM == ios ]]; then

--- a/scripts/package_examples.rb
+++ b/scripts/package_examples.rb
@@ -41,7 +41,7 @@ base_examples = [
   "examples/tvos/swift",
 ]
 
-swift_versions = %w(3.0 3.0.1 3.0.2 3.1)
+swift_versions = %w(3.0 3.0.1 3.0.2 3.1 3.2 4.0)
 
 # Remove reference to Realm.xcodeproj from all example workspaces.
 base_examples.each do |example|


### PR DESCRIPTION
This currently builds only Swift 4.0 and symlinks Swift 3.2 to it as https://swift.org/migration-guide-swift4/ suggests that a module built with Swift 4.0 should be compatible with Swift 3.2. We'll need to double-check this.