### PR TITLE
Fix the RLMDictionary_Private.h symlink

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,24 @@
+x.y.z Release notes (yyyy-MM-dd)
+=============================================================
+### Enhancements
+* None.
+
+### Fixed
+* Fixed a symlink which prevented Realm from building on case sensitive file systems. 
+  ([#7344](https://github.com/realm/realm-cocoa/issues/7344), since v10.8.0)
+
+<!-- ### Breaking Changes - ONLY INCLUDE FOR NEW MAJOR version -->
+
+### Compatibility
+* Realm Studio: 11.0.0 or later.
+* APIs are backwards compatible with all previous releases in the 10.x.y series.
+* Carthage release for Swift is built with Xcode 12.5.1.
+* CocoaPods: 1.10 or later.
+* Xcode: 12.2-13.0 beta 3.
+
+### Internal
+* Upgraded realm-core from ? to ?
+
 10.11.0 Release notes (2021-07-22)
 =============================================================
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,22 @@
 x.y.z Release notes (yyyy-MM-dd)
 =============================================================
 ### Enhancements
-* None.
+* Add two new property wrappers for opening a Realm asynchronously in a 
+  SwiftUI View:
+    - `AsyncOpen` is a property wrapper that initiates Realm.asyncOpen 
+       for the current user, notifying the view when there is a change in Realm asyncOpen state.
+    - `AutoOpen` behaves similarly to `AsyncOpen`, but in the case of no internet
+       connection this will return an opened realm. 
+* Add `EnvironmentValues.partitionValue`. This value can be injected into any view using one of 
+  our new property wrappers `AsyncOpen` and `AutoOpen`:
+  `MyView().environment(\.partitionValue, "partitionValue")`. 
 
 ### Fixed
+* Fix `configuration(partitionValue: AnyBSON)` will set always a nil partition value
+  for the user sync configuration.
+* Fix decoding a `@Persisted` property will incorrectly throw a `DecodingError.keyNotFound` 
+  for an optional property if the key is missing.
+  ([Cocoa #7358](https://github.com/realm/realm-cocoa/issues/7358), since v10.10.0)
 * Fixed a symlink which prevented Realm from building on case sensitive file systems. 
   ([#7344](https://github.com/realm/realm-cocoa/issues/7344), since v10.8.0)
 

--- a/include/Realm/RLMDictionary_Private.h
+++ b/include/Realm/RLMDictionary_Private.h
@@ -1,1 +1,1 @@
-../../realm/RLMDictionary_Private.h
+../../Realm/RLMDictionary_Private.h


### PR DESCRIPTION
~~Fixes the symlink to RLMDictionary_Private.h which causes build errors on case sensitive file systems.~~

See #7344.