### PR TITLE
Fix a crash on non-@objc `String?` properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ x.x.x Release notes (yyyy-MM-dd)
   enumerateObjects:block:]` blocks deleted objects of the same type.
 * Fix some edge-cases where `-[RLMMigration enumerateObjects:block:]`
   enumerated the incorrect objects following deletions.
+* Restore the pre-3.5.0 behavior for Swift optional properties missing an ivar
+  rather than crashing.
 
 3.5.0 Release notes (2018-04-25)
 =============================================================

--- a/Realm/RLMObjectStore.mm
+++ b/Realm/RLMObjectStore.mm
@@ -90,17 +90,24 @@ void RLMInitializeSwiftAccessorGenerics(__unsafe_unretained RLMObjectBase *const
     }
 
     for (RLMProperty *prop in object->_objectSchema.swiftGenericProperties) {
+        id ivar = object_getIvar(object, prop.swiftIvar);
+        if (!ivar) {
+            // FIXME: this should actually be an error as it's the result of an
+            // invalid object definition, but that's a breaking change so
+            // instead preserve the old behavior until the next major version bump
+            continue;
+        }
+
         if (prop.type == RLMPropertyTypeLinkingObjects) {
-            id linkingObjects = object_getIvar(object, prop.swiftIvar);
-            [linkingObjects setObject:(id)[[RLMWeakObjectHandle alloc] initWithObject:object]];
-            [linkingObjects setProperty:prop];
+            [ivar setObject:(id)[[RLMWeakObjectHandle alloc] initWithObject:object]];
+            [ivar setProperty:prop];
         }
         else if (prop.array) {
             RLMArray *array = [[RLMManagedArray alloc] initWithParent:object property:prop];
-            [object_getIvar(object, prop.swiftIvar) set_rlmArray:array];
+            [ivar set_rlmArray:array];
         }
         else {
-            RLMInitializeManagedOptional(object_getIvar(object, prop.swiftIvar), object, prop);
+            RLMInitializeManagedOptional(ivar, object, prop);
         }
     }
 }

--- a/Realm/RLMObjectStore.mm
+++ b/Realm/RLMObjectStore.mm
@@ -95,6 +95,7 @@ void RLMInitializeSwiftAccessorGenerics(__unsafe_unretained RLMObjectBase *const
             // FIXME: this should actually be an error as it's the result of an
             // invalid object definition, but that's a breaking change so
             // instead preserve the old behavior until the next major version bump
+            // https://github.com/realm/realm-cocoa/issues/5784
             continue;
         }
 

--- a/Realm/RLMOptionalBase.mm
+++ b/Realm/RLMOptionalBase.mm
@@ -125,6 +125,7 @@ private:
 id RLMGetOptional(__unsafe_unretained RLMOptionalBase *const self) {
     if (!self) {
         // FIXME: this should actually be an error
+        // https://github.com/realm/realm-cocoa/issues/5784
         return nil;
     }
     try {
@@ -138,6 +139,7 @@ id RLMGetOptional(__unsafe_unretained RLMOptionalBase *const self) {
 void RLMSetOptional(__unsafe_unretained RLMOptionalBase *const self, __unsafe_unretained const id value) {
     if (!self) {
         // FIXME: this should actually be an error
+        // https://github.com/realm/realm-cocoa/issues/5784
         return;
     }
     try {

--- a/Realm/RLMOptionalBase.mm
+++ b/Realm/RLMOptionalBase.mm
@@ -123,6 +123,10 @@ private:
 }
 
 id RLMGetOptional(__unsafe_unretained RLMOptionalBase *const self) {
+    if (!self) {
+        // FIXME: this should actually be an error
+        return nil;
+    }
     try {
         return self->_impl ? RLMCoerceToNil(self->_impl->get()) : nil;
     }
@@ -132,6 +136,10 @@ id RLMGetOptional(__unsafe_unretained RLMOptionalBase *const self) {
 }
 
 void RLMSetOptional(__unsafe_unretained RLMOptionalBase *const self, __unsafe_unretained const id value) {
+    if (!self) {
+        // FIXME: this should actually be an error
+        return;
+    }
     try {
         if (!self->_impl && value) {
             self->_impl.reset(new UnmanagedOptional);

--- a/RealmSwift/Tests/ObjectCreationTests.swift
+++ b/RealmSwift/Tests/ObjectCreationTests.swift
@@ -20,6 +20,14 @@ import XCTest
 import RealmSwift
 import Realm.Private
 
+class ObjectWithPrivateOptionals: Object {
+    private var int: Int?
+    private var float: Float?
+    private var string: String?
+
+    @objc dynamic var value = 0
+}
+
 class ObjectCreationTests: TestCase {
 
     // MARK: Init tests
@@ -752,6 +760,16 @@ class ObjectCreationTests: TestCase {
         XCTAssertEqual(object.parentSecondNumber, 200)
         XCTAssertTrue(object.firstLinking.count == 0)
         XCTAssertTrue(object.secondLinking.count == 0)
+    }
+
+    func testPrivateOptionalNonobjcString() {
+        let realm = try! Realm()
+        try! realm.write {
+            let obj = ObjectWithPrivateOptionals()
+            obj.value = 5
+            realm.add(obj)
+            XCTAssertEqual(realm.objects(ObjectWithPrivateOptionals.self).first!.value, 5)
+        }
     }
 
     // MARK: Private utilities


### PR DESCRIPTION
#5713 made it so that optional Swift properties of a supported data type (i.e. `String?` and object links) which do not have ivars due to not being declared as `@objc dynamic` would crash rather than merely fail to actually read and update the managed value when the property is used.

The idea behavior here would be to throw an error on schema initialization as it's an invalid model declaration, but that's a breaking change (as such objects do work correctly when unmanaged), so for now this just restores the pre-3.5.0 behavior.

Fixes #5781.