### PR TITLE
Ensure we get permission objects when using asyncOpen on a query-based Realm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,12 @@ x.y.z Release notes (yyyy-MM-dd)
   ([PR #6164](https://github.com/realm/realm-cocoa/pull/6164)).
 
 ### Fixed
-* <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-js/issues/????), since v?.?.?)
-* None.
+* Using asyncOpen on query-based Realms which didn't already exist on the local
+  device would fail with error 214.
+  ([#6178](https://github.com/realm/realm-cocoa/issues/6178), since 3.16.0).
+* asyncOpen on query-based Realms did not wait for the server-created
+  permission objects to be downloaded, resulting in crashes if modifications to
+  the permissions were made before creating a subscription for the first time (since 3.0.0).
 
 <!-- ### Breaking Changes - ONLY INCLUDE FOR NEW MAJOR version -->
 

--- a/Realm/RLMRealm.mm
+++ b/Realm/RLMRealm.mm
@@ -183,34 +183,71 @@ NSData *RLMRealmValidatedEncryptionKey(NSData *key) {
     return [RLMRealm realmWithConfiguration:configuration error:nil];
 }
 
+// The server doesn't send us the subscriptions for permission types until the
+// first subscription is created. This is fine for synchronous opens (if we're
+// creating a new Realm we create the permission objects ourselves), but it
+// causes issues for asyncOpen because it means that when our download completes
+// we don't actually have the full Realm state yet.
+static void waitForPartialSyncSubscriptions(Realm::Config const& config) {
+    auto realm = Realm::get_shared_realm(config);
+    auto table = ObjectStore::table_for_object_type(realm->read_group(), "__ResultSets");
+
+    realm->begin_transaction();
+    realm::sync::create_object(realm->read_group(), *table);
+    realm->commit_transaction();
+
+    NotificationToken token;
+    Results results(realm, *table);
+    CFRunLoopRef runLoop = CFRunLoopGetCurrent();
+    CFRunLoopPerformBlock(runLoop, kCFRunLoopDefaultMode, [&]() mutable {
+        token = results.add_notification_callback([&](CollectionChangeSet const&, std::exception_ptr) mutable {
+            if (table->size() > 1) {
+                token = {};
+                CFRunLoopStop(runLoop);
+            }
+        });
+    });
+    CFRunLoopRun();
+}
+
 + (void)asyncOpenWithConfiguration:(RLMRealmConfiguration *)configuration
                      callbackQueue:(dispatch_queue_t)callbackQueue
                           callback:(RLMAsyncOpenRealmCallback)callback {
     static dispatch_queue_t queue = dispatch_queue_create("io.realm.asyncOpenDispatchQueue", DISPATCH_QUEUE_CONCURRENT);
+    auto openCompletion = [=](std::shared_ptr<Realm> realm, std::exception_ptr err) {
+        @autoreleasepool {
+            if (!realm) {
+                try {
+                    std::rethrow_exception(err);
+                }
+                catch (...) {
+                    NSError *error;
+                    RLMRealmTranslateException(&error);
+                    dispatch_async(callbackQueue, ^{
+                        callback(nil, error);
+                    });
+                }
+                return;
+            }
+
+            bool needsSubscriptions = realm->is_partial() && ObjectStore::table_for_object_type(realm->read_group(), "__ResultSets")->size() == 0;
+            dispatch_async(queue, ^{
+                @autoreleasepool {
+                    if (needsSubscriptions) {
+                        waitForPartialSyncSubscriptions(realm->config());
+                    }
+                    NSError *error;
+                    RLMRealm *localRealm = [RLMRealm realmWithConfiguration:configuration error:&error];
+                    callback(localRealm, error);
+                }
+            });
+        }
+    };
+
     dispatch_async(queue, ^{
         @autoreleasepool {
             Realm::Config& config = configuration.config;
-            realm::Realm::get_shared_realm(config, [=](std::shared_ptr<Realm> realm, std::exception_ptr err) {
-                dispatch_async(callbackQueue, ^{
-                    @autoreleasepool {
-                        if (realm) {
-                            NSError *error;
-                            RLMRealm *localRealm = [RLMRealm realmWithConfiguration:configuration error:&error];
-                            callback(localRealm, error);
-                        }
-                        else {
-                            try {
-                                std::rethrow_exception(err);
-                            }
-                            catch (...) {
-                                NSError *error;
-                                RLMRealmTranslateException(&error);
-                                callback(nil, error);
-                            }
-                        }
-                    }
-                });
-            });
+            realm::Realm::get_shared_realm(config, openCompletion);
         }
     });
 }


### PR DESCRIPTION
The server doesn't send us all of the permission objects until the first time we create a subscription on the client. This causes problems when trying to modify permissions immediately after using asyncOpen to open a Realm which doesn't already exist on the client, as we expect permission objects to exist for each of the classes.

Work around this by creating a dummy subscription (that'll never actually get run) if the Realm we get from asyncOpen has zero subscriptions in it.

This maybe should actually be in object store, but I'm not sure if it's actually a problem for any other SDKs and trying to do it now would conflict with https://github.com/realm/realm-object-store/pull/803.

This also pulls in https://github.com/realm/realm-object-store/pull/802 as that's required for asyncOpen to work at all on query-based Realms.