### PR TITLE
Fix a few Combine things

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 x.y.z Release notes (yyyy-MM-dd)
 =============================================================
 ### Enhancements
-* None.
+* Add `Realm.objectWillChange`, which is a Combine publisher that will emit a
+  notification each time the Realm is refreshed or a write transaction is
+  commited.
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-cocoa/issues/????), since v?.?.?)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ x.y.z Release notes (yyyy-MM-dd)
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-cocoa/issues/????), since v?.?.?)
 * Fix the spelling of `ObjectKeyIdentifiable`. The old spelling is available
   and deprecated for compatiblity.
+* Rename `RealmCollection.publisher` to `RealmCollection.collectionPublisher`.
+  The old name interacted with the `publisher` defined by `Sequence` in very
+  confusing ways, so we need to use a different name. The `publisher` name is
+  still available for compatiblity. ([#6516](https://github.com/realm/realm-cocoa/issues/6516))
 
 <!-- ### Breaking Changes - ONLY INCLUDE FOR NEW MAJOR version -->
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ x.y.z Release notes (yyyy-MM-dd)
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-cocoa/issues/????), since v?.?.?)
-* None.
+* Fix the spelling of `ObjectKeyIdentifiable`. The old spelling is available
+  and deprecated for compatiblity.
 
 <!-- ### Breaking Changes - ONLY INCLUDE FOR NEW MAJOR version -->
 

--- a/RealmSwift/Combine.swift
+++ b/RealmSwift/Combine.swift
@@ -35,12 +35,16 @@ import Realm.Private
 ///
 /// You can also manually conform to `Identifiable` if you wish, but note that
 /// using the object's memory address does *not* work for managed objects.
