### PR TITLE
Not allow set 'deleteRealmIfMigrationNeeded' when sync is enabled.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ x.y.z Release notes (yyyy-MM-dd)
 * None.
 
 ### Fixed
-* Not allow set 'deleteRealmIfMigrationNeeded' when sync is enabled.
+* Disallow `RLMRealmConfiguration.deleteRealmIfMigrationNeeded`/`Realm.Config.deleteRealmIfMigrationNeeded` when sync is enabled.
 
 <!-- ### Breaking Changes - ONLY INCLUDE FOR NEW MAJOR version -->
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,23 @@
+x.y.z Release notes (yyyy-MM-dd)
+=============================================================
+### Enhancements
+* None.
+
+### Fixed
+* Not allow set 'deleteRealmIfMigrationNeeded' when sync is enabled.
+
+<!-- ### Breaking Changes - ONLY INCLUDE FOR NEW MAJOR version -->
+
+### Compatibility
+* Realm Studio: 10.0.0 or later.
+* APIs are backwards compatible with all previous releases in the 10.x.y series.
+* Carthage release for Swift is built with Xcode 12.1.
+* CocoaPods: 1.10 or later.
+
+### Internal
+* Upgraded realm-core from ? to ?
+* Upgraded realm-sync from ? to ?
+
 10.1.2 Release notes (2020-11-06)
 =============================================================
 

--- a/Realm/ObjectServerTests/RLMObjectServerTests.mm
+++ b/Realm/ObjectServerTests/RLMObjectServerTests.mm
@@ -2580,4 +2580,12 @@ static const NSInteger NUMBER_OF_BIG_OBJECTS = 2;
     [self waitForExpectations:@[expectation] timeout:60.0];
 }
 
+- (void)testSyncConfigShouldNotMigrate {
+    RLMUser *user = [self userForTest:_cmd];
+    NSString *realmId = self.appId;
+    RLMRealm *realm = [self openRealmForPartitionValue:realmId user:user];
+
+    XCTAssertThrows([realm.configuration setDeleteRealmIfMigrationNeeded:YES], @"Not allow 'deleteRealmIfMigrationNeeded' when sync is enabled.");
+}
+
 @end

--- a/Realm/ObjectServerTests/RLMObjectServerTests.mm
+++ b/Realm/ObjectServerTests/RLMObjectServerTests.mm
@@ -2586,6 +2586,9 @@ static const NSInteger NUMBER_OF_BIG_OBJECTS = 2;
     RLMRealm *realm = [self openRealmForPartitionValue:realmId user:user];
 
     XCTAssertThrows([realm.configuration setDeleteRealmIfMigrationNeeded:YES], @"Not allow 'deleteRealmIfMigrationNeeded' when sync is enabled.");
+    
+    RLMRealmConfiguration *localRealmConfiguration = [RLMRealmConfiguration defaultConfiguration];
+    XCTAssertNoThrow([localRealmConfiguration setDeleteRealmIfMigrationNeeded:YES]);
 }
 
 @end

--- a/Realm/ObjectServerTests/SwiftObjectServerTests.swift
+++ b/Realm/ObjectServerTests/SwiftObjectServerTests.swift
@@ -3312,7 +3312,7 @@ class CombineObjectServerTests: SwiftSyncTestCase {
         wait(for: [dergisterDeviceExpectation], timeout: 4.0)
     }
 
