### PR TITLE
Make Realm async init @MainActor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,8 +26,13 @@ x.y.z Release notes (yyyy-MM-dd)
 * Add support for dictionary subscript expressions (e.g. `"phoneNumbers['Jane'] == '123-3456-123'"`) when querying with an NSPredicate.
 * Add UserProfile to User. This contains metadata from social logins with MongoDB Realm.
 
+
 ### Fixed
 * Change default request timeout for `RLMApp` from 6 seconds to 60 seconds.
+* Async `Realm` init would often give a Realm instance which could not actually
+  be used and would throw incorrect thread exceptions. It now is `@MainActor`
+  and gives a Realm instance which always works on the main actor. The
+  non-functional `queue:` parameter has been removed (since v10.15.0).
 
 <!-- ### Breaking Changes - ONLY INCLUDE FOR NEW MAJOR version -->
 

--- a/Realm/ObjectServerTests/RLMSyncTestCase.mm
+++ b/Realm/ObjectServerTests/RLMSyncTestCase.mm
@@ -591,7 +591,7 @@ static NSURL *syncDirectoryForChildProcess() {
     NSAssert(session, @"Cannot call with invalid partition value");
     XCTestExpectation *ex = expectation ?: [self expectationWithDescription:@"Wait for download completion"];
     __block NSError *theError = nil;
-    BOOL queued = [session waitForDownloadCompletionOnQueue:nil callback:^(NSError *err) {
+    BOOL queued = [session waitForDownloadCompletionOnQueue:dispatch_get_global_queue(0, 0) callback:^(NSError *err) {
         theError = err;
         [ex fulfill];
     }];
@@ -610,7 +610,7 @@ static NSURL *syncDirectoryForChildProcess() {
     NSAssert(session, @"Cannot call with invalid Realm");
     XCTestExpectation *ex = [self expectationWithDescription:@"Wait for upload completion"];
     __block NSError *completionError;
-    BOOL queued = [session waitForUploadCompletionOnQueue:nil callback:^(NSError *error) {
+    BOOL queued = [session waitForUploadCompletionOnQueue:dispatch_get_global_queue(0, 0) callback:^(NSError *error) {
         completionError = error;
         [ex fulfill];
     }];

--- a/RealmSwift/Realm.swift
+++ b/RealmSwift/Realm.swift
@@ -1039,16 +1039,13 @@ extension Realm {
      - parameter configuration: A configuration object to use when opening the Realm.
      - parameter downloadBeforeOpen: When opening the Realm should first download
      all data from the server.
-     - parameter queue: An optional dispatch queue to confine the Realm to. If
-     given, this Realm instance can be used from within
-     blocks dispatched to the given queue rather than on the
-     current thread.
      - throws: An `NSError` if the Realm could not be initialized.
      - returns: An open Realm.
      */
+    @MainActor
     public init(configuration: Realm.Configuration = .defaultConfiguration,
-                downloadBeforeOpen: OpenBehavior = .never,
-                queue: DispatchQueue? = nil) async throws {
+                downloadBeforeOpen: OpenBehavior = .never) async throws {
+        var rlmRealm: RLMRealm?
         switch downloadBeforeOpen {
         case .never:
             break
@@ -1057,17 +1054,20 @@ extension Realm {
                 fallthrough
             }
         case .always:
-            try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Swift.Error>) in
-                RLMRealm.asyncOpen(with: configuration.rlmConfiguration, callback: { error in
+            rlmRealm = try await withCheckedThrowingContinuation { continuation in
+                RLMRealm.asyncOpen(with: configuration.rlmConfiguration, callbackQueue: .main) { (realm, error) in
                     if let error = error {
                         continuation.resume(with: .failure(error))
                     } else {
-                        continuation.resume()
+                        continuation.resume(with: .success(realm!))
                     }
-                })
+                }
             }
         }
-        try self.init(RLMRealm(configuration: configuration.rlmConfiguration, queue: queue))
+        if rlmRealm == nil {
+            rlmRealm = try RLMRealm(configuration: configuration.rlmConfiguration)
+        }
+        self.init(rlmRealm!)
     }
 }
 #endif // swift(>=5.5)


### PR DESCRIPTION
It currently doesn't appear to be possible for async init to work without being confined to a global actor. That global actor doesn't need to be MainActor, but there also doesn't appear to be a way for it to be a user-supplied one and MainActor is probably the only one people care about for now.

I'm calling this a bug fix instead of a breaking change because the thing we're currently shipping doesn't actually work.