### PR TITLE
Allow users to optionally set a file path for synchronized realms

### DIFF
--- a/Realm/ObjectServerTests/SwiftObjectServerTests.swift
+++ b/Realm/ObjectServerTests/SwiftObjectServerTests.swift
@@ -301,6 +301,41 @@ class SwiftObjectServerTests: SwiftSyncTestCase {
         XCTAssertGreaterThan(fileSize(path: pathOnDisk), 0)
         XCTAssertFalse(RLMHasCachedRealmForPath(pathOnDisk))
     }
+    
+    func testDownloadRealmToCustomPath() {
+        let user = try! synchronouslyLogInUser(for: basicCredentials(register: isParent), server: authURL)
+        if !isParent {
+            populateRealm(user: user, url: realmURL)
+            return
+        }
+
+        // Wait for the child process to upload everything.
+        executeChild()
+
+        let ex = expectation(description: "download-realm")
+        let customFileURL = realmURLForFile("copy")
+        var config = user.configuration(realmURL: realmURL, fullSynchronization: true)
+        config.fileURL = customFileURL
+        let pathOnDisk = ObjectiveCSupport.convert(object: config).pathOnDisk
+        XCTAssertEqual(pathOnDisk, customFileURL.path)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: pathOnDisk))
+        Realm.asyncOpen(configuration: config) { realm, error in
+            XCTAssertNil(error)
+            self.checkCount(expected: self.bigObjectCount, realm!, SwiftHugeSyncObject.self)
+            ex.fulfill()
+        }
+        func fileSize(path: String) -> Int {
+            if let attr = try? FileManager.default.attributesOfItem(atPath: path) {
+                return attr[.size] as! Int
+            }
+            return 0
+        }
+        XCTAssertFalse(RLMHasCachedRealmForPath(pathOnDisk))
+        waitForExpectations(timeout: 10.0, handler: nil)
+        XCTAssertGreaterThan(fileSize(path: pathOnDisk), 0)
+        XCTAssertFalse(RLMHasCachedRealmForPath(pathOnDisk))
+    }
+
 
     func testCancelDownloadRealm() {
         let user = try! synchronouslyLogInUser(for: basicCredentials(register: isParent), server: authURL)
@@ -577,5 +612,11 @@ class SwiftObjectServerTests: SwiftSyncTestCase {
 
         _ = try! Realm(configuration: config)
         self.waitForExpectations(timeout: 4.0)
+    }
+    
+    private func realmURLForFile(_ fileName: String) -> URL {
+        let testDir = RLMRealmPathForFile("realm-object-server")
+        let directory = URL(fileURLWithPath: testDir, isDirectory: true)
+        return directory.appendingPathComponent(fileName, isDirectory: false)
     }
 }

--- a/Realm/ObjectServerTests/SwiftObjectServerTests.swift
+++ b/Realm/ObjectServerTests/SwiftObjectServerTests.swift
@@ -301,7 +301,7 @@ class SwiftObjectServerTests: SwiftSyncTestCase {
         XCTAssertGreaterThan(fileSize(path: pathOnDisk), 0)
         XCTAssertFalse(RLMHasCachedRealmForPath(pathOnDisk))
     }
