### PR TITLE
Actually delete the objects when a dictionary is passed to -[RLMRealm deleteObjects:]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,12 @@ x.y.z Release notes (yyyy-MM-dd)
 ### Enhancements
 * Add `App.emailPasswordAuth.retryCustomConfirmation(email:completion:)` and `[App.emailPasswordAuth retryCustomConfirmation:completion:]`. 
   These functions support retrying a [custom confirmation](https://docs.mongodb.com/realm/authentication/email-password/#run-a-confirmation-function) function.
+* Improve performance of many Dictionary operations, especially when KVO is being used.
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-cocoa/issues/????), since v?.?.?)
-* None.
+* Calling `-[RLMRealm deleteObjects:]` on a `RLMDictionary` cleared the
+  dictionary but did not actually delete the objects in the dictionary (since v10.8.0).
 
 <!-- ### Breaking Changes - ONLY INCLUDE FOR NEW MAJOR version -->
 

--- a/Realm/RLMAccessor.hpp
+++ b/Realm/RLMAccessor.hpp
@@ -45,29 +45,29 @@ struct RLMOptionalId {
 // Use this if you require to box/unbox types and you do not have access to the
 // parent object or realm.
 struct RLMStatelessAccessorContext {
-    id box(bool v) { return @(v); }
-    id box(double v) { return @(v); }
-    id box(float v) { return @(v); }
-    id box(long long v) { return @(v); }
-    id box(realm::StringData v) { return RLMStringDataToNSString(v) ?: NSNull.null; }
-    id box(realm::BinaryData v) { return RLMBinaryDataToNSData(v) ?: NSNull.null; }
-    id box(realm::Timestamp v) { return RLMTimestampToNSDate(v) ?: NSNull.null; }
-    id box(realm::Decimal128 v) { return v.is_null() ? NSNull.null : [[RLMDecimal128 alloc] initWithDecimal128:v]; }
-    id box(realm::ObjectId v) { return [[RLMObjectId alloc] initWithValue:v]; }
-    id box(realm::UUID v) { return [[NSUUID alloc] initWithRealmUUID:v]; }
+    static id box(bool v) { return @(v); }
+    static id box(double v) { return @(v); }
+    static id box(float v) { return @(v); }
+    static id box(long long v) { return @(v); }
+    static id box(realm::StringData v) { return RLMStringDataToNSString(v) ?: NSNull.null; }
+    static id box(realm::BinaryData v) { return RLMBinaryDataToNSData(v) ?: NSNull.null; }
+    static id box(realm::Timestamp v) { return RLMTimestampToNSDate(v) ?: NSNull.null; }
+    static id box(realm::Decimal128 v) { return v.is_null() ? NSNull.null : [[RLMDecimal128 alloc] initWithDecimal128:v]; }
+    static id box(realm::ObjectId v) { return [[RLMObjectId alloc] initWithValue:v]; }
+    static id box(realm::UUID v) { return [[NSUUID alloc] initWithRealmUUID:v]; }
 
-    id box(realm::util::Optional<bool> v) { return v ? @(*v) : NSNull.null; }
-    id box(realm::util::Optional<double> v) { return v ? @(*v) : NSNull.null; }
-    id box(realm::util::Optional<float> v) { return v ? @(*v) : NSNull.null; }
-    id box(realm::util::Optional<int64_t> v) { return v ? @(*v) : NSNull.null; }
-    id box(realm::util::Optional<realm::ObjectId> v) { return v ? box(*v) : NSNull.null; }
-    id box(realm::util::Optional<realm::UUID> v) { return v ? box(*v) : NSNull.null; }
+    static id box(realm::util::Optional<bool> v) { return v ? @(*v) : NSNull.null; }
+    static id box(realm::util::Optional<double> v) { return v ? @(*v) : NSNull.null; }
+    static id box(realm::util::Optional<float> v) { return v ? @(*v) : NSNull.null; }
+    static id box(realm::util::Optional<int64_t> v) { return v ? @(*v) : NSNull.null; }
+    static id box(realm::util::Optional<realm::ObjectId> v) { return v ? box(*v) : NSNull.null; }
+    static id box(realm::util::Optional<realm::UUID> v) { return v ? box(*v) : NSNull.null; }
 
     template<typename T>
-    T unbox(id v);
+    static T unbox(id v);
 
     template<typename Func>
-    void enumerate_collection(__unsafe_unretained const id v, Func&& func) {
+    static void enumerate_collection(__unsafe_unretained const id v, Func&& func) {
         id enumerable = RLMAsFastEnumeration(v) ?: v;
         for (id value in enumerable) {
             func(value);
@@ -75,23 +75,23 @@ struct RLMStatelessAccessorContext {
     }
 
     template<typename Func>
-    void enumerate_dictionary(__unsafe_unretained const id v, Func&& func) {
+    static void enumerate_dictionary(__unsafe_unretained const id v, Func&& func) {
         id enumerable = RLMAsFastEnumeration(v) ?: v;
         for (id key in enumerable) {
             func(unbox<realm::StringData>(key), v[key]);
         }
     }
 
-    bool is_null(id v) { return v == NSNull.null; }
-    id null_value() { return NSNull.null; }
-    id no_value() { return nil; }
-    bool allow_missing(id v) { return [v isKindOfClass:[NSArray class]]; }
+    static bool is_null(id v) noexcept { return v == NSNull.null; }
+    static id null_value() noexcept { return NSNull.null; }
+    static id no_value() noexcept { return nil; }
+    static bool allow_missing(id v) noexcept { return [v isKindOfClass:[NSArray class]]; }
 
-    bool is_same_list(realm::List const& list, id v) const noexcept;
-    bool is_same_dictionary(realm::object_store::Dictionary const&, id) const noexcept;
-    bool is_same_set(realm::object_store::Set const&, id) const noexcept;
+    static bool is_same_list(realm::List const& list, id v) noexcept;
+    static bool is_same_dictionary(realm::object_store::Dictionary const&, id) noexcept;
+    static bool is_same_set(realm::object_store::Set const&, id) noexcept;
 
-    std::string print(id obj) { return [obj description].UTF8String; }
+    static std::string print(id obj) { return [obj description].UTF8String; }
 };
 
 class RLMAccessorContext : public RLMStatelessAccessorContext {

--- a/Realm/RLMAccessor.mm
+++ b/Realm/RLMAccessor.mm
@@ -1058,17 +1058,17 @@ RLMOptionalId RLMAccessorContext::default_value_for_property(realm::ObjectSchema
 }
 
 bool RLMStatelessAccessorContext::is_same_list(realm::List const& list,
-                                               __unsafe_unretained id const v) const noexcept {
+                                               __unsafe_unretained id const v) noexcept {
     return [v respondsToSelector:@selector(isBackedByList:)] && [v isBackedByList:list];
 }
 
 bool RLMStatelessAccessorContext::is_same_set(realm::object_store::Set const& set,
-                                              __unsafe_unretained id const v) const noexcept {
+                                              __unsafe_unretained id const v) noexcept {
     return [v respondsToSelector:@selector(isBackedBySet:)] && [v isBackedBySet:set];
 }
 
 bool RLMStatelessAccessorContext::is_same_dictionary(realm::object_store::Dictionary const& dict,
-                                                     __unsafe_unretained id const v) const noexcept {
+                                                     __unsafe_unretained id const v) noexcept {
     return [v respondsToSelector:@selector(isBackedByDictionary:)] && [v isBackedByDictionary:dict];
 }
 #pragma clang diagnostic push

--- a/Realm/RLMCollection_Private.hpp
+++ b/Realm/RLMCollection_Private.hpp
@@ -48,7 +48,7 @@ class RLMClassInfo;
 - (RLMFastEnumerator *)fastEnumerator;
 @end
 
-// An object which encapulates the shared logic for fast-enumerating RLMArray
+// An object which encapsulates the shared logic for fast-enumerating RLMArray
 // RLMSet and RLMResults, and has a buffer to store strong references to the current
 // set of enumerated items
 @interface RLMFastEnumerator : NSObject

--- a/Realm/RLMDictionary.h
+++ b/Realm/RLMDictionary.h
@@ -166,6 +166,7 @@ NS_ASSUME_NONNULL_BEGIN
  This will remove all elements in this dictionary and then apply each element from the given dictionary.
 
  @warning This method may only be called during a write transaction.
+ @warning If otherDictionary is self this will result in an empty dictionary.
  */
 - (void)setDictionary:(id)otherDictionary;
 

--- a/Realm/RLMDictionary.mm
+++ b/Realm/RLMDictionary.mm
@@ -48,7 +48,8 @@
 
 #pragma mark Initializers
 
-- (instancetype)initWithObjectClassName:(__unsafe_unretained NSString *const)objectClassName keyType:(RLMPropertyType)keyType {
+- (instancetype)initWithObjectClassName:(__unsafe_unretained NSString *const)objectClassName
+                                keyType:(RLMPropertyType)keyType {
     REALM_ASSERT([objectClassName length] > 0);
     REALM_ASSERT(RLMValidateKeyType(keyType));
     self = [super init];
@@ -112,7 +113,7 @@ void RLMDictionaryValidateMatchingObjectType(__unsafe_unretained RLMDictionary *
     if (auto valueObject = RLMDynamicCast<RLMObjectBase>(value)) {
         if (!valueObject->_objectSchema) {
             @throw RLMException(@"Object cannot be inserted unless the schema is initialized. "
-                                "This can happen if you try to insert objects into a RLMDictionary / Map from a default value or from an overriden unmanaged initializer (`init()`) or if the key is uninitialized.");
+                                "This can happen if you try to insert objects into a RLMDictionary / Map from a default value or from an overridden unmanaged initializer (`init()`) or if the key is uninitialized.");
         }
         if (![dictionary->_objectClassName isEqualToString:valueObject->_objectSchema.className]) {
             @throw RLMException(@"Value of type '%@' does not match RLMDictionary value type '%@'.",
@@ -168,10 +169,7 @@ static void changeDictionary(__unsafe_unretained RLMDictionary *const dictionary
 }
 
 - (nullable id)objectForKeyedSubscript:(id)key {
-    if (!_backingCollection) {
-        _backingCollection = [NSMutableDictionary new];
-    }
-    return [_backingCollection objectForKey:key];
+    return [self objectForKey:key];
 }
 
 - (BOOL)isInvalidated {
@@ -179,32 +177,34 @@ static void changeDictionary(__unsafe_unretained RLMDictionary *const dictionary
 }
 
 - (void)setValue:(nullable id)value forKey:(nonnull NSString *)key {
+    RLMDictionaryValidateMatchingObjectType(self, key, value);
     changeDictionary(self, ^{
-        RLMDictionaryValidateMatchingObjectType(self, key, value);
         [_backingCollection setValue:value forKey:key];
     });
 }
 
 - (void)setDictionary:(id)dictionary {
     changeDictionary(self, ^{
-        [self removeAllObjects];
-        [dictionary enumerateKeysAndObjectsUsingBlock:^(id _Nonnull key, id _Nonnull value, BOOL *) {
+        [_backingCollection removeAllObjects];
+        [dictionary enumerateKeysAndObjectsUsingBlock:^(id key, id value, BOOL *) {
             RLMDictionaryValidateMatchingObjectType(self, key, value);
-            self[key] = value;
+            [_backingCollection setObject:value forKey:key];
         }];
     });
 }
 
 - (void)setObject:(id)obj forKeyedSubscript:(id)key {
-    changeDictionary(self, ^{
-        RLMDictionaryValidateMatchingObjectType(self, key, obj);
-        _backingCollection[(id)key] = obj;
-    });
+    if (obj) {
+        [self setObject:obj forKey:key];
+    }
+    else {
+        [self removeObjectForKey:key];
+    }
 }
 
 - (void)setObject:(id)obj forKey:(id)key {
+    RLMDictionaryValidateMatchingObjectType(self, key, obj);
     changeDictionary(self, ^{
-        RLMDictionaryValidateMatchingObjectType(self, key, obj);
         [_backingCollection setObject:obj forKey:key];
     });
 }
@@ -227,14 +227,13 @@ static void changeDictionary(__unsafe_unretained RLMDictionary *const dictionary
     });
 }
 
-- (void)enumerateKeysAndObjectsUsingBlock:(void (^)(id key,
-                                                    id obj, BOOL *stop))block {
+- (void)enumerateKeysAndObjectsUsingBlock:(void (^)(id key, id obj, BOOL *stop))block {
     [_backingCollection enumerateKeysAndObjectsUsingBlock:block];
 }
 
 - (nullable id)valueForKey:(nonnull NSString *)key {
     // `invalidated` should be accessed with a `@` prefix when using RLMDictionary.
-    if ([key isEqualToString:[NSString stringWithFormat:@"@%@", RLMInvalidatedKey]]) {
+    if ([key isEqualToString:@"@invalidated"]) {
         return @NO; // Unmanaged dictionaries are never invalidated
     }
     if (!_backingCollection) {
@@ -264,16 +263,15 @@ static void changeDictionary(__unsafe_unretained RLMDictionary *const dictionary
     if (!otherDictionary) {
         return;
     }
-    if (![otherDictionary isKindOfClass:[RLMDictionary class]] &&
-        ![otherDictionary isKindOfClass:[NSDictionary class]]) {
+    if (![otherDictionary respondsToSelector:@selector(enumerateKeysAndObjectsUsingBlock:)]) {
         @throw RLMException(@"Cannot add entries from the object of class '%@'", [otherDictionary className]);
     }
 
     changeDictionary(self, ^{
-        for (id key in otherDictionary) {
-            RLMDictionaryValidateMatchingObjectType(self, key, otherDictionary[key]);
-            [self setObject:otherDictionary[key] forKey:key];
-        }
+        [otherDictionary enumerateKeysAndObjectsUsingBlock:^(id key, id value, BOOL *) {
+            RLMDictionaryValidateMatchingObjectType(self, key, value);
+            _backingCollection[key] = value;
+        }];
     });
 }
 

--- a/Realm/RLMDictionary.mm
+++ b/Realm/RLMDictionary.mm
@@ -184,6 +184,10 @@ static void changeDictionary(__unsafe_unretained RLMDictionary *const dictionary
 }
 
 - (void)setDictionary:(id)dictionary {
+    if (dictionary && ![dictionary respondsToSelector:@selector(enumerateKeysAndObjectsUsingBlock:)]) {
+        @throw RLMException(@"Cannot set dictionary to object of class '%@'", [dictionary className]);
+    }
+
     changeDictionary(self, ^{
         [_backingCollection removeAllObjects];
         [dictionary enumerateKeysAndObjectsUsingBlock:^(id key, id value, BOOL *) {
@@ -264,7 +268,7 @@ static void changeDictionary(__unsafe_unretained RLMDictionary *const dictionary
         return;
     }
     if (![otherDictionary respondsToSelector:@selector(enumerateKeysAndObjectsUsingBlock:)]) {
-        @throw RLMException(@"Cannot add entries from the object of class '%@'", [otherDictionary className]);
+        @throw RLMException(@"Cannot add entries from object of class '%@'", [otherDictionary className]);
     }
 
     changeDictionary(self, ^{

--- a/Realm/RLMManagedDictionary.mm
+++ b/Realm/RLMManagedDictionary.mm
@@ -293,26 +293,24 @@ static void changeDictionary(__unsafe_unretained RLMManagedDictionary *const dic
     });
 }
 
+static NSMutableArray *resultsToArray(RLMClassInfo& info, realm::Results r) {
+    RLMAccessorContext c(info);
+    NSMutableArray *array = [NSMutableArray arrayWithCapacity:r.size()];
+    for (size_t i = 0, size = r.size(); i < size; ++i) {
+        [array addObject:r.get(c, i)];
+    }
+    return array;
+}
+
 - (NSArray *)allKeys {
     return translateErrors([&] {
-        auto keyResult = _backingCollection.get_keys();
-        NSMutableArray<id> *keys = [NSMutableArray arrayWithCapacity:keyResult.size()];
-        for (size_t i=0; i<keyResult.size(); i++) {
-            [keys addObject:RLMStringDataToNSString(keyResult.get<realm::StringData>(i))];
-        }
-        return keys;
+        return resultsToArray(*_objectInfo, _backingCollection.get_keys());
     });
 }
 
 - (NSArray *)allValues {
     return translateErrors([&] {
-        NSMutableArray *values = [NSMutableArray array];
-        auto valueResult = _backingCollection.get_values();
-        RLMAccessorContext c(*_objectInfo);
-        for (size_t i=0; i<valueResult.size(); i++) {
-            [values addObject:valueResult.get(c, i)];
-        }
-        return values;
+        return resultsToArray(*_objectInfo, _backingCollection.get_values());
     });
 }
 
@@ -342,37 +340,17 @@ static void changeDictionary(__unsafe_unretained RLMManagedDictionary *const dic
 #pragma mark - Object Retrieval
 
 - (nullable id)objectForKey:(id)key {
-    return translateErrors([&] {
+    return translateErrors([&]() -> id {
         [self.realm verifyThread];
         RLMAccessorContext context(*_objectInfo);
-        auto value = _backingCollection.try_get_any(context.unbox<realm::StringData>(key));
-        if (!value)
-            return (id)nil;
-
-        return context.box(*value);
+        if (auto value = _backingCollection.try_get_any(context.unbox<realm::StringData>(key))) {
+            return context.box(*value);
+        }
+        return nil;
     });
-}
-
-- (nullable id)objectForKeyedSubscript:(id)key {
-    return [self objectForKey:key];
 }
 
 - (void)setObject:(id)obj forKey:(id)key {
-    changeDictionary(self, ^{
-        RLMDictionaryValidateMatchingObjectType(self, key, obj);
-        RLMAccessorContext context(*_objectInfo);
-        _backingCollection.insert(context,
-                                  context.unbox<realm::StringData>(key),
-                                  obj);
-    });
-}
-
-- (void)setObject:(id)obj forKeyedSubscript:(id)key {
-    // passing `nil` to the subscript should delete the object.
-    if (!obj) {
-        [self removeObjectForKey:key];
-        return;
-    }
     changeDictionary(self, ^{
         RLMDictionaryValidateMatchingObjectType(self, key, obj);
         RLMAccessorContext context(*_objectInfo);
@@ -389,9 +367,17 @@ static void changeDictionary(__unsafe_unretained RLMManagedDictionary *const dic
 }
 
 - (void)removeObjectsForKeys:(NSArray *)keyArray {
-    for (id key in keyArray) {
-        [self removeObjectForKey:key];
-    }
+    RLMAccessorContext context(*_objectInfo);
+    changeDictionary(self, [&] {
+        for (id key in keyArray) {
+            try {
+                _backingCollection.erase(context.unbox<realm::StringData>(key));
+            }
+            catch (realm::KeyNotFound const&) {
+                continue;
+            }
+        }
+    });
 }
 
 - (void)removeObjectForKey:(id)key {
@@ -409,18 +395,41 @@ static void changeDictionary(__unsafe_unretained RLMManagedDictionary *const dic
     }
 }
 
-- (void)enumerateKeysAndObjectsUsingBlock:(void (^)(id key,
-                                                    id obj, BOOL *stop))block {
-    auto keyResult = _backingCollection.get_keys();
+- (void)enumerateKeysAndObjectsUsingBlock:(void (^)(id key, id obj, BOOL *stop))block {
     RLMAccessorContext c(*_objectInfo);
-    for (size_t i = 0; i < keyResult.size(); i++) {
-        BOOL stop = false;
-        id aKey = keyResult.get(c, i);
-        block(aKey, self[aKey], &stop);
-        if (stop) {
-            break;
+    BOOL stop = false;
+    @autoreleasepool {
+        for (auto&& [key, value] : _backingCollection) {
+            block(c.box(key), c.box(value), &stop);
+            if (stop) {
+                break;
+            }
         }
     }
+}
+
+- (void)setDictionary:(id)dictionary {
+    changeDictionary(self, ^{
+        RLMAccessorContext c(*_objectInfo);
+        _backingCollection.assign(c, dictionary);
+    });
+}
+
+- (void)addEntriesFromDictionary:(id)otherDictionary {
+    if (!otherDictionary) {
+        return;
+    }
+    if (![otherDictionary respondsToSelector:@selector(enumerateKeysAndObjectsUsingBlock:)]) {
+        @throw RLMException(@"Cannot add entries from the object of class '%@'", [otherDictionary className]);
+    }
+
+    changeDictionary(self, ^{
+        RLMAccessorContext c(*_objectInfo);
+        [otherDictionary enumerateKeysAndObjectsUsingBlock:[&](id key, id value, BOOL *) {
+            RLMDictionaryValidateMatchingObjectType(self, key, value);
+            _backingCollection.insert(c, c.unbox<realm::StringData>(key), value);
+        }];
+    });
 }
 
 #pragma mark - KVC
@@ -438,22 +447,14 @@ static void changeDictionary(__unsafe_unretained RLMManagedDictionary *const dic
 }
 
 - (id)valueForKey:(NSString *)key {
-    if ([key isEqualToString:[NSString stringWithFormat:@"@%@", RLMInvalidatedKey]]) {
+    if ([key isEqualToString:@"@invalidated"]) {
         return @(!_backingCollection.is_valid());
     }
     return [self objectForKey:key];
 }
 
 - (void)setValue:(id)value forKey:(nonnull NSString *)key {
-    changeDictionary(self, ^{
-        RLMDictionaryValidateMatchingObjectType(self, key, value);
-        if (!value) {
-            [self removeObjectForKey:key];
-            return;
-        }
-        RLMAccessorContext context(*_objectInfo);
-        _backingCollection.insert(context, [key UTF8String], value);
-    });
+    [self setObject:value forKeyedSubscript:key];
 }
 
 - (id)minOfProperty:(NSString *)property {
@@ -494,7 +495,13 @@ static void changeDictionary(__unsafe_unretained RLMManagedDictionary *const dic
     }
     // delete all target rows from the realm
     RLMObservationTracker tracker(_realm, true);
-    translateErrors([&] { _backingCollection.remove_all(); });
+    translateErrors([&] {
+        for (auto&& [key, value] : _backingCollection) {
+            _realm.group.get_object(value.get_link()).remove();
+        }
+        _backingCollection.remove_all();
+
+    });
 }
 
 - (RLMResults *)sortedResultsUsingDescriptors:(NSArray<RLMSortDescriptor *> *)properties {

--- a/Realm/RLMManagedDictionary.mm
+++ b/Realm/RLMManagedDictionary.mm
@@ -506,7 +506,6 @@ static NSMutableArray *resultsToArray(RLMClassInfo& info, realm::Results r) {
             _realm.group.get_object(value.get_link()).remove();
         }
         _backingCollection.remove_all();
-
     });
 }
 

--- a/Realm/Tests/DictionaryPropertyTests.m
+++ b/Realm/Tests/DictionaryPropertyTests.m
@@ -1495,8 +1495,8 @@ static RLMDictionary<NSString *, IntObject *><RLMString, IntObject> *managedTest
 
 - (void)testAddEntriesFromDictionaryUnmanaged {
     RLMDictionary<NSString *, StringObject *> *dict = [[DictionaryPropertyObject alloc] init].stringDictionary;
-    RLMAssertThrowsWithReason([dict addEntriesFromDictionary:@[@"string"]],
-                              @"Cannot add entries from object of class 'NSConstantArray'");
+    RLMAssertThrowsWithReasonMatching([dict addEntriesFromDictionary:@[@"string"]],
+                                      @"Cannot add entries from object of class '.*Array.*'");
     RLMAssertThrowsWithReason([dict addEntriesFromDictionary:@{@"": [[IntObject alloc] init]}],
                               @"Value of type 'IntObject' does not match RLMDictionary value type 'StringObject'.");
     RLMAssertThrowsWithReason([dict addEntriesFromDictionary:@{@1: [[StringObject alloc] init]}],
@@ -1537,8 +1537,8 @@ static RLMDictionary<NSString *, IntObject *><RLMString, IntObject> *managedTest
     [dict.realm beginWriteTransaction];
     [dict removeAllObjects];
 
-    RLMAssertThrowsWithReason([dict addEntriesFromDictionary:@[@"string"]],
-                              @"Cannot add entries from object of class 'NSConstantArray'");
+    RLMAssertThrowsWithReasonMatching([dict addEntriesFromDictionary:@[@"string"]],
+                                      @"Cannot add entries from object of class '.*Array.*'");
     RLMAssertThrowsWithReason([dict addEntriesFromDictionary:@{@"": [[StringObject alloc] init]}],
                               @"Value of type 'StringObject' does not match RLMDictionary value type 'IntObject'.");
     RLMAssertThrowsWithReason([dict addEntriesFromDictionary:@{@1: [[IntObject alloc] init]}],
@@ -1578,8 +1578,8 @@ static RLMDictionary<NSString *, IntObject *><RLMString, IntObject> *managedTest
 
 - (void)testSetDictionaryUnmanaged {
     RLMDictionary<NSString *, StringObject *> *dict = [[DictionaryPropertyObject alloc] init].stringDictionary;
-    RLMAssertThrowsWithReason([dict setDictionary:@[@"string"]],
-                              @"Cannot set dictionary to object of class 'NSConstantArray'");
+    RLMAssertThrowsWithReasonMatching([dict setDictionary:@[@"string"]],
+                                      @"Cannot set dictionary to object of class '.*Array.*'");
     RLMAssertThrowsWithReason([dict setDictionary:@{@"": [[IntObject alloc] init]}],
                               @"Value of type 'IntObject' does not match RLMDictionary value type 'StringObject'.");
     RLMAssertThrowsWithReason([dict setDictionary:@{@1: [[StringObject alloc] init]}],
@@ -1624,8 +1624,8 @@ static RLMDictionary<NSString *, IntObject *><RLMString, IntObject> *managedTest
     [dict.realm beginWriteTransaction];
     [dict removeAllObjects];
 
-    RLMAssertThrowsWithReason([dict setDictionary:@[@"string"]],
-                              @"Cannot set dictionary to object of class 'NSConstantArray'");
+    RLMAssertThrowsWithReasonMatching([dict setDictionary:@[@"string"]],
+                                      @"Cannot set dictionary to object of class '.*Array.*'");
     RLMAssertThrowsWithReason([dict setDictionary:@{@"": [[StringObject alloc] init]}],
                               @"Value of type 'StringObject' does not match RLMDictionary value type 'IntObject'.");
     RLMAssertThrowsWithReason([dict setDictionary:@{@1: [[IntObject alloc] init]}],

--- a/Realm/Tests/DictionaryPropertyTests.m
+++ b/Realm/Tests/DictionaryPropertyTests.m
@@ -26,7 +26,7 @@
     
 @implementation DictionaryPropertyTests
 
--(void)testPopulateEmptyDictionary {
+- (void)testPopulateEmptyDictionary {
     RLMRealm *realm = [self realmWithTestPath];
 
     [realm beginWriteTransaction];
@@ -1491,6 +1491,180 @@ static RLMDictionary<NSString *, IntObject *><RLMString, IntObject> *managedTest
         [dict removeObjectForKey:dict.allKeys.lastObject];
     }];
     XCTAssertEqual(frozen.count, 2);
+}
+
+- (void)testAddEntriesFromDictionaryUnmanaged {
+    RLMDictionary<NSString *, StringObject *> *dict = [[DictionaryPropertyObject alloc] init].stringDictionary;
+    RLMAssertThrowsWithReason([dict addEntriesFromDictionary:@[@"string"]],
+                              @"Cannot add entries from object of class 'NSConstantArray'");
+    RLMAssertThrowsWithReason([dict addEntriesFromDictionary:@{@"": [[IntObject alloc] init]}],
+                              @"Value of type 'IntObject' does not match RLMDictionary value type 'StringObject'.");
+    RLMAssertThrowsWithReason([dict addEntriesFromDictionary:@{@1: [[StringObject alloc] init]}],
+                              @"Invalid key '1' of type '" RLMConstantInt "' for expected type 'string'.");
+
+    // Adding nil is a no-op
+    XCTAssertNoThrow([dict addEntriesFromDictionary:self.nonLiteralNil]);
+    XCTAssertEqual(dict.count, 0U);
+
+    // Add into empty adds those entries
+    [dict addEntriesFromDictionary:@{@"a": [[StringObject alloc] initWithValue:@[@"1"]],
+                                     @"b": [[StringObject alloc] initWithValue:@[@"2"]]}];
+    XCTAssertEqual(dict.count, 2U);
+    XCTAssertEqualObjects(dict[@"a"].stringCol, @"1");
+    XCTAssertEqualObjects(dict[@"b"].stringCol, @"2");
+
+    // Duplicate keys overwrite the old values and leave any non-duplicates
+    [dict addEntriesFromDictionary:@{@"a": [[StringObject alloc] initWithValue:@[@"3"]],
+                                     @"c": [[StringObject alloc] initWithValue:@[@"4"]]}];
+    XCTAssertEqual(dict.count, 3U);
+    XCTAssertEqualObjects(dict[@"a"].stringCol, @"3");
+    XCTAssertEqualObjects(dict[@"b"].stringCol, @"2");
+    XCTAssertEqualObjects(dict[@"c"].stringCol, @"4");
+
+    // Add from a RLMDictionary rather than a NSDictionary
+    RLMDictionary<NSString *, StringObject *> *dict2 = [[DictionaryPropertyObject alloc] init].stringDictionary;
+    dict2[@"d"] = [[StringObject alloc] initWithValue:@[@"5"]];
+    [dict addEntriesFromDictionary:dict2];
+    XCTAssertEqual(dict.count, 4U);
+    XCTAssertEqualObjects(dict[@"a"].stringCol, @"3");
+    XCTAssertEqualObjects(dict[@"b"].stringCol, @"2");
+    XCTAssertEqualObjects(dict[@"c"].stringCol, @"4");
+    XCTAssertEqualObjects(dict[@"d"].stringCol, @"5");
+}
+
+- (void)testAddEntriesFromDictionaryManaged {
+    RLMDictionary<NSString *, IntObject *> *dict = managedTestDictionary();
+    [dict.realm beginWriteTransaction];
+    [dict removeAllObjects];
+
+    RLMAssertThrowsWithReason([dict addEntriesFromDictionary:@[@"string"]],
+                              @"Cannot add entries from object of class 'NSConstantArray'");
+    RLMAssertThrowsWithReason([dict addEntriesFromDictionary:@{@"": [[StringObject alloc] init]}],
+                              @"Value of type 'StringObject' does not match RLMDictionary value type 'IntObject'.");
+    RLMAssertThrowsWithReason([dict addEntriesFromDictionary:@{@1: [[IntObject alloc] init]}],
+                              @"Invalid key '1' of type '" RLMConstantInt "' for expected type 'string'.");
+
+    // Adding nil is a no-op
+    XCTAssertNoThrow([dict addEntriesFromDictionary:self.nonLiteralNil]);
+    XCTAssertEqual(dict.count, 0U);
+
+    // Add into empty adds those entries
+    [dict addEntriesFromDictionary:@{@"a": [[IntObject alloc] initWithValue:@[@1]],
+                                     @"b": [[IntObject alloc] initWithValue:@[@2]]}];
+    XCTAssertEqual(dict.count, 2U);
+    XCTAssertEqual(dict[@"a"].intCol, 1);
+    XCTAssertEqual(dict[@"b"].intCol, 2);
+
+    // Duplicate keys overwrite the old values and leave any non-duplicates
+    [dict addEntriesFromDictionary:@{@"a": [[IntObject alloc] initWithValue:@[@3]],
+                                     @"c": [[IntObject alloc] initWithValue:@[@4]]}];
+    XCTAssertEqual(dict.count, 3U);
+    XCTAssertEqual(dict[@"a"].intCol, 3);
+    XCTAssertEqual(dict[@"b"].intCol, 2);
+    XCTAssertEqual(dict[@"c"].intCol, 4);
+
+    // Add from a RLMDictionary rather than a NSDictionary
+    RLMDictionary<NSString *, IntObject *> *dict2 = [[DictionaryPropertyObject alloc] init].intObjDictionary;
+    dict2[@"d"] = [[IntObject alloc] initWithValue:@[@5]];
+    [dict addEntriesFromDictionary:dict2];
+    XCTAssertEqual(dict.count, 4U);
+    XCTAssertEqual(dict[@"a"].intCol, 3);
+    XCTAssertEqual(dict[@"b"].intCol, 2);
+    XCTAssertEqual(dict[@"c"].intCol, 4);
+    XCTAssertEqual(dict[@"d"].intCol, 5);
+
+    [dict.realm cancelWriteTransaction];
+}
+
+- (void)testSetDictionaryUnmanaged {
+    RLMDictionary<NSString *, StringObject *> *dict = [[DictionaryPropertyObject alloc] init].stringDictionary;
+    RLMAssertThrowsWithReason([dict setDictionary:@[@"string"]],
+                              @"Cannot set dictionary to object of class 'NSConstantArray'");
+    RLMAssertThrowsWithReason([dict setDictionary:@{@"": [[IntObject alloc] init]}],
+                              @"Value of type 'IntObject' does not match RLMDictionary value type 'StringObject'.");
+    RLMAssertThrowsWithReason([dict setDictionary:@{@1: [[StringObject alloc] init]}],
+                              @"Invalid key '1' of type '" RLMConstantInt "' for expected type 'string'.");
+
+    // Set into empty adds those entries
+    [dict setDictionary:@{@"a": [[StringObject alloc] initWithValue:@[@"1"]],
+                          @"b": [[StringObject alloc] initWithValue:@[@"2"]]}];
+    XCTAssertEqual(dict.count, 2U);
+    XCTAssertEqualObjects(dict[@"a"].stringCol, @"1");
+    XCTAssertEqualObjects(dict[@"b"].stringCol, @"2");
+
+    // New dictionary replaces the old one entirely
+    [dict setDictionary:@{@"a": [[StringObject alloc] initWithValue:@[@"3"]],
+                          @"c": [[StringObject alloc] initWithValue:@[@"4"]]}];
+    XCTAssertEqual(dict.count, 2U);
+    XCTAssertEqualObjects(dict[@"a"].stringCol, @"3");
+    XCTAssertEqualObjects(dict[@"c"].stringCol, @"4");
+
+    // Setting to nil clears
+    XCTAssertNoThrow([dict setDictionary:self.nonLiteralNil]);
+    XCTAssertEqual(dict.count, 0U);
+
+    // Self-setting clears
+    [dict setDictionary:@{@"a": [[StringObject alloc] initWithValue:@[@"3"]],
+                          @"c": [[StringObject alloc] initWithValue:@[@"4"]]}];
+    XCTAssertEqual(dict.count, 2U);
+    [dict setDictionary:dict];
+    XCTAssertEqual(dict.count, 0U);
+
+    // Type error clears
+    [dict setDictionary:@{@"a": [[StringObject alloc] initWithValue:@[@"3"]],
+                          @"c": [[StringObject alloc] initWithValue:@[@"4"]]}];
+    XCTAssertEqual(dict.count, 2U);
+    RLMAssertThrowsWithReason([dict setDictionary:@{@"": [[IntObject alloc] init]}],
+                              @"Value of type 'IntObject' does not match RLMDictionary value type 'StringObject'.");
+    XCTAssertEqual(dict.count, 0U);
+}
+
+- (void)testSetDictionaryManaged {
+    RLMDictionary<NSString *, IntObject *> *dict = managedTestDictionary();
+    [dict.realm beginWriteTransaction];
+    [dict removeAllObjects];
+
+    RLMAssertThrowsWithReason([dict setDictionary:@[@"string"]],
+                              @"Cannot set dictionary to object of class 'NSConstantArray'");
+    RLMAssertThrowsWithReason([dict setDictionary:@{@"": [[StringObject alloc] init]}],
+                              @"Value of type 'StringObject' does not match RLMDictionary value type 'IntObject'.");
+    RLMAssertThrowsWithReason([dict setDictionary:@{@1: [[IntObject alloc] init]}],
+                              @"Invalid key '1' of type '" RLMConstantInt "' for expected type 'string'.");
+
+    // Set into empty adds those entries
+    [dict setDictionary:@{@"a": [[IntObject alloc] initWithValue:@[@1]],
+                          @"b": [[IntObject alloc] initWithValue:@[@2]]}];
+    XCTAssertEqual(dict.count, 2U);
+    XCTAssertEqual(dict[@"a"].intCol, 1);
+    XCTAssertEqual(dict[@"b"].intCol, 2);
+
+    // New dictionary replaces the old one entirely
+    [dict setDictionary:@{@"a": [[IntObject alloc] initWithValue:@[@3]],
+                          @"c": [[IntObject alloc] initWithValue:@[@4]]}];
+    XCTAssertEqual(dict.count, 2U);
+    XCTAssertEqual(dict[@"a"].intCol, 3);
+    XCTAssertEqual(dict[@"c"].intCol, 4);
+
+    // Setting to nil clears
+    XCTAssertNoThrow([dict setDictionary:self.nonLiteralNil]);
+    XCTAssertEqual(dict.count, 0U);
+
+    // Self-setting clears
+    [dict setDictionary:@{@"a": [[IntObject alloc] initWithValue:@[@3]],
+                          @"c": [[IntObject alloc] initWithValue:@[@4]]}];
+    XCTAssertEqual(dict.count, 2U);
+    [dict setDictionary:dict];
+    XCTAssertEqual(dict.count, 0U);
+
+    // Type error clears
+    [dict setDictionary:@{@"a": [[IntObject alloc] initWithValue:@[@3]],
+                          @"c": [[IntObject alloc] initWithValue:@[@4]]}];
+    XCTAssertEqual(dict.count, 2U);
+    RLMAssertThrowsWithReason([dict setDictionary:@{@"": [[StringObject alloc] init]}],
+                              @"Value of type 'StringObject' does not match RLMDictionary value type 'IntObject'.");
+    XCTAssertEqual(dict.count, 0U);
+
+    [dict.realm cancelWriteTransaction];
 }
 
 @end


### PR DESCRIPTION
Dictionary::remove_all() merely removes the values from the Dictionary and does not delete them.