### PR TITLE
Strip trailing slashes from the auth server URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ x.x.x Release notes (yyyy-mm-dd)
 * Realm Object Server errors not explicitly recognized by the client are now reported to the application
   regardless.
 * Add support for JSON Web Token as a sync credential source.
+* Automatically strip trailing slashes from auth server URLs rather than behaving oddly.
 
 ### Bugfixes
 

--- a/Realm/ObjectServerTests/RLMPermissionsAPITests.m
+++ b/Realm/ObjectServerTests/RLMPermissionsAPITests.m
@@ -992,6 +992,23 @@ static NSURL *makeTildeSubstitutedURL(NSURL *url, RLMSyncUser *user) {
     }];
 }
 
+- (void)testRetrievePermissionsWithTrailingSlash {
+    // Have A open a Realm and grant a permission to B.
+    NSURL *url = REALM_URL();
+    NSString *tildeSubstitutedPath = [makeTildeSubstitutedURL(url, self.userA) path];
+    __attribute__((objc_precise_lifetime)) RLMRealm *r = [self openRealmForURL:url user:self.userA];
+    id p1 = [[RLMSyncPermission alloc] initWithRealmPath:tildeSubstitutedPath
+                                                identity:self.userB.identity
+                                             accessLevel:RLMSyncAccessLevelRead];
+    APPLY_PERMISSION_WITH_MESSAGE(p1, self.userA, @"Setting r permission for user B should work.");
+
+    // Add a trailing slash to the auth URL and try to fetch this new permission
+    NSURL *authURL = [NSURL URLWithString:[[self.class authServerURL].absoluteString stringByAppendingString:@"/"]];
+    RLMSyncUser *userB = [self logInUserForCredentials:[RLMSyncTestCase basicCredentialsWithName:self.userBUsername register:NO]
+                                                server:authURL];
+    CHECK_PERMISSION_COUNT([self getPermissionResultsFor:userB], 1);
+}
+
 #pragma mark - Permission offer/response
 
 /// Get a token which can be used to offer the permissions as defined


### PR DESCRIPTION
Fixes #5565.

Not sure that this is a better solution than just throwing an exception. This is a bit more friendly, but has the potential for confusion by differing from other bindings. Doing this at the object store level would fix that but is pretty awkward due to that it's usually just passing a const ref onto something else, and it's harder to be sure that every place that would need this behavior was actually modified.