### PR TITLE
Searchable Extension (SwiftUI)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,31 @@
 x.y.z Release notes (yyyy-MM-dd)
 =============================================================
 ### Enhancements
+* Add support for multi-user on `@AsyncOpen` and `@AutoOpen`.
+* Add several `.searchable()` extensions which allows us to filter 
+  `@ObservedResult` results from serachable component search field
+  by a key path.
+  ```swift
+  List {
+      ForEach(reminders) { reminder in
+        ReminderRowView(reminder: reminder)
+      }
+  }
+  .searchable(text: $searchFilter,
+              collection: $reminders,
+              keyPath: \.name) {
+    ForEach(reminders) { remindersFiltered in
+      Text(remindersFiltered.name).searchCompletion(remindersFiltered.name)
+    }
+  }
+  ```
+
+### Fixed
+* Fix `@AsyncOpen` and `@AutoOpen` using `defaultConfiguration` by default if 
+  the user's doesn't provide one, will set an incorrect path which doesn't 
+  correspond to the users configuration one. (since v10.12.0)
+* Adding missing subscription completion for `AsyncOpenPublisher` after successfully 
+  returning a realm.
 * Add an api for a type safe query syntax. This allows you to filter a Realm and collections managed by a Realm
   with Swift style expressions. Here is a brief example:
   ```swift

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,6 @@ x.y.z Release notes (yyyy-MM-dd)
     }
   }
   ```
-
-### Fixed
 * Add an api for a type safe query syntax. This allows you to filter a Realm and collections managed by a Realm
   with Swift style expressions. Here is a brief example:
   ```swift

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,6 @@
 x.y.z Release notes (yyyy-MM-dd)
 =============================================================
 ### Enhancements
-* Add support for multi-user on `@AsyncOpen` and `@AutoOpen`.
 * Add `.searchable()` methods which allows us to filter 
   `@ObservedResult` results from searchable component search field
   by a key path.
@@ -21,11 +20,6 @@ x.y.z Release notes (yyyy-MM-dd)
   ```
 
 ### Fixed
