### PR TITLE
Add support for Xcode 9.2, and drop support for older Xcode versions

### DIFF
--- a/.jenkins.yml
+++ b/.jenkins.yml
@@ -2,12 +2,10 @@
 # https://wiki.jenkins-ci.org/display/JENKINS/Yaml+Axis+Plugin
 
 xcode_version:
-  - 8.0
-  - 8.1
-  - 8.2
   - 8.3.3
   - 9.0
   - 9.1
+  - 9.2
 target:
   - osx
   - docs
@@ -37,35 +35,25 @@ configuration:
 # +----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 # | Configuration Matrix | osx | docs | ios-static | ios-dynamic | ios-swift | osx-swift | watchos | cocoapods | swiftlint | tvos | osx-encryption | osx-object-server | ios-device-objc-ios8 | ios-device-swift-ios8 | ios-device-objc-ios10 | ios-device-swift-ios10 | tvos-device |
 # | -------------------- | --- | ---- | ---------- | ----------- | --------- | --------- | ------- | --------- | --------- | ---- | -------------- | ----------------- | -------------------- | --------------------- | --------------------- | ---------------------- | ----------- |
-# | 8.0   | Debug        | X   |      |            |             |           |           |         |           |           |      |                |                   |                      |                       |                       |                        |             |
-# | 8.0   | Release      | X   |      | X          | X           | X         | X         | X       | X         |           | X    |                |                   |                      |                       |                       |                        |             |
-# | -------------------- | --- | ---- | ---------- | ----------- | --------- | --------- | ------- | --------- | --------- | ---- | -------------- | ----------------- | -------------------- | --------------------- | --------------------- | ---------------------- | ----------- |
-# | 8.1   | Debug        | X   |      |            |             |           |           |         |           |           |      |                |                   |                      |                       |                       |                        |             |
-# | 8.1   | Release      | X   |      | X          | X           | X         | X         | X       | X         |           | X    |                |                   |                      |                       |                       |                        |             |
-# | -------------------- | --- | ---- | ---------- | ----------- | --------- | --------- | ------- | --------- | --------- | ---- | -------------- | ----------------- | -------------------- | --------------------- | --------------------- | ---------------------- | ----------- |
-# | 8.2   | Debug        | X   |      | X          |             |           |           |         |           |           |      |                |                   |                      |                       |                       |                        |             |
-# | 8.2   | Release      | X   |      | X          | X           | X         | X         | X       | X         |           | X    |                |                   |                      |                       |                       |                        |             |
-# | -------------------- | --- | ---- | ---------- | ----------- | --------- | --------- | ------- | --------- | --------- | ---- | -------------- | ----------------- | -------------------- | --------------------- | --------------------- | ---------------------- | ----------- |
-# | 8.3.3 | Debug        | X   |      |            |             |           |           |         |           |           |      |                |                   |                      |                       |                       |                        |             |
-# | 8.3.3 | Release      | X   | X    |            | X           | X         | X         | X       | X         |           | X    | X              | X                 | X                    |                       | X                     |                        | X           |
+# | 8.3.3 | Debug        | X   |      | X          |             |           |           |         |           |           |      |                |                   |                      |                       |                       |                        |             |
+# | 8.3.3 | Release      | X   |      | X          | X           | X         | X         | X       | X         |           | X    | X              | X                 | X                    |                       | X                     |                        | X           |
 # | -------------------- | --- | ---- | ---------- | ----------- | --------- | --------- | ------- | --------- | --------- | ---- | -------------- | ----------------- | -------------------- | --------------------- | --------------------- | ---------------------- | ----------- |
 # | 9.0   | Debug        | X   |      |            |             |           |           |         |           |           |      |                |                   |                      |                       |                       |                        |             |
-# | 9.0   | Release      | X   |      |            | X           | X         | X         | X       | X         |           | X    |                |                   |                      |                       |                       |                        |             |
+# | 9.0   | Release      | X   |      | X          | X           | X         | X         | X       | X         |           | X    |                |                   |                      |                       |                       |                        |             |
 # | -------------------- | --- | ---- | ---------- | ----------- | --------- | --------- | ------- | --------- | --------- | ---- | -------------- | ----------------- | -------------------- | --------------------- | --------------------- | ---------------------- | ----------- |
