### PR TITLE
Speed up many of the sync tests

### DIFF
--- a/Realm.xcodeproj/project.pbxproj
+++ b/Realm.xcodeproj/project.pbxproj
@@ -202,6 +202,7 @@
 		3F98162B2317763600C3543D /* libz.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 1A7B82391D51259F00750296 /* libz.tbd */; };
 		3F9863BB1D36876B00641C98 /* RLMClassInfo.mm in Sources */ = {isa = PBXBuildFile; fileRef = 3F9863B91D36876B00641C98 /* RLMClassInfo.mm */; };
 		3F9863BC1D36876B00641C98 /* RLMClassInfo.mm in Sources */ = {isa = PBXBuildFile; fileRef = 3F9863B91D36876B00641C98 /* RLMClassInfo.mm */; };
+		3F9ADA9426E7E87B007349A5 /* SwiftCollectionSyncTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F9ADA9326E7E87B007349A5 /* SwiftCollectionSyncTests.swift */; };
 		3F9B4A6624CF8C0E00C72A4A /* realm-monorepo.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3FE5B4D424CF3F06004D4EF3 /* realm-monorepo.xcframework */; };
 		3F9D91822152D42F00474F09 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = E8839B2D19E31FD90047B1A8 /* main.m */; };
 		3FA5E94D266064C4008F1345 /* ModernObjectCreationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FA5E94C266064C4008F1345 /* ModernObjectCreationTests.swift */; };
@@ -450,7 +451,6 @@
 		CF040494263DF0AA00F9AEE0 /* PrimitiveMapTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF040493263DF0A900F9AEE0 /* PrimitiveMapTests.swift */; };
 		CF052EFB25DEB671008EEF86 /* DictionaryPropertyTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CF052EFA25DEB671008EEF86 /* DictionaryPropertyTests.m */; };
 		CF052EFC25DEB671008EEF86 /* DictionaryPropertyTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CF052EFA25DEB671008EEF86 /* DictionaryPropertyTests.m */; };
-		CF087567260B98CF00B9BE60 /* SwiftCollectionSyncTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF087566260B98CF00B9BE60 /* SwiftCollectionSyncTests.swift */; };
 		CF08757D260B98E100B9BE60 /* RLMCollectionSyncTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = CF08757C260B98E100B9BE60 /* RLMCollectionSyncTests.mm */; };
 		CF0D04F1269365300038A058 /* KeyPathTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF0D04F02693652E0038A058 /* KeyPathTests.swift */; };
 		CF330BBE24E57D5F00F07EE2 /* RLMWatchTestUtility.m in Sources */ = {isa = PBXBuildFile; fileRef = CF330BBD24E57D5F00F07EE2 /* RLMWatchTestUtility.m */; };
@@ -581,13 +581,6 @@
 			remoteInfo = "Download BaaS";
 		};
 		5345F0A326E3900100827AC9 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = E8D89B8F1955FC6D00CF2B9A /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 3F1A5E711992EB7400F45F4C;
-			remoteInfo = TestHost;
-		};
-		5345F0A526E390D600827AC9 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = E8D89B8F1955FC6D00CF2B9A /* Project object */;
 			proxyType = 1;
@@ -870,6 +863,7 @@
 		3F9816292317763000C3543D /* libc++.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = "libc++.tbd"; path = "usr/lib/libc++.tbd"; sourceTree = SDKROOT; };
 		3F9863B91D36876B00641C98 /* RLMClassInfo.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = RLMClassInfo.mm; sourceTree = "<group>"; };
 		3F9863BA1D36876B00641C98 /* RLMClassInfo.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = RLMClassInfo.hpp; sourceTree = "<group>"; };
+		3F9ADA9326E7E87B007349A5 /* SwiftCollectionSyncTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SwiftCollectionSyncTests.swift; path = Realm/ObjectServerTests/SwiftCollectionSyncTests.swift; sourceTree = "<group>"; };
 		3F9D91872152D42F00474F09 /* TestHost static.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "TestHost static.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		3FA5E94C266064C4008F1345 /* ModernObjectCreationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ModernObjectCreationTests.swift; sourceTree = "<group>"; };
 		3FB19068265ECF0C00DA7C76 /* ModernObjectTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ModernObjectTests.swift; sourceTree = "<group>"; };
@@ -1015,7 +1009,6 @@
 		C0D2DD0F1B6BE0DD004E8919 /* RLMRealmConfiguration_Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RLMRealmConfiguration_Private.h; sourceTree = "<group>"; };
 		CF040493263DF0A900F9AEE0 /* PrimitiveMapTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PrimitiveMapTests.swift; sourceTree = "<group>"; };
 		CF052EFA25DEB671008EEF86 /* DictionaryPropertyTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DictionaryPropertyTests.m; sourceTree = "<group>"; };
-		CF087566260B98CF00B9BE60 /* SwiftCollectionSyncTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SwiftCollectionSyncTests.swift; path = Realm/ObjectServerTests/SwiftCollectionSyncTests.swift; sourceTree = "<group>"; };
 		CF08757C260B98E100B9BE60 /* RLMCollectionSyncTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = RLMCollectionSyncTests.mm; path = Realm/ObjectServerTests/RLMCollectionSyncTests.mm; sourceTree = "<group>"; };
 		CF0D04F02693652E0038A058 /* KeyPathTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyPathTests.swift; sourceTree = "<group>"; };
 		CF330BBB24E56E3A00F07EE2 /* RLMNetworkTransport_Private.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = RLMNetworkTransport_Private.hpp; sourceTree = "<group>"; };
@@ -1060,7 +1053,6 @@
 		CF9881C025DABC6500BD7E4F /* RLMManagedDictionary.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = RLMManagedDictionary.mm; sourceTree = "<group>"; };
 		CF9881CB25DABDE900BD7E4F /* RLMDictionary_Private.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = RLMDictionary_Private.hpp; sourceTree = "<group>"; };
 		CFA3A23D260B8427002C3266 /* RLMCollectionSyncTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = RLMCollectionSyncTests.mm; path = Realm/ObjectServerTests/RLMCollectionSyncTests.mm; sourceTree = "<group>"; };
-		CFA3A23E260B8430002C3266 /* SwiftCollectionSyncTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SwiftCollectionSyncTests.swift; path = Realm/ObjectServerTests/SwiftCollectionSyncTests.swift; sourceTree = "<group>"; };
 		CFAE926A24A0A7F40033CB31 /* AuthenticationServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AuthenticationServices.framework; path = System/Library/Frameworks/AuthenticationServices.framework; sourceTree = SDKROOT; };
 		CFAEF75F242B5F9A00EAF721 /* RLMAPIKeyAuth.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RLMAPIKeyAuth.h; sourceTree = "<group>"; };
 		CFAEF760242B5F9A00EAF721 /* RLMAPIKeyAuth.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = RLMAPIKeyAuth.mm; sourceTree = "<group>"; };
@@ -1354,10 +1346,10 @@
 			isa = PBXGroup;
 			children = (
 				3F558C8422C29A03002F0F30 /* RLMAssertions.h */,
-				3F558C8022C29A02002F0F30 /* RLMMultiProcessTestCase.h */,
-				3F558C8522C29A03002F0F30 /* RLMMultiProcessTestCase.m */,
 				533489DD26E0F9510085EEE1 /* RLMChildProcessEnvironment.h */,
 				530BA61326DFA1CB008FC550 /* RLMChildProcessEnvironment.m */,
+				3F558C8022C29A02002F0F30 /* RLMMultiProcessTestCase.h */,
+				3F558C8522C29A03002F0F30 /* RLMMultiProcessTestCase.m */,
 				3F558C7F22C29A02002F0F30 /* RLMTestCase.h */,
 				3F558C8322C29A02002F0F30 /* RLMTestCase.m */,
 				3F558C8122C29A02002F0F30 /* RLMTestObjects.h */,
@@ -1408,12 +1400,12 @@
 				5D659E6E1BE0398E006515A0 /* Debug.xcconfig */,
 				3FB56E7E250D457A00A6216B /* ObjectServerTests.xcconfig */,
 				5D659E6F1BE0398E006515A0 /* Release.xcconfig */,
+				AC8847432687DFE700DF4A65 /* SwiftUISyncTestHost.xcconfig */,
+				AC8847442687DFE700DF4A65 /* SwiftUISyncTestHostTests.xcconfig */,
 				53124A4F25B714EC00771CE4 /* SwiftUITestHost.xcconfig */,
 				53626A8C25D3172000D9515D /* SwiftUITestHostTests.xcconfig */,
 				3F35027722C43C5200FDC1E5 /* TestHost-static.xcconfig */,
 				5D6156F71BE07B6B00A4BD3F /* TestHost.xcconfig */,
-				AC8847432687DFE700DF4A65 /* SwiftUISyncTestHost.xcconfig */,
-				AC8847442687DFE700DF4A65 /* SwiftUISyncTestHostTests.xcconfig */,
 			);
 			path = Configuration;
 			sourceTree = "<group>";
