### PR TITLE
Add support for SwiftPM based dependency managers

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,8 +4,8 @@ import PackageDescription
 let package = Package(
     name: "Realm",
     products: [
-        .library(name: "Realm", targets: ["Realm"])
-        .library(name: "RealmSwift", targets: ["RealmSwift"])
+        .library(name: "Realm", targets: ["Realm"]),
+        .library(name: "RealmSwift", targets: ["RealmSwift"]),
     ],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,21 @@
+// swift-tools-version:4.2
+import PackageDescription
+
+let package = Package(
+    name: "Realm",
+    products: [
+        .library(name: "Realm", targets: ["Realm"])
+        .library(name: "RealmSwift", targets: ["RealmSwift"])
+    ],
+    targets: [
+        .target(
+            name: "Realm",
+            path: "Realm"
+        ),
+        .target(
+            name: "RealmSwift",
+            dependencies: ["Realm"],
+            path: "RealmSwift"
+        ),
+    ]
+)

--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ let package = Package(
     name: "Realm",
     products: [
         .library(name: "Realm", targets: ["Realm"]),
-        .library(name: "RealmSwift", targets: ["RealmSwift"]),
+        .library(name: "RealmSwift", targets: ["RealmSwift"])
     ],
     targets: [
         .target(
@@ -17,6 +17,6 @@ let package = Package(
             dependencies: ["Realm"],
             path: "RealmSwift",
             exclude: ["Tests"]
-        ),
+        )
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -10,12 +10,13 @@ let package = Package(
     targets: [
         .target(
             name: "Realm",
-            path: "Realm"
+            path: "Realm/Swift"
         ),
         .target(
             name: "RealmSwift",
             dependencies: ["Realm"],
-            path: "RealmSwift"
+            path: "RealmSwift",
+            exclude: ["Tests"]
         ),
     ]
 )


### PR DESCRIPTION
This adds support for SwiftPM manifest based dependency managers. Specifically this adds support for installing via [Accio](https://github.com/JamitLabs/Accio) but will probably also work with SwiftPM once it's integrated into Xcode.

Please note that this project is part of Accio's official [integration tests](https://github.com/JamitLabs/Accio/tree/work/1000-frameworks/Demo/Shared/AppDependencies) within the [Demo project](https://github.com/JamitLabs/Accio/tree/work/1000-frameworks/Demo).

Also, as there is no documentation file in the repo, here's the description on how to install Accio for copy & paste purposes into the official documentation on realm.io:

--- 

## Installation via Accio

Add the following to your `Package.swift`:

```swift
.package(url: "https://github.com/realm/realm-cocoa.git", .upToNextMajor(from: "3.15.0")),
```

Next, if your project uses Swift code, add `RealmSwift` to your App targets dependencies like so:

```swift
.target(
    name: "App",
    dependencies: [
        "RealmSwift",
    ]
),
```

Specifying `RealmSwift` will automatically integrate `Realm` for Objective-C usage, too. If you only need the Objective-C variant of Realm, specify `Realm` in your targets dependencies instead.

Then run `accio update`.