### PR TITLE
Fix a crash when iterating over the results of Realm.subscriptions()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,14 +5,15 @@ x.y.z Release notes (yyyy-MM-dd)
 
 ### Fixed
 * Fix a crash when iterating over `Realm.subscriptions()` using for-in.
-  (Since 3.13.0, PR: https://github.com/realm/realm-cocoa/pull/6050).
-
-<!-- ### Breaking Changes - ONLY INCLUDE FOR NEW MAJOR version -->
+  (Since 3.13.0, PR [#6050](https://github.com/realm/realm-cocoa/pull/6050)).
 
 ### Compatibility
 * File format: Generates Realms with format v9 (Reads and upgrades all previous formats)
 * Realm Object Server: 3.11.0 or later.
 * APIs are backwards compatible with all previous releases in the 3.x.y series.
+
+### Internal
+* None.
 
 3.13.0 Release notes (2018-12-14)
 =============================================================

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+x.y.z Release notes (yyyy-MM-dd)
+=============================================================
+### Enhancements
+* None.
+
+### Fixed
+* Fix a crash when iterating over `Realm.subscriptions()` using for-in.
+  (Since 3.13.0, PR: https://github.com/realm/realm-cocoa/pull/6050).
+
+<!-- ### Breaking Changes - ONLY INCLUDE FOR NEW MAJOR version -->
+
+### Compatibility
+* File format: Generates Realms with format v9 (Reads and upgrades all previous formats)
+* Realm Object Server: 3.11.0 or later.
+* APIs are backwards compatible with all previous releases in the 3.x.y series.
+
 3.13.0 Release notes (2018-12-14)
 =============================================================
 

--- a/Realm/ObjectServerTests/SwiftObjectServerTests.swift
+++ b/Realm/ObjectServerTests/SwiftObjectServerTests.swift
@@ -557,6 +557,10 @@ class SwiftObjectServerTests: SwiftSyncTestCase {
         let sub3 = realm.subscription(named: "query")!
         XCTAssertEqual(sub3.name, "query")
         XCTAssertEqual(sub3.state, .complete)
+        for sub in realm.subscriptions() {
+            XCTAssertEqual(sub.name, "query")
+            XCTAssertEqual(sub.state, .complete)
+        }
 
         XCTAssertNil(realm.subscription(named: "not query"))
     }

--- a/RealmSwift/RealmCollection.swift
+++ b/RealmSwift/RealmCollection.swift
@@ -43,7 +43,7 @@ public struct RLMIterator<Element: RealmCollectionValue>: IteratorProtocol {
             }
             return unsafeBitCast(next, to: Optional<Element>.self)
         }
-        return next as! Element?
+        return dynamicBridgeCast(fromObjectiveC: next as Any)
     }
 }
 


### PR DESCRIPTION
RLMIterator needs to use dynamicBridgeCast like all of the Results getters do to support SyncSubscription.