@@ -1477,11 +1469,11 @@
 			children = (
 				5D6610291BE98DAA0021E04F /* Supporting Files */,
 				CFFC8CC7262310C800929608 /* AnyRealmValueTests.swift */,
-				CF0D04F02693652E0038A058 /* KeyPathTests.swift */,
 				3FCB1A7422A9B0A2003807FB /* CodableTests.swift */,
 				3FE2BE0223D8CAD1002860E9 /* CombineTests.swift */,
 				E8AE7C251EA436F800CDFF9A /* CompactionTests.swift */,
 				CFFECBA8250646750010F585 /* Decimal128Tests.swift */,
+				CF0D04F02693652E0038A058 /* KeyPathTests.swift */,
 				5D660FFF1BE98D880021E04F /* KVOTests.swift */,
 				5D6610001BE98D880021E04F /* ListTests.swift */,
 				3F1D8D75265B075000593ABA /* MapTests.swift */,
@@ -1533,9 +1525,9 @@
 		AC8846742686573B00DF4A65 /* SwiftUISyncTestHost */ = {
 			isa = PBXGroup;
 			children = (
+				AC8846772686573B00DF4A65 /* ContentView.swift */,
 				AC8847472687E0AA00DF4A65 /* Info.plist */,
 				AC8846752686573B00DF4A65 /* SwiftUISyncTestHostApp.swift */,
-				AC8846772686573B00DF4A65 /* ContentView.swift */,
 			);
 			path = SwiftUISyncTestHost;
 			sourceTree = "<group>";
@@ -1545,8 +1537,8 @@
 			children = (
 				AC8847492687E0BD00DF4A65 /* Info.plist */,
 				AC8846B82687BD4D00DF4A65 /* SwiftUISyncTestHostUITests-Bridging-Header.h */,
-				AC8846902686573D00DF4A65 /* SwiftUISyncTestHostUITests.swift */,
 				AC2C2A43268F982D00B4DA33 /* SwiftUISyncTestHostUITests.entitlements */,
+				AC8846902686573D00DF4A65 /* SwiftUISyncTestHostUITests.swift */,
 			);
 			path = SwiftUISyncTestHostUITests;
 			sourceTree = "<group>";
@@ -1677,13 +1669,12 @@
 				3F73BC8A1E3A876600FE80B6 /* RLMTestUtils.h */,
 				3F73BC8B1E3A876600FE80B6 /* RLMTestUtils.m */,
 				49D9DFC4246C8E48003AD31D /* setup_baas.rb */,
-				AC8846B62687BC4100DF4A65 /* SwiftUIServerTests.swift */,
-				CFA3A23E260B8430002C3266 /* SwiftCollectionSyncTests.swift */,
-				CF087566260B98CF00B9BE60 /* SwiftCollectionSyncTests.swift */,
+				3F9ADA9326E7E87B007349A5 /* SwiftCollectionSyncTests.swift */,
 				AC7D182C261F2F560080E1D2 /* SwiftObjectServerPartitionTests.swift */,
 				1AA5AE9F1D98C99500ED8C27 /* SwiftObjectServerTests.swift */,
-				1AA5AE961D989BE000ED8C27 /* SwiftSyncTestCase.swift */,
 				AC2C2A3E268E1ACE00B4DA33 /* SwiftServerObjects.swift */,
+				1AA5AE961D989BE000ED8C27 /* SwiftSyncTestCase.swift */,
+				AC8846B62687BC4100DF4A65 /* SwiftUIServerTests.swift */,
 			);
 			name = "Object Server Tests";
 			sourceTree = "<group>";
@@ -1724,13 +1715,13 @@
 				5DD755CF1BE056DE002800DA /* Realm.framework */,
 				5D660FD81BE98C7C0021E04F /* RealmSwift Tests.xctest */,
 				5D660FCC1BE98C560021E04F /* RealmSwift.framework */,
+				AC8846732686573B00DF4A65 /* SwiftUISyncTestHost.app */,
+				AC88478126888C6300DF4A65 /* SwiftUISyncTestHostUITests.xctest */,
 				53124AB825B71AF600771CE4 /* SwiftUITestHost.app */,
 				53124AD425B71AF700771CE4 /* SwiftUITestHostUITests.xctest */,
 				3F9D91872152D42F00474F09 /* TestHost static.app */,
 				3F1A5E721992EB7400F45F4C /* TestHost.app */,
 				E8D89BA31955FC6D00CF2B9A /* Tests.xctest */,
-				AC8846732686573B00DF4A65 /* SwiftUISyncTestHost.app */,
-				AC88478126888C6300DF4A65 /* SwiftUISyncTestHostUITests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -1865,10 +1856,10 @@
 				E81A20061955FE1600FDED82 /* Objective-C */,
 				E8D89BA81955FC6D00CF2B9A /* Supporting Files */,
 				E81A1FC81955FE0100FDED82 /* Swift */,
-				53A34E3225CDA0AC00698930 /* SwiftUITestHost */,
-				53124AD725B71AF700771CE4 /* SwiftUITestHostUITests */,
 				AC8846742686573B00DF4A65 /* SwiftUISyncTestHost */,
 				AC88468F2686573D00DF4A65 /* SwiftUISyncTestHostUITests */,
+				53A34E3225CDA0AC00698930 /* SwiftUITestHost */,
+				53124AD725B71AF700771CE4 /* SwiftUITestHostUITests */,
 				3F1A5E731992EB7400F45F4C /* TestHost */,
 			);
 			name = "Realm Tests";
@@ -2787,6 +2778,7 @@
 				3FE2BE0323D8CAD1002860E9 /* CombineTests.swift in Sources */,
 				E8AE7C261EA436F800CDFF9A /* CompactionTests.swift in Sources */,
 				CFFECBAA250646820010F585 /* Decimal128Tests.swift in Sources */,
+				CF0D04F1269365300038A058 /* KeyPathTests.swift in Sources */,
 				3FF3FFAF1F0D6D6400B84599 /* KVOTests.swift in Sources */,
 				5D6610161BE98D880021E04F /* ListTests.swift in Sources */,
 				3F1D8D77265B075100593ABA /* MapTests.swift in Sources */,
@@ -2808,13 +2800,12 @@
 				3F2633C31E9D630000B32D30 /* PrimitiveListTests.swift in Sources */,
 				CF040494263DF0AA00F9AEE0 /* PrimitiveMapTests.swift in Sources */,
 				CF986DF625AE3EDF0039D287 /* PrimitiveMutableSetTests.swift in Sources */,
-				530BA61526DFA1CB008FC550 /* RLMChildProcessEnvironment.m in Sources */,
 				3F8825051E5E335000586B35 /* PropertyTests.swift in Sources */,
 				3F8825061E5E335000586B35 /* RealmCollectionTypeTests.swift in Sources */,
-				CF0D04F1269365300038A058 /* KeyPathTests.swift in Sources */,
 				3F8825071E5E335000586B35 /* RealmConfigurationTests.swift in Sources */,
 				3F4E10112655CA33008B8C0B /* RealmPropertyTests.swift in Sources */,
 				3F8825081E5E335000586B35 /* RealmTests.swift in Sources */,
+				530BA61526DFA1CB008FC550 /* RLMChildProcessEnvironment.m in Sources */,
 				3F558C9622C29A03002F0F30 /* RLMMultiProcessTestCase.m in Sources */,
 				3F558C9222C29A03002F0F30 /* RLMTestCase.m in Sources */,
 				3F558C8E22C29A03002F0F30 /* RLMTestObjects.m in Sources */,
@@ -2911,15 +2902,15 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				AC8847A3268925F100DF4A65 /* RLMSyncTestCase.mm in Sources */,
-				AC320BAE268E1F2D0043D484 /* SwiftServerObjects.swift in Sources */,
-				AC8847A6268925F100DF4A65 /* RLMTestCase.m in Sources */,
-				AC8847A72689260E00DF4A65 /* RLMMultiProcessTestCase.m in Sources */,
-				AC8847A82689263100DF4A65 /* TestUtils.mm in Sources */,
 				AC8847A9268926B500DF4A65 /* RealmServer.swift in Sources */,
+				530BA61826DFA1CB008FC550 /* RLMChildProcessEnvironment.m in Sources */,
+				AC8847A72689260E00DF4A65 /* RLMMultiProcessTestCase.m in Sources */,
+				AC8847A3268925F100DF4A65 /* RLMSyncTestCase.mm in Sources */,
+				AC8847A6268925F100DF4A65 /* RLMTestCase.m in Sources */,
+				AC320BAE268E1F2D0043D484 /* SwiftServerObjects.swift in Sources */,
 				AC8847A4268925F100DF4A65 /* SwiftSyncTestCase.swift in Sources */,
 				AC88478626888CEE00DF4A65 /* SwiftUISyncTestHostUITests.swift in Sources */,
-				530BA61826DFA1CB008FC550 /* RLMChildProcessEnvironment.m in Sources */,
+				AC8847A82689263100DF4A65 /* TestUtils.mm in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2929,20 +2920,20 @@
 			files = (
 				537130C824A9E417001FDBBC /* RealmServer.swift in Sources */,
 				5346E7322487AC9D00595C68 /* RLMBSONTests.mm in Sources */,
+				530BA61626DFA1CB008FC550 /* RLMChildProcessEnvironment.m in Sources */,
 				CF08757D260B98E100B9BE60 /* RLMCollectionSyncTests.mm in Sources */,
 				3F558C9422C29A03002F0F30 /* RLMMultiProcessTestCase.m in Sources */,
 				AC7D182D261F2F560080E1D2 /* RLMObjectServerPartitionTests.mm in Sources */,
-				AC2C2A40268E1B0200B4DA33 /* SwiftServerObjects.swift in Sources */,
 				E8267FF11D90B8E700E001C7 /* RLMObjectServerTests.mm in Sources */,
 				1AA5AE9C1D98A68E00ED8C27 /* RLMSyncTestCase.mm in Sources */,
-				530BA61626DFA1CB008FC550 /* RLMChildProcessEnvironment.m in Sources */,
 				3F558C9022C29A03002F0F30 /* RLMTestCase.m in Sources */,
 				3F73BC921E3A877300FE80B6 /* RLMTestUtils.m in Sources */,
 				1A1536481DB0408A00C0EC93 /* RLMUser+ObjectServerTests.mm in Sources */,
 				CF330BBE24E57D5F00F07EE2 /* RLMWatchTestUtility.m in Sources */,
-				CF087567260B98CF00B9BE60 /* SwiftCollectionSyncTests.swift in Sources */,
+				3F9ADA9426E7E87B007349A5 /* SwiftCollectionSyncTests.swift in Sources */,
 				AC7D182E261F2F560080E1D2 /* SwiftObjectServerPartitionTests.swift in Sources */,
 				1AA5AEA11D98C99800ED8C27 /* SwiftObjectServerTests.swift in Sources */,
+				AC2C2A40268E1B0200B4DA33 /* SwiftServerObjects.swift in Sources */,
 				1AA5AE981D989BE400ED8C27 /* SwiftSyncTestCase.swift in Sources */,
 				AC8846B72687BC4100DF4A65 /* SwiftUIServerTests.swift in Sources */,
 				3F558C8822C29A03002F0F30 /* TestUtils.mm in Sources */,
@@ -2975,7 +2966,6 @@
 				E856D21B195615A900FB2FCF /* ObjectTests.m in Sources */,
 				5D6156FB1BE08E7E00A4BD3F /* PerformanceTests.m in Sources */,
 				5D03FB201E0DAFBA007D53EA /* PredicateUtilTests.mm in Sources */,
-				530BA61726DFA1CB008FC550 /* RLMChildProcessEnvironment.m in Sources */,
 				3F572C961F2BDAB100F6C9AB /* PrimitiveArrayPropertyTests.m in Sources */,
 				0C86B33A25E15B6000775FED /* PrimitiveDictionaryPropertyTests.m in Sources */,
 				CF986D3225AE3BD40039D287 /* PrimitiveSetPropertyTests.m in Sources */,
@@ -2984,6 +2974,7 @@
 				C042A48E1B7522A900771ED2 /* RealmConfigurationTests.mm in Sources */,
 				E856D21E195615A900FB2FCF /* RealmTests.mm in Sources */,
 				02AFB4681A80343600E11938 /* ResultsTests.m in Sources */,
+				530BA61726DFA1CB008FC550 /* RLMChildProcessEnvironment.m in Sources */,
 				3FE5819622C2CCA700BA10E7 /* RLMMultiProcessTestCase.m in Sources */,
 				3FDE338D19C39A87003B7DBA /* RLMSupport.swift in Sources */,
 				3F558C9122C29A03002F0F30 /* RLMTestCase.m in Sources */,
