### PR TITLE
Synchronize reading `s_defaultConfiguration` in `rawDefaultConfiguration` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,17 +8,8 @@ x.x.x Release notes (yyyy-MM-dd)
 ### Bugfixes
 * `-[RLMResults<RLMSyncPermission *> indexOfObject:]` now properly accounts for access
   level.
-### API Breaking Changes
-
-* None.
-
-### Enhancements
-
-* None.
-
-### Bugfixes
-
-* None.
+* Fix a race condition that could lead to a crash accessing to the freed configuration object
+  if a default configuration was set from a different thread.
 
 3.0.0-rc.1 Release notes (2017-10-03)
 =============================================================
@@ -1554,7 +1545,7 @@ Prebuilt frameworks are now built with Xcode 7.3.
   `RLMRealm`/`Realm` instances.
 * Fail with `RLMErrorFileNotFound` instead of the more generic `RLMErrorFileAccess`,
   if no file was found when a realm was opened as read-only or if the directory part
-  of the specified path was not found when a copy should be written.
+  of the specified path was not found when a copy should be written. 
 * Greatly improve performance when deleting objects with one or more indexed
   properties.
 * Indexing `BOOL`/`Bool` and `NSDate` properties are now supported.
@@ -1589,7 +1580,7 @@ Prebuilt frameworks are now built with Xcode 7.3.
 
 * Support for tvOS.
 * Support for building Realm Swift from source when using Carthage.
-* The block parameter of `-[RLMRealm transactionWithBlock:]`/`Realm.write(_:)` is
+* The block parameter of `-[RLMRealm transactionWithBlock:]`/`Realm.write(_:)` is 
   now marked as `__attribute__((noescape))`/`@noescape`.
 * Many forms of queries with key paths on both sides of the comparison operator
   are now supported.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ x.x.x Release notes (yyyy-MM-dd)
 ### Bugfixes
 * `-[RLMResults<RLMSyncPermission *> indexOfObject:]` now properly accounts for access
   level.
+### API Breaking Changes
+
+* None.
+
+### Enhancements
+
+* None.
+
+### Bugfixes
+
+* None.
 
 3.0.0-rc.1 Release notes (2017-10-03)
 =============================================================
@@ -1543,7 +1554,7 @@ Prebuilt frameworks are now built with Xcode 7.3.
   `RLMRealm`/`Realm` instances.
 * Fail with `RLMErrorFileNotFound` instead of the more generic `RLMErrorFileAccess`,
   if no file was found when a realm was opened as read-only or if the directory part
-  of the specified path was not found when a copy should be written. 
+  of the specified path was not found when a copy should be written.
 * Greatly improve performance when deleting objects with one or more indexed
   properties.
 * Indexing `BOOL`/`Bool` and `NSDate` properties are now supported.
@@ -1578,7 +1589,7 @@ Prebuilt frameworks are now built with Xcode 7.3.
 
 * Support for tvOS.
 * Support for building Realm Swift from source when using Carthage.
-* The block parameter of `-[RLMRealm transactionWithBlock:]`/`Realm.write(_:)` is 
+* The block parameter of `-[RLMRealm transactionWithBlock:]`/`Realm.write(_:)` is
   now marked as `__attribute__((noescape))`/`@noescape`.
 * Many forms of queries with key paths on both sides of the comparison operator
   are now supported.

--- a/Realm/RLMRealmConfiguration.mm
+++ b/Realm/RLMRealmConfiguration.mm
@@ -75,12 +75,14 @@ NSString *RLMRealmPathForFile(NSString *fileName) {
 }
 
 + (RLMRealmConfiguration *)rawDefaultConfiguration {
+    RLMRealmConfiguration *configuration;
     @synchronized(c_defaultRealmFileName) {
         if (!s_defaultConfiguration) {
             s_defaultConfiguration = [[RLMRealmConfiguration alloc] init];
         }
+        configuration = s_defaultConfiguration;
     }
-    return s_defaultConfiguration;
+    return configuration;
 }
 
 + (void)resetRealmConfigurationState {


### PR DESCRIPTION
`rawDefaultConfiguration` method returns the copied configuration object. It is to prevent becoming a freed pointer when `rawDefaultConfiguration` is set in a different thread.

If you execute code like the following, you can see that it crashes.

```
dispatch_async(dispatch_get_global_queue(QOS_CLASS_DEFAULT, 0), ^{
    for (int i = 0; i < 10000; i++) {
        RLMRealm *realm = [RLMRealm defaultRealm];
        [NSThread sleepForTimeInterval:0.0001];
    }
});
dispatch_async(dispatch_get_global_queue(QOS_CLASS_DEFAULT, 0), ^{
    for (int i = 0; i < 10000; i++) {
        [RLMRealmConfiguration setDefaultConfiguration:[RLMRealmConfiguration new]];
        [NSThread sleepForTimeInterval:0.0001];
    }
});
```

This probably happens by replacing `s_defaultConfiguration` with` setDefaultConfiguration:`, but other thread has already `s_defaultConfiguration`, it becomes a freed pointer.


CC @tgoyne @bdash 