### PR TITLE
Update PR testing and release packaging for Xcode 10.3

### DIFF
--- a/.jenkins.yml
+++ b/.jenkins.yml
@@ -2,12 +2,11 @@
 # https://wiki.jenkins-ci.org/display/JENKINS/Yaml+Axis+Plugin
 
 xcode_version:
-  - 9.2
-  - 9.3
   - 9.4
   - 10.0
   - 10.1
   - 10.2.1
+  - 10.3
 target:
   - osx
   - docs
@@ -42,14 +41,8 @@ configuration:
 # +----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 # | Configuration Matrix | osx | docs | ios-static | ios-dynamic | ios-swift | osx-swift | watchos | cocoapods-ios | cocoapods-osx | cocoapods-watchos | swiftlint | swiftpm | tvos | osx-encryption | osx-object-server | ios-device-objc-ios8 | ios-device-swift-ios8 | ios-device-objc-ios10 | ios-device-swift-ios10 | tvos-device |
 # | -------------------- | --- | ---- | ---------- | ----------- | --------- | --------- | ------- | ------------- | ------------- | ----------------- | --------- | ------- | ---- | -------------- | ----------------- | -------------------- | --------------------- | --------------------- | ---------------------- | ----------- |
-# | 9.2   | Debug        | X   |      | X          |             |           |           |         |               |               |                   |           |         |      |                |                   |                      |                       |                       |                        |             |
-# | 9.2   | Release      | X   |      | X          | X           | X         | X         | X       | X             | X             | X                 |           |         | X    | X              | X                 | X                    |                       | X                     |                        |             |
-# | -------------------- | --- | ---- | ---------- | ----------- | --------- | --------- | ------- | ------------- | ------------- | ----------------- | --------- | ------- | ---- | -------------- | ----------------- | -------------------- | --------------------- | --------------------- | ---------------------- | ----------- |
-# | 9.3   | Debug        | X   |      |            |             |           |           |         |               |               |                   |           |         |      |                |                   |                      |                       |                       |                        |             |
-# | 9.3   | Release      | X   |      | X          | X           | X         | X         | X       | X             | X             | X                 |           |         | X    |                |                   |                      |                       |                       |                        |             |
-# | -------------------- | --- | ---- | ---------- | ----------- | --------- | --------- | ------- | ------------- | ------------- | ----------------- | --------- | ------- | ---- | -------------- | ----------------- | -------------------- | --------------------- | --------------------- | ---------------------- | ----------- |
-# | 9.4   | Debug        | X   |      |            |             |           |           |         |               |               |                   |           |         |      |                |                   |                      |                       |                       |                        |             |
-# | 9.4   | Release      | X   |      | X          | X           | X         | X         | X       | X             | X             | X                 |           |         | X    |                |                   |                      |                       |                       |                        |             |
+# | 9.4   | Debug        | X   |      | X          |             |           |           |         |               |               |                   |           |         |      |                |                   |                      |                       |                       |                        |             |
+# | 9.4   | Release      | X   |      | X          | X           | X         | X         | X       | X             | X             | X                 |           |         | X    | X              | X                 | X                    |                       | X                     |                        |             |
 # | -------------------- | --- | ---- | ---------- | ----------- | --------- | --------- | ------- | ------------- | ------------- | ----------------- | --------- | ------- | ---- | -------------- | ----------------- | -------------------- | --------------------- | --------------------- | ---------------------- | ----------- |
 # | 10.0  | Debug        | X   |      |            |             |           |           |         |               |               |                   |           |         |      |                |                   |                      |                       |                       |                        |             |
 # | 10.0  | Release      | X   |      | X          | X           | X         | X         | X       | X             | X             | X                 |           |         | X    |                |                   |                      |                       |                       |                        |             |
@@ -57,24 +50,25 @@ configuration:
 # | 10.1  | Debug        | X   |      |            |             |           |           |         |               |               |                   |           |         |      |                |                   |                      |                       |                       |                        |             |
 # | 10.1  | Release      | X   |      | X          | X           | X         | X         | X       | X             | X             | X                 |           |         | X    |                |                   |                      |                       |                       |                        |             |
 # | -------------------- | --- | ---- | ---------- | ----------- | --------- | --------- | ------- | ------------- | ------------- | ----------------- | --------- | ------- | ---- | -------------- | ----------------- | -------------------- | --------------------- | --------------------- | ---------------------- | ----------- |
