### PR TITLE
Add #canImport(_Concurrency) flag to code that uses the Concurrency module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,7 @@ x.y.z Release notes (yyyy-MM-dd)
 * None.
 
 ### Fixed
-* <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-cocoa/issues/????), since v?.?.?)
-* None.
+* Fix compilation error where Swift 5.5 is available but the macOS 12 SDK was not. This was notable for the Xcode 13 RC. This fix adds a #canImport check for the `_Concurrency` module that was not available before the macOS 12 SDK.
 
 <!-- ### Breaking Changes - ONLY INCLUDE FOR NEW MAJOR version -->
 

--- a/Realm/ObjectServerTests/SwiftObjectServerTests.swift
+++ b/Realm/ObjectServerTests/SwiftObjectServerTests.swift
@@ -2957,7 +2957,7 @@ class CombineObjectServerTests: SwiftSyncTestCase {
     }
 }
 
-#if swift(>=5.5)
+#if swift(>=5.5) && canImport(_Concurrency)
 
 @available(macOS 12.0, *)
 class AsyncAwaitObjectServerTests: SwiftSyncTestCase {

--- a/Realm/ObjectServerTests/SwiftSyncTestCase.swift
+++ b/Realm/ObjectServerTests/SwiftSyncTestCase.swift
@@ -199,7 +199,7 @@ open class SwiftSyncTestCase: RLMSyncTestCase {
     }
 }
 
-#if swift(>=5.5)
+#if swift(>=5.5) && canImport(_Concurrency)
 
 @available(macOS 12.0, *)
 extension SwiftSyncTestCase {

--- a/RealmSwift/App.swift
+++ b/RealmSwift/App.swift
@@ -542,7 +542,7 @@ public extension APIKeyAuth {
     }
 }
 
-#if swift(>=5.5)
+#if swift(>=5.5) && canImport(_Concurrency)
 @available(macOS 12.0, tvOS 15.0, iOS 15.0, watchOS 8.0, *)
 extension App {
     /// Login to a user for the Realm app.

--- a/RealmSwift/Realm.swift
+++ b/RealmSwift/Realm.swift
@@ -1001,7 +1001,7 @@ extension Realm {
 /// The type of a block to run for notification purposes when the data in a Realm is modified.
 public typealias NotificationBlock = (_ notification: Realm.Notification, _ realm: Realm) -> Void
 
-#if swift(>=5.5)
+#if swift(>=5.5) && canImport(_Concurrency)
 @available(macOS 12.0, tvOS 15.0, iOS 15.0, watchOS 8.0, *)
 extension Realm {
     /// Options for when to download all data from the server before opening


### PR DESCRIPTION
Fixes https://github.com/realm/realm-cocoa/issues/7441.

Can confirm that compilation succeeds on Xcode 13 RC and Xcode Beta 5. Can confirm that tests using the `_Concurrency` module run successfully in Xcode Beta 5.

This change should also be reflected in https://github.com/realm/realm-cocoa/pull/7379.