### PR TITLE
Fix cocoapods compilation with Xcode 10 Beta 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+x.x.x Release notes (yyyy-MM-dd)
+=============================================================
+
+### Breaking Changes
+
+* None.
+
+### Enhancements
+
+* None.
+
+### Bugfixes
+
+* Fix permission denied errors for RLMPlatform.h when building with CocoaPods
+  and Xcode 10 beta 3.
+
 3.7.4 Release notes (2018-06-19)
 =============================================================
 

--- a/RealmSwift/LinkingObjects.swift
+++ b/RealmSwift/LinkingObjects.swift
@@ -153,10 +153,8 @@ public final class LinkingObjects<Element: Object>: LinkingObjectsBase {
      - parameter index: The index.
      */
     public subscript(index: Int) -> Element {
-        get {
-            throwForNegativeIndex(index)
-            return unsafeBitCast(rlmResults[UInt(index)], to: Element.self)
-        }
+        throwForNegativeIndex(index)
+        return unsafeBitCast(rlmResults[UInt(index)], to: Element.self)
     }
 
     /// Returns the first object in the linking objects, or `nil` if the linking objects are empty.

--- a/build.sh
+++ b/build.sh
@@ -1005,7 +1005,7 @@ EOM
           cp Realm/ObjectStore/src/util/*.hpp include/util
           cp Realm/ObjectStore/src/util/apple/*.hpp include/util/apple
 
-          touch Realm/RLMPlatform.h
+          echo '' > Realm/RLMPlatform.h
           if [ -n "$COCOAPODS_VERSION" ]; then
             # This variable is set for the prepare_command available
             # from the 1.0 prereleases, which requires a different


### PR DESCRIPTION
Xcode now does strange things with zero-byte files, so instead generate a one-byte stub for RLMPlatform.h.

Fixes #5840.