-# | 10.2.1| Debug        | X   |      |            | X           | X         | X         | X       |               |               |                   |           |         | X    |                |                   |                      |                       |                       |                        |             |
-# | 10.2.1| Release      | X   | X    | X          | X           | X         | X         | X       | X             | X             | X                 | X         | X       | X    | X              | X                 |                      |                       | X                     |                        | X           |
+# | 10.2.1| Debug        | X   |      |            |             |           |           |         |               |               |                   |           |         |      |                |                   |                      |                       |                       |                        |             |
+# | 10.2.1| Release      | X   |      | X          | X           | X         | X         | X       | X             | X             | X                 |           |         | X    |                |                   |                      |                       |                       |                        |             |
+# | -------------------- | --- | ---- | ---------- | ----------- | --------- | --------- | ------- | ------------- | ------------- | ----------------- | --------- | ------- | ---- | -------------- | ----------------- | -------------------- | --------------------- | --------------------- | ---------------------- | ----------- |
+# | 10.3  | Debug        | X   |      |            | X           | X         | X         | X       |               |               |                   |           |         | X    |                |                   |                      |                       |                       |                        |             |
+# | 10.3  | Release      | X   | X    | X          | X           | X         | X         | X       | X             | X             | X                 | X         | X       | X    | X              | X                 |                      |                       | X                     |                        | X           |
 # +------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 
 exclude:
   ################
   # docs
   ################
-  # Just run on 10.2 Release
-  - xcode_version: 9.2
-    target: docs
-  - xcode_version: 9.3
-    target: docs
+  # Just run on 10.4 Release
   - xcode_version: 9.4
     target: docs
   - xcode_version: 10.0
     target: docs
   - xcode_version: 10.1
+    target: docs
+  - xcode_version: 10.2.1
     target: docs
   - target: docs
     configuration: Debug
@@ -82,13 +76,7 @@ exclude:
   ################
   # ios-static
   ################
-  # Skip Debug on everything but 9.2
-  - xcode_version: 9.3
-    target: ios-static
-    configuration: Debug
-  - xcode_version: 9.4
-    target: ios-static
-    configuration: Debug
+  # Skip Debug on everything but 9.4
   - xcode_version: 10.0
     target: ios-static
     configuration: Debug
@@ -98,17 +86,14 @@ exclude:
   - xcode_version: 10.2.1
     target: ios-static
     configuration: Debug
+  - xcode_version: 10.3
+    target: ios-static
+    configuration: Debug
 
   ################
   # ios-dynamic
   ################
-  # Skip Debug on everything but 10.2
-  - xcode_version: 9.2
-    target: ios-dynamic
-    configuration: Debug
-  - xcode_version: 9.3
-    target: ios-dynamic
-    configuration: Debug
+  # Skip Debug on everything but 10.3
   - xcode_version: 9.4
     target: ios-dynamic
     configuration: Debug
@@ -116,19 +101,16 @@ exclude:
     target: ios-dynamic
     configuration: Debug
   - xcode_version: 10.1
+    target: ios-dynamic
+    configuration: Debug
+  - xcode_version: 10.2.1
     target: ios-dynamic
     configuration: Debug
 
   ################
   # ios-swift
   ################
-  # Skip Debug on everything but 10.2
-  - xcode_version: 9.2
-    target: ios-swift
-    configuration: Debug
-  - xcode_version: 9.3
-    target: ios-swift
-    configuration: Debug
+  # Skip Debug on everything but 10.3
   - xcode_version: 9.4
     target: ios-swift
     configuration: Debug
@@ -136,19 +118,16 @@ exclude:
     target: ios-swift
     configuration: Debug
   - xcode_version: 10.1
+    target: ios-swift
+    configuration: Debug
+  - xcode_version: 10.2.1
     target: ios-swift
     configuration: Debug
 
   ################
   # osx-swift
   ################
