### PR TITLE
Forward the url_prefix from auth responses to the sync session

### DIFF
--- a/Realm/RLMJSONModels.h
+++ b/Realm/RLMJSONModels.h
@@ -67,6 +67,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, readonly, nullable) RLMTokenModel *accessToken;
 @property (nonatomic, readonly, nullable) RLMTokenModel *refreshToken;
+@property (nonatomic, readonly, nullable) NSString *urlPrefix;
 
 - (instancetype)initWithDictionary:(NSDictionary *)jsonDictionary
                 requireAccessToken:(BOOL)requireAccessToken

--- a/Realm/RLMJSONModels.m
+++ b/Realm/RLMJSONModels.m
@@ -97,6 +97,7 @@ static const NSString *const kRLMSyncValueKey           = @"value";
 
 @property (nonatomic, readwrite) RLMTokenModel *accessToken;
 @property (nonatomic, readwrite) RLMTokenModel *refreshToken;
+@property (nonatomic, readwrite) NSString *urlPrefix;
 
 @end
 
@@ -118,6 +119,7 @@ static const NSString *const kRLMSyncValueKey           = @"value";
         } else {
             RLM_SYNC_PARSE_OPTIONAL_MODEL(jsonDictionary, kRLMSyncRefreshTokenKey, RLMTokenModel, refreshToken);
         }
+        self.urlPrefix = jsonDictionary[@"sync_worker"][@"path"];
         return self;
     }
     return nil;

--- a/Realm/RLMSyncSessionRefreshHandle.mm
+++ b/Realm/RLMSyncSessionRefreshHandle.mm
@@ -141,6 +141,12 @@ static const NSTimeInterval RLMRefreshBuffer = 10;
         return NO;
     }
 
+    // Realm Cloud will give us a url prefix in the auth response that we need
+    // to pass onto objectstore to have it connect to the proper sync worker
+    if (model.urlPrefix) {
+        session->set_url_prefix(model.urlPrefix.UTF8String);
+    }
+
     // Calculate the resolved path.
     NSString *resolvedURLString = nil;
     RLMServerPath resolvedPath = model.accessToken.tokenData.path;


### PR DESCRIPTION
This enables Realm Cloud to bypass the sync worker proxy.