-* Fix `@AsyncOpen` and `@AutoOpen` using `defaultConfiguration` by default if 
-  the user's doesn't provide one, will set an incorrect path which doesn't 
-  correspond to the users configuration one. (since v10.12.0)
-* Adding missing subscription completion for `AsyncOpenPublisher` after successfully 
-  returning a realm.
 * Add an api for a type safe query syntax. This allows you to filter a Realm and collections managed by a Realm
   with Swift style expressions. Here is a brief example:
   ```swift

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@ x.y.z Release notes (yyyy-MM-dd)
 =============================================================
 ### Enhancements
 * Add support for multi-user on `@AsyncOpen` and `@AutoOpen`.
-* Add several `.searchable()` extensions which allows us to filter 
-  `@ObservedResult` results from serachable component search field
+* Add `.searchable()` methods which allows us to filter 
+  `@ObservedResult` results from searchable component search field
   by a key path.
   ```swift
   List {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,8 @@
 x.y.z Release notes (yyyy-MM-dd)
 =============================================================
 ### Enhancements
-* Add `.searchable()` methods which allows us to filter 
-  `@ObservedResult` results from searchable component search field
-  by a key path.
+* Add `.searchable()` SwiftUI View Modifier which allows us to filter 
+  `@ObservedResult` results from a search field component by a key path.
   ```swift
   List {
       ForEach(reminders) { reminder in

--- a/Realm/Tests/SwiftUITestHost/Objects.swift
+++ b/Realm/Tests/SwiftUITestHost/Objects.swift
@@ -19,8 +19,8 @@
 import RealmSwift
 import Foundation
 
-@objcMembers class Reminder: EmbeddedObject, ObjectKeyIdentifiable {
-    @objc enum Priority: Int, RealmEnum, CaseIterable, Identifiable, CustomStringConvertible {
+class Reminder: EmbeddedObject, Identifiable {
+     enum Priority: Int, PersistableEnum, CaseIterable, Identifiable, CustomStringConvertible {
         var id: Int { self.rawValue }
 
         case low, medium, high
@@ -33,16 +33,17 @@ import Foundation
             }
         }
     }
-    dynamic var title = ""
-    dynamic var notes = ""
-    dynamic var isFlagged = false
-    dynamic var date = Date()
-    dynamic var isComplete = false
-    dynamic var priority: Priority = .low
+    @Persisted var title = ""
+    @Persisted var notes = ""
+    @Persisted var isFlagged = false
+    @Persisted var date = Date()
+    @Persisted var isComplete = false
+    @Persisted var priority: Priority = .low
 }
 
-@objcMembers class ReminderList: Object, ObjectKeyIdentifiable {
-    dynamic var name = "New List"
-    dynamic var icon: String = "list.bullet"
-    var reminders = RealmSwift.List<Reminder>()
+class ReminderList: Object, Identifiable {
+    @Persisted(primaryKey: true) var id = ObjectId.generate()
+    @Persisted var name = "New List"
+    @Persisted var icon: String = "list.bullet"
+    @Persisted var reminders = RealmSwift.List<Reminder>()
 }

--- a/Realm/Tests/SwiftUITestHost/Objects.swift
+++ b/Realm/Tests/SwiftUITestHost/Objects.swift
@@ -19,7 +19,7 @@
 import RealmSwift
 import Foundation
 
-class Reminder: EmbeddedObject, Identifiable {
+class Reminder: EmbeddedObject, ObjectKeyIdentifiable {
      enum Priority: Int, PersistableEnum, CaseIterable, Identifiable, CustomStringConvertible {
         var id: Int { self.rawValue }
 
@@ -41,9 +41,8 @@ class Reminder: EmbeddedObject, Identifiable {
     @Persisted var priority: Priority = .low
 }
 
-class ReminderList: Object, Identifiable {
-    @Persisted(primaryKey: true) var id = ObjectId.generate()
+class ReminderList: Object, ObjectKeyIdentifiable {
     @Persisted var name = "New List"
-    @Persisted var icon: String = "list.bullet"
+    @Persisted var icon = "list.bullet"
     @Persisted var reminders = RealmSwift.List<Reminder>()
 }

--- a/Realm/Tests/SwiftUITestHost/SwiftUITestHostApp.swift
+++ b/Realm/Tests/SwiftUITestHost/SwiftUITestHostApp.swift
@@ -325,7 +325,6 @@ struct App: SwiftUI.App {
                 } else {
                     return AnyView(EmptyView())
                 }
-
             default:
                 return AnyView(ContentView())
             }

--- a/Realm/Tests/SwiftUITestHost/SwiftUITestHostApp.swift
+++ b/Realm/Tests/SwiftUITestHost/SwiftUITestHostApp.swift
@@ -272,6 +272,35 @@ struct ObservedResultsKeyPathTestRow: View {
     }
 }
 
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+struct ObservedResultsSearchableTestView: View {
+    @ObservedResults(ReminderList.self) var reminders
+    @State var searchFilter: String = ""
+
+    var body: some View {
+        NavigationView {
+            List {
+                ForEach(reminders) { reminder in
+                    Text(reminder.name)
+                }
+            }
+            .searchable(text: $searchFilter,
+                        collection: $reminders,
+                        keyPath: \.name) {
+                ForEach(reminders) { remindersFiltered in
+                    Text(remindersFiltered.name).searchCompletion(remindersFiltered.name)
+                }
+            }
+            .navigationTitle("Reminders")
+            .navigationBarItems(trailing:
+                Button("add") {
+                    let reminder = ReminderList()
+                    $reminders.append(reminder)
+                }.accessibility(identifier: "addList"))
+        }
+    }
+}
+
 @main
 struct App: SwiftUI.App {
     var body: some Scene {
@@ -290,6 +319,13 @@ struct App: SwiftUI.App {
                 return AnyView(UnmanagedObjectTestView())
             case "observed_results_key_path":
                 return AnyView(ObservedResultsKeyPathTestView())
+            case "observed_results_searchable":
+                if #available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *) {
+                    return AnyView(ObservedResultsSearchableTestView())
+                } else {
+                    return AnyView(EmptyView())
+                }
+
             default:
                 return AnyView(ContentView())
             }

--- a/Realm/Tests/SwiftUITestHostUITests/SwiftUITestHostUITests.swift
+++ b/Realm/Tests/SwiftUITestHostUITests/SwiftUITestHostUITests.swift
@@ -205,4 +205,54 @@ class SwiftUITests: XCTestCase {
         XCTAssertEqual(realm.objects(ReminderList.self).count, 2)
         XCTAssertEqual(app.tables.firstMatch.cells.count, 2)
     }
+
+    func testUpdateResultsWithSearchable() {
+        app.launchEnvironment["test_type"] = "observed_results_searchable"
+        app.launch()
+
+        let addButton = app.buttons["addList"]
+        (1...20).forEach { _ in
+            addButton.tap()
+        }
+
+        // Name every reminders list for search
+        try! realm.write {
+            for (index, obj) in (realm.objects(ReminderList.self)).enumerated() {
+                obj.name = "reminder list \(index)"
+            }
+        }
+
+        func clearSearchBar() {
+            let searchBar = app.searchFields.firstMatch
+            let deleteString = String(repeating: XCUIKeyboardKey.delete.rawValue, count: (searchBar.value as? String)!.count)
+            searchBar.typeText(deleteString)
+        }
+
+        let searchBar = app.searchFields.firstMatch
+        let table = app.tables.firstMatch
+
+        searchBar.tap()
+
+        searchBar.typeText("reminder")
+        XCTAssertEqual(table.cells.count, 20)
+
+        searchBar.typeText(" list 1")
+        XCTAssertEqual(table.cells.count, 11)
+
+        searchBar.typeText("8")
+        XCTAssertEqual(table.cells.count, 1)
+
+        searchBar.typeText("9")
+        XCTAssertEqual(table.cells.count, 0)
+
+        clearSearchBar()
+        XCTAssertEqual(table.cells.count, 20)
+
+        searchBar.typeText("5")
+        XCTAssertEqual(table.cells.count, 2)
+
+        clearSearchBar()
+        searchBar.typeText("12")
+        XCTAssertEqual(table.cells.count, 1)
+    }
 }

--- a/RealmSwift/SwiftUI.swift
+++ b/RealmSwift/SwiftUI.swift
@@ -404,8 +404,7 @@ private class ObservableStorage<ObservedType>: ObservableObject where ObservedTy
             storage.sortDescriptor = newValue
         }
     }
-
-        /// :nodoc:
+    /// :nodoc:
     public var wrappedValue: Results<ResultType> {
         if !storage.setupHasRun {
             storage.setupValue()

--- a/RealmSwift/SwiftUI.swift
+++ b/RealmSwift/SwiftUI.swift
@@ -1252,5 +1252,3 @@ extension View {
     }
 }
 #endif
-
-

--- a/RealmSwift/SwiftUI.swift
+++ b/RealmSwift/SwiftUI.swift
@@ -169,7 +169,7 @@ private func createEquatableBinding<T: ThreadConfined, V: Equatable>(
 
 // MARK: - ObservableStorage
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
-internal final class ObservableStoragePublisher<ObjectType>: Publisher where ObjectType: ThreadConfined & RealmSubscribable {
+private final class ObservableStoragePublisher<ObjectType>: Publisher where ObjectType: ThreadConfined & RealmSubscribable {
     public typealias Output = Void
     public typealias Failure = Never
 
@@ -212,7 +212,7 @@ internal final class ObservableStoragePublisher<ObjectType>: Publisher where Obj
     }
 }
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
-internal class ObservableStorage<ObservedType>: ObservableObject where ObservedType: RealmSubscribable & ThreadConfined & Equatable {
+private class ObservableStorage<ObservedType>: ObservableObject where ObservedType: RealmSubscribable & ThreadConfined & Equatable {
     @Published var value: ObservedType {
         willSet {
             if newValue != value {
@@ -351,7 +351,6 @@ internal class ObservableStorage<ObservedType>: ObservableObject where ObservedT
 @propertyWrapper public struct ObservedResults<ResultType>: DynamicProperty, BoundCollection where ResultType: Object & Identifiable {
     fileprivate class Storage: ObservableStorage<Results<ResultType>> {
         var setupHasRun = false
-        var cancellables = [AnyCancellable]()
 
         private func didSet() {
             if setupHasRun {
@@ -369,7 +368,6 @@ internal class ObservableStorage<ObservedType>: ObservableObject where ObservedT
             if let filter = filter {
                 value = value.filter(filter)
             }
-
             setupHasRun = true
         }
 

--- a/RealmSwift/SwiftUI.swift
+++ b/RealmSwift/SwiftUI.swift
@@ -1164,7 +1164,7 @@ extension SwiftUIKVO {
 }
 
 /// All methods on this extension allows us to filter @ObservedResult results from .searchable()
-/// component search field.
+/// component search field by a key path.
 ///
 ///     @State var searchString: String
 ///     @ObservedResults(Reminder.self) var reminders

--- a/RealmSwift/SwiftUI.swift
+++ b/RealmSwift/SwiftUI.swift
@@ -1287,7 +1287,7 @@ extension View {
     - parameter prompt: A string representing the prompt of the search field
                 which provides users with guidance on what to search for.
      */
-    public func searchable<T: ObjectBase, P: _QueryString & _RealmSchemaDiscoverable, S>(text: Binding<String>, collection: ObservedResults<T>, keyPath: KeyPath<T, P>, placement: SearchFieldPlacement = .automatic, prompt: S) -> some View where S : StringProtocol {
+    public func searchable<T: ObjectBase, P: _QueryString & _RealmSchemaDiscoverable, S>(text: Binding<String>, collection: ObservedResults<T>, keyPath: KeyPath<T, P>, placement: SearchFieldPlacement = .automatic, prompt: S) -> some View where S: StringProtocol {
         filterCollection(collection, for: text.wrappedValue, on: keyPath)
         return searchable(text: text,
                           placement: placement,
@@ -1331,7 +1331,7 @@ extension View {
     - parameter suggestions: A view builder that produces content that
                 populates a list of suggestions.
      */
-    public func searchable<T: ObjectBase, P: _QueryString & _RealmSchemaDiscoverable, S>(text: Binding<String>, collection: ObservedResults<T>, keyPath: KeyPath<T, P>, placement: SearchFieldPlacement = .automatic, prompt: Text? = nil, @ViewBuilder suggestions: () -> S) -> some View where S : View {
+    public func searchable<T: ObjectBase, P: _QueryString & _RealmSchemaDiscoverable, S>(text: Binding<String>, collection: ObservedResults<T>, keyPath: KeyPath<T, P>, placement: SearchFieldPlacement = .automatic, prompt: Text? = nil, @ViewBuilder suggestions: () -> S) -> some View where S: View {
         filterCollection(collection, for: text.wrappedValue, on: keyPath)
         return searchable(text: text,
                           placement: placement,
@@ -1376,7 +1376,7 @@ extension View {
     - parameter suggestions: A view builder that produces content that
                 populates a list of suggestions.
      */
-    public func searchable<T: ObjectBase, P: _QueryString & _RealmSchemaDiscoverable, S>(text: Binding<String>, collection: ObservedResults<T>, keyPath: KeyPath<T, P>, placement: SearchFieldPlacement = .automatic, prompt: LocalizedStringKey, @ViewBuilder suggestions: () -> S) -> some View where S : View {
+    public func searchable<T: ObjectBase, P: _QueryString & _RealmSchemaDiscoverable, S>(text: Binding<String>, collection: ObservedResults<T>, keyPath: KeyPath<T, P>, placement: SearchFieldPlacement = .automatic, prompt: LocalizedStringKey, @ViewBuilder suggestions: () -> S) -> some View where S: View {
         filterCollection(collection, for: text.wrappedValue, on: keyPath)
         return searchable(text: text,
                           placement: placement,
@@ -1421,7 +1421,7 @@ extension View {
     - parameter suggestions: A view builder that produces content that
                 populates a list of suggestions.
      */
-    public func searchable<T: ObjectBase, P: _QueryString & _RealmSchemaDiscoverable, V, S>(text: Binding<String>, collection: ObservedResults<T>, keyPath: KeyPath<T, P>, placement: SearchFieldPlacement = .automatic, prompt: S, @ViewBuilder suggestions: () -> V) -> some View where V : View, S : StringProtocol {
+    public func searchable<T: ObjectBase, P: _QueryString & _RealmSchemaDiscoverable, V, S>(text: Binding<String>, collection: ObservedResults<T>, keyPath: KeyPath<T, P>, placement: SearchFieldPlacement = .automatic, prompt: S, @ViewBuilder suggestions: () -> V) -> some View where V: View, S: StringProtocol {
         filterCollection(collection, for: text.wrappedValue, on: keyPath)
         return searchable(text: text,
                           placement: placement,

--- a/RealmSwift/SwiftUI.swift
+++ b/RealmSwift/SwiftUI.swift
@@ -349,7 +349,7 @@ private class ObservableStorage<ObservedType>: ObservableObject where ObservedTy
 /// the environment value `EnvironmentValues/realmConfiguration`.
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
 @propertyWrapper public struct ObservedResults<ResultType>: DynamicProperty, BoundCollection where ResultType: Object & Identifiable {
-    fileprivate class Storage: ObservableStorage<Results<ResultType>> {
+    private class Storage: ObservableStorage<Results<ResultType>> {
         var setupHasRun = false
 
         private func didSet() {
@@ -391,7 +391,7 @@ private class ObservableStorage<ObservedType>: ObservableObject where ObservedTy
     }
 
     @Environment(\.realmConfiguration) var configuration
-    @ObservedObject fileprivate var storage: Storage
+    @ObservedObject private var storage: Storage
     /// :nodoc:
     @State public var filter: NSPredicate? {
         willSet {

--- a/RealmSwift/SwiftUI.swift
+++ b/RealmSwift/SwiftUI.swift
@@ -1163,11 +1163,11 @@ extension SwiftUIKVO {
     }
 }
 
-/// all methods in this extension allows to filter @ObservedResult data from .searchable()
+/// All methods on this extension allows us to filter @ObservedResult results from .searchable()
 /// component search field.
 ///
 ///     @State var searchString: String
-///     @StObservedResults(Reminder.self) var reminders
+///     @ObservedResults(Reminder.self) var reminders
 ///
 ///     List {
 ///         ForEach(reminders) { reminder in
@@ -1184,6 +1184,7 @@ extension SwiftUIKVO {
 ///
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 extension View {
+    /// :nodoc:
     public func searchable<T: ObjectBase, P: _QueryString & _RealmSchemaDiscoverable>(text: Binding<String>, collection: ObservedResults<T>, keyPath: KeyPath<T, P>, placement: SearchFieldPlacement = .automatic, prompt: Text? = nil) -> some View {
         filterCollection(collection, for: text.wrappedValue, on: keyPath)
         return searchable(text: text,
@@ -1191,6 +1192,7 @@ extension View {
                           prompt: prompt)
     }
 
+    /// :nodoc:
     public func searchable<T: ObjectBase, P: _QueryString & _RealmSchemaDiscoverable>(text: Binding<String>, collection: ObservedResults<T>, keyPath: KeyPath<T, P>, placement: SearchFieldPlacement = .automatic, prompt: LocalizedStringKey) -> some View {
         filterCollection(collection, for: text.wrappedValue, on: keyPath)
         return searchable(text: text,
@@ -1198,6 +1200,7 @@ extension View {
                           prompt: prompt)
     }
 
+    /// :nodoc:
     public func searchable<T: ObjectBase, P: _QueryString & _RealmSchemaDiscoverable, S>(text: Binding<String>, collection: ObservedResults<T>, keyPath: KeyPath<T, P>, placement: SearchFieldPlacement = .automatic, prompt: S) -> some View where S : StringProtocol {
         filterCollection(collection, for: text.wrappedValue, on: keyPath)
         return searchable(text: text,
@@ -1205,6 +1208,7 @@ extension View {
                           prompt: prompt)
     }
 
+    /// :nodoc:
     public func searchable<T: ObjectBase, P: _QueryString & _RealmSchemaDiscoverable, S>(text: Binding<String>, collection: ObservedResults<T>, keyPath: KeyPath<T, P>, placement: SearchFieldPlacement = .automatic, prompt: Text? = nil, @ViewBuilder suggestions: () -> S) -> some View where S : View {
         filterCollection(collection, for: text.wrappedValue, on: keyPath)
         return searchable(text: text,
@@ -1213,6 +1217,7 @@ extension View {
                           suggestions: suggestions)
     }
 
+    /// :nodoc:
     public func searchable<T: ObjectBase, P: _QueryString & _RealmSchemaDiscoverable, S>(text: Binding<String>, collection: ObservedResults<T>, keyPath: KeyPath<T, P>, placement: SearchFieldPlacement = .automatic, prompt: LocalizedStringKey, @ViewBuilder suggestions: () -> S) -> some View where S : View {
         filterCollection(collection, for: text.wrappedValue, on: keyPath)
         return searchable(text: text,
@@ -1221,6 +1226,7 @@ extension View {
                           suggestions: suggestions)
     }
 
+    /// :nodoc:
     public func searchable<T: ObjectBase, P: _QueryString & _RealmSchemaDiscoverable, V, S>(text: Binding<String>, collection: ObservedResults<T>, keyPath: KeyPath<T, P>, placement: SearchFieldPlacement = .automatic, prompt: S, @ViewBuilder suggestions: () -> V) -> some View where V : View, S : StringProtocol {
         filterCollection(collection, for: text.wrappedValue, on: keyPath)
         return searchable(text: text,

--- a/RealmSwift/SwiftUI.swift
+++ b/RealmSwift/SwiftUI.swift
@@ -1163,128 +1163,12 @@ extension SwiftUIKVO {
     }
 }
 
-/// All methods on this extension allows us to filter @ObservedResult results from .searchable()
-/// component search field by a key path.
-///
-///     @State var searchString: String
-///     @ObservedResults(Reminder.self) var reminders
-///
-///     List {
-///         ForEach(reminders) { reminder in
-///             ReminderRowView(reminder: reminder)
-///         }
-///     }
-///     .searchable(text: $searchFilter,
-///                 collection: $reminders,
-///                 keyPath: \.name) {
-///         ForEach(reminders) { remindersFiltered in
-///             Text(remindersFiltered.name).searchCompletion(remindersFiltered.name)
-///         }
-///     }
-///
+// Adding `_Concurrency` flag is the only way to verify
+// if the BASE SDK contains latest framework updates
+#if swift(>=5.5) && canImport(_Concurrency)
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 extension View {
-    /// Marks this view as searchable, which configures the display of a
-    /// search field.
-    ///
-    /// Use this modifier to create a user interface appropriate for searching.
-    ///
-    /// Wrapping a navigation view results in a column of the navigation
-    /// view displaying a search field. On iOS and iPadOS, the first or second
-    /// column displays the search field in a double, or triple column
-    /// navigation view respectively. On macOS, the search field is
-    /// placed in the trailing-most position of the toolbar.
-    ///
-    ///     var body: some View {
-    ///         NavigationView {
-    ///             PrimaryView()
-    ///             SecondaryView()
-    ///             Text("Select a primary and secondary item")
-    ///         }
-    ///         .searchable(text: $text)
-    ///     }
-    ///
-    /// On iOS, iPadOS, or watchOS, wrapping a specific column of a navigation view
-    /// results in that column displaying a search field.
-    ///
-    ///     struct DestinationPageView: View {
-    ///         @State private var text = ""
-    ///         var body: some View {
-    ///             Text("Destination Page")
-    ///                 .searchable(text: $text)
-    ///         }
-    ///     }
-    ///
-    ///     var body: some View {
-    ///         NavigationView {
-    ///             List {
-    ///                 NavigationLink(
-    ///                     "Destination Page",
-    ///                     destination: DestinationPageView()
-    ///                 )
-    ///             }
-    ///             Text("Select a destination")
-    ///         }
-    ///     }
-    ///
-    /// You can query the ``EnvironmentValues/isSearching`` property to
-    /// adjust the view hierarchy within the searchable modifier.
-    /// You can also provide search suggestions using the suggestions parameter
-    /// of searchable modifiers.
-    ///
-    /// Use the ``View/searchCompletion(_:)`` modifier to associate strings
-    /// to the views provided to the suggestions view. The system
-    /// uses these strings to replace the partial text being currently
-    /// edited of the associated search field. If a view has no
-    /// completion modifier, it's displayed as is.
-    ///
-    ///     SearchPlaceholderView()
-    ///         .searchable(text: $text) {
-    ///             Text("🍎").searchCompletion("apple")
-    ///             Text("🍐").searchCompletion("pear")
-    ///             Text("🍌").searchCompletion("banana")
-    ///         }
-    ///
-    /// The presentation of the suggestions depends on whether any
-    /// content is provided to the `suggestions` parameter.
-    ///
-    ///     SearchPlaceholderView()
-    ///         .searchable(text: $text) {
-    ///             ForEach(viewModel.suggestedSearches) { suggestion in
-    ///                 Label(suggestion.title,  image: suggestion.image)
-    ///                     .searchCompletion(suggestion.text)
-    ///             }
-    ///         }
-    ///
-    /// If `viewModel.suggestedSearches` begins as an empty array, then
-    /// the suggestions aren't initially displayed. When the array
-    /// becomes populated, the suggestions are presented. Note that
-    /// the suggestions may be dismissed based on a user's action, like
-    /// moving the window of the app on macOS for example.
-    ///
-    /// > Note: On tvOS, searchable modifiers only support suggestions of type
-    /// ``Text``.
-    ///
-    /// You can associate an action to be invoked upon submission of the current
-    /// search query by using an ``View/onSubmit(of:_:)`` modifier in
-    /// conjunction with the a searchable modifier.
-    ///
-    ///     @StateObject private var viewModel = ViewModel()
-    ///
-    ///     NavigationView {
-    ///         SidebarView()
-    ///         DetailView()
-    ///     }
-    ///     .searchable(
-    ///         text: $viewModel.searchText,
-    ///         placement: .sidebar
-    ///     ) {
-    ///         SuggestionsView()
-    ///     }
-    ///     .onSubmit(of: .search) {
-    ///         viewModel.submitCurrentSearchQuery()
-    ///     }
-    ///
+    /// Marks this view as searchable, which configures the display of a search field.
     /// You can provide a collection and a key path to be filtered using the search
     /// field string provided by the searchable component, this will result in the collection
     /// querying for all items containing the search field string for the given key path.
@@ -1304,7 +1188,12 @@ extension View {
     ///             Text(remindersFiltered.name).searchCompletion(remindersFiltered.name)
     ///         }
     ///     }
+    ///
     /**
+    - Note: See ``SwiftUI/View/searchable(text:placement:prompt)``
+            <https://developer.apple.com/documentation/swiftui/form/searchable(text:placement:prompt:)-6royb>
+            for more information on searchable view modifier.
+
     - parameter text: The text to display and edit in the search field.
     - parameter collection: The collection to be filtered.
     - parameter keyPath: The key path to the property which will be used to filter
@@ -1321,107 +1210,7 @@ extension View {
                           prompt: prompt)
     }
 
-    /// Marks this view as searchable, which configures the display of a
-    /// search field.
-    ///
-    /// Use this modifier to create a user interface appropriate for searching.
-    ///
-    /// Wrapping a navigation view results in a column of the navigation
-    /// view displaying a search field. On iOS and iPadOS, the first or second
-    /// column displays the search field in a double, or triple column
-    /// navigation view respectively. On macOS, the search field is
-    /// placed in the trailing-most position of the toolbar.
-    ///
-    ///     var body: some View {
-    ///         NavigationView {
-    ///             PrimaryView()
-    ///             SecondaryView()
-    ///             Text("Select a primary and secondary item")
-    ///         }
-    ///         .searchable(text: $text)
-    ///     }
-    ///
-    /// On iOS, iPadOS, or watchOS, wrapping a specific column of a navigation view
-    /// results in that column displaying a search field.
-    ///
-    ///     struct DestinationPageView: View {
-    ///         @State private var text = ""
-    ///         var body: some View {
-    ///             Text("Destination Page")
-    ///                 .searchable(text: $text)
-    ///         }
-    ///     }
-    ///
-    ///     var body: some View {
-    ///         NavigationView {
-    ///             List {
-    ///                 NavigationLink(
-    ///                     "Destination Page",
-    ///                     destination: DestinationPageView()
-    ///                 )
-    ///             }
-    ///             Text("Select a destination")
-    ///         }
-    ///     }
-    ///
-    /// You can query the ``EnvironmentValues/isSearching`` property to
-    /// adjust the view hierarchy within the searchable modifier.
-    /// You can also provide search suggestions using the suggestions parameter
-    /// of searchable modifiers.
-    ///
-    /// Use the ``View/searchCompletion(_:)`` modifier to associate strings
-    /// to the views provided to the suggestions view. The system
-    /// uses these strings to replace the partial text being currently
-    /// edited of the associated search field. If a view has no
-    /// completion modifier, it's displayed as is.
-    ///
-    ///     SearchPlaceholderView()
-    ///         .searchable(text: $text) {
-    ///             Text("🍎").searchCompletion("apple")
-    ///             Text("🍐").searchCompletion("pear")
-    ///             Text("🍌").searchCompletion("banana")
-    ///         }
-    ///
-    /// The presentation of the suggestions depends on whether any
-    /// content is provided to the `suggestions` parameter.
-    ///
-    ///     SearchPlaceholderView()
-    ///         .searchable(text: $text) {
-    ///             ForEach(viewModel.suggestedSearches) { suggestion in
-    ///                 Label(suggestion.title,  image: suggestion.image)
-    ///                     .searchCompletion(suggestion.text)
-    ///             }
-    ///         }
-    ///
-    /// If `viewModel.suggestedSearches` begins as an empty array, then
-    /// the suggestions aren't initially displayed. When the array
-    /// becomes populated, the suggestions are presented. Note that
-    /// the suggestions may be dismissed based on a user's action, like
-    /// moving the window of the app on macOS for example.
-    ///
-    /// > Note: On tvOS, searchable modifiers only support suggestions of type
-    /// ``Text``.
-    ///
-    /// You can associate an action to be invoked upon submission of the current
-    /// search query by using an ``View/onSubmit(of:_:)`` modifier in
-    /// conjunction with the a searchable modifier.
-    ///
-    ///     @StateObject private var viewModel = ViewModel()
-    ///
-    ///     NavigationView {
-    ///         SidebarView()
-    ///         DetailView()
-    ///     }
-    ///     .searchable(
-    ///         text: $viewModel.searchText,
-    ///         placement: .sidebar
-    ///     ) {
-    ///         SuggestionsView()
-    ///     }
-    ///     .onSubmit(of: .search) {
-    ///         viewModel.submitCurrentSearchQuery()
-    ///     }
-    ///
+    /// Marks this view as searchable, which configures the display of a search field.
     /// You can provide a collection and a key path to be filtered using the search
     /// field string provided by the searchable component, this will result in the collection
     /// querying for all items containing the search field string for the given key path.
@@ -1441,7 +1230,12 @@ extension View {
     ///             Text(remindersFiltered.name).searchCompletion(remindersFiltered.name)
     ///         }
     ///     }
+    ///
     /**
+    - Note: See ``SwiftUI/View/searchable(text:placement:prompt)``
+            <https://developer.apple.com/documentation/swiftui/form/searchable(text:placement:prompt:)-2ed8t>
+            for more information on searchable view modifier.
+
     - parameter text: The text to display and edit in the search field.
     - parameter collection: The collection to be filtered.
     - parameter keyPath: The key path to the property which will be used to filter
@@ -1458,107 +1252,7 @@ extension View {
                           prompt: prompt)
     }
 
-    /// Marks this view as searchable, which configures the display of a
-    /// search field.
-    ///
-    /// Use this modifier to create a user interface appropriate for searching.
-    ///
-    /// Wrapping a navigation view results in a column of the navigation
-    /// view displaying a search field. On iOS and iPadOS, the first or second
-    /// column displays the search field in a double, or triple column
-    /// navigation view respectively. On macOS, the search field is
-    /// placed in the trailing-most position of the toolbar.
-    ///
-    ///     var body: some View {
-    ///         NavigationView {
-    ///             PrimaryView()
-    ///             SecondaryView()
-    ///             Text("Select a primary and secondary item")
-    ///         }
-    ///         .searchable(text: $text)
-    ///     }
-    ///
-    /// On iOS, iPadOS, or watchOS, wrapping a specific column of a navigation view
-    /// results in that column displaying a search field.
-    ///
-    ///     struct DestinationPageView: View {
-    ///         @State private var text = ""
-    ///         var body: some View {
-    ///             Text("Destination Page")
-    ///                 .searchable(text: $text)
-    ///         }
-    ///     }
-    ///
-    ///     var body: some View {
-    ///         NavigationView {
-    ///             List {
-    ///                 NavigationLink(
-    ///                     "Destination Page",
-    ///                     destination: DestinationPageView()
-    ///                 )
-    ///             }
-    ///             Text("Select a destination")
-    ///         }
-    ///     }
-    ///
-    /// You can query the ``EnvironmentValues/isSearching`` property to
-    /// adjust the view hierarchy within the searchable modifier.
-    /// You can also provide search suggestions using the suggestions parameter
-    /// of searchable modifiers.
-    ///
-    /// Use the ``View/searchCompletion(_:)`` modifier to associate strings
-    /// to the views provided to the suggestions view. The system
-    /// uses these strings to replace the partial text being currently
-    /// edited of the associated search field. If a view has no
-    /// completion modifier, it's displayed as is.
-    ///
-    ///     SearchPlaceholderView()
-    ///         .searchable(text: $text) {
-    ///             Text("🍎").searchCompletion("apple")
-    ///             Text("🍐").searchCompletion("pear")
-    ///             Text("🍌").searchCompletion("banana")
-    ///         }
-    ///
-    /// The presentation of the suggestions depends on whether any
-    /// content is provided to the `suggestions` parameter.
-    ///
-    ///     SearchPlaceholderView()
-    ///         .searchable(text: $text) {
-    ///             ForEach(viewModel.suggestedSearches) { suggestion in
-    ///                 Label(suggestion.title,  image: suggestion.image)
-    ///                     .searchCompletion(suggestion.text)
-    ///             }
-    ///         }
-    ///
-    /// If `viewModel.suggestedSearches` begins as an empty array, then
-    /// the suggestions aren't initially displayed. When the array
-    /// becomes populated, the suggestions are presented. Note that
-    /// the suggestions may be dismissed based on a user's action, like
-    /// moving the window of the app on macOS for example.
-    ///
-    /// > Note: On tvOS, searchable modifiers only support suggestions of type
-    /// ``Text``.
-    ///
-    /// You can associate an action to be invoked upon submission of the current
-    /// search query by using an ``View/onSubmit(of:_:)`` modifier in
-    /// conjunction with the a searchable modifier.
-    ///
-    ///     @StateObject private var viewModel = ViewModel()
-    ///
-    ///     NavigationView {
-    ///         SidebarView()
-    ///         DetailView()
-    ///     }
-    ///     .searchable(
-    ///         text: $viewModel.searchText,
-    ///         placement: .sidebar
-    ///     ) {
-    ///         SuggestionsView()
-    ///     }
-    ///     .onSubmit(of: .search) {
-    ///         viewModel.submitCurrentSearchQuery()
-    ///     }
-    ///
+    /// Marks this view as searchable, which configures the display of a search field.
     /// You can provide a collection and a key path to be filtered using the search
     /// field string provided by the searchable component, this will result in the collection
     /// querying for all items containing the search field string for the given key path.
@@ -1578,7 +1272,12 @@ extension View {
     ///             Text(remindersFiltered.name).searchCompletion(remindersFiltered.name)
     ///         }
     ///     }
+    ///
     /**
+    - Note: See ``SwiftUI/View/searchable(text:placement:prompt)``
+            <https://developer.apple.com/documentation/swiftui/form/searchable(text:placement:prompt:)-58egp>
+            for more information on searchable view modifier.
+
     - parameter text: The text to display and edit in the search field.
     - parameter collection: The collection to be filtered.
     - parameter keyPath: The key path to the property which will be used to filter
@@ -1595,107 +1294,7 @@ extension View {
                           prompt: prompt)
     }
 
-    /// Marks this view as searchable, which configures the display of a
-    /// search field.
-    ///
-    /// Use this modifier to create a user interface appropriate for searching.
-    ///
-    /// Wrapping a navigation view results in a column of the navigation
-    /// view displaying a search field. On iOS and iPadOS, the first or second
-    /// column displays the search field in a double, or triple column
-    /// navigation view respectively. On macOS, the search field is
-    /// placed in the trailing-most position of the toolbar.
-    ///
-    ///     var body: some View {
-    ///         NavigationView {
-    ///             PrimaryView()
-    ///             SecondaryView()
-    ///             Text("Select a primary and secondary item")
-    ///         }
-    ///         .searchable(text: $text)
-    ///     }
-    ///
-    /// On iOS, iPadOS, or watchOS, wrapping a specific column of a navigation view
-    /// results in that column displaying a search field.
-    ///
-    ///     struct DestinationPageView: View {
-    ///         @State private var text = ""
-    ///         var body: some View {
-    ///             Text("Destination Page")
-    ///                 .searchable(text: $text)
-    ///         }
-    ///     }
-    ///
-    ///     var body: some View {
-    ///         NavigationView {
-    ///             List {
-    ///                 NavigationLink(
-    ///                     "Destination Page",
-    ///                     destination: DestinationPageView()
-    ///                 )
-    ///             }
-    ///             Text("Select a destination")
-    ///         }
-    ///     }
-    ///
-    /// You can query the ``EnvironmentValues/isSearching`` property to
-    /// adjust the view hierarchy within the searchable modifier.
-    /// You can also provide search suggestions using the suggestions parameter
-    /// of searchable modifiers.
-    ///
-    /// Use the ``View/searchCompletion(_:)`` modifier to associate strings
-    /// to the views provided to the suggestions view. The system
-    /// uses these strings to replace the partial text being currently
-    /// edited of the associated search field. If a view has no
-    /// completion modifier, it's displayed as is.
-    ///
-    ///     SearchPlaceholderView()
-    ///         .searchable(text: $text) {
-    ///             Text("🍎").searchCompletion("apple")
-    ///             Text("🍐").searchCompletion("pear")
-    ///             Text("🍌").searchCompletion("banana")
-    ///         }
-    ///
-    /// The presentation of the suggestions depends on whether any
-    /// content is provided to the `suggestions` parameter.
-    ///
-    ///     SearchPlaceholderView()
-    ///         .searchable(text: $text) {
-    ///             ForEach(viewModel.suggestedSearches) { suggestion in
-    ///                 Label(suggestion.title,  image: suggestion.image)
-    ///                     .searchCompletion(suggestion.text)
-    ///             }
-    ///         }
-    ///
-    /// If `viewModel.suggestedSearches` begins as an empty array, then
-    /// the suggestions aren't initially displayed. When the array
-    /// becomes populated, the suggestions are presented. Note that
-    /// the suggestions may be dismissed based on a user's action, like
-    /// moving the window of the app on macOS for example.
-    ///
-    /// > Note: On tvOS, searchable modifiers only support suggestions of type
-    /// ``Text``.
-    ///
-    /// You can associate an action to be invoked upon submission of the current
-    /// search query by using an ``View/onSubmit(of:_:)`` modifier in
-    /// conjunction with the a searchable modifier.
-    ///
-    ///     @StateObject private var viewModel = ViewModel()
-    ///
-    ///     NavigationView {
-    ///         SidebarView()
-    ///         DetailView()
-    ///     }
-    ///     .searchable(
-    ///         text: $viewModel.searchText,
-    ///         placement: .sidebar
-    ///     ) {
-    ///         SuggestionsView()
-    ///     }
-    ///     .onSubmit(of: .search) {
-    ///         viewModel.submitCurrentSearchQuery()
-    ///     }
-    ///
+    /// Marks this view as searchable, which configures the display of a search field.
     /// You can provide a collection and a key path to be filtered using the search
     /// field string provided by the searchable component, this will result in the collection
     /// querying for all items containing the search field string for the given key path.
@@ -1715,7 +1314,12 @@ extension View {
     ///             Text(remindersFiltered.name).searchCompletion(remindersFiltered.name)
     ///         }
     ///     }
+    ///
     /**
+    - Note: See ``SwiftUI/View/searchable(text:placement:prompt:suggestions)``
+            <https://developer.apple.com/documentation/swiftui/form/searchable(text:placement:prompt:suggestions:)-94bdu>
+            for more information on searchable view modifier.
+
     - parameter text: The text to display and edit in the search field.
     - parameter collection: The collection to be filtered.
     - parameter keyPath: The key path to the property which will be used to filter
@@ -1735,107 +1339,7 @@ extension View {
                           suggestions: suggestions)
     }
 
-    /// Marks this view as searchable, which configures the display of a
-    /// search field.
-    ///
-    /// Use this modifier to create a user interface appropriate for searching.
-    ///
-    /// Wrapping a navigation view results in a column of the navigation
-    /// view displaying a search field. On iOS and iPadOS, the first or second
-    /// column displays the search field in a double, or triple column
-    /// navigation view respectively. On macOS, the search field is
-    /// placed in the trailing-most position of the toolbar.
-    ///
-    ///     var body: some View {
-    ///         NavigationView {
-    ///             PrimaryView()
-    ///             SecondaryView()
-    ///             Text("Select a primary and secondary item")
-    ///         }
-    ///         .searchable(text: $text)
-    ///     }
-    ///
-    /// On iOS, iPadOS, or watchOS, wrapping a specific column of a navigation view
-    /// results in that column displaying a search field.
-    ///
-    ///     struct DestinationPageView: View {
-    ///         @State private var text = ""
-    ///         var body: some View {
-    ///             Text("Destination Page")
-    ///                 .searchable(text: $text)
-    ///         }
-    ///     }
-    ///
-    ///     var body: some View {
-    ///         NavigationView {
-    ///             List {
-    ///                 NavigationLink(
-    ///                     "Destination Page",
-    ///                     destination: DestinationPageView()
-    ///                 )
-    ///             }
-    ///             Text("Select a destination")
-    ///         }
-    ///     }
-    ///
-    /// You can query the ``EnvironmentValues/isSearching`` property to
-    /// adjust the view hierarchy within the searchable modifier.
-    /// You can also provide search suggestions using the suggestions parameter
-    /// of searchable modifiers.
-    ///
-    /// Use the ``View/searchCompletion(_:)`` modifier to associate strings
-    /// to the views provided to the suggestions view. The system
-    /// uses these strings to replace the partial text being currently
-    /// edited of the associated search field. If a view has no
-    /// completion modifier, it's displayed as is.
-    ///
-    ///     SearchPlaceholderView()
-    ///         .searchable(text: $text) {
-    ///             Text("🍎").searchCompletion("apple")
-    ///             Text("🍐").searchCompletion("pear")
-    ///             Text("🍌").searchCompletion("banana")
-    ///         }
-    ///
-    /// The presentation of the suggestions depends on whether any
-    /// content is provided to the `suggestions` parameter.
-    ///
-    ///     SearchPlaceholderView()
-    ///         .searchable(text: $text) {
-    ///             ForEach(viewModel.suggestedSearches) { suggestion in
-    ///                 Label(suggestion.title,  image: suggestion.image)
-    ///                     .searchCompletion(suggestion.text)
-    ///             }
-    ///         }
-    ///
-    /// If `viewModel.suggestedSearches` begins as an empty array, then
-    /// the suggestions aren't initially displayed. When the array
-    /// becomes populated, the suggestions are presented. Note that
-    /// the suggestions may be dismissed based on a user's action, like
-    /// moving the window of the app on macOS for example.
-    ///
-    /// > Note: On tvOS, searchable modifiers only support suggestions of type
-    /// ``Text``.
-    ///
-    /// You can associate an action to be invoked upon submission of the current
-    /// search query by using an ``View/onSubmit(of:_:)`` modifier in
-    /// conjunction with the a searchable modifier.
-    ///
-    ///     @StateObject private var viewModel = ViewModel()
-    ///
-    ///     NavigationView {
-    ///         SidebarView()
-    ///         DetailView()
-    ///     }
-    ///     .searchable(
-    ///         text: $viewModel.searchText,
-    ///         placement: .sidebar
-    ///     ) {
-    ///         SuggestionsView()
-    ///     }
-    ///     .onSubmit(of: .search) {
-    ///         viewModel.submitCurrentSearchQuery()
-    ///     }
-    ///
+    /// Marks this view as searchable, which configures the display of a search field.
     /// You can provide a collection and a key path to be filtered using the search
     /// field string provided by the searchable component, this will result in the collection
     /// querying for all items containing the search field string for the given key path.
@@ -1855,7 +1359,12 @@ extension View {
     ///             Text(remindersFiltered.name).searchCompletion(remindersFiltered.name)
     ///         }
     ///     }
+    ///
     /**
+    - Note: See ``SwiftUI/View/searchable(text:placement:prompt:suggestions)``
+            <https://developer.apple.com/documentation/swiftui/form/searchable(text:placement:prompt:suggestions:)-1mw1m>
+            for more information on searchable view modifier.
+
     - parameter text: The text to display and edit in the search field.
     - parameter collection: The collection to be filtered.
     - parameter keyPath: The key path to the property which will be used to filter
@@ -1875,107 +1384,7 @@ extension View {
                           suggestions: suggestions)
     }
 
-    /// Marks this view as searchable, which configures the display of a
-    /// search field.
-    ///
-    /// Use this modifier to create a user interface appropriate for searching.
-    ///
-    /// Wrapping a navigation view results in a column of the navigation
-    /// view displaying a search field. On iOS and iPadOS, the first or second
-    /// column displays the search field in a double, or triple column
-    /// navigation view respectively. On macOS, the search field is
-    /// placed in the trailing-most position of the toolbar.
-    ///
-    ///     var body: some View {
-    ///         NavigationView {
-    ///             PrimaryView()
-    ///             SecondaryView()
-    ///             Text("Select a primary and secondary item")
-    ///         }
-    ///         .searchable(text: $text)
-    ///     }
-    ///
-    /// On iOS, iPadOS, or watchOS, wrapping a specific column of a navigation view
-    /// results in that column displaying a search field.
-    ///
-    ///     struct DestinationPageView: View {
-    ///         @State private var text = ""
-    ///         var body: some View {
-    ///             Text("Destination Page")
-    ///                 .searchable(text: $text)
-    ///         }
-    ///     }
-    ///
-    ///     var body: some View {
-    ///         NavigationView {
-    ///             List {
-    ///                 NavigationLink(
-    ///                     "Destination Page",
-    ///                     destination: DestinationPageView()
-    ///                 )
-    ///             }
-    ///             Text("Select a destination")
-    ///         }
-    ///     }
-    ///
-    /// You can query the ``EnvironmentValues/isSearching`` property to
-    /// adjust the view hierarchy within the searchable modifier.
-    /// You can also provide search suggestions using the suggestions parameter
-    /// of searchable modifiers.
-    ///
-    /// Use the ``View/searchCompletion(_:)`` modifier to associate strings
-    /// to the views provided to the suggestions view. The system
-    /// uses these strings to replace the partial text being currently
-    /// edited of the associated search field. If a view has no
-    /// completion modifier, it's displayed as is.
-    ///
-    ///     SearchPlaceholderView()
-    ///         .searchable(text: $text) {
-    ///             Text("🍎").searchCompletion("apple")
-    ///             Text("🍐").searchCompletion("pear")
-    ///             Text("🍌").searchCompletion("banana")
-    ///         }
-    ///
-    /// The presentation of the suggestions depends on whether any
-    /// content is provided to the `suggestions` parameter.
-    ///
-    ///     SearchPlaceholderView()
-    ///         .searchable(text: $text) {
-    ///             ForEach(viewModel.suggestedSearches) { suggestion in
-    ///                 Label(suggestion.title,  image: suggestion.image)
-    ///                     .searchCompletion(suggestion.text)
-    ///             }
-    ///         }
-    ///
-    /// If `viewModel.suggestedSearches` begins as an empty array, then
-    /// the suggestions aren't initially displayed. When the array
-    /// becomes populated, the suggestions are presented. Note that
-    /// the suggestions may be dismissed based on a user's action, like
-    /// moving the window of the app on macOS for example.
-    ///
-    /// > Note: On tvOS, searchable modifiers only support suggestions of type
-    /// ``Text``.
-    ///
-    /// You can associate an action to be invoked upon submission of the current
-    /// search query by using an ``View/onSubmit(of:_:)`` modifier in
-    /// conjunction with the a searchable modifier.
-    ///
-    ///     @StateObject private var viewModel = ViewModel()
-    ///
-    ///     NavigationView {
-    ///         SidebarView()
-    ///         DetailView()
-    ///     }
-    ///     .searchable(
-    ///         text: $viewModel.searchText,
-    ///         placement: .sidebar
-    ///     ) {
-    ///         SuggestionsView()
-    ///     }
-    ///     .onSubmit(of: .search) {
-    ///         viewModel.submitCurrentSearchQuery()
-    ///     }
-    ///
+    /// Marks this view as searchable, which configures the display of a search field.
     /// You can provide a collection and a key path to be filtered using the search
     /// field string provided by the searchable component, this will result in the collection
     /// querying for all items containing the search field string for the given key path.
@@ -1995,7 +1404,12 @@ extension View {
     ///             Text(remindersFiltered.name).searchCompletion(remindersFiltered.name)
     ///         }
     ///     }
+    ///
     /**
+    - Note: See ``SwiftUI/View/searchable(text:placement:prompt:suggestions)``
+            <https://developer.apple.com/documentation/swiftui/form/searchable(text:placement:prompt:suggestions:)-6h6qo>
+            for more information on searchable view modifier.
+     
     - parameter text: The text to display and edit in the search field.
     - parameter collection: The collection to be filtered.
     - parameter keyPath: The key path to the property which will be used to filter
@@ -2027,7 +1441,7 @@ extension View {
         }
     }
 }
-
+#endif
 #else
 @objc(RLMSwiftUIKVO) internal final class SwiftUIKVO: NSObject {
     @objc(removeObserversFromObject:) public static func removeObservers(object: NSObject) -> Bool {

--- a/RealmSwift/SwiftUI.swift
+++ b/RealmSwift/SwiftUI.swift
@@ -1203,7 +1203,7 @@ extension View {
     - parameter prompt: A `Text` representing the prompt of the search field
                 which provides users with guidance on what to search for.
      */
-    public func searchable<T: ObjectBase, P: _QueryString & _RealmSchemaDiscoverable>(text: Binding<String>, collection: ObservedResults<T>, keyPath: KeyPath<T, P>, placement: SearchFieldPlacement = .automatic, prompt: Text? = nil) -> some View {
+    public func searchable<T: ObjectBase>(text: Binding<String>, collection: ObservedResults<T>, keyPath: KeyPath<T, String>, placement: SearchFieldPlacement = .automatic, prompt: Text? = nil) -> some View {
         filterCollection(collection, for: text.wrappedValue, on: keyPath)
         return searchable(text: text,
                           placement: placement,
@@ -1245,7 +1245,7 @@ extension View {
     - parameter prompt: The key for the localized prompt of the search field
                 which provides users with guidance on what to search for.
      */
-    public func searchable<T: ObjectBase, P: _QueryString & _RealmSchemaDiscoverable>(text: Binding<String>, collection: ObservedResults<T>, keyPath: KeyPath<T, P>, placement: SearchFieldPlacement = .automatic, prompt: LocalizedStringKey) -> some View {
+    public func searchable<T: ObjectBase>(text: Binding<String>, collection: ObservedResults<T>, keyPath: KeyPath<T, String>, placement: SearchFieldPlacement = .automatic, prompt: LocalizedStringKey) -> some View {
         filterCollection(collection, for: text.wrappedValue, on: keyPath)
         return searchable(text: text,
                           placement: placement,
@@ -1287,7 +1287,7 @@ extension View {
     - parameter prompt: A string representing the prompt of the search field
                 which provides users with guidance on what to search for.
      */
-    public func searchable<T: ObjectBase, P: _QueryString & _RealmSchemaDiscoverable, S>(text: Binding<String>, collection: ObservedResults<T>, keyPath: KeyPath<T, P>, placement: SearchFieldPlacement = .automatic, prompt: S) -> some View where S: StringProtocol {
+    public func searchable<T: ObjectBase, S>(text: Binding<String>, collection: ObservedResults<T>, keyPath: KeyPath<T, String>, placement: SearchFieldPlacement = .automatic, prompt: S) -> some View where S: StringProtocol {
         filterCollection(collection, for: text.wrappedValue, on: keyPath)
         return searchable(text: text,
                           placement: placement,
@@ -1331,7 +1331,7 @@ extension View {
     - parameter suggestions: A view builder that produces content that
                 populates a list of suggestions.
      */
-    public func searchable<T: ObjectBase, P: _QueryString & _RealmSchemaDiscoverable, S>(text: Binding<String>, collection: ObservedResults<T>, keyPath: KeyPath<T, P>, placement: SearchFieldPlacement = .automatic, prompt: Text? = nil, @ViewBuilder suggestions: () -> S) -> some View where S: View {
+    public func searchable<T: ObjectBase, S>(text: Binding<String>, collection: ObservedResults<T>, keyPath: KeyPath<T, String>, placement: SearchFieldPlacement = .automatic, prompt: Text? = nil, @ViewBuilder suggestions: () -> S) -> some View where S: View {
         filterCollection(collection, for: text.wrappedValue, on: keyPath)
         return searchable(text: text,
                           placement: placement,
@@ -1376,7 +1376,7 @@ extension View {
     - parameter suggestions: A view builder that produces content that
                 populates a list of suggestions.
      */
-    public func searchable<T: ObjectBase, P: _QueryString & _RealmSchemaDiscoverable, S>(text: Binding<String>, collection: ObservedResults<T>, keyPath: KeyPath<T, P>, placement: SearchFieldPlacement = .automatic, prompt: LocalizedStringKey, @ViewBuilder suggestions: () -> S) -> some View where S: View {
+    public func searchable<T: ObjectBase, S>(text: Binding<String>, collection: ObservedResults<T>, keyPath: KeyPath<T, String>, placement: SearchFieldPlacement = .automatic, prompt: LocalizedStringKey, @ViewBuilder suggestions: () -> S) -> some View where S: View {
         filterCollection(collection, for: text.wrappedValue, on: keyPath)
         return searchable(text: text,
                           placement: placement,
@@ -1421,7 +1421,7 @@ extension View {
     - parameter suggestions: A view builder that produces content that
                 populates a list of suggestions.
      */
-    public func searchable<T: ObjectBase, P: _QueryString & _RealmSchemaDiscoverable, V, S>(text: Binding<String>, collection: ObservedResults<T>, keyPath: KeyPath<T, P>, placement: SearchFieldPlacement = .automatic, prompt: S, @ViewBuilder suggestions: () -> V) -> some View where V: View, S: StringProtocol {
+    public func searchable<T: ObjectBase, V, S>(text: Binding<String>, collection: ObservedResults<T>, keyPath: KeyPath<T, String>, placement: SearchFieldPlacement = .automatic, prompt: S, @ViewBuilder suggestions: () -> V) -> some View where V: View, S: StringProtocol {
         filterCollection(collection, for: text.wrappedValue, on: keyPath)
         return searchable(text: text,
                           placement: placement,
@@ -1429,13 +1429,13 @@ extension View {
                           suggestions: suggestions)
     }
 
-    private func filterCollection<T: ObjectBase, P: _QueryString & _RealmSchemaDiscoverable>(_ collection: ObservedResults<T>, for text: String, on keyPath: KeyPath<T, P>) {
+    private func filterCollection<T: ObjectBase>(_ collection: ObservedResults<T>, for text: String, on keyPath: KeyPath<T, String>) {
         DispatchQueue.main.async {
             if text.isEmpty {
                 collection.filter = nil
             } else {
-                var query: Query<P> = Query<T>()[dynamicMember: keyPath]
-                query = query.contains(text as! P)
+                var query: Query<String> = Query<T>()[dynamicMember: keyPath]
+                query = query.contains(text)
                 collection.filter = query.predicate
             }
         }

--- a/RealmSwift/SwiftUI.swift
+++ b/RealmSwift/SwiftUI.swift
@@ -1184,7 +1184,136 @@ extension SwiftUIKVO {
 ///
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 extension View {
-    /// :nodoc:
+    /// Marks this view as searchable, which configures the display of a
+    /// search field.
+    ///
+    /// Use this modifier to create a user interface appropriate for searching.
+    ///
+    /// Wrapping a navigation view results in a column of the navigation
+    /// view displaying a search field. On iOS and iPadOS, the first or second
+    /// column displays the search field in a double, or triple column
+    /// navigation view respectively. On macOS, the search field is
+    /// placed in the trailing-most position of the toolbar.
+    ///
+    ///     var body: some View {
+    ///         NavigationView {
+    ///             PrimaryView()
+    ///             SecondaryView()
+    ///             Text("Select a primary and secondary item")
+    ///         }
+    ///         .searchable(text: $text)
+    ///     }
+    ///
+    /// On iOS, iPadOS, or watchOS, wrapping a specific column of a navigation view
+    /// results in that column displaying a search field.
+    ///
+    ///     struct DestinationPageView: View {
+    ///         @State private var text = ""
+    ///         var body: some View {
+    ///             Text("Destination Page")
+    ///                 .searchable(text: $text)
+    ///         }
+    ///     }
+    ///
+    ///     var body: some View {
+    ///         NavigationView {
+    ///             List {
+    ///                 NavigationLink(
+    ///                     "Destination Page",
+    ///                     destination: DestinationPageView()
+    ///                 )
+    ///             }
+    ///             Text("Select a destination")
+    ///         }
+    ///     }
+    ///
+    /// You can query the ``EnvironmentValues/isSearching`` property to
+    /// adjust the view hierarchy within the searchable modifier.
+    /// You can also provide search suggestions using the suggestions parameter
+    /// of searchable modifiers.
+    ///
+    /// Use the ``View/searchCompletion(_:)`` modifier to associate strings
+    /// to the views provided to the suggestions view. The system
+    /// uses these strings to replace the partial text being currently
+    /// edited of the associated search field. If a view has no
+    /// completion modifier, it's displayed as is.
+    ///
+    ///     SearchPlaceholderView()
+    ///         .searchable(text: $text) {
+    ///             Text("🍎").searchCompletion("apple")
+    ///             Text("🍐").searchCompletion("pear")
+    ///             Text("🍌").searchCompletion("banana")
+    ///         }
+    ///
+    /// The presentation of the suggestions depends on whether any
+    /// content is provided to the `suggestions` parameter.
+    ///
+    ///     SearchPlaceholderView()
+    ///         .searchable(text: $text) {
+    ///             ForEach(viewModel.suggestedSearches) { suggestion in
+    ///                 Label(suggestion.title,  image: suggestion.image)
+    ///                     .searchCompletion(suggestion.text)
+    ///             }
+    ///         }
+    ///
+    /// If `viewModel.suggestedSearches` begins as an empty array, then
+    /// the suggestions aren't initially displayed. When the array
+    /// becomes populated, the suggestions are presented. Note that
+    /// the suggestions may be dismissed based on a user's action, like
+    /// moving the window of the app on macOS for example.
+    ///
+    /// > Note: On tvOS, searchable modifiers only support suggestions of type
+    /// ``Text``.
+    ///
+    /// You can associate an action to be invoked upon submission of the current
+    /// search query by using an ``View/onSubmit(of:_:)`` modifier in
+    /// conjunction with the a searchable modifier.
+    ///
+    ///     @StateObject private var viewModel = ViewModel()
+    ///
+    ///     NavigationView {
+    ///         SidebarView()
+    ///         DetailView()
+    ///     }
+    ///     .searchable(
+    ///         text: $viewModel.searchText,
+    ///         placement: .sidebar
+    ///     ) {
+    ///         SuggestionsView()
+    ///     }
+    ///     .onSubmit(of: .search) {
+    ///         viewModel.submitCurrentSearchQuery()
+    ///     }
+    ///
+    /// You can provide a collection and a key path to be filtered using the search
+    /// field string provided by the searchable component, this will result in the collection
+    /// querying for all items containing the search field string for the given key path.
+    ///
+    ///     @State var searchString: String
+    ///     @ObservedResults(Reminder.self) var reminders
+    ///
+    ///     List {
+    ///         ForEach(reminders) { reminder in
+    ///             ReminderRowView(reminder: reminder)
+    ///         }
+    ///     }
+    ///     .searchable(text: $searchFilter,
+    ///                 collection: $reminders,
+    ///                 keyPath: \.name) {
+    ///         ForEach(reminders) { remindersFiltered in
+    ///             Text(remindersFiltered.name).searchCompletion(remindersFiltered.name)
+    ///         }
+    ///     }
+    /**
+    - parameter text: The text to display and edit in the search field.
+    - parameter collection: The collection to be filtered.
+    - parameter keyPath: The key path to the property which will be used to filter
+                the collection, only key paths with `String` type are allowed.
+    - parameter placement: The preferred placement of the search field within the
+                containing view hierarchy.
+    - parameter prompt: A `Text` representing the prompt of the search field
+                which provides users with guidance on what to search for.
+     */
     public func searchable<T: ObjectBase, P: _QueryString & _RealmSchemaDiscoverable>(text: Binding<String>, collection: ObservedResults<T>, keyPath: KeyPath<T, P>, placement: SearchFieldPlacement = .automatic, prompt: Text? = nil) -> some View {
         filterCollection(collection, for: text.wrappedValue, on: keyPath)
         return searchable(text: text,
@@ -1192,7 +1321,136 @@ extension View {
                           prompt: prompt)
     }
 
-    /// :nodoc:
+    /// Marks this view as searchable, which configures the display of a
+    /// search field.
+    ///
+    /// Use this modifier to create a user interface appropriate for searching.
+    ///
+    /// Wrapping a navigation view results in a column of the navigation
+    /// view displaying a search field. On iOS and iPadOS, the first or second
+    /// column displays the search field in a double, or triple column
+    /// navigation view respectively. On macOS, the search field is
+    /// placed in the trailing-most position of the toolbar.
+    ///
+    ///     var body: some View {
+    ///         NavigationView {
+    ///             PrimaryView()
+    ///             SecondaryView()
+    ///             Text("Select a primary and secondary item")
+    ///         }
+    ///         .searchable(text: $text)
+    ///     }
+    ///
+    /// On iOS, iPadOS, or watchOS, wrapping a specific column of a navigation view
+    /// results in that column displaying a search field.
+    ///
+    ///     struct DestinationPageView: View {
+    ///         @State private var text = ""
+    ///         var body: some View {
+    ///             Text("Destination Page")
+    ///                 .searchable(text: $text)
+    ///         }
+    ///     }
+    ///
+    ///     var body: some View {
+    ///         NavigationView {
+    ///             List {
+    ///                 NavigationLink(
+    ///                     "Destination Page",
+    ///                     destination: DestinationPageView()
+    ///                 )
+    ///             }
+    ///             Text("Select a destination")
+    ///         }
+    ///     }
+    ///
+    /// You can query the ``EnvironmentValues/isSearching`` property to
+    /// adjust the view hierarchy within the searchable modifier.
+    /// You can also provide search suggestions using the suggestions parameter
+    /// of searchable modifiers.
+    ///
+    /// Use the ``View/searchCompletion(_:)`` modifier to associate strings
+    /// to the views provided to the suggestions view. The system
+    /// uses these strings to replace the partial text being currently
+    /// edited of the associated search field. If a view has no
+    /// completion modifier, it's displayed as is.
+    ///
+    ///     SearchPlaceholderView()
+    ///         .searchable(text: $text) {
+    ///             Text("🍎").searchCompletion("apple")
+    ///             Text("🍐").searchCompletion("pear")
+    ///             Text("🍌").searchCompletion("banana")
+    ///         }
+    ///
+    /// The presentation of the suggestions depends on whether any
+    /// content is provided to the `suggestions` parameter.
+    ///
+    ///     SearchPlaceholderView()
+    ///         .searchable(text: $text) {
+    ///             ForEach(viewModel.suggestedSearches) { suggestion in
+    ///                 Label(suggestion.title,  image: suggestion.image)
+    ///                     .searchCompletion(suggestion.text)
+    ///             }
+    ///         }
+    ///
+    /// If `viewModel.suggestedSearches` begins as an empty array, then
+    /// the suggestions aren't initially displayed. When the array
+    /// becomes populated, the suggestions are presented. Note that
+    /// the suggestions may be dismissed based on a user's action, like
+    /// moving the window of the app on macOS for example.
+    ///
+    /// > Note: On tvOS, searchable modifiers only support suggestions of type
+    /// ``Text``.
+    ///
+    /// You can associate an action to be invoked upon submission of the current
+    /// search query by using an ``View/onSubmit(of:_:)`` modifier in
+    /// conjunction with the a searchable modifier.
+    ///
+    ///     @StateObject private var viewModel = ViewModel()
+    ///
+    ///     NavigationView {
+    ///         SidebarView()
+    ///         DetailView()
+    ///     }
+    ///     .searchable(
+    ///         text: $viewModel.searchText,
+    ///         placement: .sidebar
+    ///     ) {
+    ///         SuggestionsView()
+    ///     }
+    ///     .onSubmit(of: .search) {
+    ///         viewModel.submitCurrentSearchQuery()
+    ///     }
+    ///
+    /// You can provide a collection and a key path to be filtered using the search
+    /// field string provided by the searchable component, this will result in the collection
+    /// querying for all items containing the search field string for the given key path.
+    ///
+    ///     @State var searchString: String
+    ///     @ObservedResults(Reminder.self) var reminders
+    ///
+    ///     List {
+    ///         ForEach(reminders) { reminder in
+    ///             ReminderRowView(reminder: reminder)
+    ///         }
+    ///     }
+    ///     .searchable(text: $searchFilter,
+    ///                 collection: $reminders,
+    ///                 keyPath: \.name) {
+    ///         ForEach(reminders) { remindersFiltered in
+    ///             Text(remindersFiltered.name).searchCompletion(remindersFiltered.name)
+    ///         }
+    ///     }
+    /**
+    - parameter text: The text to display and edit in the search field.
+    - parameter collection: The collection to be filtered.
+    - parameter keyPath: The key path to the property which will be used to filter
+                the collection.
+    - parameter placement: The preferred placement of the search field within the
+                containing view hierarchy.
+    - parameter prompt: The key for the localized prompt of the search field
+                which provides users with guidance on what to search for.
+     */
     public func searchable<T: ObjectBase, P: _QueryString & _RealmSchemaDiscoverable>(text: Binding<String>, collection: ObservedResults<T>, keyPath: KeyPath<T, P>, placement: SearchFieldPlacement = .automatic, prompt: LocalizedStringKey) -> some View {
         filterCollection(collection, for: text.wrappedValue, on: keyPath)
         return searchable(text: text,
@@ -1200,7 +1458,136 @@ extension View {
                           prompt: prompt)
     }
 
-    /// :nodoc:
+    /// Marks this view as searchable, which configures the display of a
+    /// search field.
+    ///
+    /// Use this modifier to create a user interface appropriate for searching.
+    ///
+    /// Wrapping a navigation view results in a column of the navigation
+    /// view displaying a search field. On iOS and iPadOS, the first or second
+    /// column displays the search field in a double, or triple column
+    /// navigation view respectively. On macOS, the search field is
+    /// placed in the trailing-most position of the toolbar.
+    ///
+    ///     var body: some View {
+    ///         NavigationView {
+    ///             PrimaryView()
+    ///             SecondaryView()
+    ///             Text("Select a primary and secondary item")
+    ///         }
+    ///         .searchable(text: $text)
+    ///     }
+    ///
+    /// On iOS, iPadOS, or watchOS, wrapping a specific column of a navigation view
+    /// results in that column displaying a search field.
+    ///
+    ///     struct DestinationPageView: View {
+    ///         @State private var text = ""
+    ///         var body: some View {
+    ///             Text("Destination Page")
+    ///                 .searchable(text: $text)
+    ///         }
+    ///     }
+    ///
+    ///     var body: some View {
+    ///         NavigationView {
+    ///             List {
+    ///                 NavigationLink(
+    ///                     "Destination Page",
+    ///                     destination: DestinationPageView()
+    ///                 )
+    ///             }
+    ///             Text("Select a destination")
+    ///         }
+    ///     }
+    ///
+    /// You can query the ``EnvironmentValues/isSearching`` property to
+    /// adjust the view hierarchy within the searchable modifier.
+    /// You can also provide search suggestions using the suggestions parameter
+    /// of searchable modifiers.
+    ///
+    /// Use the ``View/searchCompletion(_:)`` modifier to associate strings
+    /// to the views provided to the suggestions view. The system
+    /// uses these strings to replace the partial text being currently
+    /// edited of the associated search field. If a view has no
+    /// completion modifier, it's displayed as is.
+    ///
+    ///     SearchPlaceholderView()
+    ///         .searchable(text: $text) {
+    ///             Text("🍎").searchCompletion("apple")
+    ///             Text("🍐").searchCompletion("pear")
+    ///             Text("🍌").searchCompletion("banana")
+    ///         }
+    ///
+    /// The presentation of the suggestions depends on whether any
+    /// content is provided to the `suggestions` parameter.
+    ///
+    ///     SearchPlaceholderView()
+    ///         .searchable(text: $text) {
+    ///             ForEach(viewModel.suggestedSearches) { suggestion in
+    ///                 Label(suggestion.title,  image: suggestion.image)
+    ///                     .searchCompletion(suggestion.text)
+    ///             }
+    ///         }
+    ///
+    /// If `viewModel.suggestedSearches` begins as an empty array, then
+    /// the suggestions aren't initially displayed. When the array
+    /// becomes populated, the suggestions are presented. Note that
+    /// the suggestions may be dismissed based on a user's action, like
+    /// moving the window of the app on macOS for example.
+    ///
+    /// > Note: On tvOS, searchable modifiers only support suggestions of type
+    /// ``Text``.
+    ///
+    /// You can associate an action to be invoked upon submission of the current
+    /// search query by using an ``View/onSubmit(of:_:)`` modifier in
+    /// conjunction with the a searchable modifier.
+    ///
+    ///     @StateObject private var viewModel = ViewModel()
+    ///
+    ///     NavigationView {
+    ///         SidebarView()
+    ///         DetailView()
+    ///     }
+    ///     .searchable(
+    ///         text: $viewModel.searchText,
+    ///         placement: .sidebar
+    ///     ) {
+    ///         SuggestionsView()
+    ///     }
+    ///     .onSubmit(of: .search) {
+    ///         viewModel.submitCurrentSearchQuery()
+    ///     }
+    ///
+    /// You can provide a collection and a key path to be filtered using the search
+    /// field string provided by the searchable component, this will result in the collection
+    /// querying for all items containing the search field string for the given key path.
+    ///
+    ///     @State var searchString: String
+    ///     @ObservedResults(Reminder.self) var reminders
+    ///
+    ///     List {
+    ///         ForEach(reminders) { reminder in
+    ///             ReminderRowView(reminder: reminder)
+    ///         }
+    ///     }
+    ///     .searchable(text: $searchFilter,
+    ///                 collection: $reminders,
+    ///                 keyPath: \.name) {
+    ///         ForEach(reminders) { remindersFiltered in
+    ///             Text(remindersFiltered.name).searchCompletion(remindersFiltered.name)
+    ///         }
+    ///     }
+    /**
+    - parameter text: The text to display and edit in the search field.
+    - parameter collection: The collection to be filtered.
+    - parameter keyPath: The key path to the property which will be used to filter
+                the collection.
+    - parameter placement: The preferred placement of the search field within the
+                containing view hierarchy.
+    - parameter prompt: A string representing the prompt of the search field
+                which provides users with guidance on what to search for.
+     */
     public func searchable<T: ObjectBase, P: _QueryString & _RealmSchemaDiscoverable, S>(text: Binding<String>, collection: ObservedResults<T>, keyPath: KeyPath<T, P>, placement: SearchFieldPlacement = .automatic, prompt: S) -> some View where S : StringProtocol {
         filterCollection(collection, for: text.wrappedValue, on: keyPath)
         return searchable(text: text,
@@ -1208,7 +1595,138 @@ extension View {
                           prompt: prompt)
     }
 
-    /// :nodoc:
+    /// Marks this view as searchable, which configures the display of a
+    /// search field.
+    ///
+    /// Use this modifier to create a user interface appropriate for searching.
+    ///
+    /// Wrapping a navigation view results in a column of the navigation
+    /// view displaying a search field. On iOS and iPadOS, the first or second
+    /// column displays the search field in a double, or triple column
+    /// navigation view respectively. On macOS, the search field is
+    /// placed in the trailing-most position of the toolbar.
+    ///
+    ///     var body: some View {
+    ///         NavigationView {
+    ///             PrimaryView()
+    ///             SecondaryView()
+    ///             Text("Select a primary and secondary item")
+    ///         }
+    ///         .searchable(text: $text)
+    ///     }
+    ///
+    /// On iOS, iPadOS, or watchOS, wrapping a specific column of a navigation view
+    /// results in that column displaying a search field.
+    ///
+    ///     struct DestinationPageView: View {
+    ///         @State private var text = ""
+    ///         var body: some View {
+    ///             Text("Destination Page")
+    ///                 .searchable(text: $text)
+    ///         }
+    ///     }
+    ///
+    ///     var body: some View {
+    ///         NavigationView {
+    ///             List {
+    ///                 NavigationLink(
+    ///                     "Destination Page",
+    ///                     destination: DestinationPageView()
+    ///                 )
+    ///             }
+    ///             Text("Select a destination")
+    ///         }
+    ///     }
+    ///
+    /// You can query the ``EnvironmentValues/isSearching`` property to
+    /// adjust the view hierarchy within the searchable modifier.
+    /// You can also provide search suggestions using the suggestions parameter
+    /// of searchable modifiers.
+    ///
+    /// Use the ``View/searchCompletion(_:)`` modifier to associate strings
+    /// to the views provided to the suggestions view. The system
+    /// uses these strings to replace the partial text being currently
+    /// edited of the associated search field. If a view has no
+    /// completion modifier, it's displayed as is.
+    ///
+    ///     SearchPlaceholderView()
+    ///         .searchable(text: $text) {
+    ///             Text("🍎").searchCompletion("apple")
+    ///             Text("🍐").searchCompletion("pear")
+    ///             Text("🍌").searchCompletion("banana")
+    ///         }
+    ///
+    /// The presentation of the suggestions depends on whether any
+    /// content is provided to the `suggestions` parameter.
+    ///
+    ///     SearchPlaceholderView()
+    ///         .searchable(text: $text) {
+    ///             ForEach(viewModel.suggestedSearches) { suggestion in
+    ///                 Label(suggestion.title,  image: suggestion.image)
+    ///                     .searchCompletion(suggestion.text)
+    ///             }
+    ///         }
+    ///
+    /// If `viewModel.suggestedSearches` begins as an empty array, then
+    /// the suggestions aren't initially displayed. When the array
+    /// becomes populated, the suggestions are presented. Note that
+    /// the suggestions may be dismissed based on a user's action, like
+    /// moving the window of the app on macOS for example.
+    ///
+    /// > Note: On tvOS, searchable modifiers only support suggestions of type
+    /// ``Text``.
+    ///
+    /// You can associate an action to be invoked upon submission of the current
+    /// search query by using an ``View/onSubmit(of:_:)`` modifier in
+    /// conjunction with the a searchable modifier.
+    ///
+    ///     @StateObject private var viewModel = ViewModel()
+    ///
+    ///     NavigationView {
+    ///         SidebarView()
+    ///         DetailView()
+    ///     }
+    ///     .searchable(
+    ///         text: $viewModel.searchText,
+    ///         placement: .sidebar
+    ///     ) {
+    ///         SuggestionsView()
+    ///     }
+    ///     .onSubmit(of: .search) {
+    ///         viewModel.submitCurrentSearchQuery()
+    ///     }
+    ///
+    /// You can provide a collection and a key path to be filtered using the search
+    /// field string provided by the searchable component, this will result in the collection
+    /// querying for all items containing the search field string for the given key path.
+    ///
+    ///     @State var searchString: String
+    ///     @ObservedResults(Reminder.self) var reminders
+    ///
+    ///     List {
+    ///         ForEach(reminders) { reminder in
+    ///             ReminderRowView(reminder: reminder)
+    ///         }
+    ///     }
+    ///     .searchable(text: $searchFilter,
+    ///                 collection: $reminders,
+    ///                 keyPath: \.name) {
+    ///         ForEach(reminders) { remindersFiltered in
+    ///             Text(remindersFiltered.name).searchCompletion(remindersFiltered.name)
+    ///         }
+    ///     }
+    /**
+    - parameter text: The text to display and edit in the search field.
+    - parameter collection: The collection to be filtered.
+    - parameter keyPath: The key path to the property which will be used to filter
+                the collection.
+    - parameter placement: The preferred placement of the search field within the
+                containing view hierarchy.
+    - parameter prompt: A `Text` representing the prompt of the search field
+                which provides users with guidance on what to search for.
+    - parameter suggestions: A view builder that produces content that
+                populates a list of suggestions.
+     */
     public func searchable<T: ObjectBase, P: _QueryString & _RealmSchemaDiscoverable, S>(text: Binding<String>, collection: ObservedResults<T>, keyPath: KeyPath<T, P>, placement: SearchFieldPlacement = .automatic, prompt: Text? = nil, @ViewBuilder suggestions: () -> S) -> some View where S : View {
         filterCollection(collection, for: text.wrappedValue, on: keyPath)
         return searchable(text: text,
@@ -1217,7 +1735,138 @@ extension View {
                           suggestions: suggestions)
     }
 
-    /// :nodoc:
+    /// Marks this view as searchable, which configures the display of a
+    /// search field.
+    ///
+    /// Use this modifier to create a user interface appropriate for searching.
+    ///
+    /// Wrapping a navigation view results in a column of the navigation
+    /// view displaying a search field. On iOS and iPadOS, the first or second
+    /// column displays the search field in a double, or triple column
+    /// navigation view respectively. On macOS, the search field is
+    /// placed in the trailing-most position of the toolbar.
+    ///
+    ///     var body: some View {
+    ///         NavigationView {
+    ///             PrimaryView()
+    ///             SecondaryView()
+    ///             Text("Select a primary and secondary item")
+    ///         }
+    ///         .searchable(text: $text)
+    ///     }
+    ///
+    /// On iOS, iPadOS, or watchOS, wrapping a specific column of a navigation view
+    /// results in that column displaying a search field.
+    ///
+    ///     struct DestinationPageView: View {
+    ///         @State private var text = ""
+    ///         var body: some View {
+    ///             Text("Destination Page")
+    ///                 .searchable(text: $text)
+    ///         }
+    ///     }
+    ///
+    ///     var body: some View {
+    ///         NavigationView {
+    ///             List {
+    ///                 NavigationLink(
+    ///                     "Destination Page",
+    ///                     destination: DestinationPageView()
+    ///                 )
+    ///             }
+    ///             Text("Select a destination")
+    ///         }
+    ///     }
+    ///
+    /// You can query the ``EnvironmentValues/isSearching`` property to
+    /// adjust the view hierarchy within the searchable modifier.
+    /// You can also provide search suggestions using the suggestions parameter
+    /// of searchable modifiers.
+    ///
+    /// Use the ``View/searchCompletion(_:)`` modifier to associate strings
+    /// to the views provided to the suggestions view. The system
+    /// uses these strings to replace the partial text being currently
+    /// edited of the associated search field. If a view has no
+    /// completion modifier, it's displayed as is.
+    ///
+    ///     SearchPlaceholderView()
+    ///         .searchable(text: $text) {
+    ///             Text("🍎").searchCompletion("apple")
+    ///             Text("🍐").searchCompletion("pear")
+    ///             Text("🍌").searchCompletion("banana")
+    ///         }
+    ///
+    /// The presentation of the suggestions depends on whether any
+    /// content is provided to the `suggestions` parameter.
+    ///
+    ///     SearchPlaceholderView()
+    ///         .searchable(text: $text) {
+    ///             ForEach(viewModel.suggestedSearches) { suggestion in
+    ///                 Label(suggestion.title,  image: suggestion.image)
+    ///                     .searchCompletion(suggestion.text)
+    ///             }
+    ///         }
+    ///
+    /// If `viewModel.suggestedSearches` begins as an empty array, then
+    /// the suggestions aren't initially displayed. When the array
+    /// becomes populated, the suggestions are presented. Note that
+    /// the suggestions may be dismissed based on a user's action, like
+    /// moving the window of the app on macOS for example.
+    ///
+    /// > Note: On tvOS, searchable modifiers only support suggestions of type
+    /// ``Text``.
+    ///
+    /// You can associate an action to be invoked upon submission of the current
+    /// search query by using an ``View/onSubmit(of:_:)`` modifier in
+    /// conjunction with the a searchable modifier.
+    ///
+    ///     @StateObject private var viewModel = ViewModel()
+    ///
+    ///     NavigationView {
+    ///         SidebarView()
+    ///         DetailView()
+    ///     }
+    ///     .searchable(
+    ///         text: $viewModel.searchText,
+    ///         placement: .sidebar
+    ///     ) {
+    ///         SuggestionsView()
+    ///     }
+    ///     .onSubmit(of: .search) {
+    ///         viewModel.submitCurrentSearchQuery()
+    ///     }
+    ///
+    /// You can provide a collection and a key path to be filtered using the search
+    /// field string provided by the searchable component, this will result in the collection
+    /// querying for all items containing the search field string for the given key path.
+    ///
+    ///     @State var searchString: String
+    ///     @ObservedResults(Reminder.self) var reminders
+    ///
+    ///     List {
+    ///         ForEach(reminders) { reminder in
+    ///             ReminderRowView(reminder: reminder)
+    ///         }
+    ///     }
+    ///     .searchable(text: $searchFilter,
+    ///                 collection: $reminders,
+    ///                 keyPath: \.name) {
+    ///         ForEach(reminders) { remindersFiltered in
+    ///             Text(remindersFiltered.name).searchCompletion(remindersFiltered.name)
+    ///         }
+    ///     }
+    /**
+    - parameter text: The text to display and edit in the search field.
+    - parameter collection: The collection to be filtered.
+    - parameter keyPath: The key path to the property which will be used to filter
+                the collection.
+    - parameter placement: The preferred placement of the search field within the
+                containing view hierarchy.
+    - parameter prompt: The key for the localized prompt of the search field
+                which provides users with guidance on what to search for.
+    - parameter suggestions: A view builder that produces content that
+                populates a list of suggestions.
+     */
     public func searchable<T: ObjectBase, P: _QueryString & _RealmSchemaDiscoverable, S>(text: Binding<String>, collection: ObservedResults<T>, keyPath: KeyPath<T, P>, placement: SearchFieldPlacement = .automatic, prompt: LocalizedStringKey, @ViewBuilder suggestions: () -> S) -> some View where S : View {
         filterCollection(collection, for: text.wrappedValue, on: keyPath)
         return searchable(text: text,
@@ -1226,7 +1875,138 @@ extension View {
                           suggestions: suggestions)
     }
 
-    /// :nodoc:
+    /// Marks this view as searchable, which configures the display of a
+    /// search field.
+    ///
+    /// Use this modifier to create a user interface appropriate for searching.
+    ///
+    /// Wrapping a navigation view results in a column of the navigation
+    /// view displaying a search field. On iOS and iPadOS, the first or second
+    /// column displays the search field in a double, or triple column
+    /// navigation view respectively. On macOS, the search field is
+    /// placed in the trailing-most position of the toolbar.
+    ///
+    ///     var body: some View {
+    ///         NavigationView {
+    ///             PrimaryView()
+    ///             SecondaryView()
+    ///             Text("Select a primary and secondary item")
+    ///         }
+    ///         .searchable(text: $text)
+    ///     }
+    ///
+    /// On iOS, iPadOS, or watchOS, wrapping a specific column of a navigation view
+    /// results in that column displaying a search field.
+    ///
+    ///     struct DestinationPageView: View {
+    ///         @State private var text = ""
+    ///         var body: some View {
+    ///             Text("Destination Page")
+    ///                 .searchable(text: $text)
+    ///         }
+    ///     }
+    ///
+    ///     var body: some View {
+    ///         NavigationView {
+    ///             List {
+    ///                 NavigationLink(
+    ///                     "Destination Page",
+    ///                     destination: DestinationPageView()
+    ///                 )
+    ///             }
+    ///             Text("Select a destination")
+    ///         }
+    ///     }
+    ///
+    /// You can query the ``EnvironmentValues/isSearching`` property to
+    /// adjust the view hierarchy within the searchable modifier.
+    /// You can also provide search suggestions using the suggestions parameter
+    /// of searchable modifiers.
+    ///
+    /// Use the ``View/searchCompletion(_:)`` modifier to associate strings
+    /// to the views provided to the suggestions view. The system
+    /// uses these strings to replace the partial text being currently
+    /// edited of the associated search field. If a view has no
+    /// completion modifier, it's displayed as is.
+    ///
+    ///     SearchPlaceholderView()
+    ///         .searchable(text: $text) {
+    ///             Text("🍎").searchCompletion("apple")
+    ///             Text("🍐").searchCompletion("pear")
+    ///             Text("🍌").searchCompletion("banana")
+    ///         }
+    ///
+    /// The presentation of the suggestions depends on whether any
+    /// content is provided to the `suggestions` parameter.
+    ///
+    ///     SearchPlaceholderView()
+    ///         .searchable(text: $text) {
+    ///             ForEach(viewModel.suggestedSearches) { suggestion in
+    ///                 Label(suggestion.title,  image: suggestion.image)
+    ///                     .searchCompletion(suggestion.text)
+    ///             }
+    ///         }
+    ///
+    /// If `viewModel.suggestedSearches` begins as an empty array, then
+    /// the suggestions aren't initially displayed. When the array
+    /// becomes populated, the suggestions are presented. Note that
+    /// the suggestions may be dismissed based on a user's action, like
+    /// moving the window of the app on macOS for example.
+    ///
+    /// > Note: On tvOS, searchable modifiers only support suggestions of type
+    /// ``Text``.
+    ///
+    /// You can associate an action to be invoked upon submission of the current
+    /// search query by using an ``View/onSubmit(of:_:)`` modifier in
+    /// conjunction with the a searchable modifier.
+    ///
+    ///     @StateObject private var viewModel = ViewModel()
+    ///
+    ///     NavigationView {
+    ///         SidebarView()
+    ///         DetailView()
+    ///     }
+    ///     .searchable(
+    ///         text: $viewModel.searchText,
+    ///         placement: .sidebar
+    ///     ) {
+    ///         SuggestionsView()
+    ///     }
+    ///     .onSubmit(of: .search) {
+    ///         viewModel.submitCurrentSearchQuery()
+    ///     }
+    ///
+    /// You can provide a collection and a key path to be filtered using the search
+    /// field string provided by the searchable component, this will result in the collection
+    /// querying for all items containing the search field string for the given key path.
+    ///
+    ///     @State var searchString: String
+    ///     @ObservedResults(Reminder.self) var reminders
+    ///
+    ///     List {
+    ///         ForEach(reminders) { reminder in
+    ///             ReminderRowView(reminder: reminder)
+    ///         }
+    ///     }
+    ///     .searchable(text: $searchFilter,
+    ///                 collection: $reminders,
+    ///                 keyPath: \.name) {
+    ///         ForEach(reminders) { remindersFiltered in
+    ///             Text(remindersFiltered.name).searchCompletion(remindersFiltered.name)
+    ///         }
+    ///     }
+    /**
+    - parameter text: The text to display and edit in the search field.
+    - parameter collection: The collection to be filtered.
+    - parameter keyPath: The key path to the property which will be used to filter
+                the collection.
+    - parameter placement: The preferred placement of the search field within the
+                containing view hierarchy.
+    - parameter prompt: A string representing the prompt of the search field
+                which provides users with guidance on what to search for.
+    - parameter suggestions: A view builder that produces content that
+                populates a list of suggestions.
+     */
     public func searchable<T: ObjectBase, P: _QueryString & _RealmSchemaDiscoverable, V, S>(text: Binding<String>, collection: ObservedResults<T>, keyPath: KeyPath<T, P>, placement: SearchFieldPlacement = .automatic, prompt: S, @ViewBuilder suggestions: () -> V) -> some View where V : View, S : StringProtocol {
         filterCollection(collection, for: text.wrappedValue, on: keyPath)
         return searchable(text: text,

--- a/RealmSwift/Tests/SwiftUITests.swift
+++ b/RealmSwift/Tests/SwiftUITests.swift
@@ -313,20 +313,6 @@ class SwiftUITests: TestCase {
         XCTAssertEqual(results.wrappedValue.count, 1)
         state.projectedValue.delete()
     }
-
-    @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
-    struct ContentView: View {
-        @State var searchString: String
-        @ObservedResults(SwiftUIObject.self) var observedResults
-        var body: some View {
-            List {
-                ForEach(observedResults) { _ in }
-            }
-            .searchable(text: $searchString,
-                        collection: $observedResults,
-                        keyPath: \.str)
-        }
-    }
     // MARK: Bind
     func testUnmanagedManagedObjectBind() {
         let object = SwiftUIObject()

--- a/RealmSwift/Tests/SwiftUITests.swift
+++ b/RealmSwift/Tests/SwiftUITests.swift
@@ -22,13 +22,13 @@ import RealmSwift
 import SwiftUI
 import Combine
 
-class SwiftUIObject: Object, ObjectKeyIdentifiable {
-    @Persisted var list = RealmSwift.List<SwiftBoolObject>()
-    @Persisted var map = Map<String, SwiftBoolObject?>()
-    @Persisted var primitiveList = RealmSwift.List<Int>()
-    @Persisted var primitiveMap = Map<String, Int>()
-    @Persisted var str = "foo"
-    @Persisted var int = 0
+@objcMembers class SwiftUIObject: Object, ObjectKeyIdentifiable {
+    var list = RealmSwift.List<SwiftBoolObject>()
+    var map = Map<String, SwiftBoolObject?>()
+    var primitiveList = RealmSwift.List<Int>()
+    var primitiveMap = Map<String, Int>()
+    dynamic var str = "foo"
+    dynamic var int = 0
 
     convenience init(str: String = "foo") {
         self.init()

--- a/RealmSwift/Tests/SwiftUITests.swift
+++ b/RealmSwift/Tests/SwiftUITests.swift
@@ -313,6 +313,33 @@ class SwiftUITests: TestCase {
         XCTAssertEqual(results.wrappedValue.count, 1)
         state.projectedValue.delete()
     }
+    // MARK: - ObservedResults Search
+    @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+    func testSearchObservedResults() {
+        let fullResults = ObservedResults(SwiftUIObject.self,
+                                          configuration: inMemoryRealm(inMemoryIdentifier).configuration)
+        XCTAssertEqual(fullResults.wrappedValue.count, 0)
+        (1...20).forEach { index in
+            let object = SwiftUIObject()
+            object.str = "str_\(index)"
+            fullResults.projectedValue.append(object)
+        }
+        XCTAssertEqual(fullResults.wrappedValue.count, 20)
+
+        let searchBinding = fullResults.searchByKeypathString(["str"])
+
+        searchBinding.wrappedValue = "str"
+        XCTAssertEqual(fullResults.wrappedValue.count, 20)
+
+        searchBinding.wrappedValue = "str_5"
+        XCTAssertEqual(fullResults.wrappedValue.count, 1)
+
+        searchBinding.wrappedValue = "str_1"
+        XCTAssertEqual(fullResults.wrappedValue.count, 11)
+
+        searchBinding.wrappedValue = ""
+        XCTAssertEqual(fullResults.wrappedValue.count, 20)
+    }
     // MARK: Bind
     func testUnmanagedManagedObjectBind() {
         let object = SwiftUIObject()

--- a/examples/ios/swift/ListSwiftUI/Views/ContentView.swift
+++ b/examples/ios/swift/ListSwiftUI/Views/ContentView.swift
@@ -182,16 +182,13 @@ struct ReminderListResultsView: View {
     @Binding var searchFilter: String
 
     var body: some View {
-        let list = {
-            List {
-                ForEach(reminders) { list in
-                    NavigationLink(destination: ReminderListView(list: list)) {
-                        ReminderListRowView(list: list).tag(list)
-                    }.accessibilityIdentifier(list.name)
-                }.onDelete(perform: $reminders.remove)
-            }
-        }()
-        
+        let list = List {
+            ForEach(reminders) { list in
+                NavigationLink(destination: ReminderListView(list: list)) {
+                    ReminderListRowView(list: list).tag(list)
+                }.accessibilityIdentifier(list.name)
+            }.onDelete(perform: $reminders.remove)
+        }
         if #available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *) {
             list
                 .searchable(text: $searchFilter,

--- a/examples/ios/swift/ListSwiftUI/Views/ContentView.swift
+++ b/examples/ios/swift/ListSwiftUI/Views/ContentView.swift
@@ -190,11 +190,9 @@ struct ReminderListResultsView: View {
                     }.accessibilityIdentifier(list.name)
                 }.onDelete(perform: $reminders.remove)
             }
-            .searchable(text: $reminders.searchByKeypathString(["name"])) {
-                ForEach(reminders) { remindersFiltered in
-                    Text(remindersFiltered.name).searchCompletion(remindersFiltered.name)
-                }
-            }
+            .searchable(text: $searchFilter,
+                        collection: $reminders,
+                        keyPath: \.name)
         } else {
             List {
                 ForEach(reminders) { list in

--- a/examples/ios/swift/ListSwiftUI/Views/ContentView.swift
+++ b/examples/ios/swift/ListSwiftUI/Views/ContentView.swift
@@ -192,7 +192,11 @@ struct ReminderListResultsView: View {
             }
             .searchable(text: $searchFilter,
                         collection: $reminders,
-                        keyPath: \.name)
+                        keyPath: \.name) {
+                ForEach(reminders) { remindersFiltered in
+                    Text(remindersFiltered.name).searchCompletion(remindersFiltered.name)
+                }
+            }
         } else {
             List {
                 ForEach(reminders) { list in

--- a/examples/ios/swift/ListSwiftUI/Views/ContentView.swift
+++ b/examples/ios/swift/ListSwiftUI/Views/ContentView.swift
@@ -182,14 +182,29 @@ struct ReminderListResultsView: View {
     @Binding var searchFilter: String
 
     var body: some View {
-        List {
-            ForEach(reminders) { list in
-                NavigationLink(destination: ReminderListView(list: list)) {
-                    ReminderListRowView(list: list).tag(list)
-                }.accessibilityIdentifier(list.name)
-            }.onDelete(perform: $reminders.remove)
-        }.onChange(of: searchFilter) { value in
-            $reminders.filter = value.isEmpty ? nil : NSPredicate(format: "name CONTAINS[c] %@", value)
+        if #available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *) {
+            List {
+                ForEach(reminders) { list in
+                    NavigationLink(destination: ReminderListView(list: list)) {
+                        ReminderListRowView(list: list).tag(list)
+                    }.accessibilityIdentifier(list.name)
+                }.onDelete(perform: $reminders.remove)
+            }
+            .searchable(text: $reminders.searchByKeypathString(["name"])) {
+                ForEach(reminders) { remindersFiltered in
+                    Text(remindersFiltered.name).searchCompletion(remindersFiltered.name)
+                }
+            }
+        } else {
+            List {
+                ForEach(reminders) { list in
+                    NavigationLink(destination: ReminderListView(list: list)) {
+                        ReminderListRowView(list: list).tag(list)
+                    }.accessibilityIdentifier(list.name)
+                }.onDelete(perform: $reminders.remove)
+            }.onChange(of: searchFilter) { value in
+                $reminders.filter = value.isEmpty ? nil : NSPredicate(format: "name CONTAINS[c] %@", value)
+            }
         }
     }
 }
@@ -255,7 +270,10 @@ struct ContentView: View {
     var body: some View {
         NavigationView {
             VStack {
-                SearchView(searchFilter: $searchFilter)
+                if #available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *) {
+                } else {
+                    SearchView(searchFilter: $searchFilter)
+                }
                 ReminderListResultsView(searchFilter: $searchFilter)
                 Spacer()
                 Footer()

--- a/examples/ios/swift/ListSwiftUI/Views/ContentView.swift
+++ b/examples/ios/swift/ListSwiftUI/Views/ContentView.swift
@@ -182,31 +182,30 @@ struct ReminderListResultsView: View {
     @Binding var searchFilter: String
 
     var body: some View {
+        let list = {
+            List {
+                ForEach(reminders) { list in
+                    NavigationLink(destination: ReminderListView(list: list)) {
+                        ReminderListRowView(list: list).tag(list)
+                    }.accessibilityIdentifier(list.name)
+                }.onDelete(perform: $reminders.remove)
+            }
+        }()
+        
         if #available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *) {
-            List {
-                ForEach(reminders) { list in
-                    NavigationLink(destination: ReminderListView(list: list)) {
-                        ReminderListRowView(list: list).tag(list)
-                    }.accessibilityIdentifier(list.name)
-                }.onDelete(perform: $reminders.remove)
-            }
-            .searchable(text: $searchFilter,
-                        collection: $reminders,
-                        keyPath: \.name) {
-                ForEach(reminders) { remindersFiltered in
-                    Text(remindersFiltered.name).searchCompletion(remindersFiltered.name)
+            list
+                .searchable(text: $searchFilter,
+                            collection: $reminders,
+                            keyPath: \.name) {
+                    ForEach(reminders) { remindersFiltered in
+                        Text(remindersFiltered.name).searchCompletion(remindersFiltered.name)
+                    }
                 }
-            }
         } else {
-            List {
-                ForEach(reminders) { list in
-                    NavigationLink(destination: ReminderListView(list: list)) {
-                        ReminderListRowView(list: list).tag(list)
-                    }.accessibilityIdentifier(list.name)
-                }.onDelete(perform: $reminders.remove)
-            }.onChange(of: searchFilter) { value in
-                $reminders.filter = value.isEmpty ? nil : NSPredicate(format: "name CONTAINS[c] %@", value)
-            }
+            list
+                .onChange(of: searchFilter) { value in
+                    $reminders.filter = value.isEmpty ? nil : NSPredicate(format: "name CONTAINS[c] %@", value)
+                }
         }
     }
 }
@@ -273,6 +272,7 @@ struct ContentView: View {
         NavigationView {
             VStack {
                 if #available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *) {
+                    // Don't add a SearchView in case searchable is available
                 } else {
                     SearchView(searchFilter: $searchFilter)
                 }


### PR DESCRIPTION
All methods on this extension allow us to filter @ObservedResult results from .searchable() component search field.
  
```
@State var searchString: String
@ObservedResults(Reminder.self) var reminders


 List {
      ForEach(reminders) { reminder in
         ReminderRowView(reminder: reminder)
      }
   }
   .searchable(text: $searchFilter,
               collection: $reminders,
               keyPath: \.name) {
      ForEach(reminders) { remindersFiltered in
         Text(remindersFiltered.name).searchCompletion(remindersFiltered.name)
      }
   }
```

- [x] Changelog
- [x] Docstrings
- [x] Review Main thread approach
- [x] Fix CI issues

Merging depends on this PR (https://github.com/realm/realm-cocoa/pull/7419), that's why it is against `lm/type_safe_queries` for easier review. 