### PR TITLE
Add better support for using dispatch queues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,23 @@
 x.y.z Release notes (yyyy-MM-dd)
 =============================================================
 ### Enhancements
-* None.
+* Add support for queue-confined Realms. Rather than being bound to a specific
+  thread, queue-confined Realms are bound to a dispatch queue and can be used
+  within blocks dispatched to that queue regardless of what thread they happen
+  to run on. In addition, change notifications will be delivered to that queue
+  rather than the thread's run loop.
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-js/issues/????), since v?.?.?)
 * None.
 
-<!-- ### Breaking Changes - ONLY INCLUDE FOR NEW MAJOR version -->
+### Breaking Changes
+
+* The Realm instance passed in the callback to asyncOpen() is now confined to
+  the callback queue passed to asyncOpen() rather than the thread which the
+  callback happens to be called on. This means that the Realm instance may be
+  stored and reused in further blocks dispatched to that queue, but the queue
+  must now be a serial queue.
 
 ### Compatibility
 * File format: Generates Realms with format v9 (Reads and upgrades all previous formats)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ x.y.z Release notes (yyyy-MM-dd)
   within blocks dispatched to that queue regardless of what thread they happen
   to run on. In addition, change notifications will be delivered to that queue
   rather than the thread's run loop.
+* Add an option to deliver object and collection notifications to a specific
+  queue rather than the current thread.
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-js/issues/????), since v?.?.?)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,12 @@ x.y.z Release notes (yyyy-MM-dd)
 =============================================================
 ### Enhancements
 * Add support for queue-confined Realms. Rather than being bound to a specific
-  thread, queue-confined Realms are bound to a dispatch queue and can be used
-  within blocks dispatched to that queue regardless of what thread they happen
-  to run on. In addition, change notifications will be delivered to that queue
-  rather than the thread's run loop.
+  thread, queue-confined Realms are bound to a serial dispatch queue and can be
+  used within blocks dispatched to that queue regardless of what thread they
+  happen to run on. In addition, change notifications will be delivered to that
+  queue rather than the thread's run loop. ([PR #6478](https://github.com/realm/realm-cocoa/pull/6478)).
 * Add an option to deliver object and collection notifications to a specific
-  queue rather than the current thread.
+  serial queue rather than the current thread. ([PR #6478](https://github.com/realm/realm-cocoa/pull/6478)).
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-js/issues/????), since v?.?.?)

--- a/Package.swift
+++ b/Package.swift
@@ -70,6 +70,7 @@ let package = Package(
                 "Realm/ObjectStore/src/schema.cpp",
                 "Realm/ObjectStore/src/shared_realm.cpp",
                 "Realm/ObjectStore/src/thread_safe_reference.cpp",
+                "Realm/ObjectStore/src/util/scheduler.cpp",
                 "Realm/ObjectStore/src/util/uuid.cpp",
                 "Realm/RLMAccessor.mm",
                 "Realm/RLMAnalytics.mm",

--- a/Realm.xcodeproj/project.pbxproj
+++ b/Realm.xcodeproj/project.pbxproj
@@ -133,6 +133,8 @@
 		3F336E8A1DA2FA14006CB5A0 /* RLMSyncConfiguration_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 1A36236A1D83868F00945A54 /* RLMSyncConfiguration_Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		3F336E8B1DA2FA15006CB5A0 /* RLMSyncConfiguration_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 1A36236A1D83868F00945A54 /* RLMSyncConfiguration_Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		3F4657371F27F2EF00456B07 /* RLMTestCaseUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 297FBEFA1C19F696009D1118 /* RLMTestCaseUtils.swift */; };
+		3F553577243BD50500A91FD8 /* scheduler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3F553572243BD50500A91FD8 /* scheduler.cpp */; };
+		3F553578243BD50500A91FD8 /* scheduler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3F553572243BD50500A91FD8 /* scheduler.cpp */; };
 		3F558C7922BC023A002F0F30 /* async_open_task.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3F558C7622BC022A002F0F30 /* async_open_task.cpp */; };
 		3F558C7A22BC023B002F0F30 /* async_open_task.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3F558C7622BC022A002F0F30 /* async_open_task.cpp */; };
 		3F558C8722C29A03002F0F30 /* TestUtils.mm in Sources */ = {isa = PBXBuildFile; fileRef = 3F558C7E22C29A02002F0F30 /* TestUtils.mm */; };
@@ -753,6 +755,10 @@
 		3F35027722C43C5200FDC1E5 /* TestHost-static.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "TestHost-static.xcconfig"; sourceTree = "<group>"; };
 		3F452EC519C2279800AFC154 /* RLMSwiftSupport.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RLMSwiftSupport.m; path = Realm/RLMSwiftSupport.m; sourceTree = SOURCE_ROOT; };
 		3F4E324B1B98C6C700183A69 /* RLMSchema_Private.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = RLMSchema_Private.hpp; sourceTree = "<group>"; };
+		3F553571243BD50400A91FD8 /* checked_mutex.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = checked_mutex.hpp; sourceTree = "<group>"; };
+		3F553572243BD50500A91FD8 /* scheduler.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = scheduler.cpp; sourceTree = "<group>"; };
+		3F553573243BD50500A91FD8 /* copyable_atomic.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = copyable_atomic.hpp; sourceTree = "<group>"; };
+		3F553574243BD50500A91FD8 /* scheduler.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = scheduler.hpp; sourceTree = "<group>"; };
 		3F558C7622BC022A002F0F30 /* async_open_task.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = async_open_task.cpp; path = sync/async_open_task.cpp; sourceTree = "<group>"; };
 		3F558C7722BC022B002F0F30 /* async_open_task.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; name = async_open_task.hpp; path = sync/async_open_task.hpp; sourceTree = "<group>"; };
 		3F558C7822BC022B002F0F30 /* subscription_state.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; name = subscription_state.hpp; path = sync/subscription_state.hpp; sourceTree = "<group>"; };
@@ -1400,8 +1406,12 @@
 				5D274C511D6D16BA006FEBB1 /* apple */,
 				3F92F62A222F311C008B2333 /* aligned_union.hpp */,
 				5DB591A61D063DF8001D8F93 /* atomic_shared_ptr.hpp */,
+				3F553571243BD50400A91FD8 /* checked_mutex.hpp */,
+				3F553573243BD50500A91FD8 /* copyable_atomic.hpp */,
 				3F92F627222F311B008B2333 /* event_loop_dispatcher.hpp */,
 				5D274C4F1D6D16A8006FEBB1 /* event_loop_signal.hpp */,
+				3F553572243BD50500A91FD8 /* scheduler.cpp */,
+				3F553574243BD50500A91FD8 /* scheduler.hpp */,
 				3F92F628222F311C008B2333 /* tagged_bool.hpp */,
 				1AABD4001E9552BA00115A75 /* uuid.cpp */,
 				1AABD4011E9552BA00115A75 /* uuid.hpp */,
@@ -2413,6 +2423,7 @@
 				3F67DB3E1E26D69C0024533D /* RLMThreadSafeReference.mm in Sources */,
 				5D659E9A1BE04556006515A0 /* RLMUpdateChecker.mm in Sources */,
 				5D659E9B1BE04556006515A0 /* RLMUtil.mm in Sources */,
+				3F553577243BD50500A91FD8 /* scheduler.cpp in Sources */,
 				5D659E9C1BE04556006515A0 /* schema.cpp in Sources */,
 				5D659E9D1BE04556006515A0 /* shared_realm.cpp in Sources */,
 				5DAD372E1F7485BB00EECA8E /* sync_config.cpp in Sources */,
