### PR TITLE
RCOCOA-532 - property_copyAttributeList produces memory leak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,7 @@ x.y.z Release notes (yyyy-MM-dd)
   the block passed to it returns. Returning `Void` from the block is still allowed.
 
 ### Fixed
-* <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-js/issues/????), since v?.?.?)
-* None.
+* Fix a memory leak attributed to `property_copyAttributeList` the first time a Realm is opened when using Realm Swift. (#6409, since 4.0.0).
 
 <!-- ### Breaking Changes - ONLY INCLUDE FOR NEW MAJOR version -->
 
@@ -19,20 +18,6 @@ x.y.z Release notes (yyyy-MM-dd)
 ### Internal
 Upgraded realm-core from ? to ?
 Upgraded realm-sync from ? to ?
-
-4.3.2 Release notes (2020-02-04)
-=============================================================
-### Enhancements
-* Fix for memory leak caused by `property_copyAttributeList`
-
-### Fixed
-* property_copyAttributeList was not being released after being assigned to a local variable. 
-  We must call `free()` after using this method.
-
-### Compatibility
-* File format: Generates Realms with format v9 (Reads and upgrades all previous formats)
-* Realm Object Server: 3.21.0 or later.
-* Carthage release for Swift is built with Xcode 11.3.
 
 4.3.1 Release notes (2020-01-16)
 =============================================================

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,20 @@ x.y.z Release notes (yyyy-MM-dd)
 Upgraded realm-core from ? to ?
 Upgraded realm-sync from ? to ?
 
+4.3.2 Release notes (2020-02-04)
+=============================================================
+### Enhancements
+* Fix for memory leak caused by `property_copyAttributeList`
+
+### Fixed
+* property_copyAttributeList was not being released after being assigned to a local variable. 
+  We must call `free()` after using this method.
+
+### Compatibility
+* File format: Generates Realms with format v9 (Reads and upgrades all previous formats)
+* Realm Object Server: 3.21.0 or later.
+* Carthage release for Swift is built with Xcode 11.3.
+
 4.3.1 Release notes (2020-01-16)
 =============================================================
 

--- a/RealmSwift/Object.swift
+++ b/RealmSwift/Object.swift
@@ -736,6 +736,9 @@ internal class ObjectUtil {
             if let objcProp = class_getProperty(cls, label) {
                 var count: UInt32 = 0
                 let attrs = property_copyAttributeList(objcProp, &count)!
+                defer {
+                    free(attrs)
+                }
                 var computed = true
                 for i in 0..<Int(count) {
                     let attr = attrs[i]


### PR DESCRIPTION
Fixes #6409

The issue was that property_copyAttributeList requires you to manually free allocated memory. To solve this we are using free() and this is called in a defer block.

To test this fix I made a test app which starts Realm when a button is tapped. The current master branch would produce a memory leak when the button was tapped. The code in this branch now stops the memory leak from happening. I used Instruments to inspect.