-# | 9.1   | Debug        | X   |      |            | X           | X         | X         | X       |           |           | X    |                |                   |                      |                       |                       |                        |             |
-# | 9.1   | Release      | X   |      |            | X           | X         | X         | X       | X         | X         | X    | X              | X                 | X                    |                       | X                     |                        | X           |
+# | 9.1   | Debug        | X   |      |            |             |           |           |         |           |           |      |                |                   |                      |                       |                       |                        |             |
+# | 9.1   | Release      | X   |      | X          | X           | X         | X         | X       | X         |           | X    |                |                   |                      |                       |                       |                        |             |
+# | -------------------- | --- | ---- | ---------- | ----------- | --------- | --------- | ------- | --------- | --------- | ---- | -------------- | ----------------- | -------------------- | --------------------- | --------------------- | ---------------------- | ----------- |
+# | 9.2   | Debug        | X   |      |            | X           | X         | X         | X       |           |           | X    |                |                   |                      |                       |                       |                        |             |
+# | 9.2   | Release      | X   | X    | X          | X           | X         | X         | X       | X         | X         | X    | X              | X                 | X                    |                       | X                     |                        | X           |
 # +----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 
 exclude:
   ################
   # docs
   ################
-  # Just run on 8.3.3 Release
-  - xcode_version: 8.0
-    target: docs
-  - xcode_version: 8.1
-    target: docs
-  - xcode_version: 8.2
+  # Just run on 9.2 Release
+  - xcode_version: 8.3.3
     target: docs
   - xcode_version: 9.0
     target: docs
@@ -77,98 +65,70 @@ exclude:
   ################
   # ios-static
   ################
-  # Skip on 8.0/8.1 Debug
-  # Skip 8.3.3/9.0/9.1 altogether since it doesn't support the iOS 7 deployment target
-  - xcode_version: 8.0
-    target: ios-static
-    configuration: Debug
-  - xcode_version: 8.1
-    target: ios-static
-    configuration: Debug
-  - xcode_version: 8.3.3
-    target: ios-static
+  # Skip on 9.0/9.1/9.2 Debug
   - xcode_version: 9.0
     target: ios-static
+    configuration: Debug
   - xcode_version: 9.1
     target: ios-static
+    configuration: Debug
+  - xcode_version: 9.2
+    target: ios-static
+    configuration: Debug
 
   ################
   # ios-dynamic
   ################
-  # Skip on 8.0/8.1/8.2/8.3.3/9.0 Debug
-  - xcode_version: 8.0
-    target: ios-dynamic
-    configuration: Debug
-  - xcode_version: 8.1
-    target: ios-dynamic
-    configuration: Debug
-  - xcode_version: 8.2
-    target: ios-dynamic
-    configuration: Debug
+  # Skip on 8.3.3/9.0/9.1 Debug
   - xcode_version: 8.3.3
     target: ios-dynamic
     configuration: Debug
   - xcode_version: 9.0
+    target: ios-dynamic
+    configuration: Debug
+  - xcode_version: 9.1
     target: ios-dynamic
     configuration: Debug
 
   ################
   # ios-swift
   ################
-  # Skip 8.0/8.1/8.2/8.3.3/9.0 Debug
-  - xcode_version: 8.0
-    target: ios-swift
-    configuration: Debug
-  - xcode_version: 8.1
-    target: ios-swift
-    configuration: Debug
-  - xcode_version: 8.2
-    target: ios-swift
-    configuration: Debug
+  # Skip 8.3.3/9.0/9.1 Debug
   - xcode_version: 8.3.3
     target: ios-swift
     configuration: Debug
   - xcode_version: 9.0
+    target: ios-swift
+    configuration: Debug
+  - xcode_version: 9.1
     target: ios-swift
     configuration: Debug
 
   ################
   # osx-swift
   ################
