### PR TITLE
Correction to key generation in Encryption Example

### DIFF
--- a/examples/ios/swift/Encryption/ViewController.swift
+++ b/examples/ios/swift/Encryption/ViewController.swift
@@ -107,9 +107,8 @@ class ViewController: UIViewController {
         }
 
         // No pre-existing key from this application, so generate a new one
-        let keyData = NSMutableData(length: 64)!
-        let result = SecRandomCopyBytes(kSecRandomDefault, 64, keyData.mutableBytes.bindMemory(to: UInt8.self, capacity: 64))
-        assert(result == 0, "Failed to get random bytes")
+        let keyData = generateNewKey()
+		
 
         // Store the key in the keychain
         query = [
@@ -124,4 +123,17 @@ class ViewController: UIViewController {
 
         return keyData
     }
+	
+	/// This will simply generate the new key
+	///
+	/// - Returns: A new NSData key
+	func generateNewKey() -> NSData {
+		let length = 64 //lenght of the  key
+		let randomBytes = [UInt32](repeating: 0, count: length).map { _ in arc4random() }
+		//This is the actual key that we want
+		let keyData = Data(bytes: randomBytes, count: length)
+		
+		assert(keyData == 0, "Failed to get random bytes")
+		return keyData as NSData
+	}
 }


### PR DESCRIPTION
This is a little change but when reviewing the Encryption Example, I found that current key method was just producing NSData of just 64 0's as its key. This was also discovered on a test I did of this method (not committed) 

Although that this is a key and that the rest of the code looks like its correct, I am concerned with the non random key generation. This is because I feel for developers new to encrypting their realms they might have looked at this code and think this is correct and that it generates a random key. There is also a risk that a developer running late on a deadline may just copy this code into production code. 

I feel that this tutorial does not need to explain what is going on here that a non-unique key is being generated, and the importance of why you want a random unique key. This just means that if someone was to get the hands on on the .realm file it would be very easy to decrypt - a brute force would find this issue immediately.

This commit just adds a function that I have used in other projects to generate a unique key and a few comments to suggest to me what it is doing. 

Thanks 
Osian 