### PR TITLE
Fix for ObjectUtil `property_copyAttributeList` memory leak 

### DIFF
--- a/RealmSwift/Object.swift
+++ b/RealmSwift/Object.swift
@@ -741,6 +741,7 @@ internal class ObjectUtil {
                     let attr = attrs[i]
                     switch attr.name[0] {
                     case Int8(UInt8(ascii: "R")): // Read only
+                        attrs.deallocate()
                         return nil
                     case Int8(UInt8(ascii: "V")): // Ivar name
                         computed = false
@@ -757,8 +758,11 @@ internal class ObjectUtil {
                 // the property then this is a computed property and we should
                 // implicitly ignore it
                 if computed && class_getInstanceVariable(cls, label) == nil {
+                    attrs.deallocate()
                     return nil
                 }
+
+                attrs.deallocate()
             } else if valueType._rlmRequireObjc() {
                 // Implicitly ignore non-@objc dynamic properties
                 return nil


### PR DESCRIPTION
The `attrs` value needed to be deallocated as per the docs here 
[https://developer.apple.com/documentation/objectivec/1418675-property_copyattributelist?language=objc](url)