### PR TITLE
Publicly expose RLMSyncUser.refreshToken

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+x.x.x Release notes (yyyy-MM-dd)
+=============================================================
+
+### Breaking Changes
+
+* None.
+
+### Enhancements
+
+* Expose RLMSyncUser.refreshToken publicly so that it can be used for custom
+  HTTP requests to Realm Object Server.
+
+### Bugfixes
+
+* None.
+
 3.8.0 Release notes (2018-09-05)
 =============================================================
 

--- a/Realm/RLMSyncUser.h
+++ b/Realm/RLMSyncUser.h
@@ -97,6 +97,14 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nullable, nonatomic, readonly) NSString *identity;
 
 /**
+ The user's refresh token used to access the Realm Object Server.
+
+ This is required to make HTTP requests to Realm Object Server's REST API
+ for functionality not exposed natively. It should be treated as sensitive data.
+ */
+@property (nullable, nonatomic, readonly) NSString *refreshToken;
+
+/**
  The URL of the authentication server this user will communicate with.
  */
 @property (nullable, nonatomic, readonly) NSURL *authenticationServer;

--- a/Realm/RLMSyncUser.mm
+++ b/Realm/RLMSyncUser.mm
@@ -339,7 +339,7 @@ PermissionChangeCallback RLMWrapPermissionStatusCallback(RLMPermissionStatusBloc
         return;
     }
     [RLMSyncChangePasswordEndpoint sendRequestToServer:self.authenticationServer
-                                       JSON:@{kRLMSyncTokenKey: self._refreshToken,
+                                       JSON:@{kRLMSyncTokenKey: self.refreshToken,
                                               kRLMSyncUserIDKey: userID,
                                               kRLMSyncDataKey: @{kRLMSyncNewPasswordKey: newPassword}}
                                     options:[[RLMSyncManager sharedManager] networkRequestOptions]
@@ -397,7 +397,7 @@ PermissionChangeCallback RLMWrapPermissionStatusCallback(RLMPermissionStatusBloc
                                        JSON:@{
                                               kRLMSyncProviderKey: provider,
                                               kRLMSyncProviderIDKey: providerUserIdentity,
-                                              kRLMSyncTokenKey: self._refreshToken
+                                              kRLMSyncTokenKey: self.refreshToken
                                               }
                                     timeout:60
                                     options:[[RLMSyncManager sharedManager] networkRequestOptions]
@@ -534,7 +534,7 @@ static void verifyInRunLoop() {
     });
 }
 
-- (NSString *)_refreshToken {
+- (NSString *)refreshToken {
     if (!_user) {
         return nil;
     }

--- a/Realm/RLMSyncUser_Private.hpp
+++ b/Realm/RLMSyncUser_Private.hpp
@@ -65,7 +65,6 @@ private:
 - (instancetype)initWithSyncUser:(std::shared_ptr<SyncUser>)user;
 - (NSURL *)defaultRealmURL;
 - (std::shared_ptr<SyncUser>)_syncUser;
-- (nullable NSString *)_refreshToken;
 + (void)_setUpBindingContextFactory;
 @end
 


### PR DESCRIPTION
This is required to be able to make HTTP requests to ROS for the things which we don't have wrappers for and there isn't really any need for it to be private.