### PR TITLE
Add missing validation for observing unmanaged LinkingObjects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@ x.y.z Release notes (yyyy-MM-dd)
 * None.
 
 ### Fixed
-* <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-js/issues/????), since v?.?.?)
-* None.
+* Attempting to observe an unmanaged LinkingObjects object crashed rather than
+  throwing an approriate exception (since v0.100.0).
 
 <!-- ### Breaking Changes - ONLY INCLUDE FOR NEW MAJOR version -->
 

--- a/Realm/RLMResults.mm
+++ b/Realm/RLMResults.mm
@@ -483,6 +483,9 @@ static inline void RLMResultsValidateInWriteTransaction(__unsafe_unretained RLMR
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wmismatched-parameter-types"
 - (RLMNotificationToken *)addNotificationBlock:(void (^)(RLMResults *, RLMCollectionChange *, NSError *))block {
+    if (!_realm) {
+        @throw RLMException(@"Linking objects notifications are only supported on managed objects.");
+    }
     [_realm verifyNotificationsAreSupported:true];
     return RLMAddNotificationBlock(self, _results, block, true);
 }

--- a/Realm/Tests/LinkingObjectsTests.mm
+++ b/Realm/Tests/LinkingObjectsTests.mm
@@ -82,6 +82,9 @@
     PersonObject *mark = [[PersonObject alloc] initWithValue:@[ @"Mark", @30, @[] ]];
     XCTAssertEqual(NSNotFound, [don.parents indexOfObject:mark]);
     XCTAssertEqual(NSNotFound, [don.parents indexOfObjectWhere:@"TRUEPREDICATE"]);
+
+    RLMAssertThrowsWithReason(([don.parents addNotificationBlock:^(RLMResults *, RLMCollectionChange *, NSError *) { }]),
+                              @"Linking objects notifications are only supported on managed objects.");
 }
 
 - (void)testFilteredLinkingObjects {


### PR DESCRIPTION
This isn't supported, but we crashed rather than throwing a useful exception.