### PR TITLE
Clarify documentation for RLMRealmRefreshRequiredNotification

### DIFF
--- a/Realm/RLMConstants.h
+++ b/Realm/RLMConstants.h
@@ -176,9 +176,15 @@ typedef NSString * RLMNotification RLM_EXTENSIBLE_STRING_ENUM;
  This notification is posted by a Realm when the data in that Realm has changed.
 
  More specifically, this notification is posted after a Realm has been refreshed to
- reflect a write transaction. This can happen when an autorefresh occurs, when
+ reflect a write transaction. This can happen when
  `-[RLMRealm refresh]` is called, after an implicit refresh from `-[RLMRealm beginWriteTransaction]`,
  or after a local write transaction is completed.
+ 
+ A RLMRealmRefreshRequiredNotification notification is only ever sent for Realms
+ with autorefresh disabled.
+ 
+ In response to this notification, you can safely call `-[RLMRealm refresh]` to advance the Realm
+ to its latest state.
  */
 extern RLMNotification const RLMRealmRefreshRequiredNotification
 RLM_EXTENSIBLE_STRING_ENUM_CASE_SWIFT_NAME(RLMRealmRefreshRequiredNotification, RefreshRequired);

--- a/Realm/RLMConstants.h
+++ b/Realm/RLMConstants.h
@@ -173,18 +173,15 @@ typedef RLM_ERROR_ENUM(NSInteger, RLMError, RLMErrorDomain) {
 typedef NSString * RLMNotification RLM_EXTENSIBLE_STRING_ENUM;
 
 /**
- This notification is posted by a Realm when the data in that Realm has changed.
+ This notification is posted when a write transaction has been committed to a Realm on a different thread for
+ the same file.
 
- More specifically, this notification is posted after a Realm has been refreshed to
- reflect a write transaction. This can happen when
- `-[RLMRealm refresh]` is called, after an implicit refresh from `-[RLMRealm beginWriteTransaction]`,
- or after a local write transaction is completed.
- 
- A RLMRealmRefreshRequiredNotification notification is only ever sent for Realms
- with autorefresh disabled.
- 
- In response to this notification, you can safely call `-[RLMRealm refresh]` to advance the Realm
- to its latest state.
+ It is not posted if `autorefresh` is enabled, or if the Realm is refreshed before the notification has a chance
+ to run.
+
+ Realms with autorefresh disabled should normally install a handler for this notification which calls
+ `-[RLMRealm refresh]` after doing some work. Refreshing the Realm is optional, but not refreshing the Realm may lead to
+ large Realm files. This is because an extra copy of the data must be kept for the stale Realm.
  */
 extern RLMNotification const RLMRealmRefreshRequiredNotification
 RLM_EXTENSIBLE_STRING_ENUM_CASE_SWIFT_NAME(RLMRealmRefreshRequiredNotification, RefreshRequired);

--- a/RealmSwift/Realm.swift
+++ b/RealmSwift/Realm.swift
@@ -896,12 +896,9 @@ extension Realm {
         /**
          This notification is posted when the data in a Realm has changed.
 
-         `didChange` is posted after a Realm has been refreshed to reflect a write transaction, This can happen when 
-         `refresh()` is called, after an implicit refresh from `write(_:)`/`beginWrite()`, or after
+         `didChange` is posted after a Realm has been refreshed to reflect a write transaction, This can happen when an
+         autorefresh occurs, `refresh()` is called, after an implicit refresh from `write(_:)`/`beginWrite()`, or after
          a local write transaction is committed.
-         
-         This notification is only ever sent for Realms with autorefresh disabled.
-         In response to this notification, you can safely call `refresh()` to advance the Realm to its latest state.
          */
         case didChange = "RLMRealmDidChangeNotification"
 

--- a/RealmSwift/Realm.swift
+++ b/RealmSwift/Realm.swift
@@ -896,9 +896,12 @@ extension Realm {
         /**
          This notification is posted when the data in a Realm has changed.
 
-         `didChange` is posted after a Realm has been refreshed to reflect a write transaction, This can happen when an
-         autorefresh occurs, `refresh()` is called, after an implicit refresh from `write(_:)`/`beginWrite()`, or after
+         `didChange` is posted after a Realm has been refreshed to reflect a write transaction, This can happen when 
+         `refresh()` is called, after an implicit refresh from `write(_:)`/`beginWrite()`, or after
          a local write transaction is committed.
+         
+         This notification is only ever sent for Realms with autorefresh disabled.
+         In response to this notification, you can safely call `refresh()` to advance the Realm to its latest state.
          */
         case didChange = "RLMRealmDidChangeNotification"
 


### PR DESCRIPTION
- This updates the Swift counterpart documentation as well.
- Information is entirely based on the comment thread on the issue. Please verify in review.

Fixes https://github.com/realm/realm-cocoa/issues/4142.