### PR TITLE
Expose the factory methods for query objects by primary key.

### DIFF
--- a/Realm/RLMObject.h
+++ b/Realm/RLMObject.h
@@ -374,7 +374,7 @@ NS_ASSUME_NONNULL_BEGIN
  @return    An object of this object type, or `nil` if an object with the given primary key does not exist.
  @see       `-primaryKey`
  */
-+ (nullable instancetype)objectForPrimaryKey:(nullable id)primaryKey;
++ (nullable instancetype)objectForPrimaryKey:(nullable id)primaryKey NS_SWIFT_NAME(object(forPrimaryKey:));
 
 
 #pragma mark - Querying Specific Realms
@@ -423,7 +423,7 @@ NS_ASSUME_NONNULL_BEGIN
  @return    An object of this object type, or `nil` if an object with the given primary key does not exist.
  @see       `-primaryKey`
  */
-+ (nullable instancetype)objectInRealm:(RLMRealm *)realm forPrimaryKey:(nullable id)primaryKey;
++ (nullable instancetype)objectInRealm:(RLMRealm *)realm forPrimaryKey:(nullable id)primaryKey NS_SWIFT_NAME(object(in:forPrimaryKey:));
 
 #pragma mark - Notifications
 


### PR DESCRIPTION
This ticket seems to suggest this was possible at one point, but possibly is not longer working for Swift 4.0:
https://github.com/realm/realm-cocoa/issues/3099

For the sake of this commit msg, consider our RLMObject subclass:

```
@objcMembers
class Order: RLMObject {
    dynamic var orderId: String = ""
    override class func primaryKey() -> String {
        return "orderId"
    }
}
```

Currently, the only way to retrieve an object by primary key on an RLMObject subclass in Swift (4.0), is to do this:

```
let order = Order.objects(in: realm, where: "orderId = %@", "someOrderId").firstObject()
```

This is because the RLMObject factory method `+ objectInRealm:forPrimaryKey` is only available on the base RLMObject class as a convenience initializer. In other words, we get this if we try to use the converted init on the type Order:

```
Cannot invoke initializer for type 'Order' with an argument list of type '(in: RLMRealm, forPrimaryKey: String)'
```

In order to be able to call this factory method in Swift, we need to keep it as a factory method and not convert it to a init. To do this, we add the NS_SWIFT_NAME macro which then allows us to call the method as expected.

```
let order = Order.object(in: realm, forPrimaryKey: order.orderId) // Yay! It works!
```