@@ -2559,6 +2570,7 @@
 				3F67DB411E26D6AD0024533D /* RLMThreadSafeReference.mm in Sources */,
 				5DD755981BE056DE002800DA /* RLMUpdateChecker.mm in Sources */,
 				5DD755991BE056DE002800DA /* RLMUtil.mm in Sources */,
+				3F553578243BD50500A91FD8 /* scheduler.cpp in Sources */,
 				5DD7559A1BE056DE002800DA /* schema.cpp in Sources */,
 				5DD7559B1BE056DE002800DA /* shared_realm.cpp in Sources */,
 				5DAD372F1F7485C500EECA8E /* sync_config.cpp in Sources */,

--- a/Realm/RLMArray.h
+++ b/Realm/RLMArray.h
@@ -370,9 +370,49 @@ NS_ASSUME_NONNULL_BEGIN
  @param block The block to be called each time the array changes.
  @return A token which must be held for as long as you want updates to be delivered.
  */
-- (RLMNotificationToken *)addNotificationBlock:(void (^)(RLMArray<RLMObjectType> *__nullable array,
-                                                         RLMCollectionChange *__nullable changes,
-                                                         NSError *__nullable error))block __attribute__((warn_unused_result));
+- (RLMNotificationToken *)addNotificationBlock:(void (^)(RLMArray<RLMObjectType> *_Nullable array,
+                                                         RLMCollectionChange *_Nullable changes,
+                                                         NSError *_Nullable error))block
+__attribute__((warn_unused_result));
+
+/**
+ Registers a block to be called each time the array changes.
+
+ The block will be asynchronously called with the initial array, and then
+ called again after each write transaction which changes any of the objects in
+ the array, which objects are in the results, or the order of the objects in the
+ array.
+
+ The `changes` parameter will be `nil` the first time the block is called.
+ For each call after that, it will contain information about
+ which rows in the array were added, removed or modified. If a write transaction
+ did not modify any objects in the array, the block is not called at all.
+ See the `RLMCollectionChange` documentation for information on how the changes
+ are reported and an example of updating a `UITableView`.
+
+ If an error occurs the block will be called with `nil` for the results
+ parameter and a non-`nil` error. Currently the only errors that can occur are
+ when opening the Realm on the background worker thread.
+
+ Notifications are delivered on the given queue. If the queue is blocked and
+ notifications can't be delivered instantly, multiple notifications may be
+ coalesced into a single notification.
+
+ You must retain the returned token for as long as you want updates to continue
+ to be sent to the block. To stop receiving updates, call `-invalidate` on the token.
+
+ @warning This method cannot be called when the containing Realm is read-only or frozen.
+ @warning The queue must be a serial queue.
+
+ @param block The block to be called whenever a change occurs.
+ @param queue The serial queue to deliver notifications to.
+ @return A token which must be held for as long as you want updates to be delivered.
+ */
+- (RLMNotificationToken *)addNotificationBlock:(void (^)(RLMArray<RLMObjectType> *_Nullable array,
+                                                         RLMCollectionChange *_Nullable changes,
+                                                         NSError *_Nullable error))block
+                                receiveOnQueue:(nullable dispatch_queue_t)queue
+__attribute__((warn_unused_result));
 
 #pragma mark - Aggregating Property Values
 

--- a/Realm/RLMArray.h
+++ b/Realm/RLMArray.h
@@ -411,7 +411,7 @@ __attribute__((warn_unused_result));
 - (RLMNotificationToken *)addNotificationBlock:(void (^)(RLMArray<RLMObjectType> *_Nullable array,
                                                          RLMCollectionChange *_Nullable changes,
                                                          NSError *_Nullable error))block
-                                receiveOnQueue:(nullable dispatch_queue_t)queue
+                                         queue:(nullable dispatch_queue_t)queue
 __attribute__((warn_unused_result));
 
 #pragma mark - Aggregating Property Values

