### PR TITLE
Update object store to a slightly newer version to silence a warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
   item.
 * Fix downloading of the Realm core binaries when Xcode's command-line tools are
   set as the active developer directory for command-line interactions.
+* Fix a crash that could occur when resolving a ThreadSafeReference to a `List`
+  whose parent object had since been deleted.
 
 2.10.1 Release notes (2017-09-14)
 =============================================================


### PR DESCRIPTION
This pulls in an additional bug fix so I added it to the change log.