-  # Skip 8.0/8.1/8.2/8.3.3/9.0 Debug
-  - xcode_version: 8.0
-    target: osx-swift
-    configuration: Debug
-  - xcode_version: 8.1
-    target: osx-swift
-    configuration: Debug
-  - xcode_version: 8.2
-    target: osx-swift
-    configuration: Debug
+  # Skip 8.3.3/9.0/9.1 Debug
   - xcode_version: 8.3.3
     target: osx-swift
     configuration: Debug
   - xcode_version: 9.0
+    target: osx-swift
+    configuration: Debug
+  - xcode_version: 9.1
     target: osx-swift
     configuration: Debug
 
   ################
   # watchos
   ################
-  # Skip 8.0/8.1/8.2/8.3.3/9.0 Debug
-  - xcode_version: 8.0
-    target: watchos
-    configuration: Debug
-  - xcode_version: 8.1
-    target: watchos
-    configuration: Debug
-  - xcode_version: 8.2
-    target: watchos
-    configuration: Debug
+  # Skip 8.3.3/9.0/9.1 Debug
   - xcode_version: 8.3.3
     target: watchos
     configuration: Debug
   - xcode_version: 9.0
+    target: watchos
+    configuration: Debug
+  - xcode_version: 9.1
     target: watchos
     configuration: Debug
 
@@ -182,16 +142,12 @@ exclude:
   ################
   # swiftlint
   ################
-  # Just run on 9.1 Release
-  - xcode_version: 8.0
-    target: swiftlint
-  - xcode_version: 8.1
-    target: swiftlint
-  - xcode_version: 8.2
-    target: swiftlint
+  # Just run on 9.2 Release
   - xcode_version: 8.3.3
     target: swiftlint
   - xcode_version: 9.0
+    target: swiftlint
+  - xcode_version: 9.1
     target: swiftlint
   - target: swiftlint
     configuration: Debug
@@ -199,34 +155,24 @@ exclude:
   ################
   # tvos
   ################
-  # Skip 8.0/8.1/8.2/8.3.3/9.0 Debug
-  - xcode_version: 8.0
-    target: tvos
-    configuration: Debug
-  - xcode_version: 8.1
-    target: tvos
-    configuration: Debug
-  - xcode_version: 8.2
-    target: tvos
-    configuration: Debug
+  # Skip 8.3.3/9.0/9.1 Debug
   - xcode_version: 8.3.3
     target: tvos
     configuration: Debug
   - xcode_version: 9.0
     target: tvos
     configuration: Debug
+  - xcode_version: 9.1
+    target: tvos
+    configuration: Debug
 
   ################
   # osx-encryption
   ################
-  # Just run on 8.3.3/9.1 Release
-  - xcode_version: 8.0
-    target: osx-encryption
-  - xcode_version: 8.1
-    target: osx-encryption
-  - xcode_version: 8.2
-    target: osx-encryption
+  # Just run on 8.3.3/9.2 Release
   - xcode_version: 9.0
+    target: osx-encryption
+  - xcode_version: 9.1
     target: osx-encryption
   - target: osx-encryption
     configuration: Debug
@@ -234,14 +180,10 @@ exclude:
   ################
   # osx-object-server
   ################
-  # Just run on 8.3.3/9.1 Release
-  - xcode_version: 8.0
-    target: osx-object-server
-  - xcode_version: 8.1
-    target: osx-object-server
-  - xcode_version: 8.2
-    target: osx-object-server
+  # Just run on 8.3.3/9.2 Release
   - xcode_version: 9.0
+    target: osx-object-server
+  - xcode_version: 9.1
     target: osx-object-server
   - target: osx-object-server
     configuration: Debug
@@ -249,14 +191,10 @@ exclude:
   ################
   # ios-device-objc-ios8
   ################
-  # Just run on 8.3.3/9.1 Release
-  - xcode_version: 8.0
-    target: ios-device-objc-ios8
-  - xcode_version: 8.1
-    target: ios-device-objc-ios8
-  - xcode_version: 8.2
-    target: ios-device-objc-ios8
+  # Just run on 8.3.3/9.2 Release
   - xcode_version: 9.0
