### PR TITLE
Fix the json arguments of SyncUser.requestEmailConfirmation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+x.y.z Release notes (yyyy-MM-dd)
+=============================================================
+### Enhancements
+* None.
+
+### Fixed
+* Fix `SyncUser.requestEmailConfirmation` not triggering the email confirmation
+  flow on ROS. (PR [#5953](https://github.com/realm/realm-cocoa/pull/5953), since 3.5.0)
+
+### Compatibility
+* File format: Generates Realms with format v9 (Reads and upgrades all previous formats)
+* Realm Object Server: 3.11.0 or later.
+* APIs are backwards compatible with all previous releases in the 3.x.y series.
+
 3.11.0 Release notes (2018-10-04)
 =============================================================
 
@@ -163,7 +177,7 @@ details.
 ### Deprecations
 
 * `+[RLMSyncConfiguration initWithUser] has been deprecated in favor of `-[RLMSyncUser configurationWithURL:url].
-* `+[RLMSyncConfiguration automaticConfiguration] has been deprecated in favor of `-[RLMSyncUser configuration]. 
+* `+[RLMSyncConfiguration automaticConfiguration] has been deprecated in favor of `-[RLMSyncUser configuration].
 * `+[RLMSyncConfiguration automaticConfigurationForUser] has been deprecated in favor of `-[RLMSyncUser configuration].
 * `-[RLMSyncConfiguration isPartial] has been deprecated in favor of `-[RLMSyncConfiguration fullSynchronization]`.
 
@@ -2142,7 +2156,7 @@ Prebuilt frameworks are now built with Xcode 7.3.
   `RLMRealm`/`Realm` instances.
 * Fail with `RLMErrorFileNotFound` instead of the more generic `RLMErrorFileAccess`,
   if no file was found when a realm was opened as read-only or if the directory part
-  of the specified path was not found when a copy should be written. 
+  of the specified path was not found when a copy should be written.
 * Greatly improve performance when deleting objects with one or more indexed
   properties.
 * Indexing `BOOL`/`Bool` and `NSDate` properties are now supported.
@@ -2177,7 +2191,7 @@ Prebuilt frameworks are now built with Xcode 7.3.
 
 * Support for tvOS.
 * Support for building Realm Swift from source when using Carthage.
-* The block parameter of `-[RLMRealm transactionWithBlock:]`/`Realm.write(_:)` is 
+* The block parameter of `-[RLMRealm transactionWithBlock:]`/`Realm.write(_:)` is
   now marked as `__attribute__((noescape))`/`@noescape`.
 * Many forms of queries with key paths on both sides of the comparison operator
   are now supported.

--- a/Realm/ObjectServerTests/RLMObjectServerTests.mm
+++ b/Realm/ObjectServerTests/RLMObjectServerTests.mm
@@ -480,6 +480,10 @@
     RLMSyncCredentials *creds = [RLMSyncCredentials credentialsWithUsername:userName password:@"a" register:YES];
     [[self logInUserForCredentials:creds server:[RLMObjectServerTests authServerURL]] logOut];
 
+    // This token is sent by ROS upon user registration
+    NSString *registrationToken = [self emailForAddress:userName];
+    XCTAssertNotNil(registrationToken);
+
     XCTestExpectation *ex = [self expectationWithDescription:@"callback invoked"];
     [RLMSyncUser requestEmailConfirmationForAuthServer:[RLMObjectServerTests authServerURL]
                                              userEmail:userName completion:^(NSError *error) {
@@ -488,8 +492,10 @@
                                              }];
     [self waitForExpectationsWithTimeout:2.0 handler:nil];
 
+    // This token should have been created when requestEmailConfirmationForAuthServer was called
     NSString *token = [self emailForAddress:userName];
     XCTAssertNotNil(token);
+    XCTAssertNotEqual(token, registrationToken);
 
     // Use the token
     ex = [self expectationWithDescription:@"callback invoked"];

--- a/Realm/RLMSyncUser.mm
+++ b/Realm/RLMSyncUser.mm
@@ -371,7 +371,7 @@ PermissionChangeCallback RLMWrapPermissionStatusCallback(RLMPermissionStatusBloc
                                     userEmail:(NSString *)email
                                    completion:(RLMPasswordChangeStatusBlock)completion {
     [RLMSyncUpdateAccountEndpoint sendRequestToServer:serverURL
-                                                 JSON:@{@"provider_id": email, @"data": @{                                                                   @"action": @"request_email_confirmation"}}
+                                                 JSON:@{@"provider_id": email, @"data": @{@"action": @"request_email_confirmation"}}
                                               options:[[RLMSyncManager sharedManager] networkRequestOptions]
                                            completion:completion];
 }

--- a/Realm/RLMSyncUser.mm
+++ b/Realm/RLMSyncUser.mm
@@ -371,8 +371,7 @@ PermissionChangeCallback RLMWrapPermissionStatusCallback(RLMPermissionStatusBloc
                                     userEmail:(NSString *)email
                                    completion:(RLMPasswordChangeStatusBlock)completion {
     [RLMSyncUpdateAccountEndpoint sendRequestToServer:serverURL
-                                                 JSON:@{@"data": @{@"provider_id": email,
-                                                                   @"action": @"request_email_confirmation"}}
+                                                 JSON:@{@"provider_id": email, @"data": @{                                                                   @"action": @"request_email_confirmation"}}
                                               options:[[RLMSyncManager sharedManager] networkRequestOptions]
                                            completion:completion];
 }


### PR DESCRIPTION
The `provider_id` should have been outside the `data` argument, which had caused ROS to silently ignore the request (as it was trying too hard to ensure that an attacker cannot figure out if an email is registered with the server).

Fixes https://github.com/realm/realm-object-server-private/issues/1283.