### PR TITLE
Fix a rare crash when running the sync tests

### DIFF
--- a/Realm/ObjectServerTests/RealmServer.swift
+++ b/Realm/ObjectServerTests/RealmServer.swift
@@ -519,15 +519,16 @@ public class RealmServer: NSObject {
         let binDir = Self.buildDir.appendingPathComponent("bin").path
         let libDir = Self.buildDir.appendingPathComponent("lib").path
         let binPath = "$PATH:\(binDir)"
+        let env = [
+            "PATH": binPath,
+            "DYLD_LIBRARY_PATH": libDir
+        ]
 
         let stitchRoot = RealmServer.buildDir.path + "/go/src/github.com/10gen/stitch"
 
         // create the admin user
         let userProcess = Process()
-        userProcess.environment = [
-            "PATH": binPath,
-            "LD_LIBRARY_PATH": libDir
-        ]
+        userProcess.environment = env
         userProcess.launchPath = "\(binDir)/create_user"
         userProcess.arguments = [
             "addUser",
@@ -541,10 +542,7 @@ public class RealmServer: NSObject {
         try userProcess.run()
         userProcess.waitUntilExit()
 
-        serverProcess.environment = [
-            "PATH": binPath,
-            "LD_LIBRARY_PATH": libDir
-        ]
+        serverProcess.environment = env
         // golang server needs a tmp directory
         try! FileManager.default.createDirectory(atPath: "\(tempDir.path)/tmp",
             withIntermediateDirectories: false, attributes: nil)

--- a/Realm/ObjectServerTests/setup_baas.rb
+++ b/Realm/ObjectServerTests/setup_baas.rb
@@ -153,7 +153,7 @@ def setup_stitch
 
     exports << "export STITCH_PATH=\"#{stitch_dir}\""
     exports << "export PATH=\"$PATH:$STITCH_PATH/etc/transpiler/bin\""
-    exports << "export LD_LIBRARY_PATH='#{LIB_DIR}'"
+    exports << "export DYLD_LIBRARY_PATH='#{LIB_DIR}'"
 
     puts 'build create_user binary'
 

--- a/Realm/RLMSyncConfiguration.mm
+++ b/Realm/RLMSyncConfiguration.mm
@@ -145,8 +145,9 @@ RLMSyncSystemErrorKind errorKindForSyncError(SyncError error) {
             s.str()
         );
         _config->stop_policy = translateStopPolicy(stopPolicy);
-        RLMApp *app = user.app;
-        _config->error_handler = [app](std::shared_ptr<SyncSession> errored_session, SyncError error) {
+        RLMSyncManager *manager = [user.app syncManager];
+        __weak RLMSyncManager *weakManager = manager;
+        _config->error_handler = [weakManager](std::shared_ptr<SyncSession> errored_session, SyncError error) {
             NSString *recoveryPath;
             RLMSyncErrorActionToken *token;
             for (auto& pair : error.user_info) {
@@ -183,8 +184,10 @@ RLMSyncSystemErrorKind errorKindForSyncError(SyncError error) {
                     break;
             }
 
-            RLMSyncManager *manager = [app syncManager];
-            auto errorHandler = manager.errorHandler;
+            RLMSyncErrorReportingBlock errorHandler;
+            @autoreleasepool {
+                errorHandler = weakManager.errorHandler;
+            }
             if (!shouldMakeError || !errorHandler) {
                 return;
             }
@@ -196,7 +199,6 @@ RLMSyncSystemErrorKind errorKindForSyncError(SyncError error) {
         };
         _config->client_resync_mode = realm::ClientResyncMode::Manual;
 
-        RLMSyncManager *manager = [user.app syncManager];
         if (NSString *authorizationHeaderName = manager.authorizationHeaderName) {
             _config->authorization_header_name.emplace(authorizationHeaderName.UTF8String);
         }


### PR DESCRIPTION
Capturing a strong reference to the app in the error callback results in things breaking when that's the last remaining reference to the App. This isn't something that can happen in normal uses but our tests would occasionally hit it.