+    target: ios-device-objc-ios8
+  - xcode_version: 9.1
     target: ios-device-objc-ios8
   - target: ios-device-objc-ios8
     configuration: Debug
@@ -264,14 +202,10 @@ exclude:
   ################
   # ios-device-swift-ios8
   ################
-  # Just run on 8.3.3/9.1 Release
-  - xcode_version: 8.0
-    target: ios-device-swift-ios8
-  - xcode_version: 8.1
-    target: ios-device-swift-ios8
-  - xcode_version: 8.2
-    target: ios-device-swift-ios8
+  # Just run on 8.3.3/9.2 Release
   - xcode_version: 9.0
+    target: ios-device-swift-ios8
+  - xcode_version: 9.1
     target: ios-device-swift-ios8
   - target: ios-device-swift-ios8
     configuration: Debug
@@ -279,14 +213,10 @@ exclude:
   ################
   # ios-device-objc-ios10
   ################
-  # Just run on 8.3.3/9.1 Release
-  - xcode_version: 8.0
-    target: ios-device-objc-ios10
-  - xcode_version: 8.1
-    target: ios-device-objc-ios10
-  - xcode_version: 8.2
-    target: ios-device-objc-ios10
+  # Just run on 8.3.3/9.2 Release
   - xcode_version: 9.0
+    target: ios-device-objc-ios10
+  - xcode_version: 9.1
     target: ios-device-objc-ios10
   - target: ios-device-objc-ios10
     configuration: Debug
@@ -294,14 +224,10 @@ exclude:
   ################
   # ios-device-swift-ios10
   ################
-  # Just run on 8.3.3/9.1 Release
-  - xcode_version: 8.0
-    target: ios-device-swift-ios10
-  - xcode_version: 8.1
-    target: ios-device-swift-ios10
-  - xcode_version: 8.2
-    target: ios-device-swift-ios10
+  # Just run on 8.3.3/9.2 Release
   - xcode_version: 9.0
+    target: ios-device-swift-ios10
+  - xcode_version: 9.1
     target: ios-device-swift-ios10
   - target: ios-device-swift-ios10
     configuration: Debug
@@ -309,14 +235,10 @@ exclude:
   ################
   # tvos-device
   ################
-  # Just run on 8.3.3/9.1 Release
-  - xcode_version: 8.0
-    target: tvos-device
-  - xcode_version: 8.1
-    target: tvos-device
-  - xcode_version: 8.2
-    target: tvos-device
+  # Just run on 8.3.3/9.2 Release
   - xcode_version: 9.0
+    target: tvos-device
+  - xcode_version: 9.1
     target: tvos-device
   - target: tvos-device
     configuration: Debug

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 x.x.x Release notes (yyyy-mm-dd)
 =============================================================
 
-Prebuilt frameworks are now included for Swift 3.2.3 and 4.0.3.
-Prebuilt frameworks are no longer included for Swift 3.0.x.
+* Prebuilt frameworks are now included for Swift 3.2.3 and 4.0.3.
+* Prebuilt frameworks are no longer included for Swift 3.0.x.
+* Building from source with Xcode versions prior to Xcode 8.3 is no longer supported.
 
 ### Enhancements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 x.x.x Release notes (yyyy-mm-dd)
 =============================================================
 
+Prebuilt frameworks are now included for Swift 3.2.3 and 4.0.3.
+Prebuilt frameworks are no longer included for Swift 3.0.x.
+
 ### Enhancements
 
 * Improve performance of change checking for notifications in certain cases.

--- a/Jenkinsfile.releasability
+++ b/Jenkinsfile.releasability
@@ -1,4 +1,4 @@
-swiftVersions = ['3.0', '3.0.1', '3.0.2', '3.1', '3.2', '3.2.2', '4.0', '4.0.2']
+swiftVersions = ['3.1', '3.2', '3.2.2', '3.2.3', '4.0', '4.0.2', '4.0.3']
 platforms = ['osx', 'ios', 'watchos', 'tvos']
 platformNames = ['osx': 'macOS', 'ios': 'iOS', 'watchos': 'watchOS', 'tvos': 'tvOS']
 

