### PR TITLE
Add iOS 9 support for SPM

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -32,7 +32,7 @@ let package = Package(
     name: "Realm",
     platforms: [
         .macOS(.v10_10),
-        .iOS(.v11),
+        .iOS(.v9),
         .tvOS(.v9),
         .watchOS(.v2)
     ],
@@ -107,7 +107,9 @@ let package = Package(
                 "Realm/RLMUtil.mm"
             ],
             publicHeadersPath: "include",
-            cxxSettings: cxxSettings
+            cxxSettings: cxxSettings + [
+                .unsafeFlags(["-fno-aligned-new"])
+            ]
         ),
         .target(
             name: "RealmSwift",


### PR DESCRIPTION
Please review correct flags setup. 

Unfortunately there are no build flags separation for different archs in SPM for now so `-fno-aligned-new` is used for all architectures. 

Archive of Realm package has passed successfully.