### PR TITLE
Change RealmSwift Analytics

### DIFF
--- a/Realm.xcodeproj/project.pbxproj
+++ b/Realm.xcodeproj/project.pbxproj
@@ -460,7 +460,6 @@
 		E8917598197A1B350068ACC6 /* UnicodeTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E8917597197A1B350068ACC6 /* UnicodeTests.m */; };
 		E8917599197A1B350068ACC6 /* UnicodeTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E8917597197A1B350068ACC6 /* UnicodeTests.m */; };
 		E8AE7C261EA436F800CDFF9A /* CompactionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8AE7C251EA436F800CDFF9A /* CompactionTests.swift */; };
-		E8BF67FC1C24D07100E591CD /* SwiftVersion.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8BF67FB1C24D07100E591CD /* SwiftVersion.swift */; };
 		E8C6EAF41DD66C0C00EC1A03 /* RLMSyncUtil_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 1A1C6E241D3FFCF70077B6E7 /* RLMSyncUtil_Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E8C6EAF51DD66C0C00EC1A03 /* RLMSyncUtil_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 1A1C6E241D3FFCF70077B6E7 /* RLMSyncUtil_Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E8DA16F81E81210D0055141C /* CompactionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E8DA16F71E81210D0055141C /* CompactionTests.m */; };
@@ -2271,7 +2270,6 @@
 				68A7B91D2543538B00C703BC /* RLMSupport.swift in Sources */,
 				5D660FFC1BE98D670021E04F /* Schema.swift in Sources */,
 				5D660FFD1BE98D670021E04F /* SortDescriptor.swift in Sources */,
-				E8BF67FC1C24D07100E591CD /* SwiftVersion.swift in Sources */,
 				1AFEF8431D52D2C900495005 /* Sync.swift in Sources */,
 				3F222C4E1E26F51300CA0713 /* ThreadSafeReference.swift in Sources */,
 				5D660FFE1BE98D670021E04F /* Util.swift in Sources */,

--- a/Realm.xcodeproj/project.pbxproj
+++ b/Realm.xcodeproj/project.pbxproj
@@ -22,7 +22,6 @@
 			isa = PBXAggregateTarget;
 			buildConfigurationList = C04B4BDA1B55C47600FAE58E /* Build configuration list for PBXAggregateTarget "Download Core Library" */;
 			buildPhases = (
-				C04B4BDB1B55C47A00FAE58E /* Set Swift Version */,
 				5D659E7F1BE04556006515A0 /* Download Core and Sync */,
 			);
 			dependencies = (
@@ -2133,21 +2132,6 @@
 			shellPath = /bin/sh;
 			shellScript = "sh build.sh download-core\n";
 			showEnvVarsInLog = 0;
-		};
-		C04B4BDB1B55C47A00FAE58E /* Set Swift Version */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Set Swift Version";
-			outputPaths = (
-				"$(SRCROOT)/RealmSwift/SwiftVersion.swift",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "sh build.sh set-swift-version\n";
 		};
 		E8267FB81D90B79000E001C7 /* Get Version Number */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/Realm/RLMAnalytics.mm
+++ b/Realm/RLMAnalytics.mm
@@ -179,9 +179,8 @@ static NSDictionary *RLMAnalyticsPayload() {
     }
 
     NSString *osVersionString = [[NSProcessInfo processInfo] operatingSystemVersionString];
-    Class swiftObjectUtilClass = NSClassFromString(@"RealmSwiftObjectUtil");
-    BOOL isSwift = swiftObjectUtilClass != nil;
-    NSString *swiftVersion = isSwift ? [swiftObjectUtilClass swiftVersion] : @"N/A";
+    Class swiftDecimal128 = NSClassFromString(@"RealmSwiftDecimal128");
+    BOOL isSwift = swiftDecimal128 != nil;
 
     static NSString *kUnknownString = @"unknown";
     NSString *hashedMACAddress = RLMMACAddress() ?: kUnknownString;
