### PR TITLE
Fix building the Realm Swift unit tests with Xcode 9

### DIFF
--- a/RealmSwift/Tests/TestCase.swift
+++ b/RealmSwift/Tests/TestCase.swift
@@ -182,11 +182,8 @@ class TestCase: XCTestCase {
     }
 
     private func realmFilePrefix() -> String {
-#if swift(>=3.2)
-        return name.trimmingCharacters(in: CharacterSet(charactersIn: "-[]"))
-#else
+        let name: String? = self.name
         return name!.trimmingCharacters(in: CharacterSet(charactersIn: "-[]"))
-#endif
     }
 
     internal func testRealmURL() -> URL {


### PR DESCRIPTION
`XCTest.name` has changed from `String` to `String?` and back a few times during the Xcode 9 beta cycle. Use a `String?` local variable to accommodate either declaration.

This change was merged to `master-3.0` in #5254. It should have been made against `master` originally, then merged over. I'm not sure how we missed this omission.