### PR TITLE
Fix - Force SwiftUI weak link on Cocoapods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ x.y.z Release notes (yyyy-MM-dd)
 * None.
 
 ### Fixed
+* Fix a runtime crash which happens in some Xcode version (Xcode < 12, reported in Xcode 12.5), where SwiftUI is not weak linked by default. This fix only works for Cocoapods projects.
+  ([#7234](https://github.com/realm/realm-cocoa/issues/7234)
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-cocoa/issues/????), since v?.?.?)
 * None.
 

--- a/RealmSwift.podspec
+++ b/RealmSwift.podspec
@@ -17,6 +17,8 @@ Pod::Spec.new do |s|
   s.documentation_url         = "https://realm.io/docs/swift/latest"
   s.license                   = { :type => 'Apache 2.0', :file => 'LICENSE' }
 
+  #s.weak_frameworks = 'SwiftUI'
+
   s.dependency 'Realm', "= #{s.version}"
   s.source_files = 'RealmSwift/*.swift'
   s.exclude_files = 'RealmSwift/Nonsync.swift'

--- a/RealmSwift.podspec
+++ b/RealmSwift.podspec
@@ -17,7 +17,7 @@ Pod::Spec.new do |s|
   s.documentation_url         = "https://realm.io/docs/swift/latest"
   s.license                   = { :type => 'Apache 2.0', :file => 'LICENSE' }
 
-  #s.weak_frameworks = 'SwiftUI'
+  s.weak_frameworks = 'SwiftUI'
 
   s.dependency 'Realm', "= #{s.version}"
   s.source_files = 'RealmSwift/*.swift'


### PR DESCRIPTION
Fix https://github.com/realm/realm-cocoa/issues/7234
 Fix a runtime crash which happens in some Xcode version (Xcode < 12, reported in Xcode 12.5), where SwiftUI is not weak linked by default. This fix only works for Cocoapods projects.