### PR TITLE
Fix a memory leak on each HTTP request made to ROS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+x.y.z Release notes (yyyy-MM-dd)
+=============================================================
+### Enhancements
+* None.
+
+### Fixed
+* Fix a memory leak whenever Realm makes a HTTP(s) request to the Realm Object
+  Server (since 3.8.0, Issue [#6058](https://github.com/realm/realm-cocoa/issues/6058)).
+
+### Compatibility
+* File format: Generates Realms with format v9 (Reads and upgrades all previous formats)
+* Realm Object Server: 3.11.0 or later.
+* APIs are backwards compatible with all previous releases in the 3.x.y series.
+
 3.13.1 Release notes (2019-01-03)
 =============================================================
 

--- a/Realm/RLMNetworkClient.mm
+++ b/Realm/RLMNetworkClient.mm
@@ -425,6 +425,8 @@ didCompleteWithError:(NSError *)error
 
     // Add the request to a task and start it
     [[session dataTaskWithRequest:request] resume];
+    // Tell the session to destroy itself once it's done with the request
+    [session finishTasksAndInvalidate];
 }
 @end
 


### PR DESCRIPTION
By default NSURLSession will keep itself alive indefinitely, and has to be explicitly told to delete itself after it completes all enqueued tasks.

Fixes #6058.