### PR TITLE
Make rlm_lldb.py compatible with Python 3

### DIFF
--- a/plugin/rlm_lldb.py
+++ b/plugin/rlm_lldb.py
@@ -34,7 +34,7 @@ if __name__ == '__main__':
 
     # Copy the file into place
     try:
-        os.makedirs(destination, 0744)
+        os.makedirs(destination, 0o744)
     except os.error as e:
         # It's fine if the directory already exists
         if e.errno != errno.EEXIST:


### PR DESCRIPTION
This fixes the error when LLDB is importing rlm_lldb.py

```
error: module importing failed: invalid token (rlm_lldb.py, line 37)
  File "temp.py", line 1, in <module> 
```