### PR TITLE
Fix Swift 3.2/4.0 compilation failure

### DIFF
--- a/RealmSwift/RealmCollection.swift
+++ b/RealmSwift/RealmCollection.swift
@@ -136,6 +136,9 @@ public protocol RealmCollectionValue {
 }
 
 #if swift(>=3.2)
+// FIXME: When we drop support for Swift 3.1, change ElementType to Element
+// throughout the project (this is a non-breaking change). We use ElementType
+// only because of limitations in Swift 3.1's compiler.
 /// :nodoc:
 public protocol RealmCollectionBase: RandomAccessCollection, LazyCollectionProtocol, CustomStringConvertible, ThreadConfined where Element: RealmCollectionValue {
     typealias ElementType = Element

--- a/RealmSwift/RealmCollection.swift
+++ b/RealmSwift/RealmCollection.swift
@@ -138,6 +138,7 @@ public protocol RealmCollectionValue {
 #if swift(>=3.2)
 /// :nodoc:
 public protocol RealmCollectionBase: RandomAccessCollection, LazyCollectionProtocol, CustomStringConvertible, ThreadConfined where Element: RealmCollectionValue {
+    typealias ElementType = Element
 }
 #else
 /// :nodoc:


### PR DESCRIPTION
Fix a compilation failure when building Realm Swift for Swift 3.2/4.0.

I think this is the least bad option. Other things I tried include:

- Getting rid of `RealmCollectionBase`, since >=3.2 doesn't require it. Unfortunately, because of the way Swift's `#if` works (i.e. not like the CPP), and because the syntax for associated types changed between 3.1 and 3.2, the entire protocol would have to be declared twice, once for 3.1 and once for >=3.2.
- Making Swift 3.1 use `Element` instead of `ElementType` in all the declarations in the protocol and classes that conform to it. Unfortunately bugs in Swift 3.1's compiler make it fail to associate the generic types on the conforming types with the associated type with the same name (`Element`, from the parent `Collection` requirement), requiring them to have different names and a typealias to link them.

Ideas are welcome.