### PR TITLE
Add subscription management functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,14 @@
 x.y.z Release notes (yyyy-MM-dd)
 =============================================================
 ### Enhancements
-* None.
+* Add `Realm.subscriptions`/`-[RLMRealm subscriptions]` and
+  `Realm.subscription(named:)`/`-[RLMRealm subscriptionWithName:]` to enable
+  looking up existing query-based sync subscriptions.
+  (PR: https://github.com/realm/realm-cocoa/pull/6029).
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-js/issues/????), since v?.?.?)
 * None.
-
-<!-- ### Breaking Changes - ONLY INCLUDE FOR NEW MAJOR version -->
 
 ### Compatibility
 * File format: Generates Realms with format v9 (Reads and upgrades all previous formats)

--- a/Realm/RLMRealm_Private.h
+++ b/Realm/RLMRealm_Private.h
@@ -18,7 +18,7 @@
 
 #import <Realm/RLMRealm.h>
 
-@class RLMFastEnumerator;
+@class RLMFastEnumerator, RLMSyncSubscription;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -26,6 +26,8 @@ NS_ASSUME_NONNULL_BEGIN
 FOUNDATION_EXTERN void RLMDisableSyncToDisk(void);
 
 FOUNDATION_EXTERN NSData * _Nullable RLMRealmValidatedEncryptionKey(NSData *key);
+
+FOUNDATION_EXTERN RLMSyncSubscription *RLMCastToSyncSubscription(id obj);
 
 // Translate an in-flight exception resulting from an operation on a SharedGroup to
 // an NSError or NSException (if error is nil)

--- a/Realm/RLMRealm_Private.hpp
+++ b/Realm/RLMRealm_Private.hpp
@@ -19,16 +19,26 @@
 #import "RLMRealm_Private.h"
 
 #import "RLMClassInfo.hpp"
+#import "object_schema.hpp"
 
 namespace realm {
     class Group;
     class Realm;
 }
+struct RLMResultsSetInfo {
+    realm::ObjectSchema osObjectSchema;
+    RLMObjectSchema *rlmObjectSchema;
+    RLMClassInfo info;
+
+    RLMResultsSetInfo(__unsafe_unretained RLMRealm *const realm);
+    static RLMClassInfo& get(__unsafe_unretained RLMRealm *const realm);
+};
 
 @interface RLMRealm () {
     @public
     std::shared_ptr<realm::Realm> _realm;
     RLMSchemaInfo _info;
+    std::unique_ptr<RLMResultsSetInfo> _resultsSetInfo;
 }
 
 // FIXME - group should not be exposed

--- a/Realm/RLMResults.mm
+++ b/Realm/RLMResults.mm
@@ -111,17 +111,27 @@ void RLMThrowResultsError(NSString *aggregateMethod) {
     }
 }
 
+- (instancetype)initWithObjectInfo:(RLMClassInfo&)info
+                           results:(realm::Results&&)results {
+    if (self = [super init]) {
+        _results = std::move(results);
+        _realm = info.realm;
+        _info = &info;
+    }
+    return self;
+}
+
 + (instancetype)resultsWithObjectInfo:(RLMClassInfo&)info
-                              results:(realm::Results)results {
-    RLMResults *ar = [[self alloc] initPrivate];
-    ar->_results = std::move(results);
-    ar->_realm = info.realm;
-    ar->_info = &info;
-    return ar;
+                              results:(realm::Results&&)results {
+    return [[self alloc] initWithObjectInfo:info results:std::move(results)];
 }
 
 + (instancetype)emptyDetachedResults {
     return [[self alloc] initPrivate];
+}
+
+- (instancetype)subresultsWithResults:(realm::Results)results {
+    return [self.class resultsWithObjectInfo:*_info results:std::move(results)];
 }
 
 static inline void RLMResultsValidateInWriteTransaction(__unsafe_unretained RLMResults *const ar) {
@@ -349,7 +359,7 @@ static inline void RLMResultsValidateInWriteTransaction(__unsafe_unretained RLMR
             @throw RLMException(@"Querying is currently only implemented for arrays of Realm Objects");
         }
         auto query = RLMPredicateToQuery(predicate, _info->rlmObjectSchema, _realm.schema, _realm.group);
-        return [RLMResults resultsWithObjectInfo:*_info results:_results.filter(std::move(query))];
+        return [self subresultsWithResults:_results.filter(std::move(query))];
     });
 }
 
