### PR TITLE
Compare ascending properly in SortDescriptor comparison operator

### DIFF
--- a/RealmSwift/SortDescriptor.swift
+++ b/RealmSwift/SortDescriptor.swift
@@ -75,7 +75,7 @@ extension SortDescriptor: Equatable {
     /// Returns whether the two sort descriptors are equal.
     public static func == (lhs: SortDescriptor, rhs: SortDescriptor) -> Bool {
         return lhs.keyPath == rhs.keyPath &&
-            lhs.ascending == lhs.ascending
+            lhs.ascending == rhs.ascending
     }
 }
 

--- a/RealmSwift/Tests/SortDescriptorTests.swift
+++ b/RealmSwift/Tests/SortDescriptorTests.swift
@@ -43,4 +43,28 @@ class SortDescriptorTests: TestCase {
         XCTAssertEqual(sortDescriptor, literalSortDescriptor,
             "SortDescriptor should conform to StringLiteralConvertible")
     }
+
+    func testComparison() {
+        let sortDescriptor1 = SortDescriptor(keyPath: "property1", ascending: true)
+        let sortDescriptor2 = SortDescriptor(keyPath: "property1", ascending: false)
+        let sortDescriptor3 = SortDescriptor(keyPath: "property2", ascending: true)
+        let sortDescriptor4 = SortDescriptor(keyPath: "property2", ascending: false)
+
+        // validate different
+        XCTAssertNotEqual(sortDescriptor1, sortDescriptor2, "Should not match")
+        XCTAssertNotEqual(sortDescriptor1, sortDescriptor3, "Should not match")
+        XCTAssertNotEqual(sortDescriptor1, sortDescriptor4, "Should not match")
+
+        XCTAssertNotEqual(sortDescriptor2, sortDescriptor3, "Should not match")
+        XCTAssertNotEqual(sortDescriptor2, sortDescriptor4, "Should not match")
+
+        XCTAssertNotEqual(sortDescriptor3, sortDescriptor4, "Should not match")
+
+        let sortDescriptor5 = SortDescriptor(keyPath: "property1", ascending: true)
+        let sortDescriptor6 = SortDescriptor(keyPath: "property2", ascending: true)
+
+        // validate same
+        XCTAssertEqual(sortDescriptor1, sortDescriptor5, "Should match")
+        XCTAssertEqual(sortDescriptor3, sortDescriptor6, "Should match")
+    }
 }


### PR DESCRIPTION
It's a very small PR with a simple fix of a wrong comparison method. 
It was comparing left hand side with itself, now it compares correctly.

I've also added a unit test to cover this method.