### PR TITLE
Check the runtime type for a primary key in realm.create() rather than the static type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,11 @@ x.y.z Release notes (yyyy-MM-dd)
 * None.
 
 ### Fixed
-* <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-js/issues/????), since v?.?.?)
-* None.
+* The static type passed at compile time to `realm.create()` was checked for a
+  primary key rather than the actual type passed at runtime, resulting in
+  exceptions like "''RealmSwiftObject' does not have a primary key and can not
+  be updated'" being thrown even if the object type being created has a primary
+  key. (since 3.16.0, [#6159](https://github.com/realm/realm-cocoa/issues/6159)).
 
 <!-- ### Breaking Changes - ONLY INCLUDE FOR NEW MAJOR version -->
 

--- a/RealmSwift/Realm.swift
+++ b/RealmSwift/Realm.swift
@@ -460,11 +460,11 @@ public final class Realm {
     @discardableResult
     public func create<T: Object>(_ type: T.Type, value: Any = [:], update: UpdatePolicy = .error) -> T {
         if update != .error {
-            RLMVerifyHasPrimaryKey(T.self)
+            RLMVerifyHasPrimaryKey(type)
         }
         let typeName = (type as Object.Type).className()
         return unsafeDowncast(RLMCreateObjectInRealmWithValue(rlmRealm, typeName, value,
-                                                              RLMUpdatePolicy(rawValue: UInt(update.rawValue))!), to: T.self)
+                                                              RLMUpdatePolicy(rawValue: UInt(update.rawValue))!), to: type)
     }
 
     /**

--- a/RealmSwift/RealmCollection.swift
+++ b/RealmSwift/RealmCollection.swift
@@ -181,7 +181,7 @@ private func arrayType<T>(_ type: T.Type) -> RLMArray<AnyObject> {
     case is String.Type: return RLMArray(objectType: .string, optional: true)
     case is Data.Type:   return RLMArray(objectType: .data, optional: true)
     case is Date.Type:   return RLMArray(objectType: .date, optional: true)
-    default: fatalError("Unsupported type for List: \(T.self)?")
+    default: fatalError("Unsupported type for List: \(type)?")
     }
 }
 

--- a/RealmSwift/Tests/ObjectCreationTests.swift
+++ b/RealmSwift/Tests/ObjectCreationTests.swift
@@ -498,7 +498,6 @@ class ObjectCreationTests: TestCase {
     }
 
     func testCreateWithObjcName() {
-
         let realm = try! Realm()
         try! realm.write {
             let object = realm.create(SwiftObjcRenamedObject.self)
@@ -513,7 +512,6 @@ class ObjectCreationTests: TestCase {
     }
 
     func testCreateWithDifferentObjcName() {
-
         let realm = try! Realm()
         try! realm.write {
             let object = realm.create(SwiftObjcArbitrarilyRenamedObject.self)
@@ -710,6 +708,17 @@ class ObjectCreationTests: TestCase {
         realm.beginWrite()
         _ = realm.create(type(of: managedValue), value: managedValue, update: .modified)
         realm.cancelWrite()
+    }
+
+    func testCreateOrUpdateWithMismatchedStaticAndDynamicTypes() {
+        let realm = try! Realm()
+        let obj: Object = SwiftOptionalPrimaryObject()
+        try! realm.write {
+            let obj2 = realm.create(type(of: obj), value: obj)
+            XCTAssertEqual(obj2.objectSchema.className, "SwiftOptionalPrimaryObject")
+            let obj3 = realm.create(type(of: obj), value: obj, update: .all)
+            XCTAssertEqual(obj3.objectSchema.className, "SwiftOptionalPrimaryObject")
+        }
     }
 
     // test null object


### PR DESCRIPTION
The static type (T) may be a superclass of the type of object we're actually creating, so we need to use the dynamic type passed in rather than that for all checks.

Fixes #6159.