--- a/Realm/RLMArray.mm
+++ b/Realm/RLMArray.mm
@@ -543,6 +543,10 @@ static bool canAggregate(RLMPropertyType type, bool allowDate) {
 // http://www.openradar.me/radar?id=6135653276319744
 #pragma clang diagnostic ignored "-Wmismatched-parameter-types"
 - (RLMNotificationToken *)addNotificationBlock:(void (^)(RLMArray *, RLMCollectionChange *, NSError *))block {
+    return [self addNotificationBlock:block receiveOnQueue:nil];
+}
+- (RLMNotificationToken *)addNotificationBlock:(void (^)(RLMArray *, RLMCollectionChange *, NSError *))block
+                                receiveOnQueue:(nullable dispatch_queue_t)queue {
     @throw RLMException(@"This method may only be called on RLMArray instances retrieved from an RLMRealm");
 }
 

--- a/Realm/RLMArray.mm
+++ b/Realm/RLMArray.mm
@@ -543,10 +543,10 @@ static bool canAggregate(RLMPropertyType type, bool allowDate) {
 // http://www.openradar.me/radar?id=6135653276319744
 #pragma clang diagnostic ignored "-Wmismatched-parameter-types"
 - (RLMNotificationToken *)addNotificationBlock:(void (^)(RLMArray *, RLMCollectionChange *, NSError *))block {
-    return [self addNotificationBlock:block receiveOnQueue:nil];
+    return [self addNotificationBlock:block queue:nil];
 }
 - (RLMNotificationToken *)addNotificationBlock:(void (^)(RLMArray *, RLMCollectionChange *, NSError *))block
-                                receiveOnQueue:(nullable dispatch_queue_t)queue {
+                                         queue:(nullable dispatch_queue_t)queue {
     @throw RLMException(@"This method may only be called on RLMArray instances retrieved from an RLMRealm");
 }
 

--- a/Realm/RLMCollection_Private.hpp
+++ b/Realm/RLMCollection_Private.hpp
@@ -28,7 +28,7 @@ namespace realm {
     struct NotificationToken;
 }
 class RLMClassInfo;
-@class RLMFastEnumerator;
+@class RLMFastEnumerator, RLMManagedArray;
 
 @protocol RLMFastEnumerable
 @property (nonatomic, readonly) RLMRealm *realm;
@@ -64,19 +64,17 @@ NSUInteger RLMFastEnumerate(NSFastEnumerationState *state, NSUInteger len, id<RL
 - (RLMRealm *)realm;
 @end
 
-@interface RLMCancellationToken : RLMNotificationToken
-- (instancetype)initWithToken:(realm::NotificationToken)token realm:(RLMRealm *)realm;
-@end
-
 @interface RLMCollectionChange ()
 - (instancetype)initWithChanges:(realm::CollectionChangeSet)indices;
 @end
 
-template<typename Collection>
-RLMNotificationToken *RLMAddNotificationBlock(id objcCollection,
-                                              Collection& collection,
+realm::List& RLMGetBackingCollection(RLMManagedArray *);
+realm::Results& RLMGetBackingCollection(RLMResults *);
+
+template<typename RLMCollection>
+RLMNotificationToken *RLMAddNotificationBlock(RLMCollection *collection,
                                               void (^block)(id, RLMCollectionChange *, NSError *),
-                                              bool suppressInitialChange=false);
+                                              dispatch_queue_t queue);
 
 template<typename Collection>
 NSArray *RLMCollectionValueForKey(Collection& collection, NSString *key, RLMClassInfo& info);

--- a/Realm/RLMListBase.h
+++ b/Realm/RLMListBase.h
@@ -18,7 +18,7 @@
 
 #import <Foundation/Foundation.h>
 
-@class RLMArray, RLMObjectBase, RLMResults, RLMProperty;
+@class RLMArray, RLMObjectBase, RLMResults, RLMProperty, RLMLinkingObjects;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -33,11 +33,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface RLMLinkingObjectsHandle : NSObject
 - (instancetype)initWithObject:(RLMObjectBase *)object property:(RLMProperty *)property;
+- (instancetype)initWithLinkingObjects:(RLMResults *)linkingObjects;
 - (instancetype)freeze;
 
-@property (nonatomic, readonly) RLMResults *results;
-@property (nonatomic, readonly) RLMObjectBase *parent;
-@property (nonatomic, readonly) RLMProperty *property;
+@property (nonatomic, readonly) RLMLinkingObjects *results;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Realm/RLMListBase.mm
+++ b/Realm/RLMListBase.mm
@@ -108,14 +108,19 @@
     return self;
 }
 
+- (instancetype)initWithLinkingObjects:(RLMResults *)linkingObjects {
+    if (!(self = [super init])) {
+        return nil;
+    }
+    _realm = linkingObjects.realm;
+    _results = linkingObjects;
+
+    return self;
+}
+
 - (instancetype)freeze {
     RLMLinkingObjectsHandle *frozen = [[self.class alloc] init];
-    frozen->_tableKey = _tableKey;
-    frozen->_objKey = _objKey;
-    frozen->_info = _info;
-    frozen->_realm = _realm;
-    frozen->_property = _property;
-    frozen->_results = [[self results] freeze];
+    frozen->_results = [self.results freeze];
     return frozen;
 }
 
@@ -138,11 +143,5 @@
     _results = [RLMLinkingObjects resultsWithObjectInfo:objectInfo results:std::move(results)];
     _realm = nil;
     return _results;
-}
-
-- (RLMObjectBase *)parent {
-    RLMObjectBase *obj = RLMCreateManagedAccessor(_info->rlmObjectSchema.accessorClass, _info);
-    obj->_row = _info->realm.group.get_table(_tableKey)->get_object(_objKey);
-    return obj;
 }
 @end

--- a/Realm/RLMManagedArray.mm
+++ b/Realm/RLMManagedArray.mm
@@ -528,10 +528,16 @@ static void RLMInsertObject(RLMManagedArray *ar, id object, NSUInteger index) {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wmismatched-parameter-types"
 - (RLMNotificationToken *)addNotificationBlock:(void (^)(RLMArray *, RLMCollectionChange *, NSError *))block {
-    [_realm verifyNotificationsAreSupported:true];
-    return RLMAddNotificationBlock(self, _backingList, block);
+    return RLMAddNotificationBlock(self, block, nil);
+}
+- (RLMNotificationToken *)addNotificationBlock:(void (^)(RLMArray *, RLMCollectionChange *, NSError *))block receiveOnQueue:(dispatch_queue_t)queue {
+    return RLMAddNotificationBlock(self, block, queue);
 }
 #pragma clang diagnostic pop
+
+realm::List& RLMGetBackingCollection(RLMManagedArray *self) {
+    return self->_backingList;
+}
 
 #pragma mark - Thread Confined Protocol Conformance
 

--- a/Realm/RLMManagedArray.mm
+++ b/Realm/RLMManagedArray.mm
@@ -530,7 +530,7 @@ static void RLMInsertObject(RLMManagedArray *ar, id object, NSUInteger index) {
 - (RLMNotificationToken *)addNotificationBlock:(void (^)(RLMArray *, RLMCollectionChange *, NSError *))block {
     return RLMAddNotificationBlock(self, block, nil);
 }
-- (RLMNotificationToken *)addNotificationBlock:(void (^)(RLMArray *, RLMCollectionChange *, NSError *))block receiveOnQueue:(dispatch_queue_t)queue {
+- (RLMNotificationToken *)addNotificationBlock:(void (^)(RLMArray *, RLMCollectionChange *, NSError *))block queue:(dispatch_queue_t)queue {
     return RLMAddNotificationBlock(self, block, queue);
 }
 #pragma clang diagnostic pop

--- a/Realm/RLMObject.h
+++ b/Realm/RLMObject.h
@@ -555,7 +555,7 @@ typedef void (^RLMObjectChangeBlock)(BOOL deleted,
  deletes the object or modifies any of the managed properties of the object,
  including self-assignments that set a property to its existing value.
 
- For write transactions performed on different threads or in differen
+ For write transactions performed on different threads or in different
  processes, the block will be called when the managing Realm is
  (auto)refreshed to a version including the changes, while for local write
  transactions it will be called at some point in the future after the write
@@ -584,6 +584,44 @@ typedef void (^RLMObjectChangeBlock)(BOOL deleted,
  @return A token which must be held for as long as you want updates to be delivered.
  */
 - (RLMNotificationToken *)addNotificationBlock:(RLMObjectChangeBlock)block;
+
+/**
+ Registers a block to be called each time the object changes.
+
+ The block will be asynchronously called after each write transaction which
+ deletes the object or modifies any of the managed properties of the object,
+ including self-assignments that set a property to its existing value.
+
+ For write transactions performed on different threads or in different
+ processes, the block will be called when the managing Realm is
+ (auto)refreshed to a version including the changes, while for local write
+ transactions it will be called at some point in the future after the write
+ transaction is committed.
+
+ Notifications are delivered on the given queue. If the queue is blocked and
+ notifications can't be delivered instantly, multiple notifications may be
+ coalesced into a single notification.
+
+ Unlike with `RLMArray` and `RLMResults`, there is no "initial" callback made
+ after you add a new notification block.
+
+ Only objects which are managed by a Realm can be observed in this way. You
+ must retain the returned token for as long as you want updates to be sent to
+ the block. To stop receiving updates, call `-invalidate` on the token.
+
+ It is safe to capture a strong reference to the observed object within the
+ callback block. There is no retain cycle due to that the callback is retained
+ by the returned token and not by the object itself.
+
+ @warning This method cannot be called during a write transaction, when the
+          containing Realm is read-only, or on an unmanaged object.
+ @warning The queue must be a serial queue.
+
+ @param block The block to be called whenever a change occurs.
+ @param queue The serial queue to deliver notifications to.
+ @return A token which must be held for as long as you want updates to be delivered.
+ */
+- (RLMNotificationToken *)addNotificationBlock:(RLMObjectChangeBlock)block receiveOnQueue:(dispatch_queue_t)queue;
 
 #pragma mark - Other Instance Methods
 

--- a/Realm/RLMObject.h
+++ b/Realm/RLMObject.h
@@ -621,7 +621,7 @@ typedef void (^RLMObjectChangeBlock)(BOOL deleted,
  @param queue The serial queue to deliver notifications to.
  @return A token which must be held for as long as you want updates to be delivered.
  */
-- (RLMNotificationToken *)addNotificationBlock:(RLMObjectChangeBlock)block receiveOnQueue:(dispatch_queue_t)queue;
+- (RLMNotificationToken *)addNotificationBlock:(RLMObjectChangeBlock)block queue:(dispatch_queue_t)queue;
 
 #pragma mark - Other Instance Methods
 

--- a/Realm/RLMObject.mm
+++ b/Realm/RLMObject.mm
@@ -29,14 +29,7 @@
 #import "RLMRealm_Private.hpp"
 #import "RLMSchema_Private.h"
 
-#import "collection_notifications.hpp"
 #import "object.hpp"
-
-@interface RLMPropertyChange ()
-@property (nonatomic, readwrite, strong) NSString *name;
-@property (nonatomic, readwrite, strong, nullable) id previousValue;
-@property (nonatomic, readwrite, strong, nullable) id value;
-@end
 
 // We declare things in RLMObject which are actually implemented in RLMObjectBase
 // for documentation's sake, which leads to -Wunimplemented-method warnings.
@@ -164,26 +157,12 @@
 }
 
 - (RLMNotificationToken *)addNotificationBlock:(RLMObjectChangeBlock)block {
-    return RLMObjectAddNotificationBlock(self, ^(NSArray<NSString *> *propertyNames,
-                                                 NSArray *oldValues, NSArray *newValues, NSError *error) {
-        if (error) {
-            block(false, nil, error);
-        }
-        else if (!propertyNames) {
-            block(true, nil, nil);
-        }
-        else {
-            auto properties = [NSMutableArray arrayWithCapacity:propertyNames.count];
-            for (NSUInteger i = 0, count = propertyNames.count; i < count; ++i) {
-                auto prop = [RLMPropertyChange new];
-                prop.name = propertyNames[i];
-                prop.previousValue = RLMCoerceToNil(oldValues[i]);
-                prop.value = RLMCoerceToNil(newValues[i]);
-                [properties addObject:prop];
-            }
-            block(false, properties, nil);
-        }
-    });
+    return RLMObjectAddNotificationBlock(self, block, nil);
+}
+
+- (RLMNotificationToken *)addNotificationBlock:(RLMObjectChangeBlock)block
+                                receiveOnQueue:(nonnull dispatch_queue_t)queue {
+    return RLMObjectAddNotificationBlock(self, block, queue);
 }
 
 + (NSString *)className {
@@ -253,117 +232,3 @@ BOOL RLMIsObjectOrSubclass(Class klass) {
 BOOL RLMIsObjectSubclass(Class klass) {
     return RLMIsKindOfClass(class_getSuperclass(class_getSuperclass(klass)), RLMObjectBase.class);
 }
-
-@interface RLMObjectNotificationToken : RLMCancellationToken
-@end
-@implementation RLMObjectNotificationToken {
-@public
-    realm::Object _object;
-}
-@end
-
-RLMNotificationToken *RLMObjectAddNotificationBlock(RLMObjectBase *obj, RLMObjectNotificationCallback block) {
-    if (!obj->_realm) {
-        @throw RLMException(@"Only objects which are managed by a Realm support change notifications");
-    }
-    [obj->_realm verifyNotificationsAreSupported:true];
-
-    struct {
-        void (^block)(NSArray<NSString *> *, NSArray *, NSArray *, NSError *);
-        RLMObjectBase *object;
-
-        NSArray<NSString *> *propertyNames = nil;
-        NSArray *oldValues = nil;
-        bool deleted = false;
-
-        void populateProperties(realm::CollectionChangeSet const& c) {
-            if (propertyNames) {
-                return;
-            }
-            if (!c.deletions.empty()) {
-                deleted = true;
-                return;
-            }
-            if (c.columns.empty()) {
-                return;
-            }
-
-            auto properties = [NSMutableArray new];
-            for (RLMProperty *property in object->_info->rlmObjectSchema.properties) {
-                if (c.columns.count(object->_info->tableColumn(property).value)) {
-                    [properties addObject:property.name];
-                }
-            }
-            if (properties.count) {
-                propertyNames = properties;
-            }
-        }
-
-        NSArray *readValues(realm::CollectionChangeSet const& c) {
-            if (c.empty()) {
-                return nil;
-            }
-            populateProperties(c);
-            if (!propertyNames) {
-                return nil;
-            }
-
-            auto values = [NSMutableArray arrayWithCapacity:propertyNames.count];
-            for (NSString *name in propertyNames) {
-                id value = [object valueForKey:name];
-                if (!value || [value isKindOfClass:[RLMArray class]]) {
-                    [values addObject:NSNull.null];
-                }
-                else {
-                    [values addObject:value];
-                }
-            }
-            return values;
-        }
-
-        void before(realm::CollectionChangeSet const& c) {
-            @autoreleasepool {
-                oldValues = readValues(c);
-            }
-        }
-
-        void after(realm::CollectionChangeSet const& c) {
-            @autoreleasepool {
-                auto newValues = readValues(c);
-                if (deleted) {
-                    block(nil, nil, nil, nil);
-                }
-                else if (newValues) {
-                    block(propertyNames, oldValues, newValues, nil);
-                }
-                propertyNames = nil;
-                oldValues = nil;
-            }
-        }
-
-        void error(std::exception_ptr err) {
-            @autoreleasepool {
-                try {
-                    rethrow_exception(err);
-                }
-                catch (...) {
-                    NSError *error = nil;
-                    RLMRealmTranslateException(&error);
-                    block(nil, nil, nil, error);
-                }
-            }
-        }
-    } callback{block, obj};
-
-    realm::Object object(obj->_realm->_realm, *obj->_info->objectSchema, obj->_row);
-    auto token = [[RLMObjectNotificationToken alloc] initWithToken:object.add_notification_callback(callback) realm:obj->_realm];
-    token->_object = std::move(object);
-    return token;
-}
-
-@implementation RLMPropertyChange
-- (NSString *)description {
-    return [NSString stringWithFormat:@"<RLMPropertyChange: %p> %@ %@ -> %@",
-            (__bridge void *)self, _name, _previousValue, _value];
-}
-@end

--- a/Realm/RLMObject.mm
+++ b/Realm/RLMObject.mm
@@ -161,7 +161,7 @@
 }
 
 - (RLMNotificationToken *)addNotificationBlock:(RLMObjectChangeBlock)block
-                                receiveOnQueue:(nonnull dispatch_queue_t)queue {
+                                         queue:(nonnull dispatch_queue_t)queue {
     return RLMObjectAddNotificationBlock(self, block, queue);
 }
 

--- a/Realm/RLMObject_Private.h
+++ b/Realm/RLMObject_Private.h
@@ -54,7 +54,11 @@ typedef void (^RLMObjectNotificationCallback)(NSArray<NSString *> *_Nullable pro
                                               NSArray *_Nullable oldValues,
                                               NSArray *_Nullable newValues,
                                               NSError *_Nullable error);
-FOUNDATION_EXTERN RLMNotificationToken *RLMObjectAddNotificationBlock(RLMObjectBase *obj, RLMObjectNotificationCallback block);
+FOUNDATION_EXTERN RLMNotificationToken *RLMObjectBaseAddNotificationBlock(RLMObjectBase *obj,
+                                                                          dispatch_queue_t _Nullable queue,
+                                                                          RLMObjectNotificationCallback block);
+RLMNotificationToken *RLMObjectAddNotificationBlock(RLMObjectBase *obj, RLMObjectChangeBlock block,
+                                                    dispatch_queue_t _Nullable queue);
 
 // Returns whether the class is a descendent of RLMObjectBase
 FOUNDATION_EXTERN BOOL RLMIsObjectOrSubclass(Class klass);

--- a/Realm/RLMRealm.h
+++ b/Realm/RLMRealm.h
@@ -80,6 +80,27 @@ NS_ASSUME_NONNULL_BEGIN
 + (instancetype)defaultRealm;
 
 /**
+ Obtains an instance of the default Realm bound to the given queue.
+
+ Rather than being confined to the thread they are opened on, queue-bound
+ RLMRealms are confined to the given queue. They can be accessed from any
+ thread as long as it is from within a block dispatch to the queue, and
+ notifications will be delivered to the queue instead of a thread's run loop.
+
+ Realms can only be confined to a serial queue. Queue-confined RLMRealm
+ instances can be obtained when not on that queue, but attempting to do
+ anything with that instance without first dispatching to the queue will throw
+ an incorrect thread exception.
+
+ The default Realm is created using the default `RLMRealmConfiguration`, which
+ can be changed via `+[RLMRealmConfiguration setDefaultConfiguration:]`.
+
+ @param queue A serial dispatch queue to confine the Realm to.
+ @return The default `RLMRealm` instance for the given queue.
+ */
++ (instancetype)defaultRealmForQueue:(dispatch_queue_t)queue;
+
+/**
  Obtains an `RLMRealm` instance with the given configuration.
 
  @param configuration A configuration object to use when creating the Realm.
@@ -90,6 +111,31 @@ NS_ASSUME_NONNULL_BEGIN
  @return An `RLMRealm` instance.
  */
 + (nullable instancetype)realmWithConfiguration:(RLMRealmConfiguration *)configuration error:(NSError **)error;
+
+/**
+ Obtains an `RLMRealm` instance with the given configuration bound to the given queue.
+
+ Rather than being confined to the thread they are opened on, queue-bound
+ RLMRealms are confined to the given queue. They can be accessed from any
+ thread as long as it is from within a block dispatch to the queue, and
+ notifications will be delivered to the queue instead of a thread's run loop.
+
+ Realms can only be confined to a serial queue. Queue-confined RLMRealm
+ instances can be obtained when not on that queue, but attempting to do
+ anything with that instance without first dispatching to the queue will throw
+ an incorrect thread exception.
+
+ @param configuration A configuration object to use when creating the Realm.
+ @param queue         A serial dispatch queue to confine the Realm to.
+ @param error         If an error occurs, upon return contains an `NSError` object
+                      that describes the problem. If you are not interested in
+                      possible errors, pass in `NULL`.
+
+ @return An `RLMRealm` instance.
+ */
++ (nullable instancetype)realmWithConfiguration:(RLMRealmConfiguration *)configuration
+                                          queue:(nullable dispatch_queue_t)queue
+                                          error:(NSError **)error;
 
 /**
  Obtains an `RLMRealm` instance persisted at a specified file URL.
@@ -109,21 +155,19 @@ NS_ASSUME_NONNULL_BEGIN
  synchronized Realms wait for all remote content available at the time the
  operation began to be downloaded and available locally.
 
+ The Realm passed to the callback function is confined to the callback queue as
+ if `-[RLMRealm realmWithConfiguration:queue:error]` was used.
+
  @param configuration A configuration object to use when opening the Realm.
- @param callbackQueue The dispatch queue on which the callback should be run.
+ @param callbackQueue The serial dispatch queue on which the callback should be run.
  @param callback      A callback block. If the Realm was successfully opened,
                       it will be passed in as an argument.
                       Otherwise, an `NSError` describing what went wrong will be
                       passed to the block instead.
-
- @note The returned Realm is confined to the thread on which it was created.
-       Because GCD does not guarantee that queues will always use the same
-       thread, accessing the returned Realm outside the callback block (even if
-       accessed from `callbackQueue`) is unsafe.
  */
 + (RLMAsyncOpenTask *)asyncOpenWithConfiguration:(RLMRealmConfiguration *)configuration
-                     callbackQueue:(dispatch_queue_t)callbackQueue
-                          callback:(RLMAsyncOpenRealmCallback)callback;
+                                   callbackQueue:(dispatch_queue_t)callbackQueue
+                                        callback:(RLMAsyncOpenRealmCallback)callback;
 
 /**
  The `RLMSchema` used by the Realm.

--- a/Realm/RLMRealm.mm
+++ b/Realm/RLMRealm.mm
@@ -492,6 +492,9 @@ REALM_NOINLINE static void translateSharedGroupOpenException(NSError **error) {
             else {
                 config.scheduler = realm::util::Scheduler::make_dispatch((__bridge void *)queue);
             }
+            if (!config.scheduler->is_on_thread()) {
+                throw RLMException(@"Realm opened from incorrect dispatch queue.");
+            }
         }
         realm->_realm = Realm::get_shared_realm(config);
     }

--- a/Realm/RLMRealmUtil.hpp
+++ b/Realm/RLMRealmUtil.hpp
@@ -26,15 +26,13 @@ namespace realm {
 }
 
 // Add a Realm to the weak cache
-void RLMCacheRealm(std::string const& path, RLMRealm *realm);
+void RLMCacheRealm(std::string const& path, void *key, RLMRealm *realm);
 // Get a Realm for the given path which can be used on the current thread
-RLMRealm *RLMGetThreadLocalCachedRealmForPath(std::string const& path);
+RLMRealm *RLMGetThreadLocalCachedRealmForPath(std::string const& path, void *key);
 // Get a Realm for the given path
 RLMRealm *RLMGetAnyCachedRealmForPath(std::string const& path);
 // Clear the weak cache of Realms
 void RLMClearRealmCache();
-// Check if the current thread is currently within a running CFRunLoop
-bool RLMIsInRunLoop();
 
 RLMRealm *RLMGetFrozenRealmForSourceRealm(RLMRealm *realm);
 

--- a/Realm/RLMRealmUtil.mm
+++ b/Realm/RLMRealmUtil.mm
@@ -31,24 +31,20 @@
 
 #import <map>
 #import <mutex>
-#import <sys/event.h>
-#import <sys/stat.h>
-#import <sys/time.h>
-#import <unistd.h>
 
 // Global realm state
 static auto& s_realmCacheMutex = *new std::mutex();
 static auto& s_realmsPerPath = *new std::map<std::string, NSMapTable *>();
 static auto& s_frozenRealms = *new std::map<std::string, NSMapTable *>();
 
-void RLMCacheRealm(std::string const& path, __unsafe_unretained RLMRealm *const realm) {
+void RLMCacheRealm(std::string const& path, void *key, __unsafe_unretained RLMRealm *const realm) {
     std::lock_guard<std::mutex> lock(s_realmCacheMutex);
     NSMapTable *realms = s_realmsPerPath[path];
     if (!realms) {
         s_realmsPerPath[path] = realms = [NSMapTable mapTableWithKeyOptions:NSPointerFunctionsOpaquePersonality|NSPointerFunctionsOpaqueMemory
                                                                valueOptions:NSPointerFunctionsWeakMemory];
     }
-    [realms setObject:realm forKey:(__bridge id)pthread_self()];
+    [realms setObject:realm forKey:(__bridge id)key];
 }
 
 RLMRealm *RLMGetAnyCachedRealmForPath(std::string const& path) {
@@ -56,9 +52,9 @@ RLMRealm *RLMGetAnyCachedRealmForPath(std::string const& path) {
     return [s_realmsPerPath[path] objectEnumerator].nextObject;
 }
 
-RLMRealm *RLMGetThreadLocalCachedRealmForPath(std::string const& path) {
+RLMRealm *RLMGetThreadLocalCachedRealmForPath(std::string const& path, void *key) {
     std::lock_guard<std::mutex> lock(s_realmCacheMutex);
-    return [s_realmsPerPath[path] objectForKey:(__bridge id)pthread_self()];
+    return [s_realmsPerPath[path] objectForKey:(__bridge id)key];
 }
 
 void RLMClearRealmCache() {
@@ -86,30 +82,10 @@ RLMRealm *RLMGetFrozenRealmForSourceRealm(__unsafe_unretained RLMRealm *const so
     return realm;
 }
 
-bool RLMIsInRunLoop() {
-    // The main thread may not be in a run loop yet if we're called from
-    // something like `applicationDidFinishLaunching:`, but it presumably will
-    // be in the future
-    if ([NSThread isMainThread]) {
-        return true;
-    }
-    // Current mode indicates why the current callout from the runloop was made,
-    // and is null if a runloop callout isn't currently being processed
-    if (auto mode = CFRunLoopCopyCurrentMode(CFRunLoopGetCurrent())) {
-        CFRelease(mode);
-        return true;
-    }
-    return false;
-}
-
 namespace {
 class RLMNotificationHelper : public realm::BindingContext {
 public:
     RLMNotificationHelper(RLMRealm *realm) : _realm(realm) { }
-
-    bool can_deliver_notifications() const noexcept override {
-        return RLMIsInRunLoop();
-    }
 
     void changes_available() override {
         @autoreleasepool {

--- a/Realm/RLMResults.h
+++ b/Realm/RLMResults.h
@@ -256,9 +256,54 @@ NS_ASSUME_NONNULL_BEGIN
  @param block The block to be called whenever a change occurs.
  @return A token which must be held for as long as you want updates to be delivered.
  */
-- (RLMNotificationToken *)addNotificationBlock:(void (^)(RLMResults<RLMObjectType> *__nullable results,
-                                                         RLMCollectionChange *__nullable change,
-                                                         NSError *__nullable error))block __attribute__((warn_unused_result));
+- (RLMNotificationToken *)addNotificationBlock:(void (^)(RLMResults<RLMObjectType> *_Nullable results,
+                                                         RLMCollectionChange *_Nullable change,
+                                                         NSError *_Nullable error))block
+__attribute__((warn_unused_result));
+
+/**
+ Registers a block to be called each time the results collection changes.
+
+ The block will be asynchronously called with the initial results collection,
+ and then called again after each write transaction which changes either any
+ of the objects in the results, or which objects are in the results.
+
+ The `change` parameter will be `nil` the first time the block is called.
+ For each call after that, it will contain information about
+ which rows in the results collection were added, removed or modified. If a
+ write transaction did not modify any objects in the results collection,
+ the block is not called at all. See the `RLMCollectionChange` documentation for
+ information on how the changes are reported and an example of updating a
+ `UITableView`.
+
+ If an error occurs the block will be called with `nil` for the results
+ parameter and a non-`nil` error. Currently the only errors that can occur are
+ when opening the Realm on the background worker thread.
+
+ At the time when the block is called, the `RLMResults` object will be fully
+ evaluated and up-to-date, and as long as you do not perform a write transaction
+ on the same thread or explicitly call `-[RLMRealm refresh]`, accessing it will
+ never perform blocking work.
+
+ Notifications are delivered on the given queue. If the queue is blocked and
+ notifications can't be delivered instantly, multiple notifications may be
+ coalesced into a single notification.
+
+ You must retain the returned token for as long as you want updates to continue
+ to be sent to the block. To stop receiving updates, call `-invalidate` on the token.
+
+ @warning This method cannot be called when the containing Realm is read-only or frozen.
+ @warning The queue must be a serial queue.
+
+ @param block The block to be called whenever a change occurs.
+ @param queue The serial queue to deliver notifications to.
+ @return A token which must be held for as long as you want updates to be delivered.
+ */
+- (RLMNotificationToken *)addNotificationBlock:(void (^)(RLMResults<RLMObjectType> *_Nullable results,
+                                                         RLMCollectionChange *_Nullable change,
+                                                         NSError *_Nullable error))block
+                                receiveOnQueue:(nullable dispatch_queue_t)queue
+__attribute__((warn_unused_result));
 
 #pragma mark - Aggregating Property Values
 

--- a/Realm/RLMResults.h
+++ b/Realm/RLMResults.h
@@ -302,7 +302,7 @@ __attribute__((warn_unused_result));
 - (RLMNotificationToken *)addNotificationBlock:(void (^)(RLMResults<RLMObjectType> *_Nullable results,
                                                          RLMCollectionChange *_Nullable change,
                                                          NSError *_Nullable error))block
-                                receiveOnQueue:(nullable dispatch_queue_t)queue
+                                         queue:(nullable dispatch_queue_t)queue
 __attribute__((warn_unused_result));
 
 #pragma mark - Aggregating Property Values

--- a/Realm/RLMResults.mm
+++ b/Realm/RLMResults.mm
@@ -516,13 +516,16 @@ static inline void RLMResultsValidateInWriteTransaction(__unsafe_unretained RLMR
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wmismatched-parameter-types"
 - (RLMNotificationToken *)addNotificationBlock:(void (^)(RLMResults *, RLMCollectionChange *, NSError *))block {
-    if (!_realm) {
-        @throw RLMException(@"Linking objects notifications are only supported on managed objects.");
-    }
-    [_realm verifyNotificationsAreSupported:true];
-    return RLMAddNotificationBlock(self, _results, block, true);
+    return RLMAddNotificationBlock(self, block, nil);
+}
+- (RLMNotificationToken *)addNotificationBlock:(void (^)(RLMResults *, RLMCollectionChange *, NSError *))block receiveOnQueue:(dispatch_queue_t)queue {
+    return RLMAddNotificationBlock(self, block, queue);
 }
 #pragma clang diagnostic pop
+
+realm::Results& RLMGetBackingCollection(RLMResults *self) {
+    return self->_results;
+}
 
 - (BOOL)isAttached {
     return !!_realm;

--- a/Realm/RLMResults.mm
+++ b/Realm/RLMResults.mm
@@ -518,7 +518,7 @@ static inline void RLMResultsValidateInWriteTransaction(__unsafe_unretained RLMR
 - (RLMNotificationToken *)addNotificationBlock:(void (^)(RLMResults *, RLMCollectionChange *, NSError *))block {
     return RLMAddNotificationBlock(self, block, nil);
 }
-- (RLMNotificationToken *)addNotificationBlock:(void (^)(RLMResults *, RLMCollectionChange *, NSError *))block receiveOnQueue:(dispatch_queue_t)queue {
+- (RLMNotificationToken *)addNotificationBlock:(void (^)(RLMResults *, RLMCollectionChange *, NSError *))block queue:(dispatch_queue_t)queue {
     return RLMAddNotificationBlock(self, block, queue);
 }
 #pragma clang diagnostic pop

--- a/Realm/TestUtils/RLMTestCase.m
+++ b/Realm/TestUtils/RLMTestCase.m
@@ -202,11 +202,15 @@ static BOOL encryptTests() {
     dispatch_sync(queue, ^{});
 }
 
-- (void)dispatchAsync:(dispatch_block_t)block {
+- (dispatch_queue_t)bgQueue {
     if (!_bgQueue) {
         _bgQueue = dispatch_queue_create("test background queue", 0);
     }
-    dispatch_async(_bgQueue, ^{
+    return _bgQueue;
+}
+
+- (void)dispatchAsync:(dispatch_block_t)block {
+    dispatch_async(self.bgQueue, ^{
         @autoreleasepool {
             block();
         }

--- a/Realm/TestUtils/include/RLMTestCase.h
+++ b/Realm/TestUtils/include/RLMTestCase.h
@@ -55,6 +55,8 @@ NSData *RLMGenerateKey(void);
 - (void)dispatchAsync:(dispatch_block_t)block;
 - (void)dispatchAsyncAndWait:(dispatch_block_t)block;
 
+@property (nonatomic, readonly) dispatch_queue_t bgQueue;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Realm/Tests/ArrayPropertyTests.m
+++ b/Realm/Tests/ArrayPropertyTests.m
@@ -315,6 +315,7 @@
 
     [obj.intObj addObject:@5];
     XCTAssertEqualObjects(obj.intObj.firstObject, @5);
+    [realm cancelWriteTransaction];
 }
 
 - (void)testReplaceObjectAtIndexInUnmanagedArray {

--- a/Realm/Tests/AsyncTests.mm
+++ b/Realm/Tests/AsyncTests.mm
@@ -841,6 +841,18 @@
     }];
 }
 
+- (void)testAddNotificationBlockFromWrongQueue {
+    auto queue = dispatch_queue_create("background queue", DISPATCH_QUEUE_SERIAL);
+    RLMRealm *realm = [RLMRealm defaultRealmForQueue:queue];
+    __block RLMResults *results;
+    dispatch_sync(queue, ^{ results = [IntObject allObjectsInRealm:realm]; });
+    [self dispatchAsyncAndWait:^{
+        XCTAssertThrows([results addNotificationBlock:^(RLMResults *results, RLMCollectionChange *change, NSError *error) {
+            XCTFail(@"should not be called");
+        }]);
+    }];
+}
+
 - (void)testRemoveNotificationBlockFromWrongThread {
     // Unlike adding this is allowed, because it can happen due to capturing
     // tokens in blocks and users are very confused by errors from deallocation
@@ -978,6 +990,28 @@
 
     dispatch_semaphore_wait(sema, DISPATCH_TIME_FOREVER);
     CFRunLoopRun();
+    [token invalidate];
+}
+
+- (void)testNotificationDeliveryToQueue {
+    RLMRealm *realm = [RLMRealm defaultRealm];
+    RLMRealm *bgRealm = [RLMRealm defaultRealmForQueue:self.bgQueue];
+    __block RLMNotificationToken *token;
+    dispatch_semaphore_t sema = dispatch_semaphore_create(0);
+
+    [self dispatchAsync:^{
+        token = [[IntObject allObjectsInRealm:bgRealm] addNotificationBlock:^(RLMResults *results, RLMCollectionChange *, NSError *) {
+            XCTAssertNotNil(results);
+            XCTAssertNoThrow(results.count);
+            dispatch_semaphore_signal(sema);
+        }];
+    }];
+    dispatch_semaphore_wait(sema, DISPATCH_TIME_FOREVER);
+
+    [realm transactionWithBlock:^{
+        [IntObject createInRealm:realm withValue:@[@1]];
+    }];
+    dispatch_semaphore_wait(sema, DISPATCH_TIME_FOREVER);
     [token invalidate];
 }
 

--- a/Realm/Tests/AsyncTests.mm
+++ b/Realm/Tests/AsyncTests.mm
@@ -843,14 +843,14 @@
 
 - (void)testAddNotificationBlockFromWrongQueue {
     auto queue = dispatch_queue_create("background queue", DISPATCH_QUEUE_SERIAL);
-    RLMRealm *realm = [RLMRealm defaultRealmForQueue:queue];
     __block RLMResults *results;
-    dispatch_sync(queue, ^{ results = [IntObject allObjectsInRealm:realm]; });
-    [self dispatchAsyncAndWait:^{
-        XCTAssertThrows([results addNotificationBlock:^(RLMResults *results, RLMCollectionChange *change, NSError *error) {
-            XCTFail(@"should not be called");
-        }]);
-    }];
+    dispatch_sync(queue, ^{
+        RLMRealm *realm = [RLMRealm defaultRealmForQueue:queue];
+        results = [IntObject allObjectsInRealm:realm];
+    });
+    XCTAssertThrows([results addNotificationBlock:^(RLMResults *results, RLMCollectionChange *change, NSError *error) {
+        XCTFail(@"should not be called");
+    }]);
 }
 
 - (void)testRemoveNotificationBlockFromWrongThread {
@@ -995,11 +995,11 @@
 
 - (void)testNotificationDeliveryToQueue {
     RLMRealm *realm = [RLMRealm defaultRealm];
-    RLMRealm *bgRealm = [RLMRealm defaultRealmForQueue:self.bgQueue];
     __block RLMNotificationToken *token;
     dispatch_semaphore_t sema = dispatch_semaphore_create(0);
 
     [self dispatchAsync:^{
+        RLMRealm *bgRealm = [RLMRealm defaultRealmForQueue:self.bgQueue];
         token = [[IntObject allObjectsInRealm:bgRealm] addNotificationBlock:^(RLMResults *results, RLMCollectionChange *, NSError *) {
             XCTAssertNotNil(results);
             XCTAssertNoThrow(results.count);

--- a/Realm/Tests/NotificationTests.m
+++ b/Realm/Tests/NotificationTests.m
@@ -1079,6 +1079,9 @@ static void ExpectChange(id self, NSArray *deletions, NSArray *insertions,
         XCTFail(@"notification block for wrong object called");
     }];
 
+    // Ensure initial notification is processed so that the change can report previousValue
+    [_obj.realm transactionWithBlock:^{}];
+
     [self dispatchAsync:^{
         RLMRealm *realm = [RLMRealm defaultRealm];
         AllTypesObject *obj = [[AllTypesObject allObjectsInRealm:realm] firstObject];

--- a/Realm/Tests/ObjectCreationTests.mm
+++ b/Realm/Tests/ObjectCreationTests.mm
@@ -1416,6 +1416,7 @@
 
     RLMAssertThrowsWithReason([realm addOrUpdateObject:[DogObject new]],
                               @"'DogObject' does not have a primary key");
+    [realm cancelWriteTransaction];
 }
 
 - (void)testAddOrUpdateUpdatesExistingItemWithSamePK {

--- a/RealmSwift/LinkingObjects.swift
+++ b/RealmSwift/LinkingObjects.swift
@@ -303,7 +303,7 @@ public struct LinkingObjects<Element: Object> {
      */
     public func observe(on queue: DispatchQueue? = nil,
                         _ block: @escaping (RealmCollectionChange<LinkingObjects>) -> Void) -> NotificationToken {
-        return rlmResults.addNotificationBlock(wrapObserveBlock(block), receiveOn: queue)
+        return rlmResults.addNotificationBlock(wrapObserveBlock(block), queue: queue)
     }
 
     // MARK: Frozen Objects
@@ -385,7 +385,7 @@ extension LinkingObjects: RealmCollection {
     public func _observe(_ queue: DispatchQueue?,
                          _ block: @escaping (RealmCollectionChange<AnyRealmCollection<Element>>) -> Void)
         -> NotificationToken {
-            return rlmResults.addNotificationBlock(wrapObserveBlock(block), receiveOn: queue)
+            return rlmResults.addNotificationBlock(wrapObserveBlock(block), queue: queue)
     }
 }
 

--- a/RealmSwift/List.swift
+++ b/RealmSwift/List.swift
@@ -419,7 +419,7 @@ public final class List<Element: RealmCollectionValue>: ListBase {
      */
     public func observe(on queue: DispatchQueue? = nil,
                         _ block: @escaping (RealmCollectionChange<List>) -> Void) -> NotificationToken {
-        return _rlmArray.addNotificationBlock(wrapObserveBlock(block), receiveOn: queue)
+        return _rlmArray.addNotificationBlock(wrapObserveBlock(block), queue: queue)
     }
 
     // MARK: Frozen Objects
@@ -521,7 +521,7 @@ extension List: RealmCollection {
     public func _observe(_ queue: DispatchQueue?,
                          _ block: @escaping (RealmCollectionChange<AnyRealmCollection<Element>>) -> Void)
         -> NotificationToken {
-            return _rlmArray.addNotificationBlock(wrapObserveBlock(block), receiveOn: queue)
+            return _rlmArray.addNotificationBlock(wrapObserveBlock(block), queue: queue)
     }
 }
 

--- a/RealmSwift/ObjectiveCSupport.swift
+++ b/RealmSwift/ObjectiveCSupport.swift
@@ -47,7 +47,7 @@ public struct ObjectiveCSupport {
 
     /// Convert a `RLMArray` to a `List`.
     public static func convert(object: RLMArray<AnyObject>) -> List<Object> {
-        return List(rlmArray: object)
+        return List(objc: object)
     }
 
     /// Convert a `LinkingObjects` to a `RLMResults`.

--- a/RealmSwift/Results.swift
+++ b/RealmSwift/Results.swift
@@ -111,6 +111,9 @@ public struct Results<Element: RealmCollectionValue>: Equatable {
     internal init(_ rlmResults: RLMResults<AnyObject>) {
         self.rlmResults = rlmResults
     }
+    internal init(objc rlmResults: RLMResults<AnyObject>) {
+        self.rlmResults = rlmResults
+    }
 
     // MARK: Index Retrieval
 
@@ -299,9 +302,10 @@ public struct Results<Element: RealmCollectionValue>: Equatable {
      not perform a write transaction on the same thread or explicitly call `realm.refresh()`, accessing it will never
      perform blocking work.
 
-     Notifications are delivered via the standard run loop, and so can't be delivered while the run loop is blocked by
-     other activity. When notifications can't be delivered instantly, multiple notifications may be coalesced into a
-     single notification. This can include the notification with the initial collection.
+     If no queue is given, notifications are delivered via the standard run loop, and so can't be delivered while the
+     run loop is blocked by other activity. If a queue is given, notifications are delivered to that queue instead. When
+     notifications can't be delivered instantly, multiple notifications may be coalesced into a single notification.
+     This can include the notification with the initial collection.
 
      For example, the following code performs a write transaction immediately after adding the notification block, so
      there is no opportunity for the initial notification to be delivered first. As a result, the initial notification
@@ -336,13 +340,14 @@ public struct Results<Element: RealmCollectionValue>: Equatable {
 
      - warning: This method cannot be called during a write transaction, or when the containing Realm is read-only.
 
+     - parameter queue: The serial dispatch queue to receive notification on. If
+                        `nil`, notifications are delivered to the current thread.
      - parameter block: The block to be called whenever a change occurs.
      - returns: A token which must be held for as long as you want updates to be delivered.
      */
-    public func observe(_ block: @escaping (RealmCollectionChange<Results>) -> Void) -> NotificationToken {
-        return rlmResults.addNotificationBlock { _, change, error in
-            block(RealmCollectionChange.fromObjc(value: self, change: change, error: error))
-        }
+    public func observe(on queue: DispatchQueue? = nil,
+                        _ block: @escaping (RealmCollectionChange<Results>) -> Void) -> NotificationToken {
+        return rlmResults.addNotificationBlock(wrapObserveBlock(block), receiveOn: queue)
     }
 
     // MARK: Frozen Objects
@@ -386,12 +391,11 @@ extension Results: RealmCollection {
     public func index(before i: Int) -> Int { return i - 1 }
 
     /// :nodoc:
-    public func _observe(_ block: @escaping (RealmCollectionChange<AnyRealmCollection<Element>>) -> Void) ->
-        NotificationToken {
-        let anyCollection = AnyRealmCollection(self)
-        return rlmResults.addNotificationBlock { _, change, error in
-            block(RealmCollectionChange.fromObjc(value: anyCollection, change: change, error: error))
-        }
+    // swiftlint:disable:next identifier_name
+    public func _observe(_ queue: DispatchQueue?,
+                         _ block: @escaping (RealmCollectionChange<AnyRealmCollection<Element>>) -> Void)
+        -> NotificationToken {
+            return rlmResults.addNotificationBlock(wrapObserveBlock(block), receiveOn: queue)
     }
 }
 

--- a/RealmSwift/Results.swift
+++ b/RealmSwift/Results.swift
@@ -347,7 +347,7 @@ public struct Results<Element: RealmCollectionValue>: Equatable {
      */
     public func observe(on queue: DispatchQueue? = nil,
                         _ block: @escaping (RealmCollectionChange<Results>) -> Void) -> NotificationToken {
-        return rlmResults.addNotificationBlock(wrapObserveBlock(block), receiveOn: queue)
+        return rlmResults.addNotificationBlock(wrapObserveBlock(block), queue: queue)
     }
 
     // MARK: Frozen Objects
@@ -395,7 +395,7 @@ extension Results: RealmCollection {
     public func _observe(_ queue: DispatchQueue?,
                          _ block: @escaping (RealmCollectionChange<AnyRealmCollection<Element>>) -> Void)
         -> NotificationToken {
-            return rlmResults.addNotificationBlock(wrapObserveBlock(block), receiveOn: queue)
+            return rlmResults.addNotificationBlock(wrapObserveBlock(block), queue: queue)
     }
 }
 

--- a/RealmSwift/Tests/ObjectTests.swift
+++ b/RealmSwift/Tests/ObjectTests.swift
@@ -715,6 +715,9 @@ class ObjectTests: TestCase {
             self.checkChange("intCol", 1, 2, change)
             sema.signal()
         }
+        // wait for the notification to be registered as otherwise it may not
+        // have the old value
+        queue.sync { }
         try! realm.write {
             object.intCol = 2
         }
@@ -746,6 +749,7 @@ class ObjectTests: TestCase {
 
         // Now let token2 registration happen
         sema.signal()
+        queue.sync { }
 
         // Perform a write and make sure only token2 notifies
         try! realm.write {


### PR DESCRIPTION
This has two main pieces: Realms which are confined to a dispatch queue rather than a thread, and notifications which are delivered to a scheduler other than the current one (currently only implemented for dispatch queues, but could support other things).

Queue-confined threads replace the check for if we're on the correct thread for a check if we're on the correct queue, using dispatch_queue_set_specific()/dispatch_queue_get_specific() to set some queue-local state to perform the checking. Notifications are done via a dispatch_async() to the queue rather than a signal in the target runloop. Because we can't automatically detect which queue we're running on (dispatch_queue_get_current() is inherently broken and doesn't really work), the queue to bind to has to be passed in when the Realm is opened.

A potentially surprising implication of this is that it's possible to have both a thread-confined and a queue-confined Realm instance usable at the same time, and they potentially could be at different versions.  This hopefully will not be too confusing for users? The main queue is special-cased to actually give the main thread's Realm instance, which hopefully will eliminate the most common place where this would arise (and makes it so that registering for notifications delivered to the main thread from a background thread works sensibly).

Notifications delivered to a queue are done by adding an optional queue parameter to observe(). Implementation-wise this is just a dispatch_async() to the queue with the notification registered there, but with some extra logic to be able to return a token synchronously.

I changed asyncOpen() to produce a queue-confined Realm mostly because it seemed weird for it not to be. I'm not sure if it's actually a functionally useful change.