-  # Skip Debug on everything but 10.2
-  - xcode_version: 9.2
-    target: osx-swift
-    configuration: Debug
-  - xcode_version: 9.3
-    target: osx-swift
-    configuration: Debug
+  # Skip Debug on everything but 10.3
   - xcode_version: 9.4
     target: osx-swift
     configuration: Debug
@@ -156,19 +135,16 @@ exclude:
     target: osx-swift
     configuration: Debug
   - xcode_version: 10.1
+    target: osx-swift
+    configuration: Debug
+  - xcode_version: 10.2.1
     target: osx-swift
     configuration: Debug
 
   ################
   # watchos
   ################
-  # Skip Debug on everything but 10.2
-  - xcode_version: 9.2
-    target: watchos
-    configuration: Debug
-  - xcode_version: 9.3
-    target: watchos
-    configuration: Debug
+  # Skip Debug on everything but 10.3
   - xcode_version: 9.4
     target: watchos
     configuration: Debug
@@ -176,6 +152,9 @@ exclude:
     target: watchos
     configuration: Debug
   - xcode_version: 10.1
+    target: watchos
+    configuration: Debug
+  - xcode_version: 10.2.1
     target: watchos
     configuration: Debug
 
@@ -193,16 +172,14 @@ exclude:
   ################
   # swiftlint
   ################
-  # Just run on 10.2 Release
-  - xcode_version: 9.2
-    target: swiftlint
-  - xcode_version: 9.3
-    target: swiftlint
+  # Just run on 10.3 Release
   - xcode_version: 9.4
     target: swiftlint
   - xcode_version: 10.0
     target: swiftlint
   - xcode_version: 10.1
+    target: swiftlint
+  - xcode_version: 10.2.1
     target: swiftlint
   - target: swiftlint
     configuration: Debug
@@ -210,11 +187,7 @@ exclude:
   ################
   # swiftpm
   ################
-  # Just run on 10.2 Release
-  - xcode_version: 9.2
-    target: swiftpm
-  - xcode_version: 9.3
-    target: swiftpm
+  # Just run on 10.2/10.3 Release
   - xcode_version: 9.4
     target: swiftpm
   - xcode_version: 10.0
@@ -227,13 +200,7 @@ exclude:
   ################
   # tvos
   ################
-  # Skip Debug on everything but 10.2
-  - xcode_version: 9.2
-    target: tvos
-    configuration: Debug
-  - xcode_version: 9.3
-    target: tvos
-    configuration: Debug
+  # Skip Debug on everything but 10.3
   - xcode_version: 9.4
     target: tvos
     configuration: Debug
@@ -241,20 +208,21 @@ exclude:
     target: tvos
     configuration: Debug
   - xcode_version: 10.1
+    target: tvos
+    configuration: Debug
+  - xcode_version: 10.2.1
     target: tvos
     configuration: Debug
 
   ################
   # osx-encryption
   ################
-  # Just run on 9.2/10.2 Release
-  - xcode_version: 9.3
-    target: osx-encryption
-  - xcode_version: 9.4
-    target: osx-encryption
+  # Just run on 9.4/10.3 Release
   - xcode_version: 10.0
     target: osx-encryption
   - xcode_version: 10.1
+    target: osx-encryption
+  - xcode_version: 10.2.1
     target: osx-encryption
   - target: osx-encryption
     configuration: Debug
@@ -262,14 +230,12 @@ exclude:
   ################
   # osx-object-server
   ################
-  # Just run on 9.2/10.2 Release
-  - xcode_version: 9.3
-    target: osx-object-server
-  - xcode_version: 9.4
-    target: osx-object-server
+  # Just run on 9.4/10.3 Release
   - xcode_version: 10.0
     target: osx-object-server
   - xcode_version: 10.1
+    target: osx-object-server
+  - xcode_version: 10.2.1
     target: osx-object-server
   - target: osx-object-server
     configuration: Debug
@@ -277,12 +243,12 @@ exclude:
   ################
   # ios-device-objc-ios8
   ################
