### PR TITLE
Fix the Cocoa releasability CI job

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -24,3 +24,4 @@ disabled_rules:
   - line_length
   - vertical_whitespace
   - syntactic_sugar
+  - block_based_kvo

--- a/Jenkinsfile.releasability
+++ b/Jenkinsfile.releasability
@@ -1,0 +1,58 @@
+try {
+    build job: 'objc_prepare_workspace', parameters: [string(name: 'sha', value: sha)]
+    parallel (
+      objcOsx: { build job: 'objc_osx' },
+      cocoaDocs: { build job: 'cocoa_docs' },
+      objcIos: { build job: 'objc_ios' },
+      objcWatchos: { build job: 'objc_watchos' },
+      objcTvos: { build job: 'objc_tvos' },
+      cocoaIosDyn: { build job: 'cocoa_ios_dynamic' },
+      objcExamples: { build job: 'objc_examples' },
+      packageIosSwift: { build job: 'Package iOS Swift' },
+      packageOsxSwift: { build job: 'Package OS X Swift' },
+      packageWatchosSwift: { build job: 'Package watchOS Swift' },
+      packageTvosSwift: { build job: 'Package tvOS Swift' }
+    )
+    parallel (
+      objc: { build job: 'cocoa_release_package' },
+      swift: { build job: 'swift_release_package' }
+    )
+    parallel (
+      objcTestExamples: { build job: 'objc_test_examples', parameters: [string(name: 'sha', value: sha)] },
+      cocoaInstallationExamples: { build job: 'Cocoa Installation Examples', parameters: [string(name: 'sha', value: sha)] }
+    )  
+} catch (e) {
+    // If there was an exception thrown, the build failed
+    currentBuild.result = "FAILED"
+    throw e
+  } finally {
+    // Success or failure, always send notifications
+    notifyBuild(currentBuild.result, '#cocoa-team')
+  }
+
+def notifyBuild(String buildStatus = 'STARTED', String channel) {
+  // build status of null means successful
+  buildStatus =  buildStatus ?: 'SUCCESSFUL'
+
+  // Default values
+  def colorName = 'RED'
+  def colorCode = '#FF0000'
+  def subject = "${buildStatus}: Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]'"
+  def summary = "${subject} (${env.BUILD_URL})"
+  def details = """<p>STARTED: Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]':</p>
+    <p>Check console output at &QUOT;<a href='${env.BUILD_URL}'>${env.JOB_NAME} [${env.BUILD_NUMBER}]</a>&QUOT;</p>"""
+
+  // Override default values based on build status
+  if (buildStatus == 'STARTED') {
+    color = 'YELLOW'
+    colorCode = '#FFFF00'
+  } else if (buildStatus == 'SUCCESSFUL') {
+    color = 'GREEN'
+    colorCode = '#00FF00'
+  } else {
+    color = 'RED'
+    colorCode = '#FF0000'
+  }
+
+  slackSend(channel: channel, color: colorCode, message: summary)
+}

--- a/Jenkinsfile.releasability
+++ b/Jenkinsfile.releasability
@@ -2,9 +2,38 @@ swiftVersions = ['3.0', '3.0.1', '3.0.2', '3.1', '3.2', '4.0']
 platforms = ['osx', 'ios', 'watchos', 'tvos']
 platformNames = ['osx': 'macOS', 'ios': 'iOS', 'watchos': 'watchOS', 'tvos': 'tvOS']
 
