### PR TITLE
Fix the SwiftUI and Catalyst tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,11 @@ x.y.z Release notes (yyyy-MM-dd)
 * Synchronized Realms are no longer opened twice, cutting the address space and
   file descriptors used in half.
   ([Core #4839](https://github.com/realm/realm-core/pull/4839))
+* When using the SwiftUI helper types (@ObservedRealmObject and friends) to
+  bind to an Equatable property, self-assignment no longer performs a pointless
+  write transaction. SwiftUI appears to sometimes call a Binding's set function
+  multiple times for a single UI action, so this results in significantly fewer
+  writes being performed.
 
 ### Fixed
 
@@ -50,6 +55,7 @@ x.y.z Release notes (yyyy-MM-dd)
   next run of the application could hit the assertion failure "m_state ==
   SyncUser::State::LoggedIn" when a synchronized Realm is opened with that
   user. ([Core #4875](https://github.com/realm/realm-core/issues/4875), since v10.0.0)
+* The `keyPaths:` parameter to `@ObservedResults` did not work (since v10.12.0).
 
 ### Compatibility
 

--- a/Configuration/Realm/Tests.xcconfig
+++ b/Configuration/Realm/Tests.xcconfig
@@ -15,7 +15,6 @@ SWIFT_OPTIMIZATION_LEVEL = -Onone;
 
 TEST_HOST[sdk=iphone*] = $(BUILT_PRODUCTS_DIR)/TestHost.app/TestHost;
 TEST_HOST[sdk=appletv*] = $(BUILT_PRODUCTS_DIR)/TestHost.app/TestHost;
-TEST_HOST[sdk=macosx*] = $(BUILT_PRODUCTS_DIR)/TestHost.app/Contents/MacOS/TestHost;
 
 EXCLUDED_SOURCE_FILE_NAMES[sdk=iphone*] = InterprocessTests.m SwiftSchemaTests.swift;
 EXCLUDED_SOURCE_FILE_NAMES[sdk=appletv*] = EncryptionTests.mm InterprocessTests.m SwiftSchemaTests.swift;

--- a/Configuration/RealmSwift/Tests.xcconfig
+++ b/Configuration/RealmSwift/Tests.xcconfig
@@ -15,7 +15,6 @@ EXCLUDED_SOURCE_FILE_NAMES[sdk=macosx*] = build/ios/*;
 
 TEST_HOST[sdk=iphone*] = $(BUILT_PRODUCTS_DIR)/TestHost.app/TestHost;
 TEST_HOST[sdk=appletv*] = $(BUILT_PRODUCTS_DIR)/TestHost.app/TestHost;
-TEST_HOST[sdk=macosx*] = $(BUILT_PRODUCTS_DIR)/TestHost.app/Contents/MacOS/TestHost;
 
 MACOSX_DEPLOYMENT_TARGET = 11.0;
 IPHONEOS_DEPLOYMENT_TARGET = 14.0;

--- a/Configuration/SwiftUITestHost.xcconfig
+++ b/Configuration/SwiftUITestHost.xcconfig
@@ -1,7 +1,6 @@
 #include "TestHost.xcconfig"
 
-SUPPORTED_PLATFORMS = iphonesimulator iphoneos;
-
 INFOPLIST_FILE = Realm/Tests/SwiftUITestHost/Info.plist;
-
 IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+PRODUCT_BUNDLE_IDENTIFIER = io.realm.SwiftUITestHost;
+SUPPORTED_PLATFORMS = iphonesimulator iphoneos;

--- a/Realm.xcodeproj/project.pbxproj
+++ b/Realm.xcodeproj/project.pbxproj
@@ -573,26 +573,19 @@
 			remoteGlobalIDString = 3F1A5E711992EB7400F45F4C;
 			remoteInfo = TestHost;
 		};
+		3FF5165126E96D2B00618280 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = E8D89B8F1955FC6D00CF2B9A /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 5D660FCB1BE98C560021E04F;
+			remoteInfo = RealmSwift;
+		};
 		49E57A1B245C5B0E004AF428 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = E8D89B8F1955FC6D00CF2B9A /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = 49E57A16245C3F31004AF428;
 			remoteInfo = "Download BaaS";
-		};
-		5345F0A326E3900100827AC9 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = E8D89B8F1955FC6D00CF2B9A /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 3F1A5E711992EB7400F45F4C;
-			remoteInfo = TestHost;
-		};
-		5345F0A726E390D800827AC9 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = E8D89B8F1955FC6D00CF2B9A /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = AC8846722686573B00DF4A65;
-			remoteInfo = SwiftUISyncTestHost;
 		};
 		534DF4CF25B86F3A00655AE2 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -2103,8 +2096,8 @@
 			buildRules = (
 			);
 			dependencies = (
+				3FF5165226E96D2B00618280 /* PBXTargetDependency */,
 				534DF4D025B86F3A00655AE2 /* PBXTargetDependency */,
-				5345F0A826E390D800827AC9 /* PBXTargetDependency */,
 			);
 			name = SwiftUITestHostUITests;
 			productName = SwiftUITestHostUITests;
@@ -2222,7 +2215,6 @@
 			dependencies = (
 				AC88475A26888C6300DF4A65 /* PBXTargetDependency */,
 				AC88479E26891D4500DF4A65 /* PBXTargetDependency */,
-				5345F0A426E3900100827AC9 /* PBXTargetDependency */,
 			);
 			name = SwiftUISyncTestHostUITests;
 			productName = SwiftUISyncTestHostUITests;
@@ -2325,7 +2317,7 @@
 					};
 					53124AD325B71AF700771CE4 = {
 						CreatedOnToolsVersion = 12.3;
-						TestTargetID = AC8846722686573B00DF4A65;
+						TestTargetID = 53124AB725B71AF600771CE4;
 					};
 					5D659E7D1BE04556006515A0 = {
 						LastSwiftMigration = 1170;
@@ -3083,20 +3075,15 @@
 			target = 3F1A5E711992EB7400F45F4C /* TestHost */;
 			targetProxy = 3FC8BF34212B79F4001C2025 /* PBXContainerItemProxy */;
 		};
+		3FF5165226E96D2B00618280 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 5D660FCB1BE98C560021E04F /* RealmSwift */;
+			targetProxy = 3FF5165126E96D2B00618280 /* PBXContainerItemProxy */;
+		};
 		49E57A1C245C5B0E004AF428 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 49E57A16245C3F31004AF428 /* Download BaaS */;
 			targetProxy = 49E57A1B245C5B0E004AF428 /* PBXContainerItemProxy */;
-		};
-		5345F0A426E3900100827AC9 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = 3F1A5E711992EB7400F45F4C /* TestHost */;
-			targetProxy = 5345F0A326E3900100827AC9 /* PBXContainerItemProxy */;
-		};
-		5345F0A826E390D800827AC9 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = AC8846722686573B00DF4A65 /* SwiftUISyncTestHost */;
-			targetProxy = 5345F0A726E390D800827AC9 /* PBXContainerItemProxy */;
 		};
 		534DF4D025B86F3A00655AE2 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -3247,7 +3234,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = "";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				TEST_TARGET_NAME = SwiftUISyncTestHost;
