### PR TITLE
Fix object deletion handling within migrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ x.x.x Release notes (yyyy-MM-dd)
   strong reference to the sync session.
 * Fix some cases where comparisons to `nil` in queries were not properly
   serialized when subscribing to a query.
+* Don't delete objects added during a migration after a call to `-[RLMMigration
+  deleteDataForClassName:]`.
+* Fix incorrect results and/or crashes when multiple `-[RLMMigration
+  enumerateObjects:block:]` blocks deleted objects of the same type.
+* Fix some edge-cases where `-[RLMMigration enumerateObjects:block:]`
+  enumerated the incorrect objects following deletions.
 
 3.5.0 Release notes (2018-04-25)
 =============================================================


### PR DESCRIPTION
We defer object deletions done within a migration to until the migration completes to maintain a stable enumeration order and to ensure that the old and new objects given to the user actually correspond to each other. The logic for this turned out to have a number of bugs, including sometimes failing to exclude objects which were soft-deleted from the enumeration, deleting the incorrect objects at the end of the migration, and just plain crashing.

The revised version is probably also significantly faster as it eliminates some quadratic-time operations and avoids instantiating so many objects, but I didn't bother benchmarking as it's never actually come up as a concern.