--- a/build.sh
+++ b/build.sh
@@ -199,12 +199,6 @@ move_to_clean_dir() {
 }
 
 test_ios_static() {
-    local previous_realm_xcode_version="$REALM_XCODE_VERSION"
-    local previous_realm_swift_version="$REALM_SWIFT_VERSION"
-    if [[ "$IS_RUNNING_PACKAGING" == "1" ]]; then
-        force_xcode_82
-    fi
-
     destination="$1"
     xc "-scheme 'Realm iOS static' -configuration $CONFIGURATION -sdk iphonesimulator -destination '$destination' build"
     if (( $(xcode_version_major) < 9 )); then
@@ -218,21 +212,6 @@ test_ios_static() {
     rm "$path"
 
     xc "-scheme 'Realm iOS static' -configuration $CONFIGURATION -sdk iphonesimulator -destination '$destination' test"
-
-    if [[ "$IS_RUNNING_PACKAGING" == "1" ]]; then
-        # Reset to state before forcing Xcode 8.2
-        REALM_XCODE_VERSION="$previous_realm_xcode_version"
-        REALM_SWIFT_VERSION="$previous_realm_swift_version"
-        set_xcode_and_swift_versions
-        sh build.sh prelaunch-simulator
-    fi
-}
-
-force_xcode_82() {
-  REALM_XCODE_VERSION=8.2
-  REALM_SWIFT_VERSION=
-  set_xcode_and_swift_versions
-  sh build.sh prelaunch-simulator
 }
 
 ######################################

--- a/build.sh
+++ b/build.sh
@@ -1193,7 +1193,7 @@ EOM
         ;;
 
     "package-ios-swift")
-        for version in 8.0 8.1 8.2 8.3.3 9.0 9.1; do
+        for version in 8.3.3 9.0 9.1 9.2; do
             REALM_XCODE_VERSION=$version
             REALM_SWIFT_VERSION=
             set_xcode_and_swift_versions
@@ -1204,11 +1204,13 @@ EOM
         cd build/ios
         ln -s swift-4.0 swift-3.2
         ln -s swift-4.0.2 swift-3.2.2
-        zip --symlinks -r realm-swift-framework-ios.zip swift-3.0 swift-3.0.1 swift-3.0.2 swift-3.1 swift-3.2 swift-3.2.2 swift-4.0 swift-4.0.2
+        ln -s swift-4.0.2 swift-3.2.3
+        ln -s swift-4.0.2 swift-4.0.3
+        zip --symlinks -r realm-swift-framework-ios.zip swift-3.1 swift-3.2 swift-3.2.2 swift-3.2.3 swift-4.0 swift-4.0.2 swift-4.0.3
         ;;
 
     "package-osx-swift")
-        for version in 8.0 8.1 8.2 8.3.3 9.0 9.1; do
+        for version in 8.3.3 9.0 9.1 9.2; do
             REALM_XCODE_VERSION=$version
             REALM_SWIFT_VERSION=
             set_xcode_and_swift_versions
@@ -1219,7 +1221,9 @@ EOM
         cd build/osx
         ln -s swift-4.0 swift-3.2
         ln -s swift-4.0.2 swift-3.2.2
-        zip --symlinks -r realm-swift-framework-osx.zip swift-3.0 swift-3.0.1 swift-3.0.2 swift-3.1 swift-3.2 swift-3.2.2 swift-4.0 swift-4.0.2
+        ln -s swift-4.0.2 swift-3.2.3
+        ln -s swift-4.0.2 swift-4.0.3
+        zip --symlinks -r realm-swift-framework-osx.zip swift-3.1 swift-3.2 swift-3.2.2 swift-3.2.3 swift-4.0 swift-4.0.2 swift-4.0.3
         ;;
 
     "package-watchos")
@@ -1231,7 +1235,7 @@ EOM
         ;;
 
     "package-watchos-swift")
-        for version in 8.0 8.1 8.2 8.3.3 9.0 9.1; do
+        for version in 8.3.3 9.0 9.1 9.2; do
             REALM_XCODE_VERSION=$version
             REALM_SWIFT_VERSION=
             set_xcode_and_swift_versions
