### PR TITLE
Update the PR matrix for monorepo

### DIFF
--- a/.jenkins.yml
+++ b/.jenkins.yml
@@ -10,152 +10,267 @@ xcode_version:
  - 12.1
  - 12.2
 target:
+ - docs
+ - swiftlint
+ - osx
+ - osx-encryption
+ - osx-object-server
  - swiftpm
+ - swiftpm-debug
  - swiftpm-address
  - swiftpm-thread
  - swiftpm-ios
-configuration:
- - Debug
- - Release
+ - ios-static
+ - ios-dynamic
+ - watchos
+ - tvos
+ - osx-swift
+ - ios-swift
+ - tvos-swift
+ - osx-swift-evolution
+ - ios-swift-evolution
+ - tvos-swift-evolution
+ - catalyst
+ - catalyst-swift
+ - xcframework
+ - cocoapods-osx
+ - cocoapods-ios
+ - cocoapods-ios-dynamic
+ - cocoapods-watchos
+ - cocoapods-catalyst
 
 exclude:
 
   - xcode_version: 11.3
-    target: swiftpm
-    configuration: Debug
+    target: docs
 
   - xcode_version: 11.7
-    target: swiftpm
-    configuration: Debug
+    target: docs
+
+  - xcode_version: 12.0
+    target: docs
+
+  - xcode_version: 12.1
+    target: docs
+
+  - xcode_version: 11.3
+    target: swiftlint
 
   - xcode_version: 11.7
-    target: swiftpm
-    configuration: Release
+    target: swiftlint
 
   - xcode_version: 12.0
-    target: swiftpm
-    configuration: Debug
+    target: swiftlint
+
+  - xcode_version: 12.1
+    target: swiftlint
+
+  - xcode_version: 11.7
+    target: osx-encryption
 
   - xcode_version: 12.0
-    target: swiftpm
-    configuration: Release
+    target: osx-encryption
 
   - xcode_version: 12.1
-    target: swiftpm
-    configuration: Debug
+    target: osx-encryption
+
+  - xcode_version: 11.7
+    target: osx-object-server
+
+  - xcode_version: 12.0
+    target: osx-object-server
 
   - xcode_version: 12.1
-    target: swiftpm
-    configuration: Release
-
-  - xcode_version: 12.2
-    target: swiftpm
-    configuration: Debug
+    target: osx-object-server
 
   - xcode_version: 11.3
     target: swiftpm-address
-    configuration: Debug
-
-  - xcode_version: 11.3
-    target: swiftpm-address
-    configuration: Release
 
   - xcode_version: 11.7
     target: swiftpm-address
-    configuration: Debug
-
-  - xcode_version: 11.7
-    target: swiftpm-address
-    configuration: Release
 
   - xcode_version: 12.0
     target: swiftpm-address
-    configuration: Debug
-
-  - xcode_version: 12.0
-    target: swiftpm-address
-    configuration: Release
 
   - xcode_version: 12.1
     target: swiftpm-address
-    configuration: Debug
-
-  - xcode_version: 12.1
-    target: swiftpm-address
-    configuration: Release
-
-  - xcode_version: 12.2
-    target: swiftpm-address
-    configuration: Debug
 
   - xcode_version: 11.3
     target: swiftpm-thread
-    configuration: Debug
-
-  - xcode_version: 11.3
-    target: swiftpm-thread
-    configuration: Release
 
   - xcode_version: 11.7
     target: swiftpm-thread
-    configuration: Debug
-
-  - xcode_version: 11.7
-    target: swiftpm-thread
-    configuration: Release
 
   - xcode_version: 12.0
     target: swiftpm-thread
-    configuration: Debug
-
-  - xcode_version: 12.0
-    target: swiftpm-thread
-    configuration: Release
 
   - xcode_version: 12.1
     target: swiftpm-thread
-    configuration: Debug
-
-  - xcode_version: 12.1
-    target: swiftpm-thread
-    configuration: Release
-
-  - xcode_version: 12.2
-    target: swiftpm-thread
-    configuration: Debug
 
   - xcode_version: 11.3
     target: swiftpm-ios