-  # Just run on 9.2/10.2 Release
-  - xcode_version: 9.3
-    target: ios-device-objc-ios8
+  # Just run on 9.4/10.3 Release
   - xcode_version: 10.0
     target: ios-device-objc-ios8
   - xcode_version: 10.1
+    target: ios-device-objc-ios8
+  - xcode_version: 10.2.1
     target: ios-device-objc-ios8
   - target: ios-device-objc-ios8
     configuration: Debug
@@ -290,14 +256,12 @@ exclude:
   ################
   # ios-device-swift-ios8
   ################
-  # Just run on 9.2/10.2 Release
-  - xcode_version: 9.3
-    target: ios-device-swift-ios8
-  - xcode_version: 9.4
-    target: ios-device-swift-ios8
+  # Just run on 9.4/10.3 Release
   - xcode_version: 10.0
     target: ios-device-swift-ios8
   - xcode_version: 10.1
+    target: ios-device-swift-ios8
+  - xcode_version: 10.2.1
     target: ios-device-swift-ios8
   - target: ios-device-swift-ios8
     configuration: Debug
@@ -305,14 +269,12 @@ exclude:
   ################
   # ios-device-objc-ios10
   ################
-  # Just run on 9.2/10.2 Release
-  - xcode_version: 9.3
-    target: ios-device-objc-ios10
-  - xcode_version: 9.4
-    target: ios-device-objc-ios10
+  # Just run on 9.3/10.3 Release
   - xcode_version: 10.0
     target: ios-device-objc-ios10
   - xcode_version: 10.1
+    target: ios-device-objc-ios10
+  - xcode_version: 10.2.1
     target: ios-device-objc-ios10
   - target: ios-device-objc-ios10
     configuration: Debug
@@ -320,14 +282,12 @@ exclude:
   ################
   # ios-device-swift-ios10
   ################
-  # Just run on 9.2/10.2 Release
-  - xcode_version: 9.3
-    target: ios-device-swift-ios10
-  - xcode_version: 9.4
-    target: ios-device-swift-ios10
+  # Just run on 9.4/10.3 Release
   - xcode_version: 10.0
     target: ios-device-swift-ios10
   - xcode_version: 10.1
+    target: ios-device-swift-ios10
+  - xcode_version: 10.2.1
     target: ios-device-swift-ios10
   - target: ios-device-swift-ios10
     configuration: Debug
@@ -336,15 +296,13 @@ exclude:
   # tvos-device
   ################
   # Just run on 10.2 Release
-  - xcode_version: 9.2
-    target: tvos-device
-  - xcode_version: 9.3
-    target: tvos-device
   - xcode_version: 9.4
     target: tvos-device
   - xcode_version: 10.0
     target: tvos-device
   - xcode_version: 10.1
+    target: tvos-device
+  - xcode_version: 10.2.1
     target: tvos-device
   - target: tvos-device
     configuration: Debug

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 x.y.z Release notes (yyyy-MM-dd)
 =============================================================
 ### Enhancements
-* None.
+* Add Xcode 10.3 binaries to the release package. Remove the Xcode 9.2 and 9.3 binaries.
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-js/issues/????), since v?.?.?)
@@ -13,7 +13,7 @@ x.y.z Release notes (yyyy-MM-dd)
 * File format: Generates Realms with format v9 (Reads and upgrades all previous formats)
 * Realm Object Server: 3.21.0 or later.
 * APIs are backwards compatible with all previous releases in the 3.x.y series.
-* Carthage release for Swift is built with Xcode 10.2.1.
+* Carthage release for Swift is built with Xcode 10.3.
 
 3.17.1 Release notes (2019-07-10)
 =============================================================

--- a/Jenkinsfile.releasability
+++ b/Jenkinsfile.releasability
@@ -1,7 +1,7 @@
-xcodeVersions = ['9.2', '9.3', '9.4', '10.0', '10.1', '10.2.1']
+xcodeVersions = ['9.4', '10.0', '10.1', '10.2.1', '10.3']
 platforms = ['osx', 'ios', 'watchos', 'tvos']
 platformNames = ['osx': 'macOS', 'ios': 'iOS', 'watchos': 'watchOS', 'tvos': 'tvOS']
