### PR TITLE
Fix a case where we would accidentally reuse schedulers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,11 @@ x.y.z Release notes (yyyy-MM-dd)
 * None.
 
 ### Fixed
-* <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-cocoa/issues/????), since v?.?.?)
-* None.
+* Opening a Realm using a configuration object read from an existing Realm
+  would incorrectly bind the new Realm to the original Realm's thread/queue,
+  resulting in "Realm accessed from incorrect thread." exceptions.
+  ([#6574](https://github.com/realm/realm-cocoa/issues/6574),
+  [#6559](https://github.com/realm/realm-cocoa/issues/6559), since 5.0.0).
 
 <!-- ### Breaking Changes - ONLY INCLUDE FOR NEW MAJOR version -->
 

--- a/Realm/RLMRealm.mm
+++ b/Realm/RLMRealm.mm
@@ -450,7 +450,7 @@ REALM_NOINLINE static void translateSharedGroupOpenException(NSError **error) {
     }
 
     {
-        Realm::Config& config = configuration.config;
+        Realm::Config const& config = configuration.config;
 
         // try to reuse existing realm first
         if (cache || dynamic) {
@@ -495,6 +495,11 @@ REALM_NOINLINE static void translateSharedGroupOpenException(NSError **error) {
             if (!config.scheduler->is_on_thread()) {
                 throw RLMException(@"Realm opened from incorrect dispatch queue.");
             }
+        }
+        else {
+            // If the source config was read from a Realm it may already have a
+            // scheduler, and we don't want to reuse it.
+            config.scheduler = nullptr;
         }
         realm->_realm = Realm::get_shared_realm(config);
     }

--- a/Realm/Tests/RealmTests.mm
+++ b/Realm/Tests/RealmTests.mm
@@ -1621,6 +1621,27 @@
     });
 }
 
+- (void)testReusingConfigOnMultipleQueues {
+    auto config = [RLMRealmConfiguration defaultConfiguration];
+    auto q1 = dispatch_queue_create("queue 1", DISPATCH_QUEUE_SERIAL);
+    auto q2 = dispatch_queue_create("queue 2", DISPATCH_QUEUE_SERIAL);
+
+    dispatch_sync(q1, ^{
+        XCTAssertNoThrow([RLMRealm realmWithConfiguration:config queue:q1 error:nil]);
+    });
+    dispatch_sync(q2, ^{
+        XCTAssertNoThrow([RLMRealm realmWithConfiguration:config queue:q2 error:nil]);
+    });
+}
+
+- (void)testConfigurationFromExistingRealmOnNewThread {
+    auto r1 = [RLMRealm defaultRealm];
+    [self dispatchAsyncAndWait:^{
+        auto r2 = [RLMRealm realmWithConfiguration:r1.configuration error:nil];
+        XCTAssertNoThrow([r2 refresh]);
+    }];
+}
+
 #pragma mark - In-memory Realms
 
 - (void)testInMemoryRealm {


### PR DESCRIPTION
The configuration read from a Realm will have that Realm's scheduler, so opening a new Realm with that config and not explicitly specifying a queue would accidentally reuse the source scheduler and bind the Realm to the wrong thread/queue.

Fixes #6559. Fixes #6574.