### PR TITLE
Rework RealmOptional to work when it outlives the parent object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+x.x.x Release notes (yyyy-MM-dd)
+=============================================================
+
+### Breaking Changes
+
+* None.
+
+### Enhancements
+
+* None.
+
+### Bugfixes
+
+* Fix incorrect results when using optional chaining to access a RealmOptional
+  property in Release builds, or otherwise interacting with a RealmOptional
+  object after the owning Object has been deallocated.
+
 3.4.0 Release notes (2018-04-19)
 =============================================================
 

--- a/Realm/RLMAccessor.mm
+++ b/Realm/RLMAccessor.mm
@@ -625,7 +625,7 @@ id RLMAccessorContext::propertyValue(__unsafe_unretained id const obj, size_t pr
             return static_cast<RLMListBase *>(object_getIvar(obj, prop.swiftIvar))._rlmArray;
         }
         else { // optional
-            value = static_cast<RLMOptionalBase *>(object_getIvar(obj, prop.swiftIvar)).underlyingValue;
+            value = RLMGetOptional(static_cast<RLMOptionalBase *>(object_getIvar(obj, prop.swiftIvar)));
         }
     }
     else {

--- a/Realm/RLMObjectBase.mm
+++ b/Realm/RLMObjectBase.mm
@@ -196,8 +196,7 @@ id RLMCreateManagedAccessor(Class cls, __unsafe_unretained RLMRealm *realm, RLMC
             }
         }
         else if (property.optional) {
-            RLMOptionalBase *optional = object_getIvar(self, ivar);
-            optional.underlyingValue = value;
+            RLMSetOptional(object_getIvar(self, ivar), value);
         }
         return;
     }

--- a/Realm/RLMObjectStore.mm
+++ b/Realm/RLMObjectStore.mm
@@ -40,6 +40,11 @@
 
 using namespace realm;
 
+@interface LinkingObjectsBase : NSObject
+@property (nonatomic, nullable) RLMWeakObjectHandle *object;
+@property (nonatomic, nullable) RLMProperty *property;
+@end
+
 void RLMRealmCreateAccessors(RLMSchema *schema) {
     const size_t bufferSize = sizeof("RLM:Managed  ") // includes null terminator
                             + std::numeric_limits<unsigned long long>::digits10
@@ -95,9 +100,7 @@ void RLMInitializeSwiftAccessorGenerics(__unsafe_unretained RLMObjectBase *const
             [object_getIvar(object, prop.swiftIvar) set_rlmArray:array];
         }
         else {
-            RLMOptionalBase *optional = object_getIvar(object, prop.swiftIvar);
-            optional.property = prop;
-            optional.object = object;
+            RLMInitializeManagedOptional(object_getIvar(object, prop.swiftIvar), object, prop);
         }
     }
 }

--- a/Realm/RLMObservation.mm
+++ b/Realm/RLMObservation.mm
@@ -189,8 +189,7 @@ void RLMObservationInfo::recordObserver(realm::Row& objectRow, RLMClassInfo *obj
     }
     else if (auto swiftIvar = prop.swiftIvar) {
         if (auto optional = RLMDynamicCast<RLMOptionalBase>(object_getIvar(object, swiftIvar))) {
-            optional.property = prop;
-            optional.object = object;
+            RLMInitializeUnmanagedOptional(optional, object, prop);
         }
     }
 }

--- a/Realm/RLMOptionalBase.h
+++ b/Realm/RLMOptionalBase.h
@@ -24,15 +24,13 @@ NS_ASSUME_NONNULL_BEGIN
 @class RLMObjectBase, RLMProperty;
 
 @interface RLMOptionalBase : NSProxy
-
 - (instancetype)init;
-
-@property (nonatomic, weak) RLMObjectBase *object;
-
-@property (nonatomic, unsafe_unretained) RLMProperty *property;
-
-@property (nonatomic, strong, nullable) id underlyingValue;
-
 @end
+
+FOUNDATION_EXTERN id _Nullable RLMGetOptional(RLMOptionalBase *);
+FOUNDATION_EXTERN void RLMSetOptional(RLMOptionalBase *, id _Nullable);
+
+void RLMInitializeManagedOptional(RLMOptionalBase *, RLMObjectBase *parent, RLMProperty *prop);
+void RLMInitializeUnmanagedOptional(RLMOptionalBase *, RLMObjectBase *parent, RLMProperty *prop);
 
 NS_ASSUME_NONNULL_END

