### PR TITLE
Declare dependency on Security.framework

### DIFF
--- a/Realm.podspec
+++ b/Realm.podspec
@@ -67,6 +67,7 @@ Pod::Spec.new do |s|
                               'Realm/ObjectStore/src/util/*.cpp',
                               'Realm/ObjectStore/src/util/apple/*.cpp'
 
+  s.frameworks              = 'Security'
   s.module_map              = 'Realm/Realm.modulemap'
   s.compiler_flags          = "-DREALM_HAVE_CONFIG -DREALM_COCOA_VERSION='@\"#{s.version}\"' -D__ASSERTMACROS__ -DREALM_ENABLE_SYNC"
   s.prepare_command         = 'sh build.sh cocoapods-setup'


### PR DESCRIPTION
`keychain_helper.cpp` depends on `Security.framework`. Users may want to build Realm with Clang modules disabled `-fno-modules` because they are using `ccache` which doesn't support `-fmodules`. When modules are disabled, auto-linking of framework modules is also disabled, so this dependency needs to be expressed explicitly.

Resolves https://github.com/realm/realm-cocoa/issues/5645