+def installationTest(platform, test, language) {
+  return {
+    node('osx') {
+      deleteDir()
+      unstash 'source'
+
+      if (test == "dynamic" || test == "static") {
+        unstash "${language}-packaged"
+      }
+
+      sh """
+      archive=\$(echo \$PWD/realm-${language}-*.zip)
+      cd examples/installation
+
+      if [[ -f \$archive ]]; then
+        mv \$archive .
+        unzip realm-${language}-*zip
+        find . -name 'realm-${language}-*' -print0 | xargs -J% mv % realm-${language}-latest
+      fi
+
+      ./build.sh test-${platform}-${language}-${test}
+      """
+    }
+  }
+}
+
+
 def doBuild() {
   stage('prepare') {
     node('docker') {
+      deleteDir()
+
       checkout(
         [
           $class           : 'GitSCM',
@@ -163,7 +192,7 @@ def doBuild() {
   }
 
   stage('test') {
-    parallel (
+    def parallelBuilds = [
       "Test Examples": {
         node('osx') {
           deleteDir()
@@ -184,13 +213,44 @@ def doBuild() {
           XCMODE=xcpretty sh build.sh package-test-examples
           """
         }
-      },
-
-      "Installation Examples": {
-        // FIXME: Implement this.
-        // build job: 'Cocoa Installation Examples', parameters: [string(name: 'sha', value: sha)]
       }
-    )
+    ]
+
+    // objc / osx / dynamic
+    // objc / osx / cocoapods
+    // objc / osx / carthage
+    //
+    // objc / ios / dynamic
+    // objc / ios / cocoapods
+    // objc / ios / carthage
+
+    for (def platform in ["osx", "ios"]) {
+      def platformName = platformNames[platform]
+      for (def test in ["dynamic", "cocoapods", "carthage"]) {
+        parallelBuilds["${platformName} Obj-C ${test}"] = installationTest(platform, test, 'objc')
+      }
+    }
+
+    // objc / ios / static
+    // objc / ios / cocoapods-dynamic
+
+    parallelBuilds["iOS Obj-C static"] = installationTest('ios', 'static', 'objc')
+    parallelBuilds["iOS Obj-C CocoaPods dynamic"] = installationTest('ios', 'cocoapods-dynamic', 'objc')
+
+    // swift / osx / cocoapods
+    // swift / osx / carthage
+    //
+    // swift / ios / cocoapods
+    // swift / ios / carthage
+
+    for (def platform in ["osx", "ios"]) {
+      def platformName = platformNames[platform]
+      for (def test in ["cocoapods", "carthage"]) {
+        parallelBuilds["${platformName} Swift ${test}"] = installationTest(platform, test, 'swift')
+      }
+    }
+
+    parallel parallelBuilds
   }
 }
 

--- a/Jenkinsfile.releasability
+++ b/Jenkinsfile.releasability
@@ -40,11 +40,42 @@ def doBuild() {
         }
       },
 
-      // "macOS Obj-C": { build job: 'objc_osx' },
-      // "iOS Obj-C": { build job: 'objc_ios' },
-      // "watchOS Obj-C": { build job: 'objc_watchos' },
-      // "tvOS Obj-C": { build job: 'objc_tvos' },
-      // "iOS Obj-C dynamic": { build job: 'cocoa_ios_dynamic' },
+      "macOS Obj-C": {
+        node('osx') {
+          unstash 'source'
+          sh 'XCMODE=xcpretty ./build.sh package-osx'
+          // FIXME: Why is this file at a different location than for the other variants?
+          stash includes: 'build/DerivedData/Realm/Build/Products/Release/realm-framework-osx.zip', name: 'macos-objc'
+        }
+      },
+      "iOS Obj-C": {
+        node('osx') {
+          unstash 'source'
+          sh 'XCMODE=xcpretty ./build.sh package-ios-dynamic'
+          stash includes: 'build/ios/realm-framework-ios.zip', name: 'ios-objc'
+        }
+      },
+      "watchOS Obj-C": {
+        node('osx') {
+          unstash 'source'
+          sh 'XCMODE=xcpretty ./build.sh package-watchos'
+          stash includes: 'build/watchos/realm-framework-watchos.zip', name: 'watchos-objc'
+        }
+      },
+      "tvOS Obj-C": {
+        node('osx') {
+          unstash 'source'
+          sh 'XCMODE=xcpretty ./build.sh package-tvos'
+          stash includes: 'build/tvos/realm-framework-tvos.zip', name: 'tvos-objc'
+        }
+      },
+      "iOS Obj-C static": {
+        node('osx') {
+          unstash 'source'
+          sh 'XCMODE=xcpretty ./build.sh package-ios-static'
+          stash includes: 'build/ios-static/realm-framework-ios-static.zip', name: 'ios-objc-static'
+        }
+      },
 
       // "macOS Swift": { build job: 'Package OS X Swift' },
       // "iOS Swift": { build job: 'Package iOS Swift' },

--- a/Jenkinsfile.releasability
+++ b/Jenkinsfile.releasability
@@ -18,19 +18,38 @@ def doBuild() {
 
   stage('build') {
     parallel (
-      "docs": { build job: 'cocoa_docs' },
-      "examples": { build job: 'objc_examples' },
+      "docs": {
+        node('osx') {
+          unstash 'source'
+          sh '''
+          ./scripts/reset-simulators.sh
+          ./build.sh docs
+          cd docs
+          zip -r objc-docs.zip objc_output
+          zip -r swift-docs.zip swift_output
+          '''
+          stash includes: 'docs/*-docs.zip', name: 'docs'
+        }
+      },
 
-      "macOS Obj-C": { build job: 'objc_osx' },
-      "iOS Obj-C": { build job: 'objc_ios' },
-      "watchOS Obj-C": { build job: 'objc_watchos' },
-      "tvOS Obj-C": { build job: 'objc_tvos' },
-      "iOS Obj-C dynamic": { build job: 'cocoa_ios_dynamic' },
+      "examples": {
+        node('osx') {
+          unstash 'source'
+          sh 'XCMODE=xcpretty ./build.sh package-examples'
+          stash includes: 'realm-examples.zip', name: 'examples'
+        }
+      },
 
-      "macOS Swift": { build job: 'Package OS X Swift' },
-      "iOS Swift": { build job: 'Package iOS Swift' },
-      "watchOS Swift": { build job: 'Package watchOS Swift' },
-      "tvOS Swift": { build job: 'Package tvOS Swift' }
+      // "macOS Obj-C": { build job: 'objc_osx' },
+      // "iOS Obj-C": { build job: 'objc_ios' },
+      // "watchOS Obj-C": { build job: 'objc_watchos' },
+      // "tvOS Obj-C": { build job: 'objc_tvos' },
+      // "iOS Obj-C dynamic": { build job: 'cocoa_ios_dynamic' },
+
+      // "macOS Swift": { build job: 'Package OS X Swift' },
+      // "iOS Swift": { build job: 'Package iOS Swift' },
+      // "watchOS Swift": { build job: 'Package watchOS Swift' },
+      // "tvOS Swift": { build job: 'Package tvOS Swift' }
     )
   }
 

--- a/Jenkinsfile.releasability
+++ b/Jenkinsfile.releasability
@@ -1,9 +1,6 @@
-def swiftVersions = ['3.0', '3.0.1', '3.0.2', '3.1', '3.2', '4.0']
-def platformNames = ["macOS", "iOS", "watchOS", "tvOS"]
-
-def platformFromPlatformName(platformName) {
-  return platformName == "macOS" ? "osx" : platformName.toLowerCase()
-}
+swiftVersions = ['3.0', '3.0.1', '3.0.2', '3.1', '3.2', '4.0']
+platforms = ['osx', 'ios', 'watchos', 'tvos']
+platformNames = ['osx': 'macOS', 'ios': 'iOS', 'watchos': 'watchOS', 'tvos': 'tvOS']
 
 def doBuild() {
   stage('prepare') {
@@ -85,17 +82,17 @@ def doBuild() {
       },
     ]
 
-    for (def p in platformNames) {
-      def platformName = p
-      def platform = platformFromPlatformName(platformName)
+    for (def p in platforms) {
+      def platform = p
+      def platformName = platformNames[platform]
       for (def v in swiftVersions) {
         def swiftVersion = v
-        parallelBuilds["${platform} Swift ${swiftVersion}"] = {
+        parallelBuilds["${platformName} Swift ${swiftVersion}"] = {
           node('osx') {
             unstash 'source'
-            sh "XCMODE=xcpretty ./build.sh package-${lower_platform}-swift-${swiftVersion}"
-            stash includes: "build/${lower_platform}/realm-swift-framework-${lower_platform}-swift-${swiftVersion}.zip",
-                  name: "${lower_platform}-swift-${swiftVersion}"
+            sh "XCMODE=xcpretty ./build.sh package-${platform}-swift-${swiftVersion}"
+            stash includes: "build/${platform}/realm-swift-framework-${platform}-swift-${swiftVersion}.zip",
+                  name: "${platform}-swift-${swiftVersion}"
           }
         }
       }
@@ -106,8 +103,35 @@ def doBuild() {
 
   stage('package') {
     parallel (
-      objc: { build job: 'cocoa_release_package' },
-      swift: { build job: 'swift_release_package' }
+      "Obj-C": {
+        node('osx') {
+          for (def platform in platforms) {
+            unstash "${platform}-objc"
+          }
+
+          unstash 'ios-objc-static'
+          unstash 'examples'
+          unstash 'source'
+
+          sh './build.sh package-release objc'
+          archiveArtifacts artifacts: 'realm-objc-*.zip'
+        }
+      },
+      "Swift": {
+        node('osx') {
+          for (def platform in platforms) {
+            for (def swiftVersion in swiftVersions) {
+              unstash "${platform}-swift-${swiftVersion}"
+            }
+          }
+
+          unstash 'examples'
+          unstash 'source'
+
+          sh './build.sh package-release swift'
+          archiveArtifacts artifacts: 'realm-swift-*.zip'
+        }
+      }
     )
   }
 

--- a/Jenkinsfile.releasability
+++ b/Jenkinsfile.releasability
@@ -24,6 +24,7 @@ def doBuild() {
     def parallelBuilds = [
       "docs": {
         node('osx') {
+          deleteDir()
           unstash 'source'
           sh '''
           ./scripts/reset-simulators.sh
@@ -38,6 +39,7 @@ def doBuild() {
 
       "examples": {
         node('osx') {
+          deleteDir()
           unstash 'source'
           sh 'XCMODE=xcpretty ./build.sh package-examples'
           stash includes: 'realm-examples.zip', name: 'examples'
@@ -46,6 +48,7 @@ def doBuild() {
 
       "macOS Obj-C": {
         node('osx') {
+          deleteDir()
           unstash 'source'
           sh 'XCMODE=xcpretty ./build.sh package-osx'
           // FIXME: Why is this file at a different location than for the other variants?
@@ -54,6 +57,7 @@ def doBuild() {
       },
       "iOS Obj-C": {
         node('osx') {
+          deleteDir()
           unstash 'source'
           sh 'XCMODE=xcpretty ./build.sh package-ios-dynamic'
           stash includes: 'build/ios/realm-framework-ios.zip', name: 'ios-objc'
@@ -61,6 +65,7 @@ def doBuild() {
       },
       "watchOS Obj-C": {
         node('osx') {
+          deleteDir()
           unstash 'source'
           sh 'XCMODE=xcpretty ./build.sh package-watchos'
           stash includes: 'build/watchos/realm-framework-watchos.zip', name: 'watchos-objc'
@@ -68,6 +73,7 @@ def doBuild() {
       },
       "tvOS Obj-C": {
         node('osx') {
+          deleteDir()
           unstash 'source'
           sh 'XCMODE=xcpretty ./build.sh package-tvos'
           stash includes: 'build/tvos/realm-framework-tvos.zip', name: 'tvos-objc'
@@ -75,6 +81,7 @@ def doBuild() {
       },
       "iOS Obj-C static": {
         node('osx') {
+          deleteDir()
           unstash 'source'
           sh 'XCMODE=xcpretty ./build.sh package-ios-static'
           stash includes: 'build/ios-static/realm-framework-ios-static.zip', name: 'ios-objc-static'
@@ -89,6 +96,7 @@ def doBuild() {
         def swiftVersion = v
         parallelBuilds["${platformName} Swift ${swiftVersion}"] = {
           node('osx') {
+            deleteDir()
             unstash 'source'
             sh "XCMODE=xcpretty ./build.sh package-${platform}-swift-${swiftVersion}"
             stash includes: "build/${platform}/realm-swift-framework-${platform}-swift-${swiftVersion}.zip",
@@ -105,6 +113,8 @@ def doBuild() {
     parallel (
       "Obj-C": {
         node('osx') {
+          deleteDir()
+
           for (def platform in platforms) {
             unstash "${platform}-objc"
           }
@@ -120,6 +130,8 @@ def doBuild() {
       },
       "Swift": {
         node('osx') {
+          deleteDir()
+
           for (def platform in platforms) {
             for (def swiftVersion in swiftVersions) {
               unstash "${platform}-swift-${swiftVersion}"
@@ -142,6 +154,8 @@ def doBuild() {
     parallel (
       "Test Examples": {
         node('osx') {
+          deleteDir()
+
           // FIXME: Split Obj-C and Swift.
           unstash 'objc-packaged'
           unstash 'swift-packaged'

--- a/Jenkinsfile.releasability
+++ b/Jenkinsfile.releasability
@@ -1,5 +1,23 @@
-try {
-    build job: 'objc_prepare_workspace', parameters: [string(name: 'sha', value: sha)]
+def doBuild() {
+  stage('prepare') {
+    //  build job: 'objc_prepare_workspace', parameters: [string(name: 'sha', value: sha)]
+    node('docker') {
+      checkout(
+        [
+          $class           : 'GitSCM',
+          branches         : scm.branches,
+          gitTool          : 'native git',
+          extensions       : scm.extensions + [[$class: 'CleanCheckout'],
+                                               [$class: 'SubmoduleOption', parentCredentials: true]],
+          userRemoteConfigs: scm.userRemoteConfigs,
+        ]
+      )
+
+      stash includes: '**', name: 'source'
+    }
+  }
+
+  stage('build') {
     parallel (
       objcOsx: { build job: 'objc_osx' },
       cocoaDocs: { build job: 'cocoa_docs' },
@@ -13,22 +31,33 @@ try {
       packageWatchosSwift: { build job: 'Package watchOS Swift' },
       packageTvosSwift: { build job: 'Package tvOS Swift' }
     )
+  }
+
+  stage('package') {
     parallel (
       objc: { build job: 'cocoa_release_package' },
       swift: { build job: 'swift_release_package' }
     )
+  }
+
+  stage('test') {
     parallel (
       objcTestExamples: { build job: 'objc_test_examples', parameters: [string(name: 'sha', value: sha)] },
       cocoaInstallationExamples: { build job: 'Cocoa Installation Examples', parameters: [string(name: 'sha', value: sha)] }
-    )  
-} catch (e) {
-    // If there was an exception thrown, the build failed
-    currentBuild.result = "FAILED"
-    throw e
-  } finally {
-    // Success or failure, always send notifications
-    notifyBuild(currentBuild.result, '#cocoa-team')
+    )
   }
+}
+
+try {
+  doBuild()
+} catch (e) {
+  // If there was an exception thrown, the build failed
+  currentBuild.result = "FAILED"
+  throw e
+} finally {
+  // Success or failure, always send notifications
+  notifyBuild(currentBuild.result, '#cocoa-team')
+}
 
 def notifyBuild(String buildStatus = 'STARTED', String channel) {
   // build status of null means successful

--- a/Jenkinsfile.releasability
+++ b/Jenkinsfile.releasability
@@ -257,6 +257,5 @@ def notifyBuild(String buildStatus = 'STARTED', String channel) {
     colorCode = '#FF0000'
   }
 
-  // FIXME: Enable this once things are mostly working.
-  // slackSend(channel: channel, color: colorCode, message: summary)
+  slackSend(channel: channel, color: colorCode, message: summary)
 }

--- a/Jenkinsfile.releasability
+++ b/Jenkinsfile.releasability
@@ -28,6 +28,19 @@ def installationTest(platform, test, language) {
   }
 }
 
+def buildObjC(platform, outputDirectory=null) {
+  return {
+    node('osx') {
+      deleteDir()
+      unstash 'source'
+      sh "XCMODE=xcpretty ./build.sh package-${platform}"
+      dir(outputDirectory ?: "build/${platform}") {
+        stash includes: "realm-framework-${platform}.zip", name: "${platform}-objc"
+      }
+    }
+  }
+}
+
 
 def doBuild() {
   stage('prepare') {
@@ -51,7 +64,7 @@ def doBuild() {
 
   stage('build') {
     def parallelBuilds = [
-      "docs": {
+      'Docs': {
         node('osx') {
           deleteDir()
           unstash 'source'
@@ -66,7 +79,7 @@ def doBuild() {
         }
       },
 
-      "examples": {
+      'Examples': {
         node('osx') {
           deleteDir()
           unstash 'source'
@@ -75,57 +88,11 @@ def doBuild() {
         }
       },
 
-      "macOS Obj-C": {
-        node('osx') {
-          deleteDir()
-          unstash 'source'
-          sh 'XCMODE=xcpretty ./build.sh package-osx'
-          // FIXME: Why is this file at a different location than for the other variants?
-          dir('build/DerivedData/Realm/Build/Products/Release') {
-            stash includes: 'realm-framework-osx.zip', name: 'osx-objc'
-          }
-        }
-      },
-      "iOS Obj-C": {
-        node('osx') {
-          deleteDir()
-          unstash 'source'
-          sh 'XCMODE=xcpretty ./build.sh package-ios-dynamic'
-          dir('build/ios') {
-            stash includes: 'realm-framework-ios.zip', name: 'ios-objc'
-          }
-        }
-      },
-      "watchOS Obj-C": {
-        node('osx') {
-          deleteDir()
-          unstash 'source'
-          sh 'XCMODE=xcpretty ./build.sh package-watchos'
-          dir('build/watchos') {
-            stash includes: 'realm-framework-watchos.zip', name: 'watchos-objc'
-          }
-        }
-      },
-      "tvOS Obj-C": {
-        node('osx') {
-          deleteDir()
-          unstash 'source'
-          sh 'XCMODE=xcpretty ./build.sh package-tvos'
-          dir('build/tvos') {
-            stash includes: 'realm-framework-tvos.zip', name: 'tvos-objc'
-          }
-        }
-      },
-      "iOS Obj-C static": {
-        node('osx') {
-          deleteDir()
-          unstash 'source'
-          sh 'XCMODE=xcpretty ./build.sh package-ios-static'
-          dir('build/ios-static') {
-            stash includes: 'realm-framework-ios-static.zip', name: 'ios-objc-static'
-          }
-        }
-      },
+      'macOS Obj-C': buildObjC('osx', 'build/DerivedData/Realm/Build/Products/Release'),
+      'iOS Obj-C': buildObjC('ios'),
+      'watchOS Obj-C': buildObjC('watchos'),
+      'tvOS Obj-C': buildObjC('tvos'),
+      'iOS Obj-C static': buildObjC('ios-static'),
     ]
 
     for (def p in platforms) {
@@ -160,7 +127,7 @@ def doBuild() {
             unstash "${platform}-objc"
           }
 
-          unstash 'ios-objc-static'
+          unstash 'ios-static-objc'
           unstash 'examples'
           unstash 'source'
 

--- a/Jenkinsfile.releasability
+++ b/Jenkinsfile.releasability
@@ -54,5 +54,6 @@ def notifyBuild(String buildStatus = 'STARTED', String channel) {
     colorCode = '#FF0000'
   }
 
-  slackSend(channel: channel, color: colorCode, message: summary)
+  // FIXME: Enable this once things are mostly working.
+  // slackSend(channel: channel, color: colorCode, message: summary)
 }

--- a/Jenkinsfile.releasability
+++ b/Jenkinsfile.releasability
@@ -52,7 +52,9 @@ def doBuild() {
           unstash 'source'
           sh 'XCMODE=xcpretty ./build.sh package-osx'
           // FIXME: Why is this file at a different location than for the other variants?
-          stash includes: 'build/DerivedData/Realm/Build/Products/Release/realm-framework-osx.zip', name: 'osx-objc'
+          dir('build/DerivedData/Realm/Build/Products/Release') {
+            stash includes: 'realm-framework-osx.zip', name: 'osx-objc'
+          }
         }
       },
       "iOS Obj-C": {
@@ -60,7 +62,9 @@ def doBuild() {
           deleteDir()
           unstash 'source'
           sh 'XCMODE=xcpretty ./build.sh package-ios-dynamic'
-          stash includes: 'build/ios/realm-framework-ios.zip', name: 'ios-objc'
+          dir('build/ios') {
+            stash includes: 'realm-framework-ios.zip', name: 'ios-objc'
+          }
         }
       },
       "watchOS Obj-C": {
@@ -68,7 +72,9 @@ def doBuild() {
           deleteDir()
           unstash 'source'
           sh 'XCMODE=xcpretty ./build.sh package-watchos'
-          stash includes: 'build/watchos/realm-framework-watchos.zip', name: 'watchos-objc'
+          dir('build/watchos') {
+            stash includes: 'realm-framework-watchos.zip', name: 'watchos-objc'
+          }
         }
       },
       "tvOS Obj-C": {
@@ -76,7 +82,9 @@ def doBuild() {
           deleteDir()
           unstash 'source'
           sh 'XCMODE=xcpretty ./build.sh package-tvos'
-          stash includes: 'build/tvos/realm-framework-tvos.zip', name: 'tvos-objc'
+          dir('build/tvos') {
+            stash includes: 'realm-framework-tvos.zip', name: 'tvos-objc'
+          }
         }
       },
       "iOS Obj-C static": {
@@ -84,7 +92,9 @@ def doBuild() {
           deleteDir()
           unstash 'source'
           sh 'XCMODE=xcpretty ./build.sh package-ios-static'
-          stash includes: 'build/ios-static/realm-framework-ios-static.zip', name: 'ios-objc-static'
+          dir('build/ios-static') {
+            stash includes: 'realm-framework-ios-static.zip', name: 'ios-objc-static'
+          }
         }
       },
     ]
@@ -99,8 +109,10 @@ def doBuild() {
             deleteDir()
             unstash 'source'
             sh "XCMODE=xcpretty ./build.sh package-${platform}-swift-${swiftVersion}"
-            stash includes: "build/${platform}/realm-swift-framework-${platform}-swift-${swiftVersion}.zip",
-                  name: "${platform}-swift-${swiftVersion}"
+            dir("build/${platform}") {
+              stash includes: "realm-swift-framework-${platform}-swift-${swiftVersion}.zip",
+                    name: "${platform}-swift-${swiftVersion}"
+            }
           }
         }
       }

--- a/Jenkinsfile.releasability
+++ b/Jenkinsfile.releasability
@@ -1,6 +1,5 @@
 def doBuild() {
   stage('prepare') {
-    //  build job: 'objc_prepare_workspace', parameters: [string(name: 'sha', value: sha)]
     node('docker') {
       checkout(
         [
@@ -19,17 +18,19 @@ def doBuild() {
 
   stage('build') {
     parallel (
-      objcOsx: { build job: 'objc_osx' },
-      cocoaDocs: { build job: 'cocoa_docs' },
-      objcIos: { build job: 'objc_ios' },
-      objcWatchos: { build job: 'objc_watchos' },
-      objcTvos: { build job: 'objc_tvos' },
-      cocoaIosDyn: { build job: 'cocoa_ios_dynamic' },
-      objcExamples: { build job: 'objc_examples' },
-      packageIosSwift: { build job: 'Package iOS Swift' },
-      packageOsxSwift: { build job: 'Package OS X Swift' },
-      packageWatchosSwift: { build job: 'Package watchOS Swift' },
-      packageTvosSwift: { build job: 'Package tvOS Swift' }
+      "docs": { build job: 'cocoa_docs' },
+      "examples": { build job: 'objc_examples' },
+
+      "macOS Obj-C": { build job: 'objc_osx' },
+      "iOS Obj-C": { build job: 'objc_ios' },
+      "watchOS Obj-C": { build job: 'objc_watchos' },
+      "tvOS Obj-C": { build job: 'objc_tvos' },
+      "iOS Obj-C dynamic": { build job: 'cocoa_ios_dynamic' },
+
+      "macOS Swift": { build job: 'Package OS X Swift' },
+      "iOS Swift": { build job: 'Package iOS Swift' },
+      "watchOS Swift": { build job: 'Package watchOS Swift' },
+      "tvOS Swift": { build job: 'Package tvOS Swift' }
     )
   }
 

--- a/Jenkinsfile.releasability
+++ b/Jenkinsfile.releasability
@@ -49,7 +49,7 @@ def doBuild() {
           unstash 'source'
           sh 'XCMODE=xcpretty ./build.sh package-osx'
           // FIXME: Why is this file at a different location than for the other variants?
-          stash includes: 'build/DerivedData/Realm/Build/Products/Release/realm-framework-osx.zip', name: 'macos-objc'
+          stash includes: 'build/DerivedData/Realm/Build/Products/Release/realm-framework-osx.zip', name: 'osx-objc'
         }
       },
       "iOS Obj-C": {
@@ -114,6 +114,7 @@ def doBuild() {
           unstash 'source'
 
           sh './build.sh package-release objc'
+          stash include: 'realm-objc-*.zip', name: 'objc-packaged'
           archiveArtifacts artifacts: 'realm-objc-*.zip'
         }
       },
@@ -129,6 +130,8 @@ def doBuild() {
           unstash 'source'
 
           sh './build.sh package-release swift'
+          sh 'rm realm-swift-framework-*.zip'
+          stash include: 'realm-swift-*.zip', name: 'swift-packaged'
           archiveArtifacts artifacts: 'realm-swift-*.zip'
         }
       }
@@ -137,8 +140,30 @@ def doBuild() {
 
   stage('test') {
     parallel (
-      objcTestExamples: { build job: 'objc_test_examples', parameters: [string(name: 'sha', value: sha)] },
-      cocoaInstallationExamples: { build job: 'Cocoa Installation Examples', parameters: [string(name: 'sha', value: sha)] }
+      "Test Examples": {
+        node('osx') {
+          // FIXME: Split Obj-C and Swift.
+          unstash 'objc-packaged'
+          unstash 'swift-packaged'
+
+          def sha = params.sha
+          sh """
+          curl -O https://raw.githubusercontent.com/realm/realm-cocoa/${sha}/build.sh
+          mkdir -p scripts
+          curl https://raw.githubusercontent.com/realm/realm-cocoa/${sha}/scripts/swift-version.sh -o scripts/swift-version.sh
+          curl https://raw.githubusercontent.com/realm/realm-cocoa/${sha}/scripts/reset-simulators.sh -o scripts/reset-simulators.sh
+          curl https://raw.githubusercontent.com/realm/realm-cocoa/${sha}/scripts/reset-simulators.rb -o scripts/reset-simulators.rb
+          chmod +x scripts/reset-simulators.rb
+
+          XCMODE=xcpretty sh build.sh package-test-examples
+          """
+        }
+      },
+
+      "Installation Examples": {
+        // FIXME: Implement this.
+        // build job: 'Cocoa Installation Examples', parameters: [string(name: 'sha', value: sha)]
+      }
     )
   }
 }

--- a/Jenkinsfile.releasability
+++ b/Jenkinsfile.releasability
@@ -1,3 +1,10 @@
+def swiftVersions = ['3.0', '3.0.1', '3.0.2', '3.1', '3.2', '4.0']
+def platformNames = ["macOS", "iOS", "watchOS", "tvOS"]
+
+def platformFromPlatformName(platformName) {
+  return platformName == "macOS" ? "osx" : platformName.toLowerCase()
+}
+
 def doBuild() {
   stage('prepare') {
     node('docker') {
@@ -17,7 +24,7 @@ def doBuild() {
   }
 
   stage('build') {
-    parallel (
+    def parallelBuilds = [
       "docs": {
         node('osx') {
           unstash 'source'
@@ -76,12 +83,25 @@ def doBuild() {
           stash includes: 'build/ios-static/realm-framework-ios-static.zip', name: 'ios-objc-static'
         }
       },
+    ]
 
-      // "macOS Swift": { build job: 'Package OS X Swift' },
-      // "iOS Swift": { build job: 'Package iOS Swift' },
-      // "watchOS Swift": { build job: 'Package watchOS Swift' },
-      // "tvOS Swift": { build job: 'Package tvOS Swift' }
-    )
+    for (def p in platformNames) {
+      def platformName = p
+      def platform = platformFromPlatformName(platformName)
+      for (def v in swiftVersions) {
+        def swiftVersion = v
+        parallelBuilds["${platform} Swift ${swiftVersion}"] = {
+          node('osx') {
+            unstash 'source'
+            sh "XCMODE=xcpretty ./build.sh package-${lower_platform}-swift-${swiftVersion}"
+            stash includes: "build/${lower_platform}/realm-swift-framework-${lower_platform}-swift-${swiftVersion}.zip",
+                  name: "${lower_platform}-swift-${swiftVersion}"
+          }
+        }
+      }
+    }
+
+    parallel parallelBuilds
   }
 
   stage('package') {

--- a/Jenkinsfile.releasability
+++ b/Jenkinsfile.releasability
@@ -193,7 +193,7 @@ def doBuild() {
 
   stage('test') {
     def parallelBuilds = [
-      "Test Examples": {
+      'Test Examples': {
         node('osx') {
           deleteDir()
 
@@ -213,40 +213,41 @@ def doBuild() {
           XCMODE=xcpretty sh build.sh package-test-examples
           """
         }
+      },
+
+      'Test iOS static': {
+        node('osx') {
+          deleteDir()
+          unstash 'source'
+
+          sh 'XCMODE=xcpretty IS_RUNNING_PACKAGING=1 sh build.sh test-ios-static'
+        }
+      },
+
+      'Test macOS': {
+        node('osx') {
+          deleteDir()
+          unstash 'source'
+
+          sh 'XCMODE=xcpretty sh build.sh test-osx'
+        }
       }
     ]
-
-    // objc / osx / dynamic
-    // objc / osx / cocoapods
-    // objc / osx / carthage
-    //
-    // objc / ios / dynamic
-    // objc / ios / cocoapods
-    // objc / ios / carthage
 
     for (def platform in ["osx", "ios"]) {
       def platformName = platformNames[platform]
       for (def test in ["dynamic", "cocoapods", "carthage"]) {
-        parallelBuilds["${platformName} Obj-C ${test}"] = installationTest(platform, test, 'objc')
+        parallelBuilds["Installation - ${platformName} Obj-C ${test}"] = installationTest(platform, test, 'objc')
       }
     }
 
-    // objc / ios / static
-    // objc / ios / cocoapods-dynamic
-
-    parallelBuilds["iOS Obj-C static"] = installationTest('ios', 'static', 'objc')
-    parallelBuilds["iOS Obj-C CocoaPods dynamic"] = installationTest('ios', 'cocoapods-dynamic', 'objc')
-
-    // swift / osx / cocoapods
-    // swift / osx / carthage
-    //
-    // swift / ios / cocoapods
-    // swift / ios / carthage
+    parallelBuilds["Installation - iOS Obj-C static"] = installationTest('ios', 'static', 'objc')
+    parallelBuilds["Installation - iOS Obj-C CocoaPods dynamic"] = installationTest('ios', 'cocoapods-dynamic', 'objc')
 
     for (def platform in ["osx", "ios"]) {
       def platformName = platformNames[platform]
       for (def test in ["cocoapods", "carthage"]) {
-        parallelBuilds["${platformName} Swift ${test}"] = installationTest(platform, test, 'swift')
+        parallelBuilds["Installation - ${platformName} Swift ${test}"] = installationTest(platform, test, 'swift')
       }
     }
 

--- a/RealmSwift/Tests/KVOTests.swift
+++ b/RealmSwift/Tests/KVOTests.swift
@@ -72,7 +72,6 @@ class KVOTests: TestCase {
 
     var changeDictionary: [NSKeyValueChangeKey: Any]?
 
-    // swiftlint:disable:next block_based_kvo
     override func observeValue(forKeyPath keyPath: String?, of object: Any?,
                                change: [NSKeyValueChangeKey : Any]?, context: UnsafeMutableRawPointer?) {
         changeDictionary = change

--- a/build.sh
+++ b/build.sh
@@ -1189,7 +1189,6 @@ EOM
 
     "package-ios-static")
         sh build.sh prelaunch-simulator
-        sh build.sh test-ios-static
         sh build.sh ios-static
 
         cd build/ios-static
@@ -1204,7 +1203,7 @@ EOM
         ;;
 
     "package-osx")
-        sh build.sh test-osx
+        sh build.sh osx
 
         cd build/DerivedData/Realm/Build/Products/Release
         zip --symlinks -r realm-framework-osx.zip Realm.framework

--- a/build.sh
+++ b/build.sh
@@ -1195,7 +1195,7 @@ EOM
         zip --symlinks -r realm-framework-ios-static.zip Realm.framework
         ;;
 
-    "package-ios-dynamic")
+    "package-ios")
         sh build.sh prelaunch-simulator
         sh build.sh ios-dynamic
         cd build/ios
@@ -1432,7 +1432,7 @@ EOF
         echo 'Packaging iOS'
         sh build.sh package-ios-static
         cp build/ios-static/realm-framework-ios-static.zip ..
-        sh build.sh package-ios-dynamic
+        sh build.sh package-ios
         cp build/ios/realm-framework-ios.zip ..
         sh build.sh package-ios-swift
         cp build/ios/realm-swift-framework-ios.zip ..

--- a/build.sh
+++ b/build.sh
@@ -1155,7 +1155,6 @@ EOM
     ######################################
 
     "package-examples")
-        cd tightdb_objc
         ./scripts/package_examples.rb
         zip --symlinks -r realm-examples.zip examples -x "examples/installation/*"
         ;;
@@ -1189,8 +1188,6 @@ EOM
         ;;
 
     "package-ios-static")
-        cd tightdb_objc
-
         sh build.sh prelaunch-simulator
         sh build.sh test-ios-static
         sh build.sh ios-static
@@ -1200,8 +1197,6 @@ EOM
         ;;
 
     "package-ios-dynamic")
-        cd tightdb_objc
-
         sh build.sh prelaunch-simulator
         sh build.sh ios-dynamic
         cd build/ios
@@ -1209,7 +1204,6 @@ EOM
         ;;
 
     "package-osx")
-        cd tightdb_objc
         sh build.sh test-osx
 
         cd build/DerivedData/Realm/Build/Products/Release
@@ -1217,7 +1211,6 @@ EOM
         ;;
 
     "package-ios-swift")
-        cd tightdb_objc
         for version in 8.0 8.1 8.2 8.3.3 9.0; do
             REALM_XCODE_VERSION=$version
             REALM_SWIFT_VERSION=
@@ -1232,7 +1225,6 @@ EOM
         ;;
 
     "package-osx-swift")
