### PR TITLE
Implement the missing sync tests and make the existing ones work better

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -22,6 +22,7 @@ identifier_name:
     - id
     - pk
     - to
+    - _id
 disabled_rules:
   - block_based_kvo
   # SwiftLint considers 'Realm' and 'Realm.Private' to be duplicate imports

--- a/Realm.xcodeproj/project.pbxproj
+++ b/Realm.xcodeproj/project.pbxproj
@@ -131,6 +131,12 @@
 		3F2E66651CA0BA12004761D5 /* NotificationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 3F2E66611CA0B9D5004761D5 /* NotificationTests.m */; };
 		3F336E8A1DA2FA14006CB5A0 /* RLMSyncConfiguration_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 1A36236A1D83868F00945A54 /* RLMSyncConfiguration_Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		3F336E8B1DA2FA15006CB5A0 /* RLMSyncConfiguration_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 1A36236A1D83868F00945A54 /* RLMSyncConfiguration_Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		3F34B5BA255DCA1100303EA7 /* mongo_client.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3F34B5B4255DCA1100303EA7 /* mongo_client.cpp */; };
+		3F34B5BB255DCA1100303EA7 /* mongo_client.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3F34B5B4255DCA1100303EA7 /* mongo_client.cpp */; };
+		3F34B5BC255DCA1100303EA7 /* mongo_collection.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3F34B5B5255DCA1100303EA7 /* mongo_collection.cpp */; };
+		3F34B5BD255DCA1100303EA7 /* mongo_collection.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3F34B5B5255DCA1100303EA7 /* mongo_collection.cpp */; };
+		3F34B5C2255DCA1100303EA7 /* mongo_database.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3F34B5B8255DCA1100303EA7 /* mongo_database.cpp */; };
+		3F34B5C3255DCA1100303EA7 /* mongo_database.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3F34B5B8255DCA1100303EA7 /* mongo_database.cpp */; };
 		3F3BBAF324B8FD32009D8D51 /* RLMSyncUtil.h in Headers */ = {isa = PBXBuildFile; fileRef = 1A4FFC971D35A71000B4B65C /* RLMSyncUtil.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		3F4657371F27F2EF00456B07 /* RLMTestCaseUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 297FBEFA1C19F696009D1118 /* RLMTestCaseUtils.swift */; };
 		3F4F3AD523F71C790048DB43 /* RLMDecimal128.mm in Sources */ = {isa = PBXBuildFile; fileRef = 3F4F3ACF23F71C790048DB43 /* RLMDecimal128.mm */; };
@@ -262,9 +268,6 @@
 		492F5CB2244F48D800ACEBC0 /* regular_expression.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 49AD39F0244E1A370097500E /* regular_expression.cpp */; };
 		492F5CB3244F48D800ACEBC0 /* bson.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 49AD39F2244E1A370097500E /* bson.cpp */; };
 		494566A9246E8C59000FD07F /* ObjectiveCSupport+BSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = 494566A8246E8C59000FD07F /* ObjectiveCSupport+BSON.swift */; };
-		498C7F4124479905009DE80A /* remote_mongo_database.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 498C7F3A24479905009DE80A /* remote_mongo_database.cpp */; };
-		498C7F4224479905009DE80A /* remote_mongo_collection.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 498C7F3B24479905009DE80A /* remote_mongo_collection.cpp */; };
-		498C7F4424479905009DE80A /* remote_mongo_client.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 498C7F3D24479905009DE80A /* remote_mongo_client.cpp */; };
 		499321FC24129CFD00A0EC8E /* app_credentials.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 499321FA24129CFD00A0EC8E /* app_credentials.cpp */; };
 		499321FD24129CFD00A0EC8E /* app_credentials.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 499321FA24129CFD00A0EC8E /* app_credentials.cpp */; };
 		499321FE24129CFD00A0EC8E /* app.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 499321FB24129CFD00A0EC8E /* app.cpp */; };
@@ -483,9 +486,6 @@
 		C2CAAE771E9BB5760025454C /* system_configuration.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C2CAAE751E9BB5760025454C /* system_configuration.cpp */; };
 		C2CAAE781E9BB5760025454C /* system_configuration.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C2CAAE751E9BB5760025454C /* system_configuration.cpp */; };
 		CF330BBE24E57D5F00F07EE2 /* RLMWatchTestUtility.m in Sources */ = {isa = PBXBuildFile; fileRef = CF330BBD24E57D5F00F07EE2 /* RLMWatchTestUtility.m */; };
