### PR TITLE
Add onOpen(:) to watch Combine call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,24 @@
+x.y.z Release notes (yyyy-MM-dd)
+=============================================================
+### Enhancements
+* Add ability to listen for when a Watch Change Stream is opened when using Combine. Use `onOpen(event:)` directly after opening a `WatchPublisher`, this will allow a callback to be invoked once the change stream is opened.
+
+### Fixed
+* <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-cocoa/issues/????), since v?.?.?)
+* None.
+
+<!-- ### Breaking Changes - ONLY INCLUDE FOR NEW MAJOR version -->
+
+### Compatibility
+* File format: Generates Realms with format v12 (Reads and upgrades all previous formats)
+* Realm Studio: 10.0.0 or later.
+* APIs are backwards compatible with all previous releases in the 10.x.y series.
+* Carthage release for Swift is built with Xcode 12.
+
+### Internal
+* Upgraded realm-core from ? to ?
+* Upgraded realm-sync from ? to ?
+
 10.0.0-rc.1 Release notes (2020-10-01)
 =============================================================
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 x.y.z Release notes (yyyy-MM-dd)
 =============================================================
 ### Enhancements
-* Add ability to listen for when a Watch Change Stream is opened when using Combine. Use `onOpen(event:)` directly after opening a `WatchPublisher`, this will allow a callback to be invoked once the change stream is opened.
+* Add the ability to listen for when a Watch Change Stream is opened when using Combine. Use `onOpen(event:)` directly after opening a `WatchPublisher` to register a callback to be invoked once the change stream is opened.
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-cocoa/issues/????), since v?.?.?)

--- a/RealmSwift/MongoClient.swift
+++ b/RealmSwift/MongoClient.swift
@@ -507,7 +507,7 @@ extension MongoCollection {
     /// of all events on this collection that the active user is authorized to see based on the configured MongoDB
     /// rules.
     /// - Parameters:
-    ///   - delegate: delegate The delegate that will react to events and errors from the resulting change stream.
+    ///   - delegate: The delegate that will react to events and errors from the resulting change stream.
     ///   - queue: Dispatches streaming events to an optional queue, if no queue is provided the main queue is used
     /// - Returns: A ChangeStream which will manage the streaming events.
     public func watch(delegate: ChangeEventDelegate, queue: DispatchQueue = .main) -> ChangeStream {
@@ -582,19 +582,21 @@ import Combine
 
 @available(OSX 10.15, watchOS 6.0, iOS 13.0, iOSApplicationExtension 13.0, OSXApplicationExtension 10.15, tvOS 13.0, *)
 extension Publishers {
-
     class WatchSubscription<S: Subscriber>: ChangeEventDelegate, Subscription where S.Input == AnyBSON, S.Failure == Error {
         private let collection: MongoCollection
         private var changeStream: ChangeStream?
         private var subscriber: S?
+        private var onOpen: (() -> Void)?
 
         init(collection: MongoCollection,
              subscriber: S,
              queue: DispatchQueue = .main,
              filterIds: [ObjectId]? = nil,
-             matchFilter: Document? = nil) {
+             matchFilter: Document? = nil,
+             onOpen: (() -> Void)? = nil) {
             self.collection = collection
             self.subscriber = subscriber
+            self.onOpen = onOpen
 
             if let matchFilter = matchFilter {
                 changeStream = collection.watch(matchFilter: matchFilter,
@@ -616,7 +618,9 @@ extension Publishers {
             changeStream?.close()
         }
 
-        func changeStreamDidOpen(_ changeStream: RLMChangeStream) { }
+        func changeStreamDidOpen(_ changeStream: RLMChangeStream) {
+            onOpen?()
+        }
 
         func changeStreamDidClose(with error: Error?) {
             guard let error = error else {
@@ -647,12 +651,26 @@ extension Publishers {
         private let queue: DispatchQueue
         private let filterIds: [ObjectId]?
         private let matchFilter: Document?
+        private let openEvent: (() -> Void)?
 
-        init(collection: MongoCollection, queue: DispatchQueue, filterIds: [ObjectId]? = nil, matchFilter: Document? = nil) {
+        init(collection: MongoCollection,
+             queue: DispatchQueue,
+             filterIds: [ObjectId]? = nil,
+             matchFilter: Document? = nil,
+             onOpen: (() -> Void)? = nil) {
             self.collection = collection
             self.queue = queue
             self.filterIds = filterIds
             self.matchFilter = matchFilter
+            self.openEvent = onOpen
+        }
+
+        public func onOpen(_ event: @escaping (() -> Void)) -> Self {
+            Self(collection: collection,
+                 queue: queue,
+                 filterIds: filterIds,
+                 matchFilter: matchFilter,
+                 onOpen: event)
         }
 
         /// :nodoc:
@@ -661,7 +679,8 @@ extension Publishers {
                                                  subscriber: subscriber,
                                                  queue: queue,
                                                  filterIds: filterIds,
-                                                 matchFilter: matchFilter)
+                                                 matchFilter: matchFilter,
+                                                 onOpen: openEvent)
             subscriber.receive(subscription: subscription)
         }
 
@@ -676,7 +695,8 @@ extension Publishers {
             return Self(collection: collection,
                         queue: queue,
                         filterIds: filterIds,
-                        matchFilter: matchFilter)
+                        matchFilter: matchFilter,
+                        onOpen: openEvent)
         }
     }
 }

--- a/RealmSwift/MongoClient.swift
+++ b/RealmSwift/MongoClient.swift
@@ -665,6 +665,13 @@ extension Publishers {
             self.openEvent = onOpen
         }
 
+        /// Triggers an event when the watch change stream is opened.
+        ///
+        /// Use this function when you require a change stream to be open before you perform any work.
+        /// This should be called directly after invoking the publisher.
+        ///
+        /// - Parameter event: Callback which will be invoked once the change stream is open.
+        /// - Returns: A publisher that emits a change event each time the remote MongoDB collection changes.
         public func onOpen(_ event: @escaping (() -> Void)) -> Self {
             Self(collection: collection,
                  queue: queue,


### PR DESCRIPTION
This PR adds the ability to listen for when a Watch Change Stream is opened when using Combine. Use `onOpen(event:)` directly after opening a `WatchPublisher`, this will allow a callback to be invoked once the change stream is opened.