### PR TITLE
Fix a few more packaging/installation test issues

### DIFF
--- a/Jenkinsfile.releasability
+++ b/Jenkinsfile.releasability
@@ -81,7 +81,7 @@ def doBuild() {
         node('osx') {
           deleteDir()
           unstash 'source'
-          sh 'XCMODE=xcpretty ./build.sh package-examples'
+          sh './build.sh package-examples'
           stash includes: 'realm-examples.zip', name: 'examples'
         }
       },
@@ -90,7 +90,7 @@ def doBuild() {
         node('osx') {
           deleteDir()
           unstash 'source'
-          sh "XCMODE=xcpretty REALM_XCODE_VERSION=${objcXcodeVersion} ./build.sh package-ios-static"
+          sh "REALM_XCODE_VERSION=${objcXcodeVersion} ./build.sh package-ios-static"
           dir("build/ios-static") {
             stash includes: "realm-framework-ios-static.zip", name: "ios-static"
           }
@@ -140,7 +140,7 @@ def doBuild() {
           node('osx') {
             deleteDir()
             unstash 'source'
-            sh "XCMODE=xcpretty REALM_XCODE_VERSION=${xcodeVersion} ./build.sh package ${platform}"
+            sh "REALM_XCODE_VERSION=${xcodeVersion} ./build.sh package ${platform}"
             dir("build/${platform}") {
               stash includes: "realm-framework-${platform}-${xcodeVersion}.zip",
                     name: "${platform}-${xcodeVersion}"
@@ -235,7 +235,7 @@ def doBuild() {
           curl https://raw.githubusercontent.com/realm/realm-cocoa/${sha}/scripts/reset-simulators.rb -o scripts/reset-simulators.rb
           chmod +x scripts/reset-simulators.rb
 
-          XCMODE=xcpretty sh build.sh package-test-examples-objc
+          sh build.sh package-test-examples-objc
           """
         }
       },
@@ -256,7 +256,7 @@ def doBuild() {
           curl https://raw.githubusercontent.com/realm/realm-cocoa/${sha}/scripts/reset-simulators.rb -o scripts/reset-simulators.rb
           chmod +x scripts/reset-simulators.rb
 
-          XCMODE=xcpretty sh build.sh package-test-examples-swift
+          sh build.sh package-test-examples-swift
           """
         }
       },
@@ -267,7 +267,7 @@ def doBuild() {
           unstash 'source'
 
           sh './scripts/reset-simulators.rb'
-          sh 'XCMODE=xcpretty sh build.sh test-ios-static'
+          sh 'sh build.sh test-ios-static'
         }
       },
 
@@ -275,8 +275,7 @@ def doBuild() {
         node('osx') {
           deleteDir()
           unstash 'source'
-
-          sh 'XCMODE=xcpretty sh build.sh test-osx'
+          sh 'sh build.sh test-osx'
         }
       }
     ]

--- a/Jenkinsfile.releasability
+++ b/Jenkinsfile.releasability
@@ -17,6 +17,7 @@ def installationTest(platform, test, language) {
       }
 
       sh """
+      hostname
       export REALM_XCODE_VERSION=${carthageXcodeVersion}
       if [ "${platform}" != osx ]; then
         ./scripts/reset-simulators.sh -firstOnly
@@ -64,6 +65,7 @@ def doBuild() {
           deleteDir()
           unstash 'source'
           sh """
+          hostname
           export REALM_SWIFT_VERSION=${docsSwiftVersion}
           export PATH='/Users/realm/.rbenv/bin:/Users/realm/.rbenv/shims:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/Users/realm/.gems/bin'
           ./scripts/reset-simulators.sh
@@ -107,6 +109,7 @@ def doBuild() {
           deleteDir()
           unstash 'source'
           sh """
+          hostname
           export REALM_XCODE_VERSION=${carthageXcodeVersion}
           . ./scripts/swift-version.sh
           set_xcode_and_swift_versions
@@ -227,6 +230,7 @@ def doBuild() {
 
           def sha = params.sha
           sh """
+          hostname
           curl -O https://raw.githubusercontent.com/realm/realm-cocoa/${sha}/build.sh
           mkdir -p scripts
           curl https://raw.githubusercontent.com/realm/realm-cocoa/${sha}/scripts/swift-version.sh -o scripts/swift-version.sh
@@ -247,6 +251,7 @@ def doBuild() {
 
           def sha = params.sha
           sh """
+          hostname
           curl -O https://raw.githubusercontent.com/realm/realm-cocoa/${sha}/build.sh
           mkdir -p scripts
           curl https://raw.githubusercontent.com/realm/realm-cocoa/${sha}/scripts/swift-version.sh -o scripts/swift-version.sh

--- a/Jenkinsfile.releasability
+++ b/Jenkinsfile.releasability
@@ -19,9 +19,6 @@ def installationTest(platform, test, language) {
       sh """
       hostname
       export REALM_XCODE_VERSION=${carthageXcodeVersion}
-      if [ "${platform}" != osx ]; then
-        ./scripts/reset-simulators.sh -firstOnly
-      fi
       cd examples/installation
 
       archive=\$(echo \$PWD/realm-${language}-*.zip)

--- a/build.sh
+++ b/build.sh
@@ -1410,7 +1410,6 @@ EOM
         if [[ "$PLATFORM" = "catalyst" ]] && (( $(xcode_version_major) < 11 )); then
             mkdir -p build/catalyst/swift-$REALM_XCODE_VERSION
         else
-            sh build.sh prelaunch-simulator
             sh build.sh $PLATFORM-swift
         fi
 

--- a/examples/installation/build.sh
+++ b/examples/installation/build.sh
@@ -127,11 +127,11 @@ xctest() {
     if [ -d "$workspace" ]; then
         project=(-workspace "$workspace")
     fi
-    local code_signing_flags=(CODE_SIGN_IDENTITY= CODE_SIGNING_REQUIRED=NO AD_HOC_CODE_SIGNING_ALLOWED=YES)
+    local code_signing_flags=('CODE_SIGN_IDENTITY=' 'CODE_SIGNING_REQUIRED=NO' 'AD_HOC_CODE_SIGNING_ALLOWED=YES')
     local scheme=(-scheme "$NAME")
 
     # Ensure that dynamic framework tests try to use the correct version of the prebuilt libraries.
-    sed -i '' 's@/swift-[0-9.]*@/swift-'${REALM_XCODE_VERSION}'@' "$DIRECTORY/$NAME.xcodeproj/project.pbxproj"
+    sed -i '' 's@/swift-[0-9.]*@/swift-'"${REALM_XCODE_VERSION}"'@' "$DIRECTORY/$NAME.xcodeproj/project.pbxproj"
 
     xcodebuild "${project[@]}" "${scheme[@]}" clean build "${destination[@]}" "${code_signing_flags[@]}"
     if [[ $PLATFORM != watchos ]]; then

--- a/scripts/swift-version.sh
+++ b/scripts/swift-version.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+: "${REALM_XCODE_VERSION:=}"
+: "${REALM_SWIFT_VERSION:=}"
+: "${DEVELOPER_DIR:=}"
+
 get_swift_version() {
     "$1" --version 2>/dev/null | sed -ne 's/^Apple Swift version \([^\b ]*\).*/\1/p'
 }


### PR DESCRIPTION
[With these changes cocoa-pipeline actually fully passes](https://ci.realm.io/blue/organizations/jenkins/cocoa-pipeline/detail/cocoa-pipeline/1086/pipeline/).

Using xcpretty for packaging jobs just hides the actual errors ina. lot of places and makes it harder to see what went wrong. For PR jobs we use it to create junit xml for jenkins' test stuff so it's mildly useful there.

All of the places where we call carthage need the number of active simulators limited to one so that `xcodebuild -list` doesn't take forever and sometimes time out. There was also an issue with the previous simulator deleting logic; because it restarted the process from scratch on any error it'd sometimes get stuck in an endless loop of failing for the same reason. I made it instead try to delete all simulators, ignoring failures, then requery for the list of simulators, repeating up to 3 times or until there were no simulators left.