### PR TITLE
Add Xcode 13.2 and drop 12.2

### DIFF
--- a/.jenkins.yml
+++ b/.jenkins.yml
@@ -4,11 +4,11 @@
 # This is a generated file produced by scripts/pr-ci-matrix.rb.
 
 xcode_version:
- - 12.2
  - 12.4
  - 12.5.1
  - 13.0
  - 13.1
+ - 13.2
 target:
  - docs
  - swiftlint
@@ -44,9 +44,6 @@ configuration:
 
 exclude:
 
-  - xcode_version: 12.2
-    target: docs
-
   - xcode_version: 12.4
     target: docs
 
@@ -56,8 +53,8 @@ exclude:
   - xcode_version: 13.0
     target: docs
 
-  - xcode_version: 12.2
-    target: swiftlint
+  - xcode_version: 13.1
+    target: docs
 
   - xcode_version: 12.4
     target: swiftlint
@@ -68,8 +65,8 @@ exclude:
   - xcode_version: 13.0
     target: swiftlint
 
-  - xcode_version: 12.2
-    target: osx-encryption
+  - xcode_version: 13.1
+    target: swiftlint
 
   - xcode_version: 12.4
     target: osx-encryption
@@ -80,8 +77,8 @@ exclude:
   - xcode_version: 13.0
     target: osx-encryption
 
-  - xcode_version: 12.4
-    target: osx-object-server
+  - xcode_version: 13.1
+    target: osx-encryption
 
   - xcode_version: 12.5.1
     target: osx-object-server
@@ -89,8 +86,8 @@ exclude:
   - xcode_version: 13.0
     target: osx-object-server
 
-  - xcode_version: 12.4
-    target: swiftpm
+  - xcode_version: 13.1
+    target: osx-object-server
 
   - xcode_version: 12.5.1
     target: swiftpm
@@ -98,8 +95,8 @@ exclude:
   - xcode_version: 13.0
     target: swiftpm
 
-  - xcode_version: 12.2
-    target: swiftpm-address
+  - xcode_version: 13.1
+    target: swiftpm
 
   - xcode_version: 12.4
     target: swiftpm-address
@@ -110,8 +107,8 @@ exclude:
   - xcode_version: 13.0
     target: swiftpm-address
 
-  - xcode_version: 12.2
-    target: swiftpm-thread
+  - xcode_version: 13.1
+    target: swiftpm-address
 
   - xcode_version: 12.4
     target: swiftpm-thread
@@ -122,8 +119,8 @@ exclude:
   - xcode_version: 13.0
     target: swiftpm-thread
 
-  - xcode_version: 12.2
-    target: swiftpm-ios
+  - xcode_version: 13.1
+    target: swiftpm-thread
 
   - xcode_version: 12.4
     target: swiftpm-ios
@@ -134,26 +131,26 @@ exclude:
   - xcode_version: 13.0
     target: swiftpm-ios
 
-  - xcode_version: 12.4
+  - xcode_version: 13.1
+    target: swiftpm-ios
+
+  - xcode_version: 12.5.1
+    target: ios-static
+
+  - xcode_version: 13.0
+    target: ios-static
+
+  - xcode_version: 13.1
     target: ios-static
 
   - xcode_version: 12.5.1
-    target: ios-static
-
-  - xcode_version: 13.0
-    target: ios-static
-
-  - xcode_version: 12.4
-    target: ios-dynamic
-
-  - xcode_version: 12.5.1
     target: ios-dynamic
 
   - xcode_version: 13.0
     target: ios-dynamic
 
-  - xcode_version: 12.4
-    target: watchos
+  - xcode_version: 13.1
+    target: ios-dynamic
 
   - xcode_version: 12.5.1
     target: watchos
@@ -161,8 +158,8 @@ exclude:
   - xcode_version: 13.0
     target: watchos
 
-  - xcode_version: 12.4
-    target: tvos
+  - xcode_version: 13.1
+    target: watchos
 
   - xcode_version: 12.5.1
     target: tvos
@@ -170,8 +167,8 @@ exclude:
   - xcode_version: 13.0
     target: tvos
 
