### PR TITLE
Fix sync realm path creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,27 @@
+x.y.z Release notes (yyyy-MM-dd)
+=============================================================
+### Enhancements
+* None.
+
+### Fixed
+* The user identifier was added to the file path for synchronized Realms twice
+  and an extra level of escaping was performed on the partition value. This did
+  not cause functional problems, but made file names more confusing than they
+  needed to be. Existing Realm files will continue to be located at the old
+  path, while newly created files will be created at a shorter path. (Since v10.0.0).
+
+<!-- ### Breaking Changes - ONLY INCLUDE FOR NEW MAJOR version -->
+
+### Compatibility
+* Realm Studio: 10.0.0 or later.
+* APIs are backwards compatible with all previous releases in the 10.x.y series.
+* Carthage release for Swift is built with Xcode 12.1.
+* CocoaPods: 1.10 or later.
+
+### Internal
+* Upgraded realm-core from ? to ?
+* Upgraded realm-sync from ? to ?
+
 10.1.4 Release notes (2020-11-16)
 =============================================================
 

--- a/Realm/ObjectServerTests/RLMSyncTestCase.h
+++ b/Realm/ObjectServerTests/RLMSyncTestCase.h
@@ -89,10 +89,10 @@ NS_ASSUME_NONNULL_BEGIN
 - (RLMRealm *)openRealmWithConfiguration:(RLMRealmConfiguration *)configuration;
 
 /// Immediately open a synced Realm.
-- (RLMRealm *)immediatelyOpenRealmForPartitionValue:(NSString *)partitionValue user:(RLMUser *)user;
+- (RLMRealm *)immediatelyOpenRealmForPartitionValue:(nullable id<RLMBSON>)partitionValue user:(RLMUser *)user;
 
 /// Immediately open a synced Realm with encryption key and stop policy.
-- (RLMRealm *)immediatelyOpenRealmForPartitionValue:(NSString *)partitionValue
+- (RLMRealm *)immediatelyOpenRealmForPartitionValue:(nullable id<RLMBSON>)partitionValue
                                                user:(RLMUser *)user
                                       encryptionKey:(nullable NSData *)encryptionKey
                                          stopPolicy:(RLMSyncStopPolicy)stopPolicy;

--- a/Realm/ObjectServerTests/RLMSyncTestCase.mm
+++ b/Realm/ObjectServerTests/RLMSyncTestCase.mm
@@ -223,7 +223,7 @@ static NSURL *syncDirectoryForChildProcess() {
 
 - (void)waitForDownloadsForUser:(RLMUser *)user
                          realms:(NSArray<RLMRealm *> *)realms
-                      partitionValues:(NSArray<NSString *> *)partitionValues
+                partitionValues:(NSArray<NSString *> *)partitionValues
                  expectedCounts:(NSArray<NSNumber *> *)counts {
     NSAssert(realms.count == counts.count && realms.count == partitionValues.count,
              @"Test logic error: all array arguments must be the same size.");
@@ -241,7 +241,7 @@ static NSURL *syncDirectoryForChildProcess() {
                                  stopPolicy:RLMSyncStopPolicyAfterChangesUploaded];
 }
 
-- (RLMRealm *)openRealmForPartitionValue:(nullable NSString *)partitionValue
+- (RLMRealm *)openRealmForPartitionValue:(nullable id<RLMBSON>)partitionValue
                                     user:(RLMUser *)user
                            encryptionKey:(nullable NSData *)encryptionKey
                               stopPolicy:(RLMSyncStopPolicy)stopPolicy {

--- a/Realm/RLMRealmConfiguration+Sync.mm
+++ b/Realm/RLMRealmConfiguration+Sync.mm
@@ -55,9 +55,7 @@
     if (syncConfiguration.customFileURL) {
         self.config.path = syncConfiguration.customFileURL.path.UTF8String;
     } else {
-        RLMConvertBsonToRLMBSON(realm::bson::parse(self.config.sync_config->partition_value));
-        self.config.path = self.config.sync_config->user->sync_manager()->path_for_realm(*[user _syncUser],
-                                                                [[user pathForPartitionValue:RLMConvertBsonToRLMBSON(realm::bson::parse(self.config.sync_config->partition_value))] UTF8String]);
+        self.config.path = [user pathForPartitionValue:self.config.sync_config->partition_value];
     }
 
     if (!self.config.encryption_key.empty()) {

--- a/Realm/RLMUser_Private.hpp
+++ b/Realm/RLMUser_Private.hpp
@@ -41,7 +41,7 @@ private:
 
 @interface RLMUser ()
 - (instancetype)initWithUser:(std::shared_ptr<realm::SyncUser>)user app:(RLMApp *)app;
-- (NSString *)pathForPartitionValue:(id<RLMBSON>)partitionValue;
+- (std::string)pathForPartitionValue:(std::string const&)partitionValue;
 - (std::shared_ptr<realm::SyncUser>)_syncUser;
 + (void)_setUpBindingContextFactory;
 @property (weak, readonly) RLMApp *app;


### PR DESCRIPTION
SyncManager::path_for_realm() takes care of adding the user's identity to the path, so the calling code shouldn't do it too. There were also a lot of redundant conversions between various BSON representations.

For compatibility with existing installs we unfortunately need to keep the old logic around.