### PR TITLE
Fix change notifications from sync writes when using asyncOpen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,11 @@ x.y.z Release notes (yyyy-MM-dd)
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-cocoa/issues/????), since v?.?.?)
-* None.
+* A race condition in Realm.asyncOpen() sometimes resulted in subsequent writes
+  from Realm Sync failing to produce notifications
+  ([#7447](https://github.com/realm/realm-cocoa/issues/7447),
+  [#7453](https://github.com/realm/realm-cocoa/issues/7453),
+  [Core #4909](https://github.com/realm/realm-core/issues/4909), since v10.15.0).
 
 <!-- ### Breaking Changes - ONLY INCLUDE FOR NEW MAJOR version -->
 

--- a/Realm/RLMRealm.mm
+++ b/Realm/RLMRealm.mm
@@ -257,7 +257,7 @@ static RLMAsyncOpenTask *openAsync(RLMRealmConfiguration *configuration, void (^
 + (RLMAsyncOpenTask *)asyncOpenWithConfiguration:(RLMRealmConfiguration *)configuration
                                    callbackQueue:(dispatch_queue_t)callbackQueue
                                         callback:(RLMAsyncOpenRealmCallback)callback {
-    return openAsync(configuration, [=](ThreadSafeReference, std::exception_ptr err) {
+    return openAsync(configuration, [=](ThreadSafeReference ref, std::exception_ptr err) {
         @autoreleasepool {
             if (err) {
                 try {
@@ -272,12 +272,18 @@ static RLMAsyncOpenTask *openAsync(RLMRealmConfiguration *configuration, void (^
                 }
                 return;
             }
-            dispatch_async(callbackQueue, ^{
+            // Ensure that we keep the Realm open until we've initialized the
+            // RLMRealm on the target queue. This ensures that the existing
+            // RealmCoordinator and DB are reused rather than being reopened.
+            // We can't just capture the ThreadSafeReference as dispatch_async()
+            // requires a copyable block.
+            dispatch_async(callbackQueue, [=, ref = ref.resolve<std::shared_ptr<Realm>>(nullptr)]() mutable {
                 @autoreleasepool {
                     NSError *error;
                     RLMRealm *localRealm = [RLMRealm realmWithConfiguration:configuration
                                                                       queue:callbackQueue
                                                                       error:&error];
+                    ref.reset();
                     callback(localRealm, error);
                 }
             });


### PR DESCRIPTION
Destroying and then immediately recreating a RealmCoordinator with an active sync session can result in the new RealmCoordinator using the old SyncSession, which almost entirely works other than that it fails to set the sync notification callback correctly. That bug needs to be fixed in core, but we don't want to be destroying and recreating the RealmCoordinator in asyncOpen anyway as that has a lot of overhead.

Fixes #7447. Fixes #7453. Fixes https://github.com/realm/realm-core/issues/4909.