### PR TITLE
removes obsolete definition of 'SWIFT_WHOLE_MODULE_OPTIMIZATION'

### DIFF
--- a/RealmSwift.podspec
+++ b/RealmSwift.podspec
@@ -23,7 +23,7 @@ Pod::Spec.new do |s|
   s.prepare_command           = 'sh build.sh cocoapods-setup swift'
   s.preserve_paths            = %w(build.sh)
 
-  s.pod_target_xcconfig = { 'SWIFT_WHOLE_MODULE_OPTIMIZATION' => 'YES',
+  s.pod_target_xcconfig = { 'SWIFT_OPTIMIZATION_LEVEL' => '-Owholemodule',
                             'APPLICATION_EXTENSION_API_ONLY' => 'YES' }
 
   s.ios.deployment_target     = '8.0'


### PR DESCRIPTION
This fixes a warning generated by the Pods project when building with cocoa pods that warns that the SWIFT_WHOLE_MODULE_OPTIMIZATION is obsolete like so:

<img width="590" alt="image 2017-12-13 at 4 33 41 pm" src="https://user-images.githubusercontent.com/4205985/33969972-67ba760a-e025-11e7-95b9-c8746ca3ce3c.png">
