### PR TITLE
Add some missing fix-it hints for 3.0 renames

### DIFF
--- a/Realm/RLMRealm.h
+++ b/Realm/RLMRealm.h
@@ -645,7 +645,7 @@ NS_REFINED_FOR_SWIFT;
 - (void)invalidate;
 
 /// Stops notifications for the change subscription that returned this token.
-- (void)stop __attribute__((unavailable("Renamed to -invalidate.")));;
+- (void)stop __attribute__((unavailable("Renamed to -invalidate."))) NS_REFINED_FOR_SWIFT;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/RealmSwift/Aliases.swift
+++ b/RealmSwift/Aliases.swift
@@ -55,3 +55,8 @@ public typealias PropertyType = RLMPropertyType
  - see: `Realm.observe(_:)`
  */
 public typealias NotificationToken = RLMNotificationToken
+
+extension NotificationToken {
+    @available(*, unavailable, renamed: "invalidate()")
+    @nonobjc public func stop() { fatalError() }
+}

--- a/RealmSwift/Object.swift
+++ b/RealmSwift/Object.swift
@@ -548,12 +548,18 @@ extension Object: AssistedObjectiveCBridgeable {
 
 // MARK: - Migration assistance
 
+extension Object {
+    /// :nodoc:
+    @available(*, unavailable, renamed: "observe()")
+    public func addNotificationBlock(_ block: @escaping (ObjectChange) -> Void) -> NotificationToken {
+        fatalError()
+    }
+
 #if os(OSX)
 #else
-extension Object {
     /// :nodoc:
     @available(*, unavailable, renamed: "isSameObject(as:)") public func isEqual(to object: Any?) -> Bool {
         fatalError()
     }
-}
 #endif
+}


### PR DESCRIPTION
Clang has a similar `__attribute__((available(macos, unavailable, renamed="foo")))`, but I couldn't get it to actually produce a fix-it in Xcode, so I only bothered with the Swift versions.