### PR TITLE
Fix typo in setup-baas message.

### DIFF
--- a/Realm/ObjectServerTests/RLMSyncTestCase.mm
+++ b/Realm/ObjectServerTests/RLMSyncTestCase.mm
@@ -428,7 +428,7 @@ static NSURL *syncDirectoryForChildProcess() {
         return [super defaultTestSuite];
 
     }
-    NSLog(@"Skipping sync tests: server is not present. Run `build.sh setup-bass` to install it.");
+    NSLog(@"Skipping sync tests: server is not present. Run `build.sh setup-baas` to install it.");
     return [[XCTestSuite alloc] initWithName:[super defaultTestSuite].name];
 }
 


### PR DESCRIPTION
Fixes a typo in the `setup-baas` message in case it was not set up.