### PR TITLE
Change Credential Google auth parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,9 @@ x.y.z Release notes (yyyy-MM-dd)
 * None.
 
 ### Breaking Changes
-* The following functionality has been renamed for clarity:
-
-| Old API                                                      | New API                                                        |
-|:-------------------------------------------------------------|:---------------------------------------------------------------|
-| `Credentials(googleToken:)`                                           | `Credentials(googleAuthCode:)`                             |
-|`[RLMCredentials credentialsWithGoogleToken:]`| `[RLMCredentials credentialsWithGoogleAuthCode:]` |
+* Change Google Credential parameter names to better reflect the required auth code:
+    * `Credentials(googleToken:)` => `Credentials(googleAuthCode:)`
+    * `[RLMCredentials credentialsWithGoogleToken:]` => `[RLMCredentials credentialsWithGoogleAuthCode:]`
 
 ### Compatibility
 * File format: Generates Realms with format v11 (Reads and upgrades all previous formats)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,13 @@ x.y.z Release notes (yyyy-MM-dd)
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-cocoa/issues/????), since v?.?.?)
 * None.
 
-<!-- ### Breaking Changes - ONLY INCLUDE FOR NEW MAJOR version -->
+### Breaking Changes
+* The following functionality has changed for accuracy:
+
+| Old API                                                      | New API                                                        |
+|:-------------------------------------------------------------|:---------------------------------------------------------------|
+| `Credentials(googleToken:)`                                           | `Credentials(googleAuthCode:)`                             |
+|`[RLMCredentials credentialsWithGoogleToken:]`| `[RLMCredentials credentialsWithGoogleAuthCode:]` |
 
 ### Compatibility
 * File format: Generates Realms with format v11 (Reads and upgrades all previous formats)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ x.y.z Release notes (yyyy-MM-dd)
 * None.
 
 ### Breaking Changes
-* The following functionality has changed for accuracy:
+* The following functionality has been renamed for clarity:
 
 | Old API                                                      | New API                                                        |
 |:-------------------------------------------------------------|:---------------------------------------------------------------|

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ In case you don't want to use the precompiled version, you can build Realm yours
 
 Prerequisites:
 
-* Building Realm requires Xcode 8.x.
+* Building Realm requires Xcode 11.x or newer.
 * If cloning from git, submodules are required: `git submodule update --init --recursive`.
 * Building Realm documentation requires [jazzy](https://github.com/realm/jazzy)
 

--- a/Realm/ObjectServerTests/RLMObjectServerTests.mm
+++ b/Realm/ObjectServerTests/RLMObjectServerTests.mm
@@ -476,7 +476,7 @@
 }
 
 - (void)testGoogleCredential {
-    RLMCredentials *googleCredential = [RLMCredentials credentialsWithGoogleToken:@"google token"];
+    RLMCredentials *googleCredential = [RLMCredentials credentialsWithGoogleAuthCode:@"google token"];
     XCTAssertEqualObjects(googleCredential.provider, @"oauth2-google");
 }
 

--- a/Realm/ObjectServerTests/SwiftObjectServerTests.swift
+++ b/Realm/ObjectServerTests/SwiftObjectServerTests.swift
@@ -633,7 +633,7 @@ class SwiftObjectServerTests: SwiftSyncTestCase {
     }
 
     func testGoogleCredentials() {
-        let googleCredential = Credentials(googleToken: "token")
+        let googleCredential = Credentials(googleAuthCode: "token")
         XCTAssertEqual(googleCredential.provider.rawValue, "oauth2-google")
     }
 

--- a/Realm/RLMCredentials.h
+++ b/Realm/RLMCredentials.h
@@ -70,7 +70,7 @@ extern RLMIdentityProvider const RLMIdentityProviderServerAPIKey;
 /**
  Construct and return credentials from a Google account token.
  */
-+ (instancetype)credentialsWithGoogleToken:(RLMCredentialsToken)token;
++ (instancetype)credentialsWithGoogleAuthCode:(RLMCredentialsToken)token;
 
 /**
  Construct and return credentials from an Apple account token.

--- a/Realm/RLMCredentials.mm
+++ b/Realm/RLMCredentials.mm
@@ -38,7 +38,6 @@ using namespace realm;
     return [[self alloc] initWithAppCredentials:app::AppCredentials::facebook(token.UTF8String)];
 }
 
-// !!!: realign callsites after refactor
 + (instancetype)credentialsWithGoogleAuthCode:(RLMCredentialsToken)token {
     return [[self alloc] initWithAppCredentials:app::AppCredentials::google(token.UTF8String)];
 }

--- a/Realm/RLMCredentials.mm
+++ b/Realm/RLMCredentials.mm
@@ -38,7 +38,8 @@ using namespace realm;
     return [[self alloc] initWithAppCredentials:app::AppCredentials::facebook(token.UTF8String)];
 }
 
-+ (instancetype)credentialsWithGoogleToken:(RLMCredentialsToken)token {
+// !!!: realign callsites after refactor
++ (instancetype)credentialsWithGoogleAuthCode:(RLMCredentialsToken)token {
     return [[self alloc] initWithAppCredentials:app::AppCredentials::google(token.UTF8String)];
 }
 


### PR DESCRIPTION
This pull request intends to resolve confusion around the intended use of google auth credentials. Ultimately `Credential` in RealmSwift should be an associated enum, but this is the best immediate change.

Addresses 
https://jira.mongodb.org/browse/RCOCOA-104
https://jira.mongodb.org/browse/RCOCOA-871