### PR TITLE
Update the request headers for existing sessions when SyncManager.customRequestHeaders is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 x.y.z Release notes (yyyy-MM-dd)
 =============================================================
 ### Enhancements
-* None.
+* Updating `RLMSyncManager.customRequestHeaders` will immediately update all
+  currently active sync session with the new headers rather than requiring
+  manually closing the Realm and reopening it.
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-js/issues/????), since v?.?.?)

--- a/Realm/RLMSyncManager.h
+++ b/Realm/RLMSyncManager.h
@@ -110,6 +110,9 @@ typedef void(^RLMSyncErrorReportingBlock)(NSError *, RLMSyncSession * _Nullable)
 
 /**
  Extra HTTP headers to append to every request to a Realm Object Server.
+
+ Modifying this property while sync sessions are active will result in all
+ sessions disconnecting and reconnecting using the new headers.
  */
 @property (nullable, nonatomic, copy) NSDictionary<NSString *, NSString *> *customRequestHeaders;
 

--- a/Realm/RLMSyncManager.mm
+++ b/Realm/RLMSyncManager.mm
@@ -138,6 +138,21 @@ static RLMSyncManager *s_sharedManager = nil;
     _userAgent = userAgent;
 }
 
+- (void)setCustomRequestHeaders:(NSDictionary<NSString *,NSString *> *)customRequestHeaders {
+    _customRequestHeaders = customRequestHeaders.copy;
+
+    for (auto&& user : SyncManager::shared().all_logged_in_users()) {
+        for (auto&& session : user->all_sessions()) {
+            auto config = session->config();
+            config.custom_http_headers.clear();;
+            for (NSString *key in customRequestHeaders) {
+                config.custom_http_headers.emplace(key.UTF8String, customRequestHeaders[key].UTF8String);
+            }
+            session->update_configuration(std::move(config));
+        }
+    }
+}
+
 #pragma mark - Passthrough properties
 
 - (RLMSyncLogLevel)logLevel {


### PR DESCRIPTION
Requiring users to close and reopen Realms to update the headers doesn't work very well.

Closes https://github.com/realm/realm-object-server-private/issues/1500.