### PR TITLE
Fix creating the Carthage xcframework package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ x.y.z Release notes (yyyy-MM-dd)
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-cocoa/issues/????), since v?.?.?)
-* None.
+* Add the Info.plist file to the XCFrameworks in the Carthage xcframwork
+  package (since 10.7.3).
 
 <!-- ### Breaking Changes - ONLY INCLUDE FOR NEW MAJOR version -->
 

--- a/scripts/github_release.rb
+++ b/scripts/github_release.rb
@@ -24,7 +24,7 @@ CARTHAGE_XCODE_VERSION = BUILD_SH.parent.+('Jenkinsfile.releasability').read()[/
 
 Dir.mktmpdir do |tmp|
   Dir.chdir(tmp) do
-    system('unzip', SWIFT_ZIP.to_path, "realm-swift-#{VERSION}/#{CARTHAGE_XCODE_VERSION}/*.xcframework/**/*", :out=>"/dev/null") || exit(1)
+    system('unzip', SWIFT_ZIP.to_path, "realm-swift-#{VERSION}/#{CARTHAGE_XCODE_VERSION}/*.xcframework/*", :out=>"/dev/null") || exit(1)
     Dir.chdir("realm-swift-#{VERSION}/#{CARTHAGE_XCODE_VERSION}") do
       system('zip', '--symlinks', '-r', CARTHAGE_XCFRAMEWORK_ZIP.to_path, 'Realm.xcframework', 'RealmSwift.xcframework', :out=>"/dev/null") || exit(1)
     end


### PR DESCRIPTION
The unzip manpage says that the wildcard syntax is like shell wildcards but that's a lie and the syntax is actually significantly different as it just matches the string with no special handling for directories.

Fixes https://github.com/realm/realm-cocoa/issues/7216.