### PR TITLE
Test against Xcode 9.1 in CI, and build Swift 4.0.2 binaries during releases

### DIFF
--- a/.jenkins.yml
+++ b/.jenkins.yml
@@ -7,6 +7,7 @@ xcode_version:
   - 8.2
   - 8.3.3
   - 9.0
+  - 9.1
 target:
   - osx
   - docs
@@ -45,11 +46,14 @@ configuration:
 # | 8.2   | Debug        | X   |      | X          |             |           |           |         |           |           |      |                |                   |                      |                       |                       |                        |             |
 # | 8.2   | Release      | X   |      | X          | X           | X         | X         | X       | X         |           | X    |                |                   |                      |                       |                       |                        |             |
 # | -------------------- | --- | ---- | ---------- | ----------- | --------- | --------- | ------- | --------- | --------- | ---- | -------------- | ----------------- | -------------------- | --------------------- | --------------------- | ---------------------- | ----------- |
-# | 8.3.3 | Debug        | X   |      |            | X           | X         | X         | X       |           |           | X    |                |                   |                      |                       |                       |                        |             |
+# | 8.3.3 | Debug        | X   |      |            |             |           |           |         |           |           |      |                |                   |                      |                       |                       |                        |             |
 # | 8.3.3 | Release      | X   | X    |            | X           | X         | X         | X       | X         |           | X    | X              | X                 | X                    |                       | X                     |                        | X           |
 # | -------------------- | --- | ---- | ---------- | ----------- | --------- | --------- | ------- | --------- | --------- | ---- | -------------- | ----------------- | -------------------- | --------------------- | --------------------- | ---------------------- | ----------- |
-# | 9.0   | Debug        | X   |      |            | X           | X         | X         | X       |           |           | X    |                |                   |                      |                       |                       |                        |             |
-# | 9.0   | Release      | X   |      |            | X           | X         | X         | X       | X         | X         | X    | X              | X                 | X                    |                       | X                     |                        | X           |
+# | 9.0   | Debug        | X   |      |            |             |           |           |         |           |           |      |                |                   |                      |                       |                       |                        |             |
+# | 9.0   | Release      | X   |      |            | X           | X         | X         | X       | X         |           | X    |                |                   |                      |                       |                       |                        |             |
+# | -------------------- | --- | ---- | ---------- | ----------- | --------- | --------- | ------- | --------- | --------- | ---- | -------------- | ----------------- | -------------------- | --------------------- | --------------------- | ---------------------- | ----------- |
+# | 9.1   | Debug        | X   |      |            | X           | X         | X         | X       |           |           | X    |                |                   |                      |                       |                       |                        |             |
+# | 9.1   | Release      | X   |      |            | X           | X         | X         | X       | X         | X         | X    | X              | X                 | X                    |                       | X                     |                        | X           |
 # +----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 
 exclude:
@@ -65,6 +69,8 @@ exclude:
     target: docs
   - xcode_version: 9.0
     target: docs
+  - xcode_version: 9.1
+    target: docs
   - target: docs
     configuration: Debug
 
@@ -72,7 +78,7 @@ exclude:
   # ios-static
   ################
   # Skip on 8.0/8.1 Debug
-  # Skip 8.3.3/9.0 altogether since it doesn't support the iOS 7 deployment target
+  # Skip 8.3.3/9.0/9.1 altogether since it doesn't support the iOS 7 deployment target
   - xcode_version: 8.0
     target: ios-static
     configuration: Debug
@@ -83,11 +89,13 @@ exclude:
     target: ios-static
   - xcode_version: 9.0
     target: ios-static
+  - xcode_version: 9.1
+    target: ios-static
 
   ################
   # ios-dynamic
   ################
-  # Skip on 8.0/8.1/8.2 Debug
+  # Skip on 8.0/8.1/8.2/8.3.3/9.0 Debug
   - xcode_version: 8.0
     target: ios-dynamic
     configuration: Debug
@@ -95,13 +103,19 @@ exclude:
     target: ios-dynamic
     configuration: Debug
   - xcode_version: 8.2
+    target: ios-dynamic
+    configuration: Debug
+  - xcode_version: 8.3.3
+    target: ios-dynamic
+    configuration: Debug
+  - xcode_version: 9.0
     target: ios-dynamic
     configuration: Debug
 
   ################
   # ios-swift
   ################
-  # Skip 8.0/8.1/8.2 Debug
+  # Skip 8.0/8.1/8.2/8.3.3/9.0 Debug
   - xcode_version: 8.0
     target: ios-swift
     configuration: Debug