+				TEST_TARGET_NAME = SwiftUITestHost;
 			};
 			name = Debug;
 		};
@@ -3257,7 +3244,7 @@
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "\"-\"";
 				CODE_SIGN_STYLE = Automatic;
-				TEST_TARGET_NAME = SwiftUISyncTestHost;
+				TEST_TARGET_NAME = SwiftUITestHost;
 			};
 			name = Release;
 		};

--- a/Realm/Tests/SwiftUITestHost/SwiftUITestHostApp.swift
+++ b/Realm/Tests/SwiftUITestHost/SwiftUITestHostApp.swift
@@ -19,25 +19,8 @@
 import RealmSwift
 import SwiftUI
 
-struct ReminderRowView: View {
-    @ObservedRealmObject var list: ReminderList
-    @ObservedRealmObject var reminder: Reminder
-    @State var hasFocus: Bool
-    @State var showReminderForm = false
-
-    var body: some View {
-        NavigationLink(destination: ReminderFormView(list: list,
-                                                     reminder: reminder,
-                                                     showReminderForm: $showReminderForm), isActive: $showReminderForm) {
-            Text(reminder.title)
-        }.isDetailLink(true)
-    }
-}
-
 struct ReminderFormView: View {
-    @ObservedRealmObject var list: ReminderList
     @ObservedRealmObject var reminder: Reminder
-    @Binding var showReminderForm: Bool
 
     var body: some View {
         Form {
@@ -50,31 +33,22 @@ struct ReminderFormView: View {
             }).accessibilityIdentifier("picker")
         }
         .navigationTitle(reminder.title)
-        .navigationBarItems(trailing: Button("Save") {
-            if reminder.realm == nil {
-                $list.reminders.append(reminder)
-            }
-            showReminderForm.toggle()
-        }.disabled(reminder.title.isEmpty))
     }
 }
 
