### PR TITLE
Fixing SwiftPM file to support iOS 9

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -32,7 +32,7 @@ let package = Package(
     name: "Realm",
     platforms: [
         .macOS(.v10_10),
-        .iOS(.v11),
+        .iOS(.v9),
         .tvOS(.v9),
         .watchOS(.v2)
     ],


### PR DESCRIPTION
iOS 9 support is promised by the documentation (https://realm.io/docs/swift/latest/#installation) as well as specified in the cocoapods file (https://github.com/realm/realm-cocoa/blob/master/RealmSwift.podspec).

I think it is a good idea to align the SwiftPM file with those.