### PR TITLE
Restore support for @objc enums on Swift objects

### DIFF
--- a/.jenkins.yml
+++ b/.jenkins.yml
@@ -25,6 +25,7 @@ target:
  - tvos-swift
  - cocoapods-osx
  - cocoapods-ios
+ - cocoapods-ios-dynamic
  - cocoapods-watchos
  - swiftpm
 configuration: 
@@ -387,6 +388,30 @@ exclude:
 
   - xcode_version: 11.2
     target: cocoapods-ios
+    configuration: Debug
+
+  - xcode_version: 10.0
+    target: cocoapods-ios-dynamic
+    configuration: Debug
+
+  - xcode_version: 10.1
+    target: cocoapods-ios-dynamic
+    configuration: Debug
+
+  - xcode_version: 10.2.1
+    target: cocoapods-ios-dynamic
+    configuration: Debug
+
+  - xcode_version: 10.3
+    target: cocoapods-ios-dynamic
+    configuration: Debug
+
+  - xcode_version: 11.1
+    target: cocoapods-ios-dynamic
+    configuration: Debug
+
+  - xcode_version: 11.2
+    target: cocoapods-ios-dynamic
     configuration: Debug
 
   - xcode_version: 10.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ x.y.z Release notes (yyyy-MM-dd)
 ### Enhancements
 * Improve performance of queries over a link where the final target property
   has an index.
+* Restore support for storing `@objc enum` properties on RealmSwift.Object
+  subclasses (broken in 4.0.0), and add support for storing them in
+  RealmOptional properties.
 
 ### Fixed
 * The sync client would fail to reconnect after failing to integrate a

--- a/RealmSwift/Object.swift
+++ b/RealmSwift/Object.swift
@@ -44,14 +44,15 @@ import Realm.Private
  - `Bool`
  - `Date`, `NSDate`
  - `Data`, `NSData`
+ - `@objc enum` which has been delcared as conforming to `RealmEnum`.
  - `RealmOptional<Value>` for optional numeric properties
  - `Object` subclasses, to model many-to-one relationships
  - `List<Element>`, to model many-to-many relationships
 
  `String`, `NSString`, `Date`, `NSDate`, `Data`, `NSData` and `Object` subclass properties can be declared as optional.
- `Int`, `Int8`, `Int16`, `Int32`, `Int64`, `Float`, `Double`, `Bool`, and `List` properties cannot. To store an optional
- number, use `RealmOptional<Int>`, `RealmOptional<Float>`, `RealmOptional<Double>`, or `RealmOptional<Bool>` instead,
- which wraps an optional numeric value.
+ `Int`, `Int8`, `Int16`, `Int32`, `Int64`, `Float`, `Double`, `Bool`,  enum, and `List` properties cannot.
+ To store an optional number, use `RealmOptional<Int>`, `RealmOptional<Float>`, `RealmOptional<Double>`, or
+ `RealmOptional<Bool>` instead, which wraps an optional numeric value. Lists cannot be optional at all.
 
  All property types except for `List` and `RealmOptional` *must* be declared as `@objc dynamic var`. `List` and
  `RealmOptional` properties must be declared as non-dynamic `let` properties. Swift `lazy` properties are not allowed.
@@ -385,8 +386,55 @@ public final class DynamicObject: Object {
     }
 }
 
+/**
+ An enum type which can be stored on a Realm Object.
+
+ Only `@objc` enums backed by an Int can be stored on a Realm object, and the
+ enum type must explicitly conform to this protocol. For example:
+
+ ```
+ @objc enum class MyEnum: Int, RealmEnum {
+    case first = 1
+    case second = 2
+    case third = 7
+ }
+
+ class MyModel: Object {
+    @objc dynamic enumProperty = MyEnum.first
+    let optionalEnumProperty = RealmOptional<MyEnum>()
+ }
+ ```
+ */
+public protocol RealmEnum: RealmOptionalType, _ManagedPropertyType {
+    /// :nodoc:
+    // swiftlint:disable:next identifier_name
+    static func _rlmToRawValue(_ value: Any) -> Any
+    /// :nodoc:
+    // swiftlint:disable:next identifier_name
+    static func _rlmFromRawValue(_ value: Any) -> Any
+}
+
+// MARK: - Implementation
+
+/// :nodoc:
+public extension RealmEnum where Self: RawRepresentable, RawValue: _ManagedPropertyType {
+    // swiftlint:disable:next identifier_name
+    static func _rlmToRawValue(_ value: Any) -> Any {
+        return (value as! Self).rawValue
+    }
+    // swiftlint:disable:next identifier_name
+    static func _rlmFromRawValue(_ value: Any) -> Any {
+        return Self.init(rawValue: value as! RawValue)!
+    }
+    // swiftlint:disable:next identifier_name
+    static func _rlmProperty(_ prop: RLMProperty) {
+        RawValue._rlmProperty(prop)
+    }
+}
+
 // A type which can be a managed property on a Realm object
