### PR TITLE
Cancel pending waits when fetching a refresh token fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ x.x.x Release notes (yyyy-MM-dd)
 * Exclude the RLMObject-derived Permissions classes from the types repored by
   `Realm.Configuration.defaultConfiguration.objectTypes` to avoid a failed
   cast.
+* Cancel pending `Realm.asyncOpen()` calls when authentication fails with a
+  non-transient error such as missing the Realm path in the URL.
 
 3.3.0 Release notes (2018-03-19)
 =============================================================

--- a/Realm/ObjectServerTests/RLMObjectServerTests.mm
+++ b/Realm/ObjectServerTests/RLMObjectServerTests.mm
@@ -1451,6 +1451,22 @@
     }
 }
 
+- (void)testDownloadCancelsOnAuthError {
+    RLMSyncUser *user = [self logInUserForCredentials:[RLMObjectServerTests basicCredentialsWithName:NSStringFromSelector(_cmd)
+                                                                                            register:self.isParent]
+                                               server:[RLMObjectServerTests authServerURL]];
+    auto c = [RLMRealmConfiguration defaultConfiguration];
+    c.syncConfiguration = [[RLMSyncConfiguration alloc] initWithUser:user realmURL:[NSURL URLWithString:@"realm://localhost:9080/invalid"]];
+    auto ex = [self expectationWithDescription:@"async open"];
+    [RLMRealm asyncOpenWithConfiguration:c callbackQueue:dispatch_get_main_queue()
+                                callback:^(RLMRealm *realm, NSError *error) {
+                                    XCTAssertNil(realm);
+                                    XCTAssertNotNil(error);
+                                    [ex fulfill];
+    }];
+    [self waitForExpectationsWithTimeout:2.0 handler:nil];
+}
+
 #pragma mark - Validation
 
 - (void)testCompactOnLaunchCannotBeSet {

--- a/Realm/RLMNetworkClient.mm
+++ b/Realm/RLMNetworkClient.mm
@@ -264,6 +264,7 @@ static NSRange RLM_rangeForErrorType(RLMServerHTTPErrorCodeType type) {
         if (RLMSyncErrorResponseModel *responseModel = [self responseModelFromData:data]) {
             switch (responseModel.code) {
                 case RLMSyncAuthErrorInvalidParameters:
+                case RLMSyncAuthErrorMissingPath:
                 case RLMSyncAuthErrorInvalidCredential:
                 case RLMSyncAuthErrorUserDoesNotExist:
                 case RLMSyncAuthErrorUserAlreadyExists:

--- a/Realm/RLMSyncSessionRefreshHandle.mm
+++ b/Realm/RLMSyncSessionRefreshHandle.mm
@@ -210,6 +210,9 @@ static const NSTimeInterval RLMRefreshBuffer = 10;
     }
     if (!nextTryDate) {
         // This error isn't a network failure error. Just invalidate the refresh handle and stop.
+        if (_strongSession) {
+            _strongSession->log_out();
+        }
         unregisterRefreshHandle(_user, _path);
         [self invalidate];
         return;

--- a/Realm/RLMSyncUtil.h
+++ b/Realm/RLMSyncUtil.h
@@ -160,6 +160,9 @@ typedef RLM_ERROR_ENUM(NSInteger, RLMSyncAuthError, RLMSyncAuthErrorDomain) {
     /// An error that indicates that the provided credentials are ill-formed.
     RLMSyncAuthErrorInvalidParameters               = 601,
 
+    /// An error that indicates that no Realm path was included in the URL.
+    RLMSyncAuthErrorMissingPath                     = 602,
+
     /// An error that indicates that the provided credentials are invalid.
     RLMSyncAuthErrorInvalidCredential               = 611,
 


### PR DESCRIPTION
If we get a non-transient error and we aren't going to retry fetching the access token later, switch the session back to Inactive and notify any pending `asyncOpen` calls that they were cancelled rather than just hanging forever.

Fixes #5635.