### PR TITLE
Force CI to build at master-3.0

### DIFF
--- a/Realm/ObjectServerTests/SwiftObjectServerTests.swift
+++ b/Realm/ObjectServerTests/SwiftObjectServerTests.swift
@@ -19,6 +19,8 @@
 import XCTest
 import RealmSwift
 
+// WARNING: Do not merge me!
+
 // Used by testOfflineClientReset
 // The naming here is nonstandard as the sync-1.x.realm test file comes from the .NET unit tests.
 // swiftlint:disable identifier_name


### PR DESCRIPTION
This PR is **NOT** meant to be merged, but rather to make CI build at `master-3.0` to see if the object store test failures are due to code changes or the CI setup.