### PR TITLE
Re-fix a crash on non-@objc `String?` properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,10 @@ x.x.x Release notes (yyyy-MM-dd)
 
 ### Bugfixes
 
-* None.
+* Fix a crash when adding an object with a non-`@objc` `String?` property which
+  has not been explicitly ignored to a Realm on watchOS 5 (and possibly other
+  platforms when building with Xcode 10).
+  https://github.com/realm/realm-cocoa/issues/5929
 
 3.10.0 Release notes (2018-09-19)
 =============================================================

--- a/Realm/RLMAccessor.mm
+++ b/Realm/RLMAccessor.mm
@@ -624,6 +624,11 @@ id RLMAccessorContext::propertyValue(__unsafe_unretained id const obj, size_t pr
         if (prop.array) {
             return static_cast<RLMListBase *>(object_getIvar(obj, prop.swiftIvar))._rlmArray;
         }
+        else if (prop.swiftIvar == RLMDummySwiftIvar) {
+            // FIXME: An invalid property which we're pretending is nil until 4.0
+            // https://github.com/realm/realm-cocoa/issues/5784
+            return NSNull.null;
+        }
         else { // optional
             value = RLMGetOptional(static_cast<RLMOptionalBase *>(object_getIvar(obj, prop.swiftIvar)));
         }

--- a/Realm/RLMObjectSchema.mm
+++ b/Realm/RLMObjectSchema.mm
@@ -33,6 +33,11 @@
 
 using namespace realm;
 
+const Ivar RLMDummySwiftIvar = []() {
+    static int dummy;
+    return reinterpret_cast<objc_ivar *>(&dummy);
+}();
+
 // private properties
 @interface RLMObjectSchema ()
 @property (nonatomic, readwrite) NSDictionary<id, RLMProperty *> *allPropertiesByName;
@@ -293,8 +298,18 @@ using namespace realm;
                     break;
                 }
 
-                // RealmOptional<>
-                Ivar ivar = class_getInstanceVariable([instance class], md.propertyName.UTF8String);
+                Ivar ivar;
+                if (md.propertyType == RLMPropertyTypeString) {
+                    // FIXME: A non-@objc dynamic String? property which we
+                    // can't actually read so we're always just going to pretend it's nil
+                    // https://github.com/realm/realm-cocoa/issues/5784
+                    ivar = RLMDummySwiftIvar;
+                }
+                else {
+                    // RealmOptional<>
+                    ivar = class_getInstanceVariable([instance class], md.propertyName.UTF8String);
+                }
+
                 prop = [[RLMProperty alloc] initSwiftOptionalPropertyWithName:md.propertyName
                                                                       indexed:[indexed containsObject:md.propertyName]
                                                                          ivar:ivar

--- a/Realm/RLMObjectSchema_Private.hpp
+++ b/Realm/RLMObjectSchema_Private.hpp
@@ -30,3 +30,7 @@ namespace realm {
 // initialize with realm::ObjectSchema
 + (instancetype)objectSchemaForObjectStoreSchema:(realm::ObjectSchema const&)objectSchema;
 @end
+
+// An objc_ivar pointer which is guaranteed to not point to any actually-existing
+// ivar. Used as part of https://github.com/realm/realm-cocoa/issues/5784
+extern const Ivar RLMDummySwiftIvar;

--- a/Realm/RLMObjectStore.mm
+++ b/Realm/RLMObjectStore.mm
@@ -90,15 +90,14 @@ void RLMInitializeSwiftAccessorGenerics(__unsafe_unretained RLMObjectBase *const
     }
 
     for (RLMProperty *prop in object->_objectSchema.swiftGenericProperties) {
-        id ivar = object_getIvar(object, prop.swiftIvar);
-        if (!ivar) {
+        if (prop.swiftIvar == RLMDummySwiftIvar) {
             // FIXME: this should actually be an error as it's the result of an
             // invalid object definition, but that's a breaking change so
             // instead preserve the old behavior until the next major version bump
             // https://github.com/realm/realm-cocoa/issues/5784
             continue;
         }
-
+        id ivar = object_getIvar(object, prop.swiftIvar);
         if (prop.type == RLMPropertyTypeLinkingObjects) {
             [ivar setObject:(id)[[RLMWeakObjectHandle alloc] initWithObject:object]];
             [ivar setProperty:prop];

--- a/Realm/RLMOptionalBase.mm
+++ b/Realm/RLMOptionalBase.mm
@@ -123,11 +123,6 @@ private:
 }
 
 id RLMGetOptional(__unsafe_unretained RLMOptionalBase *const self) {
-    if (!self) {
-        // FIXME: this should actually be an error
-        // https://github.com/realm/realm-cocoa/issues/5784
-        return nil;
-    }
     try {
         return self->_impl ? RLMCoerceToNil(self->_impl->get()) : nil;
     }
@@ -137,11 +132,6 @@ id RLMGetOptional(__unsafe_unretained RLMOptionalBase *const self) {
 }
 
 void RLMSetOptional(__unsafe_unretained RLMOptionalBase *const self, __unsafe_unretained const id value) {
-    if (!self) {
-        // FIXME: this should actually be an error
-        // https://github.com/realm/realm-cocoa/issues/5784
-        return;
-    }
     try {
         if (!self->_impl && value) {
             self->_impl.reset(new UnmanagedOptional);

--- a/RealmSwift/Tests/ObjectCreationTests.swift
+++ b/RealmSwift/Tests/ObjectCreationTests.swift
@@ -21,11 +21,14 @@ import RealmSwift
 import Realm.Private
 
 class ObjectWithPrivateOptionals: Object {
-    private var int: Int?
-    private var float: Float?
-    private var string: String?
+    private var nilInt: Int?
+    private var nilFloat: Float?
+    private var nilString: String?
+    private var int: Int? = 123
+    private var float: Float? = 1.23
+    private var string: String? = "123"
 
-    @objc dynamic var value = 0
+    @objc dynamic var value = 5
 }
 
 class ObjectCreationTests: TestCase {


### PR DESCRIPTION
The previous fix in #5783 only worked if the value of the ivar happened to be `nil`. On watchOS 5 this is no longer always the case, and so we would sometimes try to treat something that was a pointer to something other than a RealmOptional as a RealmOptional.

This fixes it more robustly by instead just applying the workaround to *all* non-@objc `String?` properties to avoid reading the ivar at all.

Fixes #5929. Fixes #5932. Fixes #5933.