### PR TITLE
Fix spurious incorrect thread exceptions due to threadid reuse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,12 @@ x.y.z Release notes (yyyy-MM-dd)
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-cocoa/issues/????), since v?.?.?)
-* None.
+* Opening Realms on background threads could produce spurious Incorrect Thread
+  exceptions when a cached Realm existed for a previously existing thread with
+  the same thread ID as the current thread.
+  ([#6659](https://github.com/realm/realm-cocoa/issues/6659),
+  [#6689](https://github.com/realm/realm-cocoa/issues/6689),
+  [#6712](https://github.com/realm/realm-cocoa/issues/6712), since 5.0.0).
 
 <!-- ### Breaking Changes - ONLY INCLUDE FOR NEW MAJOR version -->
 


### PR DESCRIPTION
We key the Realm cache on the thread ID, but thread IDs are not actually unique over the lifetime of the process. This means that the cached Realm may have been created on a different thread with the same ID, which means that it'll be bound to a different runloop than the current thread's runloop. Check for this, and simply open a new Realm instead of reusing the cached Realm when this happens.

Fixes #6659. Fixes #6689. Fixes #6712.