### PR TITLE
fix testSyncErrorHandlerErrorDomain

### DIFF
--- a/Realm/ObjectServerTests/RLMObjectServerTests.mm
+++ b/Realm/ObjectServerTests/RLMObjectServerTests.mm
@@ -538,7 +538,10 @@ static NSString *randomEmail() {
     [self manuallySetAccessTokenForUser:user value:[self badAccessToken]];
     [self manuallySetRefreshTokenForUser:user value:[self badAccessToken]];
 
-    [self openRealmForPartitionValue:NSStringFromSelector(_cmd) user:user];
+    [self immediatelyOpenRealmForPartitionValue:NSStringFromSelector(_cmd)
+                                           user:user
+                                  encryptionKey:nil
+                                     stopPolicy:RLMSyncStopPolicyAfterChangesUploaded];
 
     [self waitForExpectationsWithTimeout:10.0 handler:nil];
 }


### PR DESCRIPTION
Fix testSyncErrorHandlerErrorDomain by using `immediatelyOpenRealmForPartitionValue` instead of `openRealmForPartitionValue` which allows us to bypass `waitForDownloadsForRealm` which is in the body of `openRealmForPartitionValue`. The reason for the test failure was that `waitForDownloadsForRealm` was causing a timeout.