### PR TITLE
Don't run tvOS device test with Xcode 8.3.3

### DIFF
--- a/.jenkins.yml
+++ b/.jenkins.yml
@@ -36,7 +36,7 @@ configuration:
 # | Configuration Matrix | osx | docs | ios-static | ios-dynamic | ios-swift | osx-swift | watchos | cocoapods | swiftlint | tvos | osx-encryption | osx-object-server | ios-device-objc-ios8 | ios-device-swift-ios8 | ios-device-objc-ios10 | ios-device-swift-ios10 | tvos-device |
 # | -------------------- | --- | ---- | ---------- | ----------- | --------- | --------- | ------- | --------- | --------- | ---- | -------------- | ----------------- | -------------------- | --------------------- | --------------------- | ---------------------- | ----------- |
 # | 8.3.3 | Debug        | X   |      | X          |             |           |           |         |           |           |      |                |                   |                      |                       |                       |                        |             |
-# | 8.3.3 | Release      | X   |      | X          | X           | X         | X         | X       | X         |           | X    | X              | X                 | X                    |                       | X                     |                        | X           |
+# | 8.3.3 | Release      | X   |      | X          | X           | X         | X         | X       | X         |           | X    | X              | X                 | X                    |                       | X                     |                        |             |
 # | -------------------- | --- | ---- | ---------- | ----------- | --------- | --------- | ------- | --------- | --------- | ---- | -------------- | ----------------- | -------------------- | --------------------- | --------------------- | ---------------------- | ----------- |
 # | 9.0   | Debug        | X   |      |            |             |           |           |         |           |           |      |                |                   |                      |                       |                       |                        |             |
 # | 9.0   | Release      | X   |      | X          | X           | X         | X         | X       | X         |           | X    |                |                   |                      |                       |                       |                        |             |
@@ -235,7 +235,9 @@ exclude:
   ################
   # tvos-device
   ################
-  # Just run on 8.3.3/9.2 Release
+  # Just run on 9.2 Release
+  - xcode_version: 8.3.3
+    target: tvos-device
   - xcode_version: 9.0
     target: tvos-device
   - xcode_version: 9.1

--- a/build.sh
+++ b/build.sh
@@ -305,8 +305,15 @@ fi
 ######################################
 
 kill_object_server() {
-# Based on build.sh conventions we always run ROS from a path ending in 'ros/bin/ros'.
+    set +e
+    # Based on build.sh conventions we always run ROS from a path ending in 'ros/bin/ros'.
     pkill -f ros/bin/ros\ start
+    # 0 = process killed, 1 = no processes running, 2+ = error
+    local status=$?
+    if [ $status -gt 1 ]; then
+        exit $status
+    fi
+    set -e
 }
 
 download_object_server() {


### PR DESCRIPTION
The CI device got updated to iOS 11 and so Xcode 8.3.3 can no longer push to it.