### PR TITLE
Add back in support for sorting permissions on user ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+3.0.0-rc.2 Release notes (2017-??-??)
+=============================================================
+
+### Enhancements
+* Reinstate `RLMSyncPermissionSortPropertyUserID` to allow users to sort permissions
+  to their own Realms they've granted to others.
+
+### Bugfixes
+* `-[RLMResults<RLMSyncPermission *> indexOfObject:]` now properly accounts for access
+  level.
+
 3.0.0-rc.1 Release notes (2017-10-03)
 =============================================================
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-3.0.0-rc.2 Release notes (2017-??-??)
+x.x.x Release notes (yyyy-MM-dd)
 =============================================================
 
 ### Enhancements

--- a/Realm/ObjectServerTests/RLMPermissionsAPITests.m
+++ b/Realm/ObjectServerTests/RLMPermissionsAPITests.m
@@ -204,7 +204,7 @@ static NSURL *makeTildeSubstitutedURL(NSURL *url, RLMSyncUser *user) {
 
 // FIXME ROS 2.0: works when ROS is manually provided, not when ROS is run as part of tests
 /// If user A grants user B read access to a Realm, user B should be able to read from it.
-- (void)disabled_testReadAccess {
+- (void)testReadAccess {
     __block void(^errorBlock)(NSError *) = nil;
     [[RLMSyncManager sharedManager] setErrorHandler:^(NSError *error, __unused RLMSyncSession *session) {
         if (errorBlock) {
@@ -902,7 +902,6 @@ static NSURL *makeTildeSubstitutedURL(NSURL *url, RLMSyncUser *user) {
                                              accessLevel:RLMSyncAccessLevelRead];
     XCTAssertEqual([results indexOfObject:p3], NSNotFound);
     // A permission with a differing path should not match.
-    // A permission with a differing identity should not match.
     id p4 = [[RLMSyncPermission alloc] initWithRealmPath:[makeTildeSubstitutedURL(url, self.userB) path]
                                                 identity:uB
                                              accessLevel:RLMSyncAccessLevelRead];
@@ -1105,7 +1104,7 @@ static NSURL *makeTildeSubstitutedURL(NSURL *url, RLMSyncUser *user) {
 
 // FIXME ROS 2.0: works when ROS is manually provided, not when ROS is run as part of tests
 /// A Realm which is opened improperly should report an error allowing the app to recover.
-- (void)disabled_testDeleteRealmUponPermissionDenied {
+- (void)testDeleteRealmUponPermissionDenied {
     __block void(^errorBlock)(NSError *, RLMSyncSession *session) = nil;
     [[RLMSyncManager sharedManager] setErrorHandler:^(NSError *error, RLMSyncSession *session) {
         if (errorBlock) {

--- a/Realm/RLMSyncPermission.h
+++ b/Realm/RLMSyncPermission.h
@@ -58,6 +58,8 @@ typedef NSString * RLMSyncPermissionSortProperty NS_STRING_ENUM;
 
 /// Sort by the Realm Object Server path to the Realm to which the permission applies.
 extern RLMSyncPermissionSortProperty const RLMSyncPermissionSortPropertyPath;
+/// Sort by the identity of the user to whom the permission applies.
+extern RLMSyncPermissionSortProperty const RLMSyncPermissionSortPropertyUserID;
 /// Sort by the date the permissions were last updated.
 extern RLMSyncPermissionSortProperty const RLMSyncPermissionSortPropertyUpdated;
 


### PR DESCRIPTION
ROS decided that permissions should live in both the giver and receiver's permissions Realms, so it makes sense to allow sorting by user ID again.

Also fix how permissions results' `indexForObject:` method works to properly take into account permission level.