### PR TITLE
Test the swiftpm build with asan and tsan on CI

### DIFF
--- a/.jenkins.yml
+++ b/.jenkins.yml
@@ -28,6 +28,8 @@ target:
  - cocoapods-ios-dynamic
  - cocoapods-watchos
  - swiftpm
+ - swiftpm-address
+ - swiftpm-thread
 configuration: 
  - Debug
  - Release
@@ -476,4 +478,92 @@ exclude:
 
   - xcode_version: 11.2
     target: swiftpm
+    configuration: Debug
+
+  - xcode_version: 10.0
+    target: swiftpm-address
+    configuration: Debug
+
+  - xcode_version: 10.0
+    target: swiftpm-address
+    configuration: Release
+
+  - xcode_version: 10.1
+    target: swiftpm-address
+    configuration: Debug
+
+  - xcode_version: 10.1
+    target: swiftpm-address
+    configuration: Release
+
+  - xcode_version: 10.2.1
+    target: swiftpm-address
+    configuration: Debug
+
+  - xcode_version: 10.2.1
+    target: swiftpm-address
+    configuration: Release
+
+  - xcode_version: 10.3
+    target: swiftpm-address
+    configuration: Debug
+
+  - xcode_version: 10.3
+    target: swiftpm-address
+    configuration: Release
+
+  - xcode_version: 11.1
+    target: swiftpm-address
+    configuration: Debug
+
+  - xcode_version: 11.1
+    target: swiftpm-address
+    configuration: Release
+
+  - xcode_version: 11.2
+    target: swiftpm-address
+    configuration: Debug
+
+  - xcode_version: 10.0
+    target: swiftpm-thread
+    configuration: Debug
+
+  - xcode_version: 10.0
+    target: swiftpm-thread
+    configuration: Release
+
+  - xcode_version: 10.1
+    target: swiftpm-thread
+    configuration: Debug
+
+  - xcode_version: 10.1
+    target: swiftpm-thread
+    configuration: Release
+
+  - xcode_version: 10.2.1
+    target: swiftpm-thread
+    configuration: Debug
+
+  - xcode_version: 10.2.1
+    target: swiftpm-thread
+    configuration: Release
+
+  - xcode_version: 10.3
+    target: swiftpm-thread
+    configuration: Debug
+
+  - xcode_version: 10.3
+    target: swiftpm-thread
+    configuration: Release
+
+  - xcode_version: 11.1
+    target: swiftpm-thread
+    configuration: Debug
+
+  - xcode_version: 11.1
+    target: swiftpm-thread
+    configuration: Release
+
+  - xcode_version: 11.2
+    target: swiftpm-thread
     configuration: Debug

--- a/build.sh
+++ b/build.sh
@@ -836,8 +836,13 @@ case "$COMMAND" in
         exit 0
         ;;
 
-    "test-swiftpm")
-        xcrun swift test --configuration $(echo $CONFIGURATION | tr "[:upper:]" "[:lower:]")
+    test-swiftpm*)
+        SANITIZER=$(echo $COMMAND | cut -d - -f 3)
+        if [ -n "$SANITIZER" ]; then
+            SANITIZER="--sanitize $SANITIZER"
+            export ASAN_OPTIONS='check_initialization_order=true:detect_stack_use_after_return=true'
+        fi
+        xcrun swift test --configuration $(echo $CONFIGURATION | tr "[:upper:]" "[:lower:]") $SANITIZER
         exit 0
         ;;
 
@@ -1002,8 +1007,8 @@ case "$COMMAND" in
         exit 0
         ;;
 
-    "verify-swiftpm")
-        sh build.sh test-swiftpm
+    verify-swiftpm*)
+        sh build.sh test-$(echo $COMMAND | cut -d - -f 2-)
         exit 0
         ;;
 

--- a/scripts/pr-ci-matrix.rb
+++ b/scripts/pr-ci-matrix.rb
@@ -30,7 +30,9 @@ targets = {
   'cocoapods-ios-dynamic' => release_only,
   'cocoapods-watchos' => release_only,
 
-  'swiftpm' => ->(v, c) { c == 'Release' && (v == '10.3' or v == xcode_versions.last) }
+  'swiftpm' => ->(v, c) { c == 'Release' && (v == '10.3' or v == xcode_versions.last) },
+  'swiftpm-address' => latest_only,
+  'swiftpm-thread' => latest_only,
 
   # These are disabled because the machine with the devices attached is currently offline
   # - ios-device-objc-ios8


### PR DESCRIPTION
The thing that always made testing with sanitizers enabled on CI awkward was that it requires core and sync to be built with them as well, which isn't an issue when using spm as the whole stack is built from source.