-		CF56B09B24894E7F0001251D /* remote_mongo_client.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 498C7F3D24479905009DE80A /* remote_mongo_client.cpp */; };
-		CF56B09C24894E7F0001251D /* remote_mongo_collection.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 498C7F3B24479905009DE80A /* remote_mongo_collection.cpp */; };
-		CF56B09D24894E7F0001251D /* remote_mongo_database.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 498C7F3A24479905009DE80A /* remote_mongo_database.cpp */; };
 		CF6E0482242A141200DB7F14 /* RLMEmailPasswordAuth.h in Headers */ = {isa = PBXBuildFile; fileRef = CF6E0480242A141200DB7F14 /* RLMEmailPasswordAuth.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		CF6E0483242A141200DB7F14 /* RLMEmailPasswordAuth.mm in Sources */ = {isa = PBXBuildFile; fileRef = CF6E0481242A141200DB7F14 /* RLMEmailPasswordAuth.mm */; };
 		CF6E0486242A321200DB7F14 /* RLMProviderClient.h in Headers */ = {isa = PBXBuildFile; fileRef = CF6E0484242A321200DB7F14 /* RLMProviderClient.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -842,6 +842,12 @@
 		3F2633C21E9D630000B32D30 /* PrimitiveListTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PrimitiveListTests.swift; sourceTree = "<group>"; };
 		3F275EBD2433A5DA00161E7F /* RLMApp_Private.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = RLMApp_Private.hpp; sourceTree = "<group>"; };
 		3F2E66611CA0B9D5004761D5 /* NotificationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NotificationTests.m; sourceTree = "<group>"; };
+		3F34B5B4255DCA1100303EA7 /* mongo_client.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = mongo_client.cpp; path = sync/mongo_client.cpp; sourceTree = "<group>"; };
+		3F34B5B5255DCA1100303EA7 /* mongo_collection.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = mongo_collection.cpp; path = sync/mongo_collection.cpp; sourceTree = "<group>"; };
+		3F34B5B6255DCA1100303EA7 /* mongo_collection.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = mongo_collection.hpp; path = sync/mongo_collection.hpp; sourceTree = "<group>"; };
+		3F34B5B7255DCA1100303EA7 /* mongo_database.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = mongo_database.hpp; path = sync/mongo_database.hpp; sourceTree = "<group>"; };
+		3F34B5B8255DCA1100303EA7 /* mongo_database.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = mongo_database.cpp; path = sync/mongo_database.cpp; sourceTree = "<group>"; };
+		3F34B5B9255DCA1100303EA7 /* mongo_client.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = mongo_client.hpp; path = sync/mongo_client.hpp; sourceTree = "<group>"; };
 		3F35027722C43C5200FDC1E5 /* TestHost-static.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "TestHost-static.xcconfig"; sourceTree = "<group>"; };
 		3F452EC519C2279800AFC154 /* RLMSwiftSupport.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RLMSwiftSupport.m; path = Realm/RLMSwiftSupport.m; sourceTree = SOURCE_ROOT; };
 		3F4E324B1B98C6C700183A69 /* RLMSchema_Private.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = RLMSchema_Private.hpp; sourceTree = "<group>"; };
@@ -940,12 +946,6 @@
 		3FEB383C1E70AC6900F22712 /* ObjectCreationTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ObjectCreationTests.mm; sourceTree = "<group>"; };
 		3FEC4A3D1BBB188B00F009C3 /* SwiftSchemaTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwiftSchemaTests.swift; sourceTree = "<group>"; };
 		494566A8246E8C59000FD07F /* ObjectiveCSupport+BSON.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ObjectiveCSupport+BSON.swift"; sourceTree = "<group>"; };
-		498C7F3724479904009DE80A /* remote_mongo_database.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = remote_mongo_database.hpp; path = sync/remote_mongo_database.hpp; sourceTree = "<group>"; };
-		498C7F3824479904009DE80A /* remote_mongo_client.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = remote_mongo_client.hpp; path = sync/remote_mongo_client.hpp; sourceTree = "<group>"; };
-		498C7F3924479904009DE80A /* remote_mongo_collection.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = remote_mongo_collection.hpp; path = sync/remote_mongo_collection.hpp; sourceTree = "<group>"; };
-		498C7F3A24479905009DE80A /* remote_mongo_database.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = remote_mongo_database.cpp; path = sync/remote_mongo_database.cpp; sourceTree = "<group>"; };
-		498C7F3B24479905009DE80A /* remote_mongo_collection.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = remote_mongo_collection.cpp; path = sync/remote_mongo_collection.cpp; sourceTree = "<group>"; };
-		498C7F3D24479905009DE80A /* remote_mongo_client.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = remote_mongo_client.cpp; path = sync/remote_mongo_client.cpp; sourceTree = "<group>"; };
 		498C7F452447990C009DE80A /* app_service_client.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = app_service_client.hpp; path = sync/app_service_client.hpp; sourceTree = "<group>"; };
 		499321FA24129CFD00A0EC8E /* app_credentials.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = app_credentials.cpp; path = sync/app_credentials.cpp; sourceTree = "<group>"; };
 		499321FB24129CFD00A0EC8E /* app.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = app.cpp; path = sync/app.cpp; sourceTree = "<group>"; };
@@ -1320,14 +1320,14 @@
 				49B1965B2448586000B5B852 /* auth_request_client.hpp */,
 				4993221A2412A07F00A0EC8E /* generic_network_transport.cpp */,
 				4993221B2412A07F00A0EC8E /* generic_network_transport.hpp */,
+				3F34B5B4255DCA1100303EA7 /* mongo_client.cpp */,
+				3F34B5B9255DCA1100303EA7 /* mongo_client.hpp */,
+				3F34B5B5255DCA1100303EA7 /* mongo_collection.cpp */,
+				3F34B5B6255DCA1100303EA7 /* mongo_collection.hpp */,
+				3F34B5B8255DCA1100303EA7 /* mongo_database.cpp */,
+				3F34B5B7255DCA1100303EA7 /* mongo_database.hpp */,
 				6879E7C62486B1C200A65EF4 /* push_client.cpp */,
 				6879E7C52486B1AC00A65EF4 /* push_client.hpp */,
-				498C7F3D24479905009DE80A /* remote_mongo_client.cpp */,
-				498C7F3824479904009DE80A /* remote_mongo_client.hpp */,
-				498C7F3B24479905009DE80A /* remote_mongo_collection.cpp */,
-				498C7F3924479904009DE80A /* remote_mongo_collection.hpp */,
-				498C7F3A24479905009DE80A /* remote_mongo_database.cpp */,
-				498C7F3724479904009DE80A /* remote_mongo_database.hpp */,
 				1A15364A1DB045B500C0EC93 /* sync_config.hpp */,
 				1A15364D1DB045B500C0EC93 /* sync_manager.cpp */,
 				1A15364E1DB045B500C0EC93 /* sync_manager.hpp */,
@@ -1609,11 +1609,13 @@
 				3FCB1A7422A9B0A2003807FB /* CodableTests.swift */,
 				3FE2BE0223D8CAD1002860E9 /* CombineTests.swift */,
 				E8AE7C251EA436F800CDFF9A /* CompactionTests.swift */,
+				CFFECBA8250646750010F585 /* Decimal128Tests.swift */,
 				5D660FFF1BE98D880021E04F /* KVOTests.swift */,
 				5D6610001BE98D880021E04F /* ListTests.swift */,
 				5D6610011BE98D880021E04F /* MigrationTests.swift */,
 				5D6610021BE98D880021E04F /* ObjectAccessorTests.swift */,
 				5D6610031BE98D880021E04F /* ObjectCreationTests.swift */,
+				CFFECBB225078D100010F585 /* ObjectIdTests.swift */,
 				5BC537151DD5B8D70055C524 /* ObjectiveCSupportTests.swift */,
 				5D6610041BE98D880021E04F /* ObjectSchemaInitializationTests.swift */,
 				5D6610051BE98D880021E04F /* ObjectSchemaTests.swift */,
@@ -1631,8 +1633,6 @@
 				5D6610111BE98D880021E04F /* SwiftUnicodeTests.swift */,
 				5D6610121BE98D880021E04F /* TestCase.swift */,
 				3F73BC841E3A870F00FE80B6 /* ThreadSafeReferenceTests.swift */,
-				CFFECBA8250646750010F585 /* Decimal128Tests.swift */,
-				CFFECBB225078D100010F585 /* ObjectIdTests.swift */,
 			);
 			name = "RealmSwift Tests";
 			path = RealmSwift/Tests;
@@ -1743,6 +1743,7 @@
 				E81A1FB81955FE0100FDED82 /* ArrayPropertyTests.m */,
 				3F7556731BE95A050058BC7E /* AsyncTests.mm */,
 				E8DA16F71E81210D0055141C /* CompactionTests.m */,
+				CFFECBAB250667A90010F585 /* Decimal128Tests.m */,
 				E81A1FBA1955FE0100FDED82 /* DynamicTests.m */,
 				021A882F1AAFB5BE00EEAC84 /* EncryptionTests.mm */,
 				E81A1FBB1955FE0100FDED82 /* EnumeratorTests.m */,
@@ -1753,6 +1754,7 @@
 				0207AB85195DFA15007EFB12 /* MigrationTests.mm */,
 				3F2E66611CA0B9D5004761D5 /* NotificationTests.m */,
 				3FEB383C1E70AC6900F22712 /* ObjectCreationTests.mm */,
+				CFFECBAF250690EA0010F585 /* ObjectIdTests.m */,
 				E81A1FBE1955FE0100FDED82 /* ObjectInterfaceTests.m */,
 				021A88301AAFB5BE00EEAC84 /* ObjectSchemaTests.m */,
 				E81A1FBF1955FE0100FDED82 /* ObjectTests.m */,
@@ -1769,8 +1771,6 @@
 				E81A1FD11955FE0100FDED82 /* TransactionTests.m */,
 				E8917597197A1B350068ACC6 /* UnicodeTests.m */,
 				021A88311AAFB5BE00EEAC84 /* UtilTests.mm */,
-				CFFECBAB250667A90010F585 /* Decimal128Tests.m */,
-				CFFECBAF250690EA0010F585 /* ObjectIdTests.m */,
 			);
 			name = "Objective-C";
 			sourceTree = "<group>";
@@ -2752,6 +2752,9 @@
 				1A64CA8B1D8763B400BC0F9B /* keychain_helper.cpp in Sources */,
 				3F9026111C625C5D006AE98E /* list.cpp in Sources */,
 				3F9801A51C8E4F55000A8B07 /* list_notifier.cpp in Sources */,
+				3F34B5BA255DCA1100303EA7 /* mongo_client.cpp in Sources */,
+				3F34B5BC255DCA1100303EA7 /* mongo_collection.cpp in Sources */,
+				3F34B5C2255DCA1100303EA7 /* mongo_database.cpp in Sources */,
 				C281E9301E8BC7AC0015BA4A /* network_reachability_observer.cpp in Sources */,
 				3F73BC961E3A878500FE80B6 /* NSError+RLMSync.m in Sources */,
 				3FAB08481E1EC382001BC8DA /* object.cpp in Sources */,
@@ -2762,9 +2765,6 @@
 				6879E7C72486B1C200A65EF4 /* push_client.cpp in Sources */,
 				3F0543EC1C56F71500AA5322 /* realm_coordinator.cpp in Sources */,
 				534402CE247FCBE100866F32 /* regular_expression.cpp in Sources */,
-				498C7F4424479905009DE80A /* remote_mongo_client.cpp in Sources */,
-				498C7F4224479905009DE80A /* remote_mongo_collection.cpp in Sources */,
-				498C7F4124479905009DE80A /* remote_mongo_database.cpp in Sources */,
 				3F75566B1BE94CCC0058BC7E /* results.cpp in Sources */,
 				3F9801B01C90FD2D000A8B07 /* results_notifier.cpp in Sources */,
 				5D659E851BE04556006515A0 /* RLMAccessor.mm in Sources */,
@@ -2877,19 +2877,19 @@
 				3FCB1A7522A9B0A2003807FB /* CodableTests.swift in Sources */,
 				3FE2BE0323D8CAD1002860E9 /* CombineTests.swift in Sources */,
 				E8AE7C261EA436F800CDFF9A /* CompactionTests.swift in Sources */,
+				CFFECBAA250646820010F585 /* Decimal128Tests.swift in Sources */,
 				3FF3FFAF1F0D6D6400B84599 /* KVOTests.swift in Sources */,
 				5D6610161BE98D880021E04F /* ListTests.swift in Sources */,
-				CFFECBB525078EC40010F585 /* ObjectIdTests.swift in Sources */,
 				3F8824FD1E5E335000586B35 /* MigrationTests.swift in Sources */,
 				3F8824FE1E5E335000586B35 /* ObjectAccessorTests.swift in Sources */,
 				3F8824FF1E5E335000586B35 /* ObjectCreationTests.swift in Sources */,
