### PR TITLE
Refactor parts of RLMQueryUtil to reduce template instantiations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@ x.y.z Release notes (yyyy-MM-dd)
 =============================================================
 ### Enhancements
 * Add Xcode 12.3 binary to release package.
+* Add support for queries which have nil on the left side and a keypath on the
+  right side (e.g. "nil == name" rather than "name == nil" as was previously
+  required).
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-cocoa/issues/????), since v?.?.?)

--- a/Realm/RLMQueryUtil.mm
+++ b/Realm/RLMQueryUtil.mm
@@ -43,20 +43,23 @@ NSString * const RLMUnsupportedTypesFoundInPropertyComparisonException = @"RLMUn
 NSString * const RLMPropertiesComparisonTypeMismatchReason = @"Property type mismatch between %@ and %@";
 NSString * const RLMUnsupportedTypesFoundInPropertyComparisonReason = @"Comparison between %@ and %@";
 
+namespace {
+
 // small helper to create the many exceptions thrown when parsing predicates
-static NSException *RLMPredicateException(NSString *name, NSString *format, ...) {
+[[gnu::cold]] [[noreturn]]
+void throwException(NSString *name, NSString *format, ...) {
     va_list args;
     va_start(args, format);
     NSString *reason = [[NSString alloc] initWithFormat:format arguments:args];
     va_end(args);
 
-    return [NSException exceptionWithName:name reason:reason userInfo:nil];
+    @throw [NSException exceptionWithName:name reason:reason userInfo:nil];
 }
 
 // check a precondition and throw an exception if it is not met
 // this should be used iff the condition being false indicates a bug in the caller
 // of the function checking its preconditions
-static void RLMPrecondition(bool condition, NSString *name, NSString *format, ...) {
+void RLMPrecondition(bool condition, NSString *name, NSString *format, ...) {
     if (__builtin_expect(condition, 1)) {
         return;
     }
@@ -69,16 +72,7 @@ static void RLMPrecondition(bool condition, NSString *name, NSString *format, ..
     @throw [NSException exceptionWithName:name reason:reason userInfo:nil];
 }
 
-// return the property for a validated column name
-RLMProperty *RLMValidatedProperty(RLMObjectSchema *desc, NSString *columnName) {
-    RLMProperty *prop = desc[columnName];
-    RLMPrecondition(prop, @"Invalid property name",
-                    @"Property '%@' not found in object of type '%@'", columnName, desc.className);
-    return prop;
-}
-
-namespace {
-BOOL RLMPropertyTypeIsNumeric(RLMPropertyType propertyType) {
+BOOL propertyTypeIsNumeric(RLMPropertyType propertyType) {
     switch (propertyType) {
         case RLMPropertyTypeInt:
         case RLMPropertyTypeFloat:
@@ -201,6 +195,13 @@ NSString *operatorName(NSPredicateOperatorType operatorType)
     return [NSString stringWithFormat:@"unknown operator %lu", (unsigned long)operatorType];
 }
 
+[[gnu::cold]] [[noreturn]]
+void unsupportedOperator(RLMPropertyType datatype, NSPredicateOperatorType operatorType) {
+    throwException(@"Invalid operator type",
+                   @"Operator '%@' not supported for type %@",
+                   operatorName(operatorType), RLMTypeToString(datatype));
+}
+
 Table& get_table(Group& group, RLMObjectSchema *objectSchema)
 {
     return *ObjectStore::table_for_object_type(group, objectSchema.objectName.UTF8String);
@@ -220,24 +221,15 @@ public:
     auto resolve(SubQuery&&... subquery) const
     {
         static_assert(sizeof...(SubQuery) < 2, "resolve() takes at most one subquery");
-        LinkChain lc(m_table);
-        walk_link_chain([&](Table const& link_origin, ColKey col, RLMPropertyType type) {
-            if (type != RLMPropertyTypeLinkingObjects) {
-                lc.link(col);
-            }
-            else {
-                lc.backlink(link_origin, col);
-            }
-        });
+        LinkChain lc = link_chain();
 
         if (type() != RLMPropertyTypeLinkingObjects) {
             return lc.column<T>(column(), std::forward<SubQuery>(subquery)...);
         }
 
         if constexpr (std::is_same_v<T, Link>) {
-            return with_link_origin(m_property, [&](Table& table, ColKey col) {
-                return lc.column<T>(table, col, std::forward<SubQuery>(subquery)...);
-            });
+            auto [table, col] = link_origin(m_property);
+            return lc.column<T>(table, col, std::forward<SubQuery>(subquery)...);
         }
 
         REALM_TERMINATE("LinkingObjects property did not have column type Link");
@@ -287,23 +279,35 @@ private:
                 table = table->get_link_target(index).unchecked_ptr();
             }
             else {
-                with_link_origin(link, [&](Table& link_origin_table, ColKey link_origin_column) {
-                    func(link_origin_table, link_origin_column, link.type);
-                    table = &link_origin_table;
-                });
+                auto [link_origin_table, link_origin_column] = link_origin(link);
+                func(link_origin_table, link_origin_column, link.type);
+                table = &link_origin_table;
             }
         }
         return *table;
     }
 
-    template<typename Func>
-    auto with_link_origin(RLMProperty *prop, Func&& func) const
+    std::pair<Table&, ColKey> link_origin(RLMProperty *prop) const
     {
         RLMObjectSchema *link_origin_schema = m_schema[prop.objectClassName];
         Table& link_origin_table = get_table(*m_group, link_origin_schema);
         NSString *column_name = link_origin_schema[prop.linkOriginPropertyName].columnName;
         auto link_origin_column = link_origin_table.get_column_key(column_name.UTF8String);
-        return func(link_origin_table, link_origin_column);
+        return {link_origin_table, link_origin_column};
+    }
+
+    LinkChain link_chain() const
+    {
+        LinkChain lc(m_table);
+        walk_link_chain([&](Table const& link_origin, ColKey col, RLMPropertyType type) {
+            if (type != RLMPropertyTypeLinkingObjects) {
+                lc.link(col);
+            }
+            else {
+                lc.backlink(link_origin, col);
+            }
+        });
+        return lc;
     }
 
     std::vector<RLMProperty*> m_links;
@@ -341,7 +345,7 @@ public:
             case Maximum:
             case Sum:
             case Average:
-                RLMPrecondition(m_column && RLMPropertyTypeIsNumeric(m_column->type()), @"Invalid predicate",
+                RLMPrecondition(m_column && propertyTypeIsNumeric(m_column->type()), @"Invalid predicate",
                                 @"%@ can only be applied to a numeric property.", name_for_type(m_type));
                 break;
         }
@@ -376,14 +380,14 @@ public:
     void validate_comparison(const ColumnReference& column) const {
         switch (m_type) {
             case Count:
-                RLMPrecondition(RLMPropertyTypeIsNumeric(column.type()), @"Invalid operand",
+                RLMPrecondition(propertyTypeIsNumeric(column.type()), @"Invalid operand",
                                 @"%@ can only be compared with a numeric value.", name_for_type(m_type));
                 break;
             case Average:
             case Minimum:
             case Maximum:
             case Sum:
-                RLMPrecondition(RLMPropertyTypeIsNumeric(column.type()), @"Invalid operand",
+                RLMPrecondition(propertyTypeIsNumeric(column.type()), @"Invalid operand",
                                 @"%@ on a property of type %@ cannot be compared with property of type '%@'",
                                 name_for_type(m_type), RLMTypeToString(m_column->type()), RLMTypeToString(column.type()));
                 break;
@@ -407,7 +411,7 @@ private:
         if ([name isEqualToString:@"@avg"]) {
             return Average;
         }
-        @throw RLMPredicateException(@"Invalid predicate", @"Unsupported collection operation '%@'", name);
+        throwException(@"Invalid predicate", @"Unsupported collection operation '%@'", name);
     }
 
     static NSString *name_for_type(Type type) {
@@ -436,10 +440,6 @@ public:
     void apply_collection_operator_expression(RLMObjectSchema *desc, NSString *keyPath, id value, NSComparisonPredicate *pred);
     void apply_value_expression(RLMObjectSchema *desc, NSString *keyPath, id value, NSComparisonPredicate *pred);
     void apply_column_expression(RLMObjectSchema *desc, NSString *leftKeyPath, NSString *rightKeyPath, NSComparisonPredicate *predicate);
-    void apply_subquery_count_expression(RLMObjectSchema *objectSchema, NSExpression *subqueryExpression,
-                                         NSPredicateOperatorType operatorType, NSExpression *right);
-    void apply_function_subquery_expression(RLMObjectSchema *objectSchema, NSExpression *functionExpression,
-                                            NSPredicateOperatorType operatorType, NSExpression *right);
     void apply_function_expression(RLMObjectSchema *objectSchema, NSExpression *functionExpression,
                                    NSPredicateOperatorType operatorType, NSExpression *right);
 
@@ -464,16 +464,11 @@ public:
                                Columns<String> &&column,
                                T value);
 
-    void add_string_constraint(NSPredicateOperatorType operatorType,
-                               NSComparisonPredicateOptions predicateOptions,
-                               StringData value,
-                               Columns<String>&& column);
-
-    template <typename L, typename R>
+    template <typename R>
     void add_constraint(RLMPropertyType type,
                         NSPredicateOperatorType operatorType,
                         NSComparisonPredicateOptions predicateOptions,
-                        L const& lhs, R const& rhs);
+                        ColumnReference const& column, R const& rhs);
     template <typename... T>
     void do_add_constraint(RLMPropertyType type, NSPredicateOperatorType operatorType,
                            NSComparisonPredicateOptions predicateOptions, T&&... values);
@@ -484,20 +479,18 @@ public:
     void add_binary_constraint(NSPredicateOperatorType operatorType, const ColumnReference& column, BinaryData value);
     void add_binary_constraint(NSPredicateOperatorType operatorType, const ColumnReference& column, id value);
     void add_binary_constraint(NSPredicateOperatorType operatorType, const ColumnReference& column, null);
-    void add_binary_constraint(NSPredicateOperatorType operatorType, id value, const ColumnReference& column);
     void add_binary_constraint(NSPredicateOperatorType, const ColumnReference&, const ColumnReference&);
 
     void add_link_constraint(NSPredicateOperatorType operatorType, const ColumnReference& column, RLMObjectBase *obj);
     void add_link_constraint(NSPredicateOperatorType operatorType, const ColumnReference& column, realm::null);
-    template<typename T>
-    void add_link_constraint(NSPredicateOperatorType operatorType, T obj, const ColumnReference& column);
     void add_link_constraint(NSPredicateOperatorType, const ColumnReference&, const ColumnReference&);
 
-    template <CollectionOperation::Type Operation, typename... T>
-    void add_collection_operation_constraint(RLMPropertyType propertyType, NSPredicateOperatorType operatorType, T... values);
-    template <typename... T>
+    template <CollectionOperation::Type Operation, typename R>
+    void add_collection_operation_constraint(RLMPropertyType propertyType, NSPredicateOperatorType operatorType,
+                                             const CollectionOperation& collectionOperation, R rhs);
+    template <typename R>
     void add_collection_operation_constraint(NSPredicateOperatorType operatorType,
-                                             CollectionOperation collectionOperation, T... values);
+                                             const CollectionOperation& collectionOperation, R rhs);
 
 
     CollectionOperation collection_operation_from_key_path(RLMObjectSchema *desc, NSString *keyPath);
@@ -535,9 +528,7 @@ void QueryBuilder::add_numeric_constraint(RLMPropertyType datatype,
             m_query.and_query(lhs != rhs);
             break;
         default:
-            @throw RLMPredicateException(@"Invalid operator type",
-                                         @"Operator '%@' not supported for type %@",
-                                         operatorName(operatorType), RLMTypeToString(datatype));
+            unsupportedOperator(datatype, operatorType);
     }
 }
 
@@ -553,9 +544,7 @@ void QueryBuilder::add_bool_constraint(RLMPropertyType datatype,
             m_query.and_query(lhs != rhs);
             break;
         default:
-            @throw RLMPredicateException(@"Invalid operator type",
-                                         @"Operator '%@' not supported for type %@",
-                                         operatorName(operatorType), RLMTypeToString(datatype));
+            unsupportedOperator(datatype, operatorType);
     }
 }
 
@@ -578,6 +567,39 @@ void QueryBuilder::add_substring_constraint(const Columns<T>& value, Query condi
     // We don't need to concern ourselves with the possibility of value traversing a link list
     // and producing multiple values per row as such expressions will have been rejected.
     m_query.and_query(const_cast<Columns<String>&>(value).size() != 0 && std::move(condition));
+}
+
+
+template<typename Comparator>
+Query make_diacritic_insensitive_constraint(bool caseSensitive, std::unique_ptr<Subexpr> left, std::unique_ptr<Subexpr> right) {
+    using CompareCS = Compare<typename Comparator::CaseSensitive>;
+    using CompareCI = Compare<typename Comparator::CaseInsensitive>;
+    if (caseSensitive) {
+        return make_expression<CompareCS>(std::move(left), std::move(right));
+    }
+    else {
+        return make_expression<CompareCI>(std::move(left), std::move(right));
+    }
+};
+
+Query make_diacritic_insensitive_constraint(NSPredicateOperatorType operatorType, bool caseSensitive,
+                                            std::unique_ptr<Subexpr> left, std::unique_ptr<Subexpr> right) {
+    switch (operatorType) {
+        case NSBeginsWithPredicateOperatorType: {
+            constexpr auto flags = kCFCompareDiacriticInsensitive | kCFCompareAnchored;
+            return make_diacritic_insensitive_constraint<ContainsSubstring<flags>>(caseSensitive, std::move(left), std::move(right));
+        }
+        case NSEndsWithPredicateOperatorType: {
+            constexpr auto flags = kCFCompareDiacriticInsensitive | kCFCompareAnchored | kCFCompareBackwards;
+            return make_diacritic_insensitive_constraint<ContainsSubstring<flags>>(caseSensitive, std::move(left), std::move(right));
+        }
+        case NSContainsPredicateOperatorType: {
+            constexpr auto flags = kCFCompareDiacriticInsensitive;
+            return make_diacritic_insensitive_constraint<ContainsSubstring<flags>>(caseSensitive, std::move(left), std::move(right));
+        }
+        default:
+            REALM_COMPILER_HINT_UNREACHABLE();
+    }
 }
 
 template <typename T>
@@ -609,9 +631,7 @@ void QueryBuilder::add_string_constraint(NSPredicateOperatorType operatorType,
                 m_query.and_query(column.like(value, caseSensitive));
                 break;
             default:
-                @throw RLMPredicateException(@"Invalid operator type",
-                                             @"Operator '%@' not supported for string type",
-                                             operatorName(operatorType));
+                unsupportedOperator(RLMPropertyTypeString, operatorType);
         }
         return;
     }
@@ -623,62 +643,23 @@ void QueryBuilder::add_string_constraint(NSPredicateOperatorType operatorType,
     auto left = as_subexpr(column);
     auto right = as_subexpr(value);
 
-    auto make_constraint = [&](auto comparator) {
-        using Comparator = decltype(comparator);
-        using CompareCS = Compare<typename Comparator::CaseSensitive>;
-        using CompareCI = Compare<typename Comparator::CaseInsensitive>;
-        if (caseSensitive) {
-            return make_expression<CompareCS>(std::move(left), std::move(right));
-        }
-        else {
-            return make_expression<CompareCI>(std::move(left), std::move(right));
-        }
-    };
-
     switch (operatorType) {
-        case NSBeginsWithPredicateOperatorType: {
-            using C = ContainsSubstring<kCFCompareDiacriticInsensitive | kCFCompareAnchored>;
-            add_substring_constraint(value, make_constraint(C{}));
+        case NSBeginsWithPredicateOperatorType:
+        case NSEndsWithPredicateOperatorType:
+        case NSContainsPredicateOperatorType:
+            add_substring_constraint(value, make_diacritic_insensitive_constraint(operatorType, caseSensitive, std::move(left), std::move(right)));
             break;
-        }
-        case NSEndsWithPredicateOperatorType: {
-            using C = ContainsSubstring<kCFCompareDiacriticInsensitive | kCFCompareAnchored | kCFCompareBackwards>;
-            add_substring_constraint(value, make_constraint(C{}));
-            break;
-        }
-        case NSContainsPredicateOperatorType: {
-            using C = ContainsSubstring<kCFCompareDiacriticInsensitive>;
-            add_substring_constraint(value, make_constraint(C{}));
-            break;
-        }
         case NSNotEqualToPredicateOperatorType:
             m_query.Not();
             REALM_FALLTHROUGH;
         case NSEqualToPredicateOperatorType:
-            m_query.and_query(make_constraint(Equal<kCFCompareDiacriticInsensitive>{}));
+            m_query.and_query(make_diacritic_insensitive_constraint<Equal<kCFCompareDiacriticInsensitive>>(caseSensitive, std::move(left), std::move(right)));
             break;
         case NSLikePredicateOperatorType:
-            @throw RLMPredicateException(@"Invalid operator type",
-                                         @"Operator 'LIKE' not supported with diacritic-insensitive modifier.");
+            throwException(@"Invalid operator type",
+                           @"Operator 'LIKE' not supported with diacritic-insensitive modifier.");
         default:
-            @throw RLMPredicateException(@"Invalid operator type",
-                                         @"Operator '%@' not supported for string type", operatorName(operatorType));
-    }
-}
-
-void QueryBuilder::add_string_constraint(NSPredicateOperatorType operatorType,
-                                         NSComparisonPredicateOptions predicateOptions,
-                                         StringData value,
-                                         Columns<String>&& column) {
-    switch (operatorType) {
-        case NSEqualToPredicateOperatorType:
-        case NSNotEqualToPredicateOperatorType:
-            add_string_constraint(operatorType, predicateOptions, std::move(column), value);
-            break;
-        default:
-            @throw RLMPredicateException(@"Invalid operator type",
-                                         @"Operator '%@' is not supported for string type with key path on right side of operator",
-                                         operatorName(operatorType));
+            unsupportedOperator(RLMPropertyTypeString, operatorType);
     }
 }
 
@@ -750,8 +731,7 @@ void QueryBuilder::add_binary_constraint(NSPredicateOperatorType operatorType,
             m_query.not_equal(index, value);
             break;
         default:
-            @throw RLMPredicateException(@"Invalid operator type",
-                                         @"Operator '%@' not supported for binary type", operatorName(operatorType));
+            unsupportedOperator(RLMPropertyTypeData, operatorType);
     }
 }
 
@@ -763,21 +743,8 @@ void QueryBuilder::add_binary_constraint(NSPredicateOperatorType operatorType, c
     add_binary_constraint(operatorType, column, BinaryData());
 }
 
-void QueryBuilder::add_binary_constraint(NSPredicateOperatorType operatorType, id value, const ColumnReference& column) {
-    switch (operatorType) {
-        case NSEqualToPredicateOperatorType:
-        case NSNotEqualToPredicateOperatorType:
-            add_binary_constraint(operatorType, column, value);
-            break;
-        default:
-            @throw RLMPredicateException(@"Invalid operator type",
-                                         @"Operator '%@' is not supported for binary type with key path on right side of operator",
-                                         operatorName(operatorType));
-    }
-}
-
 void QueryBuilder::add_binary_constraint(NSPredicateOperatorType, const ColumnReference&, const ColumnReference&) {
-    @throw RLMPredicateException(@"Invalid predicate", @"Comparisons between two NSData properties are not supported");
+    throwException(@"Invalid predicate", @"Comparisons between two NSData properties are not supported");
 }
 
 void QueryBuilder::add_link_constraint(NSPredicateOperatorType operatorType,
@@ -808,17 +775,10 @@ void QueryBuilder::add_link_constraint(NSPredicateOperatorType operatorType,
     add_bool_constraint(RLMPropertyTypeObject, operatorType, column.resolve<Link>(), null());
 }
 
-template<typename T>
-void QueryBuilder::add_link_constraint(NSPredicateOperatorType operatorType, T obj, const ColumnReference& column) {
-    // Link constraints only support the equal-to and not-equal-to operators. The order of operands
-    // is not important for those comparisons so we can delegate to the other implementation.
-    add_link_constraint(operatorType, column, obj);
-}
-
 void QueryBuilder::add_link_constraint(NSPredicateOperatorType, const ColumnReference&, const ColumnReference&) {
     // This is not actually reachable as this case is caught earlier, but this
     // overload is needed for the code to compile
-    @throw RLMPredicateException(@"Invalid predicate", @"Comparisons between two RLMArray properties are not supported");
+    REALM_COMPILER_HINT_UNREACHABLE();
 }
 
 
@@ -955,8 +915,8 @@ void QueryBuilder::do_add_constraint(RLMPropertyType type, NSPredicateOperatorTy
             add_link_constraint(operatorType, values...);
             break;
         default:
-            @throw RLMPredicateException(@"Unsupported predicate value type",
-                                         @"Object type %@ not supported", RLMTypeToString(type));
+            throwException(@"Unsupported predicate value type",
+                           @"Object type %@ not supported", RLMTypeToString(type));
     }
 }
 
@@ -964,8 +924,8 @@ void QueryBuilder::do_add_constraint(RLMPropertyType, NSPredicateOperatorType, N
 {
     // This is not actually reachable as this case is caught earlier, but this
     // overload is needed for the code to compile
-    @throw RLMPredicateException(@"Invalid predicate expressions",
-                                 @"Predicate expressions must compare a keypath and another keypath or a constant value");
+    throwException(@"Invalid predicate expressions",
+                   @"Predicate expressions must compare a keypath and another keypath or a constant value");
 }
 
 bool is_nsnull(id value) {
@@ -977,19 +937,15 @@ bool is_nsnull(T) {
     return false;
 }
 
-template <typename L, typename R>
+template <typename R>
 void QueryBuilder::add_constraint(RLMPropertyType type, NSPredicateOperatorType operatorType,
-                                  NSComparisonPredicateOptions predicateOptions, L const& lhs, R const& rhs)
+                                  NSComparisonPredicateOptions predicateOptions, ColumnReference const& column, R const& rhs)
 {
-    // The expression operators are only overloaded for realm::null on the rhs
-    RLMPrecondition(!is_nsnull(lhs), @"Unsupported operator",
-                    @"Nil is only supported on the right side of operators");
-
     if (is_nsnull(rhs)) {
-        do_add_constraint(type, operatorType, predicateOptions, lhs, realm::null());
+        do_add_constraint(type, operatorType, predicateOptions, column, realm::null());
     }
     else {
-        do_add_constraint(type, operatorType, predicateOptions, lhs, rhs);
+        do_add_constraint(type, operatorType, predicateOptions, column, rhs);
     }
 }
 
@@ -1040,11 +996,11 @@ ColumnReference QueryBuilder::column_reference_from_key_path(RLMObjectSchema *ob
     auto keyPath = key_path_from_string(m_schema, objectSchema, keyPathString);
 
     if (isAggregate && !keyPath.containsToManyRelationship) {
-        @throw RLMPredicateException(@"Invalid predicate",
-                                     @"Aggregate operations can only be used on key paths that include an array property");
+        throwException(@"Invalid predicate",
+                       @"Aggregate operations can only be used on key paths that include an array property");
     } else if (!isAggregate && keyPath.containsToManyRelationship) {
-        @throw RLMPredicateException(@"Invalid predicate",
-                                     @"Key paths that include an array property must use aggregate operations");
+        throwException(@"Invalid predicate",
+                       @"Key paths that include an array property must use aggregate operations");
     }
 
     return ColumnReference(m_query, m_group, m_schema, keyPath.property, std::move(keyPath.links));
@@ -1070,89 +1026,88 @@ void validate_property_value(const ColumnReference& column,
     }
 }
 
-template <typename RequestedType, CollectionOperation::Type OperationType>
-struct ValueOfTypeWithCollectionOperationHelper;
-
-template <>
-struct ValueOfTypeWithCollectionOperationHelper<Int, CollectionOperation::Count> {
-    static auto convert(const CollectionOperation& operation)
-    {
-        assert(operation.type() == CollectionOperation::Count);
-        return operation.link_column().resolve<Link>().count();
-    }
-};
-
-#define VALUE_OF_TYPE_WITH_COLLECTION_OPERATOR_HELPER(OperationType, function) \
-template <typename T> \
-struct ValueOfTypeWithCollectionOperationHelper<T, OperationType> { \
-    static auto convert(const CollectionOperation& operation) \
-    { \
-        REALM_ASSERT(operation.type() == OperationType); \
-        auto targetColumn = operation.link_column().resolve<Link>().template column<T>(operation.column().column()); \
-        return targetColumn.function(); \
-    } \
-} \
-
-VALUE_OF_TYPE_WITH_COLLECTION_OPERATOR_HELPER(CollectionOperation::Minimum, min);
-VALUE_OF_TYPE_WITH_COLLECTION_OPERATOR_HELPER(CollectionOperation::Maximum, max);
-VALUE_OF_TYPE_WITH_COLLECTION_OPERATOR_HELPER(CollectionOperation::Sum, sum);
-VALUE_OF_TYPE_WITH_COLLECTION_OPERATOR_HELPER(CollectionOperation::Average, average);
-#undef VALUE_OF_TYPE_WITH_COLLECTION_OPERATOR_HELPER
-
-template <typename Requested, CollectionOperation::Type OperationType, typename T>
-auto value_of_type_with_collection_operation(T&& value) {
-    return value_of_type<Requested>(std::forward<T>(value));
-}
-
 template <typename Requested, CollectionOperation::Type OperationType>
-auto value_of_type_with_collection_operation(CollectionOperation operation) {
-    using helper = ValueOfTypeWithCollectionOperationHelper<Requested, OperationType>;
-    return helper::convert(operation);
+auto collection_operation_expr(CollectionOperation operation) {
+    auto&& resolved = operation.link_column().resolve<Link>();
+    auto col = operation.column().column();
+
+    REALM_ASSERT(operation.type() == OperationType);
+    if constexpr (OperationType == CollectionOperation::Count) {
+        return resolved.count();
+    }
+    if constexpr (OperationType == CollectionOperation::Minimum) {
+        return resolved.template column<Requested>(col).min();
+    }
+    if constexpr (OperationType == CollectionOperation::Maximum) {
+        return resolved.template column<Requested>(col).max();
+    }
+    if constexpr (OperationType == CollectionOperation::Sum) {
+        return resolved.template column<Requested>(col).sum();
+    }
+    if constexpr (OperationType == CollectionOperation::Average) {
+        return resolved.template column<Requested>(col).average();
+    }
+    REALM_UNREACHABLE();
 }
 
-template <CollectionOperation::Type Operation, typename... T>
-void QueryBuilder::add_collection_operation_constraint(RLMPropertyType propertyType, NSPredicateOperatorType operatorType, T... values)
+template <CollectionOperation::Type Operation, typename R>
+void QueryBuilder::add_collection_operation_constraint(RLMPropertyType propertyType, NSPredicateOperatorType operatorType,
+                                                       CollectionOperation const& collectionOperation, R rhs)
 {
     switch (propertyType) {
         case RLMPropertyTypeInt:
-            add_numeric_constraint(propertyType, operatorType, value_of_type_with_collection_operation<Int, Operation>(values)...);
+            add_numeric_constraint(propertyType, operatorType,
+                                   collection_operation_expr<Int, Operation>(collectionOperation),
+                                   value_of_type<Int>(rhs));
             break;
         case RLMPropertyTypeFloat:
-            add_numeric_constraint(propertyType, operatorType, value_of_type_with_collection_operation<Float, Operation>(values)...);
+            add_numeric_constraint(propertyType, operatorType,
+                                   collection_operation_expr<Float, Operation>(collectionOperation),
+                                   value_of_type<Float>(rhs));
             break;
         case RLMPropertyTypeDouble:
-            add_numeric_constraint(propertyType, operatorType, value_of_type_with_collection_operation<Double, Operation>(values)...);
+            add_numeric_constraint(propertyType, operatorType,
+                                   collection_operation_expr<Double, Operation>(collectionOperation),
+                                   value_of_type<Double>(rhs));
             break;
         case RLMPropertyTypeDecimal128:
-            add_numeric_constraint(propertyType, operatorType, value_of_type_with_collection_operation<Decimal128, Operation>(values)...);
+            add_numeric_constraint(propertyType, operatorType,
+                                   collection_operation_expr<Decimal128, Operation>(collectionOperation),
+                                   value_of_type<Decimal128>(rhs));
             break;
         default:
             REALM_ASSERT(false && "Only numeric property types should hit this path.");
     }
 }
 
-template <typename... T>
+template <typename R>
 void QueryBuilder::add_collection_operation_constraint(NSPredicateOperatorType operatorType,
-                                                  CollectionOperation collectionOperation, T... values)
+                                                       CollectionOperation const& collectionOperation, R rhs)
 {
-    static_assert(sizeof...(T) == 2, "add_collection_operation_constraint accepts only two values as arguments");
+    auto&& resolved = collectionOperation.link_column().resolve<Link>();
 
+    if (collectionOperation.type() == CollectionOperation::Count) {
+        add_numeric_constraint(RLMPropertyTypeInt, operatorType,
+                               resolved.count(), value_of_type<Int>(rhs));
+        return;
+    }
+
+    auto col = collectionOperation.column().column();
+    auto type = collectionOperation.column().type();
     switch (collectionOperation.type()) {
         case CollectionOperation::Count:
-            add_numeric_constraint(RLMPropertyTypeInt, operatorType,
-                                   value_of_type_with_collection_operation<Int, CollectionOperation::Count>(values)...);
             break;
         case CollectionOperation::Minimum:
-            add_collection_operation_constraint<CollectionOperation::Minimum>(collectionOperation.column().type(), operatorType, values...);
+            add_collection_operation_constraint<CollectionOperation::Minimum>(type, operatorType, collectionOperation, rhs);
             break;
         case CollectionOperation::Maximum:
-            add_collection_operation_constraint<CollectionOperation::Maximum>(collectionOperation.column().type(), operatorType, values...);
+            add_collection_operation_constraint<CollectionOperation::Maximum>(type, operatorType, collectionOperation, rhs);
             break;
         case CollectionOperation::Sum:
-            add_collection_operation_constraint<CollectionOperation::Sum>(collectionOperation.column().type(), operatorType, values...);
+            add_collection_operation_constraint<CollectionOperation::Sum>(type, operatorType, collectionOperation, rhs);
             break;
         case CollectionOperation::Average:
-            add_collection_operation_constraint<CollectionOperation::Average>(collectionOperation.column().type(), operatorType, values...);
+            add_collection_operation_constraint<CollectionOperation::Average>(type, operatorType, collectionOperation, rhs);
             break;
     }
 }
@@ -1165,11 +1120,11 @@ NSString *get_collection_operation_name_from_key_path(NSString *keyPath, NSStrin
                                                       NSString **trailingKey) {
     NSRange at  = [keyPath rangeOfString:@"@"];
     if (at.location == NSNotFound || at.location >= keyPath.length - 1) {
-        @throw RLMPredicateException(@"Invalid key path", @"'%@' is not a valid key path'", keyPath);
+        throwException(@"Invalid key path", @"'%@' is not a valid key path'", keyPath);
     }
 
     if (at.location == 0 || [keyPath characterAtIndex:at.location - 1] != '.') {
-        @throw RLMPredicateException(@"Invalid key path", @"'%@' is not a valid key path'", keyPath);
+        throwException(@"Invalid key path", @"'%@' is not a valid key path'", keyPath);
     }
 
     NSRange trailingKeyRange = [keyPath rangeOfString:@"." options:0 range:{at.location, keyPath.length - at.location} locale:nil];
@@ -1201,17 +1156,38 @@ CollectionOperation QueryBuilder::collection_operation_from_key_path(RLMObjectSc
     return {collectionOperationName, std::move(linkColumn), std::move(column)};
 }
 
+NSPredicateOperatorType invert_comparison_operator(NSPredicateOperatorType type) {
+    switch (type) {
+        case NSLessThanPredicateOperatorType:
+            return NSGreaterThanPredicateOperatorType;
+        case NSLessThanOrEqualToPredicateOperatorType:
+            return NSGreaterThanOrEqualToPredicateOperatorType;
+        case NSGreaterThanPredicateOperatorType:
+            return NSLessThanPredicateOperatorType;
+        case NSGreaterThanOrEqualToPredicateOperatorType:
+            return NSLessThanOrEqualToPredicateOperatorType;
+        case NSBeginsWithPredicateOperatorType:
+        case NSEndsWithPredicateOperatorType:
+        case NSContainsPredicateOperatorType:
+        case NSLikePredicateOperatorType:
+            throwException(@"Unsupported predicate", @"Operator '%@' requires a keypath on the left side.", operatorName(type));
+        default:
+            return type;
+    }
+}
+
 void QueryBuilder::apply_collection_operator_expression(RLMObjectSchema *desc,
                                                         NSString *keyPath, id value,
                                                         NSComparisonPredicate *pred) {
     CollectionOperation operation = collection_operation_from_key_path(desc, keyPath);
     operation.validate_comparison(value);
 
-    if (pred.leftExpression.expressionType == NSKeyPathExpressionType) {
-        add_collection_operation_constraint(pred.predicateOperatorType, operation, operation, value);
-    } else {
-        add_collection_operation_constraint(pred.predicateOperatorType, operation, value, operation);
+    auto type = pred.predicateOperatorType;
+    if (pred.leftExpression.expressionType != NSKeyPathExpressionType) {
+        // Turn "a > b" into "b < a" so that we can always put the column on the lhs
+        type = invert_comparison_operator(type);
     }
+    add_collection_operation_constraint(type, operation, value);
 }
 
 void QueryBuilder::apply_value_expression(RLMObjectSchema *desc,
@@ -1247,7 +1223,7 @@ void QueryBuilder::apply_value_expression(RLMObjectSchema *desc,
     if (pred.leftExpression.expressionType == NSKeyPathExpressionType) {
         add_constraint(column.type(), pred.predicateOperatorType, pred.options, std::move(column), value);
     } else {
-        add_constraint(column.type(), pred.predicateOperatorType, pred.options, value, std::move(column));
+        add_constraint(column.type(), invert_comparison_operator(pred.predicateOperatorType), pred.options, std::move(column), value);
     }
 }
 
@@ -1258,21 +1234,22 @@ void QueryBuilder::apply_column_expression(RLMObjectSchema *desc,
     bool left_key_path_contains_collection_operator = key_path_contains_collection_operator(leftKeyPath);
     bool right_key_path_contains_collection_operator = key_path_contains_collection_operator(rightKeyPath);
     if (left_key_path_contains_collection_operator && right_key_path_contains_collection_operator) {
-        @throw RLMPredicateException(@"Unsupported predicate", @"Key paths including aggregate operations cannot be compared with other aggregate operations.");
+        throwException(@"Unsupported predicate", @"Key paths including aggregate operations cannot be compared with other aggregate operations.");
     }
 
     if (left_key_path_contains_collection_operator) {
         CollectionOperation left = collection_operation_from_key_path(desc, leftKeyPath);
         ColumnReference right = column_reference_from_key_path(desc, rightKeyPath, false);
         left.validate_comparison(right);
-        add_collection_operation_constraint(predicate.predicateOperatorType, left, left, std::move(right));
+        add_collection_operation_constraint(predicate.predicateOperatorType, left, std::move(right));
         return;
     }
     if (right_key_path_contains_collection_operator) {
         ColumnReference left = column_reference_from_key_path(desc, leftKeyPath, false);
         CollectionOperation right = collection_operation_from_key_path(desc, rightKeyPath);
         right.validate_comparison(left);
-        add_collection_operation_constraint(predicate.predicateOperatorType, right, std::move(left), right);
+        add_collection_operation_constraint(invert_comparison_operator(predicate.predicateOperatorType),
+                                            right, std::move(left));
         return;
     }
 
@@ -1315,48 +1292,33 @@ NSExpression *simplify_self_value_for_key_path_function_expression(NSExpression 
     return expression;
 }
 
-void QueryBuilder::apply_subquery_count_expression(RLMObjectSchema *objectSchema,
-                                                   NSExpression *subqueryExpression, NSPredicateOperatorType operatorType, NSExpression *right) {
-    if (right.expressionType != NSConstantValueExpressionType || ![right.constantValue isKindOfClass:[NSNumber class]]) {
-        @throw RLMPredicateException(@"Invalid predicate expression", @"SUBQUERY(…).@count is only supported when compared with a constant number.");
-    }
+void QueryBuilder::apply_function_expression(RLMObjectSchema *objectSchema, NSExpression *functionExpression,
+                                             NSPredicateOperatorType operatorType, NSExpression *right) {
+    RLMPrecondition(functionExpression.operand.expressionType == NSSubqueryExpressionType,
+                    @"Invalid predicate", @"The '%@' function is not supported.", functionExpression.function);
+    RLMPrecondition([functionExpression.function isEqualToString:@"valueForKeyPath:"] && functionExpression.arguments.count == 1,
+                    @"Invalid predicate", @"The '%@' function is not supported on the result of a SUBQUERY.", functionExpression.function);
+
+    NSExpression *keyPathExpression = functionExpression.arguments.firstObject;
+    RLMPrecondition([keyPathExpression.keyPath isEqualToString:@"@count"],
+                    @"Invalid predicate", @"SUBQUERY is only supported when immediately followed by .@count that is compared with a constant number.");
+    RLMPrecondition(right.expressionType == NSConstantValueExpressionType && [right.constantValue isKindOfClass:[NSNumber class]],
+                    @"Invalid predicate expression", @"SUBQUERY(…).@count is only supported when compared with a constant number.");
+
+    NSExpression *subqueryExpression = functionExpression.operand;
     int64_t value = [right.constantValue integerValue];
 
     ColumnReference collectionColumn = column_reference_from_key_path(objectSchema, [subqueryExpression.collection keyPath], true);
     RLMObjectSchema *collectionMemberObjectSchema = m_schema[collectionColumn.property().objectClassName];
 
     // Eliminate references to the iteration variable in the subquery.
-    NSPredicate *subqueryPredicate = [subqueryExpression.predicate predicateWithSubstitutionVariables:@{ subqueryExpression.variable : [NSExpression expressionForEvaluatedObject] }];
+    NSPredicate *subqueryPredicate = [subqueryExpression.predicate predicateWithSubstitutionVariables:@{subqueryExpression.variable: [NSExpression expressionForEvaluatedObject]}];
     subqueryPredicate = transformPredicate(subqueryPredicate, simplify_self_value_for_key_path_function_expression);
 
     Query subquery = RLMPredicateToQuery(subqueryPredicate, collectionMemberObjectSchema, m_schema, m_group);
     add_numeric_constraint(RLMPropertyTypeInt, operatorType,
                            collectionColumn.resolve<Link>(std::move(subquery)).count(), value);
 }
-
-void QueryBuilder::apply_function_subquery_expression(RLMObjectSchema *objectSchema, NSExpression *functionExpression,
-                                                      NSPredicateOperatorType operatorType, NSExpression *right) {
-    if (![functionExpression.function isEqualToString:@"valueForKeyPath:"] || functionExpression.arguments.count != 1) {
-        @throw RLMPredicateException(@"Invalid predicate", @"The '%@' function is not supported on the result of a SUBQUERY.", functionExpression.function);
-    }
-
-    NSExpression *keyPathExpression = functionExpression.arguments.firstObject;
-    if ([keyPathExpression.keyPath isEqualToString:@"@count"]) {
-        apply_subquery_count_expression(objectSchema, functionExpression.operand,  operatorType, right);
-    } else {
-        @throw RLMPredicateException(@"Invalid predicate", @"SUBQUERY is only supported when immediately followed by .@count that is compared with a constant number.");
-    }
-}
-
-void QueryBuilder::apply_function_expression(RLMObjectSchema *objectSchema, NSExpression *functionExpression,
-                                             NSPredicateOperatorType operatorType, NSExpression *right) {
-    if (functionExpression.operand.expressionType == NSSubqueryExpressionType) {
-        apply_function_subquery_expression(objectSchema, functionExpression, operatorType, right);
-    } else {
-        @throw RLMPredicateException(@"Invalid predicate", @"The '%@' function is not supported.", functionExpression.function);
-    }
-}
-
 
 void QueryBuilder::apply_predicate(NSPredicate *predicate, RLMObjectSchema *objectSchema)
 {
@@ -1394,14 +1356,13 @@ void QueryBuilder::apply_predicate(NSPredicate *predicate, RLMObjectSchema *obje
                 break;
 
             default:
-                @throw RLMPredicateException(@"Invalid compound predicate type",
-                                             @"Only support AND, OR and NOT predicate types");
+                throwException(@"Invalid compound predicate type",
+                               @"Only support AND, OR and NOT predicate types");
         }
     }
     else if ([predicate isMemberOfClass:[NSComparisonPredicate class]]) {
         NSComparisonPredicate *compp = (NSComparisonPredicate *)predicate;
 
-        // check modifier
         RLMPrecondition(compp.comparisonPredicateModifier != NSAllPredicateModifier,
                         @"Invalid predicate", @"ALL modifier not supported");
 
@@ -1430,12 +1391,12 @@ void QueryBuilder::apply_predicate(NSPredicate *predicate, RLMObjectSchema *obje
             }
             else {
                 if (compp.predicateOperatorType == NSBetweenPredicateOperatorType) {
-                    @throw RLMPredicateException(@"Invalid predicate",
-                                                 @"Predicate with BETWEEN operator must compare a KeyPath with an aggregate with two values");
+                    throwException(@"Invalid predicate",
+                                   @"Predicate with BETWEEN operator must compare a KeyPath with an aggregate with two values");
                 }
                 else if (compp.predicateOperatorType == NSInPredicateOperatorType) {
-                    @throw RLMPredicateException(@"Invalid predicate",
-                                                 @"Predicate with IN operator must compare a KeyPath with an aggregate");
+                    throwException(@"Invalid predicate",
+                                   @"Predicate with IN operator must compare a KeyPath with an aggregate");
                 }
             }
         }
@@ -1457,11 +1418,11 @@ void QueryBuilder::apply_predicate(NSPredicate *predicate, RLMObjectSchema *obje
         }
         else if (exp1Type == NSSubqueryExpressionType) {
             // The subquery expressions that we support are handled by the NSFunctionExpressionType case above.
-            @throw RLMPredicateException(@"Invalid predicate expression", @"SUBQUERY is only supported when immediately followed by .@count.");
+            throwException(@"Invalid predicate expression", @"SUBQUERY is only supported when immediately followed by .@count.");
         }
         else {
-            @throw RLMPredicateException(@"Invalid predicate expressions",
-                                         @"Predicate expressions must compare a keypath and another keypath or a constant value");
+            throwException(@"Invalid predicate expressions",
+                           @"Predicate expressions must compare a keypath and another keypath or a constant value");
         }
     }
     else if ([predicate isEqual:[NSPredicate predicateWithValue:YES]]) {
@@ -1471,8 +1432,8 @@ void QueryBuilder::apply_predicate(NSPredicate *predicate, RLMObjectSchema *obje
     }
     else {
         // invalid predicate type
-        @throw RLMPredicateException(@"Invalid predicate",
-                                     @"Only support compound, comparison, and constant predicates");
+        throwException(@"Invalid predicate",
+                       @"Only support compound, comparison, and constant predicates");
     }
 }
 } // namespace
@@ -1496,4 +1457,12 @@ realm::Query RLMPredicateToQuery(NSPredicate *predicate, RLMObjectSchema *object
     RLMPrecondition(validateMessage.empty(), @"Invalid query", @"%.*s",
                     (int)validateMessage.size(), validateMessage.c_str());
     return query;
+}
+
+// return the property for a validated column name
+RLMProperty *RLMValidatedProperty(RLMObjectSchema *desc, NSString *columnName) {
+    RLMProperty *prop = desc[columnName];
+    RLMPrecondition(prop, @"Invalid property name",
+                    @"Property '%@' not found in object of type '%@'", columnName, desc.className);
+    return prop;
 }

--- a/Realm/Tests/QueryTests.m
+++ b/Realm/Tests/QueryTests.m
@@ -196,27 +196,15 @@
     RLMAssertThrowsWithReasonMatching([PersonLinkObject objectsWhere:@"SOME person.age > 5"], @"Aggregate operations can only.*array property");
     RLMAssertThrowsWithReasonMatching([PersonLinkObject objectsWhere:@"NONE person.age > 5"], @"Aggregate operations can only.*array property");
 
-    // nil on LHS of comparison with nullable property
-    XCTAssertThrows([AllOptionalTypes objectsWhere:@"nil = boolObj"]);
-    XCTAssertThrows([AllOptionalTypes objectsWhere:@"nil = intObj"]);
-    XCTAssertThrows([AllOptionalTypes objectsWhere:@"nil = floatObj"]);
-    XCTAssertThrows([AllOptionalTypes objectsWhere:@"nil = doubleObj"]);
-    XCTAssertThrows([AllOptionalTypes objectsWhere:@"nil = string"]);
-    XCTAssertThrows([AllOptionalTypes objectsWhere:@"nil = data"]);
-    XCTAssertThrows([AllOptionalTypes objectsWhere:@"nil = date"]);
-    XCTAssertThrows([AllOptionalTypes objectsWhere:@"nil = objectId"]);
-    XCTAssertThrows([AllOptionalTypes objectsWhere:@"nil = decimal"]);
-
     // comparing two constants
-    XCTAssertThrows([PersonObject objectsWhere:@"5 = 5"]);
-    XCTAssertThrows([PersonObject objectsWhere:@"nil = nil"]);
+    RLMAssertThrowsWithReason([PersonObject objectsWhere:@"5 = 5"],
+                              @"Predicate expressions must compare a keypath and another keypath or a constant value");
+    RLMAssertThrowsWithReason([PersonObject objectsWhere:@"nil = nil"],
+                              @"Predicate expressions must compare a keypath and another keypath or a constant value");
 
     // substring operations with constant on LHS
-    XCTAssertThrows([AllOptionalTypes objectsWhere:@"'' CONTAINS string"]);
-    XCTAssertThrows([AllOptionalTypes objectsWhere:@"'' BEGINSWITH string"]);
-    XCTAssertThrows([AllOptionalTypes objectsWhere:@"'' ENDSWITH string"]);
-    XCTAssertThrows([AllOptionalTypes objectsWhere:@"'' LIKE string"]);
-    XCTAssertThrows(([AllOptionalTypes objectsWhere:@"%@ CONTAINS data", [NSData data]]));
+    RLMAssertThrowsWithReason(([AllOptionalTypes objectsWhere:@"%@ CONTAINS data", [NSData data]]),
+                              @"Operator 'CONTAINS' requires a keypath on the left side");
 
     // data is missing stuff
     XCTAssertThrows([AllOptionalTypes objectsWhere:@"data = data"]);
@@ -484,9 +472,9 @@
     RLMAssertThrowsWithReason([allObjects objectsWhere:@"boolCol BETWEEN {true, false}"],
                               @"not supported for type bool");
     RLMAssertThrowsWithReason([allObjects objectsWhere:@"stringCol BETWEEN {'', ''}"],
-                              @"not supported for string type");
+                              @"not supported for type string");
     RLMAssertThrowsWithReason(([allObjects objectsWhere:@"binaryCol BETWEEN %@", @[NSData.data, NSData.data]]),
-                              @"not supported for binary type");
+                              @"not supported for type data");
     RLMAssertThrowsWithReason([allObjects objectsWhere:@"cBoolCol BETWEEN {true, false}"],
                               @"not supported for type bool");
     RLMAssertThrowsWithReason(([allObjects objectsWhere:@"objectIdCol BETWEEN %@",
@@ -510,6 +498,13 @@
     RLMAssertCount(AllTypesObject, 3U, @"dateCol >= %@", dates[0]);
     RLMAssertCount(AllTypesObject, 1U, @"dateCol == %@", dates[0]);
     RLMAssertCount(AllTypesObject, 2U, @"dateCol != %@", dates[0]);
+
+    RLMAssertCount(AllTypesObject, 2U, @"%@ < dateCol", dates[0]);
+    RLMAssertCount(AllTypesObject, 3U, @"%@ <= dateCol", dates[0]);
+    RLMAssertCount(AllTypesObject, 2U, @"%@ > dateCol", dates[2]);
+    RLMAssertCount(AllTypesObject, 3U, @"%@ >= dateCol", dates[2]);
+    RLMAssertCount(AllTypesObject, 1U, @"%@ == dateCol", dates[0]);
+    RLMAssertCount(AllTypesObject, 2U, @"%@ != dateCol", dates[0]);
 }
 
 - (void)testDefaultRealmQuery {
@@ -2080,11 +2075,13 @@
     RLMAssertCount(self.queryObjectClass, 3U, @"%@ != objectId2", oid1);
 
     RLMAssertThrowsWithReasonMatching([self.queryObjectClass objectsWhere:@"'Realm' CONTAINS string1"].count,
-                                      @"Operator 'CONTAINS' is not supported .* right side");
+                                      @"Operator 'CONTAINS' requires a keypath on the left side.");
     RLMAssertThrowsWithReasonMatching([self.queryObjectClass objectsWhere:@"'Amazon' BEGINSWITH string2"].count,
-                                      @"Operator 'BEGINSWITH' is not supported .* right side");
+                                      @"Operator 'BEGINSWITH' requires a keypath on the left side.");
     RLMAssertThrowsWithReasonMatching([self.queryObjectClass objectsWhere:@"'Tuba' ENDSWITH string1"].count,
-                                      @"Operator 'ENDSWITH' is not supported .* right side");
+                                      @"Operator 'ENDSWITH' requires a keypath on the left side.");
+    RLMAssertThrowsWithReasonMatching([self.queryObjectClass objectsWhere:@"'Tuba' LIKE string1"].count,
+                                      @"Operator 'LIKE' requires a keypath on the left side.");
 }
 
 - (void)testLinksToDeletedOrMovedObject
@@ -2600,9 +2597,6 @@ struct NullTestData {
 - (void)testPrimitiveOperatorsOnAllNullablePropertyTypes {
     RLMRealm *realm = [self realm];
 
-    // nil on LHS is currently not supported by core
-    XCTAssertThrows([AllOptionalTypes objectsWhere:@"nil = boolObj"]);
-
     // These need to be stored in variables because the struct does not retain them
     NSData *matchingData = [@"" dataUsingEncoding:NSUTF8StringEncoding];
     NSData *notMatchingData = [@"a" dataUsingEncoding:NSUTF8StringEncoding];
@@ -2709,6 +2703,118 @@ struct NullTestData {
             RLMAssertOperator(CONTAINS, 0U, 0U, 0U);
         }
     }
+
+#undef RLMAssertCountWithString
+#undef RLMAssertCountWithPredicate
+#undef RLMAssertOperator
+}
+
+- (void)testPrimitiveOperatorsOnAllNullablePropertyTypesKeypathOnRHS {
+    RLMRealm *realm = [self realm];
+
+    // These need to be stored in variables because the struct does not retain them
+    NSData *matchingData = [@"" dataUsingEncoding:NSUTF8StringEncoding];
+    NSData *notMatchingData = [@"a" dataUsingEncoding:NSUTF8StringEncoding];
+    NSDate *matchingDate = [NSDate dateWithTimeIntervalSince1970:1];
+    NSDate *notMatchingDate = [NSDate dateWithTimeIntervalSince1970:2];
+    RLMDecimal128 *matchingDecimal = [RLMDecimal128 decimalWithNumber:@1];
+    RLMDecimal128 *notMatchingDecimal = [RLMDecimal128 decimalWithNumber:@2];
+    RLMObjectId *matchingObjectId = [RLMObjectId objectId];
+    RLMObjectId *notMatchingObjectId = [RLMObjectId objectId];
+
+    struct NullTestData data[] = {
+        {@"boolObj", @"YES", @"NO", @YES, @NO},
+        {@"intObj", @"1", @"0", @1, @0, true},
+        {@"floatObj", @"1", @"0", @1, @0, true},
+        {@"doubleObj", @"1", @"0", @1, @0, true},
+        {@"string", @"'a'", @"''", @"a", @"", false, true},
+        {@"data", nil, nil, notMatchingData, matchingData, false, true},
+        {@"date", nil, nil, notMatchingDate, matchingDate, true},
+        {@"decimal", nil, nil, notMatchingDecimal, matchingDecimal, true},
+        {@"objectId", nil, nil, notMatchingObjectId, matchingObjectId, false},
+    };
+
+    // Assert that the query "prop op value" gives expectedCount results when
+    // assembled via string formatting
+#define RLMAssertCountWithString(expectedCount, op, prop, value) \
+    do { \
+        NSString *queryStr = [NSString stringWithFormat:@"%@ " #op " %@", value, prop]; \
+        NSUInteger actual = [AllOptionalTypes objectsWhere:queryStr].count; \
+        XCTAssertEqual(expectedCount, actual, @"%@: expected %@, got %@", queryStr, @(expectedCount), @(actual)); \
+        queryStr = [NSString stringWithFormat:@"%@ " #op " %@", value, prop]; \
+        actual = [AllOptionalTypes objectsWhere:queryStr].count; \
+        XCTAssertEqual(expectedCount, actual, @"%@: expected %@, got %@", queryStr, @(expectedCount), @(actual)); \
+    } while (0)
+
+    // Assert that the query "prop op value" gives expectedCount results when
+    // assembled via predicateWithFormat
+#define RLMAssertCountWithPredicate(expectedCount, op, prop, value) \
+    do { \
+        NSPredicate *query = [NSPredicate predicateWithFormat:@ "%@ " #op " %K", value, prop]; \
+        NSUInteger actual = [AllOptionalTypes objectsWithPredicate:query].count; \
+        XCTAssertEqual(expectedCount, actual, @"%@ " #op " %@: expected %@, got %@", prop, value, @(expectedCount), @(actual)); \
+    } while (0)
+
+    // Assert that the given operator gives the expected count for each of the
+    // stored value, a different value, and nil
+#define RLMAssertOperator(op, matchingCount, notMatchingCount, nilCount) \
+    do { \
+        if (d.matchingStr) { \
+            RLMAssertCountWithString(matchingCount, op, d.propertyName, d.matchingStr); \
+            RLMAssertCountWithString(notMatchingCount, op, d.propertyName, d.nonMatchingStr); \
+        } \
+        RLMAssertCountWithString(nilCount, op, d.propertyName, nil); \
+ \
+        RLMAssertCountWithPredicate(matchingCount, op, d.propertyName, d.matchingValue); \
+        RLMAssertCountWithPredicate(notMatchingCount, op, d.propertyName, d.nonMatchingValue); \
+        RLMAssertCountWithPredicate(nilCount, op, d.propertyName, nil); \
+    } while (0)
+
+    // First test with the `matchingValue` stored in each property
+
+    [realm beginWriteTransaction];
+    [AllOptionalTypes createInRealm:realm withValue:@[@NO, @0, @0, @0, @"", matchingData, matchingDate, matchingDecimal, matchingObjectId]];
+    [realm commitWriteTransaction];
+
+    for (size_t i = 0; i < sizeof(data) / sizeof(data[0]); ++i) {
+        struct NullTestData d = data[i];
+        RLMAssertOperator(=,  1U, 0U, 0U);
+        RLMAssertOperator(!=, 0U, 1U, 1U);
+
+        if (d.orderable) {
+            RLMAssertOperator(>,  0U, 1U, 0U);
+            RLMAssertOperator(>=, 1U, 1U, 0U);
+            RLMAssertOperator(<,  0U, 0U, 0U);
+            RLMAssertOperator(<=, 1U, 0U, 0U);
+        }
+    }
+
+    // Retest with all properties nil
+
+    [realm beginWriteTransaction];
+    [realm deleteAllObjects];
+    [AllOptionalTypes createInRealm:realm withValue:@[NSNull.null, NSNull.null,
+                                                      NSNull.null, NSNull.null,
+                                                      NSNull.null, NSNull.null,
+                                                      NSNull.null]];
+    [realm commitWriteTransaction];
+
+    for (size_t i = 0; i < sizeof(data) / sizeof(data[0]); ++i) {
+        struct NullTestData d = data[i];
+        RLMAssertOperator(=, 0U, 0U, 1U);
+        RLMAssertOperator(!=, 1U, 1U, 0U);
+
+        if (d.orderable) {
+            RLMAssertOperator(>,  0U, 0U, 0U);
+            RLMAssertOperator(>=, 0U, 0U, 1U);
+            RLMAssertOperator(<,  0U, 0U, 0U);
+            RLMAssertOperator(<=, 0U, 0U, 1U);
+        }
+    }
+
+#undef RLMAssertCountWithString
+#undef RLMAssertCountWithPredicate
+#undef RLMAssertOperator
 }
 
 - (void)testINPredicateOnNullWithNonNullValues


### PR DESCRIPTION
The main change here is to transform queries which have a constant value on the LHS and a keypath on the RHS into one with the keypath on the RHS when possible. This eliminates a large number of redundant template instantiations, reducing the library size a bit and improving the build time. It also happens to make some queries which previous threw an exception work.

C++17 lets us replace some of the template metaprogramming with `if constexpr` making things a bit simpler.

Exception throwing has been shuffled around to reduce the size of the exception handler tables, and a few things have been refactored to cut down on unneeded duplication due to tmeplating.

In total this bumps about 100 kB off the macOS release binary and is a small net reduction in the amount of non-test code.