### PR TITLE
Package a valid obj-c header for Swift 5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,21 @@
+x.y.z Release notes (yyyy-MM-dd)
+=============================================================
+### Enhancements
+* None.
+
+### Fixed
+* <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-js/issues/????), since v?.?.?)
+* Fix "Cannot find interface declaration for 'RealmSwiftObject', superclass of
+  'MyRealmObjectClass'" errors when building for a simulator with Xcode 10.2
+  with "Install Objective-C Compatibility Header" enabled.
+
+<!-- ### Breaking Changes - ONLY INCLUDE FOR NEW MAJOR version -->
+
+### Compatibility
+* File format: Generates Realms with format v9 (Reads and upgrades all previous formats)
+* Realm Object Server: 3.11.0 or later.
+* APIs are backwards compatible with all previous releases in the 3.x.y series.
+
 3.14.0 Release notes (2019-03-27)
 =============================================================
 


### PR DESCRIPTION
Swift 5 has changed how the generated header for fat libraries is assembled to handle the case where it isn't identical on every architecture. However, this doesn't automatically handle simulator+device fat libraries, since those aren't officially supported. Since we use the header from the device build of the library, this resulted in errors like "Cannot find interface declaration for
'RealmSwiftObject', superclass of 'UserDefinedSubclass'" when building for the simulator.

Currently the generated header on every platform is identical so we can just grab one of the platform-specific ones and package that instead of the incompletely merged one. This will probably break at some point in the future, so the build script verifies that this is a safe thing to be doing.

This doesn't touch Carthage packaging because Carthage should be releasing a new version which deals with this problem any day now.

Note that we don't really support using RealmSwift from objective C and this is mostly just to avoid causing problems with using other Swift libraries in the same project.

No issue number in the changelog because people just commented on a bunch of preexisting issues for different problems rather than opening a new one for this.