### PR TITLE
Use autoreleasepools in sample app background transactions

### DIFF
--- a/examples/ios/objc/Draw/AppDelegate.m
+++ b/examples/ios/objc/Draw/AppDelegate.m
@@ -92,9 +92,7 @@
                                  defaultConfig.syncConfiguration = syncConfig;
                                  [RLMRealmConfiguration setDefaultConfiguration:defaultConfig];
                                  
-                                 dispatch_async(dispatch_get_main_queue(), ^{
-                                     self.window.rootViewController.view = [DrawView new];
-                                 });
+                                 self.window.rootViewController.view = [DrawView new];
                              }
                          }];
 }

--- a/examples/ios/objc/GroupedTableView/TableViewController.m
+++ b/examples/ios/objc/GroupedTableView/TableViewController.m
@@ -134,15 +134,17 @@ forRowAtIndexPath:(NSIndexPath *)indexPath
     // Import many items in a background thread
     dispatch_async(queue, ^{
         // Get new realm and table since we are in a new thread
-        RLMRealm *realm = [RLMRealm defaultRealm];
-        [realm beginWriteTransaction];
-        for (NSInteger index = 0; index < 5; index++) {
-            // Add row via dictionary. Order is ignored.
-            [DemoObject createInRealm:realm withValue:@{@"title": [self randomTitle],
-                                                         @"date": [NSDate date],
-                                                         @"sectionTitle": [self randomSectionTitle]}];
+        @autoreleasepool {
+            RLMRealm *realm = [RLMRealm defaultRealm];
+            [realm beginWriteTransaction];
+            for (NSInteger index = 0; index < 5; index++) {
+                // Add row via dictionary. Order is ignored.
+                [DemoObject createInRealm:realm withValue:@{@"title": [self randomTitle],
+                                                             @"date": [NSDate date],
+                                                             @"sectionTitle": [self randomSectionTitle]}];
+            }
+            [realm commitWriteTransaction];
         }
-        [realm commitWriteTransaction];
     });
 }
 

--- a/examples/ios/objc/RACTableView/TableViewController.m
+++ b/examples/ios/objc/RACTableView/TableViewController.m
@@ -215,10 +215,12 @@ RLM_ARRAY_TYPE(Group)
 
 - (void)modifyInBackground:(void (^)(RLMArray *))block {
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
-        GroupParent *parent = GroupParent.allObjects.firstObject;
-        [parent.realm beginWriteTransaction];
-        block(parent.groups);
-        [parent.realm commitWriteTransaction];
+        @autoreleasepool {
+            GroupParent *parent = GroupParent.allObjects.firstObject;
+            [parent.realm beginWriteTransaction];
+            block(parent.groups);
+            [parent.realm commitWriteTransaction];
+        }
     });
 }
 

--- a/examples/ios/objc/Simple/AppDelegate.m
+++ b/examples/ios/objc/Simple/AppDelegate.m
@@ -83,9 +83,11 @@ RLM_ARRAY_TYPE(Dog)
 
     // Multi-threading
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
-        RLMRealm *otherRealm = [RLMRealm defaultRealm];
-        RLMResults *otherResults = [Dog objectsInRealm:otherRealm where:@"name contains 'Rex'"];
-        NSLog(@"Number of dogs: %li", (unsigned long)otherResults.count);
+        @autoreleasepool {
+            RLMRealm *otherRealm = [RLMRealm defaultRealm];
+            RLMResults *otherResults = [Dog objectsInRealm:otherRealm where:@"name contains 'Rex'"];
+            NSLog(@"Number of dogs: %li", (unsigned long)otherResults.count);
+        }
     });
 
     return YES;

