### PR TITLE
Fix a race condition in some of the tests

### DIFF
--- a/Realm/Tests/RLMTestCase.m
+++ b/Realm/Tests/RLMTestCase.m
@@ -175,11 +175,12 @@ static BOOL encryptTests() {
 
 - (void)waitForNotification:(NSString *)expectedNote realm:(RLMRealm *)realm block:(dispatch_block_t)block {
     XCTestExpectation *notificationFired = [self expectationWithDescription:@"notification fired"];
-    RLMNotificationToken *token = [realm addNotificationBlock:^(NSString *note, RLMRealm *realm) {
+    __block RLMNotificationToken *token = [realm addNotificationBlock:^(NSString *note, RLMRealm *realm) {
         XCTAssertNotNil(note, @"Note should not be nil");
         XCTAssertNotNil(realm, @"Realm should not be nil");
         if (note == expectedNote) { // Check pointer equality to ensure we're using the interned string constant
             [notificationFired fulfill];
+            [token invalidate];
         }
     }];
 
@@ -194,8 +195,6 @@ static BOOL encryptTests() {
 
     // wait for queue to finish
     dispatch_sync(queue, ^{});
-
-    [token invalidate];
 }
 
 - (void)dispatchAsync:(dispatch_block_t)block {


### PR DESCRIPTION
With the following very specific sequence of events, it's possible to get spurious RLMRealmRefreshRequiredNotification notifications:

1. Main thread commits a write
2. Notifier thread does its work, enqueues notification on main thread runloop
3. Main thread dequeues notification, but does not yet run it
4. Background thread commits a write
5. Main thread begins processing notification, sees that the Realm is out of date, delivers RLMRealmRefreshRequiredNotification
6. Notifier thread processes commit from step 4 and enqueues notification on main thread runloop
7. Main thread dequeues next notification
8. Main thread delivers a second RLMRealmRefreshRequiredNotification despite only one commit being made

We don't guarantee that only one RLMRealmRefreshRequiredNotification will be delivered per commit, but some of our tests assumed that and so would fail. Fix this by removing the notification block after the first one.