### PR TITLE
Temporarily disable Cocoapods Catalyst CI tests

### DIFF
--- a/.jenkins.yml
+++ b/.jenkins.yml
@@ -37,7 +37,6 @@ target:
  - cocoapods-ios
  - cocoapods-ios-dynamic
  - cocoapods-watchos
- - cocoapods-catalyst
 configuration:
  - N/A
 
@@ -267,12 +266,3 @@ exclude:
 
   - xcode_version: 12.2
     target: cocoapods-watchos
-
-  - xcode_version: 11.7
-    target: cocoapods-catalyst
-
-  - xcode_version: 12.1
-    target: cocoapods-catalyst
-
-  - xcode_version: 12.2
-    target: cocoapods-catalyst

--- a/scripts/pr-ci-matrix.rb
+++ b/scripts/pr-ci-matrix.rb
@@ -46,7 +46,7 @@ targets = {
   'cocoapods-ios' => oldest_and_latest,
   'cocoapods-ios-dynamic' => oldest_and_latest,
   'cocoapods-watchos' => oldest_and_latest,
-  'cocoapods-catalyst' => oldest_and_latest,
+  # 'cocoapods-catalyst' => oldest_and_latest,
 }
 
 output_file = """


### PR DESCRIPTION
These will continue failing until https://github.com/CocoaPods/CocoaPods/pull/10224 is fixed and it isn't very useful to have it run on every PR until then.