### PR TITLE
Add unit tests for non-bridged numeric property values

### DIFF
--- a/RealmSwift/Sync.swift
+++ b/RealmSwift/Sync.swift
@@ -268,7 +268,7 @@ import Combine
 /// This handler is executed on a non-main global `DispatchQueue`.
 @dynamicMemberLookup
 @frozen public struct Functions {
-    
+
     private let user: User
 
     fileprivate init(user: User) {

--- a/RealmSwift/Tests/MigrationTests.swift
+++ b/RealmSwift/Tests/MigrationTests.swift
@@ -276,6 +276,18 @@ class MigrationTests: TestCase {
                 try! Realm().create(SwiftIntObject.self, value: [1])
                 try! Realm().create(SwiftIntObject.self, value: [2])
                 try! Realm().create(SwiftIntObject.self, value: [3])
+                try! Realm().create(SwiftInt8Object.self, value: [Int8(1)])
+                try! Realm().create(SwiftInt8Object.self, value: [Int8(2)])
+                try! Realm().create(SwiftInt8Object.self, value: [Int8(3)])
+                try! Realm().create(SwiftInt16Object.self, value: [Int16(1)])
+                try! Realm().create(SwiftInt16Object.self, value: [Int16(2)])
+                try! Realm().create(SwiftInt16Object.self, value: [Int16(3)])
+                try! Realm().create(SwiftInt32Object.self, value: [Int32(1)])
+                try! Realm().create(SwiftInt32Object.self, value: [Int32(2)])
+                try! Realm().create(SwiftInt32Object.self, value: [Int32(3)])
+                try! Realm().create(SwiftInt64Object.self, value: [Int64(1)])
+                try! Realm().create(SwiftInt64Object.self, value: [Int64(2)])
+                try! Realm().create(SwiftInt64Object.self, value: [Int64(3)])
                 try! Realm().create(SwiftBoolObject.self, value: [true])
                 try! Realm().create(SwiftBoolObject.self, value: [false])
                 try! Realm().create(SwiftBoolObject.self, value: [true])
@@ -308,6 +320,58 @@ class MigrationTests: TestCase {
                 count += 1
             }
             XCTAssertEqual(count, 2)
+            
+            count = 0
+            migration.enumerateObjects(ofType: "SwiftInt8Object") { oldObj, newObj in
+                XCTAssertEqual(newObj!["int8Col"] as! Int8, oldObj!["int8Col"] as! Int8)
+                if oldObj!["int8Col"] as! Int8 == 1 {
+                    migration.delete(newObj!)
+                }
+            }
+            migration.enumerateObjects(ofType: "SwiftInt8Object") { oldObj, newObj in
+                XCTAssertEqual(newObj!["int8Col"] as! Int8, oldObj!["int8Col"] as! Int8)
+                count += 1
+            }
+            XCTAssertEqual(count, 2)
+            
+            count = 0
+            migration.enumerateObjects(ofType: "SwiftInt16Object") { oldObj, newObj in
+                XCTAssertEqual(newObj!["int16Col"] as! Int16, oldObj!["int16Col"] as! Int16)
+                if oldObj!["int16Col"] as! Int16 == 1 {
+                    migration.delete(newObj!)
+                }
+            }
+            migration.enumerateObjects(ofType: "SwiftInt16Object") { oldObj, newObj in
+                XCTAssertEqual(newObj!["int16Col"] as! Int16, oldObj!["int16Col"] as! Int16)
+                count += 1
+            }
+            XCTAssertEqual(count, 2)
+            
+            count = 0
+            migration.enumerateObjects(ofType: "SwiftInt32Object") { oldObj, newObj in
+                XCTAssertEqual(newObj!["int32Col"] as! Int32, oldObj!["int32Col"] as! Int32)
+                if oldObj!["int32Col"] as! Int32 == 1 {
+                    migration.delete(newObj!)
+                }
+            }
+            migration.enumerateObjects(ofType: "SwiftInt32Object") { oldObj, newObj in
+                XCTAssertEqual(newObj!["int32Col"] as! Int32, oldObj!["int32Col"] as! Int32)
+                count += 1
+            }
+            XCTAssertEqual(count, 2)
+            
+            count = 0
+            migration.enumerateObjects(ofType: "SwiftInt64Object") { oldObj, newObj in
+                XCTAssertEqual(newObj!["int64Col"] as! Int64, oldObj!["int64Col"] as! Int64)
+                if oldObj!["int64Col"] as! Int64 == 1 {
+                    migration.delete(newObj!)
+                }
+            }
+            migration.enumerateObjects(ofType: "SwiftInt64Object") { oldObj, newObj in
+                XCTAssertEqual(newObj!["int64Col"] as! Int64, oldObj!["int64Col"] as! Int64)
+                count += 1
+            }
+            XCTAssertEqual(count, 2)
 
             migration.enumerateObjects(ofType: "SwiftBoolObject") { oldObj, newObj in
                 XCTAssertEqual(newObj!["boolCol"] as! Bool, oldObj!["boolCol"] as! Bool)
@@ -329,6 +393,18 @@ class MigrationTests: TestCase {
                 try! Realm().create(SwiftIntObject.self, value: [1])
                 try! Realm().create(SwiftIntObject.self, value: [2])
                 try! Realm().create(SwiftIntObject.self, value: [3])
+                try! Realm().create(SwiftInt8Object.self, value: [Int8(1)])
+                try! Realm().create(SwiftInt8Object.self, value: [Int8(2)])
+                try! Realm().create(SwiftInt8Object.self, value: [Int8(3)])
+                try! Realm().create(SwiftInt16Object.self, value: [Int16(1)])
+                try! Realm().create(SwiftInt16Object.self, value: [Int16(2)])
+                try! Realm().create(SwiftInt16Object.self, value: [Int16(3)])
+                try! Realm().create(SwiftInt32Object.self, value: [Int32(1)])
+                try! Realm().create(SwiftInt32Object.self, value: [Int32(2)])
+                try! Realm().create(SwiftInt32Object.self, value: [Int32(3)])
+                try! Realm().create(SwiftInt64Object.self, value: [Int64(1)])
+                try! Realm().create(SwiftInt64Object.self, value: [Int64(2)])
+                try! Realm().create(SwiftInt64Object.self, value: [Int64(3)])
                 try! Realm().create(SwiftBoolObject.self, value: [true])
                 try! Realm().create(SwiftBoolObject.self, value: [false])
                 try! Realm().create(SwiftBoolObject.self, value: [true])
@@ -360,6 +436,62 @@ class MigrationTests: TestCase {
             }
             migration.enumerateObjects(ofType: "SwiftIntObject") { oldObj, newObj in
                 XCTAssertEqual(newObj!["intCol"] as! Int, oldObj!["intCol"] as! Int)
+                count += 1
+            }
+            XCTAssertEqual(count, 2)
+            
+            count = 0
+            migration.enumerateObjects(ofType: "SwiftInt8Object") { oldObj, newObj in
+                XCTAssertEqual(newObj!["int8Col"] as! Int8, oldObj!["int8Col"] as! Int8)
+                if oldObj!["int8Col"] as! Int8 == 1 {
+                    migration.delete(newObj!)
+                    migration.create("SwiftInt8Object", value: [0])
+                }
+            }
+            migration.enumerateObjects(ofType: "SwiftInt8Object") { oldObj, newObj in
+                XCTAssertEqual(newObj!["int8Col"] as! Int8, oldObj!["int8Col"] as! Int8)
+                count += 1
+            }
+            XCTAssertEqual(count, 2)
+            
+            count = 0
+            migration.enumerateObjects(ofType: "SwiftInt16Object") { oldObj, newObj in
+                XCTAssertEqual(newObj!["int16Col"] as! Int16, oldObj!["int16Col"] as! Int16)
+                if oldObj!["int16Col"] as! Int16 == 1 {
+                    migration.delete(newObj!)
+                    migration.create("SwiftInt16Object", value: [0])
+                }
+            }
+            migration.enumerateObjects(ofType: "SwiftInt16Object") { oldObj, newObj in
+                XCTAssertEqual(newObj!["int16Col"] as! Int16, oldObj!["int16Col"] as! Int16)
+                count += 1
+            }
+            XCTAssertEqual(count, 2)
+            
+            count = 0
+            migration.enumerateObjects(ofType: "SwiftInt32Object") { oldObj, newObj in
+                XCTAssertEqual(newObj!["int32Col"] as! Int32, oldObj!["int32Col"] as! Int32)
+                if oldObj!["int32Col"] as! Int32 == 1 {
+                    migration.delete(newObj!)
+                    migration.create("SwiftInt32Object", value: [0])
+                }
+            }
+            migration.enumerateObjects(ofType: "SwiftInt32Object") { oldObj, newObj in
+                XCTAssertEqual(newObj!["int32Col"] as! Int32, oldObj!["int32Col"] as! Int32)
+                count += 1
+            }
+            XCTAssertEqual(count, 2)
+            
+            count = 0
+            migration.enumerateObjects(ofType: "SwiftInt64Object") { oldObj, newObj in
+                XCTAssertEqual(newObj!["int64Col"] as! Int64, oldObj!["int64Col"] as! Int64)
+                if oldObj!["int64Col"] as! Int64 == 1 {
+                    migration.delete(newObj!)
+                    migration.create("SwiftInt64Object", value: [0])
+                }
+            }
+            migration.enumerateObjects(ofType: "SwiftInt64Object") { oldObj, newObj in
+                XCTAssertEqual(newObj!["int64Col"] as! Int64, oldObj!["int64Col"] as! Int64)
                 count += 1
             }
             XCTAssertEqual(count, 2)
@@ -517,14 +649,14 @@ class MigrationTests: TestCase {
                 XCTAssertEqual((newObj!["boolCol"] as! Bool), true)
                 XCTAssertEqual((oldObj!["intCol"] as! Int), 123)
                 XCTAssertEqual((newObj!["intCol"] as! Int), 123)
-                XCTAssertEqual((oldObj!["int8Col"] as! Int), 123)
-                XCTAssertEqual((newObj!["int8Col"] as! Int), 123)
-                XCTAssertEqual((oldObj!["int16Col"] as! Int), 123)
-                XCTAssertEqual((newObj!["int16Col"] as! Int), 123)
-                XCTAssertEqual((oldObj!["int32Col"] as! Int), 123)
-                XCTAssertEqual((newObj!["int32Col"] as! Int), 123)
-                XCTAssertEqual((oldObj!["int64Col"] as! Int), 123)
-                XCTAssertEqual((newObj!["int64Col"] as! Int), 123)
+                XCTAssertEqual((oldObj!["int8Col"] as! Int8), 123)
+                XCTAssertEqual((newObj!["int8Col"] as! Int8), 123)
+                XCTAssertEqual((oldObj!["int16Col"] as! Int16), 123)
+                XCTAssertEqual((newObj!["int16Col"] as! Int16), 123)
+                XCTAssertEqual((oldObj!["int32Col"] as! Int32), 123)
+                XCTAssertEqual((newObj!["int32Col"] as! Int32), 123)
+                XCTAssertEqual((oldObj!["int64Col"] as! Int64), 123)
+                XCTAssertEqual((newObj!["int64Col"] as! Int64), 123)
                 XCTAssertEqual((oldObj!["intEnumCol"] as! Int), 1)
                 XCTAssertEqual((newObj!["intEnumCol"] as! Int), 1)
                 XCTAssertEqual((oldObj!["floatCol"] as! Float), 1.23 as Float)
@@ -558,10 +690,10 @@ class MigrationTests: TestCase {
                 // edit all values
                 newObj!["boolCol"] = false
                 newObj!["intCol"] = 1
-                newObj!["int8Col"] = 1
-                newObj!["int16Col"] = 1
-                newObj!["int32Col"] = 1
-                newObj!["int64Col"] = 1
+                newObj!["int8Col"] = Int8(1)
+                newObj!["int16Col"] = Int16(1)
+                newObj!["int32Col"] = Int32(1)
+                newObj!["int64Col"] = Int64(1)
                 newObj!["intEnumCol"] = IntEnum.value2.rawValue
                 newObj!["floatCol"] = 1.0
                 newObj!["doubleCol"] = 10.0
@@ -622,10 +754,10 @@ class MigrationTests: TestCase {
         let object = try! Realm().objects(SwiftObject.self).first!
         XCTAssertEqual(object.boolCol, false)
         XCTAssertEqual(object.intCol, 1)
-        XCTAssertEqual(object.int8Col, 1)
-        XCTAssertEqual(object.int16Col, 1)
-        XCTAssertEqual(object.int32Col, 1)
-        XCTAssertEqual(object.int64Col, 1)
+        XCTAssertEqual(object.int8Col, Int8(1))
+        XCTAssertEqual(object.int16Col, Int16(1))
+        XCTAssertEqual(object.int32Col, Int32(1))
+        XCTAssertEqual(object.int64Col, Int64(1))
         XCTAssertEqual(object.floatCol, 1.0 as Float)
         XCTAssertEqual(object.doubleCol, 10.0)
         XCTAssertEqual(object.binaryCol, Data(bytes: "b", count: 1))

--- a/RealmSwift/Tests/MigrationTests.swift
+++ b/RealmSwift/Tests/MigrationTests.swift
@@ -320,7 +320,7 @@ class MigrationTests: TestCase {
                 count += 1
             }
             XCTAssertEqual(count, 2)
-            
+
             count = 0
             migration.enumerateObjects(ofType: "SwiftInt8Object") { oldObj, newObj in
                 XCTAssertEqual(newObj!["int8Col"] as! Int8, oldObj!["int8Col"] as! Int8)
@@ -333,7 +333,7 @@ class MigrationTests: TestCase {
                 count += 1
             }
             XCTAssertEqual(count, 2)
-            
+
             count = 0
             migration.enumerateObjects(ofType: "SwiftInt16Object") { oldObj, newObj in
                 XCTAssertEqual(newObj!["int16Col"] as! Int16, oldObj!["int16Col"] as! Int16)
@@ -346,7 +346,7 @@ class MigrationTests: TestCase {
                 count += 1
             }
             XCTAssertEqual(count, 2)
-            
+
             count = 0
             migration.enumerateObjects(ofType: "SwiftInt32Object") { oldObj, newObj in
                 XCTAssertEqual(newObj!["int32Col"] as! Int32, oldObj!["int32Col"] as! Int32)
@@ -359,7 +359,7 @@ class MigrationTests: TestCase {
                 count += 1
             }
             XCTAssertEqual(count, 2)
-            
+
             count = 0
             migration.enumerateObjects(ofType: "SwiftInt64Object") { oldObj, newObj in
                 XCTAssertEqual(newObj!["int64Col"] as! Int64, oldObj!["int64Col"] as! Int64)
@@ -439,7 +439,7 @@ class MigrationTests: TestCase {
                 count += 1
             }
             XCTAssertEqual(count, 2)
-            
+
             count = 0
             migration.enumerateObjects(ofType: "SwiftInt8Object") { oldObj, newObj in
                 XCTAssertEqual(newObj!["int8Col"] as! Int8, oldObj!["int8Col"] as! Int8)
@@ -453,7 +453,7 @@ class MigrationTests: TestCase {
                 count += 1
             }
             XCTAssertEqual(count, 2)
-            
+
             count = 0
             migration.enumerateObjects(ofType: "SwiftInt16Object") { oldObj, newObj in
                 XCTAssertEqual(newObj!["int16Col"] as! Int16, oldObj!["int16Col"] as! Int16)
@@ -467,7 +467,7 @@ class MigrationTests: TestCase {
                 count += 1
             }
             XCTAssertEqual(count, 2)
-            
+
             count = 0
             migration.enumerateObjects(ofType: "SwiftInt32Object") { oldObj, newObj in
                 XCTAssertEqual(newObj!["int32Col"] as! Int32, oldObj!["int32Col"] as! Int32)
@@ -481,7 +481,7 @@ class MigrationTests: TestCase {
                 count += 1
             }
             XCTAssertEqual(count, 2)
-            
+
             count = 0
             migration.enumerateObjects(ofType: "SwiftInt64Object") { oldObj, newObj in
                 XCTAssertEqual(newObj!["int64Col"] as! Int64, oldObj!["int64Col"] as! Int64)

--- a/RealmSwift/Tests/MigrationTests.swift
+++ b/RealmSwift/Tests/MigrationTests.swift
@@ -517,6 +517,14 @@ class MigrationTests: TestCase {
                 XCTAssertEqual((newObj!["boolCol"] as! Bool), true)
                 XCTAssertEqual((oldObj!["intCol"] as! Int), 123)
                 XCTAssertEqual((newObj!["intCol"] as! Int), 123)
+                XCTAssertEqual((oldObj!["int8Col"] as! Int), 123)
+                XCTAssertEqual((newObj!["int8Col"] as! Int), 123)
+                XCTAssertEqual((oldObj!["int16Col"] as! Int), 123)
+                XCTAssertEqual((newObj!["int16Col"] as! Int), 123)
+                XCTAssertEqual((oldObj!["int32Col"] as! Int), 123)
+                XCTAssertEqual((newObj!["int32Col"] as! Int), 123)
+                XCTAssertEqual((oldObj!["int64Col"] as! Int), 123)
+                XCTAssertEqual((newObj!["int64Col"] as! Int), 123)
                 XCTAssertEqual((oldObj!["intEnumCol"] as! Int), 1)
                 XCTAssertEqual((newObj!["intEnumCol"] as! Int), 1)
                 XCTAssertEqual((oldObj!["floatCol"] as! Float), 1.23 as Float)
@@ -550,6 +558,10 @@ class MigrationTests: TestCase {
                 // edit all values
                 newObj!["boolCol"] = false
                 newObj!["intCol"] = 1
+                newObj!["int8Col"] = 1
+                newObj!["int16Col"] = 1
+                newObj!["int32Col"] = 1
+                newObj!["int64Col"] = 1
                 newObj!["intEnumCol"] = IntEnum.value2.rawValue
                 newObj!["floatCol"] = 1.0
                 newObj!["doubleCol"] = 10.0
@@ -592,7 +604,7 @@ class MigrationTests: TestCase {
                 XCTAssertEqual(list.count, 1)
                 XCTAssertEqual((list[0]["boolCol"] as! Bool), false)
 
-                self.assertMatches(newObj!.description, "SwiftObject \\{\n\tboolCol = 0;\n\tintCol = 1;\n\tintEnumCol = 3;\n\tfloatCol = 1;\n\tdoubleCol = 10;\n\tstringCol = a;\n\tbinaryCol = <.*62.*>;\n\tdateCol = 1970-01-01 00:00:02 \\+0000;\n\tdecimalCol = 5.67E10;\n\tobjectIdCol = abcdef123456abcdef123456;\n\tobjectCol = SwiftBoolObject \\{\n\t\tboolCol = 0;\n\t\\};\n\tarrayCol = List<SwiftBoolObject> <0x[0-9a-f]+> \\(\n\t\t\\[0\\] SwiftBoolObject \\{\n\t\t\tboolCol = 0;\n\t\t\\}\n\t\\);\n\\}")
+                self.assertMatches(newObj!.description, "SwiftObject \\{\n\tboolCol = 0;\n\tintCol = 1;\n\tint8Col = 1;\n\tint16Col = 1;\n\tint32Col = 1;\n\tint64Col = 1;\n\tintEnumCol = 3;\n\tfloatCol = 1;\n\tdoubleCol = 10;\n\tstringCol = a;\n\tbinaryCol = <.*62.*>;\n\tdateCol = 1970-01-01 00:00:02 \\+0000;\n\tdecimalCol = 5.67E10;\n\tobjectIdCol = abcdef123456abcdef123456;\n\tobjectCol = SwiftBoolObject \\{\n\t\tboolCol = 0;\n\t\\};\n\tarrayCol = List<SwiftBoolObject> <0x[0-9a-f]+> \\(\n\t\t\\[0\\] SwiftBoolObject \\{\n\t\t\tboolCol = 0;\n\t\t\\}\n\t\\);\n\\}")
 
                 enumerated = true
             })
@@ -600,7 +612,7 @@ class MigrationTests: TestCase {
 
             let newObj = migration.create(SwiftObject.className())
             // swiftlint:next:disable line_length
-            self.assertMatches(newObj.description, "SwiftObject \\{\n\tboolCol = 0;\n\tintCol = 123;\n\tintEnumCol = 1;\n\tfloatCol = 1\\.23;\n\tdoubleCol = 12\\.3;\n\tstringCol = a;\n\tbinaryCol = <.*61.*>;\n\tdateCol = 1970-01-01 00:00:01 \\+0000;\n\tdecimalCol = 1.23E6;\n\tobjectIdCol = 1234567890ab1234567890ab;\n\tobjectCol = SwiftBoolObject \\{\n\t\tboolCol = 0;\n\t\\};\n\tarrayCol = List<SwiftBoolObject> <0x[0-9a-f]+> \\(\n\t\n\t\\);\n\\}")
+            self.assertMatches(newObj.description, "SwiftObject \\{\n\tboolCol = 0;\n\tintCol = 123;\n\tint8Col = 123;\n\tint16Col = 123;\n\tint32Col = 123;\n\tint64Col = 123;\n\tintEnumCol = 1;\n\tfloatCol = 1\\.23;\n\tdoubleCol = 12\\.3;\n\tstringCol = a;\n\tbinaryCol = <.*61.*>;\n\tdateCol = 1970-01-01 00:00:01 \\+0000;\n\tdecimalCol = 1.23E6;\n\tobjectIdCol = 1234567890ab1234567890ab;\n\tobjectCol = SwiftBoolObject \\{\n\t\tboolCol = 0;\n\t\\};\n\tarrayCol = List<SwiftBoolObject> <0x[0-9a-f]+> \\(\n\t\n\t\\);\n\\}")
         }
 
         // refresh to update realm
@@ -610,6 +622,10 @@ class MigrationTests: TestCase {
         let object = try! Realm().objects(SwiftObject.self).first!
         XCTAssertEqual(object.boolCol, false)
         XCTAssertEqual(object.intCol, 1)
+        XCTAssertEqual(object.int8Col, 1)
+        XCTAssertEqual(object.int16Col, 1)
+        XCTAssertEqual(object.int32Col, 1)
+        XCTAssertEqual(object.int64Col, 1)
         XCTAssertEqual(object.floatCol, 1.0 as Float)
         XCTAssertEqual(object.doubleCol, 10.0)
         XCTAssertEqual(object.binaryCol, Data(bytes: "b", count: 1))

--- a/RealmSwift/Tests/ObjectAccessorTests.swift
+++ b/RealmSwift/Tests/ObjectAccessorTests.swift
@@ -33,6 +33,34 @@ class ObjectAccessorTests: TestCase {
         XCTAssertEqual(object.intCol, 0)
         object.intCol = 1
         XCTAssertEqual(object.intCol, 1)
+        
+        object.int8Col = -1
+        XCTAssertEqual(object.int8Col, -1)
+        object.int8Col = 0
+        XCTAssertEqual(object.int8Col, 0)
+        object.int8Col = 1
+        XCTAssertEqual(object.int8Col, 1)
+        
+        object.int16Col = -1
+        XCTAssertEqual(object.int16Col, -1)
+        object.int16Col = 0
+        XCTAssertEqual(object.int16Col, 0)
+        object.int16Col = 1
+        XCTAssertEqual(object.int16Col, 1)
+        
+        object.int32Col = -1
+        XCTAssertEqual(object.int32Col, -1)
+        object.int32Col = 0
+        XCTAssertEqual(object.int32Col, 0)
+        object.int32Col = 1
+        XCTAssertEqual(object.int32Col, 1)
+        
+        object.int64Col = -1
+        XCTAssertEqual(object.int64Col, -1)
+        object.int64Col = 0
+        XCTAssertEqual(object.int64Col, 0)
+        object.int64Col = 1
+        XCTAssertEqual(object.int64Col, 1)
 
         object.floatCol = 20
         XCTAssertEqual(object.floatCol, 20 as Float)

--- a/RealmSwift/Tests/ObjectAccessorTests.swift
+++ b/RealmSwift/Tests/ObjectAccessorTests.swift
@@ -33,28 +33,28 @@ class ObjectAccessorTests: TestCase {
         XCTAssertEqual(object.intCol, 0)
         object.intCol = 1
         XCTAssertEqual(object.intCol, 1)
-        
+
         object.int8Col = -1
         XCTAssertEqual(object.int8Col, -1)
         object.int8Col = 0
         XCTAssertEqual(object.int8Col, 0)
         object.int8Col = 1
         XCTAssertEqual(object.int8Col, 1)
-        
+
         object.int16Col = -1
         XCTAssertEqual(object.int16Col, -1)
         object.int16Col = 0
         XCTAssertEqual(object.int16Col, 0)
         object.int16Col = 1
         XCTAssertEqual(object.int16Col, 1)
-        
+
         object.int32Col = -1
         XCTAssertEqual(object.int32Col, -1)
         object.int32Col = 0
         XCTAssertEqual(object.int32Col, 0)
         object.int32Col = 1
         XCTAssertEqual(object.int32Col, 1)
-        
+
         object.int64Col = -1
         XCTAssertEqual(object.int64Col, -1)
         object.int64Col = 0

--- a/RealmSwift/Tests/ObjectCreationTests.swift
+++ b/RealmSwift/Tests/ObjectCreationTests.swift
@@ -72,6 +72,10 @@ class ObjectCreationTests: TestCase {
         let baselineValues: [String: Any] =
            ["boolCol": true,
             "intCol": 1,
+            "int8Col": 1 as Int8,
+            "int16Col": 1 as Int16,
+            "int32Col": 1 as Int32,
+            "int64Col": 1 as Int64,
             "floatCol": 1.1 as Float,
             "doubleCol": 11.1,
             "stringCol": "b",
@@ -117,7 +121,7 @@ class ObjectCreationTests: TestCase {
 
     func testInitWithArray() {
         // array with all values specified
-        let baselineValues: [Any] = [true, 1, IntEnum.value1.rawValue, 1.1 as Float,
+        let baselineValues: [Any] = [true, 1, Int8(1), Int16(1), Int32(1), Int64(1), IntEnum.value1.rawValue, 1.1 as Float,
                                      11.1, "b", "b".data(using: String.Encoding.utf8)!,
                                      Date(timeIntervalSince1970: 2), Decimal128(number: 123),
                                      ObjectId.generate(), ["boolCol": true], [[true], [false]]]
@@ -228,6 +232,10 @@ class ObjectCreationTests: TestCase {
         let baselineValues: [String: Any] = [
             "boolCol": true,
             "intCol": 1,
+            "int8Col": 1 as Int8,
+            "int16Col": 1 as Int16,
+            "int32Col": 1 as Int32,
+            "int64Col": 1 as Int64,
             "floatCol": 1.1 as Float,
             "doubleCol": 11.1,
             "stringCol": "b",
@@ -283,7 +291,7 @@ class ObjectCreationTests: TestCase {
 
     func testCreateWithArray() {
         // array with all values specified
-        let baselineValues: [Any] = [true, 1, IntEnum.value1.rawValue, 1.1 as Float,
+        let baselineValues: [Any] = [true, 1, Int8(1), Int16(1), Int32(1), Int64(1), IntEnum.value1.rawValue, 1.1 as Float,
                                      11.1, "b", "b".data(using: String.Encoding.utf8)!,
                                      Date(timeIntervalSince1970: 2), Decimal128(number: 123),
                                      ObjectId.generate(), ["boolCol": true], [[true], [false]]]
@@ -398,6 +406,10 @@ class ObjectCreationTests: TestCase {
         let values: [String: Any] = [
             "boolCol": true,
             "intCol": 1,
+            "int8Col": 1 as Int8,
+            "int16Col": 1 as Int16,
+            "int32Col": 1 as Int32,
+            "int64Col": 1 as Int64,
             "floatCol": 1.1 as Float,
             "doubleCol": 11.1,
             "stringCol": "b",
@@ -426,6 +438,10 @@ class ObjectCreationTests: TestCase {
         let values: [String: Any] = [
             "boolCol": true,
             "intCol": 1,
+            "int8Col": 1 as Int8,
+            "int16Col": 1 as Int16,
+            "int32Col": 1 as Int32,
+            "int64Col": 1 as Int64,
             "floatCol": 1.1 as Float,
             "doubleCol": 11.1,
             "stringCol": "b",
@@ -1246,14 +1262,18 @@ class ObjectCreationTests: TestCase {
                                                    boolObjectListValues: [Bool]) {
         XCTAssertEqual(object.boolCol, (array[0] as! Bool))
         XCTAssertEqual(object.intCol, (array[1] as! Int))
-        XCTAssertEqual(object.intEnumCol, IntEnum(rawValue: array[2] as! Int))
-        XCTAssertEqual(object.floatCol, (array[3] as! NSNumber).floatValue)
-        XCTAssertEqual(object.doubleCol, (array[4] as! Double))
-        XCTAssertEqual(object.stringCol, (array[5] as! String))
-        XCTAssertEqual(object.binaryCol, (array[6] as! Data))
-        XCTAssertEqual(object.dateCol, (array[7] as! Date))
-        XCTAssertEqual(object.decimalCol, Decimal128(value: array[8]))
-        XCTAssertEqual(object.objectIdCol, (array[9] as! ObjectId))
+        XCTAssertEqual(object.int8Col, (array[2] as! Int8))
+        XCTAssertEqual(object.int16Col, (array[3] as! Int16))
+        XCTAssertEqual(object.int32Col, (array[4] as! Int32))
+        XCTAssertEqual(object.int64Col, (array[5] as! Int64))
+        XCTAssertEqual(object.intEnumCol, IntEnum(rawValue: array[6] as! Int))
+        XCTAssertEqual(object.floatCol, (array[7] as! NSNumber).floatValue)
+        XCTAssertEqual(object.doubleCol, (array[8] as! Double))
+        XCTAssertEqual(object.stringCol, (array[9] as! String))
+        XCTAssertEqual(object.binaryCol, (array[10] as! Data))
+        XCTAssertEqual(object.dateCol, (array[11] as! Date))
+        XCTAssertEqual(object.decimalCol, Decimal128(value: array[12]))
+        XCTAssertEqual(object.objectIdCol, (array[13] as! ObjectId))
         XCTAssertEqual(object.objectCol!.boolCol, boolObjectValue)
         XCTAssertEqual(object.arrayCol.count, boolObjectListValues.count)
         for i in 0..<boolObjectListValues.count {
@@ -1264,7 +1284,11 @@ class ObjectCreationTests: TestCase {
     private func verifySwiftObjectWithDictionaryLiteral(_ object: SwiftObject, dictionary: [String: Any],
                                                         boolObjectValue: Bool, boolObjectListValues: [Bool]) {
         XCTAssertEqual(object.boolCol, (dictionary["boolCol"] as! Bool))
-        XCTAssertEqual(object.intCol, (dictionary["intCol"] as! Int))
+        XCTAssertEqual(object.intCol, (dictionary["intCol"] as? Int))
+        XCTAssertEqual(object.int8Col, (dictionary["int8Col"] as? Int8))
+        XCTAssertEqual(object.int16Col, (dictionary["int16Col"] as? Int16))
+        XCTAssertEqual(object.int32Col, (dictionary["int32Col"] as? Int32))
+        XCTAssertEqual(object.int64Col, (dictionary["int64Col"] as? Int64))
         XCTAssertEqual(object.floatCol, (dictionary["floatCol"] as! NSNumber).floatValue)
         XCTAssertEqual(object.doubleCol, (dictionary["doubleCol"] as! Double))
         XCTAssertEqual(object.stringCol, (dictionary["stringCol"] as! String))

--- a/RealmSwift/Tests/ObjectSchemaTests.swift
+++ b/RealmSwift/Tests/ObjectSchemaTests.swift
@@ -30,7 +30,7 @@ class ObjectSchemaTests: TestCase {
         let objectSchema = swiftObjectSchema
         let propertyNames = objectSchema.properties.map { $0.name }
         XCTAssertEqual(propertyNames,
-                       ["boolCol", "intCol", "intEnumCol", "floatCol", "doubleCol",
+                       ["boolCol", "intCol", "int8Col", "int16Col", "int32Col", "int64Col", "intEnumCol", "floatCol", "doubleCol",
                         "stringCol", "binaryCol", "dateCol", "decimalCol",
                         "objectIdCol", "objectCol", "arrayCol"]
         )
@@ -65,6 +65,34 @@ class ObjectSchemaTests: TestCase {
             "        optional = NO;\n" +
             "    }\n" +
             "    intCol {\n" +
+            "        type = int;\n" +
+            "        indexed = NO;\n" +
+            "        isPrimary = NO;\n" +
+            "        array = NO;\n" +
+            "        optional = NO;\n" +
+            "    }\n" +
+            "    int8Col {\n" +
+            "        type = int;\n" +
+            "        indexed = NO;\n" +
+            "        isPrimary = NO;\n" +
+            "        array = NO;\n" +
+            "        optional = NO;\n" +
+            "    }\n" +
+            "    int16Col {\n" +
+            "        type = int;\n" +
+            "        indexed = NO;\n" +
+            "        isPrimary = NO;\n" +
+            "        array = NO;\n" +
+            "        optional = NO;\n" +
+            "    }\n" +
+            "    int32Col {\n" +
+            "        type = int;\n" +
+            "        indexed = NO;\n" +
+            "        isPrimary = NO;\n" +
+            "        array = NO;\n" +
+            "        optional = NO;\n" +
+            "    }\n" +
+            "    int64Col {\n" +
             "        type = int;\n" +
             "        indexed = NO;\n" +
             "        isPrimary = NO;\n" +

--- a/RealmSwift/Tests/ObjectTests.swift
+++ b/RealmSwift/Tests/ObjectTests.swift
@@ -72,7 +72,7 @@ class ObjectTests: TestCase {
         XCTAssert(schema.properties as AnyObject is [Property])
         XCTAssertEqual(schema.className, "SwiftObject")
         XCTAssertEqual(schema.properties.map { $0.name },
-                       ["boolCol", "intCol", "intEnumCol", "floatCol", "doubleCol",
+                       ["boolCol", "intCol", "int8Col", "int16Col", "int32Col", "int64Col", "intEnumCol", "floatCol", "doubleCol",
                         "stringCol", "binaryCol", "dateCol", "decimalCol",
                         "objectIdCol", "objectCol", "arrayCol"]
         )
@@ -118,7 +118,7 @@ class ObjectTests: TestCase {
         let object = SwiftObject()
 
         // swiftlint:disable line_length
-        assertMatches(object.description, "SwiftObject \\{\n\tboolCol = 0;\n\tintCol = 123;\n\tintEnumCol = 1;\n\tfloatCol = 1\\.23;\n\tdoubleCol = 12\\.3;\n\tstringCol = a;\n\tbinaryCol = <.*61.*>;\n\tdateCol = 1970-01-01 00:00:01 \\+0000;\n\tdecimalCol = 1.23E6;\n\tobjectIdCol = 1234567890ab1234567890ab;\n\tobjectCol = SwiftBoolObject \\{\n\t\tboolCol = 0;\n\t\\};\n\tarrayCol = List<SwiftBoolObject> <0x[0-9a-f]+> \\(\n\t\n\t\\);\n\\}")
+        assertMatches(object.description, "SwiftObject \\{\n\tboolCol = 0;\n\tintCol = 123;\n\tint8Col = 123;\n\tint16Col = 123;\n\tint32Col = 123;\n\tint64Col = 123;\n\tintEnumCol = 1;\n\tfloatCol = 1\\.23;\n\tdoubleCol = 12\\.3;\n\tstringCol = a;\n\tbinaryCol = <.*61.*>;\n\tdateCol = 1970-01-01 00:00:01 \\+0000;\n\tdecimalCol = 1.23E6;\n\tobjectIdCol = 1234567890ab1234567890ab;\n\tobjectCol = SwiftBoolObject \\{\n\t\tboolCol = 0;\n\t\\};\n\tarrayCol = List<SwiftBoolObject> <0x[0-9a-f]+> \\(\n\t\n\t\\);\n\\}")
 
         let recursiveObject = SwiftRecursiveObject()
         recursiveObject.objects.append(recursiveObject)
@@ -379,6 +379,18 @@ class ObjectTests: TestCase {
 
         setter(object, 321, "intCol")
         XCTAssertEqual(getter(object, "intCol") as! Int?, 321)
+        
+        setter(object, Int8(1), "int8Col")
+        XCTAssertEqual(getter(object, "int8Col") as! Int8?, 1)
+        
+        setter(object, Int16(321), "int16Col")
+        XCTAssertEqual(getter(object, "int16Col") as! Int16?, 321)
+        
+        setter(object, Int32(321), "int32Col")
+        XCTAssertEqual(getter(object, "int32Col") as! Int32?, 321)
+        
+        setter(object, Int64(321), "int64Col")
+        XCTAssertEqual(getter(object, "int64Col") as! Int64?, 321)
 
         setter(object, NSNumber(value: 32.1 as Float), "floatCol")
         XCTAssertEqual(getter(object, "floatCol") as! Float?, 32.1 as Float)
@@ -431,6 +443,18 @@ class ObjectTests: TestCase {
 
         setter(object, 321, "intCol")
         XCTAssertEqual((getter(object, "intCol") as! Int), 321)
+        
+        setter(object, Int8(1), "int8Col")
+        XCTAssertEqual(getter(object, "int8Col") as! Int8?, 1)
+        
+        setter(object, Int16(321), "int16Col")
+        XCTAssertEqual(getter(object, "int16Col") as! Int16?, 321)
+        
+        setter(object, Int32(321), "int32Col")
+        XCTAssertEqual(getter(object, "int32Col") as! Int32?, 321)
+        
+        setter(object, Int64(321), "int64Col")
+        XCTAssertEqual(getter(object, "int64Col") as! Int64?, 321)
 
         setter(object, NSNumber(value: 32.1 as Float), "floatCol")
         XCTAssertEqual((getter(object, "floatCol") as! Float), 32.1 as Float)

--- a/RealmSwift/Tests/ObjectTests.swift
+++ b/RealmSwift/Tests/ObjectTests.swift
@@ -245,6 +245,10 @@ class ObjectTests: TestCase {
         let test: (SwiftObject) -> Void = { object in
             XCTAssertEqual(object.value(forKey: "boolCol") as! Bool?, false)
             XCTAssertEqual(object.value(forKey: "intCol") as! Int?, 123)
+            XCTAssertEqual(object.value(forKey: "int8Col") as! Int8?, 123)
+            XCTAssertEqual(object.value(forKey: "int16Col") as! Int16?, 123)
+            XCTAssertEqual(object.value(forKey: "int32Col") as! Int32?, 123)
+            XCTAssertEqual(object.value(forKey: "int64Col") as! Int64?, 123)
             XCTAssertEqual(object.value(forKey: "floatCol") as! Float?, 1.23 as Float)
             XCTAssertEqual(object.value(forKey: "doubleCol") as! Double?, 12.3)
             XCTAssertEqual(object.value(forKey: "stringCol") as! String?, "a")

--- a/RealmSwift/Tests/ObjectTests.swift
+++ b/RealmSwift/Tests/ObjectTests.swift
@@ -383,16 +383,16 @@ class ObjectTests: TestCase {
 
         setter(object, 321, "intCol")
         XCTAssertEqual(getter(object, "intCol") as! Int?, 321)
-        
+
         setter(object, Int8(1), "int8Col")
         XCTAssertEqual(getter(object, "int8Col") as! Int8?, 1)
-        
+
         setter(object, Int16(321), "int16Col")
         XCTAssertEqual(getter(object, "int16Col") as! Int16?, 321)
-        
+
         setter(object, Int32(321), "int32Col")
         XCTAssertEqual(getter(object, "int32Col") as! Int32?, 321)
-        
+
         setter(object, Int64(321), "int64Col")
         XCTAssertEqual(getter(object, "int64Col") as! Int64?, 321)
 
@@ -447,16 +447,16 @@ class ObjectTests: TestCase {
 
         setter(object, 321, "intCol")
         XCTAssertEqual((getter(object, "intCol") as! Int), 321)
-        
+
         setter(object, Int8(1), "int8Col")
         XCTAssertEqual(getter(object, "int8Col") as! Int8?, 1)
-        
+
         setter(object, Int16(321), "int16Col")
         XCTAssertEqual(getter(object, "int16Col") as! Int16?, 321)
-        
+
         setter(object, Int32(321), "int32Col")
         XCTAssertEqual(getter(object, "int32Col") as! Int32?, 321)
-        
+
         setter(object, Int64(321), "int64Col")
         XCTAssertEqual(getter(object, "int64Col") as! Int64?, 321)
 

--- a/RealmSwift/Tests/RealmTests.swift
+++ b/RealmSwift/Tests/RealmTests.swift
@@ -518,6 +518,10 @@ class RealmTests: TestCase {
 
         XCTAssertEqual(object["boolCol"] as? NSNumber, dictionary["boolCol"] as! NSNumber?)
         XCTAssertEqual(object["intCol"] as? NSNumber, dictionary["intCol"] as! NSNumber?)
+        XCTAssertEqual(object["int8Col"] as? NSNumber, dictionary["int8Col"] as! NSNumber?)
+        XCTAssertEqual(object["int16Col"] as? NSNumber, dictionary["int16Col"] as! NSNumber?)
+        XCTAssertEqual(object["int32Col"] as? NSNumber, dictionary["int32Col"] as! NSNumber?)
+        XCTAssertEqual(object["int64Col"] as? NSNumber, dictionary["int64Col"] as! NSNumber?)
         XCTAssertEqual(object["floatCol"] as! Float, dictionary["floatCol"] as! Float, accuracy: 0.001)
         XCTAssertEqual(object["doubleCol"] as? NSNumber, dictionary["doubleCol"] as! NSNumber?)
         XCTAssertEqual(object["stringCol"] as! String?, dictionary["stringCol"] as! String?)
@@ -563,6 +567,10 @@ class RealmTests: TestCase {
         for object in objects {
             XCTAssertEqual(object["boolCol"] as? NSNumber, dictionary["boolCol"] as! NSNumber?)
             XCTAssertEqual(object["intCol"] as? NSNumber, dictionary["intCol"] as! NSNumber?)
+            XCTAssertEqual(object["int8Col"] as? NSNumber, dictionary["int8Col"] as! NSNumber?)
+            XCTAssertEqual(object["int16Col"] as? NSNumber, dictionary["int16Col"] as! NSNumber?)
+            XCTAssertEqual(object["int32Col"] as? NSNumber, dictionary["int32Col"] as! NSNumber?)
+            XCTAssertEqual(object["int64Col"] as? NSNumber, dictionary["int64Col"] as! NSNumber?)
             XCTAssertEqual(object["floatCol"] as? NSNumber, dictionary["floatCol"] as! NSNumber?)
             XCTAssertEqual(object["doubleCol"] as? NSNumber, dictionary["doubleCol"] as! NSNumber?)
             XCTAssertEqual(object["stringCol"] as! String?, dictionary["stringCol"] as! String?)

--- a/RealmSwift/Tests/SwiftTestObjects.swift
+++ b/RealmSwift/Tests/SwiftTestObjects.swift
@@ -32,6 +32,22 @@ class SwiftIntObject: Object {
     @objc dynamic var intCol = 0
 }
 
+class SwiftInt8Object: Object {
+    @objc dynamic var int8Col = 0
+}
+
+class SwiftInt16Object: Object {
+    @objc dynamic var int16Col = 0
+}
+
+class SwiftInt32Object: Object {
+    @objc dynamic var int32Col = 0
+}
+
+class SwiftInt64Object: Object {
+    @objc dynamic var intCol = 0
+}
+
 class SwiftLongObject: Object {
     @objc dynamic var longCol: Int64 = 0
 }
@@ -44,6 +60,10 @@ class SwiftLongObject: Object {
 class SwiftObject: Object {
     @objc dynamic var boolCol = false
     @objc dynamic var intCol = 123
+    @objc dynamic var int8Col: Int8 = 123
+    @objc dynamic var int16Col: Int16 = 123
+    @objc dynamic var int32Col: Int32 = 123
+    @objc dynamic var int64Col: Int64 = 123
     @objc dynamic var intEnumCol = IntEnum.value1
     @objc dynamic var floatCol = 1.23 as Float
     @objc dynamic var doubleCol = 12.3
@@ -59,6 +79,10 @@ class SwiftObject: Object {
         return  [
             "boolCol": false,
             "intCol": 123,
+            "int8Col": 123 as Int8,
+            "int16Col": 123 as Int16,
+            "int32Col": 123 as Int32,
+            "int64Col": 123 as Int64,
             "floatCol": 1.23 as Float,
             "doubleCol": 12.3,
             "stringCol": "a",

--- a/RealmSwift/Tests/SwiftTestObjects.swift
+++ b/RealmSwift/Tests/SwiftTestObjects.swift
@@ -45,7 +45,7 @@ class SwiftInt32Object: Object {
 }
 
 class SwiftInt64Object: Object {
-    @objc dynamic var intCol = 0
+    @objc dynamic var int64Col = 0
 }
 
 class SwiftLongObject: Object {
@@ -186,10 +186,10 @@ class SwiftOptionalDefaultValuesObject: Object {
             "optDecimalCol": Decimal128("123"),
             "optObjectIdCol": ObjectId("1234567890ab1234567890ab"),
             "optIntCol": 1,
-            "optInt8Col": 1,
-            "optInt16Col": 1,
-            "optInt32Col": 1,
-            "optInt64Col": 1,
+            "optInt8Col": Int8(1),
+            "optInt16Col": Int16(1),
+            "optInt32Col": Int32(1),
+            "optInt64Col": Int64(1),
             "optFloatCol": 2.2 as Float,
             "optDoubleCol": 3.3,
             "optBoolCol": true
@@ -233,6 +233,10 @@ class SwiftOwnerObject: Object {
 
 class SwiftAggregateObject: Object {
     @objc dynamic var intCol = 0
+    @objc dynamic var int8Col: Int8 = 0
+    @objc dynamic var int16Col: Int16 = 0
+    @objc dynamic var int32Col: Int32 = 0
+    @objc dynamic var int64Col: Int64 = 0
     @objc dynamic var floatCol = 0 as Float
     @objc dynamic var doubleCol = 0.0
     @objc dynamic var decimalCol = 0.0 as Decimal128


### PR DESCRIPTION
Fixes #4011.

Summary:
- unit tests for `Object(value:)`
- unit tests for `Realm.create()`
- add `SwiftInt8Object`, `SwiftInt16Object`, `SwiftInt32Object` and `SwiftInt64Object` on top of the existing `SwiftIntObject`