### PR TITLE
Fix a few bugs with frozen objects in obj-c

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,7 @@ x.y.z Release notes (yyyy-MM-dd)
 * None.
 
 ### Fixed
-* <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-cocoa/issues/????), since v?.?.?)
-* None.
+* `-[RLMObject isFrozen]` always returned false. ([#6568](https://github.com/realm/realm-cocoa/issues/6568), since 5.0.0).
 
 <!-- ### Breaking Changes - ONLY INCLUDE FOR NEW MAJOR version -->
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ x.y.z Release notes (yyyy-MM-dd)
 * Freezing an object within the write transaction that the object was created
   in now throws an exception rather than crashing when the object is first
   used.
+* The schema for frozen Realms was not properly initialized, leading to crashes
+  when accessing a RLMLinkingObjects property.
+  ([#6568](https://github.com/realm/realm-cocoa/issues/6568), since 5.0.0).
 
 <!-- ### Breaking Changes - ONLY INCLUDE FOR NEW MAJOR version -->
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ x.y.z Release notes (yyyy-MM-dd)
 
 ### Fixed
 * `-[RLMObject isFrozen]` always returned false. ([#6568](https://github.com/realm/realm-cocoa/issues/6568), since 5.0.0).
+* Freezing an object within the write transaction that the object was created
+  in now throws an exception rather than crashing when the object is first
+  used.
 
 <!-- ### Breaking Changes - ONLY INCLUDE FOR NEW MAJOR version -->
 

--- a/Realm/RLMObject.mm
+++ b/Realm/RLMObject.mm
@@ -156,6 +156,10 @@
     return RLMObjectFreeze(self);
 }
 
+- (BOOL)isFrozen {
+    return _realm.isFrozen;
+}
+
 - (RLMNotificationToken *)addNotificationBlock:(RLMObjectChangeBlock)block {
     return RLMObjectAddNotificationBlock(self, block, nil);
 }

--- a/Realm/RLMObjectBase.mm
+++ b/Realm/RLMObjectBase.mm
@@ -469,6 +469,9 @@ id RLMObjectFreeze(RLMObjectBase *obj) {
     RLMRealm *frozenRealm = [obj->_realm freeze];
     RLMObjectBase *frozen = RLMCreateManagedAccessor(obj.class, &frozenRealm->_info[obj->_info->rlmObjectSchema.className]);
     frozen->_row = frozenRealm->_realm->import_copy_of(obj->_row);
+    if (!frozen->_row.is_valid()) {
+        @throw RLMException(@"Cannot freeze an object in the same write transaction as it was created in.");
+    }
     RLMInitializeSwiftAccessorGenerics(frozen);
     return frozen;
 }

--- a/Realm/RLMRealm.mm
+++ b/Realm/RLMRealm.mm
@@ -1017,6 +1017,7 @@ REALM_NOINLINE static void translateSharedGroupOpenException(NSError **error) {
     try {
         RLMRealm *realm = [[RLMRealm alloc] initPrivate];
         realm->_realm = _realm->freeze();
+        realm->_realm->set_schema_subset(_realm->schema());
         realm->_realm->read_group();
         realm->_dynamic = _dynamic;
         realm->_schema = _schema;

--- a/Realm/Tests/ObjectTests.m
+++ b/Realm/Tests/ObjectTests.m
@@ -1455,4 +1455,18 @@ static IntObject *managedObject() {
     }
 }
 
+- (void)testFreezeInsideWriteTransaction {
+    RLMRealm *realm = RLMRealm.defaultRealm;
+    [realm beginWriteTransaction];
+    IntObject *obj = [IntObject createInRealm:realm withValue:@[@1]];
+    RLMAssertThrowsWithReason([obj freeze], @"Cannot freeze an object in the same write transaction as it was created in.");
+    [realm commitWriteTransaction];
+
+    [realm beginWriteTransaction];
+    obj.intCol = 2;
+    // Frozen objects have the value of the object at the start of the transaction
+    XCTAssertEqual(obj.freeze.intCol, 1);
+    [realm cancelWriteTransaction];
+}
+
 @end

--- a/Realm/Tests/ObjectTests.m
+++ b/Realm/Tests/ObjectTests.m
@@ -1354,7 +1354,7 @@ static IntObject *managedObject() {
     IntObject *frozen = [managed freeze];
     XCTAssertFalse(standalone.isFrozen);
     XCTAssertFalse(managed.isFrozen);
-    XCTAssertFalse(frozen.isFrozen);
+    XCTAssertTrue(frozen.isFrozen);
 }
 
 - (void)testFreezeUnmanagedObject {


### PR DESCRIPTION
Linking objects on frozen objects were only tested in Swift and not obj-c, and so unsurprisingly the obj-c version had a dumb bug. -[RLMObject isFrozen] was tested, but the test was wrong. The other change here is just a bit of error checking to give a better error when the user does something that can't work.

Fixes #6568.