-    configuration: Debug
+
+  - xcode_version: 11.7
+    target: swiftpm-ios
+
+  - xcode_version: 12.0
+    target: swiftpm-ios
+
+  - xcode_version: 12.1
+    target: swiftpm-ios
+
+  - xcode_version: 11.7
+    target: ios-static
+
+  - xcode_version: 12.0
+    target: ios-static
+
+  - xcode_version: 12.1
+    target: ios-static
+
+  - xcode_version: 11.7
+    target: ios-dynamic
+
+  - xcode_version: 12.0
+    target: ios-dynamic
+
+  - xcode_version: 12.1
+    target: ios-dynamic
+
+  - xcode_version: 11.7
+    target: watchos
+
+  - xcode_version: 12.0
+    target: watchos
+
+  - xcode_version: 12.1
+    target: watchos
+
+  - xcode_version: 11.7
+    target: tvos
+
+  - xcode_version: 12.0
+    target: tvos
+
+  - xcode_version: 12.1
+    target: tvos
+
+  - xcode_version: 11.7
+    target: ios-swift
+
+  - xcode_version: 12.0
+    target: ios-swift
+
+  - xcode_version: 12.1
+    target: ios-swift
+
+  - xcode_version: 11.7
+    target: tvos-swift
+
+  - xcode_version: 12.0
+    target: tvos-swift
+
+  - xcode_version: 12.1
+    target: tvos-swift
 
   - xcode_version: 11.3
-    target: swiftpm-ios
-    configuration: Release
+    target: osx-swift-evolution
 
   - xcode_version: 11.7
-    target: swiftpm-ios
-    configuration: Debug
+    target: osx-swift-evolution
+
+  - xcode_version: 12.0
+    target: osx-swift-evolution
+
+  - xcode_version: 12.1
+    target: osx-swift-evolution
+
+  - xcode_version: 11.3
+    target: ios-swift-evolution
 
   - xcode_version: 11.7
-    target: swiftpm-ios
-    configuration: Release
+    target: ios-swift-evolution
 
   - xcode_version: 12.0
-    target: swiftpm-ios
-    configuration: Debug
+    target: ios-swift-evolution
+
+  - xcode_version: 12.1
+    target: ios-swift-evolution
+
+  - xcode_version: 11.3
+    target: tvos-swift-evolution
+
+  - xcode_version: 11.7
+    target: tvos-swift-evolution
 
   - xcode_version: 12.0
-    target: swiftpm-ios
-    configuration: Release
+    target: tvos-swift-evolution
 
   - xcode_version: 12.1
-    target: swiftpm-ios
-    configuration: Debug
+    target: tvos-swift-evolution
+
+  - xcode_version: 11.7
+    target: catalyst
+
+  - xcode_version: 12.0
+    target: catalyst
 
   - xcode_version: 12.1
-    target: swiftpm-ios
-    configuration: Release
+    target: catalyst
 
-  - xcode_version: 12.2
-    target: swiftpm-ios
-    configuration: Debug
+  - xcode_version: 11.7
+    target: catalyst-swift
+
+  - xcode_version: 12.0
+    target: catalyst-swift
+
+  - xcode_version: 12.1
+    target: catalyst-swift
+
+  - xcode_version: 11.3
+    target: xcframework
+
+  - xcode_version: 11.7
+    target: xcframework
+
+  - xcode_version: 12.0
+    target: xcframework
+
+  - xcode_version: 12.1
+    target: xcframework
+
+  - xcode_version: 11.7
+    target: cocoapods-ios
+
+  - xcode_version: 12.0
+    target: cocoapods-ios
+
+  - xcode_version: 12.1
+    target: cocoapods-ios
+
+  - xcode_version: 11.7
+    target: cocoapods-ios-dynamic
+
+  - xcode_version: 12.0
+    target: cocoapods-ios-dynamic
+
+  - xcode_version: 12.1
+    target: cocoapods-ios-dynamic
+
+  - xcode_version: 11.7
+    target: cocoapods-watchos
+
+  - xcode_version: 12.0
+    target: cocoapods-watchos
+
+  - xcode_version: 12.1
+    target: cocoapods-watchos
+
+  - xcode_version: 11.7
+    target: cocoapods-catalyst
+
+  - xcode_version: 12.0
+    target: cocoapods-catalyst
+
+  - xcode_version: 12.1
+    target: cocoapods-catalyst

