### PR TITLE
Fix inconsistent errors when running Installation tests on CI

### DIFF
--- a/Jenkinsfile.releasability
+++ b/Jenkinsfile.releasability
@@ -20,8 +20,9 @@ def installationTest(platform, test, language) {
 
       if [[ -f \$archive ]]; then
         mv \$archive .
-        unzip realm-${language}-*zip
-        find . -name 'realm-${language}-*' -print0 | xargs -J% mv % realm-${language}-latest
+        unzip realm-${language}-*.zip
+        rm realm-${language}-*.zip
+        mv realm-${language}-* realm-${language}-latest
       fi
 
       export REALM_XCODE_VERSION=${carthageXcodeVersion}


### PR DESCRIPTION
Moving the packaged build into the place expected by the installation tests build script would sometimes move the zip to realm-obj-latest rather than the extracted directory, resulting in the build script downloading the latest release instead of building against the new packaged build.

An example of a failing job: https://ci.realm.io/blue/organizations/jenkins/cocoa-pipeline/detail/cocoa-pipeline/845/pipeline
And a passing one with these changes: https://ci.realm.io/blue/organizations/jenkins/cocoa-pipeline/detail/cocoa-pipeline/854/pipeline/552