-    
+
     func testDownloadRealmToCustomPath() {
         let user = try! synchronouslyLogInUser(for: basicCredentials(register: isParent), server: authURL)
         if !isParent {
@@ -613,7 +613,7 @@ class SwiftObjectServerTests: SwiftSyncTestCase {
         _ = try! Realm(configuration: config)
         self.waitForExpectations(timeout: 4.0)
     }
-    
+
     private func realmURLForFile(_ fileName: String) -> URL {
         let testDir = RLMRealmPathForFile("realm-object-server")
         let directory = URL(fileURLWithPath: testDir, isDirectory: true)

--- a/Realm/RLMRealm.mm
+++ b/Realm/RLMRealm.mm
@@ -29,6 +29,7 @@
 #import "RLMProperty.h"
 #import "RLMProperty_Private.h"
 #import "RLMQueryUtil.hpp"
+#import "RLMRealmConfiguration+Sync.h"
 #import "RLMRealmConfiguration_Private.hpp"
 #import "RLMRealmUtil.hpp"
 #import "RLMSchema_Private.hpp"
@@ -402,6 +403,7 @@ REALM_NOINLINE static void translateSharedGroupOpenException(RLMRealmConfigurati
             case RealmFileException::Kind::IncompatibleSyncedRealm: {
                 RLMRealmConfiguration *configuration = [originalConfiguration copy];
                 configuration.fileURL = [NSURL fileURLWithPath:@(ex.path().data())];
+                configuration.syncConfiguration = nil;
                 configuration.readOnly = YES;
 
                 NSError *intermediateError = RLMMakeError(RLMErrorIncompatibleSyncedFile, ex);

--- a/Realm/RLMRealmConfiguration+Sync.mm
+++ b/Realm/RLMRealmConfiguration+Sync.mm
@@ -59,6 +59,8 @@
     } else if (self.config.path.compare(defaultRealmURL.path.UTF8String) == 0) {
         self.config.path = SyncManager::shared().path_for_realm(*[user _syncUser],
                                                                 self.config.sync_config->realm_url());
+    } else {
+        self.config.path = self.fileURL.path.UTF8String;
     }
 
     if (!self.config.encryption_key.empty()) {

--- a/Realm/RLMRealmConfiguration+Sync.mm
+++ b/Realm/RLMRealmConfiguration+Sync.mm
@@ -33,6 +33,10 @@
 #pragma mark - API
 
 - (void)setSyncConfiguration:(RLMSyncConfiguration *)syncConfiguration {
+    if (syncConfiguration == nil) {
+        self.config.sync_config = nullptr;
+        return;
+    }
     if (self.config.should_compact_on_launch_function) {
         @throw RLMException(@"Cannot set `syncConfiguration` when `shouldCompactOnLaunch` is set.");
     }
@@ -48,9 +52,11 @@
     self.config.sync_config = std::make_shared<realm::SyncConfig>([syncConfiguration rawConfiguration]);
     self.config.schema_mode = realm::SchemaMode::Additive;
 
+    static NSURL *defaultRealmURL = [NSURL fileURLWithPath:RLMRealmPathForFile(@"default.realm")];
+
     if (syncConfiguration.customFileURL) {
         self.config.path = syncConfiguration.customFileURL.path.UTF8String;
-    } else {
+    } else if (self.config.path.compare(defaultRealmURL.path.UTF8String) == 0) {
         self.config.path = SyncManager::shared().path_for_realm(*[user _syncUser],
                                                                 self.config.sync_config->realm_url());
     }

--- a/Realm/RLMRealmConfiguration.h
+++ b/Realm/RLMRealmConfiguration.h
@@ -66,8 +66,8 @@ typedef BOOL (^RLMShouldCompactOnLaunchBlock)(NSUInteger totalBytes, NSUInteger 
 
 #pragma mark - Properties
 
-/// The local URL of the Realm file. Mutually exclusive with `inMemoryIdentifier` and `syncConfiguration`;
-/// setting any one of the three properties will automatically nil out the other two.
+/// The local URL of the Realm file. Mutually exclusive with `inMemoryIdentifier`;
+/// setting one of the two properties will automatically nil out the other.
 @property (nonatomic, copy, nullable) NSURL *fileURL;
 
 /// A string used to identify a particular in-memory Realm. Mutually exclusive with `fileURL` and `syncConfiguration`;

--- a/Realm/RLMRealmConfiguration.mm
+++ b/Realm/RLMRealmConfiguration.mm
@@ -153,7 +153,7 @@ static void RLMNSStringToStdString(std::string &out, NSString *in) {
 }
 
 - (NSURL *)fileURL {
-    if (_config.in_memory || _config.sync_config) {
+    if (_config.in_memory) {
         return nil;
     }
     return [NSURL fileURLWithPath:@(_config.path.c_str())];
@@ -164,7 +164,6 @@ static void RLMNSStringToStdString(std::string &out, NSString *in) {
     if (path.length == 0) {
         @throw RLMException(@"Realm path must not be empty");
     }
-    _config.sync_config = nullptr;
 
     RLMNSStringToStdString(_config.path, path);
     _config.in_memory = false;

--- a/RealmSwift/RealmConfiguration.swift
+++ b/RealmSwift/RealmConfiguration.swift
@@ -112,11 +112,10 @@ extension Realm {
 
         /**
          A configuration value used to configure a Realm for synchronization with the Realm Object Server. Mutually
-         exclusive with `inMemoryIdentifier` and `fileURL`.
+         exclusive with `inMemoryIdentifier`.
          */
         public var syncConfiguration: SyncConfiguration? {
             set {
-                _path = nil
                 _inMemoryIdentifier = nil
                 _syncConfiguration = newValue
             }
@@ -127,11 +126,10 @@ extension Realm {
 
         private var _syncConfiguration: SyncConfiguration?
 
-        /// The local URL of the Realm file. Mutually exclusive with `inMemoryIdentifier` and `syncConfiguration`.
+        /// The local URL of the Realm file. Mutually exclusive with `inMemoryIdentifier`.
         public var fileURL: URL? {
             set {
                 _inMemoryIdentifier = nil
-                _syncConfiguration = nil
                 _path = newValue?.path
             }
             get {
@@ -221,10 +219,11 @@ extension Realm {
                 configuration.fileURL = fileURL
             } else if let inMemoryIdentifier = inMemoryIdentifier {
                 configuration.inMemoryIdentifier = inMemoryIdentifier
-            } else if let syncConfiguration = syncConfiguration {
-                configuration.syncConfiguration = syncConfiguration.asConfig()
-            } else {
+            } else if syncConfiguration == nil {
                 fatalError("A Realm Configuration must specify a path or an in-memory identifier.")
+            }
+            if let syncConfiguration = syncConfiguration {
+                configuration.syncConfiguration = syncConfiguration.asConfig()
             }
             configuration.encryptionKey = self.encryptionKey
             configuration.readOnly = self.readOnly

--- a/RealmSwift/RealmConfiguration.swift
+++ b/RealmSwift/RealmConfiguration.swift
@@ -215,15 +215,15 @@ extension Realm {
 
         internal var rlmConfiguration: RLMRealmConfiguration {
             let configuration = RLMRealmConfiguration()
+            if let syncConfiguration = syncConfiguration {
+                configuration.syncConfiguration = syncConfiguration.asConfig()
+            }
             if let fileURL = fileURL {
                 configuration.fileURL = fileURL
             } else if let inMemoryIdentifier = inMemoryIdentifier {
                 configuration.inMemoryIdentifier = inMemoryIdentifier
             } else if syncConfiguration == nil {
                 fatalError("A Realm Configuration must specify a path or an in-memory identifier.")
-            }
-            if let syncConfiguration = syncConfiguration {
-                configuration.syncConfiguration = syncConfiguration.asConfig()
             }
             configuration.encryptionKey = self.encryptionKey
             configuration.readOnly = self.readOnly


### PR DESCRIPTION
This PR lifts the restriction of `fileURL` and `syncConfiguration` being mutually exclusive. This is especially useful if you have to change the domain name of your ROS instance and want to preserve file history. The restriction isn't in Realm .NET, so this change is also a step towards consistency across SDKs.