### PR TITLE
Fix for Swift 4.0 String slicing subscript warning

### DIFF
--- a/RealmSwift/Object.swift
+++ b/RealmSwift/Object.swift
@@ -428,7 +428,7 @@ public class ObjectUtil: NSObject {
         // one named 'x', and another that is optional and is named 'x.storage'. Note
         // that '.' is illegal in either a Swift or Objective-C property name.
         if let storageRange = name.range(of: ".storage", options: [.anchored, .backwards]) {
-            return name.substring(to: storageRange.lowerBound)
+            return String(name[..<storageRange.lowerBound])
         }
         return nil
     }

--- a/RealmSwift/Object.swift
+++ b/RealmSwift/Object.swift
@@ -428,7 +428,11 @@ public class ObjectUtil: NSObject {
         // one named 'x', and another that is optional and is named 'x.storage'. Note
         // that '.' is illegal in either a Swift or Objective-C property name.
         if let storageRange = name.range(of: ".storage", options: [.anchored, .backwards]) {
-            return String(name[..<storageRange.lowerBound])
+            #if swift(>=4.0)
+                return String(name[..<storageRange.lowerBound])
+            #else
+                return name.substring(to: storageRange.lowerBound)
+            #endif
         }
         return nil
     }


### PR DESCRIPTION
Using Swift 4's string subscript method to get substring out to remove warning on Xcode 9.

<img width="808" alt="xcode 9 warning" src="https://user-images.githubusercontent.com/6898396/30986548-deac37d8-a4a4-11e7-8039-7c0b96cf297e.png">
