### PR TITLE
Reenable more tests

### DIFF
--- a/Realm/ObjectServerTests/RLMSyncTestCase.h
+++ b/Realm/ObjectServerTests/RLMSyncTestCase.h
@@ -89,8 +89,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (RLMSyncUser *)logInUserForCredentials:(RLMSyncCredentials *)credentials
                                   server:(NSURL *)url;
 
-/// Log in and/or retrieve the default administrator-privilege user that ships with ROS.
-- (RLMSyncUser *)getSharedPersistentAdminUserForURL:(NSURL *)url;
+/// Create and log in an admin user.
+- (RLMSyncUser *)createAdminUserForURL:(NSURL *)url username:(NSString *)username;
 
 /// Add a number of objects to a Realm.
 - (void)addSyncObjectsToRealm:(RLMRealm *)realm descriptions:(NSArray<NSString *> *)descriptions;

--- a/Realm/ObjectServerTests/SwiftObjectServerTests.swift
+++ b/Realm/ObjectServerTests/SwiftObjectServerTests.swift
@@ -294,6 +294,7 @@ class SwiftObjectServerTests: SwiftSyncTestCase {
     // MARK: - Administration
 
     func testRetrieveUserInfo() {
+        let adminUsername = "jyaku.swift"
         let nonAdminUsername = "meela.swift@realm.example.org"
         let password = "p"
         let server = SwiftObjectServerTests.authServerURL()
@@ -301,8 +302,8 @@ class SwiftObjectServerTests: SwiftSyncTestCase {
         // Create a non-admin user.
         _ = logInUser(for: .init(username: nonAdminUsername, password: password, register: true),
                       server: server)
-        // Get the default admin user.
-        let adminUser = getSharedPersistentAdminUser(for: server)
+        // Create an admin user.
+        let adminUser = createAdminUser(for: server, username: adminUsername)
 
         // Look up information about the non-admin user from the admin user.
         let ex = expectation(description: "Should be able to look up user information")

--- a/Realm/ObjectServerTests/SwiftSyncTestCase.swift
+++ b/Realm/ObjectServerTests/SwiftSyncTestCase.swift
@@ -109,8 +109,8 @@ class SwiftSyncTestCase: RLMSyncTestCase {
         }
         SyncManager.shared.setSessionCompletionNotifier(basicBlock)
         let realm = try Realm(configuration: configuration)
-        // FIXME: Perhaps we should have a reasonable timeout here, instead of allowing bad code to stall forever.
-        _ = semaphore.wait(timeout: .distantFuture)
+        let result = semaphore.wait(timeout: .now() + DispatchTimeInterval.seconds(20))
+        XCTAssertEqual(result, .success)
         return realm
     }
 

--- a/Realm/RLMJSONModels.m
+++ b/Realm/RLMJSONModels.m
@@ -28,7 +28,6 @@ static const NSString *const kRLMSyncErrorCodeKey       = @"code";
 static const NSString *const kRLMSyncExpiresKey         = @"expires";
 static const NSString *const kRLMSyncErrorHintKey       = @"hint";
 static const NSString *const kRLMSyncIdKey              = @"id";
-static const NSString *const kRLMSyncIsAdminKey         = @"is_admin";
 static const NSString *const kRLMSyncKeyKey             = @"key";
 static const NSString *const kRLMSyncMetadataKey        = @"metadata";
 static const NSString *const kRLMSyncRefreshTokenKey    = @"refresh_token";

--- a/Realm/RLMNetworkClient.mm
+++ b/Realm/RLMNetworkClient.mm
@@ -118,6 +118,16 @@ static NSRange RLM_rangeForErrorType(RLMServerHTTPErrorCodeType type) {
     return [authServerURL URLByAppendingPathComponent:@"auth/password"];
 }
 
+- (NSDictionary *)httpHeadersForPayload:(NSDictionary *)json {
+    NSString *authToken = [json objectForKey:kRLMSyncTokenKey];
+    if (!authToken) {
+        @throw RLMException(@"Malformed request; this indicates an internal error.");
+    }
+    NSMutableDictionary *headers = [[super httpHeadersForPayload:json] mutableCopy];
+    [headers setObject:authToken forKey:@"Authorization"];
+    return [headers copy];
+}
+
 @end
 
 @implementation RLMSyncGetUserInfoEndpoint

--- a/Realm/RLMSyncCredentials.m
+++ b/Realm/RLMSyncCredentials.m
@@ -65,6 +65,13 @@ RLMIdentityProvider const RLMIdentityProviderCloudKit               = @"cloudkit
                                                kRLMSyncRegisterKey: @(shouldRegister)}];
 }
 
