### PR TITLE
Fix a crash when using value(forKey:) on a LinkingObjects property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,9 @@ x.y.z Release notes (yyyy-MM-dd)
   to delete the Realm file and all auxiliary files for the given configuration.
 
 ### Fixed
-* <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-js/issues/????), since v?.?.?)
-* None.
+* Fix a crash when using value(forKey:) on a LinkingObjects property (including
+  when doing so indirectly, such as by querying on that property).
+  ([#6366](https://github.com/realm/realm-cocoa/issues/6366), since 4.0.0).
 
 <!-- ### Breaking Changes - ONLY INCLUDE FOR NEW MAJOR version -->
 

--- a/Realm/RLMObjectBase.mm
+++ b/Realm/RLMObjectBase.mm
@@ -180,7 +180,11 @@ id RLMCreateManagedAccessor(Class cls, RLMClassInfo *info) {
 
 // Generic Swift properties can't be dynamic, so KVO doesn't work for them by default
 - (id)valueForUndefinedKey:(NSString *)key {
-    if (Ivar ivar = _objectSchema[key].swiftIvar) {
+    RLMProperty *prop = _objectSchema[key];
+    if (Class accessor = prop.swiftAccessor) {
+        return [accessor get:(char *)(__bridge void *)self + ivar_getOffset(prop.swiftIvar)];
+    }
+    if (Ivar ivar = prop.swiftIvar) {
         return RLMCoerceToNil(object_getIvar(self, ivar));
     }
     return [super valueForUndefinedKey:key];

--- a/RealmSwift/Tests/ObjectTests.swift
+++ b/RealmSwift/Tests/ObjectTests.swift
@@ -248,7 +248,7 @@ class ObjectTests: TestCase {
 
             let expected = object.value(forKey: "binaryCol") as! Data
             let actual = "a".data(using: String.Encoding.utf8)!
-            XCTAssertTrue(expected == actual)
+            XCTAssertEqual(expected, actual)
 
             XCTAssertEqual(object.value(forKey: "dateCol") as! Date?, Date(timeIntervalSince1970: 1))
             XCTAssertEqual((object.value(forKey: "objectCol")! as! SwiftBoolObject).boolCol, false)
@@ -256,9 +256,95 @@ class ObjectTests: TestCase {
         }
 
         test(SwiftObject())
-        try! Realm().write {
-            let persistedObject = try! Realm().create(SwiftObject.self, value: [:])
-            test(persistedObject)
+        let realm = try! Realm()
+        try! realm.write {
+            test(realm.create(SwiftObject.self, value: [:]))
+            let addedObj = SwiftObject()
+            realm.add(addedObj)
+            test(addedObj)
+        }
+    }
+
+    func testValueForKeyOptionals() {
+        let test: (SwiftOptionalObject) -> Void = { object in
+            XCTAssertNil(object.value(forKey: "optNSStringCol"))
+            XCTAssertNil(object.value(forKey: "optStringCol"))
+            XCTAssertNil(object.value(forKey: "optBinaryCol"))
+            XCTAssertNil(object.value(forKey: "optDateCol"))
+            XCTAssertNil(object.value(forKey: "optIntCol"))
+            XCTAssertNil(object.value(forKey: "optInt8Col"))
+            XCTAssertNil(object.value(forKey: "optInt16Col"))
+            XCTAssertNil(object.value(forKey: "optInt32Col"))
+            XCTAssertNil(object.value(forKey: "optInt64Col"))
+            XCTAssertNil(object.value(forKey: "optFloatCol"))
+            XCTAssertNil(object.value(forKey: "optDoubleCol"))
+            XCTAssertNil(object.value(forKey: "optBoolCol"))
+            XCTAssertNil(object.value(forKey: "optEnumCol"))
+        }
+
+        test(SwiftOptionalObject())
+        let realm = try! Realm()
+        try! realm.write {
+            test(realm.create(SwiftOptionalObject.self, value: [:]))
+            let addedObj = SwiftOptionalObject()
+            realm.add(addedObj)
+            test(addedObj)
+        }
+    }
+
+    func testValueForKeyList() {
+        let test: (SwiftListObject) -> Void = { object in
+            XCTAssertNil((object.value(forKey: "int") as! List<Int>).first)
+            XCTAssertNil((object.value(forKey: "int8") as! List<Int8>).first)
+            XCTAssertNil((object.value(forKey: "int16") as! List<Int16>).first)
+            XCTAssertNil((object.value(forKey: "int32") as! List<Int32>).first)
+            XCTAssertNil((object.value(forKey: "int64") as! List<Int64>).first)
+            XCTAssertNil((object.value(forKey: "float") as! List<Float>).first)
+            XCTAssertNil((object.value(forKey: "double") as! List<Double>).first)
+            XCTAssertNil((object.value(forKey: "string") as! List<String>).first)
+            XCTAssertNil((object.value(forKey: "data") as! List<Data>).first)
+            XCTAssertNil((object.value(forKey: "date") as! List<Date>).first)
+
+            // The `as Any?` casts below are only to silence the warning about it
+            // happening implicitly and are not functionally required
+            XCTAssertNil((object.value(forKey: "intOpt") as! List<Int?>).first as Any?)
+            XCTAssertNil((object.value(forKey: "int8Opt") as! List<Int8?>).first as Any?)
+            XCTAssertNil((object.value(forKey: "int16Opt") as! List<Int16?>).first as Any?)
+            XCTAssertNil((object.value(forKey: "int32Opt") as! List<Int32?>).first as Any?)
+            XCTAssertNil((object.value(forKey: "int64Opt") as! List<Int64?>).first as Any?)
+            XCTAssertNil((object.value(forKey: "floatOpt") as! List<Float?>).first as Any?)
+            XCTAssertNil((object.value(forKey: "doubleOpt") as! List<Double?>).first as Any?)
+            XCTAssertNil((object.value(forKey: "stringOpt") as! List<String?>).first as Any?)
+            XCTAssertNil((object.value(forKey: "dataOpt") as! List<Data?>).first as Any?)
+            XCTAssertNil((object.value(forKey: "dateOpt") as! List<Date?>).first as Any?)
+        }
+
+        test(SwiftListObject())
+        let realm = try! Realm()
+        try! realm.write {
+            test(realm.create(SwiftListObject.self, value: [:]))
+            let addedObj = SwiftListObject()
+            realm.add(addedObj)
+            test(addedObj)
+        }
+    }
+
+    func testValueForKeyLinkingObjects() {
+        let test: (SwiftDogObject) -> Void = { object in
+            let owners = object.value(forKey: "owners") as! LinkingObjects<SwiftOwnerObject>
+            if object.realm != nil {
+                XCTAssertEqual(owners.first!.name, "owner name")
+            }
+        }
+
+        let dog = SwiftDogObject()
+        let owner = SwiftOwnerObject(value: ["owner name", dog])
+        test(dog)
+        let realm = try! Realm()
+        try! realm.write {
+            test(realm.create(SwiftOwnerObject.self, value: owner).dog!)
+            realm.add(owner)
+            test(dog)
         }
     }
 


### PR DESCRIPTION
Obtaining an obj-c compatible reference to LinkingObjects now requires going through the accessor rather than reading the ivar directly due to the ivar being a swift struct.

Fixes https://github.com/realm/realm-cocoa/issues/6366.