### PR TITLE
Remove class keyword from RealmEnum example

### DIFF
--- a/RealmSwift/Object.swift
+++ b/RealmSwift/Object.swift
@@ -413,7 +413,7 @@ public final class DynamicObject: Object {
  enum type must explicitly conform to this protocol. For example:
 
  ```
- @objc enum class MyEnum: Int, RealmEnum {
+ @objc enum MyEnum: Int, RealmEnum {
     case first = 1
     case second = 2
     case third = 7


### PR DESCRIPTION
When working on a documentation update to add RealmEnum to the [MongoDB Realm iOS SDK docs site](https://docs.mongodb.com/realm/sdk/ios/), I referenced this in the auto-generated SDK docs, and noticed the `class` keyword shouldn't be in the example. Hope this quick-fix PR is helpful!