+/// Intended only for testing use. Will only work if the ROS is started with the `debug` provider enabled.
++ (instancetype)credentialsWithDebugUserID:(NSString *)userID isAdmin:(BOOL)isAdmin {
+    return [[self alloc] initWithCustomToken:userID
+                                    provider:RLMIdentityProviderDebug
+                                    userInfo:@{kRLMSyncIsAdminKey: @(isAdmin)}];
+}
+
 + (instancetype)credentialsWithAccessToken:(RLMServerToken)accessToken identity:(NSString *)identity {
     return [[self alloc] initWithCustomToken:accessToken
                                     provider:RLMIdentityProviderAccessToken

--- a/Realm/RLMSyncUser.mm
+++ b/Realm/RLMSyncUser.mm
@@ -317,7 +317,8 @@ PermissionChangeCallback RLMWrapPermissionStatusCallback(RLMPermissionStatusBloc
                                      server:self.authenticationServer
                                        JSON:@{kRLMSyncTokenKey: self._refreshToken,
                                               kRLMSyncUserIDKey: userID,
-                                              kRLMSyncPasswordKey: newPassword}
+                                              kRLMSyncDataKey: @{ kRLMSyncNewPasswordKey: newPassword }
+                                              }
                                     timeout:60
                                  completion:^(NSError *error, __unused NSDictionary *json) {
         completion(error);

--- a/Realm/RLMSyncUtil.mm
+++ b/Realm/RLMSyncUtil.mm
@@ -68,12 +68,14 @@ NSString *const kRLMSyncDataKey                 = @"data";
 NSString *const kRLMSyncErrorJSONKey            = @"json";
 NSString *const kRLMSyncErrorStatusCodeKey      = @"statusCode";
 NSString *const kRLMSyncIdentityKey             = @"identity";
+NSString *const kRLMSyncIsAdminKey              = @"is_admin";
+NSString *const kRLMSyncNewPasswordKey          = @"new_password";
 NSString *const kRLMSyncPasswordKey             = @"password";
 NSString *const kRLMSyncPathKey                 = @"path";
-NSString *const kRLMSyncTokenKey                = @"token";
 NSString *const kRLMSyncProviderKey             = @"provider";
 NSString *const kRLMSyncProviderIDKey           = @"provider_id";
 NSString *const kRLMSyncRegisterKey             = @"register";
+NSString *const kRLMSyncTokenKey                = @"token";
 NSString *const kRLMSyncUnderlyingErrorKey      = @"underlying_error";
 NSString *const kRLMSyncUserIDKey               = @"user_id";
 

--- a/Realm/RLMSyncUtil_Private.h
+++ b/Realm/RLMSyncUtil_Private.h
@@ -55,6 +55,8 @@ extern NSString *const kRLMSyncDataKey;
 extern NSString *const kRLMSyncErrorJSONKey;
 extern NSString *const kRLMSyncErrorStatusCodeKey;
 extern NSString *const kRLMSyncIdentityKey;
+extern NSString *const kRLMSyncIsAdminKey;
+extern NSString *const kRLMSyncNewPasswordKey;
 extern NSString *const kRLMSyncPasswordKey;
 extern NSString *const kRLMSyncPathKey;
 extern NSString *const kRLMSyncTokenKey;


### PR DESCRIPTION
Changes:
- Fixed the way the change password request is made
- Updated ROS dependency to pull in bugfixes
- All non-permissions ROS integration tests are now enabled
- Changed the way tests create admin users
- Added a way for tests to be easily run without starting up their own ROS

Blocked on a ROS release that includes https://github.com/realm/ros/pull/384 (so, 39 or later)