### PR TITLE
Allow indexing PersistableEnum properties

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -13,8 +13,8 @@ identifier_name:
     error: 0
   excluded:
     - _id
-    - _nilValue()
     - _name(for:)
+    - _nilValue()
     - _nsError
     - _nsErrorDomain
     - _observe(_:)
@@ -41,6 +41,9 @@ identifier_name:
     - id
     - pk
     - to
+type_name:
+  excluded:
+    - _RealmValue
 disabled_rules:
   - block_based_kvo
   # SwiftLint expects a space following a double slash comment: "//".

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ x.y.z Release notes (yyyy-MM-dd)
 ### Enhancements
 * Add additional `observe` methods for Objects and RealmCollections which take a `PartialKeyPath` type key path parameter.
 * The release package once again contains Xcode 13 binaries for iOS.
+* `PersistableEnum` properties can now be indexed or used as the primary key if
+  the RawValue is an indexable or primary key type.
 
 ### Fixed
 * `Map<Key, Value>` did not conform to `Codable`. ([Cocoa #7418](https://github.com/realm/realm-cocoa/pull/7418), since v10.8.0)

--- a/RealmSwift/Impl/BasicTypes.swift
+++ b/RealmSwift/Impl/BasicTypes.swift
@@ -108,7 +108,7 @@ extension NSDate: SchemaDiscoverable {
 
 // MARK: - Modern property getters/setters
 
-private protocol _Int: BinaryInteger, _OptionalPersistable, _PrimaryKey, _Indexable {
+private protocol _Int: BinaryInteger, _OptionalPersistable, _BuiltInPersistable, _PrimaryKey, _Indexable {
 }
 
 extension _Int {
@@ -136,7 +136,7 @@ extension Int16: _Int {}
 extension Int32: _Int {}
 extension Int64: _Int {}
 
-extension Bool: _OptionalPersistable, _DefaultConstructible, _PrimaryKey, _Indexable {
+extension Bool: _OptionalPersistable, _BuiltInPersistable, _DefaultConstructible, _PrimaryKey, _Indexable {
     @inlinable
     public static func _rlmGetProperty(_ obj: ObjectBase, _ key: PropertyKey) -> Bool {
         return RLMGetSwiftPropertyBool(obj, key)
@@ -155,7 +155,7 @@ extension Bool: _OptionalPersistable, _DefaultConstructible, _PrimaryKey, _Index
     }
 }
 
-extension Float: _OptionalPersistable, _DefaultConstructible {
+extension Float: _OptionalPersistable, _BuiltInPersistable, _DefaultConstructible {
     @inlinable
     public static func _rlmGetProperty(_ obj: ObjectBase, _ key: PropertyKey) -> Float {
         return RLMGetSwiftPropertyFloat(obj, key)
@@ -174,7 +174,7 @@ extension Float: _OptionalPersistable, _DefaultConstructible {
     }
 }
 
-extension Double: _OptionalPersistable, _DefaultConstructible {
+extension Double: _OptionalPersistable, _BuiltInPersistable, _DefaultConstructible {
     @inlinable
     public static func _rlmGetProperty(_ obj: ObjectBase, _ key: PropertyKey) -> Double {
         return RLMGetSwiftPropertyDouble(obj, key)
@@ -193,7 +193,7 @@ extension Double: _OptionalPersistable, _DefaultConstructible {
     }
 }
 
-extension String: _OptionalPersistable, _DefaultConstructible, _PrimaryKey, _Indexable {
+extension String: _OptionalPersistable, _BuiltInPersistable, _DefaultConstructible, _PrimaryKey, _Indexable {
     @inlinable
     public static func _rlmGetProperty(_ obj: ObjectBase, _ key: PropertyKey) -> String {
         return RLMGetSwiftPropertyString(obj, key)!
@@ -210,7 +210,7 @@ extension String: _OptionalPersistable, _DefaultConstructible, _PrimaryKey, _Ind
     }
 }
 
-extension Data: _OptionalPersistable, _DefaultConstructible {
+extension Data: _OptionalPersistable, _BuiltInPersistable, _DefaultConstructible {
     @inlinable
     public static func _rlmGetProperty(_ obj: ObjectBase, _ key: PropertyKey) -> Data {
         return RLMGetSwiftPropertyData(obj, key)!
@@ -227,7 +227,7 @@ extension Data: _OptionalPersistable, _DefaultConstructible {
     }
 }
 
-extension ObjectId: _OptionalPersistable, _DefaultConstructible, _PrimaryKey, _Indexable {
+extension ObjectId: _OptionalPersistable, _BuiltInPersistable, _DefaultConstructible, _PrimaryKey, _Indexable {
     @inlinable
     public static func _rlmGetProperty(_ obj: ObjectBase, _ key: PropertyKey) -> ObjectId {
         return RLMGetSwiftPropertyObjectId(obj, key) as! ObjectId
@@ -248,7 +248,7 @@ extension ObjectId: _OptionalPersistable, _DefaultConstructible, _PrimaryKey, _I
     }
 }
 
-extension Decimal128: _OptionalPersistable, _DefaultConstructible {
+extension Decimal128: _OptionalPersistable, _BuiltInPersistable, _DefaultConstructible {
     @inlinable
     public static func _rlmGetProperty(_ obj: ObjectBase, _ key: PropertyKey) -> Decimal128 {
         return RLMGetSwiftPropertyDecimal128(obj, key) as! Decimal128
@@ -265,7 +265,7 @@ extension Decimal128: _OptionalPersistable, _DefaultConstructible {
     }
 }
 
-extension Date: _OptionalPersistable, _DefaultConstructible, _Indexable {
+extension Date: _OptionalPersistable, _BuiltInPersistable, _DefaultConstructible, _Indexable {
     @inlinable
     public static func _rlmGetProperty(_ obj: ObjectBase, _ key: PropertyKey) -> Date {
         return RLMGetSwiftPropertyDate(obj, key)!
@@ -282,7 +282,7 @@ extension Date: _OptionalPersistable, _DefaultConstructible, _Indexable {
     }
 }
 
-extension UUID: _OptionalPersistable, _DefaultConstructible, _PrimaryKey {
+extension UUID: _OptionalPersistable, _BuiltInPersistable, _DefaultConstructible, _PrimaryKey {
     @inlinable
     public static func _rlmGetProperty(_ obj: ObjectBase, _ key: PropertyKey) -> UUID {
         return RLMGetSwiftPropertyUUID(obj, key)!
@@ -300,6 +300,8 @@ extension UUID: _OptionalPersistable, _DefaultConstructible, _PrimaryKey {
 }
 
 extension AnyRealmValue: _Persistable, _DefaultConstructible {
+    public typealias _RealmValue = AnyRealmValue
+
     @inlinable
     public static func _rlmGetProperty(_ obj: ObjectBase, _ key: PropertyKey) -> AnyRealmValue {
         return ObjectiveCSupport.convert(value: RLMGetSwiftPropertyAny(obj, key))

--- a/RealmSwift/Impl/ComplexTypes.swift
+++ b/RealmSwift/Impl/ComplexTypes.swift
@@ -19,7 +19,7 @@
 import Realm
 import Realm.Private
 
-extension Object: SchemaDiscoverable, _OptionalPersistable, _DefaultConstructible {
+extension Object: SchemaDiscoverable, _OptionalPersistable, _BuiltInPersistable, _DefaultConstructible {
     public static var _rlmType: PropertyType { .object }
     public static func _rlmPopulateProperty(_ prop: RLMProperty) {
         if !prop.optional && !prop.collection {
@@ -55,7 +55,7 @@ extension Object: SchemaDiscoverable, _OptionalPersistable, _DefaultConstructibl
     }
 }
 
-extension EmbeddedObject: SchemaDiscoverable, _OptionalPersistable, _DefaultConstructible {
+extension EmbeddedObject: SchemaDiscoverable, _OptionalPersistable, _BuiltInPersistable, _DefaultConstructible {
     public static var _rlmType: PropertyType { .object }
     public static func _rlmPopulateProperty(_ prop: RLMProperty) {
         Object._rlmPopulateProperty(prop)
@@ -90,6 +90,7 @@ extension List: SchemaDiscoverable where Element: _RealmSchemaDiscoverable {
 }
 
 extension List: _Persistable, _DefaultConstructible where Element: _Persistable {
+    public typealias _RealmValue = List
     public static var _rlmRequiresCaching: Bool { true }
 
     public static func _rlmGetProperty(_ obj: ObjectBase, _ key: UInt16) -> Self {
@@ -124,6 +125,7 @@ extension MutableSet: SchemaDiscoverable where Element: _RealmSchemaDiscoverable
 }
 
 extension MutableSet: _Persistable, _DefaultConstructible where Element: _Persistable {
+    public typealias _RealmValue = MutableSet
     public static var _rlmRequiresCaching: Bool { true }
 
     public static func _rlmGetProperty(_ obj: ObjectBase, _ key: UInt16) -> Self {
@@ -159,6 +161,7 @@ extension Map: SchemaDiscoverable where Value: _RealmSchemaDiscoverable {
 }
 
 extension Map: _Persistable, _DefaultConstructible where Value: _Persistable {
+    public typealias _RealmValue = Map
     public static var _rlmRequiresCaching: Bool { true }
 
     public static func _rlmGetProperty(_ obj: ObjectBase, _ key: UInt16) -> Self {
@@ -209,6 +212,7 @@ extension RealmOptional: SchemaDiscoverable, _RealmSchemaDiscoverable where Valu
 }
 
 extension LinkingObjects: _Persistable where Element: _Persistable {
+    public typealias _RealmValue = Self
     public static func _rlmDefaultValue(_ forceDefaultInitialization: Bool) -> Self {
         if forceDefaultInitialization {
             return .init(propertyName: "", handle: nil)
@@ -244,6 +248,8 @@ extension Optional: SchemaDiscoverable, _RealmSchemaDiscoverable where Wrapped: 
 }
 
 extension Optional: _Persistable where Wrapped: _OptionalPersistable {
+    public typealias _RealmValue = Self
+
     public static func _rlmDefaultValue(_ forceDefaultInitialization: Bool) -> Self {
         if forceDefaultInitialization {
             return Wrapped()
@@ -268,8 +274,8 @@ extension Optional: _Persistable where Wrapped: _OptionalPersistable {
     }
 }
 
-extension Optional: _PrimaryKey where Wrapped: _PrimaryKey {}
-extension Optional: _Indexable where Wrapped: _Indexable {}
+extension Optional: _PrimaryKey where Wrapped: _Persistable, Wrapped._RealmValue: _PrimaryKey {}
+extension Optional: _Indexable where Wrapped: _Persistable, Wrapped._RealmValue: _Indexable {}
 
 extension RealmProperty: _RealmSchemaDiscoverable, SchemaDiscoverable where Value: _RealmSchemaDiscoverable {
     public static var _rlmType: PropertyType { Value._rlmType }
@@ -292,6 +298,7 @@ extension RawRepresentable where RawValue: _RealmSchemaDiscoverable {
 }
 
 extension RawRepresentable where Self: _OptionalPersistable, RawValue: _OptionalPersistable {
+    public typealias _RealmValue = RawValue
     public static func _rlmGetProperty(_ obj: ObjectBase, _ key: PropertyKey) -> Self {
         return Self(rawValue: RawValue._rlmGetProperty(obj, key))!
     }

--- a/RealmSwift/Impl/Persistable.swift
+++ b/RealmSwift/Impl/Persistable.swift
@@ -49,12 +49,21 @@ public protocol _Persistable: _RealmSchemaDiscoverable {
     // If we are in key path tracing mode, instantiate an empty object and forward
     // the lastAccessedNames array.
     static func _rlmKeyPathRecorder(with lastAccessedNames: NSMutableArray) -> Self
+    // The type which is actually stored in the Realm. This is Self for types
+    // we support directly, but may be a different type for enums and mapped types.
+    associatedtype _RealmValue: _Persistable
 }
 
 extension _Persistable {
     public static var _rlmRequiresCaching: Bool {
         false
     }
+}
+
+// A helper protocol for types which we support directly rather than via
+// mapping to a supported type.
+public protocol _BuiltInPersistable {
+    associatedtype _RealmValue = Self
 }
 
 extension _RealmSchemaDiscoverable where Self: _Persistable {

--- a/RealmSwift/PersistedProperty.swift
+++ b/RealmSwift/PersistedProperty.swift
@@ -289,9 +289,13 @@ extension Persisted: OptionalCodingWrapper where Value: ExpressibleByNilLiteral 
  }
  ```
 
- If the Realm contains a value which is not a valid member of the enum (such as if it was written by a different sync client which disagrees on which values are valid), optional enum properties will return `nil`, and non-optional properties will abort the process.
+ If the Realm contains a value which is not a valid member of the enum (such as
+ if it was written by a different sync client which disagrees on which values
+ are valid), optional enum properties will return `nil`, and non-optional
+ properties will abort the process.
  */
-public protocol PersistableEnum: _OptionalPersistable, RawRepresentable, CaseIterable, RealmEnum { }
+public protocol PersistableEnum: _OptionalPersistable, RawRepresentable, CaseIterable, RealmEnum {
+}
 
 extension PersistableEnum {
     /// :nodoc:
@@ -304,7 +308,7 @@ extension PersistableEnum {
 /// to it will simply result in runtime errors rather than compile-time errors.
 public protocol _Indexable {}
 
-extension Persisted where Value: _Indexable {
+extension Persisted where Value._RealmValue: _Indexable {
     /// Declares an indexed property which is lazily initialized to the type's default value.
     public init(indexed: Bool) {
         storage = .unmanagedNoDefault(indexed: indexed)
@@ -321,7 +325,7 @@ extension Persisted where Value: _Indexable {
 /// to it will simply result in runtime errors rather than compile-time errors.
 public protocol _PrimaryKey {}
 
-extension Persisted where Value: _PrimaryKey {
+extension Persisted where Value._RealmValue: _PrimaryKey {
     /// Declares the primary key property which is lazily initialized to the type's default value.
     public init(primaryKey: Bool) {
         storage = .unmanagedNoDefault(primary: primaryKey)

--- a/RealmSwift/Tests/ModernObjectTests.swift
+++ b/RealmSwift/Tests/ModernObjectTests.swift
@@ -134,6 +134,9 @@ class ModernObjectTests: TestCase {
         test(ModernPrimaryObjectIdObject(), ObjectId.generate(), ObjectId.generate())
         test(ModernPrimaryOptionalObjectIdObject(), ObjectId.generate(), nil)
 
+        test(ModernPrimaryIntEnumObject(), .value1, .value2)
+        test(ModernPrimaryOptionalIntEnumObject(), .value1, nil)
+
         realm.cancelWrite()
     }
 

--- a/RealmSwift/Tests/ModernTestObjects.swift
+++ b/RealmSwift/Tests/ModernTestObjects.swift
@@ -264,6 +264,22 @@ class ModernPrimaryOptionalObjectIdObject: Object, ModernPrimaryKeyObject {
     @Persisted(primaryKey: true) var pk: ObjectId?
 }
 
+class ModernPrimaryIntEnumObject: Object, ModernPrimaryKeyObject {
+    @Persisted(primaryKey: true) var pk: ModernIntEnum
+}
+
+class ModernPrimaryOptionalIntEnumObject: Object, ModernPrimaryKeyObject {
+    @Persisted(primaryKey: true) var pk: ModernIntEnum?
+}
+
+class ModernIndexedIntEnumObject: Object {
+    @Persisted(indexed: true) var value: ModernIntEnum
+}
+
+class ModernIndexedOptionalIntEnumObject: Object {
+    @Persisted(indexed: true) var value: ModernIntEnum?
+}
+
 class ModernCustomInitializerObject: Object {
     @Persisted var stringCol: String
 
@@ -384,4 +400,56 @@ class ObjectWithArcMethodCategoryNames: Object {
     @Persisted var copyValue: String
     @Persisted var mutableCopyValue: String
     @Persisted var initValue: String
+}
+
+class ModernAllIndexableTypesObject: Object {
+    @Persisted(indexed: true) var boolCol: Bool
+    @Persisted(indexed: true) var intCol: Int
+    @Persisted(indexed: true) var int8Col: Int8 = 1
+    @Persisted(indexed: true) var int16Col: Int16 = 2
+    @Persisted(indexed: true) var int32Col: Int32 = 3
+    @Persisted(indexed: true) var int64Col: Int64 = 4
+    @Persisted(indexed: true) var stringCol: String
+    @Persisted(indexed: true) var dateCol: Date
+    @Persisted(indexed: true) var objectIdCol: ObjectId
+    @Persisted(indexed: true) var intEnumCol: ModernIntEnum
+    @Persisted(indexed: true) var stringEnumCol: ModernStringEnum
+
+    @Persisted(indexed: true) var optIntCol: Int?
+    @Persisted(indexed: true) var optInt8Col: Int8?
+    @Persisted(indexed: true) var optInt16Col: Int16?
+    @Persisted(indexed: true) var optInt32Col: Int32?
+    @Persisted(indexed: true) var optInt64Col: Int64?
+    @Persisted(indexed: true) var optBoolCol: Bool?
+    @Persisted(indexed: true) var optStringCol: String?
+    @Persisted(indexed: true) var optDateCol: Date?
+    @Persisted(indexed: true) var optObjectIdCol: ObjectId?
+    @Persisted(indexed: true) var optIntEnumCol: ModernIntEnum?
+    @Persisted(indexed: true) var optStringEnumCol: ModernStringEnum?
+}
+
+class ModernAllIndexableButNotIndexedObject: Object {
+    @Persisted(indexed: false) var boolCol: Bool
+    @Persisted(indexed: false) var intCol: Int
+    @Persisted(indexed: false) var int8Col: Int8 = 1
+    @Persisted(indexed: false) var int16Col: Int16 = 2
+    @Persisted(indexed: false) var int32Col: Int32 = 3
+    @Persisted(indexed: false) var int64Col: Int64 = 4
+    @Persisted(indexed: false) var stringCol: String
+    @Persisted(indexed: false) var dateCol: Date
+    @Persisted(indexed: false) var objectIdCol: ObjectId
+    @Persisted(indexed: false) var intEnumCol: ModernIntEnum
+    @Persisted(indexed: false) var stringEnumCol: ModernStringEnum
+
+    @Persisted(indexed: false) var optIntCol: Int?
+    @Persisted(indexed: false) var optInt8Col: Int8?
+    @Persisted(indexed: false) var optInt16Col: Int16?
+    @Persisted(indexed: false) var optInt32Col: Int32?
+    @Persisted(indexed: false) var optInt64Col: Int64?
+    @Persisted(indexed: false) var optBoolCol: Bool?
+    @Persisted(indexed: false) var optStringCol: String?
+    @Persisted(indexed: false) var optDateCol: Date?
+    @Persisted(indexed: false) var optObjectIdCol: ObjectId?
+    @Persisted(indexed: false) var optIntEnumCol: ModernIntEnum?
+    @Persisted(indexed: false) var optStringEnumCol: ModernStringEnum?
 }

--- a/RealmSwift/Tests/ObjectSchemaInitializationTests.swift
+++ b/RealmSwift/Tests/ObjectSchemaInitializationTests.swift
@@ -258,6 +258,17 @@ class ObjectSchemaInitializationTests: TestCase {
                      reason: "Properties 'pk2' and 'pk1' are both marked as the primary key of 'SwiftObjectWithMultiplePrimaryKeys'")
     }
 
+    func testModernIndexableTypes() {
+        let indexed = ModernAllIndexableTypesObject().objectSchema
+        for property in indexed.properties {
+            XCTAssertTrue(property.isIndexed)
+        }
+        let notIndexed = ModernAllIndexableButNotIndexedObject().objectSchema
+        for property in notIndexed.properties {
+            XCTAssertFalse(property.isIndexed)
+        }
+    }
+
     #if DEBUG // this test depends on @testable import
     func assertType<T: SchemaDiscoverable>(_ value: T, _ propertyType: PropertyType,
                                            optional: Bool = false, list: Bool = false,


### PR DESCRIPTION
The obvious straightforward way to do this would be `extension PersistableEnum: _Indexable where RawValue: _Indexable {}`, but Swift doesn't support conditional protocol inheritance. Instead requires a backport of a bit of the custom type mapping code so that we can check if the persisted type is indexable.

This doesn't really have any tests because I'm not sure what there even is to test other than that the new model classes compile and don't produce schema validation errors.

Fixes #7404.