### PR TITLE
Fix some race conditions in tests

### DIFF
--- a/RealmSwift/Tests/ObjectTests.swift
+++ b/RealmSwift/Tests/ObjectTests.swift
@@ -724,6 +724,7 @@ class ObjectTests: TestCase {
 
         sema.wait()
         token.invalidate()
+        queue.sync { }
     }
 
     func testInvalidateObserverOnDifferentQueueBeforeRegistration() {
@@ -757,6 +758,7 @@ class ObjectTests: TestCase {
         }
         sema.wait()
         token2.invalidate()
+        queue.sync { }
     }
 
     func testEqualityForObjectTypeWithPrimaryKey() {

--- a/RealmSwift/Tests/RealmCollectionTypeTests.swift
+++ b/RealmSwift/Tests/RealmCollectionTypeTests.swift
@@ -472,7 +472,6 @@ class RealmCollectionTypeTests: TestCase {
 
     func observeOnQueue<Collection: RealmCollection>(_ collection: Collection) where Collection.Element: Object {
         let sema = DispatchSemaphore(value: 0)
-        let queue = DispatchQueue(label: "background queue")
         let token = collection.observe(on: queue) { (changes: RealmCollectionChange) in
             switch changes {
             case .initial(let collection):

--- a/RealmSwift/Tests/TestCase.swift
+++ b/RealmSwift/Tests/TestCase.swift
@@ -61,6 +61,7 @@ class TestCase: RLMTestCaseBase {
 
         exceptionThrown = false
         autoreleasepool { super.invokeTest() }
+        queue.sync { }
 
         if !exceptionThrown {
             XCTAssertFalse(RLMHasCachedRealmForPath(defaultRealmURL().path))


### PR DESCRIPTION
Tests which do things on dispatch queues need to wait for the queue to be flushed or sometimes the Realms allocated on those queues will be deallocated after the test tearDown has started.