@@ -365,8 +375,7 @@ static inline void RLMResultsValidateInWriteTransaction(__unsafe_unretained RLMR
         if (_results.get_mode() == Results::Mode::Empty) {
             return self;
         }
-        return [RLMResults resultsWithObjectInfo:*_info
-                                         results:_results.sort(RLMSortDescriptorsToKeypathArray(properties))];
+        return [self subresultsWithResults:_results.sort(RLMSortDescriptorsToKeypathArray(properties))];
     });
 }
 
@@ -387,7 +396,7 @@ static inline void RLMResultsValidateInWriteTransaction(__unsafe_unretained RLMR
             keyPathsVector.push_back(keyPath.UTF8String);
         }
         
-        return [RLMResults resultsWithObjectInfo:*_info results:_results.distinct(keyPathsVector)];
+        return [self subresultsWithResults:_results.distinct(keyPathsVector)];
     });
 }
 

--- a/Realm/RLMResults_Private.hpp
+++ b/Realm/RLMResults_Private.hpp
@@ -38,7 +38,10 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (instancetype)initWithResults:(realm::Results)results;
 
-+ (instancetype)resultsWithObjectInfo:(RLMClassInfo&)info results:(realm::Results)results;
+- (instancetype)initWithObjectInfo:(RLMClassInfo&)info results:(realm::Results&&)results;
++ (instancetype)resultsWithObjectInfo:(RLMClassInfo&)info results:(realm::Results&&)results;
+
+- (instancetype)subresultsWithResults:(realm::Results)results;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Realm/RLMSyncSubscription.h
+++ b/Realm/RLMSyncSubscription.h
@@ -16,6 +16,7 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
+#import <Realm/RLMRealm.h>
 #import <Realm/RLMResults.h>
 
 NS_ASSUME_NONNULL_BEGIN