@@ -3044,6 +3035,7 @@
 				C042A48D1B7522A900771ED2 /* RealmConfigurationTests.mm in Sources */,
 				E81A1FEB1955FE0100FDED82 /* RealmTests.mm in Sources */,
 				02AFB4671A80343600E11938 /* ResultsTests.m in Sources */,
+				530BA61426DFA1CB008FC550 /* RLMChildProcessEnvironment.m in Sources */,
 				3F558C9322C29A03002F0F30 /* RLMMultiProcessTestCase.m in Sources */,
 				3FDCFEB619F6A8D3005E414A /* RLMSupport.swift in Sources */,
 				3F558C8F22C29A03002F0F30 /* RLMTestCase.m in Sources */,
@@ -3065,7 +3057,6 @@
 				CF986D8425AE3C5A0039D287 /* SwiftSetTests.swift in Sources */,
 				3FB4FA1719F5D2740020D53B /* SwiftTestObjects.swift in Sources */,
 				3FB4FA2019F5D2740020D53B /* SwiftUnicodeTests.swift in Sources */,
-				530BA61426DFA1CB008FC550 /* RLMChildProcessEnvironment.m in Sources */,
 				3F558C8722C29A03002F0F30 /* TestUtils.mm in Sources */,
 				3F572C941F2BDAAB00F6C9AB /* ThreadSafeReferenceTests.m in Sources */,
 				E81A20021955FE0100FDED82 /* TransactionTests.m in Sources */,
@@ -3101,11 +3092,6 @@
 			isa = PBXTargetDependency;
 			target = 3F1A5E711992EB7400F45F4C /* TestHost */;
 			targetProxy = 5345F0A326E3900100827AC9 /* PBXContainerItemProxy */;
-		};
-		5345F0A626E390D600827AC9 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = 3F1A5E711992EB7400F45F4C /* TestHost */;
-			targetProxy = 5345F0A526E390D600827AC9 /* PBXContainerItemProxy */;
 		};
 		5345F0A826E390D800827AC9 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;

--- a/Realm/ObjectServerTests/RLMObjectServerTests.mm
+++ b/Realm/ObjectServerTests/RLMObjectServerTests.mm
@@ -89,6 +89,56 @@ static NSString *generateRandomString(int num) {
                                                                register:self.isParent]];
 }
 