-        cd tightdb_objc
         for version in 8.0 8.1 8.2 8.3.3 9.0; do
             REALM_XCODE_VERSION=$version
             REALM_SWIFT_VERSION=
@@ -1247,7 +1239,6 @@ EOM
         ;;
 
     "package-watchos")
-        cd tightdb_objc
         sh build.sh prelaunch-simulator
         sh build.sh watchos
 
@@ -1256,7 +1247,6 @@ EOM
         ;;
 
     "package-watchos-swift")
-        cd tightdb_objc
         for version in 8.0 8.1 8.2 8.3.3 9.0; do
             REALM_XCODE_VERSION=$version
             REALM_SWIFT_VERSION=
@@ -1271,7 +1261,6 @@ EOM
         ;;
 
     "package-tvos")
-        cd tightdb_objc
         sh build.sh prelaunch-simulator
         sh build.sh tvos
 
@@ -1280,7 +1269,6 @@ EOM
         ;;
 
     "package-tvos-swift")
-        cd tightdb_objc
         for version in 8.0 8.1 8.2 8.3.3 9.0; do
             REALM_XCODE_VERSION=$version
             REALM_SWIFT_VERSION=
@@ -1298,9 +1286,7 @@ EOM
         LANG="$2"
         TEMPDIR=$(mktemp -d $TMPDIR/realm-release-package-${LANG}.XXXX)
 
