### PR TITLE
Explicitly list the headers for the Realm.Private cocoapods module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+x.x.x Release notes (yyyy-MM-dd)
+=============================================================
+
+### Breaking Changes
+
+* None.
+
+### Enhancements
+
+* None.
+
+### Bugfixes
+
+* Fix warnings when building Realm as a static framework with CocoaPods.
+
 3.7.6 Release notes (2018-08-08)
 =============================================================
 

--- a/Realm.podspec
+++ b/Realm.podspec
@@ -52,11 +52,22 @@ Pod::Spec.new do |s|
                               'include/**/RLMObjectBase_Dynamic.h'
 
                               # Realm.Private module
-  private_header_files      = 'include/**/*_Private.h',
-                              'include/**/RLMAccessor.h',
+  private_header_files      = 'include/**/RLMAccessor.h',
+                              'include/**/RLMArray_Private.h',
+                              'include/**/RLMCollection_Private.h',
                               'include/**/RLMListBase.h',
+                              'include/**/RLMObjectBase_Private.h',
+                              'include/**/RLMObjectSchema_Private.h',
                               'include/**/RLMObjectStore.h',
-                              'include/**/RLMOptionalBase.h'
+                              'include/**/RLMObject_Private.h',
+                              'include/**/RLMOptionalBase.h',
+                              'include/**/RLMProperty_Private.h',
+                              'include/**/RLMRealmConfiguration_Private.h',
+                              'include/**/RLMRealm_Private.h',
+                              'include/**/RLMResults_Private.h',
+                              'include/**/RLMSchema_Private.h',
+                              'include/**/RLMSyncConfiguration_Private.h',
+                              'include/**/RLMSyncUtil_Private.h'
 
   source_files              = 'Realm/*.{m,mm}',
                               'Realm/ObjectStore/src/*.cpp',


### PR DESCRIPTION
There are some headers which we want in neither the Realm nor Realm.Private modules, and including them in private_header_files would implicitly result in them ending up in the Realm module (and then produce warnings about the umbrella header not importing them).

Fixes #5886.