### PR TITLE
Fix handling of implicitly-ignored Swift properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ x.x.x Release notes (yyyy-MM-dd)
 * Explicitly exclude KVO-generated object subclasses from the schema.
 * Fix regression where the type of a Realm model class is not properly determined, causing crashes
   when a type value derived at runtime by `type(of:)` is passed into certain APIs.
+* Fix a crash when an `Object` subclass has implicitly ignored `let`
+  properties.
 
 3.0.0 Release notes (2017-10-16)
 =============================================================

--- a/Realm/RLMObjectBase.mm
+++ b/Realm/RLMObjectBase.mm
@@ -479,7 +479,7 @@ Class RLMObjectUtilClass(BOOL isSwift) {
     return nil;
 }
 
-+ (NSArray *)getSwiftGenericProperties:(__unused id)obj {
++ (NSArray *)getSwiftProperties:(__unused id)obj {
     return nil;
 }
 
@@ -493,43 +493,45 @@ Class RLMObjectUtilClass(BOOL isSwift) {
 
 @end
 
-@implementation RLMGenericPropertyMetadata
+@implementation RLMSwiftPropertyMetadata
 
-+ (instancetype)metadataForListProperty:(NSString *)propertyName index:(NSInteger)index {
-    RLMGenericPropertyMetadata *md = [RLMGenericPropertyMetadata new];
++ (instancetype)metadataForOtherProperty:(NSString *)propertyName {
+    RLMSwiftPropertyMetadata *md = [RLMSwiftPropertyMetadata new];
     md.propertyName = propertyName;
-    md.index = index;
-    md.kind = RLMGenericPropertyKindList;
+    md.kind = RLMSwiftPropertyKindOther;
+    return md;
+}
+
++ (instancetype)metadataForListProperty:(NSString *)propertyName {
+    RLMSwiftPropertyMetadata *md = [RLMSwiftPropertyMetadata new];
+    md.propertyName = propertyName;
+    md.kind = RLMSwiftPropertyKindList;
     return md;
 }
 
 + (instancetype)metadataForLinkingObjectsProperty:(NSString *)propertyName
                                         className:(NSString *)className
-                               linkedPropertyName:(NSString *)linkedPropertyName
-                                            index:(NSInteger)index {
-    RLMGenericPropertyMetadata *md = [RLMGenericPropertyMetadata new];
+                               linkedPropertyName:(NSString *)linkedPropertyName {
+    RLMSwiftPropertyMetadata *md = [RLMSwiftPropertyMetadata new];
     md.propertyName = propertyName;
     md.className = className;
     md.linkedPropertyName = linkedPropertyName;
-    md.index = index;
-    md.kind = RLMGenericPropertyKindLinkingObjects;
+    md.kind = RLMSwiftPropertyKindLinkingObjects;
     return md;
 }
 
-+ (instancetype)metadataForOptionalProperty:(NSString *)propertyName type:(NSInteger)type index:(NSInteger)index {
-    RLMGenericPropertyMetadata *md = [RLMGenericPropertyMetadata new];
++ (instancetype)metadataForOptionalProperty:(NSString *)propertyName type:(RLMPropertyType)type {
+    RLMSwiftPropertyMetadata *md = [RLMSwiftPropertyMetadata new];
     md.propertyName = propertyName;
     md.propertyType = type;
-    md.index = index;
-    md.kind = RLMGenericPropertyKindOptional;
+    md.kind = RLMSwiftPropertyKindOptional;
     return md;
 }
 
-+ (instancetype)metadataForNilLiteralOptionalProperty:(NSString *)propertyName index:(NSInteger)index {
-    RLMGenericPropertyMetadata *md = [RLMGenericPropertyMetadata new];
++ (instancetype)metadataForNilLiteralOptionalProperty:(NSString *)propertyName {
+    RLMSwiftPropertyMetadata *md = [RLMSwiftPropertyMetadata new];
     md.propertyName = propertyName;
-    md.index = index;
-    md.kind = RLMGenericPropertyKindNilLiteralOptional;
+    md.kind = RLMSwiftPropertyKindNilLiteralOptional;
     return md;
 }
 

--- a/Realm/RLMObject_Private.h
+++ b/Realm/RLMObject_Private.h
@@ -20,6 +20,9 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+@class RLMProperty, RLMArray, RLMSwiftPropertyMetadata;
+typedef NS_ENUM(int32_t, RLMPropertyType);
+
 // RLMObject accessor and read/write realm
 @interface RLMObjectBase () {
 @public
@@ -96,7 +99,6 @@ FOUNDATION_EXTERN Class RLMObjectUtilClass(BOOL isSwift);
 
 FOUNDATION_EXTERN const NSUInteger RLMDescriptionMaxDepth;
 
-@class RLMProperty, RLMArray, RLMGenericPropertyMetadata;
 @interface RLMObjectUtil : NSObject
 
 + (nullable NSArray<NSString *> *)ignoredPropertiesForClass:(Class)cls;
@@ -104,40 +106,41 @@ FOUNDATION_EXTERN const NSUInteger RLMDescriptionMaxDepth;
 + (nullable NSDictionary<NSString *, NSDictionary<NSString *, NSString *> *> *)linkingObjectsPropertiesForClass:(Class)cls;
 
 // Precondition: these must be returned in ascending order.
-+ (nullable NSArray<RLMGenericPropertyMetadata *> *)getSwiftGenericProperties:(id)obj;
++ (nullable NSArray<RLMSwiftPropertyMetadata *> *)getSwiftProperties:(id)obj;
 
 + (nullable NSDictionary<NSString *, NSNumber *> *)getOptionalProperties:(id)obj;
 + (nullable NSArray<NSString *> *)requiredPropertiesForClass:(Class)cls;
 
 @end
 
-typedef NS_ENUM(NSUInteger, RLMGenericPropertyKind) {
-    RLMGenericPropertyKindList,
-    RLMGenericPropertyKindLinkingObjects,
-    RLMGenericPropertyKindOptional,
-    RLMGenericPropertyKindNilLiteralOptional,   // For Swift optional properties that reflect as nil
+typedef NS_ENUM(NSUInteger, RLMSwiftPropertyKind) {
+    RLMSwiftPropertyKindList,
+    RLMSwiftPropertyKindLinkingObjects,
+    RLMSwiftPropertyKindOptional,
+    RLMSwiftPropertyKindNilLiteralOptional,   // For Swift optional properties that reflect as nil
+    RLMSwiftPropertyKindOther,
 };
 
 // Metadata that describes a Swift generic property.
-@interface RLMGenericPropertyMetadata : NSObject
+@interface RLMSwiftPropertyMetadata : NSObject
 
 @property (nonatomic, strong) NSString *propertyName;
 @property (nullable, nonatomic, strong) NSString *className;
 @property (nullable, nonatomic, strong) NSString *linkedPropertyName;
-@property (nonatomic) NSInteger index;
-@property (nonatomic) NSInteger propertyType;
-@property (nonatomic) RLMGenericPropertyKind kind;
+@property (nonatomic) RLMPropertyType propertyType;
+@property (nonatomic) RLMSwiftPropertyKind kind;
 
-+ (instancetype)metadataForListProperty:(NSString *)propertyName index:(NSInteger)index;
++ (instancetype)metadataForOtherProperty:(NSString *)propertyName;
+
++ (instancetype)metadataForListProperty:(NSString *)propertyName;
 
 + (instancetype)metadataForLinkingObjectsProperty:(NSString *)propertyName
                                         className:(NSString *)className
-                               linkedPropertyName:(NSString *)linkedPropertyName
-                                            index:(NSInteger)index;
+                               linkedPropertyName:(NSString *)linkedPropertyName;
 
-+ (instancetype)metadataForOptionalProperty:(NSString *)propertyName type:(NSInteger)type index:(NSInteger)index;
++ (instancetype)metadataForOptionalProperty:(NSString *)propertyName type:(RLMPropertyType)type;
 
-+ (instancetype)metadataForNilLiteralOptionalProperty:(NSString *)propertyName index:(NSInteger)index;
++ (instancetype)metadataForNilLiteralOptionalProperty:(NSString *)propertyName;
 
 @end
 

--- a/RealmSwift/Object.swift
+++ b/RealmSwift/Object.swift
@@ -463,7 +463,7 @@ public class ObjectUtil: NSObject {
 
     // Build optional property metadata for a given property.
     // swiftlint:disable:next cyclomatic_complexity
-    private static func getOptionalPropertyMetadata(for child: Mirror.Child, at index: Int) -> RLMGenericPropertyMetadata? {
+    private static func getOptionalPropertyMetadata(for child: Mirror.Child, at index: Int) -> RLMSwiftPropertyMetadata? {
         guard let name = child.label else {
             return nil
         }
@@ -494,26 +494,26 @@ public class ObjectUtil: NSObject {
             throwRealmException("'\(type)' is not a valid RealmOptional type.")
             code = .int // ignored
         } else if mirror.displayStyle == .optional || type is ExpressibleByNilLiteral.Type {
-            return RLMGenericPropertyMetadata(forNilLiteralOptionalProperty: name, index: index)
+            return RLMSwiftPropertyMetadata(forNilLiteralOptionalProperty: name)
         } else {
             return nil
         }
-        return RLMGenericPropertyMetadata(forOptionalProperty: name, type: Int(code.rawValue), index: index)
+        return RLMSwiftPropertyMetadata(forOptionalProperty: name, type: code)
     }
 
-    @objc private class func getSwiftGenericProperties(_ object: Any) -> [RLMGenericPropertyMetadata] {
+    @objc private class func getSwiftProperties(_ object: Any) -> [RLMSwiftPropertyMetadata] {
         return getNonIgnoredMirrorChildren(for: object).enumerated().flatMap { idx, prop in
             if let value = prop.value as? LinkingObjectsBase {
-                return RLMGenericPropertyMetadata(forLinkingObjectsProperty: prop.label!,
-                                                  className: value.objectClassName,
-                                                  linkedPropertyName: value.propertyName,
-                                                  index: idx)
+                return RLMSwiftPropertyMetadata(forLinkingObjectsProperty: prop.label!,
+                                                className: value.objectClassName,
+                                                linkedPropertyName: value.propertyName)
             } else if prop.value is RLMListBase {
-                return RLMGenericPropertyMetadata(forListProperty: prop.label!, index: idx)
+                return RLMSwiftPropertyMetadata(forListProperty: prop.label!)
             } else if let optional = getOptionalPropertyMetadata(for: prop, at: idx) {
                 return optional
+            } else {
+                return RLMSwiftPropertyMetadata(forOtherProperty: prop.label!)
             }
-            return nil
         }
     }
 

--- a/RealmSwift/Tests/SwiftTestObjects.swift
+++ b/RealmSwift/Tests/SwiftTestObjects.swift
@@ -508,6 +508,8 @@ class SwiftCircleObject: Object {
 
 // Exists to serve as a superclass to `SwiftGenericPropsOrderingObject`
 class SwiftGenericPropsOrderingParent: Object {
+    var implicitlyIgnoredComputedProperty: Int { return 0 }
+    let implicitlyIgnoredReadOnlyProperty: Int = 1
     let parentFirstList = List<SwiftIntObject>()
     @objc dynamic var parentFirstNumber = 0
     func parentFunction() -> Int { return parentFirstNumber + 1 }


### PR DESCRIPTION
Read-only properties would throw off the property indexes reported by the Swift reflection code due to that they were implicitly ignored by the obj-c reflection but not the Swift reflection.

Rather than trying to fully align the two sets of reflection code (and probably continuing to have similar issues due to them differing slightly), instead switch to reporting all of the property names to obj-c and let that code calculate the indexes of Swift generic properties based on what properties it has decided to include.

Fixes #5423. Fixes #5411.