### PR TITLE
Add Realm.syncSession

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+x.x.x Release notes (yyyy-MM-dd)
+=============================================================
+
+### Breaking Changes
+
+* None.
+
+### Enhancements
+
+* Add `-[RLMRealm syncSession]` and  `Realm.syncSession` to obtain the session
+  used for a synchronized Realm.
+
+### Bugfixes
+
+* None.
+
 3.6.0 Release notes (2018-05-29)
 =============================================================
 

--- a/Realm/ObjectServerTests/RLMSyncTestCase.mm
+++ b/Realm/ObjectServerTests/RLMSyncTestCase.mm
@@ -437,7 +437,7 @@ static NSURL *syncDirectoryForChildProcess() {
 }
 
 - (void)waitForUploadsForRealm:(RLMRealm *)realm error:(NSError **)error {
-    RLMSyncSession *session = [RLMSyncSession sessionForRealm:realm];
+    RLMSyncSession *session = realm.syncSession;
     NSAssert(session, @"Cannot call with invalid Realm");
     XCTestExpectation *ex = [self expectationWithDescription:@"Wait for upload completion"];
     __block NSError *completionError;
@@ -455,7 +455,7 @@ static NSURL *syncDirectoryForChildProcess() {
 }
 
 - (void)waitForDownloadsForRealm:(RLMRealm *)realm error:(NSError **)error {
-    RLMSyncSession *session = [RLMSyncSession sessionForRealm:realm];
+    RLMSyncSession *session = realm.syncSession;
     NSAssert(session, @"Cannot call with invalid Realm");
     XCTestExpectation *ex = [self expectationWithDescription:@"Wait for download completion"];
     __block NSError *completionError;

--- a/Realm/ObjectServerTests/SwiftObjectServerTests.swift
+++ b/Realm/ObjectServerTests/SwiftObjectServerTests.swift
@@ -169,7 +169,7 @@ class SwiftObjectServerTests: SwiftSyncTestCase {
             let user = try synchronouslyLogInUser(for: basicCredentials(register: isParent), server: authURL)
             let realm = try synchronouslyOpenRealm(url: realmURL, user: user)
             if isParent {
-                let session = user.session(for: realmURL)
+                let session = realm.syncSession
                 XCTAssertNotNil(session)
                 let ex = expectation(description: "streaming-downloads-expectation")
                 var hasBeenFulfilled = false
@@ -212,7 +212,7 @@ class SwiftObjectServerTests: SwiftSyncTestCase {
             var transferrable = 0
             let user = try synchronouslyLogInUser(for: basicCredentials(register: isParent), server: authURL)
             let realm = try synchronouslyOpenRealm(url: realmURL, user: user)
-            let session = user.session(for: realmURL)
+            let session = realm.syncSession
             XCTAssertNotNil(session)
             let ex = expectation(description: "streaming-uploads-expectation")
             var hasBeenFulfilled = false

--- a/Realm/RLMRealm+Sync.h
+++ b/Realm/RLMRealm+Sync.h
@@ -20,7 +20,7 @@
 
 #import "RLMRealm.h"
 
-@class RLMResults;
+@class RLMResults, RLMSyncSession;
 
 /**
  A callback used to vend the results of a partial sync fetch.
@@ -44,6 +44,12 @@ NS_ASSUME_NONNULL_BEGIN
 */
 - (void)subscribeToObjects:(Class)type where:(NSString *)query callback:(RLMPartialSyncFetchCallback)callback
 __deprecated_msg("Use -[RLMResults subscribe]");
+
+/**
+ Get the RLMSyncSession used by this Realm. Will be nil if this is not a
+ synchronized Realm.
+*/
+@property (nonatomic, nullable, readonly) RLMSyncSession *syncSession;
 
 @end
 

--- a/Realm/RLMRealm+Sync.mm
+++ b/Realm/RLMRealm+Sync.mm
@@ -23,6 +23,7 @@
 #import "RLMRealm_Private.hpp"
 #import "RLMResults_Private.hpp"
 #import "RLMSchema.h"
+#import "RLMSyncSession.h"
 
 #import "results.hpp"
 #import "sync/partial_sync.hpp"
@@ -49,6 +50,10 @@ using namespace realm;
         callback([RLMResults resultsWithObjectInfo:_info[className] results:std::move(results)], nil);
     };
     partial_sync::register_query(_realm, className.UTF8String, query.UTF8String, std::move(cb));
+}
+
+- (RLMSyncSession *)syncSession {
+    return [RLMSyncSession sessionForRealm:self];
 }
 
 @end

--- a/RealmSwift/Sync.swift
+++ b/RealmSwift/Sync.swift
@@ -647,6 +647,16 @@ extension Realm {
             completion(results.map { Results<T>($0) }, error)
         }
     }
+
+    /**
+     Get the SyncSession used by this Realm. Will be nil if this is not a
+     synchronized Realm.
+    */
+    public var syncSession: SyncSession? {
+        get {
+            return SyncSession(for: rlmRealm)
+        }
+    }
 }
 
 // MARK: - Permissions and permission results


### PR DESCRIPTION
The existing interfaces for obtaining the session either don't work correctly for partially synced Realms (`+[RLMSyncSession sessionForURL:]`) or are awkward to call from Swift (`SyncSession(for: ObjectiveCSupport.convert(object: realm))`), so this adds a simple getter which works for all Realm types and doesn't require doing awkward things. The obj-c version is mostly there for symmetry with the Swift API.