### PR TITLE
Fix `isInvalidated` when using custom schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ x.y.z Release notes (yyyy-MM-dd)
   our propertyWrappers would attempt to remove the KVOs for each cancellation, when it should only be done once.
   We now correctly remove KVOs only once.
   ([#7131](https://github.com/realm/realm-cocoa/issues/7131))
+  * Fixed `isInvalidated` not returning correct value after object deletion from realm when using a custom schema . 
+  Object Schema was not updated when the object was added to the realm.
+  We now correctly update the object schema when adding it to the realm.
+  ([#7181](https://github.com/realm/realm-cocoa/issues/7181))
 
 <!-- ### Breaking Changes - ONLY INCLUDE FOR NEW MAJOR version -->
 

--- a/Realm/RLMAccessor.mm
+++ b/Realm/RLMAccessor.mm
@@ -874,6 +874,7 @@ RLMAccessorContext::createObject(id value, realm::CreatePolicy policy,
 
             objBase->_info = &_info;
             objBase->_realm = _realm;
+            objBase->_objectSchema = _info.rlmObjectSchema;
         }
     }
     if (!policy.create) {

--- a/Realm/Tests/ObjectTests.m
+++ b/Realm/Tests/ObjectTests.m
@@ -1110,6 +1110,40 @@ static void addProperty(Class cls, const char *name, const char *type, size_t si
     XCTAssertNil(obj1.realm, @"Realm should be nil after deletion");
 }
 
+#pragma mark - Invalidated
+
+- (void)testIsInvalidated {
+    RLMRealm *realm = [RLMRealm defaultRealm];
+
+    StringObject *obj1 = [[StringObject alloc] initWithValue:@[@"a"]];
+    XCTAssertEqual(obj1.isInvalidated, NO);
+    [realm transactionWithBlock:^{
+        [realm addObject:obj1];
+    }];
+    XCTAssertEqual(obj1.isInvalidated, NO);
+    [realm transactionWithBlock:^{
+        [realm deleteObject:obj1];
+    }];
+    XCTAssertEqual(obj1.isInvalidated, YES);
+}
+
+- (void)testInvalidatedWithCustomObjectClasses {
+    RLMRealmConfiguration *config = [RLMRealmConfiguration defaultConfiguration];
+    config.objectClasses = @[[StringObject class]];
+    RLMRealm *realm = [RLMRealm realmWithConfiguration:config error:nil];
+
+    StringObject *obj1 = [[StringObject alloc] initWithValue:@[@"a"]];
+    XCTAssertEqual(obj1.isInvalidated, NO);
+    [realm transactionWithBlock:^{
+        [realm addObject:obj1];
+    }];
+    XCTAssertEqual(obj1.isInvalidated, NO);
+    [realm transactionWithBlock:^{
+        [realm deleteObject:obj1];
+    }];
+    XCTAssertEqual(obj1.isInvalidated, YES);
+}
+
 #pragma mark - Primary Keys
 
 - (void)testPrimaryKey {

--- a/RealmSwift/Tests/ObjectTests.swift
+++ b/RealmSwift/Tests/ObjectTests.swift
@@ -112,6 +112,26 @@ class ObjectTests: TestCase {
         XCTAssertTrue(object.isInvalidated)
     }
 
+    func testInvalidatedWithCustomObjectClasses() {
+        var config = Realm.Configuration.defaultConfiguration
+        config.objectTypes = [SwiftObject.self, SwiftBoolObject.self]
+        let realm = try! Realm(configuration: config)
+
+        let object = SwiftObject()
+        XCTAssertFalse(object.isInvalidated)
+
+        try! realm.write {
+            realm.add(object)
+            XCTAssertFalse(object.isInvalidated)
+        }
+
+        try! realm.write {
+            realm.deleteAll()
+            XCTAssertTrue(object.isInvalidated)
+        }
+        XCTAssertTrue(object.isInvalidated)
+    }
+
     func testDescription() {
         let object = SwiftObject()
 


### PR DESCRIPTION
Fix https://github.com/realm/realm-cocoa/issues/7181
Fix `isInvalidated` not returning correct value after object deletion from realm when using a custom schema. 
Object Schema was not updated when the object was added to the realm, we are now updating the objectSchema after adding the object to the realm.
Tests added for this.