### PR TITLE
Fix crash in `MongoCollection.findOneDocument(filter:)` that occurred when no results were found for a given filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@ x.y.z Release notes (yyyy-MM-dd)
 * None.
 
 ### Fixed
-* <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-cocoa/issues/????), since v?.?.?)
-* None.
+* Fix crash in `MongoCollection.findOneDocument(filter:)` that occurred when no results were
+  found for a given filter.
 
 <!-- ### Breaking Changes - ONLY INCLUDE FOR NEW MAJOR version -->
 
@@ -17,7 +17,8 @@ x.y.z Release notes (yyyy-MM-dd)
 * Xcode: 12.2-13.0 beta 3.
 
 ### Internal
-* Upgraded realm-core from ? to ?
+* Add `Copy Bundle Resource` phase to TestHost that adds libstitchsupport as a
+  resource. This is used when booting the `RealmServer`. 
 
 10.12.0 Release notes (2021-08-03)
 =============================================================

--- a/Realm.xcodeproj/project.pbxproj
+++ b/Realm.xcodeproj/project.pbxproj
@@ -268,6 +268,7 @@
 		5346E7322487AC9D00595C68 /* RLMBSONTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5346E7312487AC9D00595C68 /* RLMBSONTests.mm */; };
 		535EA9E225B0919800DBF3CD /* SwiftUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 535EA9E125B0919800DBF3CD /* SwiftUI.swift */; };
 		535EAA7525B0B02B00DBF3CD /* SwiftUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 535EAA7425B0B02B00DBF3CD /* SwiftUITests.swift */; };
+		535F308D26BC78D1009E815F /* libstitch_support.dylib in Resources */ = {isa = PBXBuildFile; fileRef = 535F308C26BC78D1009E815F /* libstitch_support.dylib */; };
 		53626AAF25D31CAC00D9515D /* Objects.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53626AAE25D31CAC00D9515D /* Objects.swift */; };
 		53626AB025D31CAC00D9515D /* Objects.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53626AAE25D31CAC00D9515D /* Objects.swift */; };
 		537130C824A9E417001FDBBC /* RealmServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 537130C724A9E417001FDBBC /* RealmServer.swift */; };
@@ -893,6 +894,7 @@
 		5346E7312487AC9D00595C68 /* RLMBSONTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = RLMBSONTests.mm; path = Realm/ObjectServerTests/RLMBSONTests.mm; sourceTree = "<group>"; };
 		535EA9E125B0919800DBF3CD /* SwiftUI.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwiftUI.swift; sourceTree = "<group>"; };
 		535EAA7425B0B02B00DBF3CD /* SwiftUITests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwiftUITests.swift; sourceTree = "<group>"; };
+		535F308C26BC78D1009E815F /* libstitch_support.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; path = libstitch_support.dylib; sourceTree = "<group>"; };
 		53626A8C25D3172000D9515D /* SwiftUITestHostTests.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = SwiftUITestHostTests.xcconfig; sourceTree = "<group>"; };
 		53626AAE25D31CAC00D9515D /* Objects.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Objects.swift; sourceTree = "<group>"; };
 		536B7C0B24A4C223006B535D /* dependencies.list */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = dependencies.list; sourceTree = "<group>"; };
@@ -1226,6 +1228,7 @@
 		1A7B82361D51254600750296 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				535F308C26BC78D1009E815F /* libstitch_support.dylib */,
 				CFAE926A24A0A7F40033CB31 /* AuthenticationServices.framework */,
 				3F9816292317763000C3543D /* libc++.tbd */,
 				1A7B82391D51259F00750296 /* libz.tbd */,
@@ -2027,6 +2030,7 @@
 			buildPhases = (
 				3F1A5E6E1992EB7400F45F4C /* Sources */,
 				3F1A5E6F1992EB7400F45F4C /* Frameworks */,
+				535F308B26BC78B9009E815F /* Resources */,
 			);
 			buildRules = (
 			);
@@ -2222,7 +2226,6 @@
 				49E57A1C245C5B0E004AF428 /* PBXTargetDependency */,
 				E8267FB41D90B79000E001C7 /* PBXTargetDependency */,
 				537689AC24A7DD060008E57B /* PBXTargetDependency */,
-				E8267FB61D90B79000E001C7 /* PBXTargetDependency */,
 			);
 			name = ObjectServerTests;
 			productName = RealmTests;
@@ -2416,6 +2419,14 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		535F308B26BC78B9009E815F /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				535F308D26BC78D1009E815F /* libstitch_support.dylib in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Realm/ObjectServerTests/RealmServer.swift
+++ b/Realm/ObjectServerTests/RealmServer.swift
@@ -517,16 +517,18 @@ public class RealmServer: NSObject {
 
     private func launchServerProcess() throws {
         let binDir = Self.buildDir.appendingPathComponent("bin").path
-        let libDir = Self.buildDir.appendingPathComponent("lib").path
         let binPath = "$PATH:\(binDir)"
 
         let stitchRoot = RealmServer.buildDir.path + "/go/src/github.com/10gen/stitch"
-
+        guard let resourcePath = Bundle.main.resourcePath else {
+            fatalError("TestApp must contain resource dir containing libstitch_support.")
+        }
         // create the admin user
         let userProcess = Process()
         userProcess.environment = [
             "PATH": binPath,
-            "LD_LIBRARY_PATH": libDir
+            "LD_LIBRARY_PATH": resourcePath,
+            "DYLD_LIBRARY_PATH": resourcePath,
         ]
         userProcess.launchPath = "\(binDir)/create_user"
         userProcess.arguments = [
@@ -543,7 +545,8 @@ public class RealmServer: NSObject {
 
         serverProcess.environment = [
             "PATH": binPath,
-            "LD_LIBRARY_PATH": libDir
+            "LD_LIBRARY_PATH": resourcePath,
+            "DYLD_LIBRARY_PATH": resourcePath
         ]
         // golang server needs a tmp directory
         try! FileManager.default.createDirectory(atPath: "\(tempDir.path)/tmp",

--- a/Realm/ObjectServerTests/SwiftObjectServerTests.swift
+++ b/Realm/ObjectServerTests/SwiftObjectServerTests.swift
@@ -1431,6 +1431,18 @@ class SwiftMongoClientTests: SwiftSyncTestCase {
             findOneEx2.fulfill()
         }
         wait(for: [findOneEx2], timeout: 4.0)
+
+        let findOneEx3 = expectation(description: "Find one document")
+        collection.findOneDocument(filter: ["name": "tim"]) { result in
+            switch result {
+            case .success(let document):
+                XCTAssertNil(document)
+            case .failure:
+                XCTFail("Should find")
+            }
+            findOneEx3.fulfill()
+        }
+        wait(for: [findOneEx3], timeout: 4.0)
     }
 
     func testMongoFindAndReplaceResultCompletion() {

--- a/Realm/RLMMongoCollection.mm
+++ b/Realm/RLMMongoCollection.mm
@@ -151,7 +151,11 @@ static realm::bson::BsonArray toBsonArray(id<RLMBSON> bson) {
         if (error) {
             return completion(nil, RLMAppErrorToNSError(*error));
         }
-        completion((NSDictionary<NSString *, id<RLMBSON>> *)RLMConvertBsonToRLMBSON(*document), nil);
+        if (document) {
+            completion((NSDictionary<NSString *, id<RLMBSON>> *)RLMConvertBsonToRLMBSON(*document), nil);
+        } else {
+            completion(nil, nil);
+        }
     });
 }
 


### PR DESCRIPTION
Fixes #7380.