### PR TITLE
Add connection state reporting and start/stop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ x.x.x Release notes (yyyy-MM-dd)
 
 * Expose RLMSyncUser.refreshToken publicly so that it can be used for custom
   HTTP requests to Realm Object Server.
+* Add RLMSyncSession.connectionState, which reports whether the session is
+  currently connected to the Realm Object Server or if it is offline.
 
 ### Bugfixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ x.x.x Release notes (yyyy-MM-dd)
   HTTP requests to Realm Object Server.
 * Add RLMSyncSession.connectionState, which reports whether the session is
   currently connected to the Realm Object Server or if it is offline.
+* Add `-suspend` and `-resume` methods to `RLMSyncSession` to enable manually
+  pausing data synchronization.
 
 ### Bugfixes
 

--- a/Realm/ObjectServerTests/SwiftObjectServerTests.swift
+++ b/Realm/ObjectServerTests/SwiftObjectServerTests.swift
@@ -106,7 +106,7 @@ class SwiftObjectServerTests: SwiftSyncTestCase {
 
         func wait(forState desiredState: SyncSession.ConnectionState) {
             let ex = expectation(description: "Wait for connection state: \(desiredState)")
-            let token = session.observe(\.connectionState, options: .initial) { state in
+            let token = session.observe(\.connectionState, options: .initial) { _ in
                 if session.connectionState == desiredState {
                     ex.fulfill()
                 }

--- a/Realm/ObjectServerTests/SwiftObjectServerTests.swift
+++ b/Realm/ObjectServerTests/SwiftObjectServerTests.swift
@@ -106,8 +106,8 @@ class SwiftObjectServerTests: SwiftSyncTestCase {
 
         func wait(forState desiredState: SyncSession.ConnectionState) {
             let ex = expectation(description: "Wait for connection state: \(desiredState)")
-            let token = session.observe(\.connectionState, options: .initial) { _ in
-                if session.connectionState == desiredState {
+            let token = session.observe(\SyncSession.connectionState, options: .initial) { s, _ in
+                if s.connectionState == desiredState {
                     ex.fulfill()
                 }
             }

--- a/Realm/RLMSyncSession.h
+++ b/Realm/RLMSyncSession.h
@@ -24,12 +24,31 @@
  The current state of the session represented by a session object.
  */
 typedef NS_ENUM(NSUInteger, RLMSyncSessionState) {
-    /// The sync session is bound to the Realm Object Server and communicating with it.
+    /// The sync session is actively communicating or attempting to communicate
+    /// with the Realm Object Server. A session is considered Active even if
+    /// it is not currently connected. Check the connection state instead if you
+    /// wish to know if the connection is currently online.
     RLMSyncSessionStateActive,
-    /// The sync session is not currently communicating with the Realm Object Server.
+    /// The sync session is not attempting to communicate with the Realm Object
+    /// Server, due to the user logging out or synchronization being paused.
     RLMSyncSessionStateInactive,
     /// The sync session encountered a fatal error and is permanently invalid; it should be discarded.
     RLMSyncSessionStateInvalid
+};
+
+/**
+ The current state of a sync session's connection. Sessions which are not in
+ the Active state will always be Disconnected.
+ */
+typedef NS_ENUM(NSUInteger, RLMSyncConnectionState) {
+    /// The sync session is not connected to the server, and is not attempting
+    /// to connect, either because the session is inactive or because it is
+    /// waiting to retry after a failed connection.
+    RLMSyncConnectionStateDisconnected,
+    /// The sync session is attempting to connect to the Realm Object Server.
+    RLMSyncConnectionStateConnecting,
+    /// The sync session is currently connected to the Realm Object Server.
+    RLMSyncConnectionStateConnected,
 };
 
 /**
@@ -105,7 +124,16 @@ NS_ASSUME_NONNULL_BEGIN
 @interface RLMSyncSession : NSObject
 
 /// The session's current state.
+///
+/// This property is not KVO-compliant.
 @property (nonatomic, readonly) RLMSyncSessionState state;
+
+/// The session's current connection state.
+///
+/// This property is KVO-compliant and can be observed to be notified of changes.
+/// Be warned that KVO observers for this property may be called on a background
+/// thread.
+@property (atomic, readonly) RLMSyncConnectionState connectionState;
 
 /// The Realm Object Server URL of the remote Realm this session corresponds to.
 @property (nullable, nonatomic, readonly) NSURL *realmURL;

--- a/Realm/RLMSyncSession.h
+++ b/Realm/RLMSyncSession.h
@@ -148,6 +148,22 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable RLMSyncConfiguration *)configuration;
 
 /**
+ Temporarily suspend syncronization and disconnect from the server.
+
+ The session will not attempt to connect to Realm Object Server until `resume`
+ is called or the Realm file is closed and re-opened.
+ */
+- (void)suspend;
+
+/**
+ Resume syncronization and reconnect to Realm Object Server after suspending.
+
+ This is a no-op if the session was already active or if the session is invalid.
+ Newly created sessions begin in the Active state and do not need to be resumed.
+ */
+- (void)resume;
+
+/**
  Register a progress notification block.
 
  Multiple blocks can be registered with the same session at once. Each block

--- a/Realm/RLMSyncSession.mm
+++ b/Realm/RLMSyncSession.mm
@@ -149,6 +149,18 @@ static RLMSyncConnectionState convertConnectionState(SyncSession::ConnectionStat
     return RLMSyncSessionStateInvalid;
 }
 
+- (void)suspend {
+    if (auto session = _session.lock()) {
+        session->log_out();
+    }
+}
+
+- (void)resume {
+    if (auto session = _session.lock()) {
+        session->revive_if_needed();
+    }
+}
+
 - (BOOL)waitForUploadCompletionOnQueue:(dispatch_queue_t)queue callback:(void(^)(NSError *))callback {
     if (auto session = _session.lock()) {
         queue = queue ?: dispatch_get_main_queue();

--- a/Realm/RLMSyncSession.mm
+++ b/Realm/RLMSyncSession.mm
@@ -80,6 +80,7 @@ using namespace realm;
 
 @interface RLMSyncSession ()
 @property (class, nonatomic, readonly) dispatch_queue_t notificationsQueue;
+@property (atomic, readwrite) RLMSyncConnectionState connectionState;
 @end
 
 @implementation RLMSyncSession
@@ -93,9 +94,23 @@ using namespace realm;
     return queue;
 }
 
-- (instancetype)initWithSyncSession:(std::shared_ptr<SyncSession>)session {
+static RLMSyncConnectionState convertConnectionState(SyncSession::ConnectionState state) {
+    switch (state) {
+        case SyncSession::ConnectionState::Disconnected: return RLMSyncConnectionStateDisconnected;
+        case SyncSession::ConnectionState::Connecting:   return RLMSyncConnectionStateConnecting;
+        case SyncSession::ConnectionState::Connected:    return RLMSyncConnectionStateConnected;
+    }
+}
+
+- (instancetype)initWithSyncSession:(std::shared_ptr<SyncSession> const&)session {
     if (self = [super init]) {
         _session = session;
+        _connectionState = convertConnectionState(session->connection_state());
+        // No need to save the token as RLMSyncSession always outlives the
+        // underlying SyncSession
+        session->register_connection_change_callback([=](auto, auto newState) {
+            self.connectionState = convertConnectionState(newState);
+        });
         return self;
     }
     return nil;

--- a/Realm/RLMSyncSession_Private.hpp
+++ b/Realm/RLMSyncSession_Private.hpp
@@ -32,7 +32,7 @@ NS_ASSUME_NONNULL_BEGIN
     std::weak_ptr<realm::SyncSession> _session;
 } RLM_SYNC_UNINITIALIZABLE
 
-- (instancetype)initWithSyncSession:(std::shared_ptr<realm::SyncSession>)session;
+- (instancetype)initWithSyncSession:(std::shared_ptr<realm::SyncSession> const&)session;
 
 /// Wait for pending uploads to complete or the session to expire, and dispatch the callback onto the specified queue.
 - (BOOL)waitForUploadCompletionOnQueue:(nullable dispatch_queue_t)queue callback:(void(^)(NSError * _Nullable))callback;

--- a/RealmSwift/Sync.swift
+++ b/RealmSwift/Sync.swift
@@ -629,6 +629,20 @@ public typealias SyncAccessLevel = RLMSyncAccessLevel
 
 public extension SyncSession {
     /**
+     The current state of the session represented by a session object.
+
+     - see: `RLMSyncSessionState`
+     */
+    public typealias State = RLMSyncSessionState
+
+    /**
+     The current state of a sync session's connection.
+
+     - see: `RLMSyncConnectionState`
+     */
+    public typealias ConnectionState = RLMSyncConnectionState
+
+    /**
      The transfer direction (upload or download) tracked by a given progress notification block.
 
      Progress notification blocks can be registered on sessions if your app wishes to be informed


### PR DESCRIPTION
The `suspend`/`resume` names are chosen to match the convention from standard library types such as `NSURLSession`.

Like `RLMSyncSubscription` this just uses a KVO-observable property rather than a separate notification registration system.