### PR TITLE
Fix compilation via Carthage with Xcode 12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ x.y.z Release notes (yyyy-MM-dd)
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-cocoa/issues/????), since v?.?.?)
-* None.
+* Fix compilation via Carthage when using Xcode 12 ([#6717](https://github.com/realm/realm-cocoa/issues/6717)).
 
 <!-- ### Breaking Changes - ONLY INCLUDE FOR NEW MAJOR version -->
 

--- a/Jenkinsfile.releasability
+++ b/Jenkinsfile.releasability
@@ -122,21 +122,10 @@ def doBuild() {
           # for each platform.
           ./scripts/reset-simulators.rb -firstOnly
 
-          # Building the Realm scheme before the RealmSwift scheme causes
-          # mysertious problems with Xcode 12. Carthage doesn't provide any way
-          # to customize what schemes are built, so just delete all of them
-          # except for the one we want to build.
-          mv Realm.xcodeproj/xcshareddata/xcschemes/Realm.xcscheme .
-          find Realm.xcodeproj -name '*.xcscheme' -and -not -name RealmSwift.xcscheme -delete
-          carthage build --no-skip-current --platform ${platform} --derived-data DerivedData
-          rm -r DerivedData
+          # Building the iOS static scheme just wastes time, so delete it
+          rm 'Realm.xcodeproj/xcshareddata/xcschemes/Realm iOS static.xcscheme'
 
-          mv Realm.xcscheme Realm.xcodeproj/xcshareddata/xcschemes/
-          mv Realm.xcodeproj/xcshareddata/xcschemes/RealmSwift.xcscheme .
           carthage build --no-skip-current --platform ${platform} --derived-data DerivedData
-          rm -r DerivedData
-          mv RealmSwift.xcscheme Realm.xcodeproj/xcshareddata/xcschemes
-
           carthage archive --output Carthage-${platform}.framework.zip
           """
           stash includes: "Carthage-${platform}.framework.zip",

--- a/Realm.xcodeproj/project.pbxproj
+++ b/Realm.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 52;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXAggregateTarget section */
@@ -1916,6 +1916,7 @@
 				5D659E9F1BE04556006515A0 /* Headers */,
 				1A7B82351D51235600750296 /* Frameworks */,
 				5D659ECE1BE04556006515A0 /* Resources */,
+				3F1DDB5825155E33007A9630 /* Carthage post-build workaround */,
 			);
 			buildRules = (
 			);
@@ -2217,6 +2218,26 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		3F1DDB5825155E33007A9630 /* Carthage post-build workaround */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Carthage post-build workaround";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "# Something that Carthage does results in Xcode skipping the ProcessXCFramework build step in some cases, which results in compilation failing. To work around this, ensure that the modified date on the XCFramework files are always newer than the built files, so that it happens on every build. This breaks incremental compilation, so we only want to do it when building for Carthage.\nif [ -n \"$CARTHAGE\" ]; then\n    find \"${SRCROOT}/core\" -type f -exec touch {} \\;\nfi\n";
+			showEnvVarsInLog = 0;
+		};
 		5D304A2E1BE9AEFB0082C1A6 /* Get Version Number */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;

--- a/build.sh
+++ b/build.sh
@@ -369,7 +369,7 @@ download_common() {
     local versioned_dir="${download_type}-${version}${suffix}"
     if [ -e "$versioned_dir/version.txt" ]; then
         echo "Setting ${version} as the active version"
-        copy_core "$versioned_dir${suffix}"
+        copy_core "$versioned_dir"
         exit 0
     fi
 


### PR DESCRIPTION
Something that Carthage is doing makes xcode incorrectly think that it can skip the ProcessXCFramework build step for the second scheme it builds even though the intermediate directory where the xcframework files are copied to are different for the two schemes. Work around this by touching each file in the xcframework after the build, which effectively disables incremental compilation.

Fixes #6717.