### PR TITLE
Add some permissions convenience methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+x.x.x Release notes (yyyy-MM-dd)
+=============================================================
+
+### Breaking Changes
+
+* None.
+
+### Enhancements
+
+* Add `Realm.permissions`, `Realm.permissions(forType:)`, and `Realm.permissions(forClassNamed:)` as convenience
+  methods for accessing the permissions of the Realm or a type.
+
+### Bugfixes
+
+* Fix `+[RLMClassPermission objectInRealm:forClass:]` to work for classes that are part of the permissions API,
+  such as `RLMPermissionRole`.
+
 3.2.0 Release notes (2018-03-15)
 =============================================================
 

--- a/Realm/ObjectServerTests/RLMPermissionsTests.mm
+++ b/Realm/ObjectServerTests/RLMPermissionsTests.mm
@@ -613,4 +613,10 @@ static void createPermissions(RLMArray<RLMPermission> *permissions) {
     CHECK_COUNT(1, ObjectWithPermissions, userBRealm);
 }
 
+- (void)testRetrieveClassPermissionsForRenamedClass {
+    [self createRealmWithName:_cmd permissions:^(RLMRealm *realm) {
+        XCTAssertNotNil([RLMClassPermission objectInRealm:realm forClass:RLMPermissionRole.class]);
+    }];
+}
+
 @end

--- a/Realm/ObjectServerTests/SwiftPermissionsTests.swift
+++ b/Realm/ObjectServerTests/SwiftPermissionsTests.swift
@@ -19,13 +19,6 @@
 import XCTest
 import RealmSwift
 
