### PR TITLE
Add -ObjC linker flag when building XCFramework

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -580,7 +580,7 @@ case "$COMMAND" in
         ;;
 
     "xcframework")
-        export REALM_EXTRA_BUILD_ARGUMENTS="$REALM_EXTRA_BUILD_ARGUMENTS BUILD_LIBRARY_FOR_DISTRIBUTION=YES REALM_OBJC_MACH_O_TYPE=staticlib"
+        export REALM_EXTRA_BUILD_ARGUMENTS="$REALM_EXTRA_BUILD_ARGUMENTS BUILD_LIBRARY_FOR_DISTRIBUTION=YES REALM_OBJC_MACH_O_TYPE=staticlib OTHER_LDFLAGS=-ObjC"
 
         # Build all of the requested frameworks
         shift


### PR DESCRIPTION
As Realm (ObjC) is linked statically this does not play well with categories, therefor at runtime you will get a 'unrecognized selector sent to instance' when calling a method on a category. The solution is to add the `-ObjC` linker flag to tell the linker to 'Load all object files from all archives if you see that they contain any Obj-C code'

Should fix #6324