### PR TITLE
Don't create unmanaged accessor classes for types which don't need it

### DIFF
--- a/Realm/RLMObjectBase.mm
+++ b/Realm/RLMObjectBase.mm
@@ -48,15 +48,15 @@ static bool isManagedAccessorClass(Class cls) {
     return strncmp(className, accessorClassPrefix, sizeof(accessorClassPrefix) - 1) == 0;
 }
 
-static bool maybeInitObjectSchemaForUnmanaged(RLMObjectBase *obj) {
+static void maybeInitObjectSchemaForUnmanaged(RLMObjectBase *obj) {
     Class cls = obj.class;
     if (isManagedAccessorClass(cls)) {
-        return false;
+        return;
     }
 
     obj->_objectSchema = [cls sharedSchema];
     if (!obj->_objectSchema) {
-        return false;
+        return;
     }
 
     // set default values
@@ -69,14 +69,12 @@ static bool maybeInitObjectSchemaForUnmanaged(RLMObjectBase *obj) {
 
     // set unmanaged accessor class
     object_setClass(obj, obj->_objectSchema.unmanagedClass);
-    return true;
 }
 
 @interface RLMObjectBase () <RLMThreadConfined, RLMThreadConfined_Private>
 @end
 
 @implementation RLMObjectBase
-// unmanaged init
 - (instancetype)init {
     if ((self = [super init])) {
         maybeInitObjectSchemaForUnmanaged(self);
@@ -294,7 +292,7 @@ id RLMCreateManagedAccessor(Class cls, RLMClassInfo *info) {
 
 - (BOOL)isInvalidated {
     // if not unmanaged and our accessor has been detached, we have been deleted
-    return self.class == _objectSchema.accessorClass && !_row.is_valid();
+    return _info && !_row.is_valid();
 }
 
 - (BOOL)isEqual:(id)object {

--- a/Realm/RLMProperty.mm
+++ b/Realm/RLMProperty.mm
@@ -134,24 +134,6 @@ static bool rawTypeShouldBeTreatedAsComputedProperty(NSString *rawType) {
     return self;
 }
 
-- (instancetype)initWithName:(NSString *)name
-             createSelectors:(BOOL)createSelectors {
-    self = [super init];
-    if (self) {
-        _name = name;
-        if (createSelectors) {
-            [self updateAccessors];
-        }
-    }
-
-    return self;
-}
-
-- (void)setName:(NSString *)name {
-    _name = name;
-    [self updateAccessors];
-}
-
 - (void)updateAccessors {
     // populate getter/setter names if generic
     if (!_getterName) {

--- a/Realm/RLMProperty_Private.h
+++ b/Realm/RLMProperty_Private.h
@@ -77,9 +77,6 @@ static inline NSString *RLMTypeToString(RLMPropertyType type) {
                                  property:(objc_property_t)property
                                  instance:(RLMObjectBase *)objectInstance;
 
-- (instancetype)initWithName:(NSString *)name
-             createSelectors:(BOOL)createSelectors;
-
 - (void)updateAccessors;
 
 // private setters

--- a/Realm/RLMSchema.mm
+++ b/Realm/RLMSchema.mm
@@ -83,7 +83,7 @@ static RLMObjectSchema *RLMRegisterClass(Class cls) {
     RLMObjectSchema *schema = [RLMObjectSchema schemaForObjectClass:cls];
     s_sharedSchemaState = prevState;
 
-    // set unmanaged class on shared shema for unmanaged object creation
+    // set unmanaged class on shared schema for unmanaged object creation
     schema.unmanagedClass = RLMUnmanagedAccessorClassForObjectClass(schema.objectClass, schema);
 
     // override sharedSchema class methods for performance

--- a/RealmSwift/Impl/SchemaDiscovery.swift
+++ b/RealmSwift/Impl/SchemaDiscovery.swift
@@ -48,11 +48,15 @@ private func baseName(forLazySwiftProperty name: String) -> String? {
 internal extension RLMProperty {
     convenience init(name: String, value: _RealmSchemaDiscoverable) {
         let valueType = Swift.type(of: value)
-        self.init(name: name, createSelectors: valueType._rlmRequireObjc)
+        self.init()
+        self.name = name
         self.type = valueType._rlmType
         self.optional = valueType._rlmOptional
         valueType._rlmPopulateProperty(self)
         value._rlmPopulateProperty(self)
+        if valueType._rlmRequireObjc {
+            self.updateAccessors()
+        }
     }
 }
 


### PR DESCRIPTION
We only need unmanaged accessor subclasses for objective-c classes which use RLMArray, as the only thing they override is the getters and setters for collection properties. Creating accessors subclasses for all types isn't hugely wasteful but it does use a bit of memory.