### PR TITLE
Exclude classes that are not subclasses of `Object` from `customSchema`.

### DIFF
--- a/RealmSwift/RealmConfiguration.swift
+++ b/RealmSwift/RealmConfiguration.swift
@@ -195,7 +195,7 @@ extension Realm {
                 self.customSchema = newValue.map { RLMSchema(objectClasses: $0) }
             }
             get {
-                return self.customSchema.map { $0.objectSchema.map { $0.objectClass as! Object.Type } }
+                return self.customSchema.map { $0.objectSchema.flatMap { $0.objectClass as? Object.Type } }
             }
         }
 


### PR DESCRIPTION
The following code crashes the following exception:

>  Could not cast value of type 'RLMPermission' to 'RealmSwift.Object'.

```swift
let realm = try! Realm()
print(realm.configuration.objectTypes)
```

Because `objectTypes` contains classes derived from Objective-C Realm as default schama if `objectTypes` is not set.