### PR TITLE
Fix -[RLMListBase isEqual:]`

### DIFF
--- a/Realm/RLMListBase.mm
+++ b/Realm/RLMListBase.mm
@@ -90,7 +90,7 @@
         if (self._rlmArray.realm != other._rlmArray.realm) {
             return NO;
         }
-        return [self._rlmArray isEqual:other._rlmArray];
+        return !self._rlmArray.realm && [self._rlmArray isEqual:other._rlmArray];
     }
     return NO;
 }

--- a/Realm/RLMListBase.mm
+++ b/Realm/RLMListBase.mm
@@ -83,10 +83,14 @@
 }
 
 - (BOOL)isEqual:(id)object {
-    if (auto array = RLMDynamicCast<RLMListBase>(object)) {
-        return !array._rlmArray.realm
-        && ((self._rlmArray.count == 0 && array._rlmArray.count == 0) ||
-            [self._rlmArray isEqual:array._rlmArray]);
+    if (auto other = RLMDynamicCast<RLMListBase>(object)) {
+        if ((self == other) || (self._rlmArray == other._rlmArray)) {
+            return YES;
+        }
+        if (self._rlmArray.realm != other._rlmArray.realm) {
+            return NO;
+        }
+        return [self._rlmArray isEqual:other._rlmArray];
     }
     return NO;
 }

--- a/RealmSwift/Tests/ListTests.swift
+++ b/RealmSwift/Tests/ListTests.swift
@@ -598,6 +598,38 @@ class ListTests: TestCase {
 
         list.realm?.cancelWrite()
     }
+    
+    func testListEquality() {
+        let list1 = List<Int>()
+        list1.append(objectsIn: [1, 2, 3])
+        XCTAssertEqual(list1, list1)
+        
+        let list2 = List<Int>()
+        list2.append(objectsIn: [1, 2, 3])
+        XCTAssertEqual(list1, list2)
+        
+        let realm = try! Realm()
+        
+        let listObj = SwiftListObject(value: ["int": list1])
+        
+        try! realm.write {
+            realm.add(listObj)
+        }
+        
+        XCTAssertEqual(listObj.int, listObj.int)
+        XCTAssertNotEqual(list1, listObj.int)
+        XCTAssertEqual(list1, list2)
+        
+        let listObj2 = SwiftListObject(value: ["int": list2])
+        
+        try! realm.write {
+            realm.add(listObj2)
+        }
+        
+        XCTAssertEqual(listObj2.int, listObj2.int)
+        XCTAssertNotEqual(listObj2.int, list2)
+        XCTAssertEqual(list1, list2)
+    }
 
     func testUnmanagedListComparison() {
         let obj = SwiftIntObject()


### PR DESCRIPTION
There is a bug in Realm where `-[RLMListBase isEqual:]` does not correctly test for two `List<>`s equality.

Simple example:
```swift
class TestObject: RealmSwift.Object {
    let list = List<Int>()
}


let realm = try Realm()

let obj = TestObject()
obj.list.append(objectsIn: [1, 2, 3])

assert(obj.list == obj.list) // <- this will succeed (the list is currently still unmanaged)

try realm.write {
    realm.add(obj)
}

assert(obj.list == obj.list) // <- this will fail (because the list is now managed)
```


Why is this a problem? [`-[RLMListBase isEqual:]`](https://github.com/realm/realm-cocoa/blob/5b707d48ee369b22bc8648e7ae5f515309a6f725/Realm/RLMListBase.mm#L85) is currently implemented in a way that it can only ever return `YES` for unmanaged list objects (see line 87).

This change was introduced by #6845, which attempted to add support for comparing unmanaged `List`s and `RLMArray`s. However, it seems like this PR in fact changed the behaviour so that instead of _also_ being able to compare unmanaged lists, you can now _only_ compare unmanaged lists.

Note: The PR mentioned above also added `-[RLMArray isEqual:]`, with a pretty much identical implementation (only return `YES` for unmanaged objects).
However, since `RLMArray` seems to be used exclusively for unmanaged arrays, I left that method unchanged. (`RLMManagedArray` seems to have a correct `isEqual:` implementation.)