-  - xcode_version: 12.4
-    target: ios-swift
+  - xcode_version: 13.1
+    target: tvos
 
   - xcode_version: 12.5.1
     target: ios-swift
@@ -179,8 +176,8 @@ exclude:
   - xcode_version: 13.0
     target: ios-swift
 
-  - xcode_version: 12.4
-    target: tvos-swift
+  - xcode_version: 13.1
+    target: ios-swift
 
   - xcode_version: 12.5.1
     target: tvos-swift
@@ -188,8 +185,8 @@ exclude:
   - xcode_version: 13.0
     target: tvos-swift
 
-  - xcode_version: 12.2
-    target: osx-swift-evolution
+  - xcode_version: 13.1
+    target: tvos-swift
 
   - xcode_version: 12.4
     target: osx-swift-evolution
@@ -200,8 +197,8 @@ exclude:
   - xcode_version: 13.0
     target: osx-swift-evolution
 
-  - xcode_version: 12.2
-    target: ios-swift-evolution
+  - xcode_version: 13.1
+    target: osx-swift-evolution
 
   - xcode_version: 12.4
     target: ios-swift-evolution
@@ -212,8 +209,8 @@ exclude:
   - xcode_version: 13.0
     target: ios-swift-evolution
 
-  - xcode_version: 12.2
-    target: tvos-swift-evolution
+  - xcode_version: 13.1
+    target: ios-swift-evolution
 
   - xcode_version: 12.4
     target: tvos-swift-evolution
@@ -224,26 +221,26 @@ exclude:
   - xcode_version: 13.0
     target: tvos-swift-evolution
 
-  - xcode_version: 12.4
+  - xcode_version: 13.1
+    target: tvos-swift-evolution
+
+  - xcode_version: 12.5.1
+    target: catalyst
+
+  - xcode_version: 13.0
+    target: catalyst
+
+  - xcode_version: 13.1
     target: catalyst
 
   - xcode_version: 12.5.1
-    target: catalyst
-
-  - xcode_version: 13.0
-    target: catalyst
-
-  - xcode_version: 12.4
-    target: catalyst-swift
-
-  - xcode_version: 12.5.1
     target: catalyst-swift
 
   - xcode_version: 13.0
     target: catalyst-swift
 
-  - xcode_version: 12.2
-    target: xcframework
+  - xcode_version: 13.1
+    target: catalyst-swift
 
   - xcode_version: 12.4
     target: xcframework
@@ -254,8 +251,8 @@ exclude:
   - xcode_version: 13.0
     target: xcframework
 
-  - xcode_version: 12.4
-    target: cocoapods-ios
+  - xcode_version: 13.1
+    target: xcframework
 
   - xcode_version: 12.5.1
     target: cocoapods-ios
@@ -263,8 +260,8 @@ exclude:
   - xcode_version: 13.0
     target: cocoapods-ios
 
-  - xcode_version: 12.4
-    target: cocoapods-ios-dynamic
+  - xcode_version: 13.1
+    target: cocoapods-ios
 
   - xcode_version: 12.5.1
     target: cocoapods-ios-dynamic
@@ -272,8 +269,8 @@ exclude:
   - xcode_version: 13.0
     target: cocoapods-ios-dynamic
 
-  - xcode_version: 12.4
-    target: cocoapods-watchos
+  - xcode_version: 13.1
+    target: cocoapods-ios-dynamic
 
   - xcode_version: 12.5.1
     target: cocoapods-watchos
@@ -281,8 +278,8 @@ exclude:
   - xcode_version: 13.0
     target: cocoapods-watchos
 
-  - xcode_version: 12.2
-    target: swiftui-ios
+  - xcode_version: 13.1
+    target: cocoapods-watchos
 
   - xcode_version: 12.4
     target: swiftui-ios
@@ -293,8 +290,8 @@ exclude:
   - xcode_version: 13.0
     target: swiftui-ios
 
-  - xcode_version: 12.2
-    target: swiftui-server-osx
+  - xcode_version: 13.1
+    target: swiftui-ios
 
   - xcode_version: 12.4
     target: swiftui-server-osx