-        cd tightdb_objc
         VERSION=$(sh build.sh get-version)
-        cd ..
 
         FOLDER=${TEMPDIR}/realm-${LANG}-${VERSION}
 
@@ -1358,7 +1344,7 @@ EOM
         fi
 
         (
-            cd ${WORKSPACE}/tightdb_objc
+            cd ${WORKSPACE}
             cp -R plugin ${FOLDER}
             cp LICENSE ${FOLDER}/LICENSE.txt
             if [[ "${LANG}" == "objc" ]]; then
@@ -1412,44 +1398,45 @@ EOF
         WORKSPACE="$(cd "$WORKSPACE" && pwd)"
         export WORKSPACE
         cd $WORKSPACE
-        git clone --recursive $REALM_SOURCE tightdb_objc
+        git clone --recursive $REALM_SOURCE realm-cocoa
+        cd realm-cocoa
 
         echo 'Packaging iOS'
-        sh tightdb_objc/build.sh package-ios-static
-        cp tightdb_objc/build/ios-static/realm-framework-ios.zip .
-        sh tightdb_objc/build.sh package-ios-dynamic
-        cp tightdb_objc/build/ios/realm-dynamic-framework-ios.zip .
-        sh tightdb_objc/build.sh package-ios-swift
-        cp tightdb_objc/build/ios/realm-swift-framework-ios.zip .
+        sh build.sh package-ios-static
+        cp build/ios-static/realm-framework-ios.zip ..
+        sh build.sh package-ios-dynamic
+        cp build/ios/realm-dynamic-framework-ios.zip ..
+        sh build.sh package-ios-swift
+        cp build/ios/realm-swift-framework-ios.zip ..
 
         echo 'Packaging OS X'
-        sh tightdb_objc/build.sh package-osx
-        cp tightdb_objc/build/DerivedData/Realm/Build/Products/Release/realm-framework-osx.zip .
-        sh tightdb_objc/build.sh package-osx-swift
-        cp tightdb_objc/build/osx/realm-swift-framework-osx.zip .
+        sh build.sh package-osx
+        cp build/DerivedData/Realm/Build/Products/Release/realm-framework-osx.zip ..
+        sh build.sh package-osx-swift
+        cp build/osx/realm-swift-framework-osx.zip ..
 
         echo 'Packaging watchOS'
-        sh tightdb_objc/build.sh package-watchos
-        cp tightdb_objc/build/watchos/realm-framework-watchos.zip .
-        sh tightdb_objc/build.sh package-watchos-swift
-        cp tightdb_objc/build/watchos/realm-swift-framework-watchos.zip .
+        sh build.sh package-watchos
+        cp build/watchos/realm-framework-watchos.zip ..
+        sh build.sh package-watchos-swift
+        cp build/watchos/realm-swift-framework-watchos.zip ..
 
         echo 'Packaging tvOS'
-        sh tightdb_objc/build.sh package-tvos
-        cp tightdb_objc/build/tvos/realm-framework-tvos.zip .
-        sh tightdb_objc/build.sh package-tvos-swift
-        cp tightdb_objc/build/tvos/realm-swift-framework-tvos.zip .
+        sh build.sh package-tvos
+        cp build/tvos/realm-framework-tvos.zip ..
+        sh build.sh package-tvos-swift
+        cp build/tvos/realm-swift-framework-tvos.zip ..
 
         echo 'Packaging examples'
-        sh tightdb_objc/build.sh package-examples
-        cp tightdb_objc/realm-examples.zip .
+        sh build.sh package-examples
+        cp realm-examples.zip ..
 
         echo 'Building final release packages'
-        sh tightdb_objc/build.sh package-release objc
-        sh tightdb_objc/build.sh package-release swift
+        sh build.sh package-release objc
+        sh build.sh package-release swift
 
         echo 'Testing packaged examples'
-        sh tightdb_objc/build.sh package-test-examples
+        sh build.sh package-test-examples
         ;;
 
     "github-release")