@@ -1242,7 +1246,9 @@ EOM
         cd build/watchos
         ln -s swift-4.0 swift-3.2
         ln -s swift-4.0.2 swift-3.2.2
-        zip --symlinks -r realm-swift-framework-watchos.zip swift-3.0 swift-3.0.1 swift-3.0.2 swift-3.1 swift-3.2 swift-3.2.2 swift-4.0 swift-4.0.2
+        ln -s swift-4.0.2 swift-3.2.3
+        ln -s swift-4.0.2 swift-4.0.3
+        zip --symlinks -r realm-swift-framework-watchos.zip swift-3.1 swift-3.2 swift-3.2.2 swift-3.2.3 swift-4.0 swift-4.0.2 swift-4.0.3
         ;;
 
     "package-tvos")
@@ -1254,7 +1260,7 @@ EOM
         ;;
 
     "package-tvos-swift")
-        for version in 8.0 8.1 8.2 8.3.3 9.0 9.1; do
+        for version in 8.3.3 9.0 9.1 9.2; do
             REALM_XCODE_VERSION=$version
             REALM_SWIFT_VERSION=
             set_xcode_and_swift_versions
@@ -1265,7 +1271,9 @@ EOM
         cd build/tvos
         ln -s swift-4.0 swift-3.2
         ln -s swift-4.0.2 swift-3.2.2
-        zip --symlinks -r realm-swift-framework-tvos.zip swift-3.0 swift-3.0.1 swift-3.0.2 swift-3.1 swift-3.2 swift-3.2.2 swift-4.0 swift-4.0.2
+        ln -s swift-4.0.2 swift-3.2.3
+        ln -s swift-4.0.2 swift-4.0.3
+        zip --symlinks -r realm-swift-framework-tvos.zip swift-3.1 swift-3.2 swift-3.2.2 swift-3.2.3 swift-4.0 swift-4.0.2 swift-4.0.3
         ;;
 
     package-*-swift-3.2)
@@ -1282,6 +1290,22 @@ EOM
         cd build/$PLATFORM
         ln -s swift-4.0.2 swift-3.2.2
         zip --symlinks -r realm-swift-framework-$PLATFORM-swift-3.2.2.zip swift-3.2.2
+        ;;
+
+    package-*-swift-3.2.3)
+        PLATFORM=$(echo $COMMAND | cut -d - -f 2)
+        mkdir -p build/$PLATFORM
+        cd build/$PLATFORM
+        ln -s swift-4.0.2 swift-3.2.3
+        zip --symlinks -r realm-swift-framework-$PLATFORM-swift-3.2.3.zip swift-3.2.3
+        ;;
+
+    package-*-swift-4.0.3)
+        PLATFORM=$(echo $COMMAND | cut -d - -f 2)
+        mkdir -p build/$PLATFORM
+        cd build/$PLATFORM
+        ln -s swift-4.0.2 swift-4.0.3
+        zip --symlinks -r realm-swift-framework-$PLATFORM-swift-4.0.3.zip swift-4.0.3
         ;;
 
     package-*-swift-*)

--- a/scripts/package_examples.rb
+++ b/scripts/package_examples.rb
@@ -41,7 +41,7 @@ base_examples = [
   "examples/tvos/swift",
 ]
 
-swift_versions = %w(3.0 3.0.1 3.0.2 3.1 3.2 3.2.2 4.0 4.0.2)
+swift_versions = %w(3.1 3.2 3.2.2 3.2.3 4.0 4.0.2 4.0.3)
 
 # Remove reference to Realm.xcodeproj from all example workspaces.
 base_examples.each do |example|


### PR DESCRIPTION
This adds CI coverage and packaging for Xcode 9.2 (Swift 3.2.3 / 4.0.3) and removes CI coverage and packaging for Xcode versions prior to Xcode 8.3. The analytics we gather show very few users are using these old versions of Xcode with current versions of Realm. For those that are, updating to Xcode 8.3.3 should not be too challenging.