-carthageXcodeVersion = '10.2.1'
+carthageXcodeVersion = '10.3'
 docsSwiftVersion = '5.0.1'
 
 def installationTest(platform, test, language) {

--- a/build.sh
+++ b/build.sh
@@ -1236,7 +1236,7 @@ EOM
 
     package-*-swift)
         PLATFORM=$(echo $COMMAND | cut -d - -f 2)
-        for version in 9.2 9.3 9.4 10.0 10.1 10.2.1; do
+        for version in 9.4 10.0 10.1 10.2.1 10.3; do
             REALM_XCODE_VERSION=$version
             REALM_SWIFT_VERSION=
             set_xcode_and_swift_versions
@@ -1245,7 +1245,7 @@ EOM
         done
 
         cd build/$PLATFORM
-        zip --symlinks -r realm-swift-framework-$PLATFORM.zip swift-9.2 swift-9.2 swift-9.4 swift-10.0 swift-10.1 swift-10.2.1
+        zip --symlinks -r realm-swift-framework-$PLATFORM.zip swift-9.4 swift-10.0 swift-10.1 swift-10.2.1 swift-10.3
         ;;
 
     package-*-swift-*)
@@ -1451,7 +1451,7 @@ x.y.z Release notes (yyyy-MM-dd)
 * File format: Generates Realms with format v9 (Reads and upgrades all previous formats)
 * Realm Object Server: 3.21.0 or later.
 * APIs are backwards compatible with all previous releases in the 3.x.y series.
-* Carthage release for Swift is built with Xcode 10.2.1.
+* Carthage release for Swift is built with Xcode 10.3.
 EOS)
         changelog=$(cat CHANGELOG.md)
         echo "$empty_section" > CHANGELOG.md

