### PR TITLE
Actually enable encryption in the encryption-enabled tests

### DIFF
--- a/Realm/TestUtils/RLMMultiProcessTestCase.m
+++ b/Realm/TestUtils/RLMMultiProcessTestCase.m
@@ -62,6 +62,10 @@
     return self;
 }
 
+- (BOOL)encryptTests {
+    return NO;
+}
+
 - (void)setUp {
     self.isParent = !getenv("RLMProcessIsChild");
     self.xctestPath = [self locateXCTest];

--- a/Realm/TestUtils/RLMTestCase.m
+++ b/Realm/TestUtils/RLMTestCase.m
@@ -130,12 +130,16 @@ static BOOL encryptTests() {
     deleteOrThrow([fileURL URLByAppendingPathExtension:@"note"]);
 }
 
+- (BOOL)encryptTests {
+    return encryptTests();
+}
+
 - (void)invokeTest {
     @autoreleasepool {
         [self deleteFiles];
 
-        if (encryptTests()) {
-            RLMRealmConfiguration *configuration = [RLMRealmConfiguration defaultConfiguration];
+        if (self.encryptTests) {
+            RLMRealmConfiguration *configuration = [RLMRealmConfiguration rawDefaultConfiguration];
             configuration.encryptionKey = RLMGenerateKey();
         }
     }

--- a/Realm/TestUtils/include/RLMTestCase.h
+++ b/Realm/TestUtils/include/RLMTestCase.h
@@ -51,6 +51,7 @@ NSData *RLMGenerateKey(void);
 - (void)waitForNotification:(RLMNotification)expectedNote realm:(RLMRealm *)realm block:(dispatch_block_t)block;
 
 - (nullable id)nonLiteralNil;
+- (BOOL)encryptTests;
 
 - (void)dispatchAsync:(dispatch_block_t)block;
 - (void)dispatchAsyncAndWait:(dispatch_block_t)block;

--- a/Realm/Tests/CompactionTests.m
+++ b/Realm/Tests/CompactionTests.m
@@ -79,8 +79,11 @@ static const NSUInteger count = 1000;
     RLMRealmConfiguration *configuration = [RLMRealmConfiguration defaultConfiguration];
     configuration.fileURL = RLMTestRealmURL();
     configuration.shouldCompactOnLaunch = ^BOOL(NSUInteger totalBytes, NSUInteger usedBytes){
-        // Confirm expected sizes
-        XCTAssertEqual(totalBytes, _expectedTotalBytesBefore);
+        // The reported size is the logical size of the file and not the size
+        // on disk for encrypted Realms
+        if (!self.encryptTests) {
+            XCTAssertEqual(totalBytes, _expectedTotalBytesBefore);
+        }
         XCTAssertTrue((usedBytes < totalBytes) && (usedBytes > expectedUsedBytesBeforeMin));
         return true;
     };
@@ -185,8 +188,11 @@ static const NSUInteger count = 1000;
     __block BOOL compactBlockInvoked = NO;
 
     configurationWithCompactBlock.shouldCompactOnLaunch = ^BOOL(NSUInteger totalBytes, NSUInteger usedBytes){
-        // Confirm expected sizes
-        XCTAssertEqual(totalBytes, _expectedTotalBytesBefore);
+        // The reported size is the logical size of the file and not the size
+        // on disk for encrypted Realms
+        if (!self.encryptTests) {
+            XCTAssertEqual(totalBytes, _expectedTotalBytesBefore);
+        }
         XCTAssertTrue((usedBytes < totalBytes) && (usedBytes > expectedUsedBytesBeforeMin));
         compactBlockInvoked = YES;
         return true;
@@ -209,8 +215,11 @@ static const NSUInteger count = 1000;
     RLMRealmConfiguration *configuration = [RLMRealmConfiguration defaultConfiguration];
     configuration.fileURL = RLMTestRealmURL();
     configuration.shouldCompactOnLaunch = ^BOOL(NSUInteger totalBytes, NSUInteger usedBytes){
-        // Confirm expected sizes
-        XCTAssertEqual(totalBytes, _expectedTotalBytesBefore);
+        // The reported size is the logical size of the file and not the size
+        // on disk for encrypted Realms
+        if (!self.encryptTests) {
+            XCTAssertEqual(totalBytes, _expectedTotalBytesBefore);
+        }
         XCTAssertTrue((usedBytes < totalBytes) && (usedBytes > expectedUsedBytesBeforeMin));
 
         // Don't compact.

--- a/Realm/Tests/DynamicTests.m
+++ b/Realm/Tests/DynamicTests.m
@@ -83,7 +83,7 @@
     }
     XCTAssertNotNil(expectedSchema);
 
-    RLMRealmConfiguration *config = [RLMRealmConfiguration new];
+    RLMRealmConfiguration *config = [RLMRealmConfiguration defaultConfiguration];
     config.fileURL = RLMTestRealmURL();
     config.dynamic = YES;
 

--- a/Realm/Tests/EncryptionTests.mm
+++ b/Realm/Tests/EncryptionTests.mm
@@ -134,7 +134,9 @@
     }
 
     @autoreleasepool {
-        RLMRealm *realm = [self realmWithTestPath];
+        RLMRealmConfiguration *config = [self configurationWithKey:nil];
+        config.fileURL = RLMTestRealmURL();
+        RLMRealm *realm = [RLMRealm realmWithConfiguration:config error:nil];
         XCTAssertEqual(1U, [IntObject allObjectsInRealm:realm].count);
     }
 }

--- a/Realm/Tests/MigrationTests.mm
+++ b/Realm/Tests/MigrationTests.mm
@@ -147,6 +147,7 @@ RLM_ARRAY_TYPE(MigrationTestObject);
 - (RLMRealmConfiguration *)config {
     RLMRealmConfiguration *config = [RLMRealmConfiguration new];
     config.fileURL = RLMTestRealmURL();
+    config.encryptionKey = RLMRealmConfiguration.rawDefaultConfiguration.encryptionKey;
     return config;
 }
 
@@ -160,8 +161,7 @@ RLM_ARRAY_TYPE(MigrationTestObject);
 
 - (void)createTestRealmWithSchema:(NSArray *)objectSchema block:(void (^)(RLMRealm *realm))block {
     @autoreleasepool {
-        RLMRealmConfiguration *config = [RLMRealmConfiguration new];
-        config.fileURL = RLMTestRealmURL();
+        RLMRealmConfiguration *config = self.config;
         config.customSchema = [self schemaWithObjects:objectSchema];
 
         RLMRealm *realm = [RLMRealm realmWithConfiguration:config error:nil];
@@ -173,8 +173,7 @@ RLM_ARRAY_TYPE(MigrationTestObject);
 
 - (RLMRealm *)migrateTestRealmWithBlock:(RLMMigrationBlock)block NS_RETURNS_RETAINED {
     @autoreleasepool {
-        RLMRealmConfiguration *config = [RLMRealmConfiguration new];
-        config.fileURL = RLMTestRealmURL();
+        RLMRealmConfiguration *config = self.config;
         config.schemaVersion = 1;
         config.migrationBlock = block;
         XCTAssertTrue([RLMRealm performMigrationForConfiguration:config error:nil]);
@@ -187,8 +186,7 @@ RLM_ARRAY_TYPE(MigrationTestObject);
 
 - (void)failToMigrateTestRealmWithBlock:(RLMMigrationBlock)block {
     @autoreleasepool {
-        RLMRealmConfiguration *config = [RLMRealmConfiguration new];
-        config.fileURL = RLMTestRealmURL();
+        RLMRealmConfiguration *config = self.config;
         config.schemaVersion = 1;
         config.migrationBlock = block;
         XCTAssertFalse([RLMRealm performMigrationForConfiguration:config error:nil]);
@@ -219,7 +217,7 @@ RLM_ARRAY_TYPE(MigrationTestObject);
 }
 
 - (void)assertNoMigrationRequiredForChangeFrom:(NSArray *)from to:(NSArray *)to {
-    RLMRealmConfiguration *config = [RLMRealmConfiguration new];
+    RLMRealmConfiguration *config = self.config;
     config.customSchema = [self schemaWithObjects:from];
     @autoreleasepool { [RLMRealm realmWithConfiguration:config error:nil]; }
 
@@ -233,8 +231,7 @@ RLM_ARRAY_TYPE(MigrationTestObject);
 }
 
 - (RLMRealmConfiguration *)renameConfigurationWithObjectSchemas:(NSArray *)objectSchemas migrationBlock:(RLMMigrationBlock)block {
-    RLMRealmConfiguration *configuration = [RLMRealmConfiguration new];
-    configuration.fileURL = RLMTestRealmURL();
+    RLMRealmConfiguration *configuration = self.config;
     configuration.schemaVersion = 1;
     configuration.customSchema = [self schemaWithObjects:objectSchemas];
     configuration.migrationBlock = block;
@@ -310,6 +307,7 @@ RLM_ARRAY_TYPE(MigrationTestObject);
     RLMValidateRealmError(error, RLMErrorFail, @"Cannot open an uninitialized realm in read-only mode", nil);
 
     RLMRealmConfiguration *config = [RLMRealmConfiguration defaultConfiguration];
+    config.encryptionKey = nil;
     @autoreleasepool { [RLMRealm realmWithConfiguration:config error:nil]; }
     XCTAssertEqual(0U, [RLMRealm schemaVersionAtURL:config.fileURL encryptionKey:nil error:nil]);
 
@@ -326,7 +324,7 @@ RLM_ARRAY_TYPE(MigrationTestObject);
     RLMRealmConfiguration *config = [RLMRealmConfiguration defaultConfiguration];
     config.schemaVersion = 10;
     @autoreleasepool { [RLMRealm realmWithConfiguration:config error:nil]; }
-    XCTAssertEqual(10U, [RLMRealm schemaVersionAtURL:config.fileURL encryptionKey:nil error:nil]);
+    XCTAssertEqual(10U, [RLMRealm schemaVersionAtURL:config.fileURL encryptionKey:config.encryptionKey error:nil]);
 
     config.schemaVersion = 5;
     RLMAssertThrowsWithReasonMatching([RLMRealm realmWithConfiguration:config error:nil],
@@ -337,22 +335,22 @@ RLM_ARRAY_TYPE(MigrationTestObject);
     RLMRealmConfiguration *config = [RLMRealmConfiguration defaultConfiguration];
     config.schemaVersion = 10;
     @autoreleasepool { [RLMRealm realmWithConfiguration:config error:nil]; }
-    XCTAssertEqual(10U, [RLMRealm schemaVersionAtURL:config.fileURL encryptionKey:nil error:nil]);
+    XCTAssertEqual(10U, [RLMRealm schemaVersionAtURL:config.fileURL encryptionKey:config.encryptionKey error:nil]);
 
     RLMRealmConfiguration *config2 = [RLMRealmConfiguration defaultConfiguration];
     config2.schemaVersion = 5;
     config2.fileURL = RLMTestRealmURL();
     @autoreleasepool { [RLMRealm realmWithConfiguration:config2 error:nil]; }
-    XCTAssertEqual(5U, [RLMRealm schemaVersionAtURL:config2.fileURL encryptionKey:nil error:nil]);
+    XCTAssertEqual(5U, [RLMRealm schemaVersionAtURL:config2.fileURL encryptionKey:config.encryptionKey error:nil]);
 
     // Should not have been changed
-    XCTAssertEqual(10U, [RLMRealm schemaVersionAtURL:config.fileURL encryptionKey:nil error:nil]);
+    XCTAssertEqual(10U, [RLMRealm schemaVersionAtURL:config.fileURL encryptionKey:config.encryptionKey error:nil]);
 }
 
 #pragma mark - Migration Requirements
 
 - (void)testAddingClassDoesNotRequireMigration {
-    RLMRealmConfiguration *config = [RLMRealmConfiguration new];
+    RLMRealmConfiguration *config = self.config;
     config.objectClasses = @[MigrationTestObject.class];
     @autoreleasepool { [RLMRealm realmWithConfiguration:config error:nil]; }
 
@@ -361,7 +359,7 @@ RLM_ARRAY_TYPE(MigrationTestObject);
 }
 
 - (void)testRemovingClassDoesNotRequireMigration {
-    RLMRealmConfiguration *config = [RLMRealmConfiguration new];
+    RLMRealmConfiguration *config = self.config;
     config.objectClasses = @[MigrationTestObject.class, ThreeFieldMigrationTestObject.class];
     @autoreleasepool { [RLMRealm realmWithConfiguration:config error:nil]; }
 
@@ -502,7 +500,7 @@ RLM_ARRAY_TYPE(MigrationTestObject);
 
     RLMObjectSchema *to = [RLMObjectSchema schemaForObjectClass:MigrationTwoStringObject.class];
 
-    RLMRealmConfiguration *config = [RLMRealmConfiguration new];
+    RLMRealmConfiguration *config = self.config;
     config.customSchema = [self schemaWithObjects:@[from]];
     @autoreleasepool { [RLMRealm realmWithConfiguration:config error:nil]; }
 
@@ -623,7 +621,7 @@ RLM_ARRAY_TYPE(MigrationTestObject);
 #pragma mark - Migration block invocatios
 
 - (void)testMigrationBlockNotCalledForIntialRealmCreation {
-    RLMRealmConfiguration *config = [RLMRealmConfiguration new];
+    RLMRealmConfiguration *config = self.config;
     config.migrationBlock = ^(__unused RLMMigration *migration, __unused uint64_t oldSchemaVersion) {
         XCTFail(@"Migration block should not have been called");
     };
@@ -631,7 +629,7 @@ RLM_ARRAY_TYPE(MigrationTestObject);
 }
 
 - (void)testMigrationBlockNotCalledWhenSchemaVersionIsUnchanged {
-    RLMRealmConfiguration *config = [RLMRealmConfiguration new];
+    RLMRealmConfiguration *config = self.config;
     config.schemaVersion = 1;
     @autoreleasepool { XCTAssertNoThrow([RLMRealm realmWithConfiguration:config error:nil]); }
 
@@ -643,7 +641,7 @@ RLM_ARRAY_TYPE(MigrationTestObject);
 }
 
 - (void)testMigrationBlockCalledWhenSchemaVersionHasChanged {
-    RLMRealmConfiguration *config = [RLMRealmConfiguration new];
+    RLMRealmConfiguration *config = self.config;
     config.schemaVersion = 1;
     @autoreleasepool { XCTAssertNoThrow([RLMRealm realmWithConfiguration:config error:nil]); }
 
@@ -664,7 +662,7 @@ RLM_ARRAY_TYPE(MigrationTestObject);
 #pragma mark - Async Migration
 
 - (void)testAsyncMigration {
-    RLMRealmConfiguration *c = [RLMRealmConfiguration new];
+    RLMRealmConfiguration *c = self.config;
     c.schemaVersion = 1;
     @autoreleasepool { XCTAssertNoThrow([RLMRealm realmWithConfiguration:c error:nil]); }
     XCTAssertNil(RLMGetAnyCachedRealmForPath(c.pathOnDisk.UTF8String));
@@ -1135,9 +1133,8 @@ RLM_ARRAY_TYPE(MigrationTestObject);
         [IntObject createInRealm:realm withValue:@[@2]];
     }];
 
-    RLMRealmConfiguration *config = [RLMRealmConfiguration new];
+    RLMRealmConfiguration *config = self.config;
     config.objectClasses = @[StringObject.class];
-    config.fileURL = RLMTestRealmURL();
     config.schemaVersion = 1;
     config.migrationBlock = ^(RLMMigration *migration, uint64_t) {
         [migration enumerateObjects:IntObject.className block:^(RLMObject *oldObject, RLMObject *newObject) {
@@ -1321,8 +1318,7 @@ RLM_ARRAY_TYPE(MigrationTestObject);
 
     RLMRealm *realm;
     @autoreleasepool {
-        RLMRealmConfiguration *config = [RLMRealmConfiguration new];
-        config.fileURL = RLMTestRealmURL();
+        RLMRealmConfiguration *config = self.config;
         config.customSchema = [self schemaWithObjects:@[ objectSchema ]];
         config.schemaVersion = 1;
         XCTAssertTrue([RLMRealm performMigrationForConfiguration:config error:nil]);
@@ -1365,8 +1361,7 @@ RLM_ARRAY_TYPE(MigrationTestObject);
     }];
 
     objectSchema = [RLMObjectSchema schemaForObjectClass:RequiredPropertiesObject.class];
-    RLMRealmConfiguration *config = [RLMRealmConfiguration new];
-    config.fileURL = RLMTestRealmURL();
+    RLMRealmConfiguration *config = self.config;
     config.customSchema = [self schemaWithObjects:@[objectSchema]];
     config.schemaVersion = 1;
     config.migrationBlock = ^(RLMMigration *migration, uint64_t) {
@@ -1483,8 +1478,7 @@ RLM_ARRAY_TYPE(MigrationTestObject);
 
     __block bool migrationCalled = false;
 
-    RLMRealmConfiguration *config = [RLMRealmConfiguration new];
-    config.fileURL = RLMTestRealmURL();
+    RLMRealmConfiguration *config = self.config;
     config.customSchema = [self schemaWithObjects:@[schema]];
     config.schemaVersion = 2;
     config.migrationBlock = ^(RLMMigration *migration, uint64_t oldVersion){

--- a/Realm/Tests/RealmConfigurationTests.mm
+++ b/Realm/Tests/RealmConfigurationTests.mm
@@ -96,7 +96,7 @@
     RLMRealmConfiguration *defaultConfiguration = [RLMRealmConfiguration defaultConfiguration];
     XCTAssertEqualObjects(defaultConfiguration.fileURL, RLMDefaultRealmURL());
     XCTAssertNil(defaultConfiguration.inMemoryIdentifier);
-    XCTAssertNil(defaultConfiguration.encryptionKey);
+    XCTAssertEqual(!!defaultConfiguration.encryptionKey, self.encryptTests);
     XCTAssertFalse(defaultConfiguration.readOnly);
     XCTAssertEqual(defaultConfiguration.schemaVersion, 0U);
     XCTAssertNil(defaultConfiguration.migrationBlock);

--- a/Realm/Tests/RealmTests.mm
+++ b/Realm/Tests/RealmTests.mm
@@ -1746,15 +1746,14 @@
 }
 #pragma mark - Write Copy to Path
 
-- (void)testWriteCopyOfRealm
-{
+- (void)testWriteCopyOfRealm {
     RLMRealm *realm = [RLMRealm defaultRealm];
     [realm transactionWithBlock:^{
         [IntObject createInRealm:realm withValue:@[@0]];
     }];
 
     NSError *writeError;
-    XCTAssertTrue([realm writeCopyToURL:RLMTestRealmURL() encryptionKey:nil error:&writeError]);
+    XCTAssertTrue([realm writeCopyToURL:RLMTestRealmURL() encryptionKey:realm.configuration.encryptionKey error:&writeError]);
     XCTAssertNil(writeError);
     RLMRealm *copy = [self realmWithTestPath];
     XCTAssertEqual(1U, [IntObject allObjectsInRealm:copy].count);
@@ -1844,7 +1843,9 @@
         [IntObject createInRealm:realm withValue:@[@0]];
 
         NSError *writeError;
-        XCTAssertTrue([realm writeCopyToURL:RLMTestRealmURL() encryptionKey:nil error:&writeError]);
+        XCTAssertTrue([realm writeCopyToURL:RLMTestRealmURL()
+                              encryptionKey:realm.configuration.encryptionKey
+                                      error:&writeError]);
         XCTAssertNil(writeError);
         RLMRealm *copy = [self realmWithTestPath];
         XCTAssertEqual(1U, [IntObject allObjectsInRealm:copy].count);


### PR DESCRIPTION
Turns out that the encryption-enabled CI job hasn't actually been enabling encryption for the last few years because defaultConfiguration returns a copy, so mutating it doesn't do anything.