### PR TITLE
[ObjectSchema] Expose objectClass from RLMObjectSchema private interface

### DIFF
--- a/RealmSwift/ObjectSchema.swift
+++ b/RealmSwift/ObjectSchema.swift
@@ -18,6 +18,7 @@
 
 import Foundation
 import Realm
+import Realm.Private
 
 /**
  This class represents Realm model object schemas.
@@ -43,6 +44,9 @@ public struct ObjectSchema: CustomStringConvertible {
 
     /// The name of the class the schema describes.
     public var className: String { return rlmObjectSchema.className }
+
+    /// The object class the schema describes.
+    public var objectClass: AnyClass { return rlmObjectSchema.objectClass }
 
     /// The property which serves as the primary key for the class the schema describes, if any.
     public var primaryKeyProperty: Property? {

--- a/RealmSwift/Tests/ObjectSchemaTests.swift
+++ b/RealmSwift/Tests/ObjectSchemaTests.swift
@@ -40,6 +40,11 @@ class ObjectSchemaTests: TestCase {
         XCTAssertEqual(objectSchema.className, "SwiftObject")
     }
 
+    func testObjectClass() {
+        let objectSchema = swiftObjectSchema
+        XCTAssertTrue(objectSchema.objectClass === SwiftObject.self)
+    }
+
     func testPrimaryKeyProperty() {
         let objectSchema = swiftObjectSchema
         XCTAssertNil(objectSchema.primaryKeyProperty)


### PR DESCRIPTION
### Summary

This change proposes the addition of the computed variable `public var objectClass: AnyClass { get }` on `ObjectSchema` to expose the underlying `RLMObjectSchema`'s private `objectClass`.

### Motivation

When working with Swift models, realm-cocoa will 'demangle' the original class name when building the shared schema. As a result, no mechanism exists for looking up the associated class type from a Realms schema. This isn't something that most people will need to do, but it can be really beneficial in cases where we might need to store some additional information on model definitions that needs to be validated either at runtime or in unit tests.

Although the `objectClass` is private on `RLMObjectSchema`, a similar capability is possible in projects that use realm-cocoa directly since they'd be able to use `NSClassFromString(objectSchema.className)` however this will return `nil` in Swift using `objectSchema.className` since the value has been passed through `+[RLMSwiftSupport demangleClassName:]`

I hope there is no problem with such change, my inspiration for the change was that I noticed `Realm.Configuration` is actually doing a similar thing in order to expose the `objectTypes` getter since they're backed by a custom `RLMSchema` but I wanted similar functionality when reading object schemas from a Realm directly