--- a/build.sh
+++ b/build.sh
@@ -1193,14 +1193,14 @@ EOM
         sh build.sh ios-static
 
         cd build/ios-static
-        zip --symlinks -r realm-framework-ios.zip Realm.framework
+        zip --symlinks -r realm-framework-ios-static.zip Realm.framework
         ;;
 
     "package-ios-dynamic")
         sh build.sh prelaunch-simulator
         sh build.sh ios-dynamic
         cd build/ios
-        zip --symlinks -r realm-dynamic-framework-ios.zip Realm.framework
+        zip --symlinks -r realm-framework-ios.zip Realm.framework
         ;;
 
     "package-osx")
@@ -1304,12 +1304,12 @@ EOM
 
             (
                 cd ${FOLDER}/ios/static
-                unzip ${WORKSPACE}/realm-framework-ios.zip
+                unzip ${WORKSPACE}/realm-framework-ios-static.zip
             )
 
             (
                 cd ${FOLDER}/ios/dynamic
-                unzip ${WORKSPACE}/realm-dynamic-framework-ios.zip
+                unzip ${WORKSPACE}/realm-framework-ios.zip
             )
 
             (
@@ -1403,9 +1403,9 @@ EOF
 
         echo 'Packaging iOS'
         sh build.sh package-ios-static
-        cp build/ios-static/realm-framework-ios.zip ..
+        cp build/ios-static/realm-framework-ios-static.zip ..
         sh build.sh package-ios-dynamic
-        cp build/ios/realm-dynamic-framework-ios.zip ..
+        cp build/ios/realm-framework-ios.zip ..
         sh build.sh package-ios-swift
         cp build/ios/realm-swift-framework-ios.zip ..
 

--- a/build.sh
+++ b/build.sh
@@ -1282,6 +1282,27 @@ EOM
         zip --symlinks -r realm-swift-framework-tvos.zip swift-3.0 swift-3.0.1 swift-3.0.2 swift-3.1 swift-3.2 swift-4.0
         ;;
 
+    package-*-swift-3.2)
+        PLATFORM=$(echo $COMMAND | cut -d - -f 2)
+        mkdir -p build/$PLATFORM
+        cd build/$PLATFORM
+        ln -s swift-4.0 swift-3.2
+        zip --symlinks -r realm-swift-framework-$PLATFORM-swift-3.2.zip swift-3.2
+        ;;
+
+    package-*-swift-*)
+        PLATFORM=$(echo $COMMAND | cut -d - -f 2)
+        REALM_SWIFT_VERSION=$(echo $COMMAND | cut -d - -f 4)
+        REALM_XCODE_VERSION=
+
+        set_xcode_and_swift_versions
+        sh build.sh prelaunch-simulator
+        sh build.sh $PLATFORM-swift
+
+        cd build/$PLATFORM
+        zip --symlinks -r realm-swift-framework-$PLATFORM-swift-$REALM_SWIFT_VERSION.zip swift-$REALM_SWIFT_VERSION
+        ;;
+
     "package-release")
         LANG="$2"
         TEMPDIR=$(mktemp -d $TMPDIR/realm-release-package-${LANG}.XXXX)