-internal protocol ManagedPropertyType {
+/// :nodoc:
+public protocol _ManagedPropertyType {
     // swiftlint:disable:next identifier_name
     func _rlmProperty(_ prop: RLMProperty)
     // swiftlint:disable:next identifier_name
@@ -394,101 +442,117 @@ internal protocol ManagedPropertyType {
     // swiftlint:disable:next identifier_name
     static func _rlmRequireObjc() -> Bool
 }
-extension ManagedPropertyType {
+/// :nodoc:
+extension _ManagedPropertyType {
     // swiftlint:disable:next identifier_name
-    func _rlmProperty(_ prop: RLMProperty) { }
+    public func _rlmProperty(_ prop: RLMProperty) { }
     // swiftlint:disable:next identifier_name
-    static func _rlmRequireObjc() -> Bool { return true }
+    public static func _rlmRequireObjc() -> Bool { return true }
 }
 
-extension Int: ManagedPropertyType {
+/// :nodoc:
+extension Int: _ManagedPropertyType {
     // swiftlint:disable:next identifier_name
-    static func _rlmProperty(_ prop: RLMProperty) {
+    public static func _rlmProperty(_ prop: RLMProperty) {
         prop.type = .int
     }
 }
-extension Int8: ManagedPropertyType {
+/// :nodoc:
+extension Int8: _ManagedPropertyType {
     // swiftlint:disable:next identifier_name
-    static func _rlmProperty(_ prop: RLMProperty) {
+    public static func _rlmProperty(_ prop: RLMProperty) {
         prop.type = .int
     }
 }
-extension Int16: ManagedPropertyType {
+/// :nodoc:
+extension Int16: _ManagedPropertyType {
     // swiftlint:disable:next identifier_name
-    static func _rlmProperty(_ prop: RLMProperty) {
+    public static func _rlmProperty(_ prop: RLMProperty) {
         prop.type = .int
     }
 }
-extension Int32: ManagedPropertyType {
+/// :nodoc:
+extension Int32: _ManagedPropertyType {
     // swiftlint:disable:next identifier_name
-    static func _rlmProperty(_ prop: RLMProperty) {
+    public static func _rlmProperty(_ prop: RLMProperty) {
         prop.type = .int
     }
 }
-extension Int64: ManagedPropertyType {
+/// :nodoc:
+extension Int64: _ManagedPropertyType {
     // swiftlint:disable:next identifier_name
-    static func _rlmProperty(_ prop: RLMProperty) {
+    public static func _rlmProperty(_ prop: RLMProperty) {
         prop.type = .int
     }
 }
-extension Float: ManagedPropertyType {
+/// :nodoc:
+extension Float: _ManagedPropertyType {
     // swiftlint:disable:next identifier_name
-    static func _rlmProperty(_ prop: RLMProperty) {
+    public static func _rlmProperty(_ prop: RLMProperty) {
         prop.type = .float
     }
 }
-extension Double: ManagedPropertyType {
+/// :nodoc:
+extension Double: _ManagedPropertyType {
     // swiftlint:disable:next identifier_name
-    static func _rlmProperty(_ prop: RLMProperty) {
+    public static func _rlmProperty(_ prop: RLMProperty) {
         prop.type = .double
     }
 }
-extension Bool: ManagedPropertyType {
+/// :nodoc:
+extension Bool: _ManagedPropertyType {
     // swiftlint:disable:next identifier_name
-    static func _rlmProperty(_ prop: RLMProperty) {
+    public static func _rlmProperty(_ prop: RLMProperty) {
         prop.type = .bool
     }
 }
-extension String: ManagedPropertyType {
+/// :nodoc:
+extension String: _ManagedPropertyType {
     // swiftlint:disable:next identifier_name
-    static func _rlmProperty(_ prop: RLMProperty) {
+    public static func _rlmProperty(_ prop: RLMProperty) {
         prop.type = .string
     }
 }
-extension NSString: ManagedPropertyType {
+/// :nodoc:
+extension NSString: _ManagedPropertyType {
     // swiftlint:disable:next identifier_name
-    static func _rlmProperty(_ prop: RLMProperty) {
+    public static func _rlmProperty(_ prop: RLMProperty) {
         prop.type = .string
     }
 }
-extension Data: ManagedPropertyType {
+/// :nodoc:
+extension Data: _ManagedPropertyType {
     // swiftlint:disable:next identifier_name
-    static func _rlmProperty(_ prop: RLMProperty) {
+    public static func _rlmProperty(_ prop: RLMProperty) {
         prop.type = .data
     }
 }
-extension NSData: ManagedPropertyType {
+/// :nodoc:
+extension NSData: _ManagedPropertyType {
     // swiftlint:disable:next identifier_name
-    static func _rlmProperty(_ prop: RLMProperty) {
+    public static func _rlmProperty(_ prop: RLMProperty) {
         prop.type = .data
     }
 }
-extension Date: ManagedPropertyType {
+/// :nodoc:
+extension Date: _ManagedPropertyType {
     // swiftlint:disable:next identifier_name
-    static func _rlmProperty(_ prop: RLMProperty) {
+    public static func _rlmProperty(_ prop: RLMProperty) {
         prop.type = .date
     }
 }
-extension NSDate: ManagedPropertyType {
+/// :nodoc:
+extension NSDate: _ManagedPropertyType {
     // swiftlint:disable:next identifier_name
-    static func _rlmProperty(_ prop: RLMProperty) {
+    public static func _rlmProperty(_ prop: RLMProperty) {
         prop.type = .date
     }
 }
 
-extension Object: ManagedPropertyType {
+/// :nodoc:
+extension Object: _ManagedPropertyType {
     // swiftlint:disable:next identifier_name
-    static func _rlmProperty(_ prop: RLMProperty) {
+    public static func _rlmProperty(_ prop: RLMProperty) {
         if !prop.optional && !prop.array {
             throwRealmException("Object property '\(prop.name)' must be marked as optional.")
         }
@@ -500,16 +564,18 @@ extension Object: ManagedPropertyType {
     }
 }
 
-extension List: ManagedPropertyType where Element: ManagedPropertyType {
+/// :nodoc:
+extension List: _ManagedPropertyType where Element: _ManagedPropertyType {
     // swiftlint:disable:next identifier_name
-    static func _rlmProperty(_ prop: RLMProperty) {
+    public static func _rlmProperty(_ prop: RLMProperty) {
         prop.array = true
         Element._rlmProperty(prop)
     }
     // swiftlint:disable:next identifier_name
-    static func _rlmRequireObjc() -> Bool { return false }
+    public static func _rlmRequireObjc() -> Bool { return false }
 }
 
+/// :nodoc:
 class LinkingObjectsAccessor<Element: Object>: RLMManagedPropertyAccessor {
     @objc override class func initializeObject(_ ptr: UnsafeMutableRawPointer,
                                                parent: RLMObjectBase, property: RLMProperty) {
@@ -520,38 +586,41 @@ class LinkingObjectsAccessor<Element: Object>: RLMManagedPropertyAccessor {
     }
 }
 
-extension LinkingObjects: ManagedPropertyType {
+/// :nodoc:
+extension LinkingObjects: _ManagedPropertyType {
     // swiftlint:disable:next identifier_name
-    static func _rlmProperty(_ prop: RLMProperty) {
+    public static func _rlmProperty(_ prop: RLMProperty) {
         prop.array = true
         prop.type = .linkingObjects
         prop.objectClassName = Element.className()
         prop.swiftAccessor = LinkingObjectsAccessor<Element>.self
     }
     // swiftlint:disable:next identifier_name
-    func _rlmProperty(_ prop: RLMProperty) {
+    public func _rlmProperty(_ prop: RLMProperty) {
         prop.linkOriginPropertyName = self.propertyName
     }
     // swiftlint:disable:next identifier_name
-    static func _rlmRequireObjc() -> Bool { return false }
+    public static func _rlmRequireObjc() -> Bool { return false }
 }
 
-extension Optional: ManagedPropertyType where Wrapped: ManagedPropertyType {
+/// :nodoc:
+extension Optional: _ManagedPropertyType where Wrapped: _ManagedPropertyType {
     // swiftlint:disable:next identifier_name
-    static func _rlmProperty(_ prop: RLMProperty) {
+    public static func _rlmProperty(_ prop: RLMProperty) {
         prop.optional = true
         Wrapped._rlmProperty(prop)
     }
 }
 
-extension RealmOptional: ManagedPropertyType where Value: ManagedPropertyType {
+/// :nodoc:
+extension RealmOptional: _ManagedPropertyType where Value: _ManagedPropertyType {
     // swiftlint:disable:next identifier_name
-    static func _rlmProperty(_ prop: RLMProperty) {
+    public static func _rlmProperty(_ prop: RLMProperty) {
         prop.optional = true
         Value._rlmProperty(prop)
     }
     // swiftlint:disable:next identifier_name
-    static func _rlmRequireObjc() -> Bool { return false }
+    public static func _rlmRequireObjc() -> Bool { return false }
 }
 
 /// :nodoc:
@@ -639,7 +708,12 @@ internal class ObjectUtil {
 
         return getNonIgnoredMirrorChildren(for: object).compactMap { prop in
             guard let label = prop.label else { return nil }
-            guard let value = prop.value as? ManagedPropertyType else {
+            var rawValue = prop.value
+            if let value = rawValue as? RealmEnum {
+                rawValue = type(of: value)._rlmToRawValue(value)
+            }
+
+            guard let value = rawValue as? _ManagedPropertyType else {
                 if class_getProperty(cls, label) != nil {
                     throwRealmException("Property \(cls).\(label) is declared as \(type(of: prop.value)), which is not a supported managed Object property type. If it is not supposed to be a managed property, either add it to `ignoredProperties()` or do not declare it as `@objc dynamic`. See https://realm.io/docs/swift/latest/api/Classes/Object.html for more information.")
                 }

--- a/RealmSwift/Object.swift
+++ b/RealmSwift/Object.swift
@@ -417,7 +417,7 @@ public protocol RealmEnum: RealmOptionalType, _ManagedPropertyType {
 // MARK: - Implementation
 
 /// :nodoc:
-public extension RealmEnum where Self: RawRepresentable, RawValue: _ManagedPropertyType {
+public extension RealmEnum where Self: RawRepresentable, Self.RawValue: _ManagedPropertyType {
     // swiftlint:disable:next identifier_name
     static func _rlmToRawValue(_ value: Any) -> Any {
         return (value as! Self).rawValue

--- a/RealmSwift/Tests/MigrationTests.swift
+++ b/RealmSwift/Tests/MigrationTests.swift
@@ -511,6 +511,8 @@ class MigrationTests: TestCase {
                 XCTAssertEqual((newObj!["boolCol"] as! Bool), true)
                 XCTAssertEqual((oldObj!["intCol"] as! Int), 123)
                 XCTAssertEqual((newObj!["intCol"] as! Int), 123)
+                XCTAssertEqual((oldObj!["intEnumCol"] as! Int), 1)
+                XCTAssertEqual((newObj!["intEnumCol"] as! Int), 1)
                 XCTAssertEqual((oldObj!["floatCol"] as! Float), 1.23 as Float)
                 XCTAssertEqual((newObj!["floatCol"] as! Float), 1.23 as Float)
                 XCTAssertEqual((oldObj!["doubleCol"] as! Double), 12.3 as Double)
@@ -536,6 +538,7 @@ class MigrationTests: TestCase {
                 // edit all values
                 newObj!["boolCol"] = false
                 newObj!["intCol"] = 1
+                newObj!["intEnumCol"] = IntEnum.value2.rawValue
                 newObj!["floatCol"] = 1.0
                 newObj!["doubleCol"] = 10.0
                 newObj!["binaryCol"] = Data(bytes: "b", count: 1)
@@ -575,7 +578,7 @@ class MigrationTests: TestCase {
                 XCTAssertEqual(list.count, 1)
                 XCTAssertEqual((list[0]["boolCol"] as! Bool), false)
 
-                self.assertMatches(newObj!.description, "SwiftObject \\{\n\tboolCol = 0;\n\tintCol = 1;\n\tfloatCol = 1;\n\tdoubleCol = 10;\n\tstringCol = a;\n\tbinaryCol = <.*62.*>;\n\tdateCol = 1970-01-01 00:00:02 \\+0000;\n\tobjectCol = SwiftBoolObject \\{\n\t\tboolCol = 0;\n\t\\};\n\tarrayCol = List<SwiftBoolObject> <0x[0-9a-f]+> \\(\n\t\t\\[0\\] SwiftBoolObject \\{\n\t\t\tboolCol = 0;\n\t\t\\}\n\t\\);\n\\}")
+                self.assertMatches(newObj!.description, "SwiftObject \\{\n\tboolCol = 0;\n\tintCol = 1;\n\tintEnumCol = 3;\n\tfloatCol = 1;\n\tdoubleCol = 10;\n\tstringCol = a;\n\tbinaryCol = <.*62.*>;\n\tdateCol = 1970-01-01 00:00:02 \\+0000;\n\tobjectCol = SwiftBoolObject \\{\n\t\tboolCol = 0;\n\t\\};\n\tarrayCol = List<SwiftBoolObject> <0x[0-9a-f]+> \\(\n\t\t\\[0\\] SwiftBoolObject \\{\n\t\t\tboolCol = 0;\n\t\t\\}\n\t\\);\n\\}")
 
                 enumerated = true
             })
@@ -583,7 +586,7 @@ class MigrationTests: TestCase {
 
             let newObj = migration.create(SwiftObject.className())
             // swiftlint:next:disable line_length
-            self.assertMatches(newObj.description, "SwiftObject \\{\n\tboolCol = 0;\n\tintCol = 123;\n\tfloatCol = 1\\.23;\n\tdoubleCol = 12\\.3;\n\tstringCol = a;\n\tbinaryCol = <.*61.*>;\n\tdateCol = 1970-01-01 00:00:01 \\+0000;\n\tobjectCol = SwiftBoolObject \\{\n\t\tboolCol = 0;\n\t\\};\n\tarrayCol = List<SwiftBoolObject> <0x[0-9a-f]+> \\(\n\t\n\t\\);\n\\}")
+            self.assertMatches(newObj.description, "SwiftObject \\{\n\tboolCol = 0;\n\tintCol = 123;\n\tintEnumCol = 1;\n\tfloatCol = 1\\.23;\n\tdoubleCol = 12\\.3;\n\tstringCol = a;\n\tbinaryCol = <.*61.*>;\n\tdateCol = 1970-01-01 00:00:01 \\+0000;\n\tobjectCol = SwiftBoolObject \\{\n\t\tboolCol = 0;\n\t\\};\n\tarrayCol = List<SwiftBoolObject> <0x[0-9a-f]+> \\(\n\t\n\t\\);\n\\}")
         }
 
         // refresh to update realm

--- a/RealmSwift/Tests/ObjectAccessorTests.swift
+++ b/RealmSwift/Tests/ObjectAccessorTests.swift
@@ -64,9 +64,14 @@ class ObjectAccessorTests: TestCase {
 
         object.objectCol = SwiftBoolObject(value: [true])
         XCTAssertEqual(object.objectCol!.boolCol, true)
+
+        object.intEnumCol = .value1
+        XCTAssertEqual(object.intEnumCol, .value1)
+        object.intEnumCol = .value2
+        XCTAssertEqual(object.intEnumCol, .value2)
     }
 
-    func testStandaloneAccessors() {
+    func testUnmanagedAccessors() {
         let object = SwiftObject()
         setAndTestAllProperties(object)
 
@@ -74,7 +79,7 @@ class ObjectAccessorTests: TestCase {
         setAndTestAllOptionalProperties(optionalObject)
     }
 
-    func testPersistedAccessors() {
+    func testManagedAccessors() {
         let realm = try! Realm()
         realm.beginWrite()
         let object = realm.create(SwiftObject.self)
@@ -328,6 +333,13 @@ class ObjectAccessorTests: TestCase {
         XCTAssertEqual(object.optObjectCol!.boolCol, true)
         object.optObjectCol = nil
         XCTAssertNil(object.optObjectCol)
+
+        object.optEnumCol.value = .value1
+        XCTAssertEqual(object.optEnumCol.value, .value1)
+        object.optEnumCol.value = .value2
+        XCTAssertEqual(object.optEnumCol.value, .value2)
+        object.optEnumCol.value = nil
+        XCTAssertNil(object.optEnumCol.value)
     }
 
     func testLinkingObjectsDynamicGet() {

--- a/RealmSwift/Tests/ObjectCreationTests.swift
+++ b/RealmSwift/Tests/ObjectCreationTests.swift
@@ -115,8 +115,10 @@ class ObjectCreationTests: TestCase {
 
     func testInitWithArray() {
         // array with all values specified
-        let baselineValues: [Any] = [true, 1, 1.1 as Float, 11.1, "b", "b".data(using: String.Encoding.utf8)!,
-            Date(timeIntervalSince1970: 2), ["boolCol": true], [[true], [false]]]
+        let baselineValues: [Any] = [true, 1, IntEnum.value1.rawValue, 1.1 as Float,
+                                     11.1, "b", "b".data(using: String.Encoding.utf8)!,
+                                     Date(timeIntervalSince1970: 2), ["boolCol": true],
+                                     [[true], [false]]]
 
         // test with valid dictionary literals
         let props = try! Realm().schema["SwiftObject"]!.properties
@@ -277,7 +279,7 @@ class ObjectCreationTests: TestCase {
 
     func testCreateWithArray() {
         // array with all values specified
-        let baselineValues: [Any] = [true, 1, 1.1 as Float, 11.1, "b", "b".data(using: String.Encoding.utf8)!,
+        let baselineValues: [Any] = [true, 1, IntEnum.value1.rawValue, 1.1 as Float, 11.1, "b", "b".data(using: String.Encoding.utf8)!,
             Date(timeIntervalSince1970: 2), ["boolCol": true], [[true], [false]]]
 
         // test with valid dictionary literals
@@ -1002,11 +1004,12 @@ class ObjectCreationTests: TestCase {
                                                    boolObjectListValues: [Bool]) {
         XCTAssertEqual(object.boolCol, (array[0] as! Bool))
         XCTAssertEqual(object.intCol, (array[1] as! Int))
-        //XCTAssertEqual(object.floatCol, (array[2] as! Float)) // FIXME: crashes with swift 3.2
-        XCTAssertEqual(object.doubleCol, (array[3] as! Double))
-        XCTAssertEqual(object.stringCol, (array[4] as! String))
-        XCTAssertEqual(object.binaryCol, (array[5] as! Data))
-        XCTAssertEqual(object.dateCol, (array[6] as! Date))
+        XCTAssertEqual(object.intEnumCol, IntEnum(rawValue: array[2] as! Int))
+        XCTAssertEqual(object.floatCol, (array[3] as! NSNumber).floatValue)
+        XCTAssertEqual(object.doubleCol, (array[4] as! Double))
+        XCTAssertEqual(object.stringCol, (array[5] as! String))
+        XCTAssertEqual(object.binaryCol, (array[6] as! Data))
+        XCTAssertEqual(object.dateCol, (array[7] as! Date))
         XCTAssertEqual(object.objectCol!.boolCol, boolObjectValue)
         XCTAssertEqual(object.arrayCol.count, boolObjectListValues.count)
         for i in 0..<boolObjectListValues.count {

--- a/RealmSwift/Tests/ObjectSchemaTests.swift
+++ b/RealmSwift/Tests/ObjectSchemaTests.swift
@@ -30,7 +30,8 @@ class ObjectSchemaTests: TestCase {
         let objectSchema = swiftObjectSchema
         let propertyNames = objectSchema.properties.map { $0.name }
         XCTAssertEqual(propertyNames,
-            ["boolCol", "intCol", "floatCol", "doubleCol", "stringCol", "binaryCol", "dateCol", "objectCol", "arrayCol"]
+            ["boolCol", "intCol", "intEnumCol", "floatCol", "doubleCol",
+             "stringCol", "binaryCol", "dateCol", "objectCol", "arrayCol"]
         )
     }
 
@@ -65,6 +66,15 @@ class ObjectSchemaTests: TestCase {
             "        optional = NO;\n" +
             "    }\n" +
             "    intCol {\n" +
+            "        type = int;\n" +
+            "        objectClassName = (null);\n" +
+            "        linkOriginPropertyName = (null);\n" +
+            "        indexed = NO;\n" +
+            "        isPrimary = NO;\n" +
+            "        array = NO;\n" +
+            "        optional = NO;\n" +
+            "    }\n" +
+            "    intEnumCol {\n" +
             "        type = int;\n" +
             "        objectClassName = (null);\n" +
             "        linkOriginPropertyName = (null);\n" +

--- a/RealmSwift/Tests/ObjectTests.swift
+++ b/RealmSwift/Tests/ObjectTests.swift
@@ -72,7 +72,7 @@ class ObjectTests: TestCase {
         XCTAssert(schema.properties as AnyObject is [Property])
         XCTAssertEqual(schema.className, "SwiftObject")
         XCTAssertEqual(schema.properties.map { $0.name },
-            ["boolCol", "intCol", "floatCol", "doubleCol", "stringCol", "binaryCol", "dateCol", "objectCol", "arrayCol"]
+            ["boolCol", "intCol", "intEnumCol", "floatCol", "doubleCol", "stringCol", "binaryCol", "dateCol", "objectCol", "arrayCol"]
         )
     }
 
@@ -115,7 +115,7 @@ class ObjectTests: TestCase {
     func testDescription() {
         let object = SwiftObject()
         // swiftlint:disable line_length
-        assertMatches(object.description, "SwiftObject \\{\n\tboolCol = 0;\n\tintCol = 123;\n\tfloatCol = 1\\.23;\n\tdoubleCol = 12\\.3;\n\tstringCol = a;\n\tbinaryCol = <.*61.*>;\n\tdateCol = 1970-01-01 00:00:01 \\+0000;\n\tobjectCol = SwiftBoolObject \\{\n\t\tboolCol = 0;\n\t\\};\n\tarrayCol = List<SwiftBoolObject> <0x[0-9a-f]+> \\(\n\t\n\t\\);\n\\}")
+        assertMatches(object.description, "SwiftObject \\{\n\tboolCol = 0;\n\tintCol = 123;\n\tintEnumCol = 1;\n\tfloatCol = 1\\.23;\n\tdoubleCol = 12\\.3;\n\tstringCol = a;\n\tbinaryCol = <.*61.*>;\n\tdateCol = 1970-01-01 00:00:01 \\+0000;\n\tobjectCol = SwiftBoolObject \\{\n\t\tboolCol = 0;\n\t\\};\n\tarrayCol = List<SwiftBoolObject> <0x[0-9a-f]+> \\(\n\t\n\t\\);\n\\}")
 
         let recursiveObject = SwiftRecursiveObject()
         recursiveObject.objects.append(recursiveObject)

--- a/RealmSwift/Tests/SwiftTestObjects.swift
+++ b/RealmSwift/Tests/SwiftTestObjects.swift
@@ -36,9 +36,15 @@ class SwiftLongObject: Object {
     @objc dynamic var longCol: Int64 = 0
 }
 
+@objc enum IntEnum: Int, RealmEnum {
+    case value1 = 1
+    case value2 = 3
+}
+
 class SwiftObject: Object {
     @objc dynamic var boolCol = false
     @objc dynamic var intCol = 123
+    @objc dynamic var intEnumCol = IntEnum.value1
     @objc dynamic var floatCol = 1.23 as Float
     @objc dynamic var doubleCol = 12.3
     @objc dynamic var stringCol = "a"
@@ -75,6 +81,7 @@ class SwiftOptionalObject: Object {
     let optFloatCol = RealmOptional<Float>()
     let optDoubleCol = RealmOptional<Double>()
     let optBoolCol = RealmOptional<Bool>()
+    let optEnumCol = RealmOptional<IntEnum>()
     @objc dynamic var optObjectCol: SwiftBoolObject?
 }
 

--- a/RealmSwift/Util.swift
+++ b/RealmSwift/Util.swift
@@ -90,6 +90,8 @@ public func dynamicBridgeCast<T>(fromObjectiveC x: Any) -> T {
         return unsafeBitCast(x as AnyObject, to: T.self)
     } else if let bridgeableType = T.self as? CustomObjectiveCBridgeable.Type {
         return bridgeableType.bridging(objCValue: x) as! T
+    } else if let bridgeableType = T.self as? RealmEnum.Type {
+        return bridgeableType._rlmFromRawValue(x) as! T
     } else {
         return x as! T
     }
@@ -99,6 +101,8 @@ public func dynamicBridgeCast<T>(fromObjectiveC x: Any) -> T {
 public func dynamicBridgeCast<T>(fromSwift x: T) -> Any {
     if let x = x as? CustomObjectiveCBridgeable {
         return x.objCValue
+    } else if let bridgeableType = T.self as? RealmEnum.Type {
+        return bridgeableType._rlmToRawValue(x)
     } else {
         return x
     }

--- a/build.sh
+++ b/build.sh
@@ -884,6 +884,7 @@ case "$COMMAND" in
         fi
 
         sh build.sh verify-cocoapods-ios
+        sh build.sh verify-cocoapods-ios-dynamic
         sh build.sh verify-cocoapods-osx
         sh build.sh verify-cocoapods-watchos
 
@@ -899,6 +900,14 @@ case "$COMMAND" in
         sh build.sh test-watchos-swift-cocoapods
         ;;
 
+    verify-cocoapods-ios-dynamic)
+        PLATFORM=$(echo $COMMAND | cut -d - -f 3)
+        # https://github.com/CocoaPods/CocoaPods/issues/7708
+        export EXPANDED_CODE_SIGN_IDENTITY=''
+        cd examples/installation
+        sh build.sh test-ios-objc-cocoapods-dynamic
+        ;;
+
     verify-cocoapods-*)
         PLATFORM=$(echo $COMMAND | cut -d - -f 3)
         # https://github.com/CocoaPods/CocoaPods/issues/7708
@@ -906,9 +915,6 @@ case "$COMMAND" in
         cd examples/installation
         sh build.sh test-$PLATFORM-objc-cocoapods
         sh build.sh test-$PLATFORM-swift-cocoapods
-        if [[ $PLATFORM = "ios" ]]; then
-            sh build.sh test-ios-objc-cocoapods-dynamic
-        fi
         ;;
 
     "verify-osx-encryption")

--- a/scripts/pr-ci-matrix.rb
+++ b/scripts/pr-ci-matrix.rb
@@ -27,6 +27,7 @@ targets = {
 
   'cocoapods-osx' => release_only,
   'cocoapods-ios' => release_only,
+  'cocoapods-ios-dynamic' => release_only,
   'cocoapods-watchos' => release_only,
 
   'swiftpm' => ->(v, c) { c == 'Release' && (v == '10.3' or v == xcode_versions.last) }


### PR DESCRIPTION
This previously worked largely by coincidence due to these properties being reported to the objc runtime as int properties. Shifting to Swift-based introspection makes it possible for us to tell the difference, which means that we need to explicitly handle them.

Due to `extension RawRepresentable: ManagedPropertyType { ... }` not being legal Swift (you can't make an existing protocol refine another protocol in an extension), this requires adding a `RealmEnum` protocol that enums have to explicitly conform to. This also requires making ManagedPropertyType underscore-prefixed and public rather than internal because RealmEnum needs to refine it.

The upside of all this is that storing an enum in a RealmOptional now works, when it didn't in <4.0.

Fixes #6340.