### PR TITLE
Fixed an issue that crash when enumerating after clearing data during migration.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ x.x.x Release notes (yyyy-MM-dd)
   level.
 * Fix a race condition that could lead to a crash accessing to the freed configuration object
   if a default configuration was set from a different thread.
+* Fixed an issue that crash when enumerating after clearing data during migration.
 
 3.0.0-rc.1 Release notes (2017-10-03)
 =============================================================

--- a/RealmSwift/Tests/MigrationTests.swift
+++ b/RealmSwift/Tests/MigrationTests.swift
@@ -369,6 +369,34 @@ class MigrationTests: TestCase {
         }
     }
 
+    func testEnumerateObjectsAfterDeleteData() {
+        autoreleasepool {
+            // add object
+            try! Realm().write {
+                try! Realm().create(SwiftStringObject.self, value: ["1"])
+                try! Realm().create(SwiftStringObject.self, value: ["2"])
+                try! Realm().create(SwiftStringObject.self, value: ["3"])
+            }
+        }
+
+        migrateAndTestDefaultRealm(1) { migration, _ in
+            var count = 0
+            migration.enumerateObjects(ofType: "SwiftStringObject") { _, _ in
+                count += 1
+            }
+            XCTAssertEqual(count, 3)
+
+            migration.deleteData(forType: "SwiftStringObject")
+            migration.create("SwiftStringObject", value: ["A"])
+
+            count = 0
+            migration.enumerateObjects(ofType: "SwiftStringObject") { _, _ in
+                count += 1
+            }
+            XCTAssertEqual(count, 0)
+        }
+    }
+
     func testCreate() {
         autoreleasepool {
             _ = try! Realm()


### PR DESCRIPTION
Fixes #5368

Defer deletion during migration and actually delete the object when migration finished.
As for `- [RLMMigration deleteObject:]` it was already doing that. But `- [RLMMigration deleteDataForClassName:]` doesn't. This PR fixed as well.

See https://github.com/realm/realm-cocoa/pull/4864

CC @bdash @austinzheng 