--- a/examples/installation/ios/swift/DynamicExample/DynamicExample.xcodeproj/project.pbxproj
+++ b/examples/installation/ios/swift/DynamicExample/DynamicExample.xcodeproj/project.pbxproj
@@ -45,8 +45,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		C07E5D861B15083F00ED625C /* Realm.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Realm.framework; path = "../../../realm-swift-latest/ios/swift-3.2.3/Realm.framework"; sourceTree = "<group>"; };
-		E8AD59E51AFAB62100E79784 /* RealmSwift.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RealmSwift.framework; path = "../../../realm-swift-latest/ios/swift-3.2.3/RealmSwift.framework"; sourceTree = "<group>"; };
+		C07E5D861B15083F00ED625C /* Realm.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Realm.framework; path = "../../../realm-swift-latest/ios/swift-10.2.1/Realm.framework"; sourceTree = "<group>"; };
+		E8AD59E51AFAB62100E79784 /* RealmSwift.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RealmSwift.framework; path = "../../../realm-swift-latest/ios/swift-10.2.1/RealmSwift.framework"; sourceTree = "<group>"; };
 		E8E060BB1AFAB5EB00484DEE /* DynamicExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = DynamicExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		E8E060BF1AFAB5EB00484DEE /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		E8E060C01AFAB5EB00484DEE /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -335,7 +335,7 @@
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = "../../../realm-swift-latest/ios/swift-3.2.3";
+				FRAMEWORK_SEARCH_PATHS = "../../../realm-swift-latest/ios/swift-10.2.1";
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -391,7 +391,7 @@
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				FRAMEWORK_SEARCH_PATHS = "../../../realm-swift-latest/ios/swift-3.2.3";
+				FRAMEWORK_SEARCH_PATHS = "../../../realm-swift-latest/ios/swift-10.2.1";
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;

--- a/examples/installation/osx/swift/DynamicExample/DynamicExample.xcodeproj/project.pbxproj
+++ b/examples/installation/osx/swift/DynamicExample/DynamicExample.xcodeproj/project.pbxproj
@@ -53,8 +53,8 @@
 		E8D0520B1B3CCCC9007A482B /* DynamicExampleTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DynamicExampleTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		E8D052101B3CCCC9007A482B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		E8D052111B3CCCC9007A482B /* DynamicExampleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DynamicExampleTests.swift; sourceTree = "<group>"; };
-		E8D0521B1B3CCCE5007A482B /* Realm.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Realm.framework; path = "../../../realm-swift-latest/osx/swift-3.2.3/Realm.framework"; sourceTree = "<group>"; };
-		E8D0521C1B3CCCE5007A482B /* RealmSwift.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RealmSwift.framework; path = "../../../realm-swift-latest/osx/swift-3.2.3/RealmSwift.framework"; sourceTree = "<group>"; };
+		E8D0521B1B3CCCE5007A482B /* Realm.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Realm.framework; path = "../../../realm-swift-latest/osx/swift-10.2.1/Realm.framework"; sourceTree = "<group>"; };
+		E8D0521C1B3CCCE5007A482B /* RealmSwift.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RealmSwift.framework; path = "../../../realm-swift-latest/osx/swift-10.2.1/RealmSwift.framework"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -304,7 +304,7 @@
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = "../../../realm-swift-latest/osx/swift-3.2.3";
+				FRAMEWORK_SEARCH_PATHS = "../../../realm-swift-latest/osx/swift-10.2.1";
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -360,7 +360,7 @@
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				FRAMEWORK_SEARCH_PATHS = "../../../realm-swift-latest/osx/swift-3.2.3";
+				FRAMEWORK_SEARCH_PATHS = "../../../realm-swift-latest/osx/swift-10.2.1";
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;

--- a/examples/ios/objc/RealmExamples.xcodeproj/project.pbxproj
+++ b/examples/ios/objc/RealmExamples.xcodeproj/project.pbxproj
@@ -1672,7 +1672,6 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Draw/Draw-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -1698,7 +1697,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = io.realm.Draw;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Draw/Draw-Bridging-Header.h";
-				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};

--- a/examples/ios/swift/RealmExamples.xcodeproj/project.pbxproj
+++ b/examples/ios/swift/RealmExamples.xcodeproj/project.pbxproj
@@ -503,7 +503,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0730;
-				LastUpgradeCheck = 0800;
+				LastUpgradeCheck = 1030;
 				ORGANIZATIONNAME = Realm;
 				TargetAttributes = {
 					E8CB07EE19BA6AB60018434A = {
@@ -529,7 +529,7 @@
 			};
 			buildConfigurationList = E805759019BA55E600376620 /* Build configuration list for PBXProject "RealmExamples" */;
 			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
@@ -696,14 +696,22 @@
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
@@ -731,6 +739,7 @@
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -743,14 +752,22 @@
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
@@ -770,6 +787,7 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 			};
@@ -789,7 +807,6 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "io.realm.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = GroupedTableView;
-				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -803,7 +820,6 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "io.realm.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = GroupedTableView;
-				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};
@@ -820,7 +836,6 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "io.realm.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -833,7 +848,6 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "io.realm.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};
@@ -850,7 +864,6 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "io.realm.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -863,7 +876,6 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "io.realm.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};
@@ -880,7 +892,6 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "io.realm.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -893,7 +904,6 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "io.realm.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};
@@ -910,7 +920,6 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "io.realm.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -923,7 +932,6 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "io.realm.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};
@@ -940,7 +948,6 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "io.realm.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -953,7 +960,6 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "io.realm.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};
@@ -976,7 +982,6 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 3.0;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -1001,7 +1006,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = io.realm.PlaygroundFrameworkWrapper;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 3.0;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};

--- a/examples/ios/swift/RealmExamples.xcodeproj/xcshareddata/xcschemes/Backlink.xcscheme
+++ b/examples/ios/swift/RealmExamples.xcodeproj/xcshareddata/xcschemes/Backlink.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0800"
+   LastUpgradeVersion = "1030"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "NO"

--- a/examples/ios/swift/RealmExamples.xcodeproj/xcshareddata/xcschemes/Encryption.xcscheme
+++ b/examples/ios/swift/RealmExamples.xcodeproj/xcshareddata/xcschemes/Encryption.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0800"
+   LastUpgradeVersion = "1030"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "NO"

