### PR TITLE
Allow returning a value from realm.write()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 x.y.z Release notes (yyyy-MM-dd)
 =============================================================
 ### Enhancements
-* None.
+* Similar to `autoreleasepool()`, `realm.write()` now returns the value which
+  the block passed to it returns. Returning `Void` from the block is still allowed.
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-js/issues/????), since v?.?.?)

--- a/RealmSwift/Realm.swift
+++ b/RealmSwift/Realm.swift
@@ -203,19 +203,23 @@ public struct Realm {
                          notified for the changes made in this write transaction.
 
      - parameter block: The block containing actions to perform.
+     - returns: The value returned from the block, if any.
 
      - throws: An `NSError` if the transaction could not be completed successfully.
                If `block` throws, the function throws the propagated `ErrorType` instead.
      */
-    public func write(withoutNotifying tokens: [NotificationToken] = [], _ block: (() throws -> Void)) throws {
+    @discardableResult
+    public func write<Result>(withoutNotifying tokens: [NotificationToken] = [], _ block: (() throws -> Result)) throws -> Result {
         beginWrite()
+        var ret: Result!
         do {
-            try block()
+            ret = try block()
         } catch let error {
             if isInWriteTransaction { cancelWrite() }
             throw error
         }
         if isInWriteTransaction { try commitWrite(withoutNotifying: tokens) }
+        return ret
     }
 
     /**

--- a/RealmSwift/Tests/MigrationTests.swift
+++ b/RealmSwift/Tests/MigrationTests.swift
@@ -194,7 +194,7 @@ class MigrationTests: TestCase {
             XCTAssertEqual(count, 1)
         }
 
-        autoreleasepool {
+        _ = autoreleasepool {
             try! Realm().write {
                 try! Realm().create(SwiftArrayPropertyObject.self, value: ["string", [["array"]], [[2]]])
             }

--- a/RealmSwift/Tests/RealmTests.swift
+++ b/RealmSwift/Tests/RealmTests.swift
@@ -249,6 +249,14 @@ class RealmTests: TestCase {
         XCTAssertEqual(try! Realm().objects(SwiftStringObject.self).count, 1)
     }
 
+    func testWriteReturning() {
+        let realm = try! Realm()
+        let object = try! realm.write {
+            return realm.create(SwiftStringObject.self, value: ["1"])
+        }
+        XCTAssertEqual(object.stringCol, "1")
+    }
+
     func testCommitWrite() {
         try! Realm().beginWrite()
         try! Realm().create(SwiftStringObject.self, value: ["1"])


### PR DESCRIPTION
This makes it a lot less awkward to use scoped realm.write() in tests, so I'm guessing normal users will find it nice to have for the same reasons.

I think in 5.0 we'll want to drop `@discardableResult`. Without it we get a pile of warnings about unused return values, and while that isn't really a breaking change it seems better to lump it in with the breaking changes given that we have a major version bump coming soon.