### PR TITLE
Copy EmbeddedObject on initializing an unmanaged object

### DIFF
--- a/Realm/RLMObjectBase.mm
+++ b/Realm/RLMObjectBase.mm
@@ -93,7 +93,7 @@ static bool maybeInitObjectSchemaForUnmanaged(RLMObjectBase *obj) {
 }
 
 static id coerceToObjectType(id obj, Class cls, RLMSchema *schema) {
-    if ([obj isKindOfClass:cls]) {
+    if ([obj isKindOfClass:cls] && ![(id)cls isEmbedded]) {
         return obj;
     }
     id value = [[cls alloc] init];

--- a/RealmSwift/Tests/ObjectCreationTests.swift
+++ b/RealmSwift/Tests/ObjectCreationTests.swift
@@ -865,7 +865,30 @@ class ObjectCreationTests: TestCase {
         XCTAssertEqual(copy.array.count, 2)
         XCTAssertEqual(copy.array[0].value, 9)
         XCTAssertEqual(copy.array[1].value, 10)
-        realm.cancelWrite()
+        try! realm.commitWrite()
+        XCTAssertEqual(realm.objects(EmbeddedParentObject.self).count, 2)
+    }
+
+    func testCreateEmbeddedFromManagedObjectInSameRealmCopyingByAdd() {
+        let realm = try! Realm()
+        try! realm.write {
+            let parent = realm.create(EmbeddedParentObject.self, value: [
+                "object": ["value": 5, "child": ["value": 6], "children": [[7], [8]]],
+                "array": [[9], [10]]
+            ])
+            let copy = EmbeddedParentObject(value: parent)
+            realm.add(copy)
+            XCTAssertNotEqual(parent, copy)
+            XCTAssertEqual(copy.object!.value, 5)
+            XCTAssertEqual(copy.object!.child!.value, 6)
+            XCTAssertEqual(copy.object!.children.count, 2)
+            XCTAssertEqual(copy.object!.children[0].value, 7)
+            XCTAssertEqual(copy.object!.children[1].value, 8)
+            XCTAssertEqual(copy.array.count, 2)
+            XCTAssertEqual(copy.array[0].value, 9)
+            XCTAssertEqual(copy.array[1].value, 10)
+        }
+        XCTAssertEqual(realm.objects(EmbeddedParentObject.self).count, 2)
     }
 
     func testCreateEmbeddedFromManagedObjectInDifferentRealm() {


### PR DESCRIPTION
When creating an unmanaged copy of a managed object with the embedded object property we should make a copy of this embedded object instead of reusing it.

This is fix #6921 