### PR TITLE
Fix crash in `MongoCollection.findOneDocument(filter:)` that occurred when no results were found for a given filter.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@ x.y.z Release notes (yyyy-MM-dd)
 * None.
 
 ### Fixed
-* <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-cocoa/issues/????), since v?.?.?)
-* None.
+* Fix crash in `MongoCollection.findOneDocument(filter:)` that occurred when no results were 
+  found for a given filter.
 
 <!-- ### Breaking Changes - ONLY INCLUDE FOR NEW MAJOR version -->
 

--- a/Realm/ObjectServerTests/SwiftObjectServerTests.swift
+++ b/Realm/ObjectServerTests/SwiftObjectServerTests.swift
@@ -1431,6 +1431,18 @@ class SwiftMongoClientTests: SwiftSyncTestCase {
             findOneEx2.fulfill()
         }
         wait(for: [findOneEx2], timeout: 4.0)
+
+        let findOneEx3 = expectation(description: "Find one document")
+        collection.findOneDocument(filter: ["name": "tim"]) { result in
+            switch result {
+            case .success(let document):
+                XCTAssertNil(document)
+            case .failure:
+                XCTFail("Should find")
+            }
+            findOneEx3.fulfill()
+        }
+        wait(for: [findOneEx3], timeout: 4.0)
     }
 
     func testMongoFindAndReplaceResultCompletion() {

--- a/Realm/RLMMongoCollection.mm
+++ b/Realm/RLMMongoCollection.mm
@@ -151,7 +151,11 @@ static realm::bson::BsonArray toBsonArray(id<RLMBSON> bson) {
         if (error) {
             return completion(nil, RLMAppErrorToNSError(*error));
         }
-        completion((NSDictionary<NSString *, id<RLMBSON>> *)RLMConvertBsonToRLMBSON(*document), nil);
+        if (document) {
+            completion((NSDictionary<NSString *, id<RLMBSON>> *)RLMConvertBsonToRLMBSON(*document), nil);
+        } else {
+            completion(nil, nil);
+        }
     });
 }
 


### PR DESCRIPTION
Fixes #7380.