@@ -109,13 +123,19 @@ exclude:
     target: ios-swift
     configuration: Debug
   - xcode_version: 8.2
+    target: ios-swift
+    configuration: Debug
+  - xcode_version: 8.3.3
+    target: ios-swift
+    configuration: Debug
+  - xcode_version: 9.0
     target: ios-swift
     configuration: Debug
 
   ################
   # osx-swift
   ################
-  # Skip 8.0/8.1/8.2 Debug
+  # Skip 8.0/8.1/8.2/8.3.3/9.0 Debug
   - xcode_version: 8.0
     target: osx-swift
     configuration: Debug
@@ -123,13 +143,19 @@ exclude:
     target: osx-swift
     configuration: Debug
   - xcode_version: 8.2
+    target: osx-swift
+    configuration: Debug
+  - xcode_version: 8.3.3
+    target: osx-swift
+    configuration: Debug
+  - xcode_version: 9.0
     target: osx-swift
     configuration: Debug
 
   ################
   # watchos
   ################
-  # Skip 8.0/8.1/8.2 Debug
+  # Skip 8.0/8.1/8.2/8.3.3/9.0 Debug
   - xcode_version: 8.0
     target: watchos
     configuration: Debug
@@ -137,6 +163,12 @@ exclude:
     target: watchos
     configuration: Debug
   - xcode_version: 8.2
+    target: watchos
+    configuration: Debug
+  - xcode_version: 8.3.3
+    target: watchos
+    configuration: Debug
+  - xcode_version: 9.0
     target: watchos
     configuration: Debug
 
@@ -150,7 +182,7 @@ exclude:
   ################
   # swiftlint
   ################
-  # Just run on 9.0 Release
+  # Just run on 9.1 Release
   - xcode_version: 8.0
     target: swiftlint
   - xcode_version: 8.1
@@ -159,13 +191,15 @@ exclude:
     target: swiftlint
   - xcode_version: 8.3.3
     target: swiftlint
+  - xcode_version: 9.0
+    target: swiftlint
   - target: swiftlint
     configuration: Debug
 
   ################
   # tvos
   ################
-  # Skip 8.0/8.1/8.2 Debug
+  # Skip 8.0/8.1/8.2/8.3.3/9.0 Debug
   - xcode_version: 8.0
     target: tvos
     configuration: Debug
@@ -173,18 +207,26 @@ exclude:
     target: tvos
     configuration: Debug
   - xcode_version: 8.2
+    target: tvos
+    configuration: Debug
+  - xcode_version: 8.3.3
+    target: tvos
+    configuration: Debug
+  - xcode_version: 9.0
     target: tvos
     configuration: Debug
 
   ################
   # osx-encryption
   ################
-  # Just run on 8.3.3/9.0 Release
+  # Just run on 8.3.3/9.1 Release
   - xcode_version: 8.0
     target: osx-encryption
   - xcode_version: 8.1
     target: osx-encryption
   - xcode_version: 8.2
+    target: osx-encryption
+  - xcode_version: 9.0
     target: osx-encryption
   - target: osx-encryption
     configuration: Debug
@@ -192,12 +234,14 @@ exclude:
   ################
   # osx-object-server
   ################
-  # Just run on 8.3.3/9.0 Release
+  # Just run on 8.3.3/9.1 Release
   - xcode_version: 8.0
     target: osx-object-server
   - xcode_version: 8.1
     target: osx-object-server
   - xcode_version: 8.2
+    target: osx-object-server
+  - xcode_version: 9.0
     target: osx-object-server
   - target: osx-object-server
     configuration: Debug
@@ -205,12 +249,14 @@ exclude:
   ################
   # ios-device-objc-ios8
   ################
-  # Just run on 8.3.3/9.0 Release
+  # Just run on 8.3.3/9.1 Release
   - xcode_version: 8.0
     target: ios-device-objc-ios8
   - xcode_version: 8.1
     target: ios-device-objc-ios8
   - xcode_version: 8.2
+    target: ios-device-objc-ios8
+  - xcode_version: 9.0
     target: ios-device-objc-ios8
   - target: ios-device-objc-ios8
     configuration: Debug
@@ -218,12 +264,14 @@ exclude:
   ################
   # ios-device-swift-ios8
   ################
-  # Just run on 8.3.3/9.0 Release
+  # Just run on 8.3.3/9.1 Release
   - xcode_version: 8.0
     target: ios-device-swift-ios8
   - xcode_version: 8.1
     target: ios-device-swift-ios8
   - xcode_version: 8.2
