### PR TITLE
Fix exceptions when iterating frozen collections on multiple threads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ x.y.z Release notes (yyyy-MM-dd)
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-cocoa/issues/????), since v?.?.?)
-* None.
+* Iterating over frozen collections on multiple threads at the same time could
+  throw a "count underflow" NSInternalInconsistencyException.
+  ([#7237](https://github.com/realm/realm-cocoa/issues/7237), since v5.0.0).
 
 <!-- ### Breaking Changes - ONLY INCLUDE FOR NEW MAJOR version -->
 

--- a/Realm/Tests/ResultsTests.m
+++ b/Realm/Tests/ResultsTests.m
@@ -1185,4 +1185,11 @@ static RLMResults<IntObject *> *testResults() {
     XCTAssertEqual([frozen objectsWhere:@"intCol = 3"].count, 0);
 }
 
+- (void)testMultithreadedFrozenResultsEnumeration {
+    RLMResults *frozen = [testResults() freeze];
+    dispatch_apply(100, DISPATCH_APPLY_AUTO, ^(__unused size_t i) {
+        for (__unused id obj in frozen);
+    });
+}
+
 @end


### PR DESCRIPTION
Fast enumeration iterates over a snapshot of the Results rather than the Results itself so that enumerating objects and mutating them works properly (we'd otherwise rerun the query after each mutation). For performance, we defer creating the snapshot until it's needed, i.e. until the Realm enters a write transaction or is invalidated. To do this, we keep track of all active RLMFastEnumerator instances on RLMRealm. For frozen Realms, this requires locking as NSHashTable is not thread-safe and failing to lock access to it results in corrupting that type's data structures.

Fixes https://github.com/realm/realm-cocoa/issues/7237.