### PR TITLE
Fix some crashes when using a MigrationObject with List properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,9 @@ x.x.x Release notes (yyyy-MM-dd)
 
 ### Bugfixes
 
-* None.
+* Fix crash when getting the description of a `MigrationObject` which has
+  `List` properties.
+* Fix crash when calling `dynamicList()` on a `MigrationObject`.
 
 3.8.0 Release notes (2018-09-05)
 =============================================================

--- a/Realm/RLMObjectBase.mm
+++ b/Realm/RLMObjectBase.mm
@@ -247,7 +247,7 @@ id RLMCreateManagedAccessor(Class cls, __unsafe_unretained RLMRealm *realm, RLMC
     NSMutableString *mString = [NSMutableString stringWithFormat:@"%@ {\n", baseClassName];
 
     for (RLMProperty *property in _objectSchema.properties) {
-        id object = _realm ? RLMDynamicGetByName(self, property.name, true) : [self valueForKey:property.name];
+        id object = [(id)self objectForKeyedSubscript:property.name];
         NSString *sub;
         if ([object respondsToSelector:@selector(descriptionWithMaxDepth:)]) {
             sub = [object descriptionWithMaxDepth:depth - 1];

--- a/RealmSwift/Object.swift
+++ b/RealmSwift/Object.swift
@@ -371,6 +371,11 @@ public final class DynamicObject: Object {
     }
 
     /// :nodoc:
+    public override func dynamicList(_ propertyName: String) -> List<DynamicObject> {
+        return self[propertyName] as! List<DynamicObject>
+    }
+
+    /// :nodoc:
     public override func value(forUndefinedKey key: String) -> Any? {
         return self[key]
     }

--- a/RealmSwift/Tests/MigrationTests.swift
+++ b/RealmSwift/Tests/MigrationTests.swift
@@ -558,6 +558,12 @@ class MigrationTests: TestCase {
                 XCTAssertEqual((list[1]["boolCol"] as! Bool), false)
                 XCTAssertEqual((list[2]["boolCol"] as! Bool), true)
 
+                list = newObj!.dynamicList("arrayCol")
+                XCTAssertEqual(list.count, 3)
+                XCTAssertEqual((list[0]["boolCol"] as! Bool), true)
+                XCTAssertEqual((list[1]["boolCol"] as! Bool), false)
+                XCTAssertEqual((list[2]["boolCol"] as! Bool), true)
+
                 self.assertThrows(newObj!.value(forKey: "noSuchKey"))
                 self.assertThrows(newObj!.setValue(1, forKey: "noSuchKey"))
 

--- a/RealmSwift/Tests/MigrationTests.swift
+++ b/RealmSwift/Tests/MigrationTests.swift
@@ -569,10 +569,21 @@ class MigrationTests: TestCase {
 
                 // set it again
                 newObj!["arrayCol"] = [falseObj, trueObj]
+                XCTAssertEqual(list.count, 2)
+
+                newObj!["arrayCol"] = [SwiftBoolObject(value: [false])]
+                XCTAssertEqual(list.count, 1)
+                XCTAssertEqual((list[0]["boolCol"] as! Bool), false)
+
+                self.assertMatches(newObj!.description, "SwiftObject \\{\n\tboolCol = 0;\n\tintCol = 1;\n\tfloatCol = 1;\n\tdoubleCol = 10;\n\tstringCol = a;\n\tbinaryCol = <62 — 1 total bytes>;\n\tdateCol = 1970-01-01 00:00:02 \\+0000;\n\tobjectCol = SwiftBoolObject \\{\n\t\tboolCol = 0;\n\t\\};\n\tarrayCol = List<SwiftBoolObject> <0x[0-9a-f]+> \\(\n\t\t\\[0\\] SwiftBoolObject \\{\n\t\t\tboolCol = 0;\n\t\t\\}\n\t\\);\n\\}")
 
                 enumerated = true
             })
             XCTAssertEqual(enumerated, true)
+
+            let newObj = migration.create(SwiftObject.className())
+            // swiftlint:next:disable line_length
+            self.assertMatches(newObj.description, "SwiftObject \\{\n\tboolCol = 0;\n\tintCol = 123;\n\tfloatCol = 1\\.23;\n\tdoubleCol = 12\\.3;\n\tstringCol = a;\n\tbinaryCol = <61 — 1 total bytes>;\n\tdateCol = 1970-01-01 00:00:01 \\+0000;\n\tobjectCol = SwiftBoolObject \\{\n\t\tboolCol = 0;\n\t\\};\n\tarrayCol = List<SwiftBoolObject> <0x[0-9a-f]+> \\(\n\t\n\t\\);\n\\}")
         }
 
         // refresh to update realm
@@ -587,12 +598,11 @@ class MigrationTests: TestCase {
         XCTAssertEqual(object.binaryCol, Data(bytes: "b", count: 1))
         XCTAssertEqual(object.dateCol, Date(timeIntervalSince1970: 2))
         XCTAssertEqual(object.objectCol!.boolCol, false)
-        XCTAssertEqual(object.arrayCol.count, 2)
+        XCTAssertEqual(object.arrayCol.count, 1)
         XCTAssertEqual(object.arrayCol[0].boolCol, false)
-        XCTAssertEqual(object.arrayCol[1].boolCol, true)
 
         // make sure we added new bool objects as object property and in the list
-        XCTAssertEqual(try! Realm().objects(SwiftBoolObject.self).count, 4)
+        XCTAssertEqual(try! Realm().objects(SwiftBoolObject.self).count, 6)
     }
 
     func testFailOnSchemaMismatch() {


### PR DESCRIPTION
`objectForKeyedSubscript` does the same thing as the previous logic in `descriptionWithMaxDepth:` did, except with special logic for List properties on migration objects. `dynamicList()` similarly needs to use subscript on migration objects to reuse the same special logic.