### PR TITLE
Remove obsolete WholeModuleOptimization setting

### DIFF
--- a/RealmSwift.podspec
+++ b/RealmSwift.podspec
@@ -23,8 +23,7 @@ Pod::Spec.new do |s|
   s.prepare_command           = 'sh build.sh cocoapods-setup swift'
   s.preserve_paths            = %w(build.sh)
 
-  s.pod_target_xcconfig = { 'SWIFT_WHOLE_MODULE_OPTIMIZATION' => 'YES',
-                            'APPLICATION_EXTENSION_API_ONLY' => 'YES' }
+  s.pod_target_xcconfig = { 'APPLICATION_EXTENSION_API_ONLY' => 'YES' }
 
   s.ios.deployment_target     = '8.0'
   s.osx.deployment_target     = '10.9'


### PR DESCRIPTION
This PR addresses the issue #5534 . Simply removing the obsolete whole module optimization setting from the podspec allows CocoaPods to work correctly.

Because this is a Cocoapod issue this is what I did to test this:

Forked and updated the RealmSwift.podspec file to remove the optimization setting.
(Had to also make another change to the podspec source setting, which is not included in this PR)
Made a test project with a Podfile that pointed to RealmSwift in my fork.
pod update
Build the project.
Xcode did not show the warning mentioned in issue #5534 
Also inspecting the RealmSwift target in the Pods project in the workspace file showed that the Swift Compiler Optimization Settings were correct. They showed Debug - None; Release - Fast, Whole Module Optimization.