### PR TITLE
Fix the one-time initialization of RLMSyncManager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+x.x.x Release notes (yyyy-MM-dd)
+=============================================================
+
+### Breaking Changes
+
+* None.
+
+### Enhancements
+
+* None.
+
+### Bugfixes
+
+* Fix incorrect initalization of `RLMSyncManager` that made it impossible to
+  set `errorHandler`.
+
 3.2.0-beta.3 Release notes (2018-03-01)
 =============================================================
 

--- a/Realm/RLMSyncManager.mm
+++ b/Realm/RLMSyncManager.mm
@@ -89,7 +89,7 @@ struct CocoaSyncLoggerFactory : public realm::SyncLoggerFactory {
 static RLMSyncManager *s_sharedManager = nil;
 
 + (instancetype)sharedManager {
-    std::once_flag flag;
+    static std::once_flag flag;
     std::call_once(flag, [] {
         try {
             s_sharedManager = [[RLMSyncManager alloc] initWithCustomRootDirectory:nil];


### PR DESCRIPTION
Amazingly almost everything worked correctly with a new instance being created every time due to that almost all of the state is stored on the ObjectStore SyncManager.

Fixes #5649.