--- a/Package.swift
+++ b/Package.swift
@@ -16,6 +16,7 @@ let cxxSettings: [CXXSetting] = [
     .define("REALM_COCOA_VERSION", to: "@\"\(cocoaVersionStr)\""),
     .define("REALM_VERSION", to: "\"\(coreVersionStr)\""),
 
+    .define("REALM_DEBUG", .when(configuration: .debug)),
     .define("REALM_NO_CONFIG"),
     .define("REALM_INSTALL_LIBEXECDIR", to: ""),
     .define("REALM_ENABLE_ASSERTIONS", to: "1"),

--- a/scripts/pr-ci-matrix.rb
+++ b/scripts/pr-ci-matrix.rb
@@ -1,21 +1,52 @@
 #!/usr/bin/env ruby
 # A script to generate the .jenkins.yml file for the CI pull request job
 XCODE_VERSIONS = %w(11.3 11.7 12.0 12.1 12.2)
-CONFIGURATIONS = %w(Debug Release)
 
-release_only = ->(v, c) { c == 'Release' }
-latest_only = ->(v, c) { c == 'Release' and v == XCODE_VERSIONS.last }
-oldest_and_latest = ->(v, c) { c == 'Release' and (v == XCODE_VERSIONS.first or v == XCODE_VERSIONS.last) }
+all = ->(v) { true }
+latest_only = ->(v) { v == XCODE_VERSIONS.last }
+oldest_and_latest = ->(v) { v == XCODE_VERSIONS.first or v == XCODE_VERSIONS.last }
 
 def minimum_version(major)
-  ->(v, c) { v.split('.').first.to_i >= major and (c == 'Release' or v == XCODE_VERSIONS.last) }
+  ->(v) { v.split('.').first.to_i >= major }
 end
 
 targets = {
-  'swiftpm' => oldest_and_latest,
+  'docs' => latest_only,
+  'swiftlint' => latest_only,
+
+  'osx' => all,
+  'osx-encryption' => oldest_and_latest,
+  'osx-object-server' => oldest_and_latest,
+
+  'swiftpm' => all,
+  'swiftpm-debug' => all,
   'swiftpm-address' => latest_only,
   'swiftpm-thread' => latest_only,
   'swiftpm-ios' => latest_only,
+
+  'ios-static' => oldest_and_latest,
+  'ios-dynamic' => oldest_and_latest,
+  'watchos' => oldest_and_latest,
+  'tvos' => oldest_and_latest,
+
+  'osx-swift' => all,
+  'ios-swift' => oldest_and_latest,
+  'tvos-swift' => oldest_and_latest,
+
+  'osx-swift-evolution' => latest_only,
+  'ios-swift-evolution' => latest_only,
+  'tvos-swift-evolution' => latest_only,
+
+  'catalyst' => oldest_and_latest,
+  'catalyst-swift' => oldest_and_latest,
+
+  'xcframework' => latest_only,
+
+  'cocoapods-osx' => all,
+  'cocoapods-ios' => oldest_and_latest,
+  'cocoapods-ios-dynamic' => oldest_and_latest,
+  'cocoapods-watchos' => oldest_and_latest,
+  'cocoapods-catalyst' => oldest_and_latest,
 }
 
 output_file = """
@@ -25,21 +56,17 @@ output_file = """
 
 xcode_version:#{XCODE_VERSIONS.map { |v| "\n - #{v}" }.join()}
 target:#{targets.map { |k, v| "\n - #{k}" }.join()}
-configuration:#{CONFIGURATIONS.map { |v| "\n - #{v}" }.join()}
 
 exclude:
 """
 targets.each { |name, filter|
   XCODE_VERSIONS.each { |version|
-    CONFIGURATIONS.each { |configuration|
-      if not filter.call(version, configuration)
-        output_file << """
+    if not filter.call(version)
+      output_file << """
   - xcode_version: #{version}
     target: #{name}
-    configuration: #{configuration}
 """
-      end
-    }
+    end
   }
 }
 


### PR DESCRIPTION
Rather than having debug/release as a separate axis, switch to just having a single spm debug job, which tests objc, swift and object server in a single job. Switching to testing debug via SPM means we no longer need to package a debug xcframework just for these tests, and a single debug job is a reduction in the amount of redundant compilations that the PR matrix does.