### PR TITLE
Add support for overriding table and column names

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -11,6 +11,7 @@ identifier_name:
     - _nsError
     - _nsErrorDomain
     - _realmObjectName()
+    - _realmColumnNames()
     - id
     - pk
     - to

--- a/Realm/RLMAccessor.mm
+++ b/Realm/RLMAccessor.mm
@@ -199,8 +199,11 @@ RLMLinkingObjects *getLinkingObjects(__unsafe_unretained RLMObjectBase *const ob
                                      __unsafe_unretained RLMProperty *const property) {
     RLMVerifyAttached(obj);
     auto& objectInfo = obj->_realm->_info[property.objectClassName];
-    auto linkingProperty = objectInfo.objectSchema->property_for_name(property.linkOriginPropertyName.UTF8String);
-    auto backlinkView = obj->_row.get_table()->get_backlink_view(obj->_row.get_index(), objectInfo.table(), linkingProperty->table_column);
+    auto& linkOrigin = obj->_info->objectSchema->computed_properties[property.index].link_origin_property_name;
+    auto linkingProperty = objectInfo.objectSchema->property_for_name(linkOrigin);
+    auto backlinkView = obj->_row.get_table()->get_backlink_view(obj->_row.get_index(),
+                                                                 objectInfo.table(),
+                                                                 linkingProperty->table_column);
     realm::Results results(obj->_realm->_realm, std::move(backlinkView));
     return [RLMLinkingObjects resultsWithObjectInfo:objectInfo results:std::move(results)];
 }
@@ -546,7 +549,7 @@ void RLMDynamicSet(__unsafe_unretained RLMObjectBase *const obj,
     realm::Object o(obj->_info->realm->_realm, *obj->_info->objectSchema, obj->_row);
     RLMAccessorContext c(obj);
     translateError([&] {
-        o.set_property_value(c, prop.name.UTF8String, val ?: NSNull.null, false);
+        o.set_property_value(c, prop.columnName.UTF8String, val ?: NSNull.null, false);
     });
 }
 