-public protocol ObjectKeyIdentifable: Identifiable, Object {
+public protocol ObjectKeyIdentifiable: Identifiable, Object {
     /// The stable identity of the entity associated with `self`.
     var id: UInt64 { get }
 }
 
-extension ObjectKeyIdentifable {
+/// :nodoc:
+@available(*, renamed: "ObjectKeyIdentifiable")
+public typealias ObjectKeyIdentifable = ObjectKeyIdentifiable
+
+extension ObjectKeyIdentifiable {
     /// A stable identifier for this object. For managed Realm objects, this
     /// value will be the same for all object instances which refer to the same
     /// object (i.e. for which `Object.isSameObject(as:)` returns true).

--- a/RealmSwift/Combine.swift
+++ b/RealmSwift/Combine.swift
@@ -41,7 +41,7 @@ public protocol ObjectKeyIdentifiable: Identifiable, Object {
 }
 
 /// :nodoc:
-@available(*, renamed: "ObjectKeyIdentifiable")
+@available(*, deprecated, renamed: "ObjectKeyIdentifiable")
 public typealias ObjectKeyIdentifable = ObjectKeyIdentifiable
 
 extension ObjectKeyIdentifiable {
@@ -55,7 +55,7 @@ extension ObjectKeyIdentifiable {
 
 // MARK: - Combine
 
-/// A type which can be passed to `publisher()` or `changesetPublisher()`.
+/// A type which can be passed to `valuePublisher()` or `changesetPublisher()`.
 @available(OSX 10.15, watchOS 6.0, iOS 13.0, iOSApplicationExtension 13.0, OSXApplicationExtension 10.15, tvOS 13.0, *)
 public protocol RealmSubscribable {
     // swiftlint:disable identifier_name
@@ -260,8 +260,14 @@ extension RealmCollection where Self: RealmSubscribable {
         Publishers.WillChange(self)
     }
 
-    /// A publisher that emits the collection each time the collection changes.
+    /// :nodoc:
+    @available(*, deprecated, renamed: "collectionPublisher")
     public var publisher: Publishers.Value<Self> {
+        Publishers.Value(self)
+    }
+
+    /// A publisher that emits the collection each time the collection changes.
+    public var collectionPublisher: Publishers.Value<Self> {
         Publishers.Value(self)
     }
 

--- a/RealmSwift/Tests/CombineTests.swift
+++ b/RealmSwift/Tests/CombineTests.swift
@@ -627,7 +627,7 @@ private class CombineCollectionPublisherTests<Collection: RealmCollection>: Comb
     func testBasic() {
         var exp = XCTestExpectation()
         var calls = 0
-        token = collection.publisher
+        token = collection.collectionPublisher
             .assertNoFailure()
             .sink { c in
                 XCTAssertEqual(c.count, calls)
@@ -681,7 +681,7 @@ private class CombineCollectionPublisherTests<Collection: RealmCollection>: Comb
     func testSubscribeOn() {
         let sema = DispatchSemaphore(value: 0)
         var calls = 0
-        token = collection.publisher
+        token = collection.collectionPublisher
             .subscribe(on: subscribeOnQueue)
             .assertNoFailure()
             .sink { r in
@@ -700,7 +700,7 @@ private class CombineCollectionPublisherTests<Collection: RealmCollection>: Comb
     func testReceiveOn() {
         var calls = 0
         var exp = XCTestExpectation(description: "initial")
-        token = collection.publisher
+        token = collection.collectionPublisher
             .receive(on: receiveOnQueue)
             .assertNoFailure()
             .sink { r in
@@ -757,7 +757,7 @@ private class CombineCollectionPublisherTests<Collection: RealmCollection>: Comb
     func testMakeThreadSafe() {
         var calls = 0
         var exp = XCTestExpectation(description: "initial")
-        token = collection.publisher
+        token = collection.collectionPublisher
             .map { $0 }
             .threadSafeReference()
             .receive(on: receiveOnQueue)
@@ -799,7 +799,7 @@ private class CombineCollectionPublisherTests<Collection: RealmCollection>: Comb
 
     func testFrozen() {
         let exp = XCTestExpectation()
-        token = collection.publisher
+        token = collection.collectionPublisher
             .freeze()
             .prefix(10)
             .collect()
@@ -888,7 +888,7 @@ private class CombineCollectionPublisherTests<Collection: RealmCollection>: Comb
 
     func testFrozenMakeThreadSafe() {
         let sema = DispatchSemaphore(value: 0)
-        token = collection.publisher
+        token = collection.collectionPublisher
             .freeze()
             .threadSafeReference()
             .receive(on: receiveOnQueue)

--- a/RealmSwift/Tests/CombineTests.swift
+++ b/RealmSwift/Tests/CombineTests.swift
@@ -71,6 +71,34 @@ class CombineTestCase: TestCase {
 }
 
 @available(OSX 10.15, watchOS 6.0, iOS 13.0, iOSApplicationExtension 13.0, OSXApplicationExtension 10.15, tvOS 13.0, *)
+class CombineRealmTests: CombineTestCase {
+    func testWillChangeLocalWrite() {
+        var called = false
+        token = realm.objectWillChange.sink {
+            called = true
+        }
+        try! realm.write {
+            realm.create(SwiftIntObject.self, value: [])
+        }
+        XCTAssertTrue(called)
+    }
+
+    func testWillChangeRemoteWrite() {
+        let exp = XCTestExpectation()
+        token = realm.objectWillChange.sink {
+            exp.fulfill()
+        }
+        subscribeOnQueue.async {
+            let backgroundRealm = try! Realm(configuration: self.realm.configuration)
+            try! backgroundRealm.write {
+                backgroundRealm.create(SwiftIntObject.self, value: [])
+            }
+        }
+        wait(for: [exp], timeout: 1)
+    }
+}
+
+@available(OSX 10.15, watchOS 6.0, iOS 13.0, iOSApplicationExtension 13.0, OSXApplicationExtension 10.15, tvOS 13.0, *)
 class CombineObjectPublisherTests: CombineTestCase {
     var obj: SwiftIntObject!
 


### PR DESCRIPTION
ObjectKeyIdentifiable was misspelled, so fix the spelling and add a compatibility alias. A user asked for a publisher for Realm-wide changes, and that was a very simple thing to add. The name `.publisher` for collections meant that a subscriber with a failure type of Error and a failure type of Void did totally unrelated things (the former used our collection change notifications, the latter is the Sequence-provided publisher that emits each of the values in the sequence then finishes), so we need to use a different name there to not be incredibly confusing.

Fixes #6516.