### PR TITLE
Fix the sync compactOnLaunch test

### DIFF
--- a/Realm/ObjectServerTests/RLMObjectServerTests.mm
+++ b/Realm/ObjectServerTests/RLMObjectServerTests.mm
@@ -1748,10 +1748,7 @@ static const NSInteger NUMBER_OF_BIG_OBJECTS = 2;
     // Create a large object and then delete it in the next transaction so that
     // the file is bloated
     @autoreleasepool {
-        RLMRealm *realm = [self immediatelyOpenRealmForPartitionValue:partitionValue
-                                                                 user:user
-                                                        encryptionKey:nil
-                                                           stopPolicy:RLMSyncStopPolicyImmediately];
+        RLMRealm *realm = [self openRealmForPartitionValue:partitionValue user:user];
         [realm beginWriteTransaction];
         [realm addObject:[HugeSyncObject hugeSyncObject]];
         [realm commitWriteTransaction];
@@ -1760,12 +1757,11 @@ static const NSInteger NUMBER_OF_BIG_OBJECTS = 2;
         [realm beginWriteTransaction];
         [realm deleteAllObjects];
         [realm commitWriteTransaction];
-        [self waitForUploadsForRealm:realm];
-        [self waitForDownloadsForRealm:realm];
-        [realm.syncSession suspend];
 
         path = realm.configuration.pathOnDisk;
     }
+
+    RLMWaitForRealmToClose(path);
 
     auto fileManager = NSFileManager.defaultManager;
     auto initialSize = [[fileManager attributesOfItemAtPath:path error:nil][NSFileSize] unsignedLongLongValue];

--- a/Realm/RLMRealm.mm
+++ b/Realm/RLMRealm.mm
@@ -84,6 +84,13 @@ static void RLMAddSkipBackupAttributeToItemAtPath(std::string_view path) {
     [[NSURL fileURLWithPath:@(path.data())] setResourceValue:@YES forKey:NSURLIsExcludedFromBackupKey error:nil];
 }
 
+void RLMWaitForRealmToClose(NSString *path) {
+    NSString *lockfilePath = [path stringByAppendingString:@".lock"];
+    File lockfile(lockfilePath.UTF8String, File::mode_Update);
+    lockfile.set_fifo_path([path stringByAppendingString:@".management/lock.fifo"].UTF8String);
+    lockfile.lock_exclusive();
+}
+
 @implementation RLMRealmNotificationToken
 - (void)invalidate {
     [_realm verifyThread];

--- a/Realm/RLMRealm_Private.h
+++ b/Realm/RLMRealm_Private.h
@@ -29,14 +29,15 @@ FOUNDATION_EXTERN void RLMSetSkipBackupAttribute(bool value);
 
 FOUNDATION_EXTERN NSData * _Nullable RLMRealmValidatedEncryptionKey(NSData *key);
 
-FOUNDATION_EXTERN RLMSyncSubscription *RLMCastToSyncSubscription(id obj);
-
 // Set the queue used for async open. For testing purposes only.
 FOUNDATION_EXTERN void RLMSetAsyncOpenQueue(dispatch_queue_t queue);
 
 // Translate an in-flight exception resulting from an operation on a SharedGroup to
 // an NSError or NSException (if error is nil)
 void RLMRealmTranslateException(NSError **error);
+
+// Block until the Realm at the given path is closed.
+FOUNDATION_EXTERN void RLMWaitForRealmToClose(NSString *path);
 
 // RLMRealm private members
 @interface RLMRealm ()


### PR DESCRIPTION
Even with RLMSyncStopPolicyImmediately, closing a sync session is an async operation since it has to happen on the sync worker thread. This can result in the test failing due to sync not closing the Realm file fast enough. Fix this by waiting until we can acquire an exclusive lock on the Realm before we try to reopen it.