@@ -554,7 +557,7 @@ id RLMDynamicGet(__unsafe_unretained RLMObjectBase *const obj, __unsafe_unretain
     realm::Object o(obj->_realm->_realm, *obj->_info->objectSchema, obj->_row);
     RLMAccessorContext c(obj);
     c.currentProperty = prop;
-    return RLMCoerceToNil(o.get_property_value<id>(c, prop.name.UTF8String));
+    return RLMCoerceToNil(o.get_property_value<id>(c, prop.columnName.UTF8String));
 }
 
 id RLMDynamicGetByName(__unsafe_unretained RLMObjectBase *const obj,
@@ -754,7 +757,7 @@ realm::RowExpr RLMAccessorContext::unbox(__unsafe_unretained id const v, bool cr
 void RLMAccessorContext::will_change(realm::Row const& row, realm::Property const& prop) {
     _observationInfo = RLMGetObservationInfo(nullptr, row.get_index(), _info);
     if (_observationInfo) {
-        _kvoPropertyName = @(prop.name.c_str());
+        _kvoPropertyName = _info.propertyForTableColumn(prop.table_column).name;
         _observationInfo->willChange(_kvoPropertyName);
     }
 }

--- a/Realm/RLMClassInfo.mm
+++ b/Realm/RLMClassInfo.mm
@@ -102,7 +102,8 @@ RLMClassInfo& RLMSchemaInfo::operator[](NSString *name) {
 RLMSchemaInfo::RLMSchemaInfo(RLMRealm *realm) {
     RLMSchema *rlmSchema = realm.schema;
     realm::Schema const& schema = realm->_realm->schema();
-    REALM_ASSERT(rlmSchema.objectSchema.count == schema.size());
+    // rlmSchema can be larger due to multiple classes backed by one table
+    REALM_ASSERT(rlmSchema.objectSchema.count >= schema.size());
 
     m_objects.reserve(schema.size());
     for (RLMObjectSchema *rlmObjectSchema in rlmSchema.objectSchema) {

--- a/Realm/RLMObjectBase.h
+++ b/Realm/RLMObjectBase.h
@@ -37,6 +37,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (BOOL)shouldIncludeInDefaultSchema;
 
 + (nullable NSString *)_realmObjectName;
++ (nullable NSDictionary<NSString *, NSString *> *)_realmColumnNames;
 
 @end
 

--- a/Realm/RLMObjectBase.mm
+++ b/Realm/RLMObjectBase.mm
@@ -247,7 +247,7 @@ id RLMCreateManagedAccessor(Class cls, __unsafe_unretained RLMRealm *realm, RLMC
     NSMutableString *mString = [NSMutableString stringWithFormat:@"%@ {\n", baseClassName];
 
     for (RLMProperty *property in _objectSchema.properties) {
-        id object = RLMObjectBaseObjectForKeyedSubscript(self, property.name);
+        id object = _realm ? RLMDynamicGetByName(self, property.name, true) : [self valueForKey:property.name];
         NSString *sub;
         if ([object respondsToSelector:@selector(descriptionWithMaxDepth:)]) {
             sub = [object descriptionWithMaxDepth:depth - 1];

--- a/Realm/RLMObjectBase.mm
+++ b/Realm/RLMObjectBase.mm
@@ -33,6 +33,7 @@
 #import "RLMUtil.hpp"
 
 #import "object.hpp"
+#import "object_schema.hpp"
 #import "shared_realm.hpp"
 
 using namespace realm;
@@ -311,6 +312,10 @@ id RLMCreateManagedAccessor(Class cls, __unsafe_unretained RLMRealm *realm, RLMC
 }
 
 + (NSString *)_realmObjectName {
+    return nil;
+}
+
++ (NSDictionary *)_realmColumnNames {
     return nil;
 }
 

--- a/Realm/RLMObjectSchema.mm
+++ b/Realm/RLMObjectSchema.mm
@@ -28,8 +28,8 @@
 #import "RLMSwiftSupport.h"
 #import "RLMUtil.hpp"
 
-#import "object_store.hpp"
 #import "object_schema.hpp"
+#import "object_store.hpp"
 
 using namespace realm;
 

--- a/Realm/RLMObjectSchema_Private.hpp
+++ b/Realm/RLMObjectSchema_Private.hpp
@@ -18,11 +18,14 @@
 
 #import "RLMObjectSchema_Private.h"
 
-#import "object_schema.hpp"
+namespace realm {
+    class ObjectSchema;
+}
+@class RLMSchema;
 
 @interface RLMObjectSchema ()
 // create realm::ObjectSchema copy
-- (realm::ObjectSchema)objectStoreCopy;
+- (realm::ObjectSchema)objectStoreCopy:(RLMSchema *)schema;
 
 // initialize with realm::ObjectSchema
 + (instancetype)objectSchemaForObjectStoreSchema:(realm::ObjectSchema const&)objectSchema;

--- a/Realm/RLMProperty_Private.h
+++ b/Realm/RLMProperty_Private.h
@@ -93,6 +93,7 @@ static inline NSString *RLMTypeToString(RLMPropertyType type) {
 @property (nonatomic, copy, nullable) NSString *objectClassName;
 
 // private properties
+@property (nonatomic, readwrite) NSString *columnName;
 @property (nonatomic, assign) NSUInteger index;
 @property (nonatomic, assign) BOOL isPrimary;
 @property (nonatomic, assign) Ivar swiftIvar;

--- a/Realm/RLMProperty_Private.hpp
+++ b/Realm/RLMProperty_Private.hpp
@@ -18,12 +18,16 @@
 
 #import <Realm/RLMProperty_Private.h>
 
-#import "property.hpp"
+namespace realm {
+    struct Property;
+}
+
+@class RLMSchema;
 
 @interface RLMProperty ()
 
 + (instancetype)propertyForObjectStoreProperty:(const realm::Property&)property;
 
-- (realm::Property)objectStoreCopy;
+- (realm::Property)objectStoreCopy:(RLMSchema *)schema;
 
 @end

--- a/Realm/RLMQueryUtil.mm
+++ b/Realm/RLMQueryUtil.mm
@@ -213,7 +213,7 @@ public:
     : m_links(links), m_property(property), m_schema(schema), m_group(&group), m_query(&query), m_table(query.get_table().get())
     {
         auto& table = walk_link_chain([](Table&, size_t, RLMPropertyType) { });
-        m_index = table.get_column_index(m_property.name.UTF8String);
+        m_index = table.get_column_index(m_property.columnName.UTF8String);
     }
 
     template <typename T, typename... SubQuery>
@@ -292,7 +292,7 @@ private:
         auto table = m_query->get_table().get();
         for (const auto& link : m_links) {
             if (link.type != RLMPropertyTypeLinkingObjects) {
-                auto index = table->get_column_index(link.name.UTF8String);
+                auto index = table->get_column_index(link.columnName.UTF8String);
                 func(*table, index, link.type);
                 table = table->get_link_target(index).get();
             }
@@ -311,7 +311,8 @@ private:
     {
         RLMObjectSchema *link_origin_schema = m_schema[prop.objectClassName];
         Table& link_origin_table = get_table(*m_group, link_origin_schema);
-        size_t link_origin_column = link_origin_table.get_column_index(prop.linkOriginPropertyName.UTF8String);
+        NSString *column_name = link_origin_schema[prop.linkOriginPropertyName].columnName;
+        size_t link_origin_column = link_origin_table.get_column_index(column_name.UTF8String);
         return func(link_origin_table, link_origin_column);
     }
 

--- a/Realm/RLMResults.mm
+++ b/Realm/RLMResults.mm
@@ -151,7 +151,10 @@ static inline void RLMResultsValidateInWriteTransaction(__unsafe_unretained RLMR
 
 - (NSString *)objectClassName {
     return translateRLMResultsErrors([&] {
-        return RLMStringDataToNSString(_results.get_object_type());
+        if (_info && _results.get_type() == realm::PropertyType::Object) {
+            return _info->rlmObjectSchema.className;
+        }
+        return (NSString *)nil;
     });
 }
 

--- a/Realm/RLMResults.mm
+++ b/Realm/RLMResults.mm
@@ -503,4 +503,7 @@ static inline void RLMResultsValidateInWriteTransaction(__unsafe_unretained RLMR
 @end
 
 @implementation RLMLinkingObjects
+- (NSString *)description {
+    return RLMDescriptionWithMaxDepth(@"RLMLinkingObjects", self, RLMDescriptionMaxDepth);
+}
 @end

--- a/Realm/Tests/DynamicTests.m
+++ b/Realm/Tests/DynamicTests.m
@@ -92,8 +92,12 @@
     NSError *error = nil;
     RLMSchema *dynamicSchema = [[RLMRealm realmWithConfiguration:config error:&error] schema];
     XCTAssertNil(error);
-    XCTAssertEqual(dynamicSchema.objectSchema.count, expectedSchema.objectSchema.count);
     for (RLMObjectSchema *expectedObjectSchema in expectedSchema.objectSchema) {
+        Class cls = expectedObjectSchema.objectClass;
+        if ([cls _realmObjectName] || [cls _realmColumnNames]) {
+            // Class overrides names, so the dynamic schema for it shoudn't match
+            continue;
+        }
         RLMObjectSchema *dynamicObjectSchema = dynamicSchema[expectedObjectSchema.className];
         XCTAssertEqual(dynamicObjectSchema.properties.count, expectedObjectSchema.properties.count);
         for (NSUInteger propertyIndex = 0; propertyIndex < expectedObjectSchema.properties.count; propertyIndex++) {

--- a/Realm/Tests/LinkingObjectsTests.mm
+++ b/Realm/Tests/LinkingObjectsTests.mm
@@ -244,4 +244,19 @@
     [token invalidate];
 }
 
+- (void)testRenamedProperties {
+    RLMRealm *realm = self.realmWithTestPath;
+    [realm beginWriteTransaction];
+    auto obj1 = [RenamedProperties1 createInRealm:realm withValue:@[@1, @"a"]];
+    auto obj2 = [RenamedProperties2 createInRealm:realm withValue:@[@2, @"b"]];
+    auto link = [LinkToRenamedProperties1 createInRealm:realm withValue:@[obj1, obj2, @[obj1, obj1]]];
+    [realm commitWriteTransaction];
+
+    XCTAssertEqualObjects(obj1.linking1.objectClassName, @"LinkToRenamedProperties1");
+    XCTAssertEqualObjects(obj1.linking2.objectClassName, @"LinkToRenamedProperties2");
+
+    XCTAssertTrue([obj1.linking1[0] isEqualToObject:link]);
+    XCTAssertTrue([obj2.linking2[0] isEqualToObject:link]);
+}
+
 @end

--- a/Realm/Tests/MigrationTests.mm
+++ b/Realm/Tests/MigrationTests.mm
@@ -42,10 +42,10 @@ using namespace realm;
 static void RLMAssertRealmSchemaMatchesTable(id self, RLMRealm *realm) {
     for (RLMObjectSchema *objectSchema in realm.schema.objectSchema) {
         auto& info = realm->_info[objectSchema.className];
-        TableRef table = ObjectStore::table_for_object_type(realm.group, objectSchema.className.UTF8String);
+        TableRef table = ObjectStore::table_for_object_type(realm.group, objectSchema.objectName.UTF8String);
         for (RLMProperty *property in objectSchema.properties) {
             auto column = info.tableColumn(property);
-            XCTAssertEqual(column, table->get_column_index(RLMStringDataWithNSString(property.name)));
+            XCTAssertEqual(column, table->get_column_index(RLMStringDataWithNSString(property.columnName)));
             XCTAssertEqual(property.indexed || property.isPrimary, table->has_search_index(column));
         }
     }

--- a/Realm/Tests/QueryTests.m
+++ b/Realm/Tests/QueryTests.m
@@ -2746,6 +2746,68 @@ struct NullTestData {
     [self testClass:[AllOptionalTypes class] withNormalCount:0U notCount:1U where:@"date IN %@", @[[NSDate dateWithTimeIntervalSince1970:1]]];
 }
 
+- (void)testQueryOnRenamedProperties {
+    RLMRealm *realm = [self realm];
+    [realm beginWriteTransaction];
+    [RenamedProperties1 createInRealm:realm withValue:@[@1, @"a"]];
+    [RenamedProperties2 createInRealm:realm withValue:@[@2, @"b"]];
+    [realm commitWriteTransaction];
+
+    [self testClass:[RenamedProperties1 class] withNormalCount:2 notCount:0 where:@"propA != 0"];
+    [self testClass:[RenamedProperties1 class] withNormalCount:1 notCount:1 where:@"propA = 1"];
+    [self testClass:[RenamedProperties1 class] withNormalCount:1 notCount:1 where:@"propA = 2"];
+    [self testClass:[RenamedProperties1 class] withNormalCount:0 notCount:2 where:@"propA = 3"];
+
+    [self testClass:[RenamedProperties2 class] withNormalCount:2 notCount:0 where:@"propC != 0"];
+    [self testClass:[RenamedProperties2 class] withNormalCount:1 notCount:1 where:@"propC = 1"];
+    [self testClass:[RenamedProperties2 class] withNormalCount:1 notCount:1 where:@"propC = 2"];
+    [self testClass:[RenamedProperties2 class] withNormalCount:0 notCount:2 where:@"propC = 3"];
+}
+
+- (void)testQueryOverRenamedLinks {
+    RLMRealm *realm = [self realm];
+    [realm beginWriteTransaction];
+    id obj1 = [RenamedProperties1 createInRealm:realm withValue:@[@1, @"a"]];
+    id obj2 = [RenamedProperties2 createInRealm:realm withValue:@[@2, @"b"]];
+    [LinkToRenamedProperties1 createInRealm:realm withValue:@[obj1, NSNull.null, @[obj1]]];
+    [LinkToRenamedProperties2 createInRealm:realm withValue:@[obj2, NSNull.null, @[obj2]]];
+    [realm commitWriteTransaction];
+
+    [self testClass:[LinkToRenamedProperties1 class] withNormalCount:2 notCount:0 where:@"linkA.propA != 0"];
+    [self testClass:[LinkToRenamedProperties1 class] withNormalCount:1 notCount:1 where:@"linkA.propA = 1"];
+    [self testClass:[LinkToRenamedProperties1 class] withNormalCount:1 notCount:1 where:@"linkA.propA = 2"];
+    [self testClass:[LinkToRenamedProperties1 class] withNormalCount:0 notCount:2 where:@"linkA.propA = 3"];
+
+    [self testClass:[LinkToRenamedProperties2 class] withNormalCount:2 notCount:0 where:@"linkC.propC != 0"];
+    [self testClass:[LinkToRenamedProperties2 class] withNormalCount:1 notCount:1 where:@"linkC.propC = 1"];
+    [self testClass:[LinkToRenamedProperties2 class] withNormalCount:1 notCount:1 where:@"linkC.propC = 2"];
+    [self testClass:[LinkToRenamedProperties2 class] withNormalCount:0 notCount:2 where:@"linkC.propC = 3"];
+
+    [self testClass:[LinkToRenamedProperties1 class] withNormalCount:2 notCount:0 where:@"ANY array.propA != 0"];
+    [self testClass:[LinkToRenamedProperties1 class] withNormalCount:1 notCount:1 where:@"ANY array.propA = 1"];
+    [self testClass:[LinkToRenamedProperties1 class] withNormalCount:1 notCount:1 where:@"ANY array.propA = 2"];
+    [self testClass:[LinkToRenamedProperties1 class] withNormalCount:0 notCount:2 where:@"ANY array.propA = 3"];
+
+    [self testClass:[LinkToRenamedProperties2 class] withNormalCount:2 notCount:0 where:@"ANY array.propC != 0"];
+    [self testClass:[LinkToRenamedProperties2 class] withNormalCount:1 notCount:1 where:@"ANY array.propC = 1"];
+    [self testClass:[LinkToRenamedProperties2 class] withNormalCount:1 notCount:1 where:@"ANY array.propC = 2"];
+    [self testClass:[LinkToRenamedProperties2 class] withNormalCount:0 notCount:2 where:@"ANY array.propC = 3"];
+}
+
+- (void)testQueryOverRenamedBacklinks {
+    RLMRealm *realm = [self realm];
+    [realm beginWriteTransaction];
+    id obj1 = [RenamedProperties1 createInRealm:realm withValue:@[@1, @"a"]];
+    id obj2 = [RenamedProperties2 createInRealm:realm withValue:@[@2, @"b"]];
+    [LinkToRenamedProperties1 createInRealm:realm withValue:@[obj1, NSNull.null, @[obj1]]];
+    [LinkToRenamedProperties2 createInRealm:realm withValue:@[obj2, NSNull.null, @[obj2]]];
+    [realm commitWriteTransaction];
+
+    [self testClass:[RenamedProperties1 class] withNormalCount:2 notCount:0 where:@"ANY linking1.linkA.propA != 0"];
+    [self testClass:[RenamedProperties1 class] withNormalCount:1 notCount:1 where:@"ANY linking1.linkA.propA = 1"];
+    [self testClass:[RenamedProperties1 class] withNormalCount:1 notCount:1 where:@"ANY linking1.linkA.propA = 2"];
+    [self testClass:[RenamedProperties1 class] withNormalCount:0 notCount:2 where:@"ANY linking1.linkA.propA = 3"];
+}
 @end
 
 @interface AsyncQueryTests : QueryTests

--- a/Realm/Tests/RLMTestObjects.h
+++ b/Realm/Tests/RLMTestObjects.h
@@ -423,6 +423,40 @@ RLM_ARRAY_TYPE(PrimaryCompanyObject);
 @property NSURL *URL;
 @end
 
+@interface RenamedProperties1 : RLMObject
+@property (nonatomic) int propA;
+@property (nonatomic) NSString *propB;
+@property (readonly, nonatomic) RLMLinkingObjects *linking1;
+@property (readonly, nonatomic) RLMLinkingObjects *linking2;
+@end
+
+@interface RenamedProperties2 : RLMObject
+@property (nonatomic) int propC;
+@property (nonatomic) NSString *propD;
+@property (readonly, nonatomic) RLMLinkingObjects *linking1;
+@property (readonly, nonatomic) RLMLinkingObjects *linking2;
+@end
+
+RLM_ARRAY_TYPE(RenamedProperties1)
+RLM_ARRAY_TYPE(RenamedProperties2)
+
+@interface LinkToRenamedProperties1 : RLMObject
+@property (nonatomic) RenamedProperties1 *linkA;
+@property (nonatomic) RenamedProperties2 *linkB;
+@property (nonatomic) RLM_GENERIC_ARRAY(RenamedProperties1) *array;
+@end
+
+@interface LinkToRenamedProperties2 : RLMObject
+@property (nonatomic) RenamedProperties2 *linkC;
+@property (nonatomic) RenamedProperties1 *linkD;
+@property (nonatomic) RLM_GENERIC_ARRAY(RenamedProperties2) *array;
+@end
+
+@interface RenamedPrimaryKey : RLMObject
+@property (nonatomic) int pk;
+@property (nonatomic) int value;
+@end
+
 #pragma mark FakeObject
 
 @interface FakeObject : NSObject

--- a/Realm/Tests/RLMTestObjects.m
+++ b/Realm/Tests/RLMTestObjects.m
@@ -322,7 +322,63 @@
 
 @end
 
+@implementation RenamedProperties1
++ (NSString *)_realmObjectName {
+    return @"Renamed Properties";
+}
++ (NSDictionary *)_realmColumnNames {
+    return @{@"propA": @"prop 1",
+             @"propB": @"prop 2"};
+}
++ (NSDictionary *)linkingObjectsProperties {
+    return @{@"linking1": [RLMPropertyDescriptor descriptorWithClass:LinkToRenamedProperties1.class propertyName:@"linkA"],
+             @"linking2": [RLMPropertyDescriptor descriptorWithClass:LinkToRenamedProperties2.class propertyName:@"linkD"]};
+}
+@end
 
+@implementation RenamedProperties2
++ (NSString *)_realmObjectName {
+    return @"Renamed Properties";
+}
++ (NSDictionary *)_realmColumnNames {
+    return @{@"propC": @"prop 1",
+             @"propD": @"prop 2"};
+}
++ (NSDictionary *)linkingObjectsProperties {
+    return @{@"linking1": [RLMPropertyDescriptor descriptorWithClass:LinkToRenamedProperties1.class propertyName:@"linkA"],
+             @"linking2": [RLMPropertyDescriptor descriptorWithClass:LinkToRenamedProperties2.class propertyName:@"linkD"]};
+}
+@end
+
+@implementation LinkToRenamedProperties1
++ (NSString *)_realmObjectName {
+    return @"Link To Renamed Properties";
+}
++ (NSDictionary *)_realmColumnNames {
+    return @{@"linkA": @"Link A",
+             @"linkB": @"Link B"};
+}
+@end
+
+@implementation LinkToRenamedProperties2
++ (NSString *)_realmObjectName {
+    return @"Link To Renamed Properties";
+}
++ (NSDictionary *)_realmColumnNames {
+    return @{@"linkC": @"Link A",
+             @"linkD": @"Link B"};
+}
+@end
+
+@implementation RenamedPrimaryKey
++ (NSDictionary *)primaryKey {
+    return @"pk";
+}
++ (NSDictionary *)_realmColumnNames {
+    return @{@"pk": @"Primary Key",
+             @"value": @"Value"};
+}
+@end
 
 #pragma mark FakeObject
 
@@ -335,6 +391,7 @@
 + (NSDictionary *)linkingObjectsProperties { return nil; }
 + (BOOL)shouldIncludeInDefaultSchema { return NO; }
 + (NSString *)_realmObjectName { return nil; }
++ (NSDictionary *)_realmColumnNames { return nil; }
 @end
 
 #pragma mark ComputedPropertyNotExplicitlyIgnoredObject

--- a/Realm/Tests/ResultsTests.m
+++ b/Realm/Tests/ResultsTests.m
@@ -350,6 +350,29 @@
     RLMAssertThrowsWithReasonMatching([allArray maxOfProperty:@"boolCol"], @"max.*bool");
 }
 
+- (void)testRenamedPropertyAggregate {
+    RLMRealm *realm = [RLMRealm defaultRealm];
+
+    RLMResults *results = [RenamedProperties1 allObjectsInRealm:realm];
+    XCTAssertEqual(0, [results sumOfProperty:@"propA"].intValue);
+    XCTAssertNil([results averageOfProperty:@"propA"]);
+    XCTAssertNil([results minOfProperty:@"propA"]);
+    XCTAssertNil([results maxOfProperty:@"propA"]);
+    XCTAssertThrows([results sumOfProperty:@"prop 1"]);
+
+    [realm transactionWithBlock:^{
+        [RenamedProperties1 createInRealm:realm withValue:@[@1, @""]];
+        [RenamedProperties1 createInRealm:realm withValue:@[@2, @""]];
+        [RenamedProperties1 createInRealm:realm withValue:@[@3, @""]];
+    }];
+
+    XCTAssertEqual(6, [results sumOfProperty:@"propA"].intValue);
+    XCTAssertEqual(2.0, [results averageOfProperty:@"propA"].doubleValue);
+    XCTAssertEqual(1, [[results minOfProperty:@"propA"] intValue]);
+    XCTAssertEqual(3, [[results maxOfProperty:@"propA"] intValue]);
+}
+
+
 - (void)testValueForCollectionOperationKeyPath {
     RLMRealm *realm = [RLMRealm defaultRealm];
 

--- a/RealmSwift/LinkingObjects.swift
+++ b/RealmSwift/LinkingObjects.swift
@@ -106,6 +106,12 @@ public final class LinkingObjects<Element: Object>: LinkingObjectsBase {
 
     /// A human-readable description of the objects represented by the linking objects.
     public override var description: String {
+        if realm == nil {
+            var this = self
+            return withUnsafePointer(to: &this) {
+                return "LinkingObjects<\(objectClassName)> <\($0)> (\n\n)"
+            }
+        }
         return RLMDescriptionWithMaxDepth("LinkingObjects", rlmResults, RLMDescriptionMaxDepth)
     }
 

--- a/RealmSwift/Sync.swift
+++ b/RealmSwift/Sync.swift
@@ -369,7 +369,7 @@ extension SyncUser {
     /**
      An optional error handler which can be set to notify the host application when
      the user encounters an error.
-     
+
      - note: Check for `.invalidAccessToken` to see if the user has been remotely logged
              out because its refresh token expired, or because the third party authentication
              service providing the user's identity has logged the user out.

--- a/RealmSwift/Tests/ObjectAccessorTests.swift
+++ b/RealmSwift/Tests/ObjectAccessorTests.swift
@@ -354,4 +354,33 @@ class ObjectAccessorTests: TestCase {
         }
         XCTAssertEqual(firstOwner.name, "JP")
     }
+
+    func testRenamedProperties() {
+        let obj = RenamedProperties1()
+        obj.propA = 5
+        obj.propB = "a"
+
+        let link = LinkToRenamedProperties1()
+        link.linkA = obj
+        link.array.append(obj)
+
+        let realm = try! Realm()
+        try! realm.write {
+            realm.add(link)
+        }
+
+        XCTAssertEqual(obj.propA, 5)
+        XCTAssertEqual(obj.propB, "a")
+        XCTAssertTrue(link.linkA!.isSameObject(as: obj))
+        XCTAssertTrue(link.array[0].isSameObject(as: obj))
+        XCTAssertTrue(obj.linking1[0].isSameObject(as: link))
+
+        XCTAssertEqual(obj["propA"]! as! Int, 5)
+        XCTAssertEqual(obj["propB"]! as! String, "a")
+        XCTAssertTrue((link["linkA"]! as! RenamedProperties1).isSameObject(as: obj))
+        XCTAssertTrue((link["array"]! as! List<RenamedProperties1>)[0].isSameObject(as: obj))
+        XCTAssertTrue((obj["linking1"]! as! LinkingObjects<LinkToRenamedProperties1>)[0].isSameObject(as: link))
+
+        XCTAssertTrue(link.dynamicList("array")[0].isSameObject(as: obj))
+    }
 }

--- a/RealmSwift/Tests/ObjectAccessorTests.swift
+++ b/RealmSwift/Tests/ObjectAccessorTests.swift
@@ -362,7 +362,7 @@ class ObjectAccessorTests: TestCase {
 
         let link = LinkToRenamedProperties1()
         link.linkA = obj
-        link.array.append(obj)
+        link.array1.append(obj)
 
         let realm = try! Realm()
         try! realm.write {
@@ -372,15 +372,32 @@ class ObjectAccessorTests: TestCase {
         XCTAssertEqual(obj.propA, 5)
         XCTAssertEqual(obj.propB, "a")
         XCTAssertTrue(link.linkA!.isSameObject(as: obj))
-        XCTAssertTrue(link.array[0].isSameObject(as: obj))
+        XCTAssertTrue(link.array1[0].isSameObject(as: obj))
         XCTAssertTrue(obj.linking1[0].isSameObject(as: link))
 
         XCTAssertEqual(obj["propA"]! as! Int, 5)
         XCTAssertEqual(obj["propB"]! as! String, "a")
         XCTAssertTrue((link["linkA"]! as! RenamedProperties1).isSameObject(as: obj))
-        XCTAssertTrue((link["array"]! as! List<RenamedProperties1>)[0].isSameObject(as: obj))
+        XCTAssertTrue((link["array1"]! as! List<RenamedProperties1>)[0].isSameObject(as: obj))
         XCTAssertTrue((obj["linking1"]! as! LinkingObjects<LinkToRenamedProperties1>)[0].isSameObject(as: link))
 
-        XCTAssertTrue(link.dynamicList("array")[0].isSameObject(as: obj))
+        XCTAssertTrue(link.dynamicList("array1")[0].isSameObject(as: obj))
+
+        let obj2 = realm.objects(RenamedProperties2.self).first!
+        let link2 = realm.objects(LinkToRenamedProperties2.self).first!
+
+        XCTAssertEqual(obj2.propC, 5)
+        XCTAssertEqual(obj2.propD, "a")
+        XCTAssertTrue(link2.linkC!.isSameObject(as: obj))
+        XCTAssertTrue(link2.array2[0].isSameObject(as: obj))
+        XCTAssertTrue(obj2.linking1[0].isSameObject(as: link))
+
+        XCTAssertEqual(obj2["propC"]! as! Int, 5)
+        XCTAssertEqual(obj2["propD"]! as! String, "a")
+        XCTAssertTrue((link2["linkC"]! as! RenamedProperties1).isSameObject(as: obj))
+        XCTAssertTrue((link2["array2"]! as! List<RenamedProperties2>)[0].isSameObject(as: obj))
+        XCTAssertTrue((obj2["linking1"]! as! LinkingObjects<LinkToRenamedProperties1>)[0].isSameObject(as: link))
+
+        XCTAssertTrue(link2.dynamicList("array2")[0].isSameObject(as: obj))
     }
 }

--- a/RealmSwift/Tests/ObjectSchemaInitializationTests.swift
+++ b/RealmSwift/Tests/ObjectSchemaInitializationTests.swift
@@ -224,6 +224,7 @@ class SwiftFakeObject: NSObject {
     @objc class func ignoredProperties() -> [String] { return [] }
     @objc class func indexedProperties() -> [String] { return [] }
     @objc class func _realmObjectName() -> String? { return nil }
+    @objc class func _realmColumnNames() -> [String: String]? { return nil }
 }
 
 class SwiftObjectWithNSURL: SwiftFakeObject {

--- a/RealmSwift/Tests/ObjectTests.swift
+++ b/RealmSwift/Tests/ObjectTests.swift
@@ -120,6 +120,16 @@ class ObjectTests: TestCase {
         let recursiveObject = SwiftRecursiveObject()
         recursiveObject.objects.append(recursiveObject)
         assertMatches(recursiveObject.description, "SwiftRecursiveObject \\{\n\tobjects = List<SwiftRecursiveObject> <0x[0-9a-f]+> \\(\n\t\t\\[0\\] SwiftRecursiveObject \\{\n\t\t\tobjects = List<SwiftRecursiveObject> <0x[0-9a-f]+> \\(\n\t\t\t\t\\[0\\] SwiftRecursiveObject \\{\n\t\t\t\t\tobjects = <Maximum depth exceeded>;\n\t\t\t\t\\}\n\t\t\t\\);\n\t\t\\}\n\t\\);\n\\}")
+
+        let renamedObject = LinkToRenamedProperties1()
+        renamedObject.linkA = RenamedProperties1()
+        assertMatches(renamedObject.description, "LinkToRenamedProperties1 \\{\n\tlinkA = RenamedProperties1 \\{\n\t\tpropA = 0;\n\t\tpropB = ;\n\t\\};\n\tlinkB = \\(null\\);\n\tarray = List<RenamedProperties1> <0x[0-9a-f]+> \\(\n\t\n\t\\);\n\\}")
+        assertMatches(renamedObject.linkA!.linking1.description, "LinkingObjects<LinkToRenamedProperties1> <0x[0-9a-f]+> \\(\n\n\\)")
+
+        let realm = try! Realm()
+        try! realm.write { realm.add(renamedObject) }
+        assertMatches(renamedObject.description, "LinkToRenamedProperties1 \\{\n\tlinkA = RenamedProperties1 \\{\n\t\tpropA = 0;\n\t\tpropB = ;\n\t\\};\n\tlinkB = \\(null\\);\n\tarray = List<RenamedProperties1> <0x[0-9a-f]+> \\(\n\t\n\t\\);\n\\}")
+        assertMatches(renamedObject.linkA!.linking1.description, "LinkingObjects<LinkToRenamedProperties1> <0x[0-9a-f]+> \\(\n\t\\[0\\] LinkToRenamedProperties1 \\{\n\t\tlinkA = RenamedProperties1 \\{\n\t\t\tpropA = 0;\n\t\t\tpropB = ;\n\t\t\\};\n\t\tlinkB = \\(null\\);\n\t\tarray = List<RenamedProperties1> <0x[0-9a-f]+> \\(\n\t\t\n\t\t\\);\n\t\\}\n\\)")
         // swiftlint:enable line_length
     }
 

--- a/RealmSwift/Tests/ObjectTests.swift
+++ b/RealmSwift/Tests/ObjectTests.swift
@@ -123,13 +123,13 @@ class ObjectTests: TestCase {
 
         let renamedObject = LinkToRenamedProperties1()
         renamedObject.linkA = RenamedProperties1()
-        assertMatches(renamedObject.description, "LinkToRenamedProperties1 \\{\n\tlinkA = RenamedProperties1 \\{\n\t\tpropA = 0;\n\t\tpropB = ;\n\t\\};\n\tlinkB = \\(null\\);\n\tarray = List<RenamedProperties1> <0x[0-9a-f]+> \\(\n\t\n\t\\);\n\\}")
+        assertMatches(renamedObject.description, "LinkToRenamedProperties1 \\{\n\tlinkA = RenamedProperties1 \\{\n\t\tpropA = 0;\n\t\tpropB = ;\n\t\\};\n\tlinkB = \\(null\\);\n\tarray1 = List<RenamedProperties1> <0x[0-9a-f]+> \\(\n\t\n\t\\);\n\\}")
         assertMatches(renamedObject.linkA!.linking1.description, "LinkingObjects<LinkToRenamedProperties1> <0x[0-9a-f]+> \\(\n\n\\)")
 
         let realm = try! Realm()
         try! realm.write { realm.add(renamedObject) }
-        assertMatches(renamedObject.description, "LinkToRenamedProperties1 \\{\n\tlinkA = RenamedProperties1 \\{\n\t\tpropA = 0;\n\t\tpropB = ;\n\t\\};\n\tlinkB = \\(null\\);\n\tarray = List<RenamedProperties1> <0x[0-9a-f]+> \\(\n\t\n\t\\);\n\\}")
-        assertMatches(renamedObject.linkA!.linking1.description, "LinkingObjects<LinkToRenamedProperties1> <0x[0-9a-f]+> \\(\n\t\\[0\\] LinkToRenamedProperties1 \\{\n\t\tlinkA = RenamedProperties1 \\{\n\t\t\tpropA = 0;\n\t\t\tpropB = ;\n\t\t\\};\n\t\tlinkB = \\(null\\);\n\t\tarray = List<RenamedProperties1> <0x[0-9a-f]+> \\(\n\t\t\n\t\t\\);\n\t\\}\n\\)")
+        assertMatches(renamedObject.description, "LinkToRenamedProperties1 \\{\n\tlinkA = RenamedProperties1 \\{\n\t\tpropA = 0;\n\t\tpropB = ;\n\t\\};\n\tlinkB = \\(null\\);\n\tarray1 = List<RenamedProperties1> <0x[0-9a-f]+> \\(\n\t\n\t\\);\n\\}")
+        assertMatches(renamedObject.linkA!.linking1.description, "LinkingObjects<LinkToRenamedProperties1> <0x[0-9a-f]+> \\(\n\t\\[0\\] LinkToRenamedProperties1 \\{\n\t\tlinkA = RenamedProperties1 \\{\n\t\t\tpropA = 0;\n\t\t\tpropB = ;\n\t\t\\};\n\t\tlinkB = \\(null\\);\n\t\tarray1 = List<RenamedProperties1> <0x[0-9a-f]+> \\(\n\t\t\n\t\t\\);\n\t\\}\n\\)")
         // swiftlint:enable line_length
     }
 

--- a/RealmSwift/Tests/SwiftTestObjects.swift
+++ b/RealmSwift/Tests/SwiftTestObjects.swift
@@ -549,3 +549,49 @@ class SwiftGenericPropsOrderingHelper: Object {
     @objc dynamic var first: SwiftGenericPropsOrderingObject?
     @objc dynamic var second: SwiftGenericPropsOrderingObject?
 }
+
+class RenamedProperties1: Object {
+    @objc dynamic var propA = 0
+    @objc dynamic var propB = ""
+    let linking1 = LinkingObjects(fromType: LinkToRenamedProperties1.self, property: "linkA")
+    let linking2 = LinkingObjects(fromType: LinkToRenamedProperties2.self, property: "linkD")
+
+    override class func _realmObjectName() -> String { return "Renamed Properties" }
+    override class func _realmColumnNames() -> [String: String] {
+        return ["propA": "prop 1", "propB": "prop 2"]
+    }
+}
+
+class RenamedProperties2: Object {
+    @objc dynamic var propC = 0
+    @objc dynamic var propD = ""
+    let linking1 = LinkingObjects(fromType: LinkToRenamedProperties1.self, property: "linkA")
+    let linking2 = LinkingObjects(fromType: LinkToRenamedProperties2.self, property: "linkD")
+
+    override class func _realmObjectName() -> String { return "Renamed Properties" }
+    override class func _realmColumnNames() -> [String: String] {
+        return ["propC": "prop 1", "propD": "prop 2"]
+    }
+}
+
+class LinkToRenamedProperties1: Object {
+    @objc dynamic var linkA: RenamedProperties1?
+    @objc dynamic var linkB: RenamedProperties2?
+    let array = List<RenamedProperties1>()
+
+    override class func _realmObjectName() -> String { return "Link To Renamed Properties" }
+    override class func _realmColumnNames() -> [String: String] {
+        return ["linkA": "link 1", "linkB": "link 2"]
+    }
+}
+
+class LinkToRenamedProperties2: Object {
+    @objc dynamic var linkC: RenamedProperties1?
+    @objc dynamic var linkD: RenamedProperties2?
+    let array = List<RenamedProperties2>()
+
+    override class func _realmObjectName() -> String { return "Link To Renamed Properties" }
+    override class func _realmColumnNames() -> [String: String] {
+        return ["linkC": "link 1", "linkD": "link 2"]
+    }
+}

--- a/RealmSwift/Tests/SwiftTestObjects.swift
+++ b/RealmSwift/Tests/SwiftTestObjects.swift
@@ -577,21 +577,21 @@ class RenamedProperties2: Object {
 class LinkToRenamedProperties1: Object {
     @objc dynamic var linkA: RenamedProperties1?
     @objc dynamic var linkB: RenamedProperties2?
-    let array = List<RenamedProperties1>()
+    let array1 = List<RenamedProperties1>()
 
     override class func _realmObjectName() -> String { return "Link To Renamed Properties" }
     override class func _realmColumnNames() -> [String: String] {
-        return ["linkA": "link 1", "linkB": "link 2"]
+        return ["linkA": "link 1", "linkB": "link 2", "array1": "array"]
     }
 }
 
 class LinkToRenamedProperties2: Object {
     @objc dynamic var linkC: RenamedProperties1?
     @objc dynamic var linkD: RenamedProperties2?
-    let array = List<RenamedProperties2>()
+    let array2 = List<RenamedProperties2>()
 
     override class func _realmObjectName() -> String { return "Link To Renamed Properties" }
     override class func _realmColumnNames() -> [String: String] {
-        return ["linkC": "link 1", "linkD": "link 2"]
+        return ["linkC": "link 1", "linkD": "link 2", "array2": "array"]
     }
 }


### PR DESCRIPTION
Get _realmObjectName back into a working state and fix the things that never actually worked with it (such as links and arrays), and add _realmColumnNames to allow overriding the column names used.

This is needed for object-level permissions, which involves exposing some Realm objects in both obj-c and Swift. This is functionality we need to have in the public API eventually (for the same reasons as we need it internally), but for now it's internal-only to reduce the potential complications and to punt on things like public documentation and sensible error-handling for invalid schemas using it.

Currently sorting and distincting on mapped property names doesn't really work (you have to use the column name), which probably won't be an issue for the permissions types. All other operations (including querying) should work correctly.