--- a/build.sh
+++ b/build.sh
@@ -1345,22 +1345,30 @@ EOM
         else
             (
                 cd ${FOLDER}/osx
-                unzip ${WORKSPACE}/realm-swift-framework-osx.zip
+                for f in ${WORKSPACE}/realm-swift-framework-osx-swift-*.zip; do
+                    unzip "$f"
+                done
             )
 
             (
                 cd ${FOLDER}/ios
-                unzip ${WORKSPACE}/realm-swift-framework-ios.zip
+                for f in ${WORKSPACE}/realm-swift-framework-ios-swift-*.zip; do
+                    unzip "$f"
+                done
             )
 
             (
                 cd ${FOLDER}/watchos
-                unzip ${WORKSPACE}/realm-swift-framework-watchos.zip
+                for f in ${WORKSPACE}/realm-swift-framework-watchos-swift-*.zip; do
+                    unzip "$f"
+                done
             )
 
             (
                 cd ${FOLDER}/tvos
-                unzip ${WORKSPACE}/realm-swift-framework-tvos.zip
+                for f in ${WORKSPACE}/realm-swift-framework-tvos-swift-*.zip; do
+                    unzip "$f"
+                done
             )
         fi
 


### PR DESCRIPTION
Introducing Xcode 9 / Swift 3.2 / Swift 4.0 support into our release packaging caused issues with CI. We appear to be hitting timeouts due to building all of the Swift versions for iOS taking over 40 minutes. In order to address this I've split the various Swift build steps so they can run in parallel. I've also taken this opportunity to restructure the CI job using a Jenkins pipeline using Groovy.

Remaining work:
- [x] Installation examples