### PR TITLE
Add Realm module map generation

### DIFF
--- a/Realm.podspec
+++ b/Realm.podspec
@@ -89,7 +89,7 @@ Pod::Spec.new do |s|
   s.pod_target_xcconfig     = { 'APPLICATION_EXTENSION_API_ONLY' => 'YES',
                                 'CLANG_CXX_LANGUAGE_STANDARD' => 'c++14',
                                 'CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF' => 'NO',
-                                'DEFINES_MODULE' => 'YES'
+                                'DEFINES_MODULE' => 'YES',
                                 'OTHER_CPLUSPLUSFLAGS' => '-isystem "${PODS_ROOT}/Realm/include/core" -fvisibility-inlines-hidden',
                                 'USER_HEADER_SEARCH_PATHS' => '"${PODS_ROOT}/Realm/include" "${PODS_ROOT}/Realm/include/Realm"',
                               }


### PR DESCRIPTION
**Goal**
Allow RealmSwift to be added as a static library via Cocoapods.

**Workarounds**
1. Add `use_modular_headers!` to the Podfile.
2. Add `pod 'Realm', :modular_headers => true` to the Podfile.

**Additional Reading**
[CocoaPods 1.5.0 - Swift Static Libraries :: *Modular Headers*](http://blog.cocoapods.org/CocoaPods-1.5.0/#modular-headers)

**Issue**
https://github.com/realm/realm-cocoa/issues/6042