### PR TITLE
Improved build.sh to download deps from another url

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -330,8 +330,7 @@ download_common() {
         exit 1
     fi
 
-    echo "LOOK OVER HERE: ${url}"
-    echo "Downloading dependency: ${download_type} ${version}"
+    echo "Downloading dependency: ${download_type} ${version} from ${url}"
 
     if [ -z "$TMPDIR" ]; then
         TMPDIR='/tmp'

--- a/build.sh
+++ b/build.sh
@@ -16,6 +16,8 @@ set -e
 source_root="$(dirname "$0")"
 
 # You can override the version of the core library
+: ${REALM_BASE_URL:="https://static.realm.io/downloads"} # set it if you need to use a remote repo
+
 : ${REALM_CORE_VERSION:=$(sed -n 's/^REALM_CORE_VERSION=\(.*\)$/\1/p' ${source_root}/dependencies.list)} # set to "current" to always use the current build
 
 : ${REALM_SYNC_VERSION:=$(sed -n 's/^REALM_SYNC_VERSION=\(.*\)$/\1/p' ${source_root}/dependencies.list)}
@@ -319,15 +321,16 @@ download_common() {
 
     if [ "$download_type" == "core" ]; then
         version=$REALM_CORE_VERSION
-        url="https://static.realm.io/downloads/core/realm-core-${version}.tar.xz"
+        url="${REALM_BASE_URL}/core/realm-core-${version}.tar.xz"
     elif [ "$download_type" == "sync" ]; then
         version=$REALM_SYNC_VERSION
-        url="https://static.realm.io/downloads/sync/realm-sync-cocoa-${version}.tar.xz"
+        url="${REALM_BASE_URL}/sync/realm-sync-cocoa-${version}.tar.xz"
     else
         echo "Unknown dowload_type: $download_type"
         exit 1
     fi
 
+    echo "LOOK OVER HERE: ${url}"
     echo "Downloading dependency: ${download_type} ${version}"
 
     if [ -z "$TMPDIR" ]; then


### PR DESCRIPTION
Hi,

as the title says, I edited the script [build.sh](https://github.com/realm/realm-cocoa/blob/4cbcb75f1bc82536b23e7fa40c643b27dfc6a761/build.sh) to use an local environment variable (`REALM_BASE_URL`) with which you can set another URL (like a mirror).

I made this beacuse I maintain an iOS continuous delivery infrastructure (with centralized build using cocoapods) where internet access isn't enabled.

Usage example:
```bash
REALM_BASE_URL="http://foo.bar" sh build.sh cocoapods-setup
```

By default, `REALM_BASE_URL` is set to `"https://static.realm.io/downloads"`.

Regards,
Luke