### PR TITLE
Archive the generated documentation so it can be retrieved by the release-cocoa job

### DIFF
--- a/Jenkinsfile.releasability
+++ b/Jenkinsfile.releasability
@@ -75,7 +75,9 @@ def doBuild() {
           zip -r objc-docs.zip objc_output
           zip -r swift-docs.zip swift_output
           '''
-          stash includes: 'docs/*-docs.zip', name: 'docs'
+          dir('docs') {
+            archiveArtifacts artifacts: '*-docs.zip'
+          }
         }
       },
 


### PR DESCRIPTION
I noticed this omission while updating release-cocoa and its subjobs to take their input from cocoa-pipeline rather than various old subjobs that used to produce the artifacts needed by the release process.