### PR TITLE
Do not exclude ARM architectures for Carthage

### DIFF
--- a/Configuration/Base.xcconfig
+++ b/Configuration/Base.xcconfig
@@ -59,14 +59,6 @@ IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 WATCHOS_DEPLOYMENT_TARGET = 2.0;
 TVOS_DEPLOYMENT_TARGET = 9.0;
 
-// Disable building the arm64 simulators when using Carthage as it doesn't support them yet
-REALM_ARM_ARCHS_YES = arm64 arm64e;
-REALM_ARM_ARCHS = $(REALM_ARM_ARCHS_$(CARTHAGE))
-
-EXCLUDED_ARCHS[sdk=watchsimulator*] = $(REALM_ARM_ARCHS);
-EXCLUDED_ARCHS[sdk=iphonesimulator*] = $(REALM_ARM_ARCHS);
-EXCLUDED_ARCHS[sdk=appletvsimulator*] = $(REALM_ARM_ARCHS);
-
 SWIFT_VERSION = 5.0;
 TARGETED_DEVICE_FAMILY = 1,2,3,4;
 SDKROOT = $(REALM_SDKROOT);


### PR DESCRIPTION
As currently Carthage 0.37.0 is out, it is no more necessary to exclude ARM architectures from Carthage build.