### PR TITLE
Translate exceptions thrown when initializing RLMSyncManager to RLMExceptions

### DIFF
--- a/Realm/RLMSyncManager.mm
+++ b/Realm/RLMSyncManager.mm
@@ -87,11 +87,16 @@ struct CocoaSyncLoggerFactory : public realm::SyncLoggerFactory {
 @implementation RLMSyncManager
 
 static RLMSyncManager *s_sharedManager = nil;
-static dispatch_once_t s_onceToken;
 
 + (instancetype)sharedManager {
-    dispatch_once(&s_onceToken, ^{
-        s_sharedManager = [[RLMSyncManager alloc] initWithCustomRootDirectory:nil];
+    std::once_flag flag;
+    std::call_once(flag, [] {
+        try {
+            s_sharedManager = [[RLMSyncManager alloc] initWithCustomRootDirectory:nil];
+        }
+        catch (std::exception const& e) {
+            @throw RLMException(e);
+        }
     });
     return s_sharedManager;
 }


### PR DESCRIPTION
Currently if an error occurs (such as the user denying access to the keychain) the program just crashes when the exception bubbles out of dispatch_once() with no indication as to what went wrong. Rethrowing the error as a NSException and using std::call_once() (which allows propagating exceptions) makes it so that there is at least an error message printed.