-    func testShouldNotDeleteOnMigrationWithSync_2() {
+    func testShouldNotDeleteOnMigrationWithSync() {
         let user = try! synchronouslyLogInUser(for: basicCredentials())
         var configuration = user.configuration(partitionValue: appId)
 

--- a/Realm/ObjectServerTests/SwiftObjectServerTests.swift
+++ b/Realm/ObjectServerTests/SwiftObjectServerTests.swift
@@ -248,7 +248,7 @@ class SwiftObjectServerTests: SwiftSyncTestCase {
 
             var theError: SyncError?
             let ex = expectation(description: "Waiting for error handler to be called...")
-            app.syncManager.errorHandler = { (error, session) in
+            app.syncManager.errorHandler = { (error, _) in
                 if let error = error as? SyncError {
                     theError = error
                 } else {
@@ -280,7 +280,7 @@ class SwiftObjectServerTests: SwiftSyncTestCase {
             try autoreleasepool {
                 let realm = try synchronouslyOpenRealm(partitionValue: self.appId, user: user)
                 let ex = expectation(description: "Waiting for error handler to be called...")
-                app.syncManager.errorHandler = { (error, session) in
+                app.syncManager.errorHandler = { (error, _) in
                     if let error = error as? SyncError {
                         theError = error
                     } else {

--- a/Realm/ObjectServerTests/SwiftObjectServerTests.swift
+++ b/Realm/ObjectServerTests/SwiftObjectServerTests.swift
@@ -3311,4 +3311,17 @@ class CombineObjectServerTests: SwiftSyncTestCase {
             .store(in: &cancellable)
         wait(for: [dergisterDeviceExpectation], timeout: 4.0)
     }
+
+    func testShouldNotDeleteOnMigrationWithSync_2() {
+        let user = try! synchronouslyLogInUser(for: basicCredentials())
+        var configuration = user.configuration(partitionValue: appId)
+
+        assertThrows(configuration.deleteRealmIfMigrationNeeded = true,
+                     reason: "Cannot set 'deleteRealmIfMigrationNeeded' when sync is enabled ('syncConfig' is set).")
+        
+        var localConfiguration = Realm.Configuration.defaultConfiguration
+        assertSucceeds {
+            localConfiguration.deleteRealmIfMigrationNeeded = true
+        }
+    }
 }

--- a/Realm/ObjectServerTests/SwiftObjectServerTests.swift
+++ b/Realm/ObjectServerTests/SwiftObjectServerTests.swift
@@ -3318,7 +3318,7 @@ class CombineObjectServerTests: SwiftSyncTestCase {
 
         assertThrows(configuration.deleteRealmIfMigrationNeeded = true,
                      reason: "Cannot set 'deleteRealmIfMigrationNeeded' when sync is enabled ('syncConfig' is set).")
-        
+
         var localConfiguration = Realm.Configuration.defaultConfiguration
         assertSucceeds {
             localConfiguration.deleteRealmIfMigrationNeeded = true

--- a/Realm/ObjectServerTests/SwiftSyncTestCase.swift
+++ b/Realm/ObjectServerTests/SwiftSyncTestCase.swift
@@ -130,7 +130,7 @@ class SwiftSyncTestCase: RLMSyncTestCase {
                   file: file,
                   line: line)
     }
-    
+
     var exceptionThrown = false
 
     func assertThrows<T>(_ block: @autoclosure () -> T, named: String? = RLMExceptionName,

--- a/Realm/ObjectServerTests/SwiftSyncTestCase.swift
+++ b/Realm/ObjectServerTests/SwiftSyncTestCase.swift
@@ -130,4 +130,34 @@ class SwiftSyncTestCase: RLMSyncTestCase {
                   file: file,
                   line: line)
     }
+    
+    var exceptionThrown = false
+
+    func assertThrows<T>(_ block: @autoclosure () -> T, named: String? = RLMExceptionName,
+                         _ message: String? = nil, fileName: String = #file, lineNumber: UInt = #line) {
+        exceptionThrown = true
+        RLMAssertThrowsWithName(self, { _ = block() }, named, message, fileName, lineNumber)
+    }
+
+    func assertThrows<T>(_ block: @autoclosure () -> T, reason: String,
+                         _ message: String? = nil, fileName: String = #file, lineNumber: UInt = #line) {
+        exceptionThrown = true
+        RLMAssertThrowsWithReason(self, { _ = block() }, reason, message, fileName, lineNumber)
+    }
+
+    func assertThrows<T>(_ block: @autoclosure () -> T, reasonMatching regexString: String,
+                         _ message: String? = nil, fileName: String = #file, lineNumber: UInt = #line) {
+        exceptionThrown = true
+        RLMAssertThrowsWithReasonMatching(self, { _ = block() }, regexString, message, fileName, lineNumber)
+    }
+
+    func assertSucceeds(message: String? = nil, fileName: StaticString = #file,
+                        lineNumber: UInt = #line, block: () throws -> Void) {
+        do {
+            try block()
+        } catch {
+            XCTFail("Expected no error, but instead caught <\(error)>.",
+                file: (fileName), line: lineNumber)
+        }
+    }
 }

--- a/Realm/RLMRealmConfiguration.mm
+++ b/Realm/RLMRealmConfiguration.mm
@@ -233,6 +233,8 @@ static bool isSync(realm::Realm::Config const& config) {
     if (deleteRealmIfMigrationNeeded) {
         if (self.readOnly) {
             @throw RLMException(@"Cannot set `deleteRealmIfMigrationNeeded` when `readOnly` is set.");
+        } else if (isSync(_config) && !_config.sync_config->partition_value.empty()) {
+            @throw RLMException(@"Cannot set 'deleteRealmIfMigrationNeeded' when sync is enabled ('sync.partitionValue' is set).");
         }
         _config.schema_mode = realm::SchemaMode::ResetFile;
     }

--- a/Realm/RLMRealmConfiguration.mm
+++ b/Realm/RLMRealmConfiguration.mm
@@ -233,9 +233,12 @@ static bool isSync(realm::Realm::Config const& config) {
     if (deleteRealmIfMigrationNeeded) {
         if (self.readOnly) {
             @throw RLMException(@"Cannot set `deleteRealmIfMigrationNeeded` when `readOnly` is set.");
-        } else if (isSync(_config) && !_config.sync_config->partition_value.empty()) {
-            @throw RLMException(@"Cannot set 'deleteRealmIfMigrationNeeded' when sync is enabled ('sync.partitionValue' is set).");
         }
+#if REALM_ENABLE_SYNC
+        if (isSync(_config)) {
+            @throw RLMException(@"Cannot set 'deleteRealmIfMigrationNeeded' when sync is enabled ('syncConfig' is set).");
+        }
+#endif
         _config.schema_mode = realm::SchemaMode::ResetFile;
     }
     else if (self.deleteRealmIfMigrationNeeded) {

--- a/Realm/RLMRealmConfiguration.mm
+++ b/Realm/RLMRealmConfiguration.mm
@@ -234,11 +234,9 @@ static bool isSync(realm::Realm::Config const& config) {
         if (self.readOnly) {
             @throw RLMException(@"Cannot set `deleteRealmIfMigrationNeeded` when `readOnly` is set.");
         }
-#if REALM_ENABLE_SYNC
         if (isSync(_config)) {
             @throw RLMException(@"Cannot set 'deleteRealmIfMigrationNeeded' when sync is enabled ('syncConfig' is set).");
         }
-#endif
         _config.schema_mode = realm::SchemaMode::ResetFile;
     }
     else if (self.deleteRealmIfMigrationNeeded) {

--- a/RealmSwift/RealmConfiguration.swift
+++ b/RealmSwift/RealmConfiguration.swift
@@ -184,7 +184,19 @@ extension Realm {
 
          - note: Setting this property to `true` doesn't disable file format migrations.
          */
-        public var deleteRealmIfMigrationNeeded: Bool = false
+        public var deleteRealmIfMigrationNeeded: Bool {
+            set(newValue) {
+                if newValue && syncConfiguration != nil {
+                    throwRealmException("Cannot set 'deleteRealmIfMigrationNeeded' when sync is enabled ('syncConfig' is set).")
+                }
+                _deleteRealmIfMigrationNeeded = newValue
+            }
+            get {
+                return _deleteRealmIfMigrationNeeded
+            }
+        }
+
+        private var _deleteRealmIfMigrationNeeded: Bool = false
 
         /**
          A block called when opening a Realm for the first time during the

--- a/RealmSwift/RealmConfiguration.swift
+++ b/RealmSwift/RealmConfiguration.swift
@@ -185,14 +185,14 @@ extension Realm {
          - note: Setting this property to `true` doesn't disable file format migrations.
          */
         public var deleteRealmIfMigrationNeeded: Bool {
+            get {
+                return _deleteRealmIfMigrationNeeded
+            }
             set(newValue) {
                 if newValue && syncConfiguration != nil {
                     throwRealmException("Cannot set 'deleteRealmIfMigrationNeeded' when sync is enabled ('syncConfig' is set).")
                 }
                 _deleteRealmIfMigrationNeeded = newValue
-            }
-            get {
-                return _deleteRealmIfMigrationNeeded
             }
         }
 


### PR DESCRIPTION
Ending session with error: failed to validate upload changesets: clients cannot upload destructive schema changes, received "EraseColumn" instruction (ProtocolErrorCode=212)

This is a bug, the client should not be emitting this instruction, There was a bug in Object Store semi-recently that caused it to be emitted if the SDK passed configuration to the Object Store in a particular way (realm-js had this problem), The problematic config option that cause this in realm-js was deleteRealmIfMigrationNeeded
