### PR TITLE
Add support for cancelling async opens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 x.y.z Release notes (yyyy-MM-dd)
 =============================================================
 ### Enhancements
-* None.
+* Add support for canceling asynchronous opens using a new AsyncOpenTask
+  returned from the asyncOpen() call. ([PR #6913](https://github.com/realm/realm-cocoa/pull/6187)).
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-js/issues/????), since v?.?.?)

--- a/Realm/RLMRealm.h
+++ b/Realm/RLMRealm.h
@@ -19,7 +19,7 @@
 #import <Foundation/Foundation.h>
 #import "RLMConstants.h"
 
-@class RLMRealmConfiguration, RLMRealm, RLMObject, RLMSchema, RLMMigration, RLMNotificationToken, RLMThreadSafeReference;
+@class RLMRealmConfiguration, RLMRealm, RLMObject, RLMSchema, RLMMigration, RLMNotificationToken, RLMThreadSafeReference, RLMAsyncOpenTask;
 struct RLMRealmPrivileges;
 struct RLMClassPrivileges;
 struct RLMObjectPrivileges;
@@ -121,7 +121,7 @@ NS_ASSUME_NONNULL_BEGIN
        thread, accessing the returned Realm outside the callback block (even if
        accessed from `callbackQueue`) is unsafe.
  */
-+ (void)asyncOpenWithConfiguration:(RLMRealmConfiguration *)configuration
++ (RLMAsyncOpenTask *)asyncOpenWithConfiguration:(RLMRealmConfiguration *)configuration
                      callbackQueue:(dispatch_queue_t)callbackQueue
                           callback:(RLMAsyncOpenRealmCallback)callback;
 

--- a/Realm/RLMRealm_Private.h
+++ b/Realm/RLMRealm_Private.h
@@ -29,6 +29,9 @@ FOUNDATION_EXTERN NSData * _Nullable RLMRealmValidatedEncryptionKey(NSData *key)
 
 FOUNDATION_EXTERN RLMSyncSubscription *RLMCastToSyncSubscription(id obj);
 
+// Set the queue used for async open. For testing purposes only.
+FOUNDATION_EXTERN void RLMSetAsyncOpenQueue(dispatch_queue_t queue);
+
 // Translate an in-flight exception resulting from an operation on a SharedGroup to
 // an NSError or NSException (if error is nil)
 void RLMRealmTranslateException(NSError **error);

--- a/Realm/RLMSyncSession.h
+++ b/Realm/RLMSyncSession.h
@@ -233,4 +233,46 @@ NS_REFINED_FOR_SWIFT;
 
 @end
 
+/**
+ A task object which can be used to observe or cancel an async open.
+
+ When a synchronized Realm is opened asynchronously, the latest state of the
+ Realm is downloaded from the server before the completion callback is invoked.
+ This task object can be used to observe the state of the download or to cancel
+ it. This should be used instead of trying to observe the download via the sync
+ session as the sync session itself is created asynchronously, and may not exist
+ yet when -[RLMRealm asyncOpenWithConfiguration:completion:] returns.
+ */
+@interface RLMAsyncOpenTask : NSObject
+/**
+ Register a progress notification block.
+
+ Each registered progress notification block is called whenever the sync
+ subsystem has new progress data to report until the task is either cancelled
+ or the completion callback is called. Progress notifications are delivered on
+ the main queue.
+ */
+- (void)addProgressNotificationBlock:(RLMProgressNotificationBlock)block;
+
+/**
+ Register a progress notification block which is called on the given queue.
+
+ Each registered progress notification block is called whenever the sync
+ subsystem has new progress data to report until the task is either cancelled
+ or the completion callback is called. Progress notifications are delivered on
+ the supplied queue.
+ */
+- (void)addProgressNotificationOnQueue:(dispatch_queue_t)queue
+                                 block:(RLMProgressNotificationBlock)block;
+
+/**
+ Cancel the asynchronous open.
+
+ Any download in progress will be cancelled, and the completion block for this
+ async open will never be called. If multiple async opens on the same Realm are
+ happening concurrently, all other opens will fail with the error "operation cancelled".
+ */
+- (void)cancel;
+@end
+
 NS_ASSUME_NONNULL_END

--- a/Realm/RLMSyncSession_Private.hpp
+++ b/Realm/RLMSyncSession_Private.hpp
@@ -22,6 +22,7 @@
 #import <memory>
 
 namespace realm {
+class AsyncOpenTask;
 class SyncSession;
 }
 
@@ -46,6 +47,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)initWithOriginalPath:(std::string)originalPath;
 
+@end
+
+@interface RLMAsyncOpenTask ()
+@property (nonatomic) std::shared_ptr<realm::AsyncOpenTask> task;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/RealmSwift/Nonsync.swift
+++ b/RealmSwift/Nonsync.swift
@@ -25,3 +25,25 @@ public struct SyncConfiguration {
 
 public struct SyncSubscription<T: Object> {
 }
+
+public struct SyncSession {
+    public struct Progress {
+        public let transferredBytes: Int
+        public let transferrableBytes: Int
+        public var fractionTransferred: Double {
+            if transferrableBytes == 0 {
+                return 1
+            }
+            let percentage = Double(transferredBytes) / Double(transferrableBytes)
+            return percentage > 1 ? 1 : percentage
+        }
+        public var isTransferComplete: Bool {
+            return transferredBytes >= transferrableBytes
+        }
+
+        internal init(transferred: UInt, transferrable: UInt) {
+            transferredBytes = Int(transferred)
+            transferrableBytes = Int(transferrable)
+        }
+    }
+}

--- a/RealmSwift/Sync.swift
+++ b/RealmSwift/Sync.swift
@@ -730,7 +730,7 @@ public extension SyncSession {
             return transferredBytes >= transferrableBytes
         }
 
-        fileprivate init(transferred: UInt, transferrable: UInt) {
+        internal init(transferred: UInt, transferrable: UInt) {
             transferredBytes = Int(transferred)
             transferrableBytes = Int(transferrable)
         }


### PR DESCRIPTION
Make Realm.asyncOpen() return an AsyncOpenTask which can be used to get download progress notifications or cancel the async open.