### PR TITLE
Fix a crash when dynamically getting a linking objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+x.x.x Release notes (yyyy-mm-dd)
+=============================================================
+
+### Bugfixes
+
+* Fix a crash when a linking objects property is retrieved from a model object instance via
+  Swift subscripting.
+
 3.0.1 Release notes (2017-10-26)
 =============================================================
 

--- a/Realm/RLMAccessor.mm
+++ b/Realm/RLMAccessor.mm
@@ -564,10 +564,9 @@ id RLMDynamicGetByName(__unsafe_unretained RLMObjectBase *const obj,
         @throw RLMException(@"Invalid property name '%@' for class '%@'.",
                             propName, obj->_objectSchema.className);
     }
-    asList = asList && (prop.type != RLMPropertyTypeLinkingObjects);
     if (asList && prop.array && prop.swiftIvar) {
         RLMListBase *list = object_getIvar(obj, prop.swiftIvar);
-        if (!list._rlmArray) {
+        if (prop.type != RLMPropertyTypeLinkingObjects && !list._rlmArray) {
             list._rlmArray = RLMDynamicGet(obj, prop);
         }
         return list;

--- a/Realm/RLMAccessor.mm
+++ b/Realm/RLMAccessor.mm
@@ -564,6 +564,7 @@ id RLMDynamicGetByName(__unsafe_unretained RLMObjectBase *const obj,
         @throw RLMException(@"Invalid property name '%@' for class '%@'.",
                             propName, obj->_objectSchema.className);
     }
+    asList = asList && (prop.type != RLMPropertyTypeLinkingObjects);
     if (asList && prop.array && prop.swiftIvar) {
         RLMListBase *list = object_getIvar(obj, prop.swiftIvar);
         if (!list._rlmArray) {

--- a/RealmSwift/Object.swift
+++ b/RealmSwift/Object.swift
@@ -179,12 +179,7 @@ open class Object: RLMObjectBase, ThreadConfined, RealmCollectionValue {
             if realm == nil {
                 return value(forKey: key)
             }
-            let v = RLMDynamicGetByName(self, key, true)
-            if let v = v as? RLMResults<AnyObject> {
-                return Results<Object>(v) as Any
-            } else {
-                return v
-            }
+            return RLMDynamicGetByName(self, key, true)
         }
         set(value) {
             if realm == nil {

--- a/RealmSwift/Object.swift
+++ b/RealmSwift/Object.swift
@@ -179,7 +179,12 @@ open class Object: RLMObjectBase, ThreadConfined, RealmCollectionValue {
             if realm == nil {
                 return value(forKey: key)
             }
-            return RLMDynamicGetByName(self, key, true)
+            let v = RLMDynamicGetByName(self, key, true)
+            if let v = v as? RLMResults<AnyObject> {
+                return Results<Object>(v) as Any
+            } else {
+                return v
+            }
         }
         set(value) {
             if realm == nil {

--- a/RealmSwift/Tests/ObjectAccessorTests.swift
+++ b/RealmSwift/Tests/ObjectAccessorTests.swift
@@ -346,13 +346,12 @@ class ObjectAccessorTests: TestCase {
             XCTFail("Got an unexpected nil for fido[\"owners\"]")
             return
         }
-        XCTAssertTrue(owners is Results<Object>)
+        XCTAssertTrue(owners is LinkingObjects<SwiftOwnerObject>)
         // Make sure the results actually functions.
-        guard let firstOwner = (owners as? Results<Object>)?.first else {
+        guard let firstOwner = (owners as? LinkingObjects<SwiftOwnerObject>)?.first else {
             XCTFail("Was not able to get first owner")
             return
         }
-        let ownerName = firstOwner["name"] as? String
-        XCTAssertEqual(ownerName, "JP")
+        XCTAssertEqual(firstOwner.name, "JP")
     }
 }

--- a/RealmSwift/Tests/ObjectAccessorTests.swift
+++ b/RealmSwift/Tests/ObjectAccessorTests.swift
@@ -329,4 +329,30 @@ class ObjectAccessorTests: TestCase {
         object.optObjectCol = nil
         XCTAssertNil(object.optObjectCol)
     }
+
+    func testLinkingObjectsDynamicGet() {
+        let fido = SwiftDogObject()
+        let owner = SwiftOwnerObject()
+        owner.dog = fido
+        owner.name = "JP"
+        let realm = try! Realm()
+        try! realm.write {
+            realm.add([fido, owner])
+        }
+
+        // Get the linking objects property via subscript.
+        let dynamicOwners = fido["owners"]
+        guard let owners = dynamicOwners else {
+            XCTFail("Got an unexpected nil for fido[\"owners\"]")
+            return
+        }
+        XCTAssertTrue(owners is Results<Object>)
+        // Make sure the results actually functions.
+        guard let firstOwner = (owners as? Results<Object>)?.first else {
+            XCTFail("Was not able to get first owner")
+            return
+        }
+        let ownerName = firstOwner["name"] as? String
+        XCTAssertEqual(ownerName, "JP")
+    }
 }


### PR DESCRIPTION
See the connected issue for more information. This PR makes it so that retrieving a linking objects property using the dynamic getter in Swift produces a sensible result instead of crashing.

I'm not completely happy with this solution because it relies on the Swift part of the binding to perform a conditional cast (and because it returns a `Results` rather than a `LinkingObjects`), but it was the least invasive solution I could come up with.

Fixes #5436.