### PR TITLE
Remove arm64 exclusion

### DIFF
--- a/Configuration/Base.xcconfig
+++ b/Configuration/Base.xcconfig
@@ -60,15 +60,6 @@ IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 WATCHOS_DEPLOYMENT_TARGET = 2.0;
 TVOS_DEPLOYMENT_TARGET = 9.0;
 
-// Xcode 11 "helpfully" "corrects" arm64 to x86_64 when you try to exclude
-// arm64 on platforms that it doesn't support building for arm64 on.
-REALM_ARM_ARCHS_1200 = arm64 arm64e;
-REALM_ARM_ARCHS = $(REALM_ARM_ARCHS_$(XCODE_VERSION_MAJOR))
-
-EXCLUDED_ARCHS[sdk=watchsimulator*] = $(REALM_ARM_ARCHS);
-EXCLUDED_ARCHS[sdk=iphonesimulator*] = $(REALM_ARM_ARCHS);
-EXCLUDED_ARCHS[sdk=appletvsimulator*] = $(REALM_ARM_ARCHS);
-
 SWIFT_VERSION = 5.0;
 TARGETED_DEVICE_FAMILY = 1,2,3,4;
 SDKROOT = $(REALM_SDKROOT);


### PR DESCRIPTION
Arm64 should be available on all platforms now.