### PR TITLE
Fix some UBSan warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+x.x.x Release notes (yyyy-MM-dd)
+=============================================================
+
+### Breaking Changes
+
+* None.
+
+### Enhancements
+
+* None.
+
+### Bugfixes
+
+* Fix some warnings when running with UBsan.
+
 3.1.1 Release notes (2018-02-03)
 =============================================================
 

--- a/Realm/RLMObjectStore.mm
+++ b/Realm/RLMObjectStore.mm
@@ -229,13 +229,13 @@ RLMResults *RLMGetObjects(__unsafe_unretained RLMRealm *const realm,
 id RLMGetObject(RLMRealm *realm, NSString *objectClassName, id key) {
     RLMVerifyRealmRead(realm);
 
-    RLMAccessorContext *c = nullptr;
     auto& info = realm->_info[objectClassName];
     if (RLMProperty *prop = info.propertyForPrimaryKey()) {
         RLMValidateValueForProperty(key, info.rlmObjectSchema, prop);
     }
     try {
-        auto obj = realm::Object::get_for_primary_key(*c, realm->_realm, *info.objectSchema,
+        RLMAccessorContext c{realm, info};
+        auto obj = realm::Object::get_for_primary_key(c, realm->_realm, *info.objectSchema,
                                                       key ?: NSNull.null);
         if (!obj.is_valid())
             return nil;

--- a/Realm/RLMResults.mm
+++ b/Realm/RLMResults.mm
@@ -259,6 +259,9 @@ static inline void RLMResultsValidateInWriteTransaction(__unsafe_unretained RLMR
 }
 
 - (id)valueForKey:(NSString *)key {
+    if (!_info) {
+        return @[];
+    }
     return translateRLMResultsErrors([&] {
         return RLMCollectionValueForKey(_results, key, _realm, *_info);
     });


### PR DESCRIPTION
Forming a reference to null is UB even if the reference is never actually used.

See #5478.