+    target: ios-device-swift-ios8
+  - xcode_version: 9.0
     target: ios-device-swift-ios8
   - target: ios-device-swift-ios8
     configuration: Debug
@@ -231,12 +279,14 @@ exclude:
   ################
   # ios-device-objc-ios10
   ################
-  # Just run on 8.3.3/9.0 Release
+  # Just run on 8.3.3/9.1 Release
   - xcode_version: 8.0
     target: ios-device-objc-ios10
   - xcode_version: 8.1
     target: ios-device-objc-ios10
   - xcode_version: 8.2
+    target: ios-device-objc-ios10
+  - xcode_version: 9.0
     target: ios-device-objc-ios10
   - target: ios-device-objc-ios10
     configuration: Debug
@@ -244,12 +294,14 @@ exclude:
   ################
   # ios-device-swift-ios10
   ################
-  # Just run on 8.3.3/9.0 Release
+  # Just run on 8.3.3/9.1 Release
   - xcode_version: 8.0
     target: ios-device-swift-ios10
   - xcode_version: 8.1
     target: ios-device-swift-ios10
   - xcode_version: 8.2
+    target: ios-device-swift-ios10
+  - xcode_version: 9.0
     target: ios-device-swift-ios10
   - target: ios-device-swift-ios10
     configuration: Debug
@@ -257,12 +309,14 @@ exclude:
   ################
   # tvos-device
   ################
-  # Just run on 8.3.3/9.0 Release
+  # Just run on 8.3.3/9.1 Release
   - xcode_version: 8.0
     target: tvos-device
   - xcode_version: 8.1
     target: tvos-device
   - xcode_version: 8.2
+    target: tvos-device
+  - xcode_version: 9.0
     target: tvos-device
   - target: tvos-device
     configuration: Debug

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ x.x.x Release notes (yyyy-mm-dd)
 * Fix a crash when a linking objects property is retrieved from a model object instance via
   Swift subscripting.
 
+### Enhancements
+
+* Prebuilt binaries are now included for Swift 4.0.2.
+
 3.0.1 Release notes (2017-10-26)
 =============================================================
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ x.x.x Release notes (yyyy-mm-dd)
 
 ### Enhancements
 
-* Prebuilt binaries are now included for Swift 4.0.2.
+* Prebuilt binaries are now included for Swift 3.2.2 and 4.0.2.
 
 3.0.1 Release notes (2017-10-26)
 =============================================================

--- a/Jenkinsfile.releasability
+++ b/Jenkinsfile.releasability
@@ -1,4 +1,4 @@
-swiftVersions = ['3.0', '3.0.1', '3.0.2', '3.1', '3.2', '4.0']
+swiftVersions = ['3.0', '3.0.1', '3.0.2', '3.1', '3.2', '4.0', '4.0.2']
 platforms = ['osx', 'ios', 'watchos', 'tvos']
 platformNames = ['osx': 'macOS', 'ios': 'iOS', 'watchos': 'watchOS', 'tvos': 'tvOS']
 

--- a/Jenkinsfile.releasability
+++ b/Jenkinsfile.releasability
@@ -1,4 +1,4 @@
-swiftVersions = ['3.0', '3.0.1', '3.0.2', '3.1', '3.2', '4.0', '4.0.2']
+swiftVersions = ['3.0', '3.0.1', '3.0.2', '3.1', '3.2', '3.2.2', '4.0', '4.0.2']
 platforms = ['osx', 'ios', 'watchos', 'tvos']
 platformNames = ['osx': 'macOS', 'ios': 'iOS', 'watchos': 'watchOS', 'tvos': 'tvOS']
 

--- a/build.sh
+++ b/build.sh
@@ -1193,7 +1193,7 @@ EOM
         ;;
 
     "package-ios-swift")
-        for version in 8.0 8.1 8.2 8.3.3 9.0; do
+        for version in 8.0 8.1 8.2 8.3.3 9.0 9.1; do
             REALM_XCODE_VERSION=$version
             REALM_SWIFT_VERSION=
             set_xcode_and_swift_versions
@@ -1203,11 +1203,12 @@ EOM
 
         cd build/ios
         ln -s swift-4.0 swift-3.2
-        zip --symlinks -r realm-swift-framework-ios.zip swift-3.0 swift-3.0.1 swift-3.0.2 swift-3.1 swift-3.2 swift-4.0
+        ln -s swift-4.0.2 swift-3.2.2
+        zip --symlinks -r realm-swift-framework-ios.zip swift-3.0 swift-3.0.1 swift-3.0.2 swift-3.1 swift-3.2 swift-3.2.2 swift-4.0 swift-4.0.2
         ;;
 
     "package-osx-swift")