+
 struct ReminderListView: View {
     @ObservedRealmObject var list: ReminderList
-    @State var newReminderAdded = false
-    @State var showReminderForm = false
-
-    func shouldFocusReminder(_ reminder: Reminder) -> Bool {
-        return newReminderAdded && list.reminders.last == reminder
-    }
+    @State var activeReminder: Reminder.ID?
 
     var body: some View {
         VStack {
             List {
                 ForEach(list.reminders) { reminder in
-                    ReminderRowView(list: list,
-                                    reminder: reminder,
-                                    hasFocus: shouldFocusReminder(reminder))
+                    NavigationLink(destination: ReminderFormView(reminder: reminder),
+                                   tag: reminder.id, selection: $activeReminder) {
+                        Text(reminder.title)
+                    }
                 }
                 .onMove(perform: $list.reminders.move)
                 .onDelete(perform: $list.reminders.remove)
@@ -83,36 +57,41 @@ struct ReminderListView: View {
         .navigationBarItems(trailing: HStack {
             EditButton()
             Button("add") {
-                newReminderAdded = true
-                $list.reminders.append(Reminder())
+                let reminder = Reminder()
+                $list.reminders.append(reminder)
+                activeReminder = reminder.id
             }.accessibility(identifier: "addReminder")
         })
     }
 }
 
-struct ReminderListRowView: View {
-    @ObservedRealmObject var list: ReminderList
-
-    var body: some View {
-        HStack {
-            Image(systemName: list.icon)
-            TextField("List Name", text: $list.name).accessibility(identifier: "listRow")
-            Spacer()
-            Text("\(list.reminders.count)")
-        }.frame(minWidth: 100).accessibility(identifier: "hstack")
-    }
-}
-
 struct ReminderListResultsView: View {
-    @ObservedResults(ReminderList.self) var reminders
+    // Only receive notifications on "name" to work around what appears to be
+    // a SwiftUI bug introduced in iOS 14.5: when we're two levels deep in
+    // NagivationLinks, refreshing this view makes the second NavigationLink pop
+    @ObservedResults(ReminderList.self, keyPaths: ["name", "icon"]) var reminders
     @Binding var searchFilter: String
+    @State var activeList: ReminderList.ID?
+
+    struct Row: View {
+        @ObservedRealmObject var list: ReminderList
+
+        var body: some View {
+            HStack {
+                Image(systemName: list.icon)
+                TextField("List Name", text: $list.name)
+                Spacer()
+                Text("\(list.reminders.count)")
+            }.accessibility(identifier: "hstack")
+        }
+    }
 
     var body: some View {
         List {
             ForEach(reminders) { list in
-                NavigationLink(destination: ReminderListView(list: list)) {
-                    ReminderListRowView(list: list).tag(list)
-                }.accessibilityIdentifier(list.name)
+                NavigationLink(destination: ReminderListView(list: list), tag: list.id, selection: $activeList) {
+                    Row(list: list)
+                }.accessibilityIdentifier(list.name).accessibilityActivationPoint(CGPoint(x: 0, y: 0))
             }.onDelete(perform: $reminders.remove)
         }.onChange(of: searchFilter) { value in
             $reminders.filter = value.isEmpty ? nil : NSPredicate(format: "name CONTAINS[c] %@", value)
@@ -156,12 +135,14 @@ struct SearchView: View {
 }
 
 struct Footer: View {
-    @ObservedResults(ReminderList.self) var lists
+    let realm = try! Realm()
 
     var body: some View {
         HStack {
             Button(action: {
-                $lists.append(ReminderList())
+                try! realm.write {
+                    realm.add(ReminderList())
+                }
             }, label: {
                 HStack {
                     Image(systemName: "plus.circle")

--- a/Realm/Tests/SwiftUITestHostUITests/SwiftUITestHostUITests.swift
+++ b/Realm/Tests/SwiftUITestHostUITests/SwiftUITestHostUITests.swift
@@ -32,15 +32,12 @@ class SwiftUITests: XCTestCase {
         // write permissions
         let realmPath = URL(string: "\(FileManager.default.temporaryDirectory)\(UUID())")!
         let configuration = Realm.Configuration(fileURL: realmPath)
+        _ = try Realm.deleteFiles(for: configuration)
         self.realm = try! Realm(configuration: configuration)
 
         app.launchEnvironment = [
             "REALM_PATH": realmPath.absoluteString
         ]
-
-        try realm.write {
-            realm.deleteAll()
-        }
     }
 
     override func tearDownWithError() throws {
@@ -48,7 +45,7 @@ class SwiftUITests: XCTestCase {
         self.realm.invalidate()
         let config = realm.configuration
         self.realm = nil
-        XCTAssert(try Realm.deleteFiles(for: config))
+        XCTAssertTrue(try Realm.deleteFiles(for: config))
     }
 
     private func deleteString(for string: String) -> String {
@@ -81,26 +78,27 @@ class SwiftUITests: XCTestCase {
 
         // add another list, and tap into the ReminderView
         addButton.tap()
-        app.tables.firstMatch.cells.buttons.firstMatch.tap()
+        app.buttons["New List"].tap()
+        XCTAssertTrue(app.navigationBars.staticTexts["New List"].waitForExistence(timeout: 1.0))
         app.buttons["addReminder"].tap()
         // type in a name
-        app.tables.cells.firstMatch.buttons.firstMatch.tap()
+        app.textFields["title"].tap()
         app.textFields["title"].tap()
         app.textFields["title"].typeText("My Reminder")
         // check to see if it is reflected live in the title view
-        XCTAssert(app.navigationBars.staticTexts["My Reminder"].waitForExistence(timeout: 1.0))
+        XCTAssertTrue(app.navigationBars.staticTexts["My Reminder"].waitForExistence(timeout: 1.0))
         let myReminder = realm.objects(ReminderList.self).first!.reminders.first!
         XCTAssertEqual(myReminder.priority, .low)
         app.buttons["picker"].tap()
-        app.buttons["medium"].tap()
+        app.tables.switches["medium"].tap()
         XCTAssertEqual(myReminder.priority, .medium)
-
         app.navigationBars.buttons.element(boundBy: 0).tap()
 
         // MARK: Test Move
         app.buttons["addReminder"].tap()
         XCTAssertEqual(realm.objects(ReminderList.self).first!.reminders.first!.title, "My Reminder")
         XCTAssertEqual(realm.objects(ReminderList.self).first!.reminders[1].title, "")
+        app.navigationBars.buttons.element(boundBy: 0).tap()
 
         app.buttons["Edit"].tap()
         app.buttons.matching(identifier: "Reorder").firstMatch.press(forDuration: 0.5, thenDragTo: app.tables.cells.element(boundBy: 1))


### PR DESCRIPTION
This turned out to be a whole pile of problems:

1. The project file had some weird incorrect dependencies such as SwiftUITestHostTests depending on SwiftUISyncTestHost and not RealmSwift. The build happened to work if things were built in the correct order but broke if you tried to run the tests directly from a clean state.
2. iOS 14.5 did some weird things to NavigationLink. There's a bug where if a List has exactly two NavigationLinks then following one will immediately pop back to the parent, and a simulator-specific bug where if the parent refreshes when you're 2+ NavigationLinks deep it reloads the intermediate View even if the ID matches. Since we need our UI test to work on the simulator, I worked around that by using keypath filtering to avoid refreshing the top-level view when editing in the detail view.
3. It turned out that keypath filtering with @ObservedResults didn't work. The fix was trivial, but this suggests that it's entirely untested.
4. `tap()` by default taps in the exact middle of the element. On iOS 14.5+, this meant that accessiblity taps on the NavigationLink in the top-level View happens to land on the TextField and switch to editing mode instead of going to the next View. I worked around this by setting the tap location to 0,0 which happens to work at the moment.
5. Each character typed in a TextField is setting the property *twice*. I'm not sure why, but I made createBinding() only perform a write if the value has actually changed, which makes TextFields a lot less laggy.
6. There were some half-implemented ideas in the test app (such as the Save button in the detail edit form) that I removed while trying to figure out what was going on and didn't restore afterwards.
7. Unrelated to this, using a test host app seemed to be causing problems for catalyst. When catalyst is running with the app hidden, catalyst itself seems to hang sometimes for 20+ seconds, which makes our CI jobs take a very long time and often outright time out. For whatever reason, this only happened when launching the tests via xcodebuild and not Xcode. Attaching Xcode to the app after launching it via xcodebuild would make the window for the app appear, and so also sidestep the problem. Using xctest rather than a test host app seems to fix this. We only actually need to use a test host for on-device testing, and only used it everywhere because that used to be simpler (but now isn't with how TEST_HOST is now set).
