### PR TITLE
Change not to ignore necessary files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,7 @@ core
 core-*
 
 # sync
-sync*
+/sync-*
 
 # sh build.sh config
 /Realm/config.mk


### PR DESCRIPTION
Since .gitignore says it ignores `sync*`, some files in submodules are unexpectedly ignored by Git.

It doesn't matter when we develop `realm-cocoa` itself but once we checkout `realm-cocoa` with Carthage, it matters.

When we checkout `realm-cocoa` with carthage and checkin `Carthage/Checkouts` into VCS, the following files are unexpectedly ignored, therefore `carthage build` will fail.

```
Carthage/Checkouts/realm-cocoa/Realm/ObjectStore/src/sync/impl/apple/network_reachability_observer.cpp
Carthage/Checkouts/realm-cocoa/Realm/ObjectStore/src/sync/impl/apple/network_reachability_observer.hpp
Carthage/Checkouts/realm-cocoa/Realm/ObjectStore/src/sync/impl/apple/system_configuration.cpp
Carthage/Checkouts/realm-cocoa/Realm/ObjectStore/src/sync/impl/apple/system_configuration.hpp
Carthage/Checkouts/realm-cocoa/Realm/ObjectStore/src/sync/impl/network_reachability.hpp
Carthage/Checkouts/realm-cocoa/Realm/ObjectStore/src/sync/impl/sync_client.hpp
Carthage/Checkouts/realm-cocoa/Realm/ObjectStore/src/sync/impl/sync_file.cpp
Carthage/Checkouts/realm-cocoa/Realm/ObjectStore/src/sync/impl/sync_file.hpp
Carthage/Checkouts/realm-cocoa/Realm/ObjectStore/src/sync/impl/sync_metadata.cpp
Carthage/Checkouts/realm-cocoa/Realm/ObjectStore/src/sync/impl/sync_metadata.hpp
Carthage/Checkouts/realm-cocoa/Realm/ObjectStore/src/sync/impl/work_queue.cpp
Carthage/Checkouts/realm-cocoa/Realm/ObjectStore/src/sync/impl/work_queue.hpp
Carthage/Checkouts/realm-cocoa/Realm/ObjectStore/src/sync/partial_sync.cpp
Carthage/Checkouts/realm-cocoa/Realm/ObjectStore/src/sync/partial_sync.hpp
Carthage/Checkouts/realm-cocoa/Realm/ObjectStore/src/sync/subscription_state.hpp
Carthage/Checkouts/realm-cocoa/Realm/ObjectStore/src/sync/sync_config.cpp
Carthage/Checkouts/realm-cocoa/Realm/ObjectStore/src/sync/sync_config.hpp
Carthage/Checkouts/realm-cocoa/Realm/ObjectStore/src/sync/sync_manager.cpp
Carthage/Checkouts/realm-cocoa/Realm/ObjectStore/src/sync/sync_manager.hpp
Carthage/Checkouts/realm-cocoa/Realm/ObjectStore/src/sync/sync_permission.cpp
Carthage/Checkouts/realm-cocoa/Realm/ObjectStore/src/sync/sync_permission.hpp
Carthage/Checkouts/realm-cocoa/Realm/ObjectStore/src/sync/sync_session.cpp
Carthage/Checkouts/realm-cocoa/Realm/ObjectStore/src/sync/sync_session.hpp
Carthage/Checkouts/realm-cocoa/Realm/ObjectStore/src/sync/sync_user.cpp
Carthage/Checkouts/realm-cocoa/Realm/ObjectStore/src/sync/sync_user.hpp
Carthage/Checkouts/realm-cocoa/Realm/ObjectStore/tests/sync/file.cpp
Carthage/Checkouts/realm-cocoa/Realm/ObjectStore/tests/sync/metadata.cpp
Carthage/Checkouts/realm-cocoa/Realm/ObjectStore/tests/sync/partial_sync.cpp
Carthage/Checkouts/realm-cocoa/Realm/ObjectStore/tests/sync/permission.cpp
Carthage/Checkouts/realm-cocoa/Realm/ObjectStore/tests/sync/session/connection_change_notifications.cpp
Carthage/Checkouts/realm-cocoa/Realm/ObjectStore/tests/sync/session/progress_notifications.cpp
Carthage/Checkouts/realm-cocoa/Realm/ObjectStore/tests/sync/session/session.cpp
Carthage/Checkouts/realm-cocoa/Realm/ObjectStore/tests/sync/session/session_util.hpp
Carthage/Checkouts/realm-cocoa/Realm/ObjectStore/tests/sync/session/wait_for_completion.cpp
Carthage/Checkouts/realm-cocoa/Realm/ObjectStore/tests/sync/sync_manager.cpp
Carthage/Checkouts/realm-cocoa/Realm/ObjectStore/tests/sync/sync_test_utils.cpp
Carthage/Checkouts/realm-cocoa/Realm/ObjectStore/tests/sync/sync_test_utils.hpp
Carthage/Checkouts/realm-cocoa/Realm/ObjectStore/tests/sync/user.cpp
Carthage/Checkouts/realm-cocoa/RealmSwift/Sync.swift
```

FYI Carthage says we can include `Carthage/Checkouts/` under VCS if needed.
> https://github.com/Carthage/Carthage/blob/83bbffd25172df767cf578ca17b0cfbbbf913d35/Documentation/Artifacts.md#carthagecheckouts
> You are not required to commit this folder to your repository, but you may wish to, if you want to guarantee that the source checkouts of each dependency will always be accessible at a later date.