### PR TITLE
Always include permission related object classes as the default schema.

### DIFF
--- a/Realm/RLMRealmConfiguration.mm
+++ b/Realm/RLMRealmConfiguration.mm
@@ -21,6 +21,7 @@
 #import "RLMObjectSchema_Private.hpp"
 #import "RLMRealm_Private.h"
 #import "RLMSchema_Private.hpp"
+#import "RLMSyncPermission.h"
 #import "RLMUtil.hpp"
 
 #import "schema.hpp"
@@ -253,7 +254,9 @@ static void RLMNSStringToStdString(std::string &out, NSString *in) {
 }
 
 - (void)setObjectClasses:(NSArray *)objectClasses {
-    self.customSchema = [RLMSchema schemaWithObjectClasses:objectClasses];
+    NSArray *permissionObjectClasses = @[RLMRealmPermission.class, RLMClassPermission.class,
+                                         RLMPermission.class, RLMPermissionUser.class, RLMPermissionRole.class];
+    self.customSchema = [RLMSchema schemaWithObjectClasses:[objectClasses arrayByAddingObjectsFromArray:permissionObjectClasses]];
 }
 
 - (void)setDynamic:(bool)dynamic {

--- a/Realm/Tests/RLMTestCase.h
+++ b/Realm/Tests/RLMTestCase.h
@@ -51,6 +51,8 @@ NSData *RLMGenerateKey(void);
 - (void)dispatchAsync:(dispatch_block_t)block;
 - (void)dispatchAsyncAndWait:(dispatch_block_t)block;
 
++ (NSArray *)permissionObjectClasses;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Realm/Tests/RLMTestCase.m
+++ b/Realm/Tests/RLMTestCase.m
@@ -219,5 +219,10 @@ static BOOL encryptTests() {
     return nil;
 }
 
++ (NSArray *)permissionObjectClasses {
+    return @[RLMRealmPermission.class, RLMClassPermission.class,
+             RLMPermission.class, RLMPermissionUser.class, RLMPermissionRole.class];
+}
+
 @end
 

--- a/Realm/Tests/RealmTests.mm
+++ b/Realm/Tests/RealmTests.mm
@@ -82,7 +82,9 @@
     RLMRealmConfiguration *newDefaultConfiguration = [originalDefaultConfiguration copy];
     newDefaultConfiguration.objectClasses = @[];
     [RLMRealmConfiguration setDefaultConfiguration:newDefaultConfiguration];
-    XCTAssertEqual([[[[RLMRealm realmWithURL:RLMTestRealmURL()] configuration] objectClasses] count], 0U);
+    NSArray *permissionObjectClasses = @[RLMRealmPermission.class, RLMClassPermission.class,
+                                         RLMPermission.class, RLMPermissionUser.class, RLMPermissionRole.class];
+    XCTAssertEqual([[[[RLMRealm realmWithURL:RLMTestRealmURL()] configuration] objectClasses] count], permissionObjectClasses.count);
     [RLMRealmConfiguration setDefaultConfiguration:originalDefaultConfiguration];
 }
 

