### PR TITLE
Work around canImport(Combine) being broken in Xcode 13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,11 @@ x.y.z Release notes (yyyy-MM-dd)
 * None.
 
 ### Fixed
-* Fix crash in `MongoCollection.findOneDocument(filter:)` that occurred when no results were 
+* Fix crash in `MongoCollection.findOneDocument(filter:)` that occurred when no results were
   found for a given filter.
 * Some of the SwiftUI property wrappers incorrectly required objects to conform
   to ObjectKeyIdentifiable rather than Identifiable.
+* Work around Xcode 13 beta 3+ shipping a broken swiftinterface file for Combine on 32-bit iOS.
 
 <!-- ### Breaking Changes - ONLY INCLUDE FOR NEW MAJOR version -->
 

--- a/Realm/ObjectServerTests/SwiftObjectServerTests.swift
+++ b/Realm/ObjectServerTests/SwiftObjectServerTests.swift
@@ -20,6 +20,7 @@
 
 import Combine
 import Realm
+import Realm.Private
 import RealmSwift
 import XCTest
 

--- a/RealmSwift/App.swift
+++ b/RealmSwift/App.swift
@@ -156,7 +156,7 @@ extension App {
     }
 }
 
-#if canImport(Combine)
+#if !(os(iOS) && (arch(i386) || arch(arm)))
 import Combine
 
 /// :nodoc:

--- a/RealmSwift/Combine.swift
+++ b/RealmSwift/Combine.swift
@@ -16,8 +16,9 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-#if canImport(Combine)
+#if !(os(iOS) && (arch(i386) || arch(arm)))
 import Combine
+import Realm
 import Realm.Private
 
 // MARK: - Identifiable

--- a/RealmSwift/Impl/SchemaDiscovery.swift
+++ b/RealmSwift/Impl/SchemaDiscovery.swift
@@ -17,6 +17,7 @@
 ////////////////////////////////////////////////////////////////////////////
 
 import Foundation
+import Realm
 import Realm.Private
 
 // A type which we can get the runtime schema information from

--- a/RealmSwift/MongoClient.swift
+++ b/RealmSwift/MongoClient.swift
@@ -729,7 +729,7 @@ private class ChangeEventDelegateProxy: RLMChangeEventDelegate {
     }
 }
 
-#if canImport(Combine)
+#if !(os(iOS) && (arch(i386) || arch(arm)))
 import Combine
 
 @available(OSX 10.15, watchOS 6.0, iOS 13.0, iOSApplicationExtension 13.0, OSXApplicationExtension 10.15, tvOS 13.0, *)

--- a/RealmSwift/Realm.swift
+++ b/RealmSwift/Realm.swift
@@ -141,7 +141,7 @@ import Realm.Private
         }))
     }
 
-    #if canImport(Combine)
+    #if !(os(iOS) && (arch(i386) || arch(arm)))
     /**
      Asynchronously open a Realm and deliver it to a block on the given queue.
 

--- a/RealmSwift/SwiftUI.swift
+++ b/RealmSwift/SwiftUI.swift
@@ -18,7 +18,7 @@
 
 import Foundation
 
-#if canImport(SwiftUI) && canImport(Combine)
+#if !(os(iOS) && (arch(i386) || arch(arm)))
 import SwiftUI
 import Combine
 import Realm

--- a/RealmSwift/Sync.swift
+++ b/RealmSwift/Sync.swift
@@ -19,6 +19,10 @@
 import Realm
 import Realm.Private
 
+#if !(os(iOS) && (arch(i386) || arch(arm)))
+import Combine
+#endif
+
 /**
  An object representing a MongoDB Realm user.
 
@@ -248,10 +252,6 @@ public typealias Provider = RLMIdentityProvider
     }
 }
 
-#if canImport(Combine)
-import Combine
-#endif
-
 /// Structure providing an interface to call a MongoDB Realm function with the provided name and arguments.
 ///
 ///     user.functions.sum([1, 2, 3, 4, 5]) { sum, error in
@@ -311,7 +311,7 @@ import Combine
         }
     }
 
-    #if canImport(Combine)
+    #if !(os(iOS) && (arch(i386) || arch(arm)))
     /// The implementation of @dynamicMemberLookup that allows for dynamic remote function calls.
     @available(OSX 10.15, watchOS 6.0, iOS 13.0, iOSApplicationExtension 13.0, OSXApplicationExtension 10.15, tvOS 13.0, macCatalyst 13.0, macCatalystApplicationExtension 13.0, *)
     public subscript(dynamicMember string: String) -> ([AnyBSON]) -> Future<AnyBSON, Error> {
@@ -583,7 +583,7 @@ extension Realm {
     }
 }
 
-#if canImport(Combine)
+#if !(os(iOS) && (arch(i386) || arch(arm)))
 @available(OSX 10.15, watchOS 6.0, iOS 13.0, iOSApplicationExtension 13.0, OSXApplicationExtension 10.15, tvOS 13.0, macCatalyst 13.0, macCatalystApplicationExtension 13.0, *)
 public extension User {
     /// Refresh a user's custom data. This will, in effect, refresh the user's auth session.

--- a/RealmSwift/Tests/CombineTests.swift
+++ b/RealmSwift/Tests/CombineTests.swift
@@ -16,7 +16,7 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-#if canImport(Combine)
+#if !(os(iOS) && (arch(i386) || arch(arm)))
 import XCTest
 import Combine
 import RealmSwift

--- a/RealmSwift/Tests/SwiftUITests.swift
+++ b/RealmSwift/Tests/SwiftUITests.swift
@@ -16,7 +16,7 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-#if canImport(SwiftUI) && canImport(Combine)
+#if !(os(iOS) && (arch(i386) || arch(arm)))
 import XCTest
 import RealmSwift
 import SwiftUI


### PR DESCRIPTION
Xcode 13 beta 3 added a swiftinterface file for armv7 Combine which makes canImport(Combine) return true, but the swiftinterface file doesn't actually compile (and no armv7 devices can run OS versions with Combine). Work around this by replacing the `canImport(Combine)` checks with a define we manually set when building for armv7.