### PR TITLE
Convert `flatMap` → `compactMap` for Swift 4.1+ users

### DIFF
--- a/RealmSwift/RealmConfiguration.swift
+++ b/RealmSwift/RealmConfiguration.swift
@@ -195,7 +195,11 @@ extension Realm {
                 self.customSchema = newValue.map { RLMSchema(objectClasses: $0) }
             }
             get {
+                #if swift(>=4.1)
+                return self.customSchema.map { $0.objectSchema.compactMap { $0.objectClass as? Object.Type } }
+                #else
                 return self.customSchema.map { $0.objectSchema.flatMap { $0.objectClass as? Object.Type } }
+                #endif
             }
         }
 


### PR DESCRIPTION
Convert `flatMap` → `compactMap` for Swift 4.1+ users.