### PR TITLE
Fix SPM test compilation for iOS

### DIFF
--- a/Realm/ObjectServerTests/RLMBSONTests.mm
+++ b/Realm/ObjectServerTests/RLMBSONTests.mm
@@ -94,7 +94,7 @@ using namespace realm::bson;
     auto bson = Bson(realm::ObjectId::gen());
     RLMObjectId *rlm = (RLMObjectId *)RLMConvertBsonToRLMBSON(bson);
     RLMObjectId *d = [[RLMObjectId alloc] initWithString:rlm.stringValue error:nil];
-    XCTAssert([rlm isEqualTo: d]);
+    XCTAssertEqualObjects(rlm, d);
     XCTAssertEqual(RLMConvertRLMBSONToBson(rlm), bson);
 }
 

--- a/Realm/ObjectServerTests/RLMObjectServerTests.mm
+++ b/Realm/ObjectServerTests/RLMObjectServerTests.mm
@@ -38,6 +38,8 @@
 #import <realm/object-store/shared_realm.hpp>
 #import <realm/object-store/sync/sync_manager.hpp>
 
+#if TARGET_OS_OSX
+
 #pragma mark - Helpers
 
 // These are defined in Swift. Importing the auto-generated header doesn't work
@@ -124,7 +126,7 @@ static NSString *generateRandomString(int num) {
     RLMUser *secondUser = [self logInUserForCredentials:[self basicCredentialsWithName:@"test1@10gen.com"
                                                                               register:YES]];
 
-    XCTAssertTrue([[self.app currentUser].identifier isEqualTo:secondUser.identifier]);
+    XCTAssertEqualObjects(self.app.currentUser.identifier, secondUser.identifier);
     // `[app currentUser]` will now be `secondUser`, so let's logout firstUser and ensure
     // the state is correct
     XCTestExpectation *expectation = [self expectationWithDescription:@"should log out current user"];
@@ -2526,3 +2528,5 @@ static NSString *oldPathForPartitionValue(RLMUser *user, id<RLMBSON> partitionVa
 }
 
 @end
+
+#endif // TARGET_OS_OSX

--- a/Realm/ObjectServerTests/RLMSyncTestCase.mm
+++ b/Realm/ObjectServerTests/RLMSyncTestCase.mm
@@ -33,6 +33,8 @@
 #import <realm/object-store/sync/sync_session.hpp>
 #import <realm/object-store/sync/sync_user.hpp>
 
+#if TARGET_OS_OSX
+
 @interface RealmServer : NSObject
 + (RealmServer *)shared;
 + (bool)haveServer;
@@ -558,3 +560,5 @@ static NSURL *syncDirectoryForChildProcess() {
 }
 
 @end
+
+#endif // TARGET_OS_OSX

--- a/Realm/ObjectServerTests/RealmServer.swift
+++ b/Realm/ObjectServerTests/RealmServer.swift
@@ -20,6 +20,8 @@ import Foundation
 import RealmSwift
 import XCTest
 
+#if os(macOS)
+
 extension URLSession {
     fileprivate func resultDataTask(with request: URLRequest, _ completionHandler: @escaping (Result<Data, Error>) -> Void) {
         URLSession(configuration: .default, delegate: nil, delegateQueue: OperationQueue()).dataTask(with: request) { (data, response, error) in
@@ -805,3 +807,5 @@ public class RealmServer: NSObject {
         return clientAppId
     }
 }
+
+#endif

--- a/Realm/ObjectServerTests/SwiftObjectServerTests.swift
+++ b/Realm/ObjectServerTests/SwiftObjectServerTests.swift
@@ -16,6 +16,8 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
+#if os(macOS)
+
 import Combine
 import Realm
 import RealmSwift
@@ -2784,3 +2786,5 @@ class CombineObjectServerTests: SwiftSyncTestCase {
     }
 }
 #endif
+
+#endif // os(macOS)

--- a/Realm/ObjectServerTests/SwiftSyncTestCase.swift
+++ b/Realm/ObjectServerTests/SwiftSyncTestCase.swift
@@ -16,6 +16,8 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
+#if os(macOS)
+
 import XCTest
 import RealmSwift
 
@@ -164,3 +166,5 @@ open class SwiftSyncTestCase: RLMSyncTestCase {
         }
     }
 }
+
+#endif // os(macOS)

--- a/Realm/ObjectServerTests/TimeoutProxyServer.swift
+++ b/Realm/ObjectServerTests/TimeoutProxyServer.swift
@@ -16,6 +16,8 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
+#if os(macOS)
+
 import Foundation
 import Network
 
@@ -88,3 +90,5 @@ public class TimeoutProxyServer: NSObject {
         }
     }
 }
+
+#endif // os(macOS)

--- a/Realm/RLMUtil.mm
+++ b/Realm/RLMUtil.mm
@@ -426,8 +426,6 @@ id RLMMixedToObjc(realm::Mixed const& mixed) {
             return [[RLMObjectId alloc] initWithValue:mixed.get<realm::ObjectId>()];
         case realm::type_Link:
         case realm::type_LinkList:
-        case realm::type_OldTable:
-        case realm::type_OldDateTime:
             REALM_UNREACHABLE();
         default:
             @throw RLMException(@"Invalid data type for RLMPropertyTypeAny property.");


### PR DESCRIPTION
`isEqualTo:` is a dumb thing from the AppleScript API that doesn't exist on iOS and shouldn't be used, and the sync tests need platform guards since we can't make the files macOS-specific.