### PR TITLE
Override the objc names for Permission classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ x.x.x Release notes (yyyy-MM-dd)
 
 * Fix `+[RLMClassPermission objectInRealm:forClass:]` to work for classes that are part of the permissions API,
   such as `RLMPermissionRole`.
+* Fix runtime errors when applications define an `Object` subclass with the
+  same name as one of the Permissions object types.
 
 3.2.0 Release notes (2018-03-15)
 =============================================================

--- a/Realm/ObjectServerTests/SwiftPermissionsTests.swift
+++ b/Realm/ObjectServerTests/SwiftPermissionsTests.swift
@@ -19,6 +19,11 @@
 import XCTest
 import RealmSwift
 
+final class PermissionUser: Object {
+    // A class with a name that conflicts with an Object class from RealmSwift to verify
+    // that it doesn't break anything
+}
+
 class SwiftPermissionsAPITests: SwiftSyncTestCase {
     var userA: SyncUser!
     var userB: SyncUser!
@@ -130,7 +135,7 @@ class SwiftPermissionsAPITests: SwiftSyncTestCase {
     }
 
     func add(user: SyncUser, toRole roleName: String, inRealm realm: Realm) {
-        let user = realm.create(PermissionUser.self, value: [user.identity!], update: true)
+        let user = realm.create(RealmSwift.PermissionUser.self, value: [user.identity!], update: true)
         realm.create(PermissionRole.self, value: [roleName], update: true).users.append(user)
     }
 

--- a/RealmSwift/Sync.swift
+++ b/RealmSwift/Sync.swift
@@ -837,6 +837,7 @@ public final class SyncPermissionValue { }
  `ObjectPrivileges` for details about what each of the properties mean when applied to
  that type.
  */
+@objc(RealmSwiftPermission)
 public class Permission: Object {
     /// The Role which this Permission applies to. All users within the Role are
     /// granted the permissions specified by the fields below any
@@ -897,6 +898,7 @@ public class Permission: Object {
  connect to the Realm are automatically added to it. Any other roles you wish to use are
  managed as normal Realm objects.
  */
+@objc(RealmSwiftPermissionRole)
 public class PermissionRole: Object {
     /// The name of the Role
     @objc dynamic public var name = ""
@@ -925,6 +927,7 @@ public class PermissionRole: Object {
  which has not yet connected to this Realm. When creating a PermissionUser manually, you
  must also manually add it to the "everyone" Role.
  */
+@objc(RealmSwiftPermissionUser)
 public class PermissionUser: Object {
     /// The unique Realm Object Server user ID string identifying this user. This will
     /// have the same value as `SyncUser.identity`
@@ -959,6 +962,7 @@ public class PermissionUser: Object {
 
  See `RealmPrivileges` for the meaning of permissions applied to a Realm.
  */
+@objc(RealmSwiftRealmPermission)
 public class RealmPermission: Object {
     @objc private var id = 0
 
@@ -981,6 +985,7 @@ public class RealmPermission: Object {
  An instance of this object is automatically created in the Realm for class in your schema,
  and should not be created manually.
  */
+@objc(RealmSwiftClassPermission)
 public class ClassPermission: Object {
     /// The name of the class which these permissions apply to.
     @objc dynamic public var name = ""


### PR DESCRIPTION
This makes it possible to users to define their `Object` subclasses with the same names.