### PR TITLE
Allow opening full-sync Realms in read-only mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,12 @@
 x.y.z Release notes (yyyy-MM-dd)
 =============================================================
 ### Enhancements
-* None.
+* Allow opening full-sync Realms in read-only mode. This disables local schema
+  initialization, which makes it possible to open a Realm which the user does
+  not have write access to without using asyncOpen. In addition, it will report
+  errors immediately when an operation would require writing to the Realm
+  rather than reporting it via the sync error handler only after the server
+  rejects the write.
 
 ### Fixed
 * Opening a Realm using a configuration object read from an existing Realm

--- a/Realm/ObjectServerTests/RLMSyncTestCase.h
+++ b/Realm/ObjectServerTests/RLMSyncTestCase.h
@@ -58,6 +58,12 @@ NS_ASSUME_NONNULL_BEGIN
 /// Synchronously open a synced Realm and wait until the binding process has completed or failed.
 - (RLMRealm *)openRealmWithConfiguration:(RLMRealmConfiguration *)configuration;
 
+/// Synchronously open a synced Realm via asyncOpen and return the Realm.
+- (RLMRealm *)asyncOpenRealmWithConfiguration:(RLMRealmConfiguration *)configuration;
+
+/// Synchronously open a synced Realm via asyncOpen and return the expected error.
+- (NSError *)asyncOpenErrorWithConfiguration:(RLMRealmConfiguration *)configuration;
+
 /// Synchronously open a synced Realm. Also run a block right after the Realm is created.
 - (RLMRealm *)openRealmForURL:(NSURL *)url
                          user:(RLMSyncUser *)user

--- a/Realm/ObjectServerTests/RLMSyncTestCase.mm
+++ b/Realm/ObjectServerTests/RLMSyncTestCase.mm
@@ -349,6 +349,37 @@ static NSURL *syncDirectoryForChildProcess() {
               @"Timed out while trying to asynchronously open Realm for URL: %@", syncConfig.realmURL);
     return realm;
 }
+
+- (RLMRealm *)asyncOpenRealmWithConfiguration:(RLMRealmConfiguration *)config {
+    __block RLMRealm *realm = nil;
+    XCTestExpectation *ex = [self expectationWithDescription:@"Should asynchronously open a Realm"];
+    [RLMRealm asyncOpenWithConfiguration:config
+                           callbackQueue:dispatch_get_main_queue()
+                                callback:^(RLMRealm *r, NSError *err){
+        XCTAssertNil(err);
+        XCTAssertNotNil(r);
+        realm = r;
+        [ex fulfill];
+    }];
+    [self waitForExpectationsWithTimeout:10.0 handler:nil];
+    return realm;
+}
+
+- (NSError *)asyncOpenErrorWithConfiguration:(RLMRealmConfiguration *)config {
+    __block NSError *error = nil;
+    XCTestExpectation *ex = [self expectationWithDescription:@"Should fail to asynchronously open a Realm"];
+    [RLMRealm asyncOpenWithConfiguration:config
+                           callbackQueue:dispatch_get_main_queue()
+                                callback:^(RLMRealm *r, NSError *err){
+        XCTAssertNotNil(err);
+        XCTAssertNil(r);
+        error = err;
+        [ex fulfill];
+    }];
+    [self waitForExpectationsWithTimeout:10.0 handler:nil];
+    return error;
+}
+
 - (RLMRealm *)immediatelyOpenRealmForURL:(NSURL *)url user:(RLMSyncUser *)user {
     return [self immediatelyOpenRealmForURL:url
                                        user:user

--- a/Realm/ObjectServerTests/SwiftPartialSyncTests.swift
+++ b/Realm/ObjectServerTests/SwiftPartialSyncTests.swift
@@ -377,7 +377,7 @@ class SwiftPartialSyncTests: SwiftSyncTestCase {
 
         func assertCount(_ filter: String, _ count: Int, fileName: StaticString = #file, lineNumber: UInt = #line) {
             waitForState(objects.filter(filter).subscribe(named: "query", update: true), .complete)
-            XCTAssertEqual(objects.count, count, file: fileName, line: lineNumber)
+            XCTAssertEqual(objects.distinct(by: ["number"]).count, count, file: fileName, line: lineNumber)
         }
         assertCount("string CONTAINS 'art'", 4)
         assertCount("string CONTAINS 'ART'", 0)

--- a/Realm/RLMRealmConfiguration.h
+++ b/Realm/RLMRealmConfiguration.h
@@ -79,13 +79,23 @@ typedef BOOL (^RLMShouldCompactOnLaunchBlock)(NSUInteger totalBytes, NSUInteger 
 
 /// Whether to open the Realm in read-only mode.
 ///
-/// This is required to be able to open Realm files which are not writeable or
-/// are in a directory which is not writeable. This should only be used on files
-/// which will not be modified by anyone while they are open, and not just to
-/// get a read-only view of a file which may be written to by another thread or
-/// process. Opening in read-only mode requires disabling Realm's reader/writer
-/// coordination, so committing a write transaction from another process will
-/// result in crashes.
+/// For non-synchronized Realms, this is required to be able to open Realm
+/// files which are not writeable or are in a directory which is not writeable.
+/// This should only be used on files which will not be modified by anyone
+/// while they are open, and not just to get a read-only view of a file which
+/// may be written to by another thread or process. Opening in read-only mode
+/// requires disabling Realm's reader/writer coordination, so committing a
+/// write transaction from another process will result in crashes.
+///
+/// Syncronized Realms must always be writeable (as otherwise no
+/// synchronization could happen), and this instead merely disallows performing
+/// write transactions on the Realm. In addition, it will skip some automatic
+/// writes made to the Realm, such as to initialize the Realm's schema. Setting
+/// `readOnly = YES` is not strictly required for Realms which the sync user
+/// does not have write access to, but is highly recommended as it will improve
+/// error reporting and catch some errors earlier.
+///
+/// Realms using query-based sync cannot be opened in read-only mode.
 @property (nonatomic) BOOL readOnly;
 
 /// The current schema version.

--- a/Realm/RLMRealmConfiguration.mm
+++ b/Realm/RLMRealmConfiguration.mm
@@ -205,7 +205,14 @@ static void RLMNSStringToStdString(std::string &out, NSString *in) {
 }
 
 - (BOOL)readOnly {
-    return _config.immutable();
+    return _config.immutable() || _config.read_only_alternative();
+}
+
+static bool isSync(realm::Realm::Config const& config) {
+#if REALM_ENABLE_SYNC
+    return !!config.sync_config;
+#endif
+    return false;
 }
 
 - (void)setReadOnly:(BOOL)readOnly {
@@ -215,10 +222,15 @@ static void RLMNSStringToStdString(std::string &out, NSString *in) {
         } else if (self.shouldCompactOnLaunch) {
             @throw RLMException(@"Cannot set `readOnly` when `shouldCompactOnLaunch` is set.");
         }
-        _config.schema_mode = realm::SchemaMode::Immutable;
+#if REALM_ENABLE_SYNC
+        if (_config.sync_config && _config.sync_config->is_partial) {
+            @throw RLMException(@"Read-only mode is not supported for query-based sync.");
+        }
+#endif
+        _config.schema_mode = isSync(_config) ? realm::SchemaMode::ReadOnlyAlternative : realm::SchemaMode::Immutable;
     }
     else if (self.readOnly) {
-        _config.schema_mode = realm::SchemaMode::Automatic;
+        _config.schema_mode = isSync(_config) ? realm::SchemaMode::Additive : realm::SchemaMode::Automatic;
     }
 }
 
@@ -300,7 +312,7 @@ static void RLMNSStringToStdString(std::string &out, NSString *in) {
 
 - (void)setShouldCompactOnLaunch:(RLMShouldCompactOnLaunchBlock)shouldCompactOnLaunch {
     if (shouldCompactOnLaunch) {
-        if (self.readOnly) {
+        if (_config.immutable()) {
             @throw RLMException(@"Cannot set `shouldCompactOnLaunch` when `readOnly` is set.");
         }
         _config.should_compact_on_launch_function = [=](size_t totalBytes, size_t usedBytes) {

--- a/Realm/RLMSyncSession.mm
+++ b/Realm/RLMSyncSession.mm
@@ -231,6 +231,21 @@ static RLMSyncConnectionState convertConnectionState(SyncSession::ConnectionStat
     return nil;
 }
 
+- (NSString *)description {
+    return [NSString stringWithFormat:
+            @"<RLMSyncSession: %p> {\n"
+            "\tstate = %d;\n"
+            "\tconnectionState = %d;\n"
+            "\trealmURL = %@;\n"
+            "\tuser = %@;\n"
+            "}",
+            (__bridge void *)self,
+            static_cast<int>(self.state),
+            static_cast<int>(self.connectionState),
+            self.realmURL,
+            self.parentUser.identity];
+}
+
 @end
 
 // MARK: - Error action token

--- a/RealmSwift/RealmConfiguration.swift
+++ b/RealmSwift/RealmConfiguration.swift
@@ -160,11 +160,21 @@ extension Realm {
         /**
          Whether to open the Realm in read-only mode.
 
-         This is required to be able to open Realm files which are not writeable or are in a directory which is not
-         writeable. This should only be used on files which will not be modified by anyone while they are open, and not
-         just to get a read-only view of a file which may be written to by another thread or process. Opening in
-         read-only mode requires disabling Realm's reader/writer coordination, so committing a write transaction from
-         another process will result in crashes.
+         For non-synchronized Realms, this is required to be able to open Realm files which are not
+         writeable or are in a directory which is not writeable.  This should only be used on files
+         which will not be modified by anyone while they are open, and not just to get a read-only
+         view of a file which may be written to by another thread or process. Opening in read-only
+         mode requires disabling Realm's reader/writer coordination, so committing a write
+         transaction from another process will result in crashes.
+
+         Syncronized Realms must always be writeable (as otherwise no synchronization could happen),
+         and this instead merely disallows performing write transactions on the Realm. In addition,
+         it will skip some automatic writes made to the Realm, such as to initialize the Realm's
+         schema. Setting `readOnly = YES` is not strictly required for Realms which the sync user
+         does not have write access to, but is highly recommended as it will improve error reporting
+         and catch some errors earlier.
+
+         Realms using query-based sync cannot be opened in read-only mode.
          */
         public var readOnly: Bool = false
 


### PR DESCRIPTION
This is something that object store has supported for a while but we never exposed.

This has a few effects:

1. The schema won't be initialized locally, which means that read-only Realms no longer have to use asyncOpen the first time they're opened to avoid making a write that'll be rejected by the server.
2. Having extra types in the local schema that aren't present on the server will work fine. This works around the problem with partial sync permissions types ending up in the schema for full-sync Realms, and just generally removes the need to always explicitly list object types for a read-only Realm.
3. Incompatible schema changes such as adding a property to a type that isn't present on the server is more likely to produce a useful error immediately rather than a confusing one via the sync session error handler.
4. Better error reporting in general for accidental misuse.