-        for version in 8.0 8.1 8.2 8.3.3 9.0; do
+        for version in 8.0 8.1 8.2 8.3.3 9.0 9.1; do
             REALM_XCODE_VERSION=$version
             REALM_SWIFT_VERSION=
             set_xcode_and_swift_versions
@@ -1217,7 +1218,8 @@ EOM
 
         cd build/osx
         ln -s swift-4.0 swift-3.2
-        zip --symlinks -r realm-swift-framework-osx.zip swift-3.0 swift-3.0.1 swift-3.0.2 swift-3.1 swift-3.2 swift-4.0
+        ln -s swift-4.0.2 swift-3.2.2
+        zip --symlinks -r realm-swift-framework-osx.zip swift-3.0 swift-3.0.1 swift-3.0.2 swift-3.1 swift-3.2 swift-3.2.2 swift-4.0 swift-4.0.2
         ;;
 
     "package-watchos")
@@ -1229,7 +1231,7 @@ EOM
         ;;
 
     "package-watchos-swift")
-        for version in 8.0 8.1 8.2 8.3.3 9.0; do
+        for version in 8.0 8.1 8.2 8.3.3 9.0 9.1; do
             REALM_XCODE_VERSION=$version
             REALM_SWIFT_VERSION=
             set_xcode_and_swift_versions
@@ -1239,7 +1241,8 @@ EOM
 
         cd build/watchos
         ln -s swift-4.0 swift-3.2
-        zip --symlinks -r realm-swift-framework-watchos.zip swift-3.0 swift-3.0.1 swift-3.0.2 swift-3.1 swift-3.2 swift-4.0
+        ln -s swift-4.0.2 swift-3.2.2
+        zip --symlinks -r realm-swift-framework-watchos.zip swift-3.0 swift-3.0.1 swift-3.0.2 swift-3.1 swift-3.2 swift-3.2.2 swift-4.0 swift-4.0.2
         ;;
 
     "package-tvos")
@@ -1251,7 +1254,7 @@ EOM
         ;;
 
     "package-tvos-swift")
-        for version in 8.0 8.1 8.2 8.3.3 9.0; do
+        for version in 8.0 8.1 8.2 8.3.3 9.0 9.1; do
             REALM_XCODE_VERSION=$version
             REALM_SWIFT_VERSION=
             set_xcode_and_swift_versions
@@ -1261,7 +1264,8 @@ EOM
 
         cd build/tvos
         ln -s swift-4.0 swift-3.2
-        zip --symlinks -r realm-swift-framework-tvos.zip swift-3.0 swift-3.0.1 swift-3.0.2 swift-3.1 swift-3.2 swift-4.0
+        ln -s swift-4.0.2 swift-3.2.2
+        zip --symlinks -r realm-swift-framework-tvos.zip swift-3.0 swift-3.0.1 swift-3.0.2 swift-3.1 swift-3.2 swift-3.2.2 swift-4.0 swift-4.0.2
         ;;
 
     package-*-swift-3.2)
@@ -1270,6 +1274,14 @@ EOM
         cd build/$PLATFORM
         ln -s swift-4.0 swift-3.2
         zip --symlinks -r realm-swift-framework-$PLATFORM-swift-3.2.zip swift-3.2
+        ;;
+
+    package-*-swift-3.2.2)
+        PLATFORM=$(echo $COMMAND | cut -d - -f 2)
+        mkdir -p build/$PLATFORM
+        cd build/$PLATFORM
+        ln -s swift-4.0.2 swift-3.2.2
+        zip --symlinks -r realm-swift-framework-$PLATFORM-swift-3.2.2.zip swift-3.2.2
         ;;
 
     package-*-swift-*)

--- a/scripts/package_examples.rb
+++ b/scripts/package_examples.rb
@@ -41,7 +41,7 @@ base_examples = [
   "examples/tvos/swift",
 ]
 
-swift_versions = %w(3.0 3.0.1 3.0.2 3.1 3.2 4.0)
+swift_versions = %w(3.0 3.0.1 3.0.2 3.1 3.2 3.2.2 4.0 4.0.2)
 
 # Remove reference to Realm.xcodeproj from all example workspaces.
 base_examples.each do |example|


### PR DESCRIPTION
I thinned out the CI matrix a little to limit the increase in CPU time that's required by the new Xcode version.