### PR TITLE
Add runloop checks to the permissions API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ x.x.x Release notes (yyyy-mm-dd)
   regardless.
 * Add support for JSON Web Token as a sync credential source.
 
+### Bugfixes
+
+* Add a missing check for a run loop in the permission API methods which
+  require one.
+
 3.0.2 Release notes (2017-11-08)
 =============================================================
 

--- a/Realm/ObjectServerTests/RLMPermissionsAPITests.m
+++ b/Realm/ObjectServerTests/RLMPermissionsAPITests.m
@@ -984,6 +984,14 @@ static NSURL *makeTildeSubstitutedURL(NSURL *url, RLMSyncUser *user) {
     CHECK_PERMISSION_ABSENT(results, p);
 }
 
+- (void)testRetrievingPermissionsChecksThreadHasRunLoop {
+    [self dispatchAsyncAndWait:^{
+        RLMAssertThrowsWithReason([self.userA retrievePermissionsWithCallback:^(__unused RLMResults *r, __unused NSError *e) {
+            XCTFail(@"callback should ot have been invoked");
+        }], @"Can only access or modify permissions from a thread which has a run loop");
+    }];
+}
+
 #pragma mark - Permission offer/response
 
 /// Get a token which can be used to offer the permissions as defined

--- a/Realm/ObjectServerTests/RLMPermissionsAPITests.m
+++ b/Realm/ObjectServerTests/RLMPermissionsAPITests.m
@@ -987,7 +987,7 @@ static NSURL *makeTildeSubstitutedURL(NSURL *url, RLMSyncUser *user) {
 - (void)testRetrievingPermissionsChecksThreadHasRunLoop {
     [self dispatchAsyncAndWait:^{
         RLMAssertThrowsWithReason([self.userA retrievePermissionsWithCallback:^(__unused RLMResults *r, __unused NSError *e) {
-            XCTFail(@"callback should ot have been invoked");
+            XCTFail(@"callback should not have been invoked");
         }], @"Can only access or modify permissions from a thread which has a run loop");
     }];
 }

--- a/Realm/RLMRealmUtil.hpp
+++ b/Realm/RLMRealmUtil.hpp
@@ -16,7 +16,6 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-#import <Foundation/Foundation.h>
 #import <memory>
 #import <string>
 
@@ -34,5 +33,7 @@ RLMRealm *RLMGetThreadLocalCachedRealmForPath(std::string const& path);
 RLMRealm *RLMGetAnyCachedRealmForPath(std::string const& path);
 // Clear the weak cache of Realms
 void RLMClearRealmCache();
+// Check if the current thread is currently within a running CFRunLoop
+bool RLMIsInRunLoop();
 
 std::unique_ptr<realm::BindingContext> RLMCreateBindingContext(RLMRealm *realm);

--- a/Realm/RLMSyncUser.mm
+++ b/Realm/RLMSyncUser.mm
@@ -22,12 +22,13 @@
 #import "RLMNetworkClient.h"
 #import "RLMRealmConfiguration+Sync.h"
 #import "RLMRealmConfiguration_Private.hpp"
+#import "RLMRealmUtil.hpp"
 #import "RLMResults_Private.hpp"
 #import "RLMSyncManager_Private.h"
 #import "RLMSyncPermissionResults.h"
 #import "RLMSyncPermission_Private.hpp"
-#import "RLMSyncSession_Private.hpp"
 #import "RLMSyncSessionRefreshHandle.hpp"
+#import "RLMSyncSession_Private.hpp"
 #import "RLMSyncUtil_Private.hpp"
 #import "RLMUtil.hpp"
 
@@ -338,7 +339,14 @@ PermissionChangeCallback RLMWrapPermissionStatusCallback(RLMPermissionStatusBloc
 
 #pragma mark - Permissions API
 
+static void verifyInRunLoop() {
+    if (!RLMIsInRunLoop()) {
+        @throw RLMException(@"Can only access or modify permissions from a thread which has a run loop (by default, only the main thread)`.");
+    }
+}
+
 - (void)retrievePermissionsWithCallback:(RLMPermissionResultsBlock)callback {
+    verifyInRunLoop();
     if (!_user || _user->state() == SyncUser::State::Error) {
         callback(nullptr, make_permission_error_get(@"Permissions cannot be retrieved using an invalid user."));
         return;
@@ -347,6 +355,7 @@ PermissionChangeCallback RLMWrapPermissionStatusCallback(RLMPermissionStatusBloc
 }
 
 - (void)applyPermission:(RLMSyncPermission *)permission callback:(RLMPermissionStatusBlock)callback {
+    verifyInRunLoop();
     if (!_user || _user->state() == SyncUser::State::Error) {
         callback(make_permission_error_change(@"Permissions cannot be applied using an invalid user."));
         return;
@@ -358,6 +367,7 @@ PermissionChangeCallback RLMWrapPermissionStatusCallback(RLMPermissionStatusBloc
 }
 
 - (void)revokePermission:(RLMSyncPermission *)permission callback:(RLMPermissionStatusBlock)callback {
+    verifyInRunLoop();
     if (!_user || _user->state() == SyncUser::State::Error) {
         callback(make_permission_error_change(@"Permissions cannot be revoked using an invalid user."));
         return;
@@ -372,6 +382,7 @@ PermissionChangeCallback RLMWrapPermissionStatusCallback(RLMPermissionStatusBloc
                      accessLevel:(RLMSyncAccessLevel)accessLevel
                       expiration:(NSDate *)expirationDate
                         callback:(RLMPermissionOfferStatusBlock)callback {
+    verifyInRunLoop();
     if (!_user || _user->state() == SyncUser::State::Error) {
         callback(nil, make_permission_error_change(@"A permission offer cannot be created using an invalid user."));
         return;
@@ -396,6 +407,7 @@ PermissionChangeCallback RLMWrapPermissionStatusCallback(RLMPermissionStatusBloc
 
 - (void)acceptOfferForToken:(NSString *)token
                    callback:(RLMPermissionOfferResponseStatusBlock)callback {
+    verifyInRunLoop();
     if (!_user || _user->state() == SyncUser::State::Error) {
         callback(nil, make_permission_error_change(@"A permission offer cannot be accepted by an invalid user."));
         return;

--- a/Realm/RLMSyncUser.mm
+++ b/Realm/RLMSyncUser.mm
@@ -341,7 +341,7 @@ PermissionChangeCallback RLMWrapPermissionStatusCallback(RLMPermissionStatusBloc
 
 static void verifyInRunLoop() {
     if (!RLMIsInRunLoop()) {
-        @throw RLMException(@"Can only access or modify permissions from a thread which has a run loop (by default, only the main thread)`.");
+        @throw RLMException(@"Can only access or modify permissions from a thread which has a run loop (by default, only the main thread).");
     }
 }
 


### PR DESCRIPTION
Attempting to fetch or modify permissions from a background thread would just silently fail to ever call the callback. This makes them throw an exception like RLMResults/etc. do.