@@ -303,4 +300,7 @@ exclude:
     target: swiftui-server-osx
 
   - xcode_version: 13.0
+    target: swiftui-server-osx
+
+  - xcode_version: 13.1
     target: swiftui-server-osx

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 x.y.z Release notes (yyyy-MM-dd)
 =============================================================
+
+Xcode 12.4 is now the minimum supported version of Xcode.
+
 ### Enhancements
 * None.
 
@@ -14,7 +17,7 @@ x.y.z Release notes (yyyy-MM-dd)
 * APIs are backwards compatible with all previous releases in the 10.x.y series.
 * Carthage release for Swift is built with Xcode 13.1.
 * CocoaPods: 1.10 or later.
-* Xcode: 12.2-13.1.
+* Xcode: 12.2-13.2 beta 2.
 
 ### Internal
 * Upgraded realm-core from ? to ?
@@ -154,7 +157,7 @@ x.y.z Release notes (yyyy-MM-dd)
 * APIs are backwards compatible with all previous releases in the 10.x.y series.
 * Carthage release for Swift is built with Xcode 13.1.
 * CocoaPods: 1.10 or later.
-* Xcode: 12.2-13.1.
+* Xcode: 12.4-13.2.
 
 ### Internal
 

--- a/Jenkinsfile.releasability
+++ b/Jenkinsfile.releasability
@@ -1,10 +1,10 @@
-xcodeVersions = ['12.2', '12.4', '12.5.1', '13.0', '13.1']
+xcodeVersions = ['12.4', '12.5.1', '13.0', '13.1', '13.2']
 platforms = ['osx', 'ios', 'watchos', 'tvos', 'catalyst']
 carthagePlatforms = ['osx', 'ios', 'watchos', 'tvos']
 platformNames = ['osx': 'macOS', 'ios': 'iOS', 'watchos': 'watchOS', 'tvos': 'tvOS', 'catalyst': 'Catalyst']
 carthageXcodeVersion = '13.1'
-objcXcodeVersion = '12.2'
-docsSwiftVersion = '5.5'
+objcXcodeVersion = '12.4'
+docsSwiftVersion = '5.5.1'
 
 def installationTest(platform, test, language) {
   return {

--- a/build.sh
+++ b/build.sh
@@ -644,12 +644,17 @@ case "$COMMAND" in
 
     test-swiftpm*)
         SANITIZER=$(echo "$COMMAND" | cut -d - -f 3)
+        SWIFT_TEST_FLAGS=(-Xcc -g0)
         if [ -n "$SANITIZER" ]; then
-            SANITIZER="--sanitize $SANITIZER"
+            SWIFT_TEST_FLAGS+=(--sanitize "$SANITIZER")
             export ASAN_OPTIONS='check_initialization_order=true:detect_stack_use_after_return=true'
         fi
         xcrun swift package resolve
-        xcrun swift test -Xcc -g0 --configuration "$(echo "$CONFIGURATION" | tr "[:upper:]" "[:lower:]")" $SANITIZER
+        # Xcode 13.2 beta fails to link the concurrency framework without this
+        if [ "$REALM_XCODE_VERSION" = 13.2 ]; then
+          SWIFT_TEST_FLAGS+=(-Xlinker -rpath -Xlinker "$(xcode-select -p)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift-5.5/macosx")
+        fi
+        xcrun swift test --configuration "$(echo "$CONFIGURATION" | tr "[:upper:]" "[:lower:]")" "${SWIFT_TEST_FLAGS[@]}"
         exit 0
         ;;
 
@@ -1366,7 +1371,7 @@ x.y.z Release notes (yyyy-MM-dd)
 * APIs are backwards compatible with all previous releases in the 10.x.y series.
 * Carthage release for Swift is built with Xcode 13.1.
 * CocoaPods: 1.10 or later.
-* Xcode: 12.2-13.1.
+* Xcode: 12.4-13.2.
 
 ### Internal
 * Upgraded realm-core from ? to ?

--- a/examples/installation/catalyst/swift/CocoaPodsExample/CocoaPodsExample/AppDelegate.swift
+++ b/examples/installation/catalyst/swift/CocoaPodsExample/CocoaPodsExample/AppDelegate.swift
@@ -27,13 +27,7 @@ open class MyModel: Object {
 class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
-#if swift(>=4.2)
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
         return true
     }
-#else
-    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]? = nil) -> Bool {
-        return true
-    }
-#endif
 }

