### PR TITLE
Set the minimum cocoapods version in the podspec

### DIFF
--- a/Realm.podspec
+++ b/Realm.podspec
@@ -3,6 +3,7 @@ Pod::Spec.new do |s|
   s.name                    = 'Realm'
   version                   = `sh build.sh get-version`
   s.version                 = version
+  s.cocoapods_version       = '>= 1.10'
   s.summary                 = 'Realm is a modern data framework & database for iOS, macOS, tvOS & watchOS.'
   s.description             = <<-DESC
                               The Realm Mobile Database, for Objective-C. (If you want to use Realm from Swift, see the “RealmSwift” pod.)


### PR DESCRIPTION
I assume this reports a better error if people try to use older versions of cocoapods.