### PR TITLE
Create a xcframework package for Carthage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 x.y.z Release notes (yyyy-MM-dd)
 =============================================================
 ### Enhancements
-* None.
+* Package a prebuilt XCFramework for Carthage. Carthage 0.38 and later will
+  download this instead of the old frameworks when using `--use-xcframeworks`.
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-cocoa/issues/????), since v?.?.?)

--- a/scripts/github_release.rb
+++ b/scripts/github_release.rb
@@ -14,8 +14,22 @@ BUILD = BUILD_SH.parent + 'build'
 OBJC_ZIP = BUILD + "realm-objc-#{VERSION}.zip"
 SWIFT_ZIP = BUILD + "realm-swift-#{VERSION}.zip"
 CARTHAGE_ZIP = BUILD + 'Carthage.framework.zip'
+CARTHAGE_XCFRAMEWORK_ZIP = BUILD + 'Carthage.xcframework.zip'
 
 REPOSITORY = 'realm/realm-cocoa'
+
+puts 'Creating Carthage XCFramework package'
+FileUtils.rm_f CARTHAGE_XCFRAMEWORK_ZIP
+CARTHAGE_XCODE_VERSION = BUILD_SH.parent.+('Jenkinsfile.releasability').read()[/carthageXcodeVersion = '([0-9.]+)'/, 1]
+
+Dir.mktmpdir do |tmp|
+  Dir.chdir(tmp) do
+    system('unzip', SWIFT_ZIP.to_path, "realm-swift-#{VERSION}/#{CARTHAGE_XCODE_VERSION}/*.xcframework/**/*", :out=>"/dev/null") || exit(1)
+    Dir.chdir("realm-swift-#{VERSION}/#{CARTHAGE_XCODE_VERSION}") do
+      system('zip', '--symlinks', '-r', CARTHAGE_XCFRAMEWORK_ZIP.to_path, 'Realm.xcframework', 'RealmSwift.xcframework', :out=>"/dev/null") || exit(1)
+    end
+  end
+end
 
 def release_notes(version)
   changelog = BUILD_SH.parent.+('CHANGELOG.md').readlines
@@ -42,7 +56,7 @@ prerelease = (VERSION =~ /alpha|beta|rc/) ? true : false
 response = github.create_release(REPOSITORY, RELEASE, name: RELEASE, body: RELEASE_NOTES, prerelease: prerelease)
 release_url = response[:url]
 
-uploads = [OBJC_ZIP, SWIFT_ZIP, CARTHAGE_ZIP]
+uploads = [OBJC_ZIP, SWIFT_ZIP, CARTHAGE_ZIP, CARTHAGE_XCFRAMEWORK_ZIP]
 uploads.each do |upload|
   puts "Uploading #{upload.basename} to GitHub"
   github.upload_asset(release_url, upload.to_path, content_type: 'application/zip')


### PR DESCRIPTION
Carthage can't actually consume this until 0.38 comes out, but adding the XCFramework version doesn't break the existing one so there's no need to wait for that to be released.