--- a/Realm/Tests/SchemaTests.mm
+++ b/Realm/Tests/SchemaTests.mm
@@ -753,6 +753,8 @@ RLM_ARRAY_TYPE(NotARealClass)
 // Can't spawn child processes on iOS
 #if !TARGET_OS_IPHONE && !TARGET_IPHONE_SIMULATOR
 - (void)testPartialSharedSchemaInit {
+    NSArray *permissionObjectClasses = [RLMTestCase permissionObjectClasses];
+
     if (self.isParent) {
         RLMRunChildAndWait();
         return;
@@ -765,14 +767,14 @@ RLM_ARRAY_TYPE(NotARealClass)
     config.objectClasses = @[IntObject.class];
     @autoreleasepool {
         RLMRealm *realm = [RLMRealm realmWithConfiguration:config error:nil];
-        XCTAssertEqual(1U, realm.schema.objectSchema.count);
+        XCTAssertEqual(1 + permissionObjectClasses.count, realm.schema.objectSchema.count);
         XCTAssertNoThrow(realm.schema[@"IntObject"]);
     }
 
     config.objectClasses = @[IntObject.class, StringObject.class];
     @autoreleasepool {
         RLMRealm *realm = [RLMRealm realmWithConfiguration:config error:nil];
-        XCTAssertEqual(2U, realm.schema.objectSchema.count);
+        XCTAssertEqual(2 + permissionObjectClasses.count, realm.schema.objectSchema.count);
         XCTAssertNoThrow(realm.schema[@"IntObject"]);
         XCTAssertNoThrow(realm.schema[@"StringObject"]);
     }
@@ -800,6 +802,8 @@ RLM_ARRAY_TYPE(NotARealClass)
 }
 
 - (void)testPartialSharedSchemaInitInheritance {
+    NSArray *permissionObjectClasses = [RLMTestCase permissionObjectClasses];
+
     if (self.isParent) {
         RLMRunChildAndWait();
         return;
@@ -809,7 +813,7 @@ RLM_ARRAY_TYPE(NotARealClass)
     config.objectClasses = @[NumberObject.class];
 
     RLMRealm *realm = [RLMRealm realmWithConfiguration:config error:nil];
-    XCTAssertEqual(1U, realm.schema.objectSchema.count);
+    XCTAssertEqual(1 + permissionObjectClasses.count, realm.schema.objectSchema.count);
     XCTAssertEqualObjects(@"NumberObject", [[[[NumberObject alloc] init] objectSchema] className]);
     // Verify that child class doesn't use the parent class's schema
     XCTAssertEqualObjects(@"NumberDefaultsObject", [[[[NumberDefaultsObject alloc] init] objectSchema] className]);
@@ -909,12 +913,14 @@ RLM_ARRAY_TYPE(NotARealClass)
 #endif
 
 - (void)testOpeningFileWithDifferentClassSubsetsInDifferentProcesses {
+    NSArray *permissionObjectClasses = [RLMTestCase permissionObjectClasses];
+
     if (!self.isParent) {
         RLMRealmConfiguration *config = [RLMRealmConfiguration defaultConfiguration];
         config.objectClasses = @[StringObject.class];
 
         RLMRealm *realm = [RLMRealm realmWithConfiguration:config error:nil];
-        XCTAssertEqual(1U, realm.schema.objectSchema.count);
+        XCTAssertEqual(1 + permissionObjectClasses.count, realm.schema.objectSchema.count);
 
         // Verify that the StringObject table actually exists
         [realm beginWriteTransaction];
@@ -928,7 +934,7 @@ RLM_ARRAY_TYPE(NotARealClass)
 
     RLMRealm *realm = [RLMRealm realmWithConfiguration:config error:nil];
     realm.autorefresh = false;
-    XCTAssertEqual(1U, realm.schema.objectSchema.count);
+    XCTAssertEqual(1 + permissionObjectClasses.count, realm.schema.objectSchema.count);
 
     [realm beginWriteTransaction];
     [IntObject createInRealm:realm withValue:@[@1]];
@@ -952,6 +958,8 @@ RLM_ARRAY_TYPE(NotARealClass)
 }
 
 - (void)testAddingIndexToExistingColumnInBackgroundProcess {
+    NSArray *permissionObjectClasses = [RLMTestCase permissionObjectClasses];
+
     if (!self.isParent) {
         RLMSchema *schema = [RLMSchema schemaWithObjectClasses:@[IntObject.class]];
         RLMObjectSchema *objectSchema = schema.objectSchema[0];
@@ -969,7 +977,7 @@ RLM_ARRAY_TYPE(NotARealClass)
 
     RLMRealm *realm = [RLMRealm realmWithConfiguration:config error:nil];
     realm.autorefresh = false;
-    XCTAssertEqual(1U, realm.schema.objectSchema.count);
+    XCTAssertEqual(1 + permissionObjectClasses.count, realm.schema.objectSchema.count);
 
     // Insert a value to ensure stuff actually happens when the index is added/removed
     [realm beginWriteTransaction];
@@ -983,6 +991,8 @@ RLM_ARRAY_TYPE(NotARealClass)
 }
 
 - (void)testRemovingIndexFromExistingColumnInBackgroundProcess {
+    NSArray *permissionObjectClasses = [RLMTestCase permissionObjectClasses];
+
     if (!self.isParent) {
         RLMSchema *schema = [RLMSchema schemaWithObjectClasses:@[IndexedStringObject.class]];
         RLMObjectSchema *objectSchema = schema.objectSchema[0];
@@ -1000,7 +1010,7 @@ RLM_ARRAY_TYPE(NotARealClass)
 
     RLMRealm *realm = [RLMRealm realmWithConfiguration:config error:nil];
     realm.autorefresh = false;
-    XCTAssertEqual(1U, realm.schema.objectSchema.count);
+    XCTAssertEqual(1 + permissionObjectClasses.count, realm.schema.objectSchema.count);
 
     // Insert a value to ensure stuff actually happens when the index is added/removed
     [realm beginWriteTransaction];

--- a/RealmSwift/RealmConfiguration.swift
+++ b/RealmSwift/RealmConfiguration.swift
@@ -192,7 +192,13 @@ extension Realm {
         /// The classes managed by the Realm.
         public var objectTypes: [Object.Type]? {
             set {
-                self.customSchema = newValue.map { RLMSchema(objectClasses: $0) }
+                if let newValue = newValue {
+                    let permissionObjectTypes = [RealmPermission.self, ClassPermission.self,
+                                                 Permission.self, PermissionUser.self, PermissionRole.self]
+                    self.customSchema = RLMSchema(objectClasses: newValue + permissionObjectTypes)
+                } else {
+                    self.customSchema = nil
+                }
             }
             get {
                 return self.customSchema.map { $0.objectSchema.map { $0.objectClass as! Object.Type } }

--- a/RealmSwift/Tests/RealmTests.swift
+++ b/RealmSwift/Tests/RealmTests.swift
@@ -190,9 +190,11 @@ class RealmTests: TestCase {
     func testInitCustomClassList() {
         let configuration = Realm.Configuration(fileURL: Realm.Configuration.defaultConfiguration.fileURL,
             objectTypes: [SwiftStringObject.self])
-        XCTAssert(configuration.objectTypes! is [SwiftStringObject.Type])
         let realm = try! Realm(configuration: configuration)
-        XCTAssertEqual(["SwiftStringObject"], realm.schema.objectSchema.map { $0.className })
+        let permissionObjectTypes = [RealmPermission.self, ClassPermission.self,
+                                     Permission.self, PermissionUser.self, PermissionRole.self]
+        XCTAssertEqual(([SwiftStringObject.self] + permissionObjectTypes).map { $0.className() }.sorted(),
+                       realm.schema.objectSchema.map { $0.className }.sorted())
     }
 
     func testWrite() {


### PR DESCRIPTION
It seems that fine-grained permission related classes should always be included in the default schema.