@@ -213,7 +212,8 @@ static NSDictionary *RLMAnalyticsPayload() {
 #else
                      @"Target OS Type": @"osx",
 #endif
-                     @"Swift Version": swiftVersion,
+                     @"Clang Version": @__clang_version__,
+                     @"Clang Major Version": @__clang_major__,
                      // Current OS version the app is targetting
                      @"Target OS Version": osVersionString,
                      // Minimum OS version the app is targetting

--- a/RealmSwift.podspec
+++ b/RealmSwift.podspec
@@ -22,7 +22,6 @@ Pod::Spec.new do |s|
   s.source_files = 'RealmSwift/*.swift'
   s.exclude_files = 'RealmSwift/Nonsync.swift'
 
-  s.prepare_command           = 'sh build.sh cocoapods-setup swift'
   s.preserve_paths            = %w(build.sh)
 
   s.pod_target_xcconfig = { 'APPLICATION_EXTENSION_API_ONLY' => 'YES' }

--- a/RealmSwift/Object.swift
+++ b/RealmSwift/Object.swift
@@ -693,14 +693,6 @@ internal class ObjectUtil {
         }
     }()
 
-    private class func swiftVersion() -> NSString {
-#if SWIFT_PACKAGE
-        return "5.1"
-#else
-        return swiftLanguageVersion as NSString
-#endif
-    }
-
     // If the property is a storage property for a lazy Swift property, return
     // the base property name (e.g. `foo.storage` becomes `foo`). Otherwise, nil.
     private static func baseName(forLazySwiftProperty name: String) -> String? {

--- a/build.sh
+++ b/build.sh
@@ -246,7 +246,6 @@ build_docs() {
     local objc="--objc"
 
     if [[ "$language" == "swift" ]]; then
-        sh build.sh set-swift-version
         xcodebuild_arguments="-scheme,RealmSwift"
         module="RealmSwift"
         objc=""
@@ -425,21 +424,6 @@ case "$COMMAND" in
 
     "setup-baas")
         ruby Realm/ObjectServerTests/setup_baas.rb
-        exit 0
-        ;;
-
-    ######################################
-    # Swift versioning
-    ######################################
-    "set-swift-version")
-        version=${2:-$REALM_SWIFT_VERSION}
-
-        SWIFT_VERSION_FILE="RealmSwift/SwiftVersion.swift"
-        CONTENTS="let swiftLanguageVersion = \"$version\""
-        if [ ! -f "$SWIFT_VERSION_FILE" ] || ! grep -q "$CONTENTS" "$SWIFT_VERSION_FILE"; then
-            echo "$CONTENTS" > "$SWIFT_VERSION_FILE"
-        fi
-
         exit 0
         ;;
 
@@ -1057,21 +1041,17 @@ case "$COMMAND" in
     # CocoaPods
     ######################################
     "cocoapods-setup")
-        if [[ "$2" != "swift" ]]; then
-          if [ ! -f core/version.txt ]; then
-            sh build.sh download-core
-          fi
-
-          rm -rf include
-          mkdir -p include
-          cp -R core/realm-monorepo.xcframework/ios-armv7_arm64/Headers include/core
-
-          mkdir -p include
-          echo '' > Realm/RLMPlatform.h
-          cp Realm/*.h Realm/*.hpp include
-        else
-          sh build.sh set-swift-version
+        if [ ! -f core/version.txt ]; then
+          sh build.sh download-core
         fi
+
+        rm -rf include
+        mkdir -p include
+        cp -R core/realm-monorepo.xcframework/ios-armv7_arm64/Headers include/core
+
+        mkdir -p include
+        echo '' > Realm/RLMPlatform.h
+        cp Realm/*.h Realm/*.hpp include
         ;;
 
     ######################################
@@ -1094,7 +1074,6 @@ case "$COMMAND" in
         fi
 
         if [ "$target" = "docs" ]; then
-            sh build.sh set-swift-version
             sh build.sh verify-docs
         elif [ "$target" = "swiftlint" ]; then
             sh build.sh verify-swiftlint


### PR DESCRIPTION
RLMAnalytics will check for `RealmSwiftDecimal128` when determining if RealmSwift is in use.
"SwiftVersion" is removed. Instead "Clang Version" and "Clang Major Version" are reported. These are [tied to Xcode](https://gist.github.com/yamaya/2924292) version.