+- (RLMRealm *)realmForTest:(SEL)sel {
+    RLMUser *user = [self userForTest:sel];
+    NSString *realmId = NSStringFromSelector(sel);
+    return [self openRealmForPartitionValue:realmId user:user];
+}
+
+- (void)writeToConfiguration:(RLMRealmConfiguration *)config block:(void (^)(RLMRealm *))block {
+    @autoreleasepool {
+        RLMRealm *realm = [RLMRealm realmWithConfiguration:config error:nullptr];
+        [self waitForDownloadsForRealm:realm];
+        [realm beginWriteTransaction];
+        block(realm);
+        [realm commitWriteTransaction];
+        [self waitForUploadsForRealm:realm];
+    }
+
+    // A synchronized Realm is not closed immediately when we release our last
+    // reference as the sync worker thread also has to clean up, so retry deleting
+    // it until we can, waiting up to one second. This typically takes a single
+    // retry.
+    int retryCount = 0;
+    NSError *error;
+    while (![RLMRealm deleteFilesForConfiguration:config error:&error]) {
+        XCTAssertEqual(error.code, RLMErrorAlreadyOpen);
+        if (++retryCount > 1000) {
+            XCTFail(@"Waiting for Realm to be closed timed out");
+            break;
+        }
+        usleep(1000);
+    }
+}
+
+- (void)writeToPartition:(SEL)testSel block:(void (^)(RLMRealm *))block {
+    NSString *testName = NSStringFromSelector(testSel);
+    [self writeToPartition:testName userName:testName block:block];
+}
+
+- (void)writeToPartition:(NSString *)testName userName:(NSString *)userNameBase block:(void (^)(RLMRealm *))block {
+    @autoreleasepool {
+        NSString *userName = [userNameBase stringByAppendingString:[NSUUID UUID].UUIDString];
+        RLMUser *user = [self logInUserForCredentials:[self basicCredentialsWithName:userName
+                                                                            register:YES]];
+        auto c = [user configurationWithPartitionValue:testName];
+        c.objectClasses = @[Dog.self, Person.self, HugeSyncObject.self, RLMSetSyncObject.self,
+                            RLMArraySyncObject.self, UUIDPrimaryKeyObject.self, StringPrimaryKeyObject.self,
+                            IntPrimaryKeyObject.self, AllTypesSyncObject.self, RLMDictionarySyncObject.self];
+        [self writeToConfiguration:c block:block];
+    }
+}
+
 #pragma mark - Authentication and Tokens
 
 - (void)testAnonymousAuthentication {
@@ -560,8 +610,7 @@ static NSString *randomEmail() {
 
 /// It should be possible to successfully open a Realm configured for sync with a normal user.
 - (void)testOpenRealmWithNormalCredentials {
-    RLMUser *user = [self userForTest:_cmd];
-    RLMRealm *realm = [self openRealmForPartitionValue:NSStringFromSelector(_cmd) user:user];
+    RLMRealm *realm = [self realmForTest:_cmd];
     XCTAssertTrue(realm.isEmpty);
 }
 
@@ -573,110 +622,62 @@ static NSString *randomEmail() {
 
 /// If client B adds objects to a synced Realm, client A should see those objects.
 - (void)testAddObjects {
-    RLMUser *user = [self userForTest:_cmd];
-    NSString *realmId = NSStringFromSelector(_cmd);
-    RLMRealm *realm = [self openRealmForPartitionValue:realmId user:user];
+    RLMRealm *realm = [self realmForTest:_cmd];
     NSDictionary *values = [AllTypesSyncObject values:1];
+    CHECK_COUNT(0, Person, realm);
+    CHECK_COUNT(0, AllTypesSyncObject, realm)
 
-    if (self.isParent) {
-        CHECK_COUNT(0, Person, realm);
-        CHECK_COUNT(0, AllTypesSyncObject, realm)
-        RLMRunChildAndWait();
-        [self waitForDownloadsForRealm:realm];
-        CHECK_COUNT(4, Person, realm);
-        CHECK_COUNT(1, AllTypesSyncObject, realm);
+    [self writeToPartition:_cmd block:^(RLMRealm *realm) {
+        [realm addObjects:@[[Person john], [Person paul], [Person george]]];
+        AllTypesSyncObject *obj = [[AllTypesSyncObject alloc] initWithValue:values];
+        obj.objectCol = [Person ringo];
+        [realm addObject:obj];
+    }];
+    [self waitForDownloadsForRealm:realm];
+    CHECK_COUNT(4, Person, realm);
+    CHECK_COUNT(1, AllTypesSyncObject, realm);
 
-        AllTypesSyncObject *obj = [[AllTypesSyncObject allObjectsInRealm:realm] firstObject];
-        XCTAssertEqual(obj.boolCol, [values[@"boolCol"] boolValue]);
-        XCTAssertEqual(obj.cBoolCol, [values[@"cBoolCol"] boolValue]);
-        XCTAssertEqual(obj.intCol, [values[@"intCol"] intValue]);
-        XCTAssertEqual(obj.doubleCol, [values[@"doubleCol"] doubleValue]);
-        XCTAssertEqualObjects(obj.stringCol, values[@"stringCol"]);
-        XCTAssertEqualObjects(obj.binaryCol, values[@"binaryCol"]);
-        XCTAssertEqualObjects(obj.decimalCol, values[@"decimalCol"]);
-        XCTAssertEqual(obj.dateCol, values[@"dateCol"]);
-        XCTAssertEqual(obj.longCol, [values[@"longCol"] longValue]);
-        XCTAssertEqualObjects(obj.uuidCol, values[@"uuidCol"]);
-        XCTAssertEqualObjects((NSNumber *)obj.anyCol, values[@"anyCol"]);
-        XCTAssertEqualObjects(obj.objectCol.firstName, [Person ringo].firstName);
-
-    } else {
-        // Add objects.
-        [self addPersonsToRealm:realm
-                        persons:@[[Person john],
-                                  [Person paul],
-                                  [Person george]]];
-
-        [self addAllTypesSyncObjectToRealm:realm
-                                    values:values
-                                    person:[Person ringo]];
-
-        [self waitForUploadsForRealm:realm];
-        CHECK_COUNT(4, Person, realm);
-        CHECK_COUNT(1, AllTypesSyncObject, realm)
-    }
+    AllTypesSyncObject *obj = [[AllTypesSyncObject allObjectsInRealm:realm] firstObject];
+    XCTAssertEqual(obj.boolCol, [values[@"boolCol"] boolValue]);
+    XCTAssertEqual(obj.cBoolCol, [values[@"cBoolCol"] boolValue]);
+    XCTAssertEqual(obj.intCol, [values[@"intCol"] intValue]);
+    XCTAssertEqual(obj.doubleCol, [values[@"doubleCol"] doubleValue]);
+    XCTAssertEqualObjects(obj.stringCol, values[@"stringCol"]);
+    XCTAssertEqualObjects(obj.binaryCol, values[@"binaryCol"]);
+    XCTAssertEqualObjects(obj.decimalCol, values[@"decimalCol"]);
+    XCTAssertEqual(obj.dateCol, values[@"dateCol"]);
+    XCTAssertEqual(obj.longCol, [values[@"longCol"] longValue]);
+    XCTAssertEqualObjects(obj.uuidCol, values[@"uuidCol"]);
+    XCTAssertEqualObjects((NSNumber *)obj.anyCol, values[@"anyCol"]);
+    XCTAssertEqualObjects(obj.objectCol.firstName, [Person ringo].firstName);
 }
 
 - (void)testAddObjectsWithNilPartitionValue {
     RLMRealm *realm = [self openRealmForPartitionValue:nil user:self.anonymousUser];
 
-    if (self.isParent) {
-        CHECK_COUNT(0, Person, realm);
-        RLMRunChildAndWait();
-        [self waitForDownloadsForRealm:realm];
-        CHECK_COUNT(4, Person, realm);
+    CHECK_COUNT(0, Person, realm);
+    [self writeToPartition:nil userName:NSStringFromSelector(_cmd) block:^(RLMRealm *realm) {
+        [realm addObjects:@[[Person john], [Person paul], [Person george], [Person ringo]]];
+    }];
+    [self waitForDownloadsForRealm:realm];
+    CHECK_COUNT(4, Person, realm);
 
-        // Other tests expect the nil partition to be empty so we need to clean up
-        [realm transactionWithBlock:^{
-            [realm deleteAllObjects];
-        }];
-        [self waitForUploadsForRealm:realm];
-    } else {
-        // Add objects.
-        [self addPersonsToRealm:realm
-                        persons:@[[Person john],
-                                  [Person paul],
-                                  [Person ringo],
-                                  [Person george]]];
-        [self waitForUploadsForRealm:realm];
-        CHECK_COUNT(4, Person, realm);
-    }
+    // Other tests expect the nil partition to be empty so we need to clean up
+    [realm transactionWithBlock:^{
+        [realm deleteAllObjects];
+    }];
+    [self waitForUploadsForRealm:realm];
 }
 
 - (void)testRountripForDistinctPrimaryKey {
-    RLMUser *user = [self userForTest:_cmd];
-    NSString *realmId = NSStringFromSelector(_cmd);
-    RLMRealm *realm = [self openRealmForPartitionValue:realmId user:user];
-    if (self.isParent) {
-        CHECK_COUNT(0, Person, realm);
-        CHECK_COUNT(0, UUIDPrimaryKeyObject, realm);
-        CHECK_COUNT(0, StringPrimaryKeyObject, realm);
-        CHECK_COUNT(0, IntPrimaryKeyObject, realm);
+    RLMRealm *realm = [self realmForTest:_cmd];
 
-        RLMRunChildAndWait();
-        [self waitForDownloadsForRealm:realm];
-        CHECK_COUNT(1, Person, realm);
-        CHECK_COUNT(1, UUIDPrimaryKeyObject, realm);
-        CHECK_COUNT(1, StringPrimaryKeyObject, realm);
-        CHECK_COUNT(1, IntPrimaryKeyObject, realm);
+    CHECK_COUNT(0, Person, realm);
+    CHECK_COUNT(0, UUIDPrimaryKeyObject, realm);
+    CHECK_COUNT(0, StringPrimaryKeyObject, realm);
+    CHECK_COUNT(0, IntPrimaryKeyObject, realm);
 
-        Person *person = [Person objectInRealm:realm forPrimaryKey:[[RLMObjectId alloc] initWithString:@"1234567890ab1234567890ab" error:nil]];
-        XCTAssertEqualObjects(person.firstName, @"Ringo");
-        XCTAssertEqualObjects(person.lastName, @"Starr");
-
-        UUIDPrimaryKeyObject *uuidPrimaryKeyObject = [UUIDPrimaryKeyObject objectInRealm:realm forPrimaryKey:[[NSUUID alloc] initWithUUIDString:@"85d4fbee-6ec6-47df-bfa1-615931903d7e"]];
-        XCTAssertEqualObjects(uuidPrimaryKeyObject.strCol, @"Steve");
-        XCTAssertEqual(uuidPrimaryKeyObject.intCol, 10);
-
-        StringPrimaryKeyObject *stringPrimaryKeyObject = [StringPrimaryKeyObject objectInRealm:realm forPrimaryKey:@"1234567890ab1234567890aa"];
-        XCTAssertEqualObjects(stringPrimaryKeyObject.strCol, @"Paul");
-        XCTAssertEqual(stringPrimaryKeyObject.intCol, 20);
-
-        IntPrimaryKeyObject *intPrimaryKeyObject = [IntPrimaryKeyObject objectInRealm:realm forPrimaryKey:@1234567890];
-        XCTAssertEqualObjects(intPrimaryKeyObject.strCol, @"Jackson");
-        XCTAssertEqual(intPrimaryKeyObject.intCol, 30);
-
-    } else {
+    [self writeToPartition:_cmd block:^(RLMRealm *realm) {
         Person *person = [[Person alloc] initWithPrimaryKey:[[RLMObjectId alloc] initWithString:@"1234567890ab1234567890ab" error:nil]
                                                         age:5
                                                   firstName:@"Ringo"
@@ -691,21 +692,33 @@ static NSString *randomEmail() {
                                                                                             strCol:@"Jackson"
                                                                                             intCol:30];
 
-        [realm beginWriteTransaction];
         [realm addObject:person];
         [realm addObject:uuidPrimaryKeyObject];
         [realm addObject:stringPrimaryKeyObject];
         [realm addObject:intPrimaryKeyObject];
-        [realm commitWriteTransaction];
-        [self waitForUploadsForRealm:realm];
-        CHECK_COUNT(1, Person, realm);
-        CHECK_COUNT(1, UUIDPrimaryKeyObject, realm);
-        CHECK_COUNT(1, StringPrimaryKeyObject, realm);
-        CHECK_COUNT(1, IntPrimaryKeyObject, realm);
-    }
+    }];
+    [self waitForDownloadsForRealm:realm];
+    CHECK_COUNT(1, Person, realm);
+    CHECK_COUNT(1, UUIDPrimaryKeyObject, realm);
+    CHECK_COUNT(1, StringPrimaryKeyObject, realm);
+    CHECK_COUNT(1, IntPrimaryKeyObject, realm);
+
+    Person *person = [Person objectInRealm:realm forPrimaryKey:[[RLMObjectId alloc] initWithString:@"1234567890ab1234567890ab" error:nil]];
+    XCTAssertEqualObjects(person.firstName, @"Ringo");
+    XCTAssertEqualObjects(person.lastName, @"Starr");
+
+    UUIDPrimaryKeyObject *uuidPrimaryKeyObject = [UUIDPrimaryKeyObject objectInRealm:realm forPrimaryKey:[[NSUUID alloc] initWithUUIDString:@"85d4fbee-6ec6-47df-bfa1-615931903d7e"]];
+    XCTAssertEqualObjects(uuidPrimaryKeyObject.strCol, @"Steve");
+    XCTAssertEqual(uuidPrimaryKeyObject.intCol, 10);
+
+    StringPrimaryKeyObject *stringPrimaryKeyObject = [StringPrimaryKeyObject objectInRealm:realm forPrimaryKey:@"1234567890ab1234567890aa"];
+    XCTAssertEqualObjects(stringPrimaryKeyObject.strCol, @"Paul");
+    XCTAssertEqual(stringPrimaryKeyObject.intCol, 20);
+
+    IntPrimaryKeyObject *intPrimaryKeyObject = [IntPrimaryKeyObject objectInRealm:realm forPrimaryKey:@1234567890];
+    XCTAssertEqualObjects(intPrimaryKeyObject.strCol, @"Jackson");
+    XCTAssertEqual(intPrimaryKeyObject.intCol, 30);
 }
-
-
 
 /// If client B adds objects to a synced Realm, client A should see those objects.
 - (void)testAddObjectsMultipleApps {
@@ -821,12 +834,9 @@ static NSString *randomEmail() {
 #pragma mark - RLMValue Sync with missing schema -
 
 - (void)testMissingSchema {
-    RLMUser *user = [self userForTest:_cmd];
-    auto c = [user configurationWithPartitionValue:NSStringFromSelector(_cmd)];
-    if (!self.isParent) {
-        c.objectClasses = @[Person.self,
-                            AllTypesSyncObject.self,
-                            RLMSetSyncObject.self];
+    @autoreleasepool {
+        auto c = [self.anonymousUser configurationWithPartitionValue:NSStringFromSelector(_cmd)];
+        c.objectClasses = @[Person.self, AllTypesSyncObject.self, RLMSetSyncObject.self];
         RLMRealm *realm = [RLMRealm realmWithConfiguration:c error:nil];
         [self waitForDownloadsForRealm:realm];
         AllTypesSyncObject *obj = [[AllTypesSyncObject alloc] initWithValue:[AllTypesSyncObject values:0]];
@@ -840,10 +850,10 @@ static NSString *randomEmail() {
         [realm commitWriteTransaction];
         [self waitForUploadsForRealm:realm];
         CHECK_COUNT(1, AllTypesSyncObject, realm);
-        return;
     }
-    RLMRunChildAndWait();
 
+    RLMUser *user = [self userForTest:_cmd];
+    auto c = [user configurationWithPartitionValue:NSStringFromSelector(_cmd)];
     c.objectClasses = @[Person.self, AllTypesSyncObject.self];
     RLMRealm *realm = [RLMRealm realmWithConfiguration:c error:nil];
     [self waitForDownloadsForRealm:realm];
@@ -890,42 +900,26 @@ static NSString *randomEmail() {
 - (void)testEncryptedSyncedRealmWrongKey {
     RLMUser *user = [self userForTest:_cmd];
 
-    if (self.isParent) {
-        NSString *path;
-        @autoreleasepool {
-            RLMRealm *realm = [self openRealmForPartitionValue:NSStringFromSelector(_cmd)
-                                                          user:user
-                                                 encryptionKey:RLMGenerateKey()
-                                                    stopPolicy:RLMSyncStopPolicyImmediately];
-            path = realm.configuration.pathOnDisk;
-            CHECK_COUNT(0, Person, realm);
-            RLMRunChildAndWait();
-            [self waitForDownloadsForUser:user
-                                   realms:@[realm]
-                          partitionValues:@[NSStringFromSelector(_cmd)]
-                           expectedCounts:@[@1]];
-        }
-
-        RLMRealmConfiguration *c = [RLMRealmConfiguration defaultConfiguration];
-        c.fileURL = [NSURL fileURLWithPath:path];
-        RLMAssertThrowsWithError([RLMRealm realmWithConfiguration:c error:nil],
-                                 @"Unable to open a realm at path",
-                                 RLMErrorFileAccess,
-                                 @"Realm file initial open failed");
-        c.encryptionKey = RLMGenerateKey();
-        RLMAssertThrowsWithError([RLMRealm realmWithConfiguration:c error:nil],
-                                 @"Unable to open a realm at path",
-                                 RLMErrorFileAccess,
-                                 @"Realm file decryption failed");
-    } else {
+    NSString *path;
+    @autoreleasepool {
         RLMRealm *realm = [self openRealmForPartitionValue:NSStringFromSelector(_cmd)
                                                       user:user
                                              encryptionKey:RLMGenerateKey()
                                                 stopPolicy:RLMSyncStopPolicyImmediately];
-        [self addPersonsToRealm:realm persons:@[[Person john]]];
-        [self waitForUploadsForRealm:realm];
-        CHECK_COUNT(1, Person, realm);
+        path = realm.configuration.pathOnDisk;
     }
+
+    RLMRealmConfiguration *c = [RLMRealmConfiguration defaultConfiguration];
+    c.fileURL = [NSURL fileURLWithPath:path];
+    RLMAssertThrowsWithError([RLMRealm realmWithConfiguration:c error:nil],
+                             @"Unable to open a realm at path",
+                             RLMErrorFileAccess,
+                             @"Realm file initial open failed");
+    c.encryptionKey = RLMGenerateKey();
+    RLMAssertThrowsWithError([RLMRealm realmWithConfiguration:c error:nil],
+                             @"Unable to open a realm at path",
+                             RLMErrorFileAccess,
+                             @"Realm file decryption failed");
 }
 
 #pragma mark - Multiple Realm Sync

--- a/Realm/ObjectServerTests/RLMSyncTestCase.h
+++ b/Realm/ObjectServerTests/RLMSyncTestCase.h
@@ -160,9 +160,10 @@ RLM_COLLECTION_TYPE(Person);
 /// Any stray app ids passed between processes
 @property (nonatomic, readonly) NSArray<NSString *> *appIds;
 
-- (RLMCredentials *)basicCredentialsWithName:(NSString *)name register:(BOOL)shouldRegister;
+- (RLMCredentials *)basicCredentialsWithName:(NSString *)name register:(BOOL)shouldRegister NS_SWIFT_NAME(basicCredentials(name:register:));
 
-- (RLMCredentials *)basicCredentialsWithName:(NSString *)name register:(BOOL)shouldRegister app:(nullable RLMApp*) app;
+- (RLMCredentials *)basicCredentialsWithName:(NSString *)name register:(BOOL)shouldRegister
+                                         app:(nullable RLMApp*)app NS_SWIFT_NAME(basicCredentials(name:register:app:));
 
 /// Synchronously open a synced Realm via asyncOpen and return the Realm.
 - (RLMRealm *)asyncOpenRealmWithConfiguration:(RLMRealmConfiguration *)configuration;

--- a/Realm/ObjectServerTests/SwiftCollectionSyncTests.swift
+++ b/Realm/ObjectServerTests/SwiftCollectionSyncTests.swift
@@ -26,609 +26,398 @@ import RealmSyncTestSupport
 import RealmTestSupport
 #endif
 
-class ListSyncTests: SwiftSyncTestCase {
-    private func roundTrip<T>(keyPath: KeyPath<SwiftCollectionSyncObject, List<T>>,
-                              values: [T],
-                              partitionValue: String = #function) throws {
-        let user = logInUser(for: basicCredentials(withName: partitionValue,
-                                                   register: isParent))
-        let realm = try openRealm(partitionValue: partitionValue, user: user)
-        if isParent {
-            checkCount(expected: 0, realm, SwiftCollectionSyncObject.self)
-            executeChild()
-            waitForDownloads(for: realm)
-            checkCount(expected: 1, realm, SwiftCollectionSyncObject.self)
-            // Run the child again to add the values
-            executeChild()
-            waitForDownloads(for: realm)
-            checkCount(expected: 1, realm, SwiftCollectionSyncObject.self)
-            let object = realm.objects(SwiftCollectionSyncObject.self).first!
-            let collection = object[keyPath: keyPath]
-            XCTAssertEqual(collection.count, values.count*2)
-            for (el, ex) in zip(collection, values + values) {
-                if let person = el as? SwiftPerson, let otherPerson = ex as? SwiftPerson {
-                    XCTAssertEqual(person.firstName, otherPerson.firstName, "\(el) is not equal to \(ex)")
-                } else {
-                    XCTAssertEqual(el, ex)
-                }
-            }
-            // Run the child again to delete the last 3 objects
-            executeChild()
-            waitForDownloads(for: realm)
-            XCTAssertEqual(collection.count, values.count)
-            // Run the child again to modify the first element
-            executeChild()
-            waitForDownloads(for: realm)
-            if T.self is SwiftPerson.Type {
-                XCTAssertEqual((collection as! List<SwiftPerson>)[0].firstName,
-                               (values as! [SwiftPerson])[1].firstName)
-            } else {
-                XCTAssertEqual(collection[0], values[1])
-            }
+class CollectionSyncTestCase: SwiftSyncTestCase {
+    var readRealm: Realm!
+    var writeRealm: Realm!
+
+    override func setUp() {
+        super.setUp()
+
+        let readUser = logInUser(for: basicCredentials(name: self.name + " read user", register: true))
+        let writeUser = logInUser(for: basicCredentials(name: self.name + " write user", register: true))
+        // This autoreleasepool is needed to ensure that the Realms are closed
+        // immediately in tearDown() rather than escaping to an outer pool.
+        autoreleasepool {
+            readRealm = try! openRealm(partitionValue: self.name, user: readUser)
+            writeRealm = try! openRealm(partitionValue: self.name, user: writeUser)
+        }
+    }
+
+    override func tearDown() {
+        readRealm = nil
+        writeRealm = nil
+        super.tearDown()
+    }
+
+    func write(_ fn: (Realm) -> Void) throws {
+        try writeRealm.write {
+            fn(writeRealm)
+        }
+        waitForUploads(for: writeRealm)
+        waitForDownloads(for: readRealm)
+    }
+
+    func assertEqual<T: RealmCollectionValue>(_ left: T, _ right: T, _ line: UInt = #line) {
+        if let person = left as? SwiftPerson, let otherPerson = right as? SwiftPerson {
+            XCTAssertEqual(person.firstName, otherPerson.firstName, line: line)
         } else {
-            guard let object = realm.objects(SwiftCollectionSyncObject.self).first else {
-                try realm.write {
-                    realm.add(SwiftCollectionSyncObject())
-                }
-                waitForUploads(for: realm)
-                checkCount(expected: 1, realm, SwiftCollectionSyncObject.self)
-                return
-            }
-            let collection = object[keyPath: keyPath]
-
-            if collection.count == 0 {
-                try realm.write {
-                    collection.append(objectsIn: values + values)
-                }
-                XCTAssertEqual(collection.count, values.count*2)
-            } else if collection.count == 6 {
-                try realm.write {
-                    collection.removeSubrange(3...5)
-                }
-                XCTAssertEqual(collection.count, values.count)
-            } else {
-                if T.self is SwiftPerson.Type {
-                    try realm.write {
-                        (collection as! List<SwiftPerson>)[0].firstName
-                            = (values as! [SwiftPerson])[1].firstName
-                    }
-                    XCTAssertEqual((collection as! List<SwiftPerson>)[0].firstName,
-                                   (values as! [SwiftPerson])[1].firstName)
-                } else {
-                    try realm.write {
-                        collection[0] = values[1]
-                    }
-                    XCTAssertEqual(collection[0], values[1])
-                }
-            }
-            waitForUploads(for: realm)
-            checkCount(expected: 1, realm, SwiftCollectionSyncObject.self)
-        }
-    }
-
-    func testIntList() {
-        do {
-            try roundTrip(keyPath: \.intList, values: [1, 2, 3])
-        } catch {
-            XCTFail(error.localizedDescription)
-        }
-    }
-
-    func testBoolList() {
-        do {
-            try roundTrip(keyPath: \.boolList, values: [true, false, false])
-        } catch {
-            XCTFail(error.localizedDescription)
-        }
-    }
-
-    func testStringList() {
-        do {
-            try roundTrip(keyPath: \.stringList, values: ["Hey", "Hi", "Bye"])
-        } catch {
-            XCTFail(error.localizedDescription)
-        }
-    }
-
-    func testDataList() {
-        do {
-            try roundTrip(keyPath: \.dataList, values: [Data(repeating: 0, count: 64),
-                                                        Data(repeating: 1, count: 64),
-                                                        Data(repeating: 2, count: 64)])
-        } catch {
-            XCTFail(error.localizedDescription)
-        }
-    }
-
-    func testDateList() {
-        do {
-            try roundTrip(keyPath: \.dateList, values: [Date(timeIntervalSince1970: 10000000),
-                                                        Date(timeIntervalSince1970: 20000000),
-                                                        Date(timeIntervalSince1970: 30000000)])
-        } catch {
-            XCTFail(error.localizedDescription)
-        }
-    }
-
-    func testDoubleList() {
-        do {
-            try roundTrip(keyPath: \.doubleList, values: [123.456, 234.456, 567.333])
-        } catch {
-            XCTFail(error.localizedDescription)
-        }
-    }
-
-    func testObjectIdList() {
-        do {
-            try roundTrip(keyPath: \.objectIdList, values: [.init("6058f12b957ba06156586a7c"),
-                                                            .init("6058f12682b2fbb1f334ef1d"),
-                                                            .init("6058f12d42e5a393e67538d0")])
-        } catch {
-            XCTFail(error.localizedDescription)
-        }
-    }
-
-    func testDecimalList() {
-        do {
-            try roundTrip(keyPath: \.decimalList, values: [123.345,
-                                                           213.345,
-                                                           321.345])
-        } catch {
-            XCTFail(error.localizedDescription)
-        }
-    }
-
-    func testUuidList() {
-        do {
-            try roundTrip(keyPath: \.uuidList, values: [UUID(uuidString: "6b28ec45-b29a-4b0a-bd6a-343c7f6d90fd")!,
-                                                        UUID(uuidString: "6b28ec45-b29a-4b0a-bd6a-343c7f6d90fe")!,
-                                                        UUID(uuidString: "6b28ec45-b29a-4b0a-bd6a-343c7f6d90ff")!])
-        } catch {
-            XCTFail(error.localizedDescription)
-        }
-    }
-
-    func testObjectList() {
-        do {
-            try roundTrip(keyPath: \.objectList, values: [SwiftPerson(firstName: "Peter", lastName: "Parker"),
-                                                          SwiftPerson(firstName: "Bruce", lastName: "Wayne"),
-                                                          SwiftPerson(firstName: "Stephen", lastName: "Strange")])
-        } catch {
-            XCTFail(error.localizedDescription)
-        }
-    }
-
-    func testAnyList() {
-        do {
-            try roundTrip(keyPath: \.anyList, values: [.int(12345), .string("Hello"), .none])
-        } catch {
-            XCTFail(error.localizedDescription)
+            XCTAssertEqual(left, right, line: line)
         }
     }
 }
 
-class SetSyncTests: SwiftSyncTestCase {
+class ListSyncTests: CollectionSyncTestCase {
+    private func roundTrip<T>(keyPath: KeyPath<SwiftCollectionSyncObject, List<T>>,
+                              values: [T], partitionValue: String = #function) throws {
+        checkCount(expected: 0, readRealm, SwiftCollectionSyncObject.self)
+
+        // Create the object
+        try write { realm in
+            realm.add(SwiftCollectionSyncObject())
+        }
+        checkCount(expected: 1, readRealm, SwiftCollectionSyncObject.self)
+        let object = readRealm.objects(SwiftCollectionSyncObject.self).first!
+        let collection = object[keyPath: keyPath]
+        XCTAssertEqual(collection.count, 0)
+
+        // Populate the collection
+        try write { realm in
+            let object = realm.objects(SwiftCollectionSyncObject.self).first!
+            object[keyPath: keyPath].append(objectsIn: values + values)
+        }
+        checkCount(expected: 1, readRealm, SwiftCollectionSyncObject.self)
+        XCTAssertEqual(collection.count, values.count*2)
+        for (el, ex) in zip(collection, values + values) {
+            assertEqual(el, ex)
+        }
+
+        // Remove the last three objects from the collection
+        try write { realm in
+            let object = realm.objects(SwiftCollectionSyncObject.self).first!
+            object[keyPath: keyPath].removeSubrange(3...5)
+        }
+        XCTAssertEqual(collection.count, values.count)
+
+        // Modify the first element
+        try write { realm in
+            let object = realm.objects(SwiftCollectionSyncObject.self).first!
+            let collection = object[keyPath: keyPath]
+            if T.self is SwiftPerson.Type {
+                (collection as! List<SwiftPerson>)[0].firstName
+                    = (values as! [SwiftPerson])[1].firstName
+            } else {
+                collection[0] = values[1]
+            }
+        }
+        assertEqual(collection[0], values[1])
+    }
+
+    func testIntList() throws {
+        try roundTrip(keyPath: \.intList, values: [1, 2, 3])
+    }
+
+    func testBoolList() throws {
+        try roundTrip(keyPath: \.boolList, values: [true, false, false])
+    }
+
+    func testStringList() throws {
+        try roundTrip(keyPath: \.stringList, values: ["Hey", "Hi", "Bye"])
+    }
+
+    func testDataList() throws {
+        try roundTrip(keyPath: \.dataList, values: [Data(repeating: 0, count: 64),
+                                                    Data(repeating: 1, count: 64),
+                                                    Data(repeating: 2, count: 64)])
+    }
+
+    func testDateList() throws {
+        try roundTrip(keyPath: \.dateList, values: [Date(timeIntervalSince1970: 10000000),
+                                                    Date(timeIntervalSince1970: 20000000),
+                                                    Date(timeIntervalSince1970: 30000000)])
+    }
+
+    func testDoubleList() throws {
+        try roundTrip(keyPath: \.doubleList, values: [123.456, 234.456, 567.333])
+    }
+
+    func testObjectIdList() throws {
+        try roundTrip(keyPath: \.objectIdList, values: [.init("6058f12b957ba06156586a7c"),
+                                                        .init("6058f12682b2fbb1f334ef1d"),
+                                                        .init("6058f12d42e5a393e67538d0")])
+    }
+
+    func testDecimalList() throws {
+        try roundTrip(keyPath: \.decimalList, values: [123.345, 213.345, 321.345])
+    }
+
+    func testUuidList() throws {
+        try roundTrip(keyPath: \.uuidList, values: [UUID(uuidString: "6b28ec45-b29a-4b0a-bd6a-343c7f6d90fd")!,
+                                                    UUID(uuidString: "6b28ec45-b29a-4b0a-bd6a-343c7f6d90fe")!,
+                                                    UUID(uuidString: "6b28ec45-b29a-4b0a-bd6a-343c7f6d90ff")!])
+    }
+
+    func testObjectList() throws {
+        try roundTrip(keyPath: \.objectList, values: [SwiftPerson(firstName: "Peter", lastName: "Parker"),
+                                                      SwiftPerson(firstName: "Bruce", lastName: "Wayne"),
+                                                      SwiftPerson(firstName: "Stephen", lastName: "Strange")])
+    }
+
+    func testAnyList() throws {
+        try roundTrip(keyPath: \.anyList, values: [.int(12345), .string("Hello"), .none])
+    }
+}
+
+class SetSyncTests: CollectionSyncTestCase {
     private typealias MutableSetKeyPath<T: RealmCollectionValue> = KeyPath<SwiftCollectionSyncObject, MutableSet<T>>
     private typealias MutableSetKeyValues<T: RealmCollectionValue> = (keyPath: MutableSetKeyPath<T>, values: [T])
 
     private func roundTrip<T>(set: MutableSetKeyValues<T>,
                               otherSet: MutableSetKeyValues<T>,
                               partitionValue: String = #function) throws {
-        let user = logInUser(for: basicCredentials(withName: partitionValue, register: isParent))
-        let realm = try openRealm(partitionValue: partitionValue, user: user)
-        if isParent {
-            checkCount(expected: 0, realm, SwiftCollectionSyncObject.self)
-            executeChild()
-            waitForDownloads(for: realm)
-            checkCount(expected: 1, realm, SwiftCollectionSyncObject.self)
+        checkCount(expected: 0, readRealm, SwiftCollectionSyncObject.self)
+
+        // Create the object
+        try write { realm in
+            realm.add(SwiftCollectionSyncObject())
+        }
+        checkCount(expected: 1, readRealm, SwiftCollectionSyncObject.self)
+        let object = readRealm.objects(SwiftCollectionSyncObject.self).first!
+        let collection = object[keyPath: set.keyPath]
+        let otherCollection = object[keyPath: otherSet.keyPath]
+        XCTAssertEqual(collection.count, 0)
+        XCTAssertEqual(otherCollection.count, 0)
+
+        // Populate the collection
+        try write { realm in
             let object = realm.objects(SwiftCollectionSyncObject.self).first!
-            // Run the child again to insert the values
-            executeChild()
-            waitForDownloads(for: realm)
-            checkCount(expected: 1, realm, SwiftCollectionSyncObject.self)
+            object[keyPath: set.keyPath].insert(objectsIn: set.values)
+            object[keyPath: otherSet.keyPath].insert(objectsIn: otherSet.values)
+        }
+        checkCount(expected: 1, readRealm, SwiftCollectionSyncObject.self)
+        XCTAssertEqual(collection.count, set.values.count)
+        XCTAssertEqual(otherCollection.count, otherSet.values.count)
+
+        // Intersect the values
+        try write { realm in
+            let object = realm.objects(SwiftCollectionSyncObject.self).first!
             let collection = object[keyPath: set.keyPath]
             let otherCollection = object[keyPath: otherSet.keyPath]
-            XCTAssertEqual(collection.count, set.values.count)
-            XCTAssertEqual(otherCollection.count, otherSet.values.count)
-            // Run the child again to intersect the values
-            executeChild()
-            waitForDownloads(for: realm)
-            checkCount(expected: 1, realm, SwiftCollectionSyncObject.self)
-            if !(T.self is SwiftPerson.Type) {
-                XCTAssertTrue(collection.intersects(object[keyPath: otherSet.keyPath]))
-                XCTAssertEqual(collection.count, 1)
-            }
-            // The intersection should have assigned the last value from `values`
-            if !(T.self is SwiftPerson.Type) {
-                XCTAssertTrue(collection.contains(set.values.last!))
-            }
-            // Run the child again to delete the objects in the sets.
-            executeChild()
-            waitForDownloads(for: realm)
-            XCTAssertEqual(collection.count, 0)
-            XCTAssertEqual(otherCollection.count, 0)
-        } else {
-            guard let object = realm.objects(SwiftCollectionSyncObject.self).first else {
-                try realm.write {
-                    realm.add(SwiftCollectionSyncObject())
-                }
-                waitForUploads(for: realm)
-                checkCount(expected: 1, realm, SwiftCollectionSyncObject.self)
-                return
-            }
-            let collection = object[keyPath: set.keyPath]
-            let otherCollection = object[keyPath: otherSet.keyPath]
-            if collection.count == 0,
-               otherCollection.count == 0 {
-                try realm.write {
-                    collection.insert(objectsIn: set.values)
-                    otherCollection.insert(objectsIn: otherSet.values)
-                }
-                XCTAssertEqual(collection.count, set.values.count)
-                XCTAssertEqual(otherCollection.count, otherSet.values.count)
-            } else if collection.count == 3,
-                      otherCollection.count == 3 {
-                if !(T.self is SwiftPerson.Type) {
-                    try realm.write {
-                        collection.formIntersection(otherCollection)
-                    }
-                } else {
-                    try realm.write {
-                        // formIntersection won't work with unique Objects
-                        collection.removeAll()
-                        collection.insert(set.values[0])
-                    }
-                }
-                XCTAssertEqual(collection.count, 1)
-                XCTAssertEqual(otherCollection.count, otherSet.values.count)
+            if T.self is SwiftPerson.Type {
+                // formIntersection won't work with unique Objects
+                collection.removeAll()
+                collection.insert(set.values[0])
             } else {
-                try realm.write {
-                    collection.removeAll()
-                    otherCollection.removeAll()
-                }
-                XCTAssertEqual(collection.count, 0)
-                XCTAssertEqual(otherCollection.count, 0)
+                collection.formIntersection(otherCollection)
             }
-            waitForUploads(for: realm)
-            checkCount(expected: 1, realm, SwiftCollectionSyncObject.self)
         }
+
+        if !(T.self is SwiftPerson.Type) {
+            XCTAssertTrue(collection.intersects(object[keyPath: otherSet.keyPath]))
+            XCTAssertEqual(collection.count, 1)
+            // The intersection should have assigned the last value from `values`
+            XCTAssertTrue(collection.contains(set.values.last!))
+        }
+
+        // Delete the objects from the sets
+        try write { realm in
+            let object = realm.objects(SwiftCollectionSyncObject.self).first!
+            object[keyPath: set.keyPath].removeAll()
+            object[keyPath: otherSet.keyPath].removeAll()
+        }
+        XCTAssertEqual(collection.count, 0)
+        XCTAssertEqual(otherCollection.count, 0)
     }
 
-    func testIntSet() {
-        do {
-            try roundTrip(set: (\.intSet, [1, 2, 3]), otherSet: (\.otherIntSet, [3, 4, 5]))
-        } catch {
-            XCTFail(error.localizedDescription)
-        }
+    func testIntSet() throws {
+        try roundTrip(set: (\.intSet, [1, 2, 3]), otherSet: (\.otherIntSet, [3, 4, 5]))
     }
 
-    func testStringSet() {
-        do {
-            try roundTrip(set: (\.stringSet, ["Who", "What", "When"]),
-                          otherSet: (\.otherStringSet, ["When", "Strings", "Collide"]))
-        } catch {
-            XCTFail(error.localizedDescription)
-        }
+    func testStringSet() throws {
+        try roundTrip(set: (\.stringSet, ["Who", "What", "When"]),
+                      otherSet: (\.otherStringSet, ["When", "Strings", "Collide"]))
     }
 
-    func testDataSet() {
-        do {
-            try roundTrip(set: (\.dataSet, [Data(repeating: 1, count: 64),
-                                            Data(repeating: 2, count: 64),
-                                            Data(repeating: 3, count: 64)]),
-                          otherSet: (\.otherDataSet, [Data(repeating: 3, count: 64),
-                                                      Data(repeating: 4, count: 64),
-                                                      Data(repeating: 5, count: 64)]))
-        } catch {
-            XCTFail(error.localizedDescription)
-        }
+    func testDataSet() throws {
+        try roundTrip(set: (\.dataSet, [Data(repeating: 1, count: 64),
+                                        Data(repeating: 2, count: 64),
+                                        Data(repeating: 3, count: 64)]),
+                      otherSet: (\.otherDataSet, [Data(repeating: 3, count: 64),
+                                                  Data(repeating: 4, count: 64),
+                                                  Data(repeating: 5, count: 64)]))
     }
 
-    func testDateSet() {
-        do {
-            try roundTrip(set: (\.dateSet, [Date(timeIntervalSince1970: 10000000),
-                                            Date(timeIntervalSince1970: 20000000),
-                                            Date(timeIntervalSince1970: 30000000)]),
-                          otherSet: (\.otherDateSet, [Date(timeIntervalSince1970: 30000000),
-                                                      Date(timeIntervalSince1970: 40000000),
-                                                      Date(timeIntervalSince1970: 50000000)]))
-        } catch {
-            XCTFail(error.localizedDescription)
-        }
+    func testDateSet() throws {
+        try roundTrip(set: (\.dateSet, [Date(timeIntervalSince1970: 10000000),
+                                        Date(timeIntervalSince1970: 20000000),
+                                        Date(timeIntervalSince1970: 30000000)]),
+                      otherSet: (\.otherDateSet, [Date(timeIntervalSince1970: 30000000),
+                                                  Date(timeIntervalSince1970: 40000000),
+                                                  Date(timeIntervalSince1970: 50000000)]))
     }
 
-    func testDoubleSet() {
-        do {
-            try roundTrip(set: (\.doubleSet, [123.456, 345.456, 789.456]),
-                          otherSet: (\.otherDoubleSet, [789.456,
-                                                        888.456,
-                                                        987.456]))
-        } catch {
-            XCTFail(error.localizedDescription)
-        }
+    func testDoubleSet() throws {
+        try roundTrip(set: (\.doubleSet, [123.456, 345.456, 789.456]),
+                      otherSet: (\.otherDoubleSet, [789.456,
+                                                    888.456,
+                                                    987.456]))
     }
 
-    func testObjectIdSet() {
-        do {
-            try roundTrip(set: (\.objectIdSet, [.init("6058f12b957ba06156586a7c"),
-                                                .init("6058f12682b2fbb1f334ef1d"),
-                                                .init("6058f12d42e5a393e67538d0")]),
-                          otherSet: (\.otherObjectIdSet, [.init("6058f12d42e5a393e67538d0"),
-                                                          .init("6058f12682b2fbb1f334ef1f"),
-                                                          .init("6058f12d42e5a393e67538d1")]))
-        } catch {
-            XCTFail(error.localizedDescription)
-        }
+    func testObjectIdSet() throws {
+        try roundTrip(set: (\.objectIdSet, [.init("6058f12b957ba06156586a7c"),
+                                            .init("6058f12682b2fbb1f334ef1d"),
+                                            .init("6058f12d42e5a393e67538d0")]),
+                      otherSet: (\.otherObjectIdSet, [.init("6058f12d42e5a393e67538d0"),
+                                                      .init("6058f12682b2fbb1f334ef1f"),
+                                                      .init("6058f12d42e5a393e67538d1")]))
     }
 
-    func testDecimalSet() {
-        do {
-            try roundTrip(set: (\.decimalSet, [123.345,
-                                               213.345,
-                                               321.345]),
-                          otherSet: (\.otherDecimalSet, [321.345,
-                                                         333.345,
-                                                         444.345]))
-        } catch {
-            XCTFail(error.localizedDescription)
-        }
+    func testDecimalSet() throws {
+        try roundTrip(set: (\.decimalSet, [123.345,
+                                           213.345,
+                                           321.345]),
+                      otherSet: (\.otherDecimalSet, [321.345,
+                                                     333.345,
+                                                     444.345]))
     }
 
-    func testUuidSet() {
-        do {
-            try roundTrip(set: (\.uuidSet, [UUID(uuidString: "6b28ec45-b29a-4b0a-bd6a-343c7f6d90fd")!,
-                                            UUID(uuidString: "6b28ec45-b29a-4b0a-bd6a-343c7f6d90fe")!,
-                                            UUID(uuidString: "6b28ec45-b29a-4b0a-bd6a-343c7f6d90ff")!]),
-                          otherSet: (\.otherUuidSet, [UUID(uuidString: "6b28ec45-b29a-4b0a-bd6a-343c7f6d90ff")!,
-                                                      UUID(uuidString: "6b28ec45-b29a-4b0a-bd6a-343c7f6d90ae")!,
-                                                      UUID(uuidString: "6b28ec45-b29a-4b0a-bd6a-343c7f6d90bf")!]))
-        } catch {
-            XCTFail(error.localizedDescription)
-        }
+    func testUuidSet() throws {
+        try roundTrip(set: (\.uuidSet, [UUID(uuidString: "6b28ec45-b29a-4b0a-bd6a-343c7f6d90fd")!,
+                                        UUID(uuidString: "6b28ec45-b29a-4b0a-bd6a-343c7f6d90fe")!,
+                                        UUID(uuidString: "6b28ec45-b29a-4b0a-bd6a-343c7f6d90ff")!]),
+                      otherSet: (\.otherUuidSet, [UUID(uuidString: "6b28ec45-b29a-4b0a-bd6a-343c7f6d90ff")!,
+                                                  UUID(uuidString: "6b28ec45-b29a-4b0a-bd6a-343c7f6d90ae")!,
+                                                  UUID(uuidString: "6b28ec45-b29a-4b0a-bd6a-343c7f6d90bf")!]))
     }
 
-    func testObjectSet() {
-        do {
-            try roundTrip(set: (\.objectSet, [SwiftPerson(firstName: "Peter", lastName: "Parker"),
-                                              SwiftPerson(firstName: "Bruce", lastName: "Wayne"),
-                                              SwiftPerson(firstName: "Stephen", lastName: "Strange")]),
-                          otherSet: (\.otherObjectSet, [SwiftPerson(firstName: "Stephen", lastName: "Strange"),
-                                                        SwiftPerson(firstName: "Tony", lastName: "Stark"),
-                                                        SwiftPerson(firstName: "Clark", lastName: "Kent")]))
-        } catch {
-            XCTFail(error.localizedDescription)
-        }
+    func testObjectSet() throws {
+        try roundTrip(set: (\.objectSet, [SwiftPerson(firstName: "Peter", lastName: "Parker"),
+                                          SwiftPerson(firstName: "Bruce", lastName: "Wayne"),
+                                          SwiftPerson(firstName: "Stephen", lastName: "Strange")]),
+                      otherSet: (\.otherObjectSet, [SwiftPerson(firstName: "Stephen", lastName: "Strange"),
+                                                    SwiftPerson(firstName: "Tony", lastName: "Stark"),
+                                                    SwiftPerson(firstName: "Clark", lastName: "Kent")]))
     }
 
-    func testAnySet() {
-        do {
-            try roundTrip(set: (\.anySet, [.int(12345), .none, .string("Hello")]),
-                          otherSet: (\.otherAnySet, [.string("Hello"), .double(765.6543), .objectId(.generate())]))
-        } catch {
-            XCTFail(error.localizedDescription)
-        }
+    func testAnySet() throws {
+        try roundTrip(set: (\.anySet, [.int(12345), .none, .string("Hello")]),
+                      otherSet: (\.otherAnySet, [.string("Hello"), .double(765.6543), .objectId(.generate())]))
     }
 }
 
-class MapSyncTests: SwiftSyncTestCase {
-
+class MapSyncTests: CollectionSyncTestCase {
     private typealias MapKeyPath<T: RealmCollectionValue> = KeyPath<SwiftCollectionSyncObject, Map<String, T>>
 
-    private func roundTrip<T>(keyPath: MapKeyPath<T>, values: Map<String, T>,
+    private func roundTrip<T>(keyPath: MapKeyPath<T>, values: [T],
                               partitionValue: String = #function) throws {
-        let user = logInUser(for: basicCredentials(withName: partitionValue, register: isParent))
-        let realm = try openRealm(partitionValue: partitionValue, user: user)
-        if isParent {
-            // Run to add initial empty object
-            checkCount(expected: 0, realm, SwiftCollectionSyncObject.self)
-            executeChild()
-            waitForDownloads(for: realm)
-            checkCount(expected: 1, realm, SwiftCollectionSyncObject.self)
+        checkCount(expected: 0, readRealm, SwiftCollectionSyncObject.self)
 
-            // Run the child again to add the values
-            executeChild()
-            waitForDownloads(for: realm)
-            checkCount(expected: 1, realm, SwiftCollectionSyncObject.self)
+        // Create the object
+        try write { realm in
+            realm.add(SwiftCollectionSyncObject())
+        }
+        checkCount(expected: 1, readRealm, SwiftCollectionSyncObject.self)
+        let object = readRealm.objects(SwiftCollectionSyncObject.self).first!
+        let collection = object[keyPath: keyPath]
+        XCTAssertEqual(collection.count, 0)
+
+        // Populate the collection
+        try write { realm in
             let object = realm.objects(SwiftCollectionSyncObject.self).first!
             let collection = object[keyPath: keyPath]
-            XCTAssertEqual(collection.count, values.count)
-            for element in values {
-                if let person = element.value as? SwiftPerson, let otherPerson = collection[element.key] as? SwiftPerson {
-                    XCTAssertEqual(person.firstName, otherPerson.firstName, "\(person) is not equal to \(otherPerson)")
-                } else {
-                    XCTAssertEqual(element.value, collection[element.key])
-                }
+            for (i, value) in values.enumerated() {
+                collection["\(i)"] = value
             }
-
-            // Run the child again to delete 3 objects
-            executeChild()
-            waitForDownloads(for: realm)
-            XCTAssertEqual(collection.count, 2)
-
-            // Run the child again to modify the first element
-            executeChild()
-            waitForDownloads(for: realm)
-            let keyA = collection.keys[0]
-            let keyB = collection.keys[1]
-            if T.self is SwiftPerson.Type {
-                XCTAssertEqual((collection[keyA] as! SwiftPerson).firstName, (collection[keyB] as! SwiftPerson).firstName)
-            } else {
-                XCTAssertEqual(collection[keyA], collection[keyB])
-            }
-
-            let ex = self.expectation(description: "should remove user")
-            user.remove { error in
-                XCTAssertNil(error)
-                ex.fulfill()
-            }
-            self.wait(for: [ex], timeout: 30)
-        } else {
-            guard let object = realm.objects(SwiftCollectionSyncObject.self).first else {
-                try realm.write {
-                    realm.add(SwiftCollectionSyncObject())
-                }
-                waitForUploads(for: realm)
-                checkCount(expected: 1, realm, SwiftCollectionSyncObject.self)
-                return
-            }
-            let collection = object[keyPath: keyPath]
-            if collection.count == 0 {
-                try realm.write {
-                    for entry in values {
-                        collection[entry.key] = entry.value
-                    }
-                }
-                XCTAssertEqual(collection.count, 5)
-            } else if collection.count == values.count {
-                try realm.write {
-                    var i = 0
-                    for entry in values {
-                        collection[entry.key] = nil
-                        i += 1
-                        if i >= 3 {
-                            break
-                        }
-                    }
-                }
-                XCTAssertEqual(collection.count, 2)
-            } else {
-                try realm.write {
-                    let keyA = collection.keys[0]
-                    let keyB = collection.keys[1]
-                    collection[keyA] = collection[keyB]
-                }
-                XCTAssertEqual(collection.count, 2)
-            }
-            waitForUploads(for: realm)
-            checkCount(expected: 1, realm, SwiftCollectionSyncObject.self)
         }
-    }
-
-    func createMap<T>(_ values: [T]) -> Map<String, T> {
-        let map = Map<String, T>()
+        checkCount(expected: 1, readRealm, SwiftCollectionSyncObject.self)
+        XCTAssertEqual(collection.count, values.count)
         for (i, value) in values.enumerated() {
-            map[String(i)] = value
+            assertEqual(collection["\(i)"]!, value)
         }
-        return map
+
+        // Remove the last three objects from the collection
+        try write { realm in
+            let object = realm.objects(SwiftCollectionSyncObject.self).first!
+            let collection = object[keyPath: keyPath]
+            for i in 0..<3 {
+                collection.removeObject(for: "\(i)")
+            }
+        }
+        XCTAssertEqual(collection.count, values.count - 3)
+
+        // Modify the first element
+        try write { realm in
+            let object = realm.objects(SwiftCollectionSyncObject.self).first!
+            let collection = object[keyPath: keyPath]
+            collection["3"] = collection["4"]
+        }
+        assertEqual(collection["3"]!, values[4])
     }
 
-    func testIntMap() {
-        do {
-            let map = createMap([1, 2, 3, 4, 5])
-            try roundTrip(keyPath: \.intMap, values: map)
-        } catch {
-            XCTFail(error.localizedDescription)
-        }
+
+    func testIntMap() throws {
+        try roundTrip(keyPath: \.intMap, values: [1, 2, 3, 4, 5])
     }
 
-    func testStringMap() {
-        do {
-            let map = createMap(["Who", "What", "When", "Strings", "Collide"])
-            try roundTrip(keyPath: \.stringMap, values: map)
-        } catch {
-            XCTFail(error.localizedDescription)
-        }
+    func testStringMap() throws {
+        try roundTrip(keyPath: \.stringMap, values: ["Who", "What", "When", "Strings", "Collide"])
     }
 
-    func testDataMap() {
-        do {
-            let map = createMap([Data(repeating: 1, count: 64),
-                                 Data(repeating: 2, count: 64),
-                                 Data(repeating: 3, count: 64),
-                                      Data(repeating: 4, count: 64),
-                                      Data(repeating: 5, count: 64)])
-            try roundTrip(keyPath: \.dataMap, values: map)
-        } catch {
-            XCTFail(error.localizedDescription)
-        }
+    func testDataMap() throws {
+        try roundTrip(keyPath: \.dataMap, values: [Data(repeating: 1, count: 64),
+                                                   Data(repeating: 2, count: 64),
+                                                   Data(repeating: 3, count: 64),
+                                                   Data(repeating: 4, count: 64),
+                                                   Data(repeating: 5, count: 64)])
     }
 
-    func testDateMap() {
-        do {
-            let map = createMap([Date(timeIntervalSince1970: 10000000),
-                                 Date(timeIntervalSince1970: 20000000),
-                                 Date(timeIntervalSince1970: 30000000),
-                                 Date(timeIntervalSince1970: 40000000),
-                                 Date(timeIntervalSince1970: 50000000)])
-            try roundTrip(keyPath: \.dateMap, values: map)
-        } catch {
-            XCTFail(error.localizedDescription)
-        }
+    func testDateMap() throws {
+        try roundTrip(keyPath: \.dateMap, values: [Date(timeIntervalSince1970: 10000000),
+                                                   Date(timeIntervalSince1970: 20000000),
+                                                   Date(timeIntervalSince1970: 30000000),
+                                                   Date(timeIntervalSince1970: 40000000),
+                                                   Date(timeIntervalSince1970: 50000000)])
     }
 
-    func testDoubleMap() {
-        do {
-            let map = createMap([123.456, 345.456, 789.456, 888.456, 987.456])
-            try roundTrip(keyPath: \.doubleMap, values: map)
-        } catch {
-            XCTFail(error.localizedDescription)
-        }
+    func testDoubleMap() throws {
+        try roundTrip(keyPath: \.doubleMap, values: [123.456, 345.456, 789.456, 888.456, 987.456])
     }
 
-    func testObjectIdMap() {
-        do {
-            let map = createMap([ObjectId("6058f12b957ba06156586a7c"),
-                                 ObjectId("6058f12682b2fbb1f334ef1d"),
-                                 ObjectId("6058f12d42e5a393e67538d0"),
-                                 ObjectId("6058f12682b2fbb1f334ef1f"),
-                                 ObjectId("6058f12d42e5a393e67538d1")])
-            try roundTrip(keyPath: \.objectIdMap, values: map)
-        } catch {
-            XCTFail(error.localizedDescription)
-        }
+    func testObjectIdMap() throws {
+        try roundTrip(keyPath: \.objectIdMap, values: [ObjectId("6058f12b957ba06156586a7c"),
+                                                       ObjectId("6058f12682b2fbb1f334ef1d"),
+                                                       ObjectId("6058f12d42e5a393e67538d0"),
+                                                       ObjectId("6058f12682b2fbb1f334ef1f"),
+                                                       ObjectId("6058f12d42e5a393e67538d1")])
     }
 
-    func testDecimalMap() {
-        do {
-            let map = createMap([Decimal128(123.345),
-                                 Decimal128(213.345),
-                                 Decimal128(321.345),
-                                 Decimal128(333.345),
-                                 Decimal128(444.345)])
-            try roundTrip(keyPath: \.decimalMap, values: map)
-        } catch {
-            XCTFail(error.localizedDescription)
-        }
+    func testDecimalMap() throws {
+        try roundTrip(keyPath: \.decimalMap, values: [Decimal128(123.345),
+                                                      Decimal128(213.345),
+                                                      Decimal128(321.345),
+                                                      Decimal128(333.345),
+                                                      Decimal128(444.345)])
     }
 
-    func testUuidMap() {
-        do {
-            let map = createMap([UUID(uuidString: "6b28ec45-b29a-4b0a-bd6a-343c7f6d90fd")!,
-                                 UUID(uuidString: "6b28ec45-b29a-4b0a-bd6a-343c7f6d90fe")!,
-                                 UUID(uuidString: "6b28ec45-b29a-4b0a-bd6a-343c7f6d90ff")!,
-                                 UUID(uuidString: "6b28ec45-b29a-4b0a-bd6a-343c7f6d90ae")!,
-                                 UUID(uuidString: "6b28ec45-b29a-4b0a-bd6a-343c7f6d90bf")!])
-            try roundTrip(keyPath: \.uuidMap, values: map)
-        } catch {
-            XCTFail(error.localizedDescription)
-        }
+    func testUuidMap() throws {
+        try roundTrip(keyPath: \.uuidMap, values: [UUID(uuidString: "6b28ec45-b29a-4b0a-bd6a-343c7f6d90fd")!,
+                                                   UUID(uuidString: "6b28ec45-b29a-4b0a-bd6a-343c7f6d90fe")!,
+                                                   UUID(uuidString: "6b28ec45-b29a-4b0a-bd6a-343c7f6d90ff")!,
+                                                   UUID(uuidString: "6b28ec45-b29a-4b0a-bd6a-343c7f6d90ae")!,
+                                                   UUID(uuidString: "6b28ec45-b29a-4b0a-bd6a-343c7f6d90bf")!])
     }
 
     // FIXME: We need to add a test where a value in a map of objects is `null`. currently the server
     // is throwing a bad changeset error when that happens.
-    func testObjectMap() {
-        do {
-            let map = createMap([SwiftPerson(firstName: "Peter", lastName: "Parker") as SwiftPerson?,
-                                 SwiftPerson(firstName: "Bruce", lastName: "Wayne") as SwiftPerson?,
-                                 SwiftPerson(firstName: "Stephen", lastName: "Strange") as SwiftPerson?,
-                                 SwiftPerson(firstName: "Tony", lastName: "Stark") as SwiftPerson?,
-                                 SwiftPerson(firstName: "Clark", lastName: "Kent") as SwiftPerson?])
-            try roundTrip(keyPath: \.objectMap, values: map)
-        } catch {
-            XCTFail(error.localizedDescription)
-        }
+    func testObjectMap() throws {
+        try roundTrip(keyPath: \.objectMap, values: [SwiftPerson(firstName: "Peter", lastName: "Parker"),
+                                                     SwiftPerson(firstName: "Bruce", lastName: "Wayne"),
+                                                     SwiftPerson(firstName: "Stephen", lastName: "Strange"),
+                                                     SwiftPerson(firstName: "Tony", lastName: "Stark"),
+                                                     SwiftPerson(firstName: "Clark", lastName: "Kent")])
     }
 
-    func testAnyMap() {
-        do {
-            let map: Map<String, AnyRealmValue> = createMap([.int(12345),
-                                                             .none,
-                                                             .string("Hello"),
-                                                             .double(765.6543),
-                                                             .objectId(ObjectId("507f1f77bcf86cd799439011"))])
-            try roundTrip(keyPath: \.anyMap, values: map)
-        } catch {
-            XCTFail(error.localizedDescription)
-        }
+    func testAnyMap() throws {
+        try roundTrip(keyPath: \.anyMap, values: [.int(12345), .none, .string("Hello"), .double(765.6543),
+                                                  .objectId(ObjectId("507f1f77bcf86cd799439011"))])
     }
 }

--- a/Realm/RLMManagedSet.mm
+++ b/Realm/RLMManagedSet.mm
@@ -302,8 +302,18 @@ static void ensureInWriteTransaction(NSString *message, RLMManagedSet *set, RLMM
     if (!managedSet) {
         @throw RLMException(@"Right hand side value must be a managed Set.");
     }
-    if (_type != managedSet->_type || _objectInfo != managedSet->_objectInfo) {
-        @throw RLMException(@"Set must match type of \"self\" '%@'", RLMTypeToString(_type));
+    if (_type != managedSet->_type) {
+        @throw RLMException(@"Cannot intersect sets of type '%@' and '%@'.",
+                            RLMTypeToString(_type), RLMTypeToString(managedSet->_type));
+    }
+    if (_realm != managedSet->_realm) {
+        @throw RLMException(@"Cannot insersect sets managed by different Realms.");
+    }
+    if (_objectInfo != managedSet->_objectInfo) {
+        @throw RLMException(@"Cannot intersect sets of type '%@' and '%@'.",
+                            _objectInfo->rlmObjectSchema.className,
+                            managedSet->_objectInfo->rlmObjectSchema.className);
+
     }
     return managedSet;
 }


### PR DESCRIPTION
This eliminates the use of multiple processes in all of the collection round trip tests and begins to update RLMObjectServerTests to work in a single process. Using multiple users actives the same effect and is much faster as there's a lot of startup overhead. It also makes the tests a lot easier to follow. On my machine these changes reduce the runtime of the sync test suite from 240 seconds to 150 seconds.

There's still a bunch more tests to do this to - I only updated a few in RLMObjectServerTests, and the swift version needs similar changes - but this chunk is mergeable without finishing it. There appears to be about 60 seconds of multiprocess overhead remaining that could be removed.

The project changes are fixing CollectionSyncTestCase.swift appearing twice in the project, and then sorting the files.