--- a/Realm/RLMProperty.mm
+++ b/Realm/RLMProperty.mm
@@ -23,7 +23,6 @@
 #import "RLMObject.h"
 #import "RLMObjectSchema_Private.hpp"
 #import "RLMObject_Private.h"
-#import "RLMOptionalBase.h"
 #import "RLMSchema_Private.h"
 #import "RLMSwiftSupport.h"
 #import "RLMUtil.hpp"

--- a/Realm/RLMUtil.hpp
+++ b/Realm/RLMUtil.hpp
@@ -82,15 +82,19 @@ static inline T *RLMDynamicCast(__unsafe_unretained id obj) {
     return nil;
 }
 
-template<typename T>
-static inline T RLMCoerceToNil(__unsafe_unretained T obj) {
+static inline id RLMCoerceToNil(__unsafe_unretained id obj) {
     if (static_cast<id>(obj) == NSNull.null) {
         return nil;
     }
     else if (__unsafe_unretained auto optional = RLMDynamicCast<RLMOptionalBase>(obj)) {
-        return RLMCoerceToNil(optional.underlyingValue);
+        return RLMCoerceToNil(RLMGetOptional(optional));
     }
     return obj;
+}
+
+template<typename T>
+static inline T RLMCoerceToNil(__unsafe_unretained T obj) {
+    return RLMCoerceToNil(static_cast<id>(obj));
 }
 
 // String conversion utilities

--- a/RealmSwift/Optional.swift
+++ b/RealmSwift/Optional.swift
@@ -47,10 +47,10 @@ public final class RealmOptional<Value: RealmOptionalType>: RLMOptionalBase {
     /// The value the optional represents.
     public var value: Value? {
         get {
-            return underlyingValue.map(dynamicBridgeCast)
+            return RLMGetOptional(self).map(dynamicBridgeCast)
         }
         set {
-            underlyingValue = newValue.map(dynamicBridgeCast)
+            RLMSetOptional(self, newValue.map(dynamicBridgeCast))
         }
     }
 

--- a/RealmSwift/Tests/ObjectCreationTests.swift
+++ b/RealmSwift/Tests/ObjectCreationTests.swift
@@ -43,7 +43,7 @@ class ObjectCreationTests: TestCase {
         for prop in object.objectSchema.properties {
             let value = object[prop.name]
             if let value = value as? RLMOptionalBase {
-                XCTAssertNil(value.underlyingValue)
+                XCTAssertNil(RLMGetOptional(value))
             } else {
                 XCTAssertNil(value)
             }

--- a/RealmSwift/Tests/ObjectTests.swift
+++ b/RealmSwift/Tests/ObjectTests.swift
@@ -167,9 +167,9 @@ class ObjectTests: TestCase {
             assertThrows(intObj.setValue(2, forKey: "intCol"), reasonMatching: primaryKeyReason)
 
             realm.add(optionalIntObj)
-            assertThrows(optionalIntObj.intCol.value = 2, reasonMatching: primaryKeyReason)
+            assertThrows(optionalIntObj.intCol.value = 2, reasonMatching: "Cannot modify primary key")
             assertThrows(optionalIntObj["intCol"] = 2, reasonMatching: primaryKeyReason)
-            assertThrows(optionalIntObj.setValue(2, forKey: "intCol"), reasonMatching: primaryKeyReason)
+            assertThrows(optionalIntObj.setValue(2, forKey: "intCol"), reasonMatching: "Cannot modify primary key")
 
             realm.add(stringObj)
             assertThrows(stringObj.stringCol = "c", reasonMatching: primaryKeyReason)


### PR DESCRIPTION
Storing a weak pointer to the parent object and performing accesses via that relies on the parent object always outliving the RealmOptional, and it turns out that that doesn't always happen even with completely innocuous code. Instead, rework it to work more like RLMArray with separate managed/unmanaged implementations and a strongly-owned ObjectStore backing object for the managed version.

Fixes #5640. Fixes #5622.