+				CFFECBB525078EC40010F585 /* ObjectIdTests.swift in Sources */,
 				3F8825001E5E335000586B35 /* ObjectiveCSupportTests.swift in Sources */,
 				3F8825011E5E335000586B35 /* ObjectSchemaInitializationTests.swift in Sources */,
 				3F8825021E5E335000586B35 /* ObjectSchemaTests.swift in Sources */,
 				3F8825031E5E335000586B35 /* ObjectTests.swift in Sources */,
 				3F8825041E5E335000586B35 /* PerformanceTests.swift in Sources */,
 				3F2633C31E9D630000B32D30 /* PrimitiveListTests.swift in Sources */,
-				CFFECBAA250646820010F585 /* Decimal128Tests.swift in Sources */,
 				3F8825051E5E335000586B35 /* PropertyTests.swift in Sources */,
 				3F8825061E5E335000586B35 /* RealmCollectionTypeTests.swift in Sources */,
 				3F8825071E5E335000586B35 /* RealmConfigurationTests.swift in Sources */,
@@ -2928,6 +2928,9 @@
 				E8FD2E381D93345100569F10 /* keychain_helper.cpp in Sources */,
 				3F9026131C625C63006AE98E /* list.cpp in Sources */,
 				3F9801A71C8E4F5A000A8B07 /* list_notifier.cpp in Sources */,
+				3F34B5BB255DCA1100303EA7 /* mongo_client.cpp in Sources */,
+				3F34B5BD255DCA1100303EA7 /* mongo_collection.cpp in Sources */,
+				3F34B5C3255DCA1100303EA7 /* mongo_database.cpp in Sources */,
 				C281E9291E8A9CC90015BA4A /* network_reachability_observer.cpp in Sources */,
 				3F73BC981E3A879E00FE80B6 /* NSError+RLMSync.m in Sources */,
 				3FAB08491E1EC385001BC8DA /* object.cpp in Sources */,
@@ -2938,9 +2941,6 @@
 				6879E7C82486B1C200A65EF4 /* push_client.cpp in Sources */,
 				3F0543ED1C56F71900AA5322 /* realm_coordinator.cpp in Sources */,
 				492F5CB2244F48D800ACEBC0 /* regular_expression.cpp in Sources */,
-				CF56B09B24894E7F0001251D /* remote_mongo_client.cpp in Sources */,
-				CF56B09C24894E7F0001251D /* remote_mongo_collection.cpp in Sources */,
-				CF56B09D24894E7F0001251D /* remote_mongo_database.cpp in Sources */,
 				3F75566D1BE94CEA0058BC7E /* results.cpp in Sources */,
 				3F9801B11C90FD31000A8B07 /* results_notifier.cpp in Sources */,
 				5DD755831BE056DE002800DA /* RLMAccessor.mm in Sources */,
@@ -3039,6 +3039,7 @@
 				E856D214195615A900FB2FCF /* ArrayPropertyTests.m in Sources */,
 				3F7556761BE95A0D0058BC7E /* AsyncTests.mm in Sources */,
 				E8DA16F91E81210D0055141C /* CompactionTests.m in Sources */,
+				CFFECBAE250667B20010F585 /* Decimal128Tests.m in Sources */,
 				E856D216195615A900FB2FCF /* DynamicTests.m in Sources */,
 				021A88331AAFB5C900EEAC84 /* EncryptionTests.mm in Sources */,
 				E856D217195615A900FB2FCF /* EnumeratorTests.m in Sources */,
@@ -3048,6 +3049,7 @@
 				0207AB88195DFA15007EFB12 /* MigrationTests.mm in Sources */,
 				3F2E66651CA0BA12004761D5 /* NotificationTests.m in Sources */,
 				3FEB38401E70AC8800F22712 /* ObjectCreationTests.mm in Sources */,
+				CFFECBB1250690EA0010F585 /* ObjectIdTests.m in Sources */,
 				E856D21A195615A900FB2FCF /* ObjectInterfaceTests.m in Sources */,
 				021A88371AAFB5CE00EEAC84 /* ObjectSchemaTests.m in Sources */,
 				E856D21B195615A900FB2FCF /* ObjectTests.m in Sources */,
@@ -3057,7 +3059,6 @@
 				02AFB4641A80343600E11938 /* PropertyTests.m in Sources */,
 				E856D21D195615A900FB2FCF /* QueryTests.m in Sources */,
 				C042A48E1B7522A900771ED2 /* RealmConfigurationTests.mm in Sources */,
-				CFFECBAE250667B20010F585 /* Decimal128Tests.m in Sources */,
 				E856D21E195615A900FB2FCF /* RealmTests.mm in Sources */,
 				02AFB4681A80343600E11938 /* ResultsTests.m in Sources */,
 				3FE5819622C2CCA700BA10E7 /* RLMMultiProcessTestCase.m in Sources */,
@@ -3072,7 +3073,6 @@
 				3F8DCA7919930FCB0008BD7F /* SwiftLinkTests.swift in Sources */,
 				3F8DCA7B19930FCB0008BD7F /* SwiftObjectInterfaceTests.swift in Sources */,
 				3F8DCA7C19930FCB0008BD7F /* SwiftPropertyTypeTest.swift in Sources */,
-				CFFECBB1250690EA0010F585 /* ObjectIdTests.m in Sources */,
 				3F8DCA7D19930FCB0008BD7F /* SwiftRealmTests.swift in Sources */,
 				3F8DCA7519930FCB0008BD7F /* SwiftTestObjects.swift in Sources */,
 				3F8DCA7E19930FCB0008BD7F /* SwiftUnicodeTests.swift in Sources */,
@@ -3090,8 +3090,8 @@
 			files = (
 				E81A1FD51955FE0100FDED82 /* ArrayPropertyTests.m in Sources */,
 				3F7556751BE95A0C0058BC7E /* AsyncTests.mm in Sources */,
-				CFFECBAD250667B20010F585 /* Decimal128Tests.m in Sources */,
 				E8DA16F81E81210D0055141C /* CompactionTests.m in Sources */,
+				CFFECBAD250667B20010F585 /* Decimal128Tests.m in Sources */,
 				02E334C31A5F41C7009F8810 /* DynamicTests.m in Sources */,
 				021A88321AAFB5C800EEAC84 /* EncryptionTests.mm in Sources */,
 				E81A1FDB1955FE0100FDED82 /* EnumeratorTests.m in Sources */,
@@ -3102,6 +3102,7 @@
 				0207AB87195DFA15007EFB12 /* MigrationTests.mm in Sources */,
 				3F2E66641CA0BA11004761D5 /* NotificationTests.m in Sources */,
 				3FEB383F1E70AC8800F22712 /* ObjectCreationTests.mm in Sources */,
+				CFFECBB0250690EA0010F585 /* ObjectIdTests.m in Sources */,
 				E81A1FE11955FE0100FDED82 /* ObjectInterfaceTests.m in Sources */,
 				021A88361AAFB5CD00EEAC84 /* ObjectSchemaTests.m in Sources */,
 				E81A1FE31955FE0100FDED82 /* ObjectTests.m in Sources */,
@@ -3119,7 +3120,6 @@
 				3F558C8B22C29A03002F0F30 /* RLMTestObjects.m in Sources */,
 				0207AB89195DFA15007EFB12 /* SchemaTests.mm in Sources */,
 				3FB4FA1819F5D2740020D53B /* SwiftArrayPropertyTests.swift in Sources */,
-				CFFECBB0250690EA0010F585 /* ObjectIdTests.m in Sources */,
 				3FB4FA1919F5D2740020D53B /* SwiftArrayTests.swift in Sources */,
 				3FB4FA1A19F5D2740020D53B /* SwiftDynamicTests.swift in Sources */,
 				3FB4FA1B19F5D2740020D53B /* SwiftLinkTests.swift in Sources */,

--- a/Realm.xcodeproj/project.pbxproj
+++ b/Realm.xcodeproj/project.pbxproj
@@ -304,13 +304,6 @@
 		537130C824A9E417001FDBBC /* RealmServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 537130C724A9E417001FDBBC /* RealmServer.swift */; };
 		53C4E952253A34DE0004835F /* app_utils.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 53C4E950253A34DE0004835F /* app_utils.cpp */; };
 		53C4E96A253A3B460004835F /* app_utils.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 53C4E950253A34DE0004835F /* app_utils.cpp */; };
