### PR TITLE
Explicitly exclude KVO-generated subclasses from the schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+x.x.x Release notes (yyyy-MM-dd)
+=============================================================
+
+### Breaking Changes
+
+* None.
+
+### Enhancements
+
+* None.
+
+### Bugfixes
+
+* Explicitly exclude KVO-generated object subclasses from the schema.
+
 3.0.0 Release notes (2017-10-16)
 =============================================================
 

--- a/Realm/RLMSchema.mm
+++ b/Realm/RLMSchema.mm
@@ -106,7 +106,7 @@ static void RLMRegisterClassLocalNames(Class *classes, NSUInteger count) {
         }
 
         NSString *className = NSStringFromClass(cls);
-        if ([className hasPrefix:@"RLM:"]) {
+        if ([className hasPrefix:@"RLM:"] || [className hasPrefix:@"NSKVONotifying"]) {
             continue;
         }
 

--- a/Realm/Tests/SchemaTests.mm
+++ b/Realm/Tests/SchemaTests.mm
@@ -836,6 +836,20 @@ RLM_ARRAY_TYPE(NotARealClass)
     XCTAssertNoThrow([[MutualLink1Object alloc] initWithValue:@[@[@{}]]]);
 }
 
+- (void)testKVOSubclassesDoNotAppearInSchema {
+    if (self.isParent) {
+        RLMRunChildAndWait();
+        return;
+    }
+
+    auto obj = [IntObject new];
+    [obj addObserver:self forKeyPath:@"intCol" options:0 context:0];
+    for (RLMObjectSchema *objectSchema in RLMRealm.defaultRealm.schema.objectSchema) {
+        XCTAssertEqual([objectSchema.className rangeOfString:@"RLM:"].location, NSNotFound);
+    }
+    [obj removeObserver:self forKeyPath:@"intCol" context:0];
+}
+
 #if !DEBUG
 - (void)testMultipleProcessesTryingToInitializeSchema {
     RLMRealm *syncRealm = [self realmWithTestPath];

--- a/build.sh
+++ b/build.sh
@@ -1459,7 +1459,7 @@ EOF
         ;;
 
     "add-empty-changelog")
-        read -r -d '' empty_section << EOS
+        empty_section=$(cat <<EOS
 x.x.x Release notes (yyyy-MM-dd)
 =============================================================
 
@@ -1474,7 +1474,7 @@ x.x.x Release notes (yyyy-MM-dd)
 ### Bugfixes
 
 * None.
-EOS
+EOS)
         changelog=$(cat CHANGELOG.md)
         echo "$empty_section" > CHANGELOG.md
         echo >> CHANGELOG.md


### PR DESCRIPTION
Fixes #5410.

If an unmanged object was observed prior to the shared schema being initialized, the KVO-generated subclass would end up in the shared schema. For obj-c classes this was fairly harmless (it'd just result in an extra table being created), but for Swift classes this could result in crashes due to the resulting schema being invalid.