### PR TITLE
Add numberOfActiveVersions property to RLMRealm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 x.y.z Release notes (yyyy-MM-dd)
 =============================================================
 ### Enhancements
-* Add ability to view the active number of a versions of a Realm by using `RLMRealm.numberOfActiveVersions`. The purpose of this is to
+* Add `RLMRealm.numberOfActiveVersions` which returns the number of versions of a Realm that's currently in use. The purpose of this is to
   help remedy a situation where a Realm is growing in size and the user can not figure out where in their codebase the Realm may be getting pinned.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,26 @@
+x.y.z Release notes (yyyy-MM-dd)
+=============================================================
+### Enhancements
+* Add ability to view the active number of a versions of a Realm by using `RLMRealm.numberOfActiveVersions`. The purpose of this is to
+  help remedy a situation where a Realm is growing in size and the user can not figure out where in their codebase the Realm may be getting pinned.
+
+### Fixed
+* <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-cocoa/issues/????), since v?.?.?)
+* None.
+
+<!-- ### Breaking Changes - ONLY INCLUDE FOR NEW MAJOR version -->
+
+### Compatibility
+* File format: Generates Realms with format v11 (Reads and upgrades all previous formats)
+* Realm Object Server: 3.21.0 or later.
+* Realm Studio: 5.0.0 or later.
+* APIs are backwards compatible with all previous releases in the 5.x.y series.
+* Carthage release for Swift is built with Xcode 12.
+
+### Internal
+* Upgraded realm-core from ? to ?
+* Upgraded realm-sync from ? to ?
+
 5.5.0 Release notes (2020-10-12)
 =============================================================
 

--- a/Realm/RLMRealm.h
+++ b/Realm/RLMRealm.h
@@ -817,6 +817,12 @@ NS_REFINED_FOR_SWIFT;
 
 #pragma mark - Utilities
 
+/**
+ Returns the current active number of versions of a Realm instance.
+
+ There will always be at least 2 active versions of the Realm
+ because the previous version won't be cleaned up until the next commit.
+*/
 @property (nonatomic, readonly) NSUInteger numberOfActiveVersions;
 
 #pragma mark - Unavailable Methods

--- a/Realm/RLMRealm.h
+++ b/Realm/RLMRealm.h
@@ -815,6 +815,10 @@ NS_REFINED_FOR_SWIFT;
  */
 - (struct RLMClassPrivileges)privilegesForClassNamed:(NSString *)className;
 
+#pragma mark - Utilities
+
+@property (nonatomic, readonly) NSUInteger numberOfActiveVersions;
+
 #pragma mark - Unavailable Methods
 
 /**

--- a/Realm/RLMRealm.h
+++ b/Realm/RLMRealm.h
@@ -818,7 +818,7 @@ NS_REFINED_FOR_SWIFT;
 #pragma mark - Utilities
 
 /**
- Returns the current active number of versions of a Realm instance.
+ Returns the number of active versions of this Realm.
 
  There will always be at least 2 active versions of the Realm
  because the previous version won't be cleaned up until the next commit.

--- a/Realm/RLMRealm.mm
+++ b/Realm/RLMRealm.mm
@@ -1034,6 +1034,10 @@ REALM_NOINLINE static void translateSharedGroupOpenException(NSError **error) {
     }
 }
 
+- (NSUInteger)numberOfActiveVersions {
+    return _realm->get_number_of_versions();
+}
+
 #if REALM_ENABLE_SYNC
 using Privilege = realm::ComputedPrivileges;
 static bool hasPrivilege(realm::ComputedPrivileges actual, realm::ComputedPrivileges expected) {

--- a/Realm/Tests/RealmTests.mm
+++ b/Realm/Tests/RealmTests.mm
@@ -1437,6 +1437,23 @@
     XCTAssertNotNil(error);
 }
 
+- (void)testActiveVersionCount {
+    RLMRealmConfiguration *config = RLMRealmConfiguration.defaultConfiguration;
+    config.maximumNumberOfActiveVersions = 3;
+    RLMRealm *realm = [RLMRealm realmWithConfiguration:config error:nil];
+
+    // Pin this version
+    __attribute((objc_precise_lifetime)) RLMRealm *frozen = [realm freeze];
+
+    // There will always be at least 2 active versions of the Realm
+    // because the previous version won't be cleaned up until the next commit.
+    XCTAssertEqual(realm.numberOfActiveVersions, (uint64_t)2);
+    [realm transactionWithBlock:^{ }];
+    [realm transactionWithBlock:^{ }];
+    [realm transactionWithBlock:^{ }];
+    XCTAssertEqual(realm.numberOfActiveVersions, (uint64_t)4);
+}
+
 #pragma mark - Threads
 
 - (void)testCrossThreadAccess

--- a/RealmSwift/Realm.swift
+++ b/RealmSwift/Realm.swift
@@ -891,9 +891,16 @@ public struct Realm {
         return try RLMRealm.deleteFiles(for: config.rlmConfiguration)
     }
 
-    // MARK: Utility
+    // MARK: Utilities
 
-    public var numberOfActiveVersions
+    /// Returns the current active number of versions of a Realm instance.
+    ///
+    /// - Note:
+    /// There will always be at least 2 active versions of the Realm
+    /// because the previous version won't be cleaned up until the next commit.
+    public var numberOfActiveVersions: UInt {
+        rlmRealm.numberOfActiveVersions
+    }
 
     // MARK: Internal
 

--- a/RealmSwift/Realm.swift
+++ b/RealmSwift/Realm.swift
@@ -891,6 +891,10 @@ public struct Realm {
         return try RLMRealm.deleteFiles(for: config.rlmConfiguration)
     }
 
+    // MARK: Utility
+
+    public var numberOfActiveVersions
+
     // MARK: Internal
 
     internal var rlmRealm: RLMRealm

--- a/RealmSwift/Realm.swift
+++ b/RealmSwift/Realm.swift
@@ -893,7 +893,7 @@ public struct Realm {
 
     // MARK: Utilities
 
-    /// Returns the current active number of versions of a Realm instance.
+    /// Returns the number of active versions of this Realm.
     ///
     /// - Note:
     /// There will always be at least 2 active versions of the Realm

--- a/RealmSwift/Tests/RealmTests.swift
+++ b/RealmSwift/Tests/RealmTests.swift
@@ -862,4 +862,17 @@ class RealmTests: TestCase {
         XCTAssertTrue(try! Realm.deleteFiles(for: config))
         XCTAssertFalse(Realm.fileExists(for: config))
     }
+
+    func testNumberOfActiveVersions() {
+        let realm = try! Realm()
+        // There will always be at least 2 active versions of the Realm
+        // because the previous version won't be cleaned up until the next commit.
+        XCTAssertEqual(realm.numberOfActiveVersions, 2)
+        let frozen = realm.freeze() // pin this version
+        try! realm.write { realm.add(SwiftObject()) }
+        try! realm.write { realm.add(SwiftObject()) }
+        try! realm.write { realm.add(SwiftObject()) }
+        XCTAssertEqual(frozen.numberOfActiveVersions, 4)
+        XCTAssertEqual(realm.numberOfActiveVersions, 4)
+    }
 }


### PR DESCRIPTION
This adds a `numberOfActiveVersions ` property onto `RLMRealm`. Its use is for helping users debug where a Realm instance might be getting pinned.

Addresses: https://github.com/realm/realm-cocoa/issues/6801