@@ -54,30 +55,38 @@ typedef NS_ENUM(NSInteger, RLMSyncSubscriptionState) {
 /**
  `RLMSyncSubscription` represents a subscription to a set of objects in a synced Realm.
 
- When partial sync is enabled for a synced Realm, the only objects that the server synchronizes to the
- client are those that match a sync subscription registered by that client. A subscription consists of
- of a query (represented by an `RLMResults`) and an optional name.
+ When query-based sync is enabled for a synchronized Realm, the server only
+ synchronizes objects to the client when they match a sync subscription
+ registered by that client. A subscription consists of of a query (represented
+ by an `RLMResults`) and an optional name.
 
- The state of the subscription can be observed using [Key-Value Observing](https://developer.apple.com/library/content/documentation/Cocoa/Conceptual/KeyValueObserving/KeyValueObserving.html) on the `state` property.
+ The state of the subscription can be observed using
+ [Key-Value Observing](https://developer.apple.com/library/content/documentation/Cocoa/Conceptual/KeyValueObserving/KeyValueObserving.html)
+ on the `state` property.
 
- Subscriptions are created using `-[RLMResults subscribe]` or `-[RLMResults subscribeWithName:]`.
+ Subscriptions are created using `-[RLMResults subscribe]` or
+ `-[RLMResults subscribeWithName:]`. Existing subscriptions for a Realm can be
+ looked up with `-[RLMRealm subscriptions]` or `-[RLMRealm subscriptionWithName:]`.
  */
 @interface RLMSyncSubscription : NSObject
 
 /**
  The unique name for this subscription.
 
- This will be `nil` if a name was not provided when the subscription was created.
+ This will be `nil` if this object was created with `-[RLMResults subscribe]`.
+ Subscription objects read from a Realm with `-[RLMRealm subscriptions]` will
+ always have a non-`nil` name and subscriptions which were not explicitly named
+ will have an automatically generated one.
  */
 @property (nonatomic, readonly, nullable) NSString *name;
 
 /**
- The state of the subscription. See `RLMSyncSubscriptionState`.
+ The current state of the subscription. See `RLMSyncSubscriptionState`.
  */
 @property (nonatomic, readonly) RLMSyncSubscriptionState state;
 
 /**
- The error associated with this subscription, if any.
+ The error which occurred when registering this subscription, if any.
 
  Will be non-nil only when `state` is `RLMSyncSubscriptionStateError`.
  */
@@ -86,10 +95,15 @@ typedef NS_ENUM(NSInteger, RLMSyncSubscriptionState) {
 /**
  Remove this subscription.
 
- Removing a subscription will delete all objects from the local Realm that were matched
- only by that subscription and not any remaining subscriptions. The deletion is performed
- by the server, and so has no immediate impact on the contents of the local Realm. If the
- device is currently offline, the removal will not be processed until the device returns online.
+ Removing a subscription will delete all objects from the local Realm that were
+ matched only by that subscription and not any remaining subscriptions. The
+ deletion is performed by the server, and so has no immediate impact on the
+ contents of the local Realm. If the device is currently offline, the removal
+ will not be processed until the device returns online.
+
+ Unsubscribing is an asynchronous operation and will not immediately remove the
+ subscription from the Realm's list of subscriptions. Observe the state property
+ to be notified of when the subscription has actually been removed.
  */
 - (void)unsubscribe;
 
@@ -123,9 +137,11 @@ typedef NS_ENUM(NSInteger, RLMSyncSubscriptionState) {
  notified of when the subscription has been processed by the server and
  all objects matching the query are available.
 
- The subscription will not be explicitly named.
+ The subscription will not be explicitly named. A name will be automatically
+ generated for internal use. The exact format of this name may change without
+ warning and should not be depended on.
 
- @return The subscription
+ @return An object representing the newly-created subscription.
 
  @see RLMSyncSubscription
 */
@@ -148,9 +164,14 @@ typedef NS_ENUM(NSInteger, RLMSyncSubscriptionState) {
  performing the same subscription twice followed by removing it once will
  result in no subscription existing.
 
- @param subscriptionName The name of the subscription
+ The newly created subscription will not be reported by
+ `-[RLMRealm subscriptions]` or `-[RLMRealm subscriptionWithName:]` until
+ `state` has transitioned from `RLMSyncSubscriptionStateCreating` to any of the
+ other states.
 
- @return The subscription
+ @param subscriptionName The name of the subscription.
+
+ @return An object representing the newly-created subscription.
 
  @see RLMSyncSubscription
 */
@@ -173,14 +194,17 @@ typedef NS_ENUM(NSInteger, RLMSyncSubscriptionState) {
  performing the same subscription twice followed by removing it once will
  result in no subscription existing.
 
+ The newly created subscription will not be reported by
+ `-[RLMRealm subscriptions]` or `-[RLMRealm subscriptionWithName:]` until
+ `state` has transitioned from `RLMSyncSubscriptionStateCreating` to any of the
+ other states.
+
  The number of top-level matches may optionally be limited. This limit
  respects the sort and distinct order of the query being subscribed to,
  if any. Please note that the limit does not count or apply to objects
  which are added indirectly due to being linked to by the objects in the
  subscription. If the limit is larger than the number of objects which
- match the query, all objects will be included. Limiting a subscription
- requires ROS 3.10.1 or newer, and will fail with an invalid predicate
- error with older versions.
+ match the query, all objects will be included.
 
  @param subscriptionName The name of the subscription
  @param limit The maximum number of objects to include in the subscription.
@@ -190,6 +214,38 @@ typedef NS_ENUM(NSInteger, RLMSyncSubscriptionState) {
  @see RLMSyncSubscription
  */
 - (RLMSyncSubscription *)subscribeWithName:(nullable NSString *)subscriptionName limit:(NSUInteger)limit;
+@end
+
+@interface RLMRealm (SyncSubscription)
+/**
+ Get a list of the query-based sync subscriptions made for this Realm.
+
+ This list includes all subscriptions which are currently in the states `Pending`,
+ `Created`, and `Error`. Newly created subscriptions which are still in the
+ `Creating` state are not included, and calling this immediately after calling
+ `-[RLMResults subscribe]` will typically not include that subscription. Similarly,
+ because unsubscription happens asynchronously, this may continue to include
+ subscriptions after `-[RLMSyncSubscription unsubscribe]` is called on them.
+
+ This method can only be called on a Realm which is using query-based sync and
+ will throw an exception if called on a non-synchronized or full-sync Realm.
+ */
+- (RLMResults<RLMSyncSubscription *> *)subscriptions;
+
+/**
+ Look up a specific query-based sync subscription by name.
+
+ Subscriptions are created asynchronously, so calling this immediately after
+ calling `subscribeWithName:` on a `RLMResults` will typically return `nil`.
+ Only subscriptions which are currently in the states `Pending`, `Created`,
+ and `Error` can be retrieved with this method.
+
+ This method can only be called on a Realm which is using query-based sync and
+ will throw an exception if called on a non-synchronized or full-sync Realm.
+
+ @return The named subscription, or `nil` if no subscription exists with that name.
+ */
+- (nullable RLMSyncSubscription *)subscriptionWithName:(NSString *)name;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Realm/RLMSyncSubscription.h
+++ b/Realm/RLMSyncSubscription.h
@@ -216,6 +216,9 @@ typedef NS_ENUM(NSInteger, RLMSyncSubscriptionState) {
 - (RLMSyncSubscription *)subscribeWithName:(nullable NSString *)subscriptionName limit:(NSUInteger)limit;
 @end
 
+/**
+ Support for managing existing subscriptions to object queries in a Realm.
+ */
 @interface RLMRealm (SyncSubscription)
 /**
  Get a list of the query-based sync subscriptions made for this Realm.

--- a/Realm/RLMSyncSubscription.mm
+++ b/Realm/RLMSyncSubscription.mm
@@ -18,38 +18,144 @@
 
 #import "RLMSyncSubscription.h"
 
+#import "RLMObjectSchema_Private.hpp"
+#import "RLMObject_Private.hpp"
+#import "RLMProperty_Private.hpp"
 #import "RLMRealm_Private.hpp"
 #import "RLMResults_Private.hpp"
 #import "RLMUtil.hpp"
 
+#import "object_store.hpp"
 #import "sync/partial_sync.hpp"
 
 using namespace realm;
 
 @interface RLMSyncSubscription ()
-- (instancetype)initWithName:(NSString *)name results:(Results const&)results realm:(RLMRealm *)realm;
-
 @property (nonatomic, readwrite) RLMSyncSubscriptionState state;
 @property (nonatomic, readwrite, nullable) NSError *error;
 @end
 
 @implementation RLMSyncSubscription {
+    @public
+    NSString *_name;
+}
+
+- (instancetype)initPrivate {
+    return (self = [super init]);
+}
+
+- (void)unsubscribe {
+    __builtin_unreachable();
+}
+@end
+
+@interface RLMSyncSubscriptionObject : RLMObjectBase
+@end
+@implementation RLMSyncSubscriptionObject {
+    util::Optional<NotificationToken> _token;
+    Object _obj;
+}
+
+- (NSString *)name {
+    return _row.is_attached() ? RLMStringDataToNSString(_row.get_string(_row.get_column_index("name"))) : nil;
+}
+
+- (RLMSyncSubscriptionState)state {
+    if (!_row.is_attached()) {
+        return RLMSyncSubscriptionStateInvalidated;
+    }
+    return (RLMSyncSubscriptionState)_row.get_int(_row.get_column_index("status"));
+}
+
+- (NSError *)error {
+    if (!_row.is_attached()) {
+        return nil;
+    }
+    StringData err = _row.get_string(_row.get_column_index("error_message"));
+    if (!err.size()) {
+        return nil;
+    }
+    return [NSError errorWithDomain:RLMErrorDomain
+                               code:RLMErrorFail
+                           userInfo:@{NSLocalizedDescriptionKey: RLMStringDataToNSString(err)}];
+}
+
+- (NSString *)descriptionWithMaxDepth:(NSUInteger)depth {
+    if (depth == 0) {
+        return @"<Maximum depth exceeded>";
+    }
+
+    auto objectType = _row.get_string(_row.get_column_index("matches_property"));
+    objectType = objectType.substr(0, objectType.size() - strlen("_matches"));
+    return [NSString stringWithFormat:@"RLMSyncSubscription {\n\tname = %@\n\tobjectType = %@\n\tquery = %@\n\tstatus = %@\n\terror = %@\n}",
+            self.name, RLMStringDataToNSString(objectType),
+            RLMStringDataToNSString(_row.get_string(_row.get_column_index("query"))),
+            @(self.state), self.error];
+}
+
+- (void)unsubscribe {
+    if (_row) {
+        partial_sync::unsubscribe(Object(_realm->_realm, *_info->objectSchema, _row));
+    }
+}
+
+- (void)addObserver:(id)observer
+         forKeyPath:(NSString *)keyPath
+            options:(NSKeyValueObservingOptions)options
+            context:(void *)context {
+    // Make the `state` property observable by using an object notifier to
+    // trigger changes. The normal KVO mechanisms don't work for this class due
+    // to it not being a normal part of the schema.
+    if (!_token) {
+        struct {
+            __weak RLMSyncSubscriptionObject *weakSelf;
+
+            void before(realm::CollectionChangeSet const&) {
+                @autoreleasepool {
+                    [weakSelf willChangeValueForKey:@"state"];
+                }
+            }
+
+            void after(realm::CollectionChangeSet const&) {
+                @autoreleasepool {
+                    [weakSelf didChangeValueForKey:@"state"];
+                }
+            }
+
+            void error(std::exception_ptr) {}
+        } callback{self};
+        _obj = Object(_realm->_realm, *_info->objectSchema, _row);
+        _token = _obj.add_notification_callback(callback);
+    }
+    [super addObserver:observer forKeyPath:keyPath options:options context:context];
+}
+@end
+
+@interface RLMNewSyncSubscription : RLMSyncSubscription
+@end
+
+@implementation RLMNewSyncSubscription {
     partial_sync::SubscriptionNotificationToken _token;
     util::Optional<partial_sync::Subscription> _subscription;
     RLMRealm *_realm;
 }
 
 - (instancetype)initWithName:(NSString *)name results:(Results const&)results realm:(RLMRealm *)realm {
-    if (!(self = [super init]))
+    if (!(self = [super initPrivate]))
         return nil;
 
     _name = [name copy];
     _realm = realm;
-    _subscription = partial_sync::subscribe(results, name ? util::make_optional<std::string>(name.UTF8String) : util::none);
+    try {
+        _subscription = partial_sync::subscribe(results, name ? util::make_optional<std::string>(name.UTF8String) : util::none);
+    }
+    catch (std::exception const& e) {
+        @throw RLMException(e);
+    }
     self.state = (RLMSyncSubscriptionState)_subscription->state();
-    __weak RLMSyncSubscription *weakSelf = self;
+    __weak auto weakSelf = self;
     _token = _subscription->add_notification_callback([weakSelf] {
-        RLMSyncSubscription *self = weakSelf;
+        auto self = weakSelf;
         if (!self)
             return;
 
@@ -71,8 +177,19 @@ using namespace realm;
         }
 
         auto status = (RLMSyncSubscriptionState)self->_subscription->state();
-        if (status != self.state)
-            self.state = (RLMSyncSubscriptionState)status;
+        if (status != self.state) {
+            if (status == RLMSyncSubscriptionStateCreating) {
+                // If a subscription is deleted without going through this
+                // object's unsubscribe() method the subscription will transition
+                // back to Creating rather than Invalidated since it doesn't
+                // have a good way to track that it previously existed
+                if (self.state != RLMSyncSubscriptionStateInvalidated)
+                    self.state = RLMSyncSubscriptionStateInvalidated;
+            }
+            else {
+                self.state = status;
+            }
+        }
     });
 
     return self;
@@ -83,18 +200,89 @@ using namespace realm;
 }
 @end
 
-@implementation RLMResults (SyncSubscription)
+// RLMClassInfo stores pointers into the schema rather than owning the objects
+// it points to, so for a ClassInfo that's not part of the schema we need a
+// wrapper object that owns them
+RLMResultsSetInfo::RLMResultsSetInfo(__unsafe_unretained RLMRealm *const realm)
+: osObjectSchema(ObjectSchema(realm->_realm->read_group(), partial_sync::result_sets_type_name))
+, rlmObjectSchema([RLMObjectSchema objectSchemaForObjectStoreSchema:osObjectSchema])
+, info(realm, rlmObjectSchema, &osObjectSchema)
+{
+    rlmObjectSchema.accessorClass = [RLMSyncSubscriptionObject class];
+}
 
+RLMClassInfo& RLMResultsSetInfo::get(__unsafe_unretained RLMRealm *const realm) {
+    if (!realm->_resultsSetInfo) {
+        realm->_resultsSetInfo = std::make_unique<RLMResultsSetInfo>(realm);
+    }
+    return realm->_resultsSetInfo->info;
+}
+
+@interface RLMSubscriptionResults : RLMResults
+@end
+
+@implementation RLMSubscriptionResults
++ (instancetype)resultsWithRealm:(RLMRealm *)realm {
+    auto table = ObjectStore::table_for_object_type(realm->_realm->read_group(), partial_sync::result_sets_type_name);
+    if (!table) {
+        @throw RLMException(@"-[RLMRealm subscriptions] can only be called on a Realm using query-based sync");
+    }
+    // The server automatically adds a few subscriptions for the permissions
+    // types which we want to hide. They're just an implementation detail and
+    // deleting them won't work out well for the user.
+    auto query = table->where().ends_with(table->get_column_index("matches_property"), "_matches");
+    return [self resultsWithObjectInfo:RLMResultsSetInfo::get(realm)
+                               results:Results(realm->_realm, std::move(query))];
+}
+
+// These operations require a valid schema for the type. It's unclear how they
+// would be useful so it's probably not worth fixing this.
+- (RLMResults *)sortedResultsUsingDescriptors:(__unused NSArray<RLMSortDescriptor *> *)properties {
+    @throw RLMException(@"Sorting subscription results is currently not implemented");
+}
+
+- (RLMResults *)distinctResultsUsingKeyPaths:(__unused NSArray<NSString *> *)keyPaths {
+    @throw RLMException(@"Distincting subscription results is currently not implemented");
+}
+@end
+
+@implementation RLMResults (SyncSubscription)
 - (RLMSyncSubscription *)subscribe {
-    return [[RLMSyncSubscription alloc] initWithName:nil results:_results realm:self.realm];
+    return [[RLMNewSyncSubscription alloc] initWithName:nil results:_results realm:self.realm];
 }
 
 - (RLMSyncSubscription *)subscribeWithName:(NSString *)subscriptionName {
-    return [[RLMSyncSubscription alloc] initWithName:subscriptionName results:_results realm:self.realm];
+    return [[RLMNewSyncSubscription alloc] initWithName:subscriptionName results:_results realm:self.realm];
 }
 
 - (RLMSyncSubscription *)subscribeWithName:(NSString *)subscriptionName limit:(NSUInteger)limit {
-    return [[RLMSyncSubscription alloc] initWithName:subscriptionName results:_results.limit(limit) realm:self.realm];
+    return [[RLMNewSyncSubscription alloc] initWithName:subscriptionName results:_results.limit(limit) realm:self.realm];
+}
+@end
+
+@implementation RLMRealm (SyncSubscription)
+- (RLMResults<RLMSyncSubscription *> *)subscriptions {
+    [self verifyThread];
+    return [RLMSubscriptionResults resultsWithRealm:self];
 }
 
+- (nullable RLMSyncSubscription *)subscriptionWithName:(NSString *)name {
+    [self verifyThread];
+    auto& info = RLMResultsSetInfo::get(self);
+    if (!info.table()) {
+        @throw RLMException(@"-[RLMRealm subcriptionWithName:] can only be called on a Realm using query-based sync");
+    }
+    auto row = info.table()->find_first(info.table()->get_column_index("name"),
+                                        RLMStringDataWithNSString(name));
+    if (row == npos) {
+        return nil;
+    }
+    RLMObjectBase *acc = RLMCreateManagedAccessor(info.rlmObjectSchema.accessorClass, self, &info);
+    acc->_row = info.table()->get(row);
+    return (RLMSyncSubscription *)acc;
+}
 @end
+
+RLMSyncSubscription *RLMCastToSyncSubscription(id obj) {
+    return obj;
+}

--- a/RealmSwift/Sync.swift
+++ b/RealmSwift/Sync.swift
@@ -913,6 +913,10 @@ public class SyncSubscription<T: RealmCollectionValue>: RealmCollectionValue {
         self.rlmSubscription = rlmSubscription
     }
 
+    public static func == (lhs: SyncSubscription, rhs: SyncSubscription) -> Bool {
+        return lhs.rlmSubscription == rhs.rlmSubscription
+    }
+
 // Partial sync subscriptions are only observable in Swift 3.2 and newer.
 #if swift(>=3.2)
 

--- a/RealmSwift/Sync.swift
+++ b/RealmSwift/Sync.swift
@@ -844,10 +844,6 @@ extension Results where Element == SyncPermission {
 
 // MARK: - Partial sync subscriptions
 
-// Partial sync subscriptions are only available in Swift 3.2 and newer.
-#if swift(>=3.2)
-
-
 /// The possible states of a sync subscription.
 public enum SyncSubscriptionState: Equatable {
     /// The subscription is being created, but has not yet been written to the synced Realm.
@@ -902,7 +898,7 @@ public enum SyncSubscriptionState: Equatable {
 /// Changes to the state of the subscription can be observed using `SyncSubscription.observe(_:options:_:)`.
 ///
 /// Subscriptions are created using `Results.subscribe()` or `Results.subscribe(named:)`.
-public class SyncSubscription<Type: RealmCollectionValue> {
+public class SyncSubscription<T: RealmCollectionValue>: RealmCollectionValue {
     private let rlmSubscription: RLMSyncSubscription
 
     /// The name of the subscription.
@@ -916,6 +912,9 @@ public class SyncSubscription<Type: RealmCollectionValue> {
     internal init(_ rlmSubscription: RLMSyncSubscription) {
         self.rlmSubscription = rlmSubscription
     }
+
+// Partial sync subscriptions are only observable in Swift 3.2 and newer.
+#if swift(>=3.2)
 
     /// Observe the subscription for state changes.
     ///
@@ -940,6 +939,8 @@ public class SyncSubscription<Type: RealmCollectionValue> {
         }
         return KeyValueObservationNotificationToken(observation)
     }
+
+#endif // Swift >= 3.2
 
     /// Remove this subscription
     ///
@@ -974,9 +975,12 @@ extension Results {
     /// if any. Please note that the limit does not count or apply to objects
     /// which are added indirectly due to being linked to by the objects in the
     /// subscription. If the limit is larger than the number of objects which
-    /// match the query, all objects will be included. Limiting a subscription
-    /// requires ROS 3.10.1 or newer, and will fail with an invalid predicate
-    /// error with older versions.
+    /// match the query, all objects will be included.
+    ///
+    /// Creating a subscription is an asynchronous operation and the newly
+    /// created subscription will not be reported by Realm.subscriptions() until
+    /// it has transitioned from the `.creating` state to `.pending`,
+    /// `.created` or `.error`.
     ///
     /// - parameter subscriptionName: An optional name for the subscription.
     /// - parameter limit: The maximum number of objects to include in the subscription.
@@ -992,6 +996,7 @@ extension Results {
     }
 }
 
+#if swift(>=3.2)
 internal class KeyValueObservationNotificationToken: NotificationToken {
     public var observation: NSKeyValueObservation?
 
@@ -1393,7 +1398,8 @@ extension Realm {
     operation is permitted but the server will still reject it if permission is
     revoked before the changes have been integrated on the server.
 
-    Non-synchronized Realms always have permission to perform all operations.
+    Non-synchronized and fully-synchronized Realms always have permission to
+    perform all operations.
 
      - returns: The privileges which the current user has for the current Realm.
      */
@@ -1413,7 +1419,8 @@ extension Realm {
     operation is permitted but the server will still reject it if permission is
     revoked before the changes have been integrated on the server.
 
-    Non-synchronized Realms always have permission to perform all operations.
+    Non-synchronized and fully-synchronized Realms always have permission to
+    perform all operations.
 
     The object must be a valid object managed by this Realm. Passing in an
     invalidated object, an unmanaged object, or an object managed by a
@@ -1438,7 +1445,8 @@ extension Realm {
     operation is permitted but the server will still reject it if permission is
     revoked before the changes have been integrated on the server.
 
-    Non-synchronized Realms always have permission to perform all operations.
+    Non-synchronized and fully-synchronized Realms always have permission to
+    perform all operations.
 
      - parameter cls: An Object subclass to get the privileges for.
      - returns: The privileges which the current user has for the given class.
@@ -1459,7 +1467,8 @@ extension Realm {
     operation is permitted but the server will still reject it if permission is
     revoked before the changes have been integrated on the server.
 
-    Non-synchronized Realms always have permission to perform all operations.
+    Non-synchronized and fully-synchronized Realms always have permission to
+    perform all operations.
 
      - parameter className: The name of an Object subclass to get the privileges for.
      - returns: The privileges which the current user has for the named class.
@@ -1473,7 +1482,7 @@ extension Realm {
 
      - parameter cls: An Object subclass to get the permissions for.
      - returns: The class-wide permissions for the given class.
-     - requires: This must only be called on a partially-synced Realm.
+     - requires: This must only be called on a Realm using query-based sync.
     */
     public func permissions<T: Object>(forType cls: T.Type) -> List<Permission> {
         return permissions(forClassNamed: cls._realmObjectName() ?? cls.className())
@@ -1485,7 +1494,7 @@ extension Realm {
      - parameter cls: The name of an Object subclass to get the permissions for.
      - returns: The class-wide permissions for the named class.
      - requires: className must name a class in this Realm's schema.
-     - requires: This must only be called on a partially-synced Realm.
+     - requires: This must only be called on a Realm using query-based sync.
     */
     public func permissions(forClassNamed className: String) -> List<Permission> {
         let classPermission = object(ofType: ClassPermission.self, forPrimaryKey: className)!
@@ -1495,10 +1504,41 @@ extension Realm {
     /**
     Returns the Realm-wide permissions.
 
-     - requires: This must only be called on a partially-synced Realm.
+     - requires: This must only be called on a Realm using query-based sync.
     */
     public var permissions: List<Permission> {
         return object(ofType: RealmPermission.self, forPrimaryKey: 0)!.permissions
+    }
+
+    /**
+    Returns this list of the query-based sync subscriptions made for this Realm.
+
+    This list includes all subscriptions which are currently in the states
+    `.pending`, `.created`, and `.error`. Newly created subscriptions which are
+    still in the `.creating` state are not included, and calling this
+    immediately after calling `Results.subscribe()` will typically not include
+    that subscription. Similarly, because unsubscription happens asynchronously,
+    this may continue to include subscriptions after
+    `SyncSubscription.unsubscribe()` is called on them.
+
+     - requires: This must only be called on a Realm using query-based sync.
+    */
+    public func subscriptions() -> Results<SyncSubscription<Object>> {
+        return Results(rlmRealm.subscriptions() as! RLMResults<AnyObject>)
+    }
+
+    /**
+    Returns the named query-based sync subscription, if it exists.
+
+    Subscriptions are created asynchronously, so calling this immediately after
+    calling Results.subscribe(named:)` will typically return `nil`. Only
+    subscriptions which are currently in the states `.pending`, `.created`,
+    and `.error` can be retrieved with this method.
+
+     - requires: This must only be called on a Realm using query-based sync.
+    */
+    public func subscription(named: String) -> SyncSubscription<Object>? {
+        return rlmRealm.subscription(withName: named).map(SyncSubscription.init)
     }
 }
 

--- a/RealmSwift/Util.swift
+++ b/RealmSwift/Util.swift
@@ -83,13 +83,19 @@ extension Object {
 
 // MARK: CustomObjectiveCBridgeable
 
+fileprivate extension SyncSubscription {
+    fileprivate convenience init(_ rlmSubscription: Any) {
+        self.init(RLMCastToSyncSubscription(rlmSubscription as AnyObject))
+    }
+}
+
 internal func dynamicBridgeCast<T>(fromObjectiveC x: Any) -> T {
     if T.self == DynamicObject.self {
         return unsafeBitCast(x as AnyObject, to: T.self)
     } else if let bridgeableType = T.self as? CustomObjectiveCBridgeable.Type {
         return bridgeableType.bridging(objCValue: x) as! T
     } else if T.self == SyncSubscription<Object>.self {
-        return SyncSubscription<Object>(RLMCastToSyncSubscription(x as AnyObject)) as! T
+        return SyncSubscription<Object>(x) as! T
     } else {
         return x as! T
     }

--- a/RealmSwift/Util.swift
+++ b/RealmSwift/Util.swift
@@ -88,6 +88,8 @@ internal func dynamicBridgeCast<T>(fromObjectiveC x: Any) -> T {
         return unsafeBitCast(x as AnyObject, to: T.self)
     } else if let bridgeableType = T.self as? CustomObjectiveCBridgeable.Type {
         return bridgeableType.bridging(objCValue: x) as! T
+    } else if T.self == SyncSubscription<Object>.self {
+        return SyncSubscription<Object>(RLMCastToSyncSubscription(x as AnyObject)) as! T
     } else {
         return x as! T
     }

--- a/build.sh
+++ b/build.sh
@@ -1055,7 +1055,7 @@ EOM
         else
             export sha=$GITHUB_PR_SOURCE_BRANCH
             export CONFIGURATION=$configuration
-            export REALM_EXTRA_BUILD_ARGUMENTS='GCC_GENERATE_DEBUGGING_SYMBOLS=NO'
+            export REALM_EXTRA_BUILD_ARGUMENTS='GCC_GENERATE_DEBUGGING_SYMBOLS=NO -allowProvisioningUpdates'
             sh build.sh prelaunch-simulator
 
             source $(brew --prefix nvm)/nvm.sh


### PR DESCRIPTION
This adds `-[RLMRealm subscriptions]` which returns a `RLMResults` of subscriptions and `-[RLMRealm subscriptionWithName:]` to look up a specific subscription, along with Swift wrappers for these. Rather than having a special thing using LIKE syntax as JS has, the `RLMResults` is simply filterable like any other collection.

The implementation of this is made awkward by that we already have a RLMSyncSubscription type that's not an RLMObject and doesn't behave like an RLMObject. Fortunately, obj-c is sufficiently dynamic that we can sometimes return the existing objectstore `Subscription`-backed type and sometimes return a new `RLMObjectBase`-backed type and have them behave (hopefully) identically.

Closes #6010.