### PR TITLE
Add Realm.fileExists() and Realm.deleteFiles()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 x.y.z Release notes (yyyy-MM-dd)
 =============================================================
 ### Enhancements
-* None.
+* Add `-[RLMRealm fileExistsForConfiguration:]`/`Realm.fileExists(for:)`,
+  which checks if a local Realm file exists for the given configuration.
+* Add `-[RLMRealm deleteFilesForConfiguration:]`/`Realm.deleteFiles(for:)`
+  to delete the Realm file and all auxiliary files for the given configuration.
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-js/issues/????), since v?.?.?)

--- a/Realm/RLMConstants.h
+++ b/Realm/RLMConstants.h
@@ -161,6 +161,10 @@ typedef RLM_ERROR_ENUM(NSInteger, RLMError, RLMErrorDomain) {
      If you wish to migrate any data from the backup Realm, you can open it using the provided Realm configuration.
      */
     RLMErrorIncompatibleSyncedFile = 11,
+    /**
+     Denotates an error where an operation was requested which cannot be performed on an open file.
+     */
+    RLMErrorAlreadyOpen = 12,
 };
 
 #pragma mark - Constants

--- a/RealmSwift/Realm.swift
+++ b/RealmSwift/Realm.swift
@@ -764,7 +764,7 @@ public struct Realm {
         rlmRealm.invalidate()
     }
 
-    // MARK: Writing a Copy
+    // MARK: File Management
 
     /**
      Writes a compacted and optionally encrypted copy of the Realm to the given local URL.
@@ -781,6 +781,43 @@ public struct Realm {
      */
     public func writeCopy(toFile fileURL: URL, encryptionKey: Data? = nil) throws {
         try rlmRealm.writeCopy(to: fileURL, encryptionKey: encryptionKey)
+    }
+
+    /**
+     Checks if the Realm file for the given configuration exists locally on disk.
+
+     For non-synchronized, non-in-memory Realms, this is equivalent to
+     `FileManager.default.fileExists(atPath:)`. For synchronized Realms, it
+     takes care of computing the actual path on disk based on the server,
+     virtual path, and user as is done when opening the Realm.
+
+     @param config A Realm configuration to check the existence of.
+     @return true if the Realm file for the given configuration exists on disk, false otherwise.
+     */
+    public static func fileExists(for config: Configuration) -> Bool {
+        return RLMRealm.fileExists(for: config.rlmConfiguration)
+    }
+
+    /**
+     Deletes the local Realm file and associated temporary files for the given configuration.
+
+     This deletes the ".realm", ".note" and ".management" files which would be
+     created by opening the Realm with the given configuration. It does not
+     delete the ".lock" file (which contains no persisted data and is recreated
+     from scratch every time the Realm file is opened).
+
+     The Realm must not be currently open on any thread or in another process.
+     If it is, this will throw the error .alreadyOpen. Attempting to open the
+     Realm on another thread while the deletion is happening will block, and
+     then create a new Realm and open that afterwards.
+
+     If the Realm already does not exist this will return `false`.
+
+     @param config A Realm configuration identifying the Realm to be deleted.
+     @return true if any files were deleted, false otherwise.
+     */
+    public static func deleteFiles(for config: Configuration) throws -> Bool {
+        return try RLMRealm.deleteFiles(for: config.rlmConfiguration)
     }
 
     // MARK: Internal

--- a/RealmSwift/Tests/RealmTests.swift
+++ b/RealmSwift/Tests/RealmTests.swift
@@ -845,4 +845,13 @@ class RealmTests: TestCase {
             XCTFail("Failed to brigde RLMError to Realm.Error")
         }
     }
+
+    func testExists() {
+        let config = Realm.Configuration()
+        XCTAssertFalse(Realm.fileExists(for: config))
+        autoreleasepool { _ = try! Realm(configuration: config) }
+        XCTAssertTrue(Realm.fileExists(for: config))
+        XCTAssertTrue(try! Realm.deleteFiles(for: config))
+        XCTAssertFalse(Realm.fileExists(for: config))
+    }
 }


### PR DESCRIPTION
For synchronized Realms checking if the Realm file exists or deleting it is slightly nontrivial as we automatically manage the storage location of those, so we need to expose a helper function. For deletion we can also help prevent race conditions around deleting the Realm at the same time as someone else is trying to open it.

This diverges slightly from the name used by JS and Java (Realm.exists()) to match NSFileManager.