--- a/examples/ios/swift/RealmExamples.xcodeproj/xcshareddata/xcschemes/GroupedTableView.xcscheme
+++ b/examples/ios/swift/RealmExamples.xcodeproj/xcshareddata/xcschemes/GroupedTableView.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0800"
+   LastUpgradeVersion = "1030"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "NO"

--- a/examples/ios/swift/RealmExamples.xcodeproj/xcshareddata/xcschemes/Migration.xcscheme
+++ b/examples/ios/swift/RealmExamples.xcodeproj/xcshareddata/xcschemes/Migration.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0800"
+   LastUpgradeVersion = "1030"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "NO"

--- a/examples/ios/swift/RealmExamples.xcodeproj/xcshareddata/xcschemes/Simple.xcscheme
+++ b/examples/ios/swift/RealmExamples.xcodeproj/xcshareddata/xcschemes/Simple.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0800"
+   LastUpgradeVersion = "1030"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "NO"

--- a/examples/ios/swift/RealmExamples.xcodeproj/xcshareddata/xcschemes/TableView.xcscheme
+++ b/examples/ios/swift/RealmExamples.xcodeproj/xcshareddata/xcschemes/TableView.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0800"
+   LastUpgradeVersion = "1030"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "NO"

--- a/examples/tvos/swift/DownloadCache/RepositoriesViewController.swift
+++ b/examples/tvos/swift/DownloadCache/RepositoriesViewController.swift
@@ -62,7 +62,7 @@ class RepositoriesViewController: UICollectionViewController, UITextFieldDelegat
                         repository.name = item["name"] as? String
                         repository.avatarURL = item["owner"]!["avatar_url"] as? String;
 
-                        realm.add(repository, update: true)
+                        realm.add(repository, update: .modified)
                     }
                 }
             } catch {

--- a/examples/tvos/swift/RealmExamples.xcodeproj/project.pbxproj
+++ b/examples/tvos/swift/RealmExamples.xcodeproj/project.pbxproj
@@ -210,7 +210,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0720;
-				LastUpgradeCheck = 0800;
+				LastUpgradeCheck = 1030;
 				ORGANIZATIONNAME = Realm;
 				TargetAttributes = {
 					14835E171BFE5E4000B9A267 = {
@@ -227,6 +227,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 				Base,
 			);
@@ -365,6 +366,7 @@
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = appletvos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = 3;
 				TVOS_DEPLOYMENT_TARGET = 9.1;
 			};
@@ -404,6 +406,7 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = appletvos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = 3;
 				TVOS_DEPLOYMENT_TARGET = 9.1;
 				VALIDATE_PRODUCT = YES;
@@ -420,7 +423,6 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = io.realm.DownloadCache;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -434,7 +436,6 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = io.realm.DownloadCache;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};
@@ -448,7 +449,6 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = io.realm.PreloadedData;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -462,7 +462,6 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = io.realm.PreloadedData;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};

--- a/examples/tvos/swift/RealmExamples.xcodeproj/xcshareddata/xcschemes/DownloadCache.xcscheme
+++ b/examples/tvos/swift/RealmExamples.xcodeproj/xcshareddata/xcschemes/DownloadCache.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0800"
+   LastUpgradeVersion = "1030"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "NO"

--- a/examples/tvos/swift/RealmExamples.xcodeproj/xcshareddata/xcschemes/PreloadedData.xcscheme
+++ b/examples/tvos/swift/RealmExamples.xcodeproj/xcshareddata/xcschemes/PreloadedData.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0800"
+   LastUpgradeVersion = "1030"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "NO"

--- a/scripts/package_examples.rb
+++ b/scripts/package_examples.rb
@@ -41,7 +41,7 @@ base_examples = [
   "examples/tvos/swift",
 ]
 
-xcode_versions = %w(9.2 9.3 9.4 10.0 10.1)
+xcode_versions = %w(9.4 10.0 10.1 10.2.1 10.3)
 
 # Remove reference to Realm.xcodeproj from all example workspaces.
 base_examples.each do |example|


### PR DESCRIPTION
No code changes appear to be needed.

Xcode 9.2+9.3 combined are 0.1% of builders using 3.17.1, so this drops them to keep the build matrix from getting too huge.