--- a/examples/ios/objc/TableView/TableViewController.m
+++ b/examples/ios/objc/TableView/TableViewController.m
@@ -131,14 +131,16 @@ static NSString * const kTableName = @"table";
     // Import many items in a background thread
     dispatch_async(queue, ^{
         // Get new realm and table since we are in a new thread
-        RLMRealm *realm = [RLMRealm defaultRealm];
-        [realm beginWriteTransaction];
-        for (NSInteger index = 0; index < 5; index++) {
-            // Add row via dictionary. Order is ignored.
-            [DemoObject createInRealm:realm withValue:@{@"title": [self randomString],
-                                                         @"date": [self randomDate]}];
+        @autoreleasepool {
+            RLMRealm *realm = [RLMRealm defaultRealm];
+            [realm beginWriteTransaction];
+            for (NSInteger index = 0; index < 5; index++) {
+                // Add row via dictionary. Order is ignored.
+                [DemoObject createInRealm:realm withValue:@{@"title": [self randomString],
+                                                             @"date": [self randomDate]}];
+            }
+            [realm commitWriteTransaction];
         }
-        [realm commitWriteTransaction];
     });
 }
 

--- a/examples/ios/swift/GroupedTableView/TableViewController.swift
+++ b/examples/ios/swift/GroupedTableView/TableViewController.swift
@@ -109,13 +109,15 @@ class TableViewController: UITableViewController {
         // Import many items in a background thread
         DispatchQueue.global().async {
             // Get new realm and table since we are in a new thread
-            let realm = try! Realm()
-            realm.beginWrite()
-            for _ in 0..<5 {
-                // Add row via dictionary. Order is ignored.
-                realm.create(DemoObject.self, value: ["title": randomTitle(), "date": NSDate(), "sectionTitle": randomSectionTitle()])
+            autoreleasepool {
+                let realm = try! Realm()
+                realm.beginWrite()
+                for _ in 0..<5 {
+                    // Add row via dictionary. Order is ignored.
+                    realm.create(DemoObject.self, value: ["title": randomTitle(), "date": NSDate(), "sectionTitle": randomSectionTitle()])
+                }
+                try! realm.commitWrite()
             }
-            try! realm.commitWrite()
         }
     }
 

--- a/examples/ios/swift/Simple/AppDelegate.swift
+++ b/examples/ios/swift/Simple/AppDelegate.swift
@@ -78,9 +78,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         // Multi-threading
         DispatchQueue.global().async {
-            let otherRealm = try! Realm()
-            let otherResults = otherRealm.objects(Dog.self).filter(NSPredicate(format: "name contains 'Rex'"))
-            print("Number of dogs \(otherResults.count)")
+            autoreleasepool {
+                let otherRealm = try! Realm()
+                let otherResults = otherRealm.objects(Dog.self).filter(NSPredicate(format: "name contains 'Rex'"))
+                print("Number of dogs \(otherResults.count)")
+            }
         }
 
         return true

--- a/examples/ios/swift/TableView/TableViewController.swift
+++ b/examples/ios/swift/TableView/TableViewController.swift
@@ -110,13 +110,15 @@ class TableViewController: UITableViewController {
         // Import many items in a background thread
         DispatchQueue.global().async {
             // Get new realm and table since we are in a new thread
-            let realm = try! Realm()
-            realm.beginWrite()
-            for _ in 0..<5 {
-                // Add row via dictionary. Order is ignored.
-                realm.create(DemoObject.self, value: ["title": TableViewController.randomString(), "date": TableViewController.randomDate()])
+            autoreleasepool {
+                let realm = try! Realm()
+                realm.beginWrite()
+                for _ in 0..<5 {
+                    // Add row via dictionary. Order is ignored.
+                    realm.create(DemoObject.self, value: ["title": TableViewController.randomString(), "date": TableViewController.randomDate()])
+                }
+                try! realm.commitWrite()
             }
-            try! realm.commitWrite()
         }
     }
 


### PR DESCRIPTION
Our code samples have confused users on a few occasions. This clarifies things a bit.

Also removed an dispatch-to-main-thread pattern from a sync user login completion block, since that is no longer necessary with versions 3.0.0 and later.