### PR TITLE
Revert a breaking change to Realm.writeCopy() on synchronized Realms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,8 @@ x.y.z Release notes (yyyy-MM-dd)
   be used and would throw incorrect thread exceptions. It now is `@MainActor`
   and gives a Realm instance which always works on the main actor. The
   non-functional `queue:` parameter has been removed (since v10.15.0).
+* Restore the pre-v10.12.0 of calling `writeCopy()` on a synchronized Realm
+  which produced a local non-synchronized Realm ([#7513](https://github.com/realm/realm-cocoa/issues/7513)).
 
 <!-- ### Breaking Changes - ONLY INCLUDE FOR NEW MAJOR version -->
 

--- a/Realm/ObjectServerTests/RLMObjectServerTests.mm
+++ b/Realm/ObjectServerTests/RLMObjectServerTests.mm
@@ -1857,6 +1857,26 @@ static const NSInteger NUMBER_OF_BIG_OBJECTS = 2;
     XCTAssertLessThanOrEqual(finalSize, usedSize + realm::util::page_size());
 }
 
+- (void)testWriteCopy {
+    RLMUser *user = [self userForTest:_cmd];
+    NSString *partitionValue = NSStringFromSelector(_cmd);
+    RLMRealm *syncRealm = [self openRealmForPartitionValue:partitionValue user:user];
+    [self addPersonsToRealm:syncRealm persons:@[[Person john]]];
+
+    NSError *writeError;
+    XCTAssertTrue([syncRealm writeCopyToURL:RLMTestRealmURL()
+                              encryptionKey:syncRealm.configuration.encryptionKey
+                                      error:&writeError]);
+    XCTAssertNil(writeError);
+
+    RLMRealmConfiguration *localConfig = [RLMRealmConfiguration new];
+    localConfig.fileURL = RLMTestRealmURL();
+    localConfig.schemaVersion = 1;
+
+    RLMRealm *localCopy = [RLMRealm realmWithConfiguration:localConfig error:nil];
+    XCTAssertEqual(1U, [Person allObjectsInRealm:localCopy].count);
+}
+
 #pragma mark - Read Only
 
 - (void)testOpenSynchronouslyInReadOnlyBeforeRemoteSchemaIsInitialized {

--- a/Realm/ObjectServerTests/RLMObjectServerTests.mm
+++ b/Realm/ObjectServerTests/RLMObjectServerTests.mm
@@ -971,6 +971,7 @@ static NSString *randomEmail() {
                                                 stopPolicy:RLMSyncStopPolicyImmediately];
         path = realm.configuration.pathOnDisk;
     }
+    [user.app.syncManager waitForSessionTermination];
 
     RLMRealmConfiguration *c = [RLMRealmConfiguration defaultConfiguration];
     c.fileURL = [NSURL fileURLWithPath:path];

--- a/Realm/RLMRealm.mm
+++ b/Realm/RLMRealm.mm
@@ -948,7 +948,13 @@ REALM_NOINLINE void RLMRealmTranslateException(NSError **error) {
     NSString *path = fileURL.path;
 
     try {
-        _realm->write_copy(path.UTF8String, {static_cast<const char *>(key.bytes), key.length});
+        _realm->verify_thread();
+        try {
+            _realm->read_group().write(path.UTF8String, static_cast<const char *>(key.bytes));
+        }
+        catch (...) {
+            _impl::translate_file_exception(path.UTF8String);
+        }
         return YES;
     }
     catch (...) {

--- a/Realm/RLMSyncManager.mm
+++ b/Realm/RLMSyncManager.mm
@@ -232,6 +232,10 @@ struct CallbackLoggerFactory : public realm::SyncLoggerFactory {
 - (std::shared_ptr<realm::SyncManager>)syncManager {
     return _syncManager;
 }
+
+- (void)waitForSessionTermination {
+    _syncManager->wait_for_sessions_to_terminate();
+}
 @end
 
 #pragma mark - RLMSyncTimeoutOptions

--- a/Realm/RLMSyncManager_Private.hpp
+++ b/Realm/RLMSyncManager_Private.hpp
@@ -49,6 +49,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)_fireError:(NSError *)error;
 
 - (void)resetForTesting;
+- (void)waitForSessionTermination;
 
 NS_ASSUME_NONNULL_END
 


### PR DESCRIPTION
Changing writeCopy() from producing a file with no history to one with sync history is a breaking change, so bypass Realm::write_copy() and just do what it used to do.

Fixes #7513.