### PR TITLE
Fix comparing unmanaged lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ x.y.z Release notes (yyyy-MM-dd)
 * When using `Realm.write(withoutNotifying:)` there was a chance that the 
   supplied observation blocks would not be skipped when in a write transaction.
   ([Object Store #1103](https://github.com/realm/realm-object-store/pull/1103))
-* Comparing two identical unmanaged `List<>` objects would fail.
+* Comparing two identical unmanaged `List<>`/`RLMArray` objects would fail.
   ([#5665](https://github.com/realm/realm-cocoa/issues/5665)).
 
 <!-- ### Breaking Changes - ONLY INCLUDE FOR NEW MAJOR version -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ x.y.z Release notes (yyyy-MM-dd)
 * When using `Realm.write(withoutNotifying:)` there was a chance that the 
   supplied observation blocks would not be skipped when in a write transaction.
   ([Object Store #1103](https://github.com/realm/realm-object-store/pull/1103))
+* Comparing two identical unmanaged `List<>` objects would fail.
+  ([#5665](https://github.com/realm/realm-cocoa/issues/5665)).
 
 <!-- ### Breaking Changes - ONLY INCLUDE FOR NEW MAJOR version -->
 

--- a/Realm/RLMArray.mm
+++ b/Realm/RLMArray.mm
@@ -514,6 +514,13 @@ static bool canAggregate(RLMPropertyType type, bool allowDate) {
     return [_backingArray objectsAtIndexes:indexes];
 }
 
+- (BOOL)isEqual:(id)object {
+    if (![object isKindOfClass:[RLMArray class]]) {
+        return NO;
+    }
+    return [_backingArray isEqual:((RLMArray *)object)->_backingArray];
+}
+
 - (void)addObserver:(NSObject *)observer forKeyPath:(NSString *)keyPath
             options:(NSKeyValueObservingOptions)options context:(void *)context {
     RLMValidateArrayObservationKey(keyPath, self);

--- a/Realm/RLMArray.mm
+++ b/Realm/RLMArray.mm
@@ -515,7 +515,7 @@ static bool canAggregate(RLMPropertyType type, bool allowDate) {
 }
 
 - (BOOL)isEqual:(id)object {
-    if (![object isKindOfClass:[RLMArray class]]) {
+    if (![object isKindOfClass:RLMArray.class]) {
         return NO;
     }
     return [_backingArray isEqual:((RLMArray *)object)->_backingArray];

--- a/Realm/RLMArray.mm
+++ b/Realm/RLMArray.mm
@@ -515,10 +515,12 @@ static bool canAggregate(RLMPropertyType type, bool allowDate) {
 }
 
 - (BOOL)isEqual:(id)object {
-    if (![object isKindOfClass:RLMArray.class]) {
-        return NO;
+    if (auto array = RLMDynamicCast<RLMArray>(object)) {
+        return !array.realm
+        && ((_backingArray.count == 0 && array->_backingArray.count == 0)
+            || [_backingArray isEqual:array->_backingArray]);
     }
-    return [_backingArray isEqual:((RLMArray *)object)->_backingArray];
+    return NO;
 }
 
 - (void)addObserver:(NSObject *)observer forKeyPath:(NSString *)keyPath

--- a/Realm/RLMListBase.mm
+++ b/Realm/RLMListBase.mm
@@ -83,7 +83,7 @@
 }
 
 - (BOOL)isEqual:(id)object {
-    if (![object isKindOfClass:[RLMListBase class]]) {
+    if (![object isKindOfClass:RLMListBase.class]) {
         return NO;
     }
     return [((RLMListBase *)object)._rlmArray isEqual:self._rlmArray];

--- a/Realm/RLMListBase.mm
+++ b/Realm/RLMListBase.mm
@@ -82,6 +82,13 @@
     [super addObserver:observer forKeyPath:keyPath options:options context:context];
 }
 
+- (BOOL)isEqual:(id)object {
+    if (![object isKindOfClass:[RLMListBase class]]) {
+        return NO;
+    }
+    return [((RLMListBase *)object)._rlmArray isEqual:self._rlmArray];
+}
+
 @end
 
 @implementation RLMLinkingObjectsHandle {
@@ -144,4 +151,5 @@
     _realm = nil;
     return _results;
 }
+
 @end

--- a/Realm/RLMListBase.mm
+++ b/Realm/RLMListBase.mm
@@ -83,10 +83,12 @@
 }
 
 - (BOOL)isEqual:(id)object {
-    if (![object isKindOfClass:RLMListBase.class]) {
-        return NO;
+    if (auto array = RLMDynamicCast<RLMListBase>(object)) {
+        return !array._rlmArray.realm
+        && ((self._rlmArray.count == 0 && array._rlmArray.count == 0) ||
+            [self._rlmArray isEqual:array._rlmArray]);
     }
-    return [((RLMListBase *)object)._rlmArray isEqual:self._rlmArray];
+    return NO;
 }
 
 @end

--- a/Realm/Tests/ArrayPropertyTests.m
+++ b/Realm/Tests/ArrayPropertyTests.m
@@ -287,6 +287,48 @@
     __unused ArrayPropertyObject *obj = [[ArrayPropertyObject alloc] initWithValue:@[@"n", @[], @[[[IntObject alloc] initWithValue:@[@1]]]]];
 }
 
+- (void)testUnmanagedComparision {
+    RLMRealm *realm = [self realmWithTestPath];
+
+    ArrayPropertyObject *array = [[ArrayPropertyObject alloc] init];
+    ArrayPropertyObject *array2 = [[ArrayPropertyObject alloc] init];
+
+    array.name = @"name";
+    array2.name = @"name2";
+    XCTAssertNotNil(array.array, @"RLMArray property should get created on access");
+    XCTAssertNotNil(array2.array, @"RLMArray property should get created on access");
+
+    XCTAssertNil(array.array.firstObject, @"No objects added yet");
+    XCTAssertNil(array2.array.lastObject, @"No objects added yet");
+
+    StringObject *obj1 = [[StringObject alloc] init];
+    obj1.stringCol = @"a";
+    StringObject *obj2 = [[StringObject alloc] init];
+    obj2.stringCol = @"b";
+    StringObject *obj3 = [[StringObject alloc] init];
+    obj3.stringCol = @"c";
+    [array.array addObject:obj1];
+    [array.array addObject:obj2];
+    [array.array addObject:obj3];
+
+    [array2.array addObject:obj1];
+    [array2.array addObject:obj2];
+    [array2.array addObject:obj3];
+
+    XCTAssertTrue([array.array isEqual:array2.array], @"Arrays should be equal");
+    [array2.array removeLastObject];
+    XCTAssertFalse([array.array isEqual:array2.array], @"Arrays should not be equal");
+    [array2.array addObject:obj3];
+    XCTAssertTrue([array.array isEqual:array2.array], @"Arrays should be equal");
+
+    [realm beginWriteTransaction];
+    [realm addObject:array];
+    [realm commitWriteTransaction];
+
+    XCTAssertFalse([array.array isEqual:array2.array], @"Comparing a managed array to an unmanaged one should fail");
+    XCTAssertFalse([array2.array isEqual:array.array], @"Comparing a managed array to an unmanaged one should fail");
+}
+
 - (void)testUnmanagedPrimitive {
     AllPrimitiveArrays *obj = [[AllPrimitiveArrays alloc] init];
     XCTAssertTrue([obj.intObj isKindOfClass:[RLMArray class]]);

--- a/Realm/Tests/ArrayPropertyTests.m
+++ b/Realm/Tests/ArrayPropertyTests.m
@@ -297,6 +297,7 @@
     array2.name = @"name2";
     XCTAssertNotNil(array.array, @"RLMArray property should get created on access");
     XCTAssertNotNil(array2.array, @"RLMArray property should get created on access");
+    XCTAssertTrue([array.array isEqual:array2.array], @"Empty arrays should be equal");
 
     XCTAssertNil(array.array.firstObject, @"No objects added yet");
     XCTAssertNil(array2.array.lastObject, @"No objects added yet");

--- a/RealmSwift/Tests/ListTests.swift
+++ b/RealmSwift/Tests/ListTests.swift
@@ -612,8 +612,8 @@ class ListTests: TestCase {
         XCTAssertEqual(list1, list2, "instances should be equal by `==` operator")
         XCTAssertNotEqual(list1, list3, "instances should be equal by `==` operator")
 
-        XCTAssertTrue(list1.isEqual(to: list2), "instances should be equal by `isEqual` method")
-        XCTAssertTrue(!list1.isEqual(to: list3), "instances should be equal by `isEqual` method")
+        XCTAssertTrue(list1.isEqual(list2), "instances should be equal by `isEqual` method")
+        XCTAssertTrue(!list1.isEqual(list3), "instances should be equal by `isEqual` method")
 
         XCTAssertEqual(Array(list1), Array(list2), "instances converted to Swift.Array should be equal")
         XCTAssertNotEqual(Array(list1), Array(list3), "instances converted to Swift.Array should be equal")

--- a/RealmSwift/Tests/ListTests.swift
+++ b/RealmSwift/Tests/ListTests.swift
@@ -607,14 +607,16 @@ class ListTests: TestCase {
 
         XCTAssertTrue(list1 !== list2, "instances should not be identical")
 
-        XCTAssertTrue(list1 == list2, "instances should be equal by `==` operator")
-        XCTAssertTrue(list1 != list3, "instances should be equal by `==` operator")
+        XCTAssertEqual(list1, list2, "instances should be equal by `==` operator")
+        XCTAssertNotEqual(list1, list3, "instances should be equal by `==` operator")
 
         XCTAssertTrue(list1.isEqual(to: list2), "instances should be equal by `isEqual` method")
         XCTAssertTrue(!list1.isEqual(to: list3), "instances should be equal by `isEqual` method")
 
-        XCTAssertTrue(Array(list1) == Array(list2), "instances converted to Swift.Array should be equal")
-        XCTAssertTrue(Array(list1) != Array(list3), "instances converted to Swift.Array should be equal")
+        XCTAssertEqual(Array(list1), Array(list2), "instances converted to Swift.Array should be equal")
+        XCTAssertNotEqual(Array(list1), Array(list3), "instances converted to Swift.Array should be equal")
+        list3.append(obj3)
+        XCTAssertEqual(list1, list3, "instances should be equal by `==` operator")
     }
 }
 

--- a/RealmSwift/Tests/ListTests.swift
+++ b/RealmSwift/Tests/ListTests.swift
@@ -598,8 +598,10 @@ class ListTests: TestCase {
         let objects2 = [obj, obj2]
 
         let list1 = List<SwiftIntObject>()
-        list1.append(objectsIn: objects)
         let list2 = List<SwiftIntObject>()
+        XCTAssertEqual(list1, list2, "Empty instances should be equal by `==` operator")
+
+        list1.append(objectsIn: objects)
         list2.append(objectsIn: objects)
 
         let list3 = List<SwiftIntObject>()

--- a/RealmSwift/Tests/ListTests.swift
+++ b/RealmSwift/Tests/ListTests.swift
@@ -585,6 +585,37 @@ class ListTests: TestCase {
             }
         }
     }
+
+    func testUnmanagedListComparison() {
+        let obj = SwiftIntObject()
+        obj.intCol = 5
+        let obj2 = SwiftIntObject()
+        obj2.intCol = 6
+        let obj3 = SwiftIntObject()
+        obj3.intCol = 8
+
+        let objects = [obj, obj2, obj3]
+        let objects2 = [obj, obj2]
+
+        let list1 = List<SwiftIntObject>()
+        list1.append(objectsIn: objects)
+        let list2 = List<SwiftIntObject>()
+        list2.append(objectsIn: objects)
+
+        let list3 = List<SwiftIntObject>()
+        list3.append(objectsIn: objects2)
+
+        XCTAssertTrue(list1 !== list2, "instances should not be identical")
+
+        XCTAssertTrue(list1 == list2, "instances should be equal by `==` operator")
+        XCTAssertTrue(list1 != list3, "instances should be equal by `==` operator")
+
+        XCTAssertTrue(list1.isEqual(to: list2), "instances should be equal by `isEqual` method")
+        XCTAssertTrue(!list1.isEqual(to: list3), "instances should be equal by `isEqual` method")
+
+        XCTAssertTrue(Array(list1) == Array(list2), "instances converted to Swift.Array should be equal")
+        XCTAssertTrue(Array(list1) != Array(list3), "instances converted to Swift.Array should be equal")
+    }
 }
 
 class ListStandaloneTests: ListTests {


### PR DESCRIPTION
When comparing two unmanaged `List<>`/`RLMArray` objects, the backing array was not used for the comparison. Therefor doing any sort of comparison on `List<>` or `RLMArray` would always give the incorrect result.

Fixes: https://github.com/realm/realm-cocoa/issues/5665