-		53ECFDAC24AA0C0D00A4CB89 /* assisted_agg in Resources */ = {isa = PBXBuildFile; fileRef = 53ECFDAB24AA0C0D00A4CB89 /* assisted_agg */; };
-		53ECFDAE24AA0C1100A4CB89 /* create_user in Resources */ = {isa = PBXBuildFile; fileRef = 53ECFDAD24AA0C1100A4CB89 /* create_user */; };
-		53ECFDB024AA0C1700A4CB89 /* stitch_server in Resources */ = {isa = PBXBuildFile; fileRef = 53ECFDAF24AA0C1700A4CB89 /* stitch_server */; };
-		53ECFDB224AA0C1B00A4CB89 /* update_doc in Resources */ = {isa = PBXBuildFile; fileRef = 53ECFDB124AA0C1B00A4CB89 /* update_doc */; };
-		53ECFDB624AA0C3F00A4CB89 /* transpiler in Resources */ = {isa = PBXBuildFile; fileRef = 53ECFDB524AA0C3F00A4CB89 /* transpiler */; };
-		53ECFDB824AA0C4900A4CB89 /* test_config.json in Resources */ = {isa = PBXBuildFile; fileRef = 53ECFDB724AA0C4900A4CB89 /* test_config.json */; };
-		53ECFDB924AA0DE500A4CB89 /* libstitch_support.dylib in Resources */ = {isa = PBXBuildFile; fileRef = 53ECFDB324AA0C3500A4CB89 /* libstitch_support.dylib */; };
 		5B77EACE1DCC5614006AB51D /* ObjectiveCSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B77EACD1DCC5614006AB51D /* ObjectiveCSupport.swift */; };
 		5D03FB1F1E0DAFBA007D53EA /* PredicateUtilTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5D03FB1E1E0DAFBA007D53EA /* PredicateUtilTests.mm */; };
 		5D03FB201E0DAFBA007D53EA /* PredicateUtilTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5D03FB1E1E0DAFBA007D53EA /* PredicateUtilTests.mm */; };