--- a/examples/installation/ios/swift/CarthageExample/CarthageExample/AppDelegate.swift
+++ b/examples/installation/ios/swift/CarthageExample/CarthageExample/AppDelegate.swift
@@ -27,13 +27,7 @@ public class MyModel: Object {
 class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
-#if swift(>=4.2)
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
         return true
     }
-#else
-    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]? = nil) -> Bool {
-        return true
-    }
-#endif
 }

--- a/examples/installation/ios/swift/CocoaPodsExample/CocoaPodsExample/AppDelegate.swift
+++ b/examples/installation/ios/swift/CocoaPodsExample/CocoaPodsExample/AppDelegate.swift
@@ -27,13 +27,7 @@ open class MyModel: Object {
 class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
-#if swift(>=4.2)
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
         return true
     }
-#else
-    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]? = nil) -> Bool {
-        return true
-    }
-#endif
 }

--- a/examples/installation/ios/swift/DynamicExample/DynamicExample/AppDelegate.swift
+++ b/examples/installation/ios/swift/DynamicExample/DynamicExample/AppDelegate.swift
@@ -27,13 +27,7 @@ public class MyModel: Object {
 class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
-#if swift(>=4.2)
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
         return true
     }
-#else
-    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]? = nil) -> Bool {
-        return true
-    }
-#endif
 }

--- a/examples/installation/ios/swift/XCFrameworkExample/XCFrameworkExample/AppDelegate.swift
+++ b/examples/installation/ios/swift/XCFrameworkExample/XCFrameworkExample/AppDelegate.swift
@@ -25,13 +25,7 @@ public class MyModel: RealmSwift.Object {}
 class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
-#if swift(>=4.2)
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
         return true
     }
-#else
-    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]? = nil) -> Bool {
-        return true
-    }
-#endif
 }

--- a/examples/tvos/swift/DownloadCache/AppDelegate.swift
+++ b/examples/tvos/swift/DownloadCache/AppDelegate.swift
@@ -22,13 +22,7 @@ import UIKit
 class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
-#if swift(>=4.2)
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
         return true
     }
-#else
-    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]? = nil) -> Bool {
-        return true
-    }
-#endif
 }

--- a/examples/tvos/swift/PreloadedData/AppDelegate.swift
+++ b/examples/tvos/swift/PreloadedData/AppDelegate.swift
@@ -22,13 +22,7 @@ import UIKit
 class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
-#if swift(>=4.2)
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
         return true
     }
-#else
-    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]? = nil) -> Bool {
-        return true
-    }
-#endif
 }

--- a/scripts/package_examples.rb
+++ b/scripts/package_examples.rb
@@ -44,7 +44,7 @@ base_examples = [
   "examples/tvos/swift",
 ]
 
-xcode_versions = %w(12.2 12.4 12.5.1 13.0 13.1)
+xcode_versions = %w(12.4 12.5.1 13.0 13.1 13.2)
 
 # Remove reference to Realm.xcodeproj from all example workspaces.
 base_examples.each do |example|

--- a/scripts/pr-ci-matrix.rb
+++ b/scripts/pr-ci-matrix.rb
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 # A script to generate the .jenkins.yml file for the CI pull request job
-XCODE_VERSIONS = %w(12.2 12.4 12.5.1 13.0 13.1)
+XCODE_VERSIONS = %w(12.4 12.5.1 13.0 13.1 13.2)
 
 all = ->(v) { true }
 latest_only = ->(v) { v == XCODE_VERSIONS.last }


### PR DESCRIPTION
Xcode 13.2 puts us up to 6 versions of Xcode and 12.2 is the least used one, so it's time for it to go.