### PR TITLE
Switch to building with Xcode 11.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 x.y.z Release notes (yyyy-MM-dd)
 =============================================================
 ### Enhancements
-* None.
+* Add prebuilt binary for Xcode 11.7 to the release package.
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-cocoa/issues/????), since v?.?.?)
@@ -14,7 +14,7 @@ x.y.z Release notes (yyyy-MM-dd)
 * Realm Object Server: 3.21.0 or later.
 * Realm Studio: 3.12 or later.
 * APIs are backwards compatible with all previous releases in the 5.x.y series.
-* Carthage release for Swift is built with Xcode 11.6.
+* Carthage release for Swift is built with Xcode 11.7.
 
 ### Internal
 * Upgraded realm-core from ? to ?

--- a/Jenkinsfile.releasability
+++ b/Jenkinsfile.releasability
@@ -1,8 +1,8 @@
-xcodeVersions = ['11.3', '11.4.1', '11.5', '11.6']
+xcodeVersions = ['11.3', '11.4.1', '11.7']
 platforms = ['osx', 'ios', 'watchos', 'tvos', 'catalyst']
 carthagePlatforms = ['osx', 'ios', 'watchos', 'tvos']
 platformNames = ['osx': 'macOS', 'ios': 'iOS', 'watchos': 'watchOS', 'tvos': 'tvOS', 'catalyst': 'Catalyst']
-carthageXcodeVersion = '11.5'
+carthageXcodeVersion = '11.7'
 objcXcodeVersion = '11.3'
 docsSwiftVersion = '5.2.4'
 

--- a/build.sh
+++ b/build.sh
@@ -1538,7 +1538,7 @@ x.y.z Release notes (yyyy-MM-dd)
 * Realm Object Server: 3.21.0 or later.
 * Realm Studio: 3.12 or later.
 * APIs are backwards compatible with all previous releases in the 5.x.y series.
-* Carthage release for Swift is built with Xcode 11.6.
+* Carthage release for Swift is built with Xcode 11.7.
 
 ### Internal
 * Upgraded realm-core from ? to ?

--- a/scripts/package_examples.rb
+++ b/scripts/package_examples.rb
@@ -41,7 +41,7 @@ base_examples = [
   "examples/tvos/swift",
 ]
 
-xcode_versions = %w(11.3 11.4.1 11.5 11.6)
+xcode_versions = %w(11.3 11.4.1 11.7)
 
 # Remove reference to Realm.xcodeproj from all example workspaces.
 base_examples.each do |example|

--- a/scripts/pr-ci-matrix.rb
+++ b/scripts/pr-ci-matrix.rb
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 # A script to generate the .jenkins.yml file for the CI pull request job
-XCODE_VERSIONS = %w(11.3 11.4.1 11.5 11.6 12.0)
+XCODE_VERSIONS = %w(11.3 11.4.1 11.7 12.0)
 CONFIGURATIONS = %w(Debug Release)
 
 release_only = ->(v, c) { c == 'Release' }


### PR DESCRIPTION
11.7 is the same swift version as 11.5 and 11.6, so we can drop those two versions.