-protocol ThingWithPrivileges {
-    var permissions: List<Permission> { get }
-}
-
-extension RealmPermission: ThingWithPrivileges {}
-extension ClassPermission: ThingWithPrivileges {}
-
 class SwiftPermissionsAPITests: SwiftSyncTestCase {
     var userA: SyncUser!
     var userB: SyncUser!
@@ -113,8 +106,8 @@ class SwiftPermissionsAPITests: SwiftSyncTestCase {
         return url
     }
 
-    func createDefaultPermisisons<T: ThingWithPrivileges>(obj: T) {
-        var p = obj.permissions.findOrCreate(forRoleNamed: "everyone")
+    func createDefaultPermisisons(_ permissions: List<Permission>) {
+        var p = permissions.findOrCreate(forRoleNamed: "everyone")
         p.canCreate = false
         p.canRead = false
         p.canQuery = false
@@ -123,16 +116,16 @@ class SwiftPermissionsAPITests: SwiftSyncTestCase {
         p.canModifySchema = false
         p.canSetPermissions = false
 
-        p = obj.permissions.findOrCreate(forRoleNamed: "reader")
+        p = permissions.findOrCreate(forRoleNamed: "reader")
         p.canRead = true
         p.canQuery = true
 
-        p = obj.permissions.findOrCreate(forRoleNamed: "writer")
+        p = permissions.findOrCreate(forRoleNamed: "writer")
         p.canUpdate = true
         p.canCreate = true
         p.canDelete = true
 
-        p = obj.permissions.findOrCreate(forRoleNamed: "admin")
+        p = permissions.findOrCreate(forRoleNamed: "admin")
         p.canSetPermissions = true
     }
 
@@ -146,7 +139,7 @@ class SwiftPermissionsAPITests: SwiftSyncTestCase {
 
     func testRealmRead() {
         let url = createRealm(name: "testRealmRead") { realm in
-            createDefaultPermisisons(obj: realm.objects(RealmPermission.self).first!)
+            createDefaultPermisisons(realm.permissions)
             add(user: userA, toRole: "reader", inRealm: realm)
         }
 
@@ -176,7 +169,7 @@ class SwiftPermissionsAPITests: SwiftSyncTestCase {
 
     func testRealmWrite() {
         let url = createRealm(name: "testRealmWrite") { realm in
-            createDefaultPermisisons(obj: realm.objects(RealmPermission.self).first!)
+            createDefaultPermisisons(realm.permissions)
             add(user: userA, toRole: "reader", inRealm: realm)
             add(user: userA, toRole: "writer", inRealm: realm)
             add(user: userB, toRole: "reader", inRealm: realm)
@@ -220,7 +213,7 @@ class SwiftPermissionsAPITests: SwiftSyncTestCase {
 
     func testClassRead() {
         let url = createRealm(name: "testClassRead") { realm in
-            createDefaultPermisisons(obj: realm.object(ofType: ClassPermission.self, forPrimaryKey: "SwiftSyncObject")!)
+            createDefaultPermisisons(realm.permissions(forType: SwiftSyncObject.self))
             add(user: userA, toRole: "reader", inRealm: realm)
         }
 

--- a/Realm/RLMSyncPermission.mm
+++ b/Realm/RLMSyncPermission.mm
@@ -193,7 +193,7 @@ id RLMPermissionForRole(RLMArray *array, id role) {
     return [RLMClassPermission objectInRealm:realm forPrimaryKey:name];
 }
 + (instancetype)objectInRealm:(RLMRealm *)realm forClass:(Class)cls {
-    return [RLMClassPermission objectInRealm:realm forPrimaryKey:[cls className]];
+    return [RLMClassPermission objectInRealm:realm forPrimaryKey:[cls _realmObjectName] ?: [cls className]];
 }
 @end
 

--- a/RealmSwift/Sync.swift
+++ b/RealmSwift/Sync.swift
@@ -1274,6 +1274,39 @@ extension Realm {
     public func getPrivileges(forClassNamed className: String) -> ClassPrivileges {
         return ClassPrivileges(rawValue: RLMGetComputedPermissions(rlmRealm, className))
     }
+
+    /**
+    Returns the class-wide permissions for the given class.
+
+     - parameter cls: An Object subclass to get the permissions for.
+     - returns: The class-wide permissions for the given class.
+     - requires: This must only be called on a partially-synced Realm.
+    */
+    public func permissions<T: Object>(forType cls: T.Type) -> List<Permission> {
+        return permissions(forClassNamed: cls._realmObjectName() ?? cls.className())
+    }
+
+    /**
+    Returns the class-wide permissions for the named class.
+
+     - parameter cls: The name of an Object subclass to get the permissions for.
+     - returns: The class-wide permissions for the named class.
+     - requires: className must name a class in this Realm's schema.
+     - requires: This must only be called on a partially-synced Realm.
+    */
+    public func permissions(forClassNamed className: String) -> List<Permission> {
+        let classPermission = object(ofType: ClassPermission.self, forPrimaryKey: className)!
+        return classPermission.permissions
+    }
+
+    /**
+    Returns the Realm-wide permissions.
+
+     - requires: This must only be called on a partially-synced Realm.
+    */
+    public var permissions: List<Permission> {
+        return object(ofType: RealmPermission.self, forPrimaryKey: 0)!.permissions
+    }
 }
 
 extension List where Element == Permission {


### PR DESCRIPTION
These helped to simplify the permissions code in the object permissions demo app a little. For instance:
```diff
-    let realmPermissions = realm.objects(RealmPermission.self).first!
-    let everyonePermission = realmPermissions.permissions.findOrCreate(forRoleNamed: "everyone")
+    let everyonePermission = realm.permissions.findOrCreate(forRoleNamed: "everyone")
```

And:
```diff
-        let classPermissions = realm.object(ofType: ClassPermission.self, forPrimaryKey: cls.className())!
-        let everyonePermission = classPermissions.permissions.findOrCreate(forRoleNamed: "everyone")
+        let everyonePermission = realm.permissions(forType: cls).findOrCreate(forRoleNamed: "everyone")
```

One thing I opted to do was document that these methods are only applicable to partially-synced Realms, since otherwise they'd have to return an optional, making them slightly less pleasant to use. I'm not sure if that's the best choice.