### PR TITLE
Add support for suppressing notifications using closure-based write/transaction methods

### DIFF
--- a/Realm/RLMRealm.h
+++ b/Realm/RLMRealm.h
@@ -326,14 +326,14 @@ typedef void (^RLMNotificationBlock)(RLMNotification notification, RLMRealm *rea
 /**
  Performs actions contained within the given block inside a write transaction.
 
- @see `[RLMRealm transactionWithBlock:withoutNotifying:error:]`
+ @see `[RLMRealm transactionWithoutNotifying:block:error:]`
  */
 - (void)transactionWithBlock:(__attribute__((noescape)) void(^)(void))block NS_SWIFT_UNAVAILABLE("");
 
 /**
  Performs actions contained within the given block inside a write transaction.
 
- @see `[RLMRealm transactionWithBlock:withoutNotifying:error:]`
+ @see `[RLMRealm transactionWithoutNotifying:block:error:]`
  */
 - (BOOL)transactionWithBlock:(__attribute__((noescape)) void(^)(void))block error:(NSError **)error;
 
@@ -360,17 +360,17 @@ typedef void (^RLMNotificationBlock)(RLMNotification notification, RLMRealm *rea
  `RLMRealm` instance. Notifications for different threads cannot be skipped
  using this method.
 
- @param block The block containing actions to perform.
  @param tokens An array of notification tokens which were returned from adding
                callbacks which you do not want to be notified for the changes
                made in this write transaction.
+ @param block The block containing actions to perform.
  @param error If an error occurs, upon return contains an `NSError` object
               that describes the problem. If you are not interested in
               possible errors, pass in `NULL`.
 
  @return Whether the transaction succeeded.
  */
-- (BOOL)transactionWithBlock:(__attribute__((noescape)) void(^)(void))block withoutNotifying:(NSArray<RLMNotificationToken *> *)tokens error:(NSError **)error;
+- (BOOL)transactionWithoutNotifying:(NSArray<RLMNotificationToken *> *)tokens block:(__attribute__((noescape)) void(^)(void))block error:(NSError **)error;
 
 /**
  Updates the Realm and outstanding objects managed by the Realm to point to the

--- a/Realm/RLMRealm.h
+++ b/Realm/RLMRealm.h
@@ -340,6 +340,13 @@ typedef void (^RLMNotificationBlock)(RLMNotification notification, RLMRealm *rea
 /**
  Performs actions contained within the given block inside a write transaction.
 
+ @see `[RLMRealm transactionWithoutNotifying:block:error:]`
+ */
+- (void)transactionWithoutNotifying:(NSArray<RLMNotificationToken *> *)tokens block:(__attribute__((noescape)) void(^)(void))block;
+
+/**
+ Performs actions contained within the given block inside a write transaction.
+
  Write transactions cannot be nested, and trying to execute a write transaction
  on a Realm which is already participating in a write transaction will throw an
  exception. Calls to `transactionWithBlock:` from `RLMRealm` instances in other

--- a/Realm/RLMRealm.h
+++ b/Realm/RLMRealm.h
@@ -326,9 +326,16 @@ typedef void (^RLMNotificationBlock)(RLMNotification notification, RLMRealm *rea
 /**
  Performs actions contained within the given block inside a write transaction.
 
- @see `[RLMRealm transactionWithBlock:error:]`
+ @see `[RLMRealm transactionWithBlock:withoutNotifying:error:]`
  */
 - (void)transactionWithBlock:(__attribute__((noescape)) void(^)(void))block NS_SWIFT_UNAVAILABLE("");
+
+/**
+ Performs actions contained within the given block inside a write transaction.
+
+ @see `[RLMRealm transactionWithBlock:withoutNotifying:error:]`
+ */
+- (BOOL)transactionWithBlock:(__attribute__((noescape)) void(^)(void))block error:(NSError **)error;
 
 /**
  Performs actions contained within the given block inside a write transaction.
@@ -343,14 +350,27 @@ typedef void (^RLMNotificationBlock)(RLMNotification notification, RLMRealm *rea
  generates notifications if applicable. This has no effect if the Realm
  was already up to date.
 
+ You can skip notifiying specific notification blocks about the changes made
+ in this write transaction by passing in their associated notification tokens.
+ This is primarily useful when the write transaction is saving changes already
+ made in the UI and you do not want to have the notification block attempt to
+ re-apply the same changes.
+
+ The tokens passed to this method must be for notifications for this specific
+ `RLMRealm` instance. Notifications for different threads cannot be skipped
+ using this method.
+
  @param block The block containing actions to perform.
+ @param tokens An array of notification tokens which were returned from adding
+               callbacks which you do not want to be notified for the changes
+               made in this write transaction.
  @param error If an error occurs, upon return contains an `NSError` object
               that describes the problem. If you are not interested in
               possible errors, pass in `NULL`.
 
  @return Whether the transaction succeeded.
  */
-- (BOOL)transactionWithBlock:(__attribute__((noescape)) void(^)(void))block error:(NSError **)error;
+- (BOOL)transactionWithBlock:(__attribute__((noescape)) void(^)(void))block withoutNotifying:(NSArray<RLMNotificationToken *> *)tokens error:(NSError **)error;
 
 /**
  Updates the Realm and outstanding objects managed by the Realm to point to the

--- a/Realm/RLMRealm.mm
+++ b/Realm/RLMRealm.mm
@@ -648,14 +648,7 @@ REALM_NOINLINE static void translateSharedGroupOpenException(RLMRealmConfigurati
 }
 
 - (BOOL)commitWriteTransaction:(NSError **)outError {
-    try {
-        _realm->commit_transaction();
-        return YES;
-    }
-    catch (...) {
-        RLMRealmTranslateException(outError);
-        return NO;
-    }
+    return [self commitWriteTransactionWithoutNotifying:@[] error:outError];
 }
 
 - (BOOL)commitWriteTransactionWithoutNotifying:(NSArray<RLMNotificationToken *> *)tokens error:(NSError **)error {

--- a/Realm/RLMRealm.mm
+++ b/Realm/RLMRealm.mm
@@ -677,6 +677,10 @@ REALM_NOINLINE static void translateSharedGroupOpenException(RLMRealmConfigurati
     return [self transactionWithoutNotifying:@[] block:block error:outError];
 }
 
+- (void)transactionWithoutNotifying:(NSArray<RLMNotificationToken *> *)tokens block:(__attribute__((noescape)) void(^)(void))block {
+    [self transactionWithoutNotifying:tokens block:block error:nil];
+}
+
 - (BOOL)transactionWithoutNotifying:(NSArray<RLMNotificationToken *> *)tokens block:(__attribute__((noescape)) void(^)(void))block error:(NSError **)error {
     [self beginWriteTransaction];
     block();

--- a/Realm/RLMRealm.mm
+++ b/Realm/RLMRealm.mm
@@ -647,8 +647,8 @@ REALM_NOINLINE static void translateSharedGroupOpenException(RLMRealmConfigurati
     [self commitWriteTransaction:nil];
 }
 
-- (BOOL)commitWriteTransaction:(NSError **)outError {
-    return [self commitWriteTransactionWithoutNotifying:@[] error:outError];
+- (BOOL)commitWriteTransaction:(NSError **)error {
+    return [self commitWriteTransactionWithoutNotifying:@[] error:error];
 }
 
 - (BOOL)commitWriteTransactionWithoutNotifying:(NSArray<RLMNotificationToken *> *)tokens error:(NSError **)error {
@@ -674,10 +674,14 @@ REALM_NOINLINE static void translateSharedGroupOpenException(RLMRealmConfigurati
 }
 
 - (BOOL)transactionWithBlock:(__attribute__((noescape)) void(^)(void))block error:(NSError **)outError {
+    return [self transactionWithBlock:block withoutNotifying:@[] error:outError];
+}
+
+- (BOOL)transactionWithBlock:(__attribute__((noescape)) void(^)(void))block withoutNotifying:(NSArray<RLMNotificationToken *> *)tokens error:(NSError **)error {
     [self beginWriteTransaction];
     block();
     if (_realm->is_in_transaction()) {
-        return [self commitWriteTransaction:outError];
+        return [self commitWriteTransactionWithoutNotifying:tokens error:error];
     }
     return YES;
 }

--- a/Realm/RLMRealm.mm
+++ b/Realm/RLMRealm.mm
@@ -674,10 +674,10 @@ REALM_NOINLINE static void translateSharedGroupOpenException(RLMRealmConfigurati
 }
 
 - (BOOL)transactionWithBlock:(__attribute__((noescape)) void(^)(void))block error:(NSError **)outError {
-    return [self transactionWithBlock:block withoutNotifying:@[] error:outError];
+    return [self transactionWithoutNotifying:@[] block:block error:outError];
 }
 
-- (BOOL)transactionWithBlock:(__attribute__((noescape)) void(^)(void))block withoutNotifying:(NSArray<RLMNotificationToken *> *)tokens error:(NSError **)error {
+- (BOOL)transactionWithoutNotifying:(NSArray<RLMNotificationToken *> *)tokens block:(__attribute__((noescape)) void(^)(void))block error:(NSError **)error {
     [self beginWriteTransaction];
     block();
     if (_realm->is_in_transaction()) {

--- a/Realm/Tests/NotificationTests.m
+++ b/Realm/Tests/NotificationTests.m
@@ -174,9 +174,9 @@
         XCTFail(@"should not have been called");
     }];
 
-    [realm transactionWithBlock:^{
+    [realm transactionWithoutNotifying:@[token] block:^{
         [realm deleteAllObjects];
-    } withoutNotifying:@[token] error:nil];
+    } error:nil];
 
     // local realm notifications are called synchronously so no need to wait for anything
     [token invalidate];

--- a/Realm/Tests/NotificationTests.m
+++ b/Realm/Tests/NotificationTests.m
@@ -168,6 +168,20 @@
     [token invalidate];
 }
 
+- (void)testSuppressRealmNotificationInTransactionWithBlock {
+    RLMRealm *realm = [RLMRealm defaultRealm];
+    RLMNotificationToken *token = [realm addNotificationBlock:^(__unused RLMNotification notification, __unused RLMRealm *realm) {
+        XCTFail(@"should not have been called");
+    }];
+
+    [realm transactionWithBlock:^{
+        [realm deleteAllObjects];
+    } withoutNotifying:@[token] error:nil];
+
+    // local realm notifications are called synchronously so no need to wait for anything
+    [token invalidate];
+}
+
 - (void)testSuppressRealmNotificationForWrongRealm {
     RLMRealm *otherRealm = [self realmWithTestPath];
     RLMNotificationToken *token = [otherRealm addNotificationBlock:^(__unused RLMNotification notification, __unused RLMRealm *realm) {

--- a/Realm/Tests/NotificationTests.m
+++ b/Realm/Tests/NotificationTests.m
@@ -176,7 +176,7 @@
 
     [realm transactionWithoutNotifying:@[token] block:^{
         [realm deleteAllObjects];
-    } error:nil];
+    }];
 
     // local realm notifications are called synchronously so no need to wait for anything
     [token invalidate];

--- a/RealmSwift/Realm.swift
+++ b/RealmSwift/Realm.swift
@@ -187,12 +187,27 @@ public final class Realm {
      and generates notifications if applicable. This has no effect if the Realm
      was already up to date.
 
+     You can skip notifiying specific notification blocks about the changes made
+     in this write transaction by passing in their associated notification
+     tokens. This is primarily useful when the write transaction is saving
+     changes already made in the UI and you do not want to have the notification
+     block attempt to re-apply the same changes.
+
+     The tokens passed to this function must be for notifications for this Realm
+     which were added on the same thread as the write transaction is being
+     performed on. Notifications for different threads cannot be skipped using
+     this method.
+
+     - parameter tokens: An array of notification tokens which were returned
+                         from adding callbacks which you do not want to be
+                         notified for the changes made in this write transaction.
+
      - parameter block: The block containing actions to perform.
 
      - throws: An `NSError` if the transaction could not be completed successfully.
                If `block` throws, the function throws the propagated `ErrorType` instead.
      */
-    public func write(_ block: (() throws -> Void)) throws {
+    public func write(withoutNotifying tokens: [NotificationToken] = [], _ block: (() throws -> Void)) throws {
         beginWrite()
         do {
             try block()
@@ -200,7 +215,7 @@ public final class Realm {
             if isInWriteTransaction { cancelWrite() }
             throw error
         }
-        if isInWriteTransaction { try commitWrite() }
+        if isInWriteTransaction { try commitWrite(withoutNotifying: tokens) }
     }
 
     /**
@@ -249,6 +264,10 @@ public final class Realm {
      this method.
 
      - warning: This method may only be called during a write transaction.
+
+     - parameter tokens: An array of notification tokens which were returned
+                         from adding callbacks which you do not want to be
+                         notified for the changes made in this write transaction.
 
      - throws: An `NSError` if the transaction could not be written due to
                running out of disk space or other i/o errors.

--- a/RealmSwift/Tests/RealmTests.swift
+++ b/RealmSwift/Tests/RealmTests.swift
@@ -215,6 +215,20 @@ class RealmTests: TestCase {
         XCTAssertEqual(try! Realm().objects(SwiftStringObject.self).count, 1)
     }
 
+    func testWriteWithoutNotifying() {
+        let realm = try! Realm()
+        let token = realm.observe { _, _ in
+            XCTFail("should not have been called")
+        }
+
+        try! realm.write(withoutNotifying: [token]) {
+            realm.deleteAll()
+        }
+
+        // local realm notifications are called synchronously so no need to wait for anything
+        token.invalidate()
+    }
+
     func testDynamicWriteSubscripting() {
         try! Realm().beginWrite()
         let object = try! Realm().dynamicCreate("SwiftStringObject", value: ["1"])


### PR DESCRIPTION
# Motivation

We currently use the closure-based `Realm.write(_:)` method in our current projects and have recently started needing to utilise the notification suppression functionality that exists on `Realm.commitWrite(withoutNotifying:)`. 

Since the closure-based APIs don't currently support this, we've added an extension internally to work around this however after digging through the original implementation PR, I noticed that it was mentioned that the exact same extension I was introducing had already been considered but not yet implemented - https://github.com/realm/realm-cocoa/pull/4253#issuecomment-263374494

I thought it might be worth giving it a go here since it would mean one less extension for us and also provide some use for other people as well in the longer run 🙂 

# Changes

I've done a few things in this PR, hopefully none of them are too significant. This change aims to bring the same functionality to `RLMRealm` as well as `Realm`.

The first commit in this PR slightly cleans up the previous implementation of `-[RLMRealm commitWriteTransaction:]` by calling through to `-[RLMRealm commitWriteTransactionWithoutNotifying:error:]` directly instead of just duplicating part of the implementation. Since this method is so similar to the one I'm about to introduce, I thought it would be worthwhile making the two methods behave in a consistent way.

The second commit then introduces the Objective C support by adding a new method:

```objc
- (BOOL)transactionWithBlock:(__attribute__((noescape)) void(^)(void))block withoutNotifying:(NSArray<RLMNotificationToken *> *)tokens error:(NSError **)error;
```

The signature here is a tad lengthy so please let me know if there is a way that I can improve it. It's been a while since I've touched Objective C so I'm not really up to date with recommended API design guidelines.

Anyway, this method does exactly what the existing `-[RLMRealm transactionWithBlock:error:]` was doing but instead it calls through to `-[RLMRealm commitWriteTransactionWithoutNotifying:error:]` when committing the write and the previous method will pass an empty array (`@[]`) for convenience. 

I've also added a simple test to validate the behaviour. 

The last commit then does similar to Swift's `Realm` object by updating the existing method to introduce a new argument at the beginning. I've also added another unit test here as well to verify the functionality. 

# API Compatibility

All changes here are additive and shouldn't break when users update to the latest version however there is a slight downside to this since to achieve this, I'd have to leave the `block` argument without a label which isn't that much of a deal, but it doesn't really follow API design guidelines in Swift as it's now the secondary argument. 

I could change it from `write(withoutNotifying:_:)` to `write(withoutNotifying:block:)` however it would cause a compile error in the event that the block was declared within the braces such as the following:

```swift
try realm.write { ... } // Compiles
try realm.write({ ... }) // Error: Missing argument for parameter 'block' in call
```

I'd prefer to re-introduce the `block` label as I think its better matches api design guidelines but I might be wrong.. It seems like it did exist at one time and then was removed in #4078 ... I've left it unlabelled for now but something to think about, I'm not sure what the thoughts are on introducing breaking changes. 

I guess sone other option could be to deprecate the old method signature like so:

```swift
@available(*, deprecated, message: "Renamed, use write(withoutNotifying:block:) instead")
public func write(_ block: (() throws -> Void)) throws {
    try write(block: block)
}
```

# Documentation

The header documentation added in this PR is mostly explanations that existed on other methods but I think it covered everything... I also think it might be good to update the code snippet on https://realm.io/docs/swift/latest#interface-driven-writes however I can't see that in the repo so I'm guessing it's managed elsewhere