@@ -981,13 +974,6 @@
 		537130C724A9E417001FDBBC /* RealmServer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = RealmServer.swift; path = Realm/ObjectServerTests/RealmServer.swift; sourceTree = "<group>"; };
 		53C4E950253A34DE0004835F /* app_utils.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = app_utils.cpp; path = sync/app_utils.cpp; sourceTree = "<group>"; };
 		53C4E951253A34DE0004835F /* app_utils.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = app_utils.hpp; path = sync/app_utils.hpp; sourceTree = "<group>"; };
-		53ECFDAB24AA0C0D00A4CB89 /* assisted_agg */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.executable"; name = assisted_agg; path = build/go/src/github.com/10gen/stitch/assisted_agg; sourceTree = "<group>"; };
-		53ECFDAD24AA0C1100A4CB89 /* create_user */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.executable"; name = create_user; path = build/go/src/github.com/10gen/stitch/create_user; sourceTree = "<group>"; };
-		53ECFDAF24AA0C1700A4CB89 /* stitch_server */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.executable"; name = stitch_server; path = build/go/src/github.com/10gen/stitch/stitch_server; sourceTree = "<group>"; };
-		53ECFDB124AA0C1B00A4CB89 /* update_doc */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.executable"; name = update_doc; path = build/go/src/github.com/10gen/stitch/update_doc; sourceTree = "<group>"; };
-		53ECFDB324AA0C3500A4CB89 /* libstitch_support.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libstitch_support.dylib; path = build/go/src/github.com/10gen/stitch/etc/dylib/lib/libstitch_support.dylib; sourceTree = "<group>"; };
-		53ECFDB524AA0C3F00A4CB89 /* transpiler */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.executable"; name = transpiler; path = build/go/src/github.com/10gen/stitch/etc/transpiler/bin/transpiler; sourceTree = "<group>"; };
-		53ECFDB724AA0C4900A4CB89 /* test_config.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = test_config.json; path = build/go/src/github.com/10gen/stitch/etc/configs/test_config.json; sourceTree = "<group>"; };
 		5B77EACD1DCC5614006AB51D /* ObjectiveCSupport.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ObjectiveCSupport.swift; sourceTree = "<group>"; };
 		5BC537151DD5B8D70055C524 /* ObjectiveCSupportTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ObjectiveCSupportTests.swift; sourceTree = "<group>"; };
 		5D03FB1E1E0DAFBA007D53EA /* PredicateUtilTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = PredicateUtilTests.mm; sourceTree = "<group>"; };
@@ -1367,7 +1353,6 @@
 		1AA5AEA21D98CA5300ED8C27 /* Utility */ = {
 			isa = PBXGroup;
 			children = (
-				53ECFD9C24AA08C700A4CB89 /* Server */,
 				1AA5AE9A1D98A1B000ED8C27 /* Object-Server-Tests-Bridging-Header.h */,
 				3F73BC871E3A876600FE80B6 /* ObjectServerTests-Info.plist */,
 				537130C724A9E417001FDBBC /* RealmServer.swift */,
@@ -1506,20 +1491,6 @@
 				49AD39F3244E1A370097500E /* regular_expression.hpp */,
 			);
 			path = bson;
-			sourceTree = "<group>";
-		};
-		53ECFD9C24AA08C700A4CB89 /* Server */ = {
-			isa = PBXGroup;
-			children = (
-				53ECFDAB24AA0C0D00A4CB89 /* assisted_agg */,
-				53ECFDAD24AA0C1100A4CB89 /* create_user */,
-				53ECFDAF24AA0C1700A4CB89 /* stitch_server */,
-				53ECFDB524AA0C3F00A4CB89 /* transpiler */,
-				53ECFDB124AA0C1B00A4CB89 /* update_doc */,
-				53ECFDB324AA0C3500A4CB89 /* libstitch_support.dylib */,
-				53ECFDB724AA0C4900A4CB89 /* test_config.json */,
-			);
-			name = Server;
 			sourceTree = "<group>";
 		};
 		5D274C511D6D16BA006FEBB1 /* apple */ = {
@@ -2518,15 +2489,8 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				53ECFDAC24AA0C0D00A4CB89 /* assisted_agg in Resources */,
-				53ECFDAE24AA0C1100A4CB89 /* create_user in Resources */,
 				536B7C0C24A4C223006B535D /* dependencies.list in Resources */,
-				53ECFDB924AA0DE500A4CB89 /* libstitch_support.dylib in Resources */,
 				536B7C1024A509AC006B535D /* setup_baas.rb in Resources */,
-				53ECFDB024AA0C1700A4CB89 /* stitch_server in Resources */,
-				53ECFDB824AA0C4900A4CB89 /* test_config.json in Resources */,
-				53ECFDB624AA0C3F00A4CB89 /* transpiler in Resources */,
-				53ECFDB224AA0C1B00A4CB89 /* update_doc in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2535,7 +2499,6 @@
 /* Begin PBXShellScriptBuildPhase section */
 		3F1DDB5825155E33007A9630 /* Carthage post-build workaround */ = {
 			isa = PBXShellScriptBuildPhase;
-			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -2561,15 +2524,15 @@
 			inputFileListPaths = (
 			);
 			inputPaths = (
+				"$(SRCROOT)/Realm/ObjectServerTests/setup_baas.rb",
 			);
 			outputFileListPaths = (
 			);
 			outputPaths = (
-				"$(SRCROOT)/baas",
-				"$(SRCROOT)/build/go/src/github.com/10gen/stitch/assisted_agg",
-				"$(SRCROOT)/build/go/src/github.com/10gen/stitch/create_user",
-				"$(SRCROOT)/build/go/src/github.com/10gen/stitch/stitch_server",
-				"$(SRCROOT)/build/go/src/github.com/10gen/stitch/update_doc",
+				"$(SRCROOT)/build/bin/assisted_agg",
+				"$(SRCROOT)/build/bin/create_user",
+				"$(SRCROOT)/build/bin/stitch_server",
+				"$(SRCROOT)/build/bin/update_doc",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/Realm/ObjectServerTests/RLMSyncTestCase.h
+++ b/Realm/ObjectServerTests/RLMSyncTestCase.h
@@ -60,10 +60,9 @@ NS_ASSUME_NONNULL_BEGIN
 @interface RLMSyncTestCase : RLMMultiProcessTestCase
 
 @property (nonatomic, readonly) NSString *appId;
-
-- (RLMAppConfiguration *)defaultAppConfiguration;
-
 @property (nonatomic, readonly) RLMApp *app;
+@property (nonatomic, readonly) RLMUser *anonymousUser;
+@property (nonatomic, readonly) RLMAppConfiguration *defaultAppConfiguration;
 
 /// Any stray app ids passed between processes
 @property (nonatomic, readonly) NSArray<NSString *> *appIds;

--- a/Realm/ObjectServerTests/RLMSyncTestCase.h
+++ b/Realm/ObjectServerTests/RLMSyncTestCase.h
@@ -24,11 +24,6 @@ typedef void(^RLMSyncBasicErrorReportingBlock)(NSError * _Nullable);
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface RLMSyncManager ()
-- (void)setSessionCompletionNotifier:(nullable RLMSyncBasicErrorReportingBlock)sessionCompletionNotifier;
-@end
-
-
 @interface Dog : RLMObject
 
 @property RLMObjectId *_id;
@@ -57,6 +52,9 @@ NS_ASSUME_NONNULL_BEGIN
 @property NSString *realm_id;
 @property NSData *dataProp;
 + (instancetype)objectWithRealmId:(NSString *)realmId;
+@end
+
+@interface AsyncOpenConnectionTimeoutTransport : RLMNetworkTransport
 @end
 
 @interface RLMSyncTestCase : RLMMultiProcessTestCase
@@ -116,6 +114,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /// Synchronously create, log in, and return a user.
 - (RLMUser *)logInUserForCredentials:(RLMCredentials *)credentials;
+- (RLMUser *)logInUserForCredentials:(RLMCredentials *)credentials app:(RLMApp *)app;
 
 /// Synchronously, log out.
 - (void)logOutUser:(RLMUser *)user;
@@ -127,10 +126,6 @@ NS_ASSUME_NONNULL_BEGIN
                          realms:(NSArray<RLMRealm *> *)realms
                       partitionValues:(NSArray<NSString *> *)partitionValues
                  expectedCounts:(NSArray<NSNumber *> *)counts;
-
-/// "Prime" the sync manager to signal the given semaphore the next time a session is bound. This method should be
-/// called right before a Realm is opened if that Realm's session is the one to be monitored.
-- (void)primeSyncManagerWithSemaphore:(nullable dispatch_semaphore_t)semaphore;
 
 /// Wait for downloads to complete; drop any error.
 - (void)waitForDownloadsForRealm:(RLMRealm *)realm;

--- a/Realm/ObjectServerTests/RLMSyncTestCase.h
+++ b/Realm/ObjectServerTests/RLMSyncTestCase.h
@@ -70,38 +70,24 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (RLMCredentials *)basicCredentialsWithName:(NSString *)name register:(BOOL)shouldRegister;
 
-+ (NSURL *)onDiskPathForSyncedRealm:(RLMRealm *)realm;
-
-/// Synchronously open a synced Realm and wait until the binding process has completed or failed.
-- (RLMRealm *)openRealmForPartitionValue:(nullable NSString *)partitionValue user:(RLMUser *)user;
-
-/// Synchronously open a synced Realm and wait until the binding process has completed or failed.
-- (RLMRealm *)openRealmWithConfiguration:(RLMRealmConfiguration *)configuration;
-
 /// Synchronously open a synced Realm via asyncOpen and return the Realm.
 - (RLMRealm *)asyncOpenRealmWithConfiguration:(RLMRealmConfiguration *)configuration;
 
 /// Synchronously open a synced Realm via asyncOpen and return the expected error.
 - (NSError *)asyncOpenErrorWithConfiguration:(RLMRealmConfiguration *)configuration;
 
-/// Synchronously open a synced Realm. Also run a block right after the Realm is created.
-- (RLMRealm *)openRealmForPartitionValue:(nullable NSString *)partitionValue
-                                    user:(RLMUser *)user
-                        immediatelyBlock:(nullable void(^)(void))block;
+/// Synchronously open a synced Realm and wait for downloads.
+- (RLMRealm *)openRealmForPartitionValue:(nullable id<RLMBSON>)partitionValue
+                                    user:(RLMUser *)user;
 
-/// Synchronously open a synced Realm with encryption key and stop policy.
-/// Also run a block right after the Realm is created.
-- (RLMRealm *)openRealmForPartitionValue:(nullable NSString *)partitionValue
+/// Synchronously open a synced Realm with encryption key and stop policy and wait for downloads.
+- (RLMRealm *)openRealmForPartitionValue:(nullable id<RLMBSON>)partitionValue
                                     user:(RLMUser *)user
                            encryptionKey:(nullable NSData *)encryptionKey
-                              stopPolicy:(RLMSyncStopPolicy)stopPolicy
-                        immediatelyBlock:(nullable void(^)(void))block;
+                              stopPolicy:(RLMSyncStopPolicy)stopPolicy;
 
-/// Synchronously open a synced Realm and wait until the binding process has completed or failed.
-/// Also run a block right after the Realm is created.
-- (RLMRealm *)openRealmWithConfiguration:(RLMRealmConfiguration *)configuration
-                        immediatelyBlock:(nullable void(^)(void))block;
-;
+/// Synchronously open a synced Realm.
+- (RLMRealm *)openRealmWithConfiguration:(RLMRealmConfiguration *)configuration;
 
 /// Immediately open a synced Realm.
 - (RLMRealm *)immediatelyOpenRealmForPartitionValue:(NSString *)partitionValue user:(RLMUser *)user;
@@ -124,7 +110,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// Synchronously wait for downloads to complete for any number of Realms, and then check their `SyncObject` counts.
 - (void)waitForDownloadsForUser:(RLMUser *)user
                          realms:(NSArray<RLMRealm *> *)realms
-                      partitionValues:(NSArray<NSString *> *)partitionValues
+                partitionValues:(NSArray<NSString *> *)partitionValues
                  expectedCounts:(NSArray<NSNumber *> *)counts;
 
 /// Wait for downloads to complete; drop any error.
@@ -137,7 +123,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /// Wait for downloads to complete while spinning the runloop. This method uses expectations.
 - (void)waitForDownloadsForUser:(RLMUser *)user
-                            partitionValue:(NSString *)partitionValue
+                 partitionValue:(NSString *)partitionValue
                     expectation:(nullable XCTestExpectation *)expectation
                           error:(NSError **)error;
 

--- a/Realm/ObjectServerTests/RLMSyncTestCase.h
+++ b/Realm/ObjectServerTests/RLMSyncTestCase.h
@@ -147,7 +147,6 @@ NS_ASSUME_NONNULL_BEGIN
 /// Manually set the refresh token for a user. Used for testing invalid token conditions.
 - (void)manuallySetRefreshTokenForUser:(RLMUser *)user value:(NSString *)tokenValue;
 
-- (void)setupSyncManager;
 - (void)resetSyncManager;
 
 - (NSString *)badAccessToken;

--- a/Realm/ObjectServerTests/RLMSyncTestCase.mm
+++ b/Realm/ObjectServerTests/RLMSyncTestCase.mm
@@ -190,8 +190,8 @@ static NSURL *syncDirectoryForChildProcess() {
 
 #pragma mark - Helper methods
 
-- (BOOL)isPartial {
-    return NO;
+- (RLMUser *)anonymousUser {
+    return [self logInUserForCredentials:[RLMCredentials anonymousCredentials]];
 }
 
 - (RLMCredentials *)basicCredentialsWithName:(NSString *)name register:(BOOL)shouldRegister {

--- a/Realm/ObjectServerTests/SwiftObjectServerTests.swift
+++ b/Realm/ObjectServerTests/SwiftObjectServerTests.swift
@@ -1191,9 +1191,14 @@ class SwiftObjectServerTests: SwiftSyncTestCase {
         XCTAssertEqual(app.currentUser?.customData["favourite_colour"], .string("green"))
         XCTAssertEqual(app.currentUser?.customData["apples"], .int64(10))
     }
+}
 
     // MARK: - Mongo Client
-
+class SwiftMongoClientTests: SwiftSyncTestCase {
+    override func tearDown() {
+        _ = setupMongoCollection()
+        super.tearDown()
+    }
     func testMongoClient() {
         let user = try! synchronouslyLogInUser(for: Credentials.anonymous)
         let mongoClient = user.mongoClient("mongodb1")

--- a/Realm/ObjectServerTests/SwiftSyncTestCase.swift
+++ b/Realm/ObjectServerTests/SwiftSyncTestCase.swift
@@ -29,14 +29,12 @@ class SwiftSyncTestCase: RLMSyncTestCase {
       return String((0..<length).map { _ in letters.randomElement()! })
     }
 
-    func basicCredentials(usernameSuffix: String = "",
-                          file: StaticString = #file,
-                          line: UInt = #line) -> Credentials {
+    public func basicCredentials(usernameSuffix: String = "", app: App? = nil) -> Credentials {
         let email = "\(randomString(10))\(usernameSuffix)"
         let password = "abcdef"
         let credentials = Credentials.emailPassword(email: email, password: password)
         let ex = expectation(description: "Should register in the user properly")
-        app.emailPasswordAuth.registerUser(email: email, password: password, completion: { error in
+        (app ?? self.app).emailPasswordAuth.registerUser(email: email, password: password, completion: { error in
             XCTAssertNil(error)
             ex.fulfill()
         })
@@ -70,19 +68,20 @@ class SwiftSyncTestCase: RLMSyncTestCase {
         return try Realm(configuration: user.configuration(partitionValue: partitionValue))
     }
 
-    func synchronouslyLogInUser(for credentials: Credentials,
-                                file: StaticString = #file,
-                                line: UInt = #line) throws -> User {
+    open func synchronouslyLogInUser(for credentials: Credentials,
+                                     app: App? = nil,
+                                     file: StaticString = #file,
+                                     line: UInt = #line) throws -> User {
         var theUser: User!
         let ex = expectation(description: "Should log in the user properly")
 
-        self.app.login(credentials: credentials) { result in
+        (app ?? self.app).login(credentials: credentials) { result in
             switch result {
             case .success(let user):
                 theUser = user
                 XCTAssertTrue(theUser.isLoggedIn)
-            case .failure:
-                XCTFail("Should login user")
+            case .failure(let error):
+                XCTFail("Should login user: \(error)")
             }
             ex.fulfill()
         }

--- a/Realm/ObjectServerTests/TimeoutProxyServer.swift
+++ b/Realm/ObjectServerTests/TimeoutProxyServer.swift
@@ -17,78 +17,62 @@
 ////////////////////////////////////////////////////////////////////////////
 
 import Foundation
+import Network
 
+@available(OSX 10.14, *)
 @objc(TimeoutProxyServer)
-class TimeoutProxyServer: NSObject {
-    var incomingRequests: [FileHandle: CFHTTPMessage] = [:]
-    var socket: CFSocket?
-    let port: Int
-    var listeningHandle: FileHandle?
+public class TimeoutProxyServer: NSObject {
+    let port: NWEndpoint.Port
+    let targetPort: NWEndpoint.Port
 
-    @objc init(port: Int) {
-        self.port = port
+    let queue = DispatchQueue(label: "TimeoutProxyServer")
+    var listener: NWListener!
+    var connections = [NWConnection]()
+
+    let serverEndpoint = NWEndpoint.Host("127.0.0.1")
+
+    @objc public var delay: Double = 0
+
+    @objc public init(port: UInt16, targetPort: UInt16) {
+        self.port = NWEndpoint.Port(rawValue: port)!
+        self.targetPort = NWEndpoint.Port(rawValue: targetPort)!
     }
 
-    @objc func start() throws {
-        socket = CFSocketCreate(kCFAllocatorDefault,
-                                PF_INET,
-                                SOCK_STREAM,
-                                IPPROTO_TCP, 0, nil, nil)
-        guard let socket = socket else {
-            throw NSError(domain: "TimeoutServerError",
-                          code: -1,
-                          userInfo: [NSLocalizedDescriptionKey: "Unable to create socket"])
+    @objc public func start() throws {
+        listener = try NWListener(using: NWParameters.tcp, on: port)
+        listener.newConnectionHandler = { incomingConnection in
+            self.connections.append(incomingConnection)
+            incomingConnection.start(queue: self.queue)
+
+            let targetConnection = NWConnection(host: self.serverEndpoint, port: self.targetPort, using: .tcp)
+            targetConnection.start(queue: self.queue)
+            self.connections.append(targetConnection)
+
+            self.queue.asyncAfter(deadline: .now() + self.delay) {
+                self.copy(from: incomingConnection, to: targetConnection)
+                self.copy(from: targetConnection, to: incomingConnection)
+            }
         }
-
-
-        var reuse = true
-        let fileDescriptor = CFSocketGetNative(socket)
-        guard setsockopt(fileDescriptor, SOL_SOCKET, SO_REUSEADDR,
-                       &reuse, socklen_t(MemoryLayout.size(ofValue: Int.self))) != 0 else {
-            throw NSError(domain: "TimeoutServerError",
-                          code: -1,
-                          userInfo: [NSLocalizedDescriptionKey: "Unable to set socket options"])
-        }
-
-        var address = sockaddr_in()
-        address.sin_len = __uint8_t(MemoryLayout.size(ofValue: address))
-        address.sin_family = sa_family_t(AF_INET)
-        address.sin_addr.s_addr = INADDR_ANY.bigEndian
-        address.sin_port = UInt16(port).bigEndian
-
-        let data = Data(bytes: &address, count: MemoryLayout.size(ofValue: address)) as CFData
-        guard CFSocketSetAddress(socket, data) == .success else {
-            throw NSError(domain: "TimeoutServerError",
-                          code: -1,
-                          userInfo: [NSLocalizedDescriptionKey: "Unable to create socket"])
-        }
-
-        listeningHandle = FileHandle(fileDescriptor: fileDescriptor, closeOnDealloc: true)
-        NotificationCenter.default.addObserver(self,
-                                               selector: #selector(receiveIncomingConnectionNotification(notification:)),
-                                               name: NSNotification.Name.NSFileHandleConnectionAccepted,
-                                               object: nil)
-        listeningHandle!.acceptConnectionInBackgroundAndNotify()
+        listener.start(queue: self.queue)
     }
 
-    @objc func receiveIncomingConnectionNotification(notification: Notification) {
-        let userInfo = notification.userInfo
-        let incomingFileHandle = userInfo?[NSFileHandleNotificationFileHandleItem] as? FileHandle
-
-        if let incomingFileHandle = incomingFileHandle {
-            incomingRequests[incomingFileHandle] = CFHTTPMessageCreateEmpty(kCFAllocatorDefault, true).takeRetainedValue()
-            NotificationCenter.default.addObserver(self,
-                                                   selector: #selector(receiveIncomingDataNotification(notification:)),
-                                                   name: NSNotification.Name.NSFileHandleDataAvailable,
-                                                   object: incomingFileHandle)
-
-            incomingFileHandle.waitForDataInBackgroundAndNotify()
+    @objc public func stop() {
+        for connection in connections {
+            connection.forceCancel()
         }
-
-        listeningHandle?.acceptConnectionInBackgroundAndNotify()
+        listener.cancel()
     }
 
-    @objc func receiveIncomingDataNotification(notification: Notification) {
-        // let the incoming requests timeout
+    private func copy(from: NWConnection, to: NWConnection) {
+        from.receive(minimumIncompleteLength: 1, maximumLength: 8192) { [weak self] (data, context, isComplete, _) in
+            guard let data = data else {
+                self?.copy(from: from, to: to)
+                return
+            }
+            to.send(content: data, contentContext: context ?? .defaultMessage,
+                    isComplete: isComplete, completion: .contentProcessed({ [weak self] _ in
+                        self?.copy(from: from, to: to)
+                    }))
+        }
     }
 }

--- a/Realm/ObjectServerTests/setup_baas.rb
+++ b/Realm/ObjectServerTests/setup_baas.rb
@@ -6,7 +6,12 @@ require 'pathname'
 
 BASE_DIR = Dir.pwd
 BUILD_DIR = "#{BASE_DIR}/build"
+BIN_DIR = "#{BUILD_DIR}/bin"
+LIB_DIR = "#{BUILD_DIR}/lib"
 PID_FILE = "#{BUILD_DIR}/pid.txt"
+
+MONGO_EXE = "'#{BIN_DIR}'/mongo"
+MONGOD_EXE = "'#{BIN_DIR}'/mongod"
 
 DEPENDENCIES = File.open("#{BASE_DIR}/dependencies.list").map { |line|
   line.chomp.split("=")
@@ -20,23 +25,25 @@ STITCH_VERSION=DEPENDENCIES["STITCH_VERSION"]
 MONGODB_URL="https://fastdl.mongodb.org/osx/mongodb-macos-x86_64-#{MONGODB_VERSION}.tgz"
 TRANSPILER_TARGET='node8-macos'
 SERVER_STITCH_LIB_URL="https://s3.amazonaws.com/stitch-artifacts/stitch-support/stitch-support-macos-debug-4.3.2-721-ge791a2e-patch-5e2a6ad2a4cf473ae2e67b09.tgz"
-MONGO_DIR="'#{BUILD_DIR}'/mongodb-macos-x86_64-#{MONGODB_VERSION}"
+MONGO_DIR="#{BUILD_DIR}/mongodb-macos-x86_64-#{MONGODB_VERSION}"
 
 def setup_mongod
-    if !Dir.exists?(MONGO_DIR)
+    if !File.exist?("#{BIN_DIR}/mongo")
         `cd '#{BUILD_DIR}' && curl --silent '#{MONGODB_URL}' | tar xz`
+        FileUtils.cp("#{MONGO_DIR}/bin/mongo", BIN_DIR)
+        FileUtils.cp("#{MONGO_DIR}/bin/mongod", BIN_DIR)
     end
 end
 
 def run_mongod
     puts "starting mongod..."
-    puts `mkdir #{MONGO_DIR}/db_files`
-    puts `#{MONGO_DIR}/bin/mongod --quiet \
-        --dbpath #{MONGO_DIR}/db_files \
+    puts `mkdir '#{BUILD_DIR}'/db_files`
+    puts `#{MONGOD_EXE} --quiet \
+        --dbpath '#{BUILD_DIR}'/db_files \
         --port 26000 \
         --replSet test \
         --fork \
-        --logpath #{MONGO_DIR}/mongod.log`
+        --logpath '#{BUILD_DIR}'/mongod.log`
     puts "mongod starting"
 
     retries = 0
@@ -49,14 +56,14 @@ def run_mongod
             abort('could not connect to mongod')
         end
     end
-    puts `#{MONGO_DIR}/bin/mongo --port 26000 --eval 'rs.initiate()'`
+    puts `#{MONGO_EXE} --port 26000 --eval 'rs.initiate()'`
     puts "mongod started"
 end
 
 def shutdown_mongod
     puts 'shutting down mongod'
-    if Dir.exists?(MONGO_DIR)
-        puts `#{MONGO_DIR}/bin/mongo --port 26000 admin --eval "db.shutdownServer({force: true})"`
+    if File.exist?("#{BIN_DIR}/mongo")
+        puts `#{MONGO_EXE} --port 26000 admin --eval "db.shutdownServer({force: true})"`
     end
     puts 'mongod is down'
 end
@@ -66,61 +73,77 @@ def setup_stitch
     exports = []
     go_root = "#{BUILD_DIR}/go"
 
-    if !File.exists?("#{go_root}/bin/go")
+    if !File.exist?("#{go_root}/bin/go")
         puts 'downloading go'
         `cd #{BUILD_DIR} && curl --silent "https://dl.google.com/go/go#{GO_VERSION}.darwin-amd64.tar.gz" | tar xz`
         puts `mkdir -p #{go_root}/src/github.com/10gen`
     end
 
     stitch_dir = "#{BUILD_DIR}/stitch"
-    if !Dir.exists?(stitch_dir)
+    if !Dir.exist?(stitch_dir)
         puts 'cloning stitch'
-        `git clone git@github.com:10gen/baas #{stitch_dir}`
+        puts `git clone git@github.com:10gen/baas #{stitch_dir}`
     else
         puts 'stitch dir exists'
     end
 
     puts 'checking out stitch'
-    `git -C '#{stitch_dir}' fetch && git -C '#{stitch_dir}' checkout #{STITCH_VERSION}`
-
-    `mv #{stitch_dir} #{go_root}/src/github.com/10gen`
-    stitch_dir = "#{go_root}/src/github.com/10gen/stitch"
-    dylib_dir = "#{stitch_dir}/etc/dylib"
-    if !Dir.exists?(dylib_dir)
-        puts 'downloading mongodb dylibs'
-        Dir.mkdir dylib_dir
-        puts `curl -s "#{SERVER_STITCH_LIB_URL}" | tar xvfz - --strip-components=1 -C '#{dylib_dir}'`
+    stitch_worktree = "#{go_root}/src/github.com/10gen/stitch"
+    if Dir.exist?("#{stitch_dir}/.git")
+        # Fetch the BaaS version if we don't have it
+        puts `git -C '#{stitch_dir}' show-ref --verify --quiet #{STITCH_VERSION} || git -C '#{stitch_dir}' fetch`
+        # Set the worktree to the correct version
+        if Dir.exist?(stitch_worktree)
+            puts `git -C '#{stitch_worktree}' checkout #{STITCH_VERSION}`
+        else
+            puts `git -C '#{stitch_dir}' worktree add '#{stitch_worktree}' #{STITCH_VERSION}`
+        end
+    else
+        # We have a stitch directory with no .git directory, meaning we're
+        # running on CI and just need to copy the files into place
+        if !Dir.exist?(stitch_worktree)
+            puts `cp -Rc '#{stitch_dir}' '#{stitch_worktree}'`
+        end
     end
 
-    update_doc_filepath = "#{stitch_dir}/update_doc"
-    if !File.exists?(update_doc_filepath)
+    stitch_dir = stitch_worktree
+    if !File.exist?("#{LIB_DIR}/libstitch_support.dylib")
+        puts 'downloading mongodb dylibs'
+        FileUtils.mkdir_p "#{BUILD_DIR}/go/src/github.com/10gen/stitch/etc/dylib"
+        puts `curl -s '#{SERVER_STITCH_LIB_URL}' | tar xvfz - --strip-components=1 -C '#{BUILD_DIR}/go/src/github.com/10gen/stitch/etc/dylib'`
+        FileUtils.copy("#{BUILD_DIR}/go/src/github.com/10gen/stitch/etc/dylib/lib/libstitch_support.dylib", LIB_DIR)
+    end
+
+    update_doc_filepath = "#{BIN_DIR}/update_doc"
+    if !File.exist?(update_doc_filepath)
         puts "downloading update_doc"
-        puts `cd '#{stitch_dir}' && curl --silent -O "https://s3.amazonaws.com/stitch-artifacts/stitch-mongo-libs/stitch_mongo_libs_osx_patch_cbcbfd8ebefcca439ff2e4d99b022aedb0d61041_59e2b7a5c9ec4432c400181c_17_10_15_01_19_33/update_doc"`
+        puts `cd '#{BIN_DIR}' && curl --silent -O "https://s3.amazonaws.com/stitch-artifacts/stitch-mongo-libs/stitch_mongo_libs_osx_patch_cbcbfd8ebefcca439ff2e4d99b022aedb0d61041_59e2b7a5c9ec4432c400181c_17_10_15_01_19_33/update_doc"`
         puts `chmod +x '#{update_doc_filepath}'`
     end
 
-    assisted_agg_filepath = "#{stitch_dir}/assisted_agg"
-    if !File.exists?(assisted_agg_filepath)
+    assisted_agg_filepath = "#{BIN_DIR}/assisted_agg"
+    if !File.exist?(assisted_agg_filepath)
         puts "downloading assisted_agg"
-        puts `cd '#{stitch_dir}' && curl --silent -O "https://s3.amazonaws.com/stitch-artifacts/stitch-mongo-libs/stitch_mongo_libs_osx_patch_b1c679a26ecb975372de41238ea44e4719b8fbf0_5f3d91c10ae6066889184912_20_08_19_20_57_17/assisted_agg"`
+        puts `cd '#{BIN_DIR}' && curl --silent -O "https://s3.amazonaws.com/stitch-artifacts/stitch-mongo-libs/stitch_mongo_libs_osx_patch_b1c679a26ecb975372de41238ea44e4719b8fbf0_5f3d91c10ae6066889184912_20_08_19_20_57_17/assisted_agg"`
         puts `chmod +x '#{assisted_agg_filepath}'`
     end
 
-    if `which node`.empty? && !Dir.exists?("#{stitch_dir}/node-v#{NODE_VERSION}-darwin-x64")
+    if `which node`.empty? && !Dir.exist?("#{BUILD_DIR}/node-v#{NODE_VERSION}-darwin-x64")
         puts "downloading node 🚀"
-        puts `cd '#{stitch_dir}' && curl -O "https://nodejs.org/dist/v#{NODE_VERSION}/node-v#{NODE_VERSION}-darwin-x64.tar.gz" && tar xzf node-v#{NODE_VERSION}-darwin-x64.tar.gz`
-        exports << "export PATH=\"#{stitch_dir}/node-v#{NODE_VERSION}-darwin-x64/bin/:$PATH\""
+        puts `cd '#{BUILD_DIR}' && curl -O "https://nodejs.org/dist/v#{NODE_VERSION}/node-v#{NODE_VERSION}-darwin-x64.tar.gz" && tar xzf node-v#{NODE_VERSION}-darwin-x64.tar.gz`
+        exports << "export PATH=\"#{BUILD_DIR}/node-v#{NODE_VERSION}-darwin-x64/bin/:$PATH\""
     end
 
     if `which yarn`.empty?
         `rm -rf "$HOME/.yarn"`
-        `export PATH=\"#{stitch_dir}/node-v#{NODE_VERSION}-darwin-x64/bin/:$PATH\" && curl -o- -L https://yarnpkg.com/install.sh | bash`
+        `export PATH=\"#{BUILD_DIR}/node-v#{NODE_VERSION}-darwin-x64/bin/:$PATH\" && curl -o- -L https://yarnpkg.com/install.sh | bash`
         exports << "export PATH=\"$HOME/.yarn/bin:$HOME/.config/yarn/global/node_modules/.bin:$PATH\""
     end
 
     puts 'building transpiler'
     puts `#{exports.length() == 0 ? "" : exports.join(' && ') + ' &&'} \
-        cd '#{stitch_dir}/etc/transpiler' && yarn install && yarn run build -t "#{TRANSPILER_TARGET}"`
+        cd '#{stitch_dir}/etc/transpiler' && yarn install && yarn run build -t "#{TRANSPILER_TARGET}" &&
+        cp -c bin/transpiler #{BUILD_DIR}/bin`
 
     puts "TRANSPILER SIZE"
     puts `ls -l #{stitch_dir}/etc/transpiler/bin`
@@ -130,13 +153,14 @@ def setup_stitch
 
     exports << "export STITCH_PATH=\"#{stitch_dir}\""
     exports << "export PATH=\"$PATH:$STITCH_PATH/etc/transpiler/bin\""
-    exports << "export LD_LIBRARY_PATH=\"$STITCH_PATH/etc/dylib/lib\""
+    exports << "export LD_LIBRARY_PATH='#{LIB_DIR}'"
 
     puts 'build create_user binary'
 
     puts `#{exports.join(' && ')} && \
         cd '#{stitch_dir}' && \
-        #{go_root}/bin/go build -o create_user cmd/auth/user.go`
+        #{go_root}/bin/go build -o create_user cmd/auth/user.go &&
+        cp -c create_user '#{BIN_DIR}'`
 
     puts 'create_user binary built'
 
@@ -144,7 +168,8 @@ def setup_stitch
 
     puts `#{exports.join(' && ')} && \
         cd '#{stitch_dir}' && \
-        #{go_root}/bin/go build -o stitch_server cmd/server/main.go`
+        #{go_root}/bin/go build -o stitch_server cmd/server/main.go
+        cp -c stitch_server '#{BIN_DIR}'`
 
     puts 'server binary built'
 end
@@ -152,7 +177,8 @@ end
 def build_action
     puts 'building baas'
     begin
-        FileUtils.mkdir_p BUILD_DIR
+        FileUtils.mkdir_p BIN_DIR
+        FileUtils.mkdir_p LIB_DIR
         setup_mongod
         run_mongod
         shutdown_mongod

--- a/Realm/ObjectServerTests/setup_baas.rb
+++ b/Realm/ObjectServerTests/setup_baas.rb
@@ -17,7 +17,7 @@ DEPENDENCIES = File.open("#{BASE_DIR}/dependencies.list").map { |line|
   line.chomp.split("=")
 }.to_h
 
-MONGODB_VERSION='4.4.0-rc5'
+MONGODB_VERSION='4.4.1'
 GO_VERSION='1.15.2'
 NODE_VERSION='8.11.2'
 STITCH_VERSION=DEPENDENCIES["STITCH_VERSION"]

--- a/Realm/RLMApp.h
+++ b/Realm/RLMApp.h
@@ -62,7 +62,7 @@ Create a new Realm App configuration.
 */
 - (instancetype)initWithBaseURL:(nullable NSString *)baseURL
                       transport:(nullable id<RLMNetworkTransport>)transport
-                   localAppName:(nullable NSString *) localAppName
+                   localAppName:(nullable NSString *)localAppName
                 localAppVersion:(nullable NSString *)localAppVersion;
 
 /**

--- a/Realm/RLMApp_Private.hpp
+++ b/Realm/RLMApp_Private.hpp
@@ -40,6 +40,7 @@
 
 - (nonnull instancetype)initWithApp:(std::shared_ptr<realm::app::App>)app;
 
++ (void)resetAppCache;
 @end
 
 NSError * _Nonnull RLMAppErrorToNSError(realm::app::AppError const& appError);

--- a/Realm/RLMFindOneAndModifyOptions_Private.hpp
+++ b/Realm/RLMFindOneAndModifyOptions_Private.hpp
@@ -17,7 +17,7 @@
 ////////////////////////////////////////////////////////////////////////////
 
 #import <Realm/RLMFindOneAndModifyOptions.h>
-#import "sync/remote_mongo_collection.hpp"
+#import "sync/mongo_collection.hpp"
 
 @interface RLMFindOneAndModifyOptions ()
 

--- a/Realm/RLMFindOptions_Private.hpp
+++ b/Realm/RLMFindOptions_Private.hpp
@@ -17,7 +17,7 @@
 ////////////////////////////////////////////////////////////////////////////
 
 #import <Realm/RLMFindOptions.h>
-#import "sync/remote_mongo_collection.hpp"
+#import "sync/mongo_collection.hpp"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Realm/RLMMongoClient.mm
+++ b/Realm/RLMMongoClient.mm
@@ -21,8 +21,8 @@
 #import "RLMMongoCollection_Private.hpp"
 #import "RLMApp_Private.hpp"
 
-#import "sync/remote_mongo_client.hpp"
-#import "sync/remote_mongo_database.hpp"
+#import "sync/mongo_client.hpp"
+#import "sync/mongo_database.hpp"
 
 #import <realm/util/optional.hpp>
 

--- a/Realm/RLMMongoCollection.mm
+++ b/Realm/RLMMongoCollection.mm
@@ -26,9 +26,9 @@
 #import "RLMUpdateResult_Private.hpp"
 #import "RLMUser_Private.hpp"
 
-#import "sync/remote_mongo_client.hpp"
-#import "sync/remote_mongo_collection.hpp"
-#import "sync/remote_mongo_database.hpp"
+#import "sync/mongo_client.hpp"
+#import "sync/mongo_collection.hpp"
+#import "sync/mongo_database.hpp"
 
 @implementation RLMChangeStream {
     realm::app::WatchStream _watchStream;

--- a/Realm/RLMNetworkTransport.mm
+++ b/Realm/RLMNetworkTransport.mm
@@ -30,8 +30,6 @@
 
 using namespace realm;
 
-typedef void(^RLMServerURLSessionCompletionBlock)(NSData *, NSURLResponse *, NSError *);
-
 static_assert((int)RLMHTTPMethodGET        == (int)app::HttpMethod::get);
 static_assert((int)RLMHTTPMethodPOST       == (int)app::HttpMethod::post);
 static_assert((int)RLMHTTPMethodPUT        == (int)app::HttpMethod::put);

--- a/Realm/RLMSyncManager_Private.hpp
+++ b/Realm/RLMSyncManager_Private.hpp
@@ -39,8 +39,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface RLMSyncManager ()
 
-@property (nullable, nonatomic, copy) RLMSyncBasicErrorReportingBlock sessionCompletionNotifier;
-
 - (std::weak_ptr<realm::app::App>)app;
 - (std::shared_ptr<realm::SyncManager>)syncManager;
 - (instancetype)initWithSyncManager:(std::shared_ptr<realm::SyncManager>)syncManager;

--- a/Realm/RLMUpdateResult_Private.hpp
+++ b/Realm/RLMUpdateResult_Private.hpp
@@ -17,7 +17,7 @@
 ////////////////////////////////////////////////////////////////////////////
 
 #import <Realm/RLMUpdateResult.h>
-#import "sync/remote_mongo_collection.hpp"
+#import "sync/mongo_collection.hpp"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Realm/TestUtils/include/RLMMultiProcessTestCase.h
+++ b/Realm/TestUtils/include/RLMMultiProcessTestCase.h
@@ -37,5 +37,5 @@
 #define RLMRunChildAndWait() \
     XCTAssertEqual(0, [self runChildAndWait], @"Tests in child process failed")
 
-#define RLMRunChildAndWaitWithAppIds(appIds) \
-    XCTAssertEqual(0, [self runChildAndWaitWithAppIds:appIds], @"Tests in child process failed")
+#define RLMRunChildAndWaitWithAppIds(...) \
+    XCTAssertEqual(0, [self runChildAndWaitWithAppIds:@[__VA_ARGS__]], @"Tests in child process failed")


### PR DESCRIPTION
The changes to how BaaS is installed is for the sake of SPM; copying the BaaS files into the bundle is awkward to do there, so instead the tests just run it directly from the build directory (and the installation paths are adjusted to make that easier).

Reusing a single App for all of the tests cuts the runtime of the test suite in half and doesn't change anything about how the tests work, as the only thing that creating a new App per test was actually doing was generating unique partition values for each test.

While trying to get the tests passing when running via SPM I noticed that some of them weren't testing what they were trying to test, and then I ended up just implementing all of the tests which weren't fully ported from the old ROS tests.