### PR TITLE
Fix running the tests via spm with Xcode 12.5

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -45,6 +45,22 @@ func combineFlags() -> [SwiftSetting]? {
     return nil
 }
 
+// Xcode 12.5's xctest crashes when reading obj-c metadata if the Swift tests
+// aren't built targeting macOS 11. We still want all of the non-test code to
+// target the normal lower version, though.
+func hostMachineArch() -> String {
+    var systemInfo = utsname()
+    uname(&systemInfo)
+    let machineBytes = Mirror(reflecting: systemInfo.machine).children.map { UInt8($0.value as! Int8) }.prefix { $0 != 0 }
+    return String(bytes: machineBytes, encoding: .utf8)!
+}
+let testSwiftSettings: [SwiftSetting]?
+#if swift(>=5.4)
+testSwiftSettings = [.unsafeFlags(["-target", "\(hostMachineArch())-apple-macosx11.0"])] + (combineFlags() ?? [])
+#else
+testSwiftSettings = combineFlags()
+#endif
+
 let package = Package(
     name: "Realm",
     platforms: [
@@ -160,14 +176,15 @@ let package = Package(
         .testTarget(
             name: "RealmObjcSwiftTests",
             dependencies: ["Realm", "RealmTestSupport"],
-            path: "Realm/Tests/Swift"
+            path: "Realm/Tests/Swift",
+            swiftSettings: testSwiftSettings
         ),
         .testTarget(
             name: "RealmSwiftTests",
             dependencies: ["RealmSwift", "RealmTestSupport"],
             path: "RealmSwift/Tests",
             exclude: ["TestUtils.mm"],
-            swiftSettings: combineFlags()
+            swiftSettings: testSwiftSettings
         ),
 
         // Object server tests have support code written in both obj-c and
@@ -190,7 +207,8 @@ let package = Package(
                  "TimeoutProxyServer.swift",
                  "WatchTestUtility.swift",
                  "RealmServer.swift"
-            ]
+            ],
+            swiftSettings: testSwiftSettings
         ),
         .testTarget(
             name: "SwiftObjectServerTests",
@@ -200,7 +218,7 @@ let package = Package(
                  "SwiftObjectServerTests.swift",
                  "SwiftBSONTests.swift"
             ],
-            swiftSettings: combineFlags()
+            swiftSettings: testSwiftSettings
         ),
         .testTarget(
             name: "ObjcObjectServerTests",


### PR DESCRIPTION
Loading test bundles with a deployment target older than macOS 11 into xctest when using SPM and Xcode 12.5 causes crashes when accessing objective-c metadata, presumably because it's incorrectly expecting the modern format. This appears to be specific to xctest, so we don't want to bump the minimum deployment target of everything, and instead only the tests.