### PR TITLE
Fix Combine for Swift 5.3 (XCode 12 beta)

### DIFF
--- a/RealmSwift/Combine.swift
+++ b/RealmSwift/Combine.swift
@@ -395,7 +395,7 @@ extension RealmCollection {
                 case .update(let collection, deletions: _, insertions: _, modifications: _):
                     _ = subscriber.receive(collection)
                 case .error(let error):
-                    _ = subscriber.receive(completion: .failure(error))
+                    subscriber.receive(completion: .failure(error))
                 }
             }
     }


### PR DESCRIPTION
Using `_ =` for Void functions is now a warning/error. Not sure I have warnings as errors turned on.