### PR TITLE
Remove an obsolete build setting from Base.xcconfig

### DIFF
--- a/Configuration/Base.xcconfig
+++ b/Configuration/Base.xcconfig
@@ -44,7 +44,6 @@ GCC_WARN_UNUSED_PARAMETER = YES;
 GCC_WARN_UNUSED_VARIABLE = YES;
 SWIFT_COMPILATION_MODE = wholemodule;
 SWIFT_OPTIMIZATION_LEVEL = -Owholemodule;
-SWIFT_WHOLE_MODULE_OPTIMIZATION = YES;
 WARNING_CFLAGS = -Wmismatched-tags -Wunused-private-field -Wpartial-availability;
 OTHER_CFLAGS = -fvisibility-inlines-hidden;
 


### PR DESCRIPTION
SWIFT_WHOLE_MODULE_OPTIMIZATION last did anything with Xcode 7.