### PR TITLE
Don't copy the RLMSchema every time a swift Realm is opened with explicit object types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+x.x.x Release notes (yyyy-MM-dd)
+=============================================================
+
+### Breaking Changes
+
+* None.
+
+### Enhancements
+
+* None.
+
+### Bugfixes
+
+* Fix a memory leak when opening Realms with an explicit `objectTypes` array
+  from Swift.
+
 3.1.0 Release notes (2018-01-16)
 =============================================================
 

--- a/Realm/RLMRealmConfiguration.mm
+++ b/Realm/RLMRealmConfiguration.mm
@@ -298,4 +298,8 @@ static void RLMNSStringToStdString(std::string &out, NSString *in) {
     _shouldCompactOnLaunch = shouldCompactOnLaunch;
 }
 
+- (void)setCustomSchemaWithoutCopying:(RLMSchema *)schema {
+    _customSchema = schema;
+}
+
 @end

--- a/Realm/RLMRealmConfiguration_Private.h
+++ b/Realm/RLMRealmConfiguration_Private.h
@@ -34,6 +34,8 @@ NS_ASSUME_NONNULL_BEGIN
 + (RLMRealmConfiguration *)rawDefaultConfiguration;
 
 + (void)resetRealmConfigurationState;
+
+- (void)setCustomSchemaWithoutCopying:(nullable RLMSchema *)schema;
 @end
 
 // Get a path in the platform-appropriate documents directory with the given filename

--- a/RealmSwift/RealmConfiguration.swift
+++ b/RealmSwift/RealmConfiguration.swift
@@ -228,7 +228,7 @@ extension Realm {
             } else {
                 configuration.shouldCompactOnLaunch = nil
             }
-            configuration.customSchema = self.customSchema
+            configuration.setCustomSchemaWithoutCopying(self.customSchema)
             configuration.disableFormatUpgrade = self.disableFormatUpgrade
             return configuration
         }


### PR DESCRIPTION
Translating the Realm.Configuration to a RLMRealmConfiguration was making a copy of the RLMSchema, which on top of being somewhat slow was breaking the object accessor caching and thus leaking some memory each time.

This leaves the property as `copy` in case there's anything actually relying on that and just bypasses the property setter when converting types.

Fixes 5590.