### PR TITLE
Rework querying on dictionaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,10 @@ let people: Results<PersonProjection> = realm.objects(PersonProjection.self)
 * Queries on collections of PersistableEnums can now be performed with `where()`.
 * Add support for querying on the rawValue of an enum with `where()`.
 * `.count` is supported for Maps of all types rather than just numeric types in `where()`.
+* Add support for querying on the properties of objects contained in
+  dictionaries (e.g. "dictProperty.@allValues.name CONTAINS 'a'").
+* Improve the error message for many types of invalid predicates in queries.
+* Add support for comparing `@allKeys` to another property on the same object.
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-cocoa/issues/????), since v?.?.?)
@@ -45,6 +49,10 @@ let people: Results<PersonProjection> = realm.objects(PersonProjection.self)
 * Add missing `Indexable` support for UUID. 
   ([Cocoa #7545](https://github.com/realm/realm-cocoa/issues/7545), since v10.10.0)
 * `where()` allowed constructing some nonsensical queries due to boolean comparisons returning `Query<T>` rather than `Query<Bool>`.
+* `@allValues` queries on dictionaries accidentally did not require "ANY".
+* Case-insensitive and diacritic-insensitive modifiers were ignored when
+  comparing the result of an aggregate operation to another property in a
+  query.
 
 <!-- ### Breaking Changes - ONLY INCLUDE FOR NEW MAJOR version -->
 

--- a/Realm/RLMProperty.mm
+++ b/Realm/RLMProperty.mm
@@ -739,6 +739,24 @@ static realm::util::Optional<RLMPropertyType> typeFromProtocolString(const char 
     return p;
 }
 
+- (NSString *)typeName {
+    if (!self.collection) {
+        return RLMTypeToString(_type);
+    }
+    NSString *collectionName;
+    if (_swiftAccessor) {
+        collectionName = _array ? @"List" :
+                         _set   ? @"MutableSet" :
+                                  @"Map";
+    }
+    else {
+        collectionName = _array ? @"RLMArray" :
+                         _set   ? @"RLMSet" :
+                                  @"RLMDictionary";
+    }
+    return [NSString stringWithFormat:@"%@<%@>", collectionName, RLMTypeToString(_type)];
+}
+
 @end
 
 @implementation RLMPropertyDescriptor

--- a/Realm/RLMProperty_Private.h
+++ b/Realm/RLMProperty_Private.h
@@ -106,6 +106,7 @@ static inline NSString *RLMTypeToString(RLMPropertyType type) {
 @property (nonatomic, nullable) SEL setterSel;
 
 - (RLMProperty *)copyWithNewName:(NSString *)name;
+- (NSString *)typeName;
 
 @end
 

--- a/Realm/RLMQueryUtil.mm
+++ b/Realm/RLMQueryUtil.mm
@@ -84,9 +84,13 @@ BOOL propertyTypeIsNumeric(RLMPropertyType propertyType) {
     }
 }
 
+bool propertyTypeIsLink(RLMPropertyType type) {
+    return type == RLMPropertyTypeObject || type == RLMPropertyTypeLinkingObjects;
+}
+
 bool isObjectValidForProperty(id value, RLMProperty *prop) {
     if (prop.collection) {
-        if (prop.type == RLMPropertyTypeObject || prop.type == RLMPropertyTypeLinkingObjects) {
+        if (propertyTypeIsLink(prop.type)) {
             return [RLMObjectBaseObjectSchema(RLMDynamicCast<RLMObjectBase>(value)).className isEqualToString:prop.objectClassName];
         }
         return RLMValidateValue(value, prop.type, prop.optional, false, nil);
@@ -246,19 +250,28 @@ Table& get_table(Group& group, RLMObjectSchema *objectSchema)
 // A reference to a column within a query. Can be resolved to a Columns<T> for use in query expressions.
 class ColumnReference {
 public:
-    ColumnReference(Query& query, Group& group, RLMSchema *schema, RLMProperty* property, const std::vector<RLMProperty*>& links = {})
-    : m_links(links), m_property(property), m_schema(schema), m_group(&group), m_query(&query), m_table(query.get_table())
+    ColumnReference(Query& query, Group& group, RLMSchema *schema, RLMProperty* property, std::vector<RLMProperty*>&& links = {})
+    : m_links(std::move(links)), m_property(property), m_schema(schema), m_group(&group), m_query(&query), m_link_chain(query.get_table())
     {
-        auto& table = walk_link_chain([](Table const&, ColKey, RLMPropertyType) { });
-        m_col = table.get_column_key(m_property.columnName.UTF8String);
+        for (const auto& link : m_links) {
+            if (link.type != RLMPropertyTypeLinkingObjects) {
+                m_link_chain.link(link.columnName.UTF8String);
+            }
+            else {
+                auto [link_origin_table, link_origin_column] = link_origin(link);
+                m_link_chain.backlink(link_origin_table, link_origin_column);
+            }
+        }
+        m_col = m_link_chain.get_current_table()->get_column_key(m_property.columnName.UTF8String);
     }
 
     template <typename T, typename... SubQuery>
     auto resolve(SubQuery&&... subquery) const
     {
         static_assert(sizeof...(SubQuery) < 2, "resolve() takes at most one subquery");
-        LinkChain lc = link_chain();
 
+        // LinkChain::column() doesn't mutate it but isn't marked as const
+        auto& lc = const_cast<LinkChain&>(m_link_chain);
         if (type() != RLMPropertyTypeLinkingObjects) {
             return lc.column<T>(column(), std::forward<SubQuery>(subquery)...);
         }
@@ -274,7 +287,6 @@ public:
     RLMProperty *property() const { return m_property; }
     ColKey column() const { return m_col; }
     RLMPropertyType type() const { return property().type; }
-    Group& group() const { return *m_group; }
 
     RLMObjectSchema *link_target_object_schema() const
     {
@@ -283,7 +295,7 @@ public:
     }
 
     bool is_link() const noexcept {
-        return type() == RLMPropertyTypeLinkingObjects || type() == RLMPropertyTypeObject;
+        return propertyTypeIsLink(type());
     }
 
     bool has_any_to_many_links() const {
@@ -300,26 +312,17 @@ public:
         return {query, *m_group, m_schema, m_property};
     }
 
-private:
-    template<typename Func>
-    Table const& walk_link_chain(Func&& func) const
-    {
-        auto table = m_query->get_table().unchecked_ptr();
-        for (const auto& link : m_links) {
-            if (link.type != RLMPropertyTypeLinkingObjects) {
-                auto index = table->get_column_key(link.columnName.UTF8String);
-                func(*table, index, link.type);
-                table = table->get_link_target(index).unchecked_ptr();
-            }
-            else {
-                auto [link_origin_table, link_origin_column] = link_origin(link);
-                func(link_origin_table, link_origin_column, link.type);
-                table = &link_origin_table;
-            }
+    void validate_comparison(id value) const {
+        RLMPrecondition(isObjectValidForProperty(value, m_property),
+                        @"Invalid value", @"Cannot compare value '%@' of type '%@' to property '%@' of type '%@'",
+                        value, [value class], m_property.name, m_property.objectClassName ?: RLMTypeToString(m_property.type));
+        if (RLMObjectBase *obj = RLMDynamicCast<RLMObjectBase>(value)) {
+            RLMPrecondition(!obj->_row.is_valid() || m_group == &obj->_realm.group,
+                            @"Invalid value origin", @"Object must be from the Realm being queried");
         }
-        return *table;
     }
 
+private:
     std::pair<Table&, ColKey> link_origin(RLMProperty *prop) const
     {
         RLMObjectSchema *link_origin_schema = m_schema[prop.objectClassName];
@@ -329,83 +332,39 @@ private:
         return {link_origin_table, link_origin_column};
     }
 
-    LinkChain link_chain() const
-    {
-        LinkChain lc(m_table);
-        walk_link_chain([&](Table const& link_origin, ColKey col, RLMPropertyType type) {
-            if (type != RLMPropertyTypeLinkingObjects) {
-                lc.link(col);
-            }
-            else {
-                lc.backlink(link_origin, col);
-            }
-        });
-        return lc;
-    }
-
     std::vector<RLMProperty*> m_links;
     RLMProperty *m_property;
     RLMSchema *m_schema;
     Group *m_group;
     Query *m_query;
-    ConstTableRef m_table;
+    LinkChain m_link_chain;
     ColKey m_col;
 };
 
 class CollectionOperation {
 public:
     enum Type {
+        None,
         Count,
         Minimum,
         Maximum,
         Sum,
         Average,
         // Dictionary specific.
-        AllKeys,
-        AllValues
+        AllKeys
     };
 
-    CollectionOperation(Type type, ColumnReference link_column, util::Optional<ColumnReference> column)
+    CollectionOperation(Type type, ColumnReference&& link_column, ColumnReference&& column)
         : m_type(type)
         , m_link_column(std::move(link_column))
         , m_column(std::move(column))
     {
-        RLMPrecondition((m_link_column.property().collection),
-                        @"Invalid predicate", @"Collection operation can only be applied to a property of type RLMArray / RLMSet.");
-
-        switch (m_type) {
-            case Count:
-                RLMPrecondition(!m_column, @"Invalid predicate", @"Result of @count does not have any properties.");
-                break;
-            case Minimum:
-            case Maximum:
-            case Sum:
-            case Average: {
-                if (!m_link_column.is_link()) {
-                    m_column = m_link_column;
-                }
-                RLMPrecondition(m_column && propertyTypeIsNumeric(m_column->type()), @"Invalid predicate",
-                                @"%@ can only be applied to a numeric property.", name_for_type(m_type));
-                break;
-            case AllKeys:
-            case AllValues:
-                bool valid = m_link_column.property().dictionary;
-                RLMPrecondition(valid, @"Invalid operand",
-                                @"%@ is only valid for dictionary", name_for_type(m_type));
-                return;
-            }
-        }
-    }
-
-    CollectionOperation(NSString *operationName, ColumnReference link_column,
-                        util::Optional<ColumnReference> column = util::none)
-        : CollectionOperation(type_for_name(operationName), std::move(link_column), std::move(column))
-    {
+        REALM_ASSERT(m_type != None);
     }
 
     Type type() const { return m_type; }
     const ColumnReference& link_column() const { return m_link_column; }
-    const ColumnReference& column() const { return *m_column; }
+    const ColumnReference& column() const { return m_column; }
 
     void validate_comparison(id value) const {
         bool valid = true;
@@ -418,22 +377,21 @@ public:
             case Minimum:
             case Maximum:
                 // Null on min/max/average matches arrays with no non-null values, including on non-nullable types
-                valid = isNSNull(value) || isObjectValidForProperty(value, m_column->property());
+                valid = isNSNull(value) || isObjectValidForProperty(value, m_column.property());
                 break;
             case Sum:
                 // Sums are never null
-                valid = !isNSNull(value) && isObjectValidForProperty(value, m_column->property());
+                valid = !isNSNull(value) && isObjectValidForProperty(value, m_column.property());
                 break;
             case AllKeys:
-            case AllValues:
-                valid = link_column().property().dictionary;
-                RLMPrecondition(valid, @"Invalid operand",
-                                @"%@ is only valid for dictionary", name_for_type(m_type));
+                RLMPrecondition(isNSNull(value) || [value isKindOfClass:[NSString class]], @"Invalid operand",
+                                @"@allKeys can only be compared with a string value.");
                 return;
+            case None: break;
         }
         RLMPrecondition(valid, @"Invalid operand",
                         @"%@ on a property of type %@ cannot be compared with '%@'",
-                        name_for_type(m_type), RLMTypeToString(m_column->type()), value);
+                        name_for_type(m_type), RLMTypeToString(m_column.type()), value);
     }
 
     void validate_comparison(const ColumnReference& column) const {
@@ -442,24 +400,19 @@ public:
                 RLMPrecondition(propertyTypeIsNumeric(column.type()), @"Invalid operand",
                                 @"%@ can only be compared with a numeric value.", name_for_type(m_type));
                 break;
-            case Average:
-            case Minimum:
-            case Maximum:
-            case Sum:
+            case Average: case Minimum: case Maximum: case Sum:
                 RLMPrecondition(propertyTypeIsNumeric(column.type()), @"Invalid operand",
                                 @"%@ on a property of type %@ cannot be compared with property of type '%@'",
-                                name_for_type(m_type), RLMTypeToString(m_column->type()), RLMTypeToString(column.type()));
+                                name_for_type(m_type), RLMTypeToString(m_column.type()), RLMTypeToString(column.type()));
                 break;
             case AllKeys:
-            case AllValues:
-                bool valid = link_column().property().dictionary;
-                RLMPrecondition(valid, @"Invalid operand",
-                                @"%@ is only valid for dictionary", name_for_type(m_type));
-                return;
+                RLMPrecondition(column.type() == RLMPropertyTypeString, @"Invalid operand",
+                                @"@allKeys can only be compared with a string value.");
+                break;
+            case None: break;
         }
     }
 
-private:
     static Type type_for_name(NSString *name) {
         if ([name isEqualToString:@"@count"]) {
             return Count;
@@ -479,12 +432,10 @@ private:
         if ([name isEqualToString:@"@allKeys"]) {
             return AllKeys;
         }
-        if ([name isEqualToString:@"@allValues"]) {
-            return AllValues;
-        }
-        throwException(@"Invalid predicate", @"Unsupported collection operation '%@'", name);
+        return None;
     }
 
+private:
     static NSString *name_for_type(Type type) {
         switch (type) {
             case Count: return @"@count";
@@ -493,14 +444,16 @@ private:
             case Sum: return @"@sum";
             case Average: return @"@avg";
             case AllKeys: return @"@allKeys";
-            case AllValues: return @"@allValues";
+            case None: REALM_UNREACHABLE();
         }
     }
 
     Type m_type;
     ColumnReference m_link_column;
-    util::Optional<ColumnReference> m_column;
+    ColumnReference m_column;
 };
+
+struct KeyPath;
 
 class QueryBuilder {
 public:
@@ -510,9 +463,9 @@ public:
     void apply_predicate(NSPredicate *predicate, RLMObjectSchema *objectSchema);
 
 
-    void apply_collection_operator_expression(RLMObjectSchema *desc, NSString *keyPath, id value, NSComparisonPredicate *pred);
-    void apply_value_expression(RLMObjectSchema *desc, NSString *keyPath, id value, NSComparisonPredicate *pred);
-    void apply_column_expression(RLMObjectSchema *desc, NSString *leftKeyPath, NSString *rightKeyPath, NSComparisonPredicate *predicate);
+    void apply_collection_operator_expression(KeyPath&& kp, id value, NSComparisonPredicate *pred);
+    void apply_value_expression(KeyPath&& kp, id value, NSComparisonPredicate *pred);
+    void apply_column_expression(KeyPath&& left, KeyPath&& right, NSComparisonPredicate *predicate);
     void apply_function_expression(RLMObjectSchema *objectSchema, NSExpression *functionExpression,
                                    NSPredicateOperatorType operatorType, NSExpression *right);
     void apply_map_expression(RLMObjectSchema *objectSchema, NSExpression *functionExpression,
@@ -530,20 +483,17 @@ public:
     template <typename C, typename T>
     void add_mixed_constraint(NSPredicateOperatorType operatorType,
                               NSComparisonPredicateOptions predicateOptions,
-                              Columns<C>&& column,
-                              T value);
+                              Columns<C>&& column, T value);
 
     template <typename C>
     void add_mixed_constraint(NSPredicateOperatorType operatorType,
                               NSComparisonPredicateOptions predicateOptions,
-                              Columns<C>&& column,
-                              const ColumnReference& c);
+                              Columns<C>&& column, const ColumnReference& c);
 
     template <typename C>
     void do_add_mixed_constraint(NSPredicateOperatorType operatorType,
                                  NSComparisonPredicateOptions predicateOptions,
-                                 Columns<C>&& column,
-                                 Mixed&& value);
+                                 Columns<C>&& column, Mixed&& value);
 
     template<typename T>
     void add_substring_constraint(const T& value, Query condition);
@@ -553,19 +503,16 @@ public:
     template <typename C, typename T>
     void add_string_constraint(NSPredicateOperatorType operatorType,
                                NSComparisonPredicateOptions predicateOptions,
-                               C&& column,
-                               T value);
+                               C&& column, T&& value);
 
     template <typename C, typename T>
     void add_diacritic_sensitive_string_constraint(NSPredicateOperatorType operatorType,
                                                    NSComparisonPredicateOptions predicateOptions,
-                                                   C&& column,
-                                                   T value);
+                                                   C&& column, T&& value);
     template <typename C, typename T>
     void do_add_diacritic_sensitive_string_constraint(NSPredicateOperatorType operatorType,
                                                       NSComparisonPredicateOptions predicateOptions,
-                                                      C&& column,
-                                                      T value);
+                                                      C&& column, T&& value);
 
     template <typename R>
     void add_constraint(NSPredicateOperatorType operatorType,
@@ -575,36 +522,29 @@ public:
     void do_add_constraint(RLMPropertyType type, NSPredicateOperatorType operatorType,
                            NSComparisonPredicateOptions predicateOptions, ColumnReference const& column, T&& value);
 
-    template <typename T>
-    void add_dictionary_constraint(RLMPropertyType type, NSPredicateOperatorType operatorType,
-                                   NSComparisonPredicateOptions predicateOptions, ColumnReference const& column, T&& value);
-
     void add_between_constraint(const ColumnReference& column, id value);
 
-    void add_link_constraint(NSPredicateOperatorType operatorType, const Columns<Link>& column, RLMObjectBase *obj);
-    void add_link_constraint(NSPredicateOperatorType operatorType, const Columns<Link>& column, realm::null);
-    void add_link_constraint(NSPredicateOperatorType, const Columns<Link>&, const ColumnReference&);
+    void add_link_constraint(NSPredicateOperatorType operatorType, const ColumnReference& column, RLMObjectBase *obj);
+    void add_link_constraint(NSPredicateOperatorType operatorType, const ColumnReference& column, realm::null);
+    void add_link_constraint(NSPredicateOperatorType, const ColumnReference&, const ColumnReference&);
 
-    void add_link_constraint(NSPredicateOperatorType operatorType, Columns<Dictionary>& column, RLMObjectBase *obj);
-    void add_link_constraint(NSPredicateOperatorType operatorType, Columns<Dictionary>& column, realm::null);
-    void add_link_constraint(NSPredicateOperatorType, Columns<Dictionary>&, const ColumnReference&);
-
-    template <CollectionOperation::Type Operation, bool IsLinkCollection, typename R>
+    template <CollectionOperation::Type Operation, bool IsLinkCollection, bool IsDictionary, typename R>
     void add_collection_operation_constraint(NSPredicateOperatorType operatorType,
-                                             const CollectionOperation& collectionOperation, R rhs,
-                                             NSComparisonPredicateOptions comparisionOptions=0);
+                                             const CollectionOperation& collectionOperation, R&& rhs,
+                                             NSComparisonPredicateOptions comparisionOptions);
     template <CollectionOperation::Type Operation, typename R>
     void add_collection_operation_constraint(NSPredicateOperatorType operatorType,
-                                             const CollectionOperation& collectionOperation, R rhs,
-                                             NSComparisonPredicateOptions comparisionOptions=0);
+                                             const CollectionOperation& collectionOperation, R&& rhs,
+                                             NSComparisonPredicateOptions comparisionOptions);
     template <typename R>
     void add_collection_operation_constraint(NSPredicateOperatorType operatorType,
-                                             const CollectionOperation& collectionOperation, R rhs,
-                                             NSComparisonPredicateOptions comparisionOptions=0);
+                                             const CollectionOperation& collectionOperation, R&& rhs,
+                                             NSComparisonPredicateOptions comparisionOptions);
 
 
-    CollectionOperation collection_operation_from_key_path(RLMObjectSchema *desc, NSString *keyPath);
-    ColumnReference column_reference_from_key_path(RLMObjectSchema *objectSchema, NSString *keyPath, bool isAggregate);
+    CollectionOperation collection_operation_from_key_path(KeyPath&& kp);
+    ColumnReference column_reference_from_key_path(KeyPath&& kp, bool isAggregate);
+
 
 private:
     Query& m_query;
@@ -722,8 +662,7 @@ Query make_diacritic_insensitive_constraint(NSPredicateOperatorType operatorType
 template <typename C, typename T>
 void QueryBuilder::do_add_diacritic_sensitive_string_constraint(NSPredicateOperatorType operatorType,
                                                                 NSComparisonPredicateOptions predicateOptions,
-                                                                C&& column,
-                                                                T value) {
+                                                                C&& column, T&& value) {
     bool caseSensitive = !(predicateOptions & NSCaseInsensitivePredicateOption);
     switch (operatorType) {
         case NSBeginsWithPredicateOperatorType:
@@ -769,8 +708,7 @@ void QueryBuilder::do_add_diacritic_sensitive_string_constraint(NSPredicateOpera
 template <typename C, typename T>
 void QueryBuilder::add_diacritic_sensitive_string_constraint(NSPredicateOperatorType operatorType,
                                                              NSComparisonPredicateOptions predicateOptions,
-                                                             C&& column,
-                                                             T value) {
+                                                             C&& column, T&& value) {
     if constexpr (is_any_v<C, Columns<Dictionary>>) {
         // This nesting isnt pretty but without it the compiler will complain about `T` having no known
         // conversion from Columns<StringData> to Mixed. This is due to the fact that all values on a
@@ -787,25 +725,15 @@ void QueryBuilder::add_diacritic_sensitive_string_constraint(NSPredicateOperator
 template <typename C, typename T>
 void QueryBuilder::add_string_constraint(NSPredicateOperatorType operatorType,
                                          NSComparisonPredicateOptions predicateOptions,
-                                         C&& column,
-                                         T value) {
+                                         C&& column, T&& value) {
     if (!(predicateOptions & NSDiacriticInsensitivePredicateOption)) {
-        add_diacritic_sensitive_string_constraint(operatorType, predicateOptions, std::forward<C>(column), value);
+        add_diacritic_sensitive_string_constraint(operatorType, predicateOptions, std::forward<C>(column), std::move(value));
         return;
     }
 
     auto as_subexpr = util::overload{
         [](StringData value) { return make_subexpr<ConstantStringValue>(value); },
-        [](const Columns<String>& c) { return c.clone(); },
-        [](const Columns<Lst<String>>& c) { return c.clone(); },
-        [](const Columns<Set<String>>& c) { return c.clone(); },
         [](BinaryData value) { return make_subexpr<ConstantStringValue>(StringData(value.data(), value.size())); },
-        [](const Columns<BinaryData>& c) { return c.clone(); },
-        [](const Columns<Lst<BinaryData>>& c) { return c.clone(); },
-        [](const Columns<Set<BinaryData>>& c) { return c.clone(); },
-        [](const Columns<Mixed>& c) { return c.clone(); },
-        [](const Columns<Lst<Mixed>>& c) { return c.clone(); },
-        [](const Columns<Set<Mixed>>& c) { return c.clone(); },
         [](Mixed value) {
             // When Mixed is null calling `get_type` will throw an exception.
             if (value.is_null())
@@ -819,8 +747,7 @@ void QueryBuilder::add_string_constraint(NSPredicateOperatorType operatorType,
                     REALM_UNREACHABLE();
             }
         },
-        [](const Columns<Dictionary>& c) { return c.clone(); },
-        [](const ColumnDictionaryKeys& c) { return c.clone(); }
+        [](auto& c) { return c.clone(); }
     };
     auto left = as_subexpr(column);
     auto right = as_subexpr(value);
@@ -897,14 +824,14 @@ void QueryBuilder::add_between_constraint(const ColumnReference& column, id valu
 #pragma mark Link Constraints
 
 void QueryBuilder::add_link_constraint(NSPredicateOperatorType operatorType,
-                                       const Columns<Link>& column, RLMObjectBase *obj) {
+                                       const ColumnReference& column, RLMObjectBase *obj) {
     if (!obj->_row.is_valid()) {
         // Unmanaged or deleted objects are not equal to any managed objects.
         // For arrays this effectively checks if there are any objects in the
         // array, while for links it's just always constant true or false
         // (for != and = respectively).
-        if (!column.link_map().only_unary_links()) {
-            add_bool_constraint(RLMPropertyTypeObject, operatorType, column, null());
+        if (column.has_any_to_many_links() || column.property().collection) {
+            add_link_constraint(operatorType, column, null());
         }
         else if (operatorType == NSEqualToPredicateOperatorType) {
             m_query.and_query(std::unique_ptr<Expression>(new FalseExpression));
@@ -914,50 +841,33 @@ void QueryBuilder::add_link_constraint(NSPredicateOperatorType operatorType,
         }
     }
     else {
-        add_bool_constraint(RLMPropertyTypeObject, operatorType, column, obj->_row);
+        if (column.property().dictionary) {
+            add_bool_constraint(RLMPropertyTypeObject, operatorType, column.resolve<Dictionary>(), obj->_row);
+        }
+        else {
+            add_bool_constraint(RLMPropertyTypeObject, operatorType, column.resolve<Link>(), obj->_row);
+        }
     }
 }
 
 void QueryBuilder::add_link_constraint(NSPredicateOperatorType operatorType,
-                                       const Columns<Link>& column,
-                                       realm::null) {
-    add_bool_constraint(RLMPropertyTypeObject, operatorType, column, null());
-}
-
-void QueryBuilder::add_link_constraint(NSPredicateOperatorType operatorType,
-                                       const Columns<Link>& a, const ColumnReference& b) {
-    add_bool_constraint(RLMPropertyTypeObject, operatorType, a, b.resolve<Link>());
-}
-
-void QueryBuilder::add_link_constraint(NSPredicateOperatorType operatorType,
-                                       Columns<Dictionary>& column, RLMObjectBase *obj) {
-    switch (operatorType) {
-        case NSEqualToPredicateOperatorType:
-            if (!obj->_row.is_valid())
-                m_query.and_query(std::unique_ptr<Expression>(new FalseExpression));
-            else
-                m_query.and_query(column == obj->_row);
-            break;
-        case NSNotEqualToPredicateOperatorType:
-            if (!obj->_row.is_valid())
-                m_query.and_query(std::unique_ptr<Expression>(new TrueExpression));
-            else
-                m_query.and_query(column != obj->_row);
-            break;
-        default:
-            unsupportedOperator(RLMPropertyTypeObject, operatorType);
+                                       const ColumnReference& column, realm::null) {
+    if (column.property().dictionary) {
+        add_bool_constraint(RLMPropertyTypeObject, operatorType, column.resolve<Dictionary>(), null());
+    }
+    else {
+        add_bool_constraint(RLMPropertyTypeObject, operatorType, column.resolve<Link>(), null());
     }
 }
 
 void QueryBuilder::add_link_constraint(NSPredicateOperatorType operatorType,
-                                       Columns<Dictionary>& column,
-                                       realm::null) {
-    add_bool_constraint(RLMPropertyTypeObject, operatorType, column, null());
-}
-
-void QueryBuilder::add_link_constraint(NSPredicateOperatorType operatorType,
-                                       Columns<Dictionary>& a, const ColumnReference& b) {
-    add_bool_constraint(RLMPropertyTypeObject, operatorType, a, b.resolve<Dictionary>());
+                                       const ColumnReference& a, const ColumnReference& b) {
+    if (a.property().dictionary) {
+        add_bool_constraint(RLMPropertyTypeObject, operatorType, a.resolve<Dictionary>(), b.resolve<Dictionary>());
+    }
+    else {
+        add_bool_constraint(RLMPropertyTypeObject, operatorType, a.resolve<Link>(), b.resolve<Link>());
+    }
 }
 
 // iterate over an array of subpredicates, using @func to build a query from each
@@ -1021,90 +931,9 @@ void convert_null(T&& value, Fn&& fn) {
     }
 }
 
-template <typename T>
-void QueryBuilder::add_dictionary_constraint(RLMPropertyType type, NSPredicateOperatorType operatorType,
-                                             NSComparisonPredicateOptions predicateOptions, ColumnReference const& column, T&& value)
-{
-    switch (type) {
-        case RLMPropertyTypeBool:
-            convert_null(value, [&](auto&& value) {
-                add_bool_constraint(type, operatorType, column.resolve<Dictionary>(),
-                                    value_of_type<bool>(value));
-            });
-            break;
-        case RLMPropertyTypeObjectId:
-            convert_null(value, [&](auto&& value) {
-                add_bool_constraint(type, operatorType, column.resolve<Dictionary>(),
-                                    value_of_type<ObjectId>(value));
-            });
-            break;
-        case RLMPropertyTypeDate:
-            convert_null(value, [&](auto&& value) {
-                add_numeric_constraint(type, operatorType, column.resolve<Dictionary>(),
-                                       value_of_type<Timestamp>(value));
-            });
-            break;
-        case RLMPropertyTypeDouble:
-            convert_null(value, [&](auto&& value) {
-                add_numeric_constraint(type, operatorType, column.resolve<Dictionary>(),
-                                       value_of_type<Double>(value));
-            });
-            break;
-        case RLMPropertyTypeFloat:
-            convert_null(value, [&](auto&& value) {
-                add_numeric_constraint(type, operatorType, column.resolve<Dictionary>(),
-                                       value_of_type<Float>(value));
-            });
-            break;
-        case RLMPropertyTypeInt:
-            convert_null(value, [&](auto&& value) {
-                add_numeric_constraint(type, operatorType, column.resolve<Dictionary>(),
-                                       value_of_type<Int>(value));
-            });
-            break;
-        case RLMPropertyTypeDecimal128:
-            convert_null(value, [&](auto&& value) {
-                add_numeric_constraint(type, operatorType, column.resolve<Dictionary>(),
-                                       value_of_type<Decimal128>(value));
-            });
-            break;
-        case RLMPropertyTypeString:
-            add_string_constraint(operatorType, predicateOptions, column.resolve<Dictionary>(),
-                                  value_of_type<String>(value));
-            break;
-        case RLMPropertyTypeData:
-            add_string_constraint(operatorType, predicateOptions,
-                                  column.resolve<Dictionary>(),
-                                  value_of_type<Binary>(value));
-            break;
-        case RLMPropertyTypeObject:
-        case RLMPropertyTypeLinkingObjects:
-            convert_null(value, [&](auto&& value) {
-                // pass without const because it looks like core does not support
-                // comparision queries on a 'const& Columns<Dictionary>' type.
-                auto col = column.resolve<Dictionary>();
-                add_link_constraint(operatorType, col, value);
-            });
-            break;
-        case RLMPropertyTypeUUID:
-            convert_null(value, [&](auto&& value) {
-                add_bool_constraint(type, operatorType, column.resolve<Dictionary>(),
-                                    value_of_type<UUID>(value));
-            });
-            break;
-        case RLMPropertyTypeAny:
-            convert_null(value, [&](auto&& value) {
-                add_mixed_constraint(operatorType,
-                                     predicateOptions,
-                                     column.resolve<Dictionary>(),
-                                     value);
-            });
-    }
-}
-
 template <template<typename> typename W, typename T>
 void QueryBuilder::do_add_constraint(RLMPropertyType type, NSPredicateOperatorType operatorType,
-                       NSComparisonPredicateOptions predicateOptions, ColumnReference const& column, T&& value)
+                                     NSComparisonPredicateOptions predicateOptions, ColumnReference const& column, T&& value)
 {
     switch (type) {
         case RLMPropertyTypeBool:
@@ -1161,7 +990,7 @@ void QueryBuilder::do_add_constraint(RLMPropertyType type, NSPredicateOperatorTy
         case RLMPropertyTypeObject:
         case RLMPropertyTypeLinkingObjects:
             convert_null(value, [&](auto&& value) {
-                add_link_constraint(operatorType, column.resolve<Link>(), value);
+                add_link_constraint(operatorType, column, value);
             });
             break;
         case RLMPropertyTypeUUID:
@@ -1252,6 +1081,8 @@ void QueryBuilder::add_mixed_constraint(NSPredicateOperatorType operatorType,
 
 template<typename T>
 using Identity = T;
+template<typename>
+using AlwaysDictionary = Dictionary;
 
 template <typename R>
 void QueryBuilder::add_constraint(NSPredicateOperatorType operatorType,
@@ -1265,7 +1096,7 @@ void QueryBuilder::add_constraint(NSPredicateOperatorType operatorType,
         do_add_constraint<Set>(type, operatorType, predicateOptions, column, rhs);
     }
     else if (column.property().dictionary) {
-        add_dictionary_constraint(type, operatorType, predicateOptions, column, rhs);
+        do_add_constraint<AlwaysDictionary>(type, operatorType, predicateOptions, column, rhs);
     }
     else {
         do_add_constraint<Identity>(type, operatorType, predicateOptions, column, rhs);
@@ -1275,6 +1106,7 @@ void QueryBuilder::add_constraint(NSPredicateOperatorType operatorType,
 struct KeyPath {
     std::vector<RLMProperty *> links;
     RLMProperty *property;
+    CollectionOperation::Type collectionOperation;
     bool containsToManyRelationship;
 };
 
@@ -1283,65 +1115,103 @@ KeyPath key_path_from_string(RLMSchema *schema, RLMObjectSchema *objectSchema, N
     RLMProperty *property;
     std::vector<RLMProperty *> links;
 
+    CollectionOperation::Type collectionOperation = CollectionOperation::None;
+    NSString *collectionOperationName;
     bool keyPathContainsToManyRelationship = false;
 
-    NSUInteger start = 0, length = keyPath.length, end = NSNotFound;
-    do {
+    NSUInteger start = 0, length = keyPath.length, end = length;
+    for (; end != NSNotFound; start = end + 1) {
         end = [keyPath rangeOfString:@"." options:0 range:{start, length - start}].location;
+        RLMPrecondition(end == NSNotFound || end + 1 < length, @"Invalid predicate",
+                        @"Invalid keypath '%@': no key name after last '.'", keyPath);
+        RLMPrecondition(end > start, @"Invalid predicate",
+                        @"Invalid keypath '%@': no key name before '.'", keyPath);
+
         NSString *propertyName = [keyPath substringWithRange:{start, end == NSNotFound ? length - start : end - start}];
+
+        if ([propertyName characterAtIndex:0] == '@') {
+            if ([propertyName isEqualToString:@"@allValues"]) {
+                RLMPrecondition(property.dictionary, @"Invalid predicate",
+                                @"Invalid keypath '%@': @allValues must follow a dictionary property.", keyPath);
+                continue;
+            }
+            RLMPrecondition(collectionOperation == CollectionOperation::None, @"Invalid predicate",
+                            @"Invalid keypath '%@': at most one collection operation per keypath is supported.", keyPath);
+            collectionOperation = CollectionOperation::type_for_name(propertyName);
+            RLMPrecondition(collectionOperation != CollectionOperation::None, @"Invalid predicate",
+                            @"Invalid keypath '%@': Unsupported collection operation '%@'", keyPath, propertyName);
+
+            RLMPrecondition(property.collection, @"Invalid predicate",
+                            @"Invalid keypath '%@': collection operation '%@' must be applied to a collection", keyPath, propertyName);
+            switch (collectionOperation) {
+                case CollectionOperation::None:
+                    REALM_UNREACHABLE();
+                case CollectionOperation::Count:
+                    RLMPrecondition(end == NSNotFound, @"Invalid predicate",
+                                    @"Invalid keypath '%@': @count must appear at the end of a keypath.", keyPath);
+                    break;
+                case CollectionOperation::AllKeys:
+                    RLMPrecondition(end == NSNotFound, @"Invalid predicate",
+                                    @"Invalid keypath '%@': @allKeys must appear at the end of a keypath.", keyPath);
+                    RLMPrecondition(property.dictionary, @"Invalid predicate",
+                                    @"Invalid keypath '%@': @allKeys must follow a dictionary property.", keyPath);
+                    break;
+                default:
+                    if (propertyTypeIsLink(property.type)) {
+                        RLMPrecondition(end != NSNotFound, @"Invalid predicate",
+                                        @"Invalid keypath '%@': %@ on a collection of objects cannot appear at the end of a keypath.", keyPath, propertyName);
+                    }
+                    else {
+                        RLMPrecondition(end == NSNotFound, @"Invalid predicate",
+                                        @"Invalid keypath '%@': %@ on a collection of values must appear at the end of a keypath.", keyPath, propertyName);
+                        RLMPrecondition(propertyTypeIsNumeric(property.type), @"Invalid predicate",
+                                        @"Invalid keypath '%@': %@ can only be applied to a collection of numeric values.", keyPath, propertyName);
+                    }
+            }
+            collectionOperationName = propertyName;
+            continue;
+        }
+
+        RLMPrecondition(objectSchema, @"Invalid predicate",
+                        @"Invalid keypath '%@': %@ property %@ can only be followed by a collection operation.",
+                        keyPath, property.typeName, property.name);
+
         property = objectSchema[propertyName];
-        RLMPrecondition(property, @"Invalid property name",
-                        @"Property '%@' not found in object of type '%@'",
-                        propertyName, objectSchema.className);
+        RLMPrecondition(property, @"Invalid predicate",
+                        @"Invalid keypath '%@': Property '%@' not found in object of type '%@'",
+                        keyPath, propertyName, objectSchema.className);
+        RLMPrecondition(collectionOperation == CollectionOperation::None || (propertyTypeIsNumeric(property.type) && !property.collection),
+                        @"Invalid predicate",
+                        @"Invalid keypath '%@': %@ must be followed by a numeric property.", keyPath, collectionOperationName);
 
         if (property.collection)
             keyPathContainsToManyRelationship = true;
 
+        links.push_back(property);
+
         if (end != NSNotFound) {
-            RLMPrecondition(property.type == RLMPropertyTypeObject || property.type == RLMPropertyTypeLinkingObjects,
-                            @"Invalid value", @"Property '%@' is not a link in object of type '%@'",
-                            propertyName, objectSchema.className);
-
-            links.push_back(property);
-            REALM_ASSERT(property.objectClassName);
-            objectSchema = schema[property.objectClassName];
+            RLMPrecondition(property.type == RLMPropertyTypeObject || property.type == RLMPropertyTypeLinkingObjects || property.collection,
+                            @"Invalid predicate", @"Invalid keypath '%@': Property '%@.%@' is not a link or collection and can only appear at the end of a keypath.",
+                            keyPath, objectSchema.className, propertyName);
+            objectSchema = property.objectClassName ? schema[property.objectClassName] : nil;
         }
+    };
 
-        start = end + 1;
-    } while (end != NSNotFound);
-
-    return {std::move(links), property, keyPathContainsToManyRelationship};
+    links.pop_back();
+    return {std::move(links), property, collectionOperation, keyPathContainsToManyRelationship};
 }
 
-ColumnReference QueryBuilder::column_reference_from_key_path(RLMObjectSchema *objectSchema,
-                                                             NSString *keyPathString, bool isAggregate)
+ColumnReference QueryBuilder::column_reference_from_key_path(KeyPath&& kp, bool isAggregate)
 {
-    auto keyPath = key_path_from_string(m_schema, objectSchema, keyPathString);
-
-    if (isAggregate && !keyPath.containsToManyRelationship) {
+    if (isAggregate && !kp.containsToManyRelationship) {
         throwException(@"Invalid predicate",
                        @"Aggregate operations can only be used on key paths that include an collection property");
-    } else if (!isAggregate && keyPath.containsToManyRelationship) {
+    } else if (!isAggregate && kp.containsToManyRelationship) {
         throwException(@"Invalid predicate",
                        @"Key paths that include a collection property must use aggregate operations");
     }
 
-    return ColumnReference(m_query, m_group, m_schema, keyPath.property, std::move(keyPath.links));
-}
-
-void validate_property_value(const ColumnReference& column,
-                             __unsafe_unretained id const value,
-                             __unsafe_unretained NSString *const err,
-                             __unsafe_unretained RLMObjectSchema *const objectSchema,
-                             __unsafe_unretained NSString *const keyPath) {
-    RLMProperty *prop = column.property();
-    RLMPrecondition(isObjectValidForProperty(value, prop),
-                    @"Invalid value", err, prop.objectClassName ?: RLMTypeToString(prop.type),
-                    keyPath, objectSchema.className, value);
-    if (RLMObjectBase *obj = RLMDynamicCast<RLMObjectBase>(value)) {
-        RLMPrecondition(!obj->_row.is_valid() || &column.group() == &obj->_realm.group,
-                        @"Invalid value origin", @"Object must be from the Realm being queried");
-    }
+    return ColumnReference(m_query, m_group, m_schema, kp.property, std::move(kp.links));
 }
 
 #pragma mark Collection Operations
@@ -1370,7 +1240,7 @@ auto collection_operation_expr_2(Column&& column) {
     }
 }
 
-template <typename Requested, CollectionOperation::Type OperationType, bool IsLinkCollection, bool IsDictionary=false>
+template <typename Requested, CollectionOperation::Type OperationType, bool IsLinkCollection, bool IsDictionary>
 auto collection_operation_expr(CollectionOperation operation) {
     REALM_ASSERT(operation.type() == OperationType);
 
@@ -1379,118 +1249,77 @@ auto collection_operation_expr(CollectionOperation operation) {
         auto col = operation.column().column();
         return collection_operation_expr_2<OperationType>(resolved.template column<Requested>(col));
     }
+    else if constexpr (IsDictionary) {
+        return collection_operation_expr_2<OperationType>(operation.link_column().resolve<Dictionary>());
+    }
     else {
-        if constexpr (IsDictionary)
-            return collection_operation_expr_2<OperationType>(operation.link_column().resolve<Dictionary>());
-        else
-            return collection_operation_expr_2<OperationType>(operation.link_column().resolve<Lst<Requested>>());
+        return collection_operation_expr_2<OperationType>(operation.link_column().resolve<Lst<Requested>>());
     }
 }
 
-template <CollectionOperation::Type Operation, bool IsLinkCollection, typename R>
+template <CollectionOperation::Type Operation, bool IsLinkCollection, bool IsDictionary, typename R>
 void QueryBuilder::add_collection_operation_constraint(NSPredicateOperatorType operatorType,
-                                                       CollectionOperation const& collectionOperation, R rhs,
+                                                       CollectionOperation const& collectionOperation, R&& rhs,
                                                        NSComparisonPredicateOptions)
 {
     auto type = IsLinkCollection ? collectionOperation.column().type() : collectionOperation.link_column().type();
 
-    if (collectionOperation.column().property().dictionary) {
-        switch (type) {
-            case RLMPropertyTypeInt:
+    switch (type) {
+        case RLMPropertyTypeInt:
+            add_numeric_constraint(type, operatorType,
+                                   collection_operation_expr<Int, Operation, IsLinkCollection, IsDictionary>(collectionOperation),
+                                   value_of_type<Int>(rhs));
+            break;
+        case RLMPropertyTypeFloat:
+            add_numeric_constraint(type, operatorType,
+                                   collection_operation_expr<Float, Operation, IsLinkCollection, IsDictionary>(collectionOperation),
+                                   value_of_type<Float>(rhs));
+            break;
+        case RLMPropertyTypeDouble:
+            add_numeric_constraint(type, operatorType,
+                                   collection_operation_expr<Double, Operation, IsLinkCollection, IsDictionary>(collectionOperation),
+                                   value_of_type<Double>(rhs));
+            break;
+        case RLMPropertyTypeDecimal128:
+            add_numeric_constraint(type, operatorType,
+                                   collection_operation_expr<Decimal128, Operation, IsLinkCollection, IsDictionary>(collectionOperation),
+                                   value_of_type<Decimal128>(rhs));
+            break;
+        case RLMPropertyTypeDate:
+            if constexpr (Operation == CollectionOperation::Sum || Operation == CollectionOperation::Average) {
+                throwException(@"Unsupported predicate value type",
+                               @"Cannot sum or average date properties");
+            }
+            else {
                 add_numeric_constraint(type, operatorType,
-                                       collection_operation_expr<Int, Operation, IsLinkCollection, true>(collectionOperation),
-                                       value_of_type<Int>(rhs));
-                break;
-            case RLMPropertyTypeFloat:
-                add_numeric_constraint(type, operatorType,
-                                       collection_operation_expr<Float, Operation, IsLinkCollection, true>(collectionOperation),
-                                       value_of_type<Float>(rhs));
-                break;
-            case RLMPropertyTypeDouble:
-                add_numeric_constraint(type, operatorType,
-                                       collection_operation_expr<Double, Operation, IsLinkCollection, true>(collectionOperation),
-                                       value_of_type<Double>(rhs));
-                break;
-            case RLMPropertyTypeDecimal128:
-                add_numeric_constraint(type, operatorType,
-                                       collection_operation_expr<Decimal128, Operation, IsLinkCollection, true>(collectionOperation),
-                                       value_of_type<Decimal128>(rhs));
-                break;
-            case RLMPropertyTypeDate:
-                if constexpr (Operation == CollectionOperation::Sum || Operation == CollectionOperation::Average) {
-                    throwException(@"Unsupported predicate value type",
-                                   @"Cannot sum or average date properties");
-                }
-                else {
-                    add_numeric_constraint(type, operatorType,
-                                           collection_operation_expr<Timestamp, Operation, IsLinkCollection, true>(collectionOperation),
-                                           value_of_type<Timestamp>(rhs));
-                }
-                break;
-            case RLMPropertyTypeAny:
-                add_numeric_constraint(type, operatorType,
-                                       collection_operation_expr<Mixed, Operation, IsLinkCollection, true>(collectionOperation),
-                                       value_of_type<Mixed>(rhs));
-                break;
-            default:
-                REALM_ASSERT(false && "Only numeric property types should hit this path.");
-        }
-    }
-    else {
-        switch (type) {
-            case RLMPropertyTypeInt:
-                add_numeric_constraint(type, operatorType,
-                                       collection_operation_expr<Int, Operation, IsLinkCollection>(collectionOperation),
-                                       value_of_type<Int>(rhs));
-                break;
-            case RLMPropertyTypeFloat:
-                add_numeric_constraint(type, operatorType,
-                                       collection_operation_expr<Float, Operation, IsLinkCollection>(collectionOperation),
-                                       value_of_type<Float>(rhs));
-                break;
-            case RLMPropertyTypeDouble:
-                add_numeric_constraint(type, operatorType,
-                                       collection_operation_expr<Double, Operation, IsLinkCollection>(collectionOperation),
-                                       value_of_type<Double>(rhs));
-                break;
-            case RLMPropertyTypeDecimal128:
-                add_numeric_constraint(type, operatorType,
-                                       collection_operation_expr<Decimal128, Operation, IsLinkCollection>(collectionOperation),
-                                       value_of_type<Decimal128>(rhs));
-                break;
-            case RLMPropertyTypeDate:
-                if constexpr (Operation == CollectionOperation::Sum || Operation == CollectionOperation::Average) {
-                    throwException(@"Unsupported predicate value type",
-                                   @"Cannot sum or average date properties");
-                }
-                else {
-                    add_numeric_constraint(type, operatorType,
-                                           collection_operation_expr<Timestamp, Operation, IsLinkCollection>(collectionOperation),
-                                           value_of_type<Timestamp>(rhs));
-                }
-                break;
-            case RLMPropertyTypeAny:
-                add_numeric_constraint(type, operatorType,
-                                       collection_operation_expr<Mixed, Operation, IsLinkCollection>(collectionOperation),
-                                       value_of_type<Mixed>(rhs));
-                break;
-            default:
-                REALM_ASSERT(false && "Only numeric property types should hit this path.");
-        }
+                                       collection_operation_expr<Timestamp, Operation, IsLinkCollection, IsDictionary>(collectionOperation),
+                                       value_of_type<Timestamp>(rhs));
+            }
+            break;
+        case RLMPropertyTypeAny:
+            add_numeric_constraint(type, operatorType,
+                                   collection_operation_expr<Mixed, Operation, IsLinkCollection, IsDictionary>(collectionOperation),
+                                   value_of_type<Mixed>(rhs));
+            break;
+        default:
+            REALM_ASSERT(false && "Only numeric property types should hit this path.");
     }
 }
 
 template <CollectionOperation::Type Operation, typename R>
 void QueryBuilder::add_collection_operation_constraint(NSPredicateOperatorType operatorType,
-                                                       CollectionOperation const& collectionOperation, R rhs,
-                                                       NSComparisonPredicateOptions)
+                                                       CollectionOperation const& collectionOperation, R&& rhs,
+                                                       NSComparisonPredicateOptions options)
 {
     convert_null(rhs, [&](auto&& rhs) {
         if (collectionOperation.link_column().is_link()) {
-            add_collection_operation_constraint<Operation, true>(operatorType, collectionOperation, rhs);
+            add_collection_operation_constraint<Operation, true, false>(operatorType, collectionOperation, std::move(rhs), options);
+        }
+        else if (collectionOperation.column().property().dictionary) {
+            add_collection_operation_constraint<Operation, false, true>(operatorType, collectionOperation, std::move(rhs), options);
         }
         else {
-            add_collection_operation_constraint<Operation, false>(operatorType, collectionOperation, rhs);
+            add_collection_operation_constraint<Operation, false, false>(operatorType, collectionOperation, std::move(rhs), options);
         }
     });
 }
@@ -1510,165 +1339,90 @@ void get_collection_type(__unsafe_unretained RLMProperty *prop, Fn&& fn) {
 
 template <typename R>
 void QueryBuilder::add_collection_operation_constraint(NSPredicateOperatorType operatorType,
-                                                       CollectionOperation const& collectionOperation, R rhs,
-                                                       NSComparisonPredicateOptions comparisionOptions)
+                                                       CollectionOperation const& collectionOperation, R&& rhs,
+                                                       NSComparisonPredicateOptions comparisonOptions)
 {
     switch (collectionOperation.type()) {
+        case CollectionOperation::None:
+            break;
         case CollectionOperation::Count: {
             auto& column = collectionOperation.link_column();
             RLMPropertyType type = column.type();
             auto rhsValue = value_of_type<Int>(rhs);
+            auto continuation = [&](auto t) {
+                add_numeric_constraint(type, operatorType, column.resolve<std::decay_t<decltype(*t)>>().size(), rhsValue);
+            };
 
             switch (type) {
                 case RLMPropertyTypeBool:
-                    get_collection_type<Bool>(column.property(), [&](auto t) {
-                        add_numeric_constraint(type, operatorType, column.resolve<std::decay_t<decltype(*t)>>().size(), rhsValue);
-                    });
-                    return;
+                    return get_collection_type<Bool>(column.property(), std::move(continuation));
                 case RLMPropertyTypeObjectId:
-                    get_collection_type<ObjectId>(column.property(), [&](auto t) {
-                        add_numeric_constraint(type, operatorType, column.resolve<std::decay_t<decltype(*t)>>().size(), rhsValue);
-                    });
-                    return;
+                    return get_collection_type<ObjectId>(column.property(), std::move(continuation));
                 case RLMPropertyTypeDate:
-                    get_collection_type<Timestamp>(column.property(), [&](auto t) {
-                        add_numeric_constraint(type, operatorType, column.resolve<std::decay_t<decltype(*t)>>().size(), rhsValue);
-                    });
-                    return;
+                    return get_collection_type<Timestamp>(column.property(), std::move(continuation));
                 case RLMPropertyTypeDouble:
-                    get_collection_type<Double>(column.property(), [&](auto t) {
-                        add_numeric_constraint(type, operatorType, column.resolve<std::decay_t<decltype(*t)>>().size(), rhsValue);
-                    });
-                    return;
+                    return get_collection_type<Double>(column.property(), std::move(continuation));
                 case RLMPropertyTypeFloat:
-                    get_collection_type<Float>(column.property(), [&](auto t) {
-                        add_numeric_constraint(type, operatorType, column.resolve<std::decay_t<decltype(*t)>>().size(), rhsValue);
-                    });
-                    return;
+                    return get_collection_type<Float>(column.property(), std::move(continuation));
                 case RLMPropertyTypeInt:
-                    get_collection_type<Int>(column.property(), [&](auto t) {
-                        add_numeric_constraint(type, operatorType, column.resolve<std::decay_t<decltype(*t)>>().size(), rhsValue);
-                    });
-                    return;
+                    return get_collection_type<Int>(column.property(), std::move(continuation));
                 case RLMPropertyTypeDecimal128:
-                    get_collection_type<Decimal128>(column.property(), [&](auto t) {
-                        add_numeric_constraint(type, operatorType, column.resolve<std::decay_t<decltype(*t)>>().size(), rhsValue);
-                    });
-                    return;
+                    return get_collection_type<Decimal128>(column.property(), std::move(continuation));
                 case RLMPropertyTypeString:
-                    get_collection_type<String>(column.property(), [&](auto t) {
-                        add_numeric_constraint(type, operatorType, column.resolve<std::decay_t<decltype(*t)>>().size(), rhsValue);
-                    });
-                    return;
+                    return get_collection_type<String>(column.property(), std::move(continuation));
                 case RLMPropertyTypeData:
-                    get_collection_type<Binary>(column.property(), [&](auto t) {
-                        add_numeric_constraint(type, operatorType, column.resolve<std::decay_t<decltype(*t)>>().size(), rhsValue);
-                    });
-                    return;
+                    return get_collection_type<Binary>(column.property(), std::move(continuation));
+                case RLMPropertyTypeUUID:
+                    return get_collection_type<UUID>(column.property(), std::move(continuation));
+                case RLMPropertyTypeAny:
+                    return get_collection_type<Mixed>(column.property(), std::move(continuation));
                 case RLMPropertyTypeObject:
                 case RLMPropertyTypeLinkingObjects:
-                    add_numeric_constraint(type, operatorType, column.resolve<Link>().count(), rhsValue);
-                    return;
-                case RLMPropertyTypeUUID:
-                    get_collection_type<UUID>(column.property(), [&](auto t) {
-                        add_numeric_constraint(type, operatorType, column.resolve<std::decay_t<decltype(*t)>>().size(), rhsValue);
-                    });
-                    return;
-                case RLMPropertyTypeAny:
-                    get_collection_type<Mixed>(column.property(), [&](auto t) {
-                        add_numeric_constraint(type, operatorType, column.resolve<std::decay_t<decltype(*t)>>().size(), rhsValue);
-                    });
-                    return;
+                    return add_numeric_constraint(type, operatorType, column.resolve<Link>().count(), rhsValue);
             }
         }
         case CollectionOperation::Minimum:
-            add_collection_operation_constraint<CollectionOperation::Minimum>(operatorType, collectionOperation, rhs);
+            add_collection_operation_constraint<CollectionOperation::Minimum>(operatorType, collectionOperation, std::move(rhs), comparisonOptions);
             break;
         case CollectionOperation::Maximum:
-            add_collection_operation_constraint<CollectionOperation::Maximum>(operatorType, collectionOperation, rhs);
+            add_collection_operation_constraint<CollectionOperation::Maximum>(operatorType, collectionOperation, std::move(rhs), comparisonOptions);
             break;
         case CollectionOperation::Sum:
-            add_collection_operation_constraint<CollectionOperation::Sum>(operatorType, collectionOperation, rhs);
+            add_collection_operation_constraint<CollectionOperation::Sum>(operatorType, collectionOperation, std::move(rhs), comparisonOptions);
             break;
         case CollectionOperation::Average:
-            add_collection_operation_constraint<CollectionOperation::Average>(operatorType, collectionOperation, rhs);
+            add_collection_operation_constraint<CollectionOperation::Average>(operatorType, collectionOperation, std::move(rhs), comparisonOptions);
             break;
         case CollectionOperation::AllKeys: {
             // BETWEEN and IN are not supported by @allKeys as the parsing for collection
             // operators happens before and disection of a rhs array of values.
-            add_string_constraint(operatorType,
-                                  comparisionOptions,
+            add_string_constraint(operatorType, comparisonOptions,
                                   Columns<Dictionary>(collectionOperation.link_column().column(), m_query.get_table()).keys(),
                                   value_of_type<StringData>(rhs));
             break;
         }
-        case CollectionOperation::AllValues: {
-            auto& column = collectionOperation.link_column();
-            RLMPropertyType type = column.type();
-            switch (type) {
-                case RLMPropertyTypeObjectId:
-                case RLMPropertyTypeDate:
-                    if (operatorType == NSLikePredicateOperatorType ||
-                        operatorType == NSBeginsWithPredicateOperatorType ||
-                        operatorType == NSContainsPredicateOperatorType ||
-                        operatorType == NSEndsWithPredicateOperatorType) {
-                        unsupportedOperator(type, operatorType);
-                    }
-                default:
-                    break;
-            }
-            add_dictionary_constraint(type,
-                                      operatorType,
-                                      comparisionOptions,
-                                      column,
-                                      rhs);
-            break;
-        }
     }
 }
 
-bool key_path_contains_collection_operator(NSString *keyPath) {
-    return [keyPath rangeOfString:@"@"].location != NSNotFound;
+bool key_path_contains_collection_operator(const KeyPath& kp) {
+    return kp.collectionOperation != CollectionOperation::None;
 }
 
-NSString *get_collection_operation_name_from_key_path(NSString *keyPath, NSString **leadingKeyPath,
-                                                      NSString **trailingKey) {
-    NSRange at = [keyPath rangeOfString:@"@"];
-    if (at.location == NSNotFound || at.location >= keyPath.length - 1) {
-        throwException(@"Invalid key path", @"'%@' is not a valid key path'", keyPath);
+CollectionOperation QueryBuilder::collection_operation_from_key_path(KeyPath&& kp) {
+    // Collection operations can either come at the end, or immediately before
+    // the last property. Count and AllKeys are always the end, while
+    // min/max/sum/avg are at the end for collections of primitives and one
+    // before the end for collections of objects (with the aggregate done on a
+    // property of those objects). For one-before-the-end we need to construct
+    // a KeyPath to both the final link and the final property.
+    KeyPath linkPrefix = kp;
+    if (kp.collectionOperation != CollectionOperation::Count && kp.collectionOperation != CollectionOperation::AllKeys && !kp.property.collection) {
+        REALM_ASSERT(!kp.links.empty());
+        linkPrefix.property = linkPrefix.links.back();
+        linkPrefix.links.pop_back();
     }
-
-    if (at.location == 0 || [keyPath characterAtIndex:at.location - 1] != '.') {
-        throwException(@"Invalid key path", @"'%@' is not a valid key path'", keyPath);
-    }
-
-    NSRange trailingKeyRange = [keyPath rangeOfString:@"." options:0 range:{at.location, keyPath.length - at.location} locale:nil];
-
-    *leadingKeyPath = [keyPath substringToIndex:at.location - 1];
-    if (trailingKeyRange.location == NSNotFound) {
-        *trailingKey = nil;
-        return [keyPath substringFromIndex:at.location];
-    } else {
-        *trailingKey = [keyPath substringFromIndex:trailingKeyRange.location + 1];
-        return [keyPath substringWithRange:{at.location, trailingKeyRange.location - at.location}];
-    }
-}
-
-CollectionOperation QueryBuilder::collection_operation_from_key_path(RLMObjectSchema *desc, NSString *keyPath) {
-    NSString *leadingKeyPath;
-    NSString *trailingKey;
-    NSString *collectionOperationName = get_collection_operation_name_from_key_path(keyPath, &leadingKeyPath, &trailingKey);
-
-    ColumnReference linkColumn = column_reference_from_key_path(desc, leadingKeyPath, true);
-    util::Optional<ColumnReference> column;
-    if (trailingKey) {
-        RLMPrecondition([trailingKey rangeOfString:@"."].location == NSNotFound, @"Invalid key path",
-                        @"Right side of collection operator may only have a single level key");
-        NSString *fullKeyPath = [leadingKeyPath stringByAppendingFormat:@".%@", trailingKey];
-        column = column_reference_from_key_path(desc, fullKeyPath, true);
-    }
-
-    return {collectionOperationName, std::move(linkColumn), std::move(column)};
+    return CollectionOperation(kp.collectionOperation, column_reference_from_key_path(std::move(linkPrefix), true),
+                               column_reference_from_key_path(std::move(kp), true));
 }
 
 NSPredicateOperatorType invert_comparison_operator(NSPredicateOperatorType type) {
@@ -1691,10 +1445,9 @@ NSPredicateOperatorType invert_comparison_operator(NSPredicateOperatorType type)
     }
 }
 
-void QueryBuilder::apply_collection_operator_expression(RLMObjectSchema *desc,
-                                                        NSString *keyPath, id value,
+void QueryBuilder::apply_collection_operator_expression(KeyPath&& kp, id value,
                                                         NSComparisonPredicate *pred) {
-    CollectionOperation operation = collection_operation_from_key_path(desc, keyPath);
+    CollectionOperation operation = collection_operation_from_key_path(std::move(kp));
     operation.validate_comparison(value);
 
     auto type = pred.predicateOperatorType;
@@ -1705,17 +1458,15 @@ void QueryBuilder::apply_collection_operator_expression(RLMObjectSchema *desc,
     add_collection_operation_constraint(type, operation, value, pred.options);
 }
 
-void QueryBuilder::apply_value_expression(RLMObjectSchema *desc,
-                                          NSString *keyPath, id value,
-                                          NSComparisonPredicate *pred)
+void QueryBuilder::apply_value_expression(KeyPath&& kp, id value, NSComparisonPredicate *pred)
 {
-    if (key_path_contains_collection_operator(keyPath)) {
-        apply_collection_operator_expression(desc, keyPath, value, pred);
+    if (key_path_contains_collection_operator(kp)) {
+        apply_collection_operator_expression(std::move(kp), value, pred);
         return;
     }
 
     bool isAny = pred.comparisonPredicateModifier == NSAnyPredicateModifier;
-    ColumnReference column = column_reference_from_key_path(desc, keyPath, isAny);
+    ColumnReference column = column_reference_from_key_path(std::move(kp), isAny);
 
     // check to see if this is a between query
     if (pred.predicateOperatorType == NSBetweenPredicateOperatorType) {
@@ -1727,14 +1478,13 @@ void QueryBuilder::apply_value_expression(RLMObjectSchema *desc,
     if (pred.predicateOperatorType == NSInPredicateOperatorType) {
         process_or_group(m_query, value, [&](id item) {
             id normalized = value_from_constant_expression_or_value(item);
-            validate_property_value(column, normalized,
-                                    @"Expected object of type %@ in IN clause for property '%@' on object of type '%@', but received: %@", desc, keyPath);
+            column.validate_comparison(normalized);
             add_constraint(NSEqualToPredicateOperatorType, pred.options, column, normalized);
         });
         return;
     }
 
-    validate_property_value(column, value, @"Expected object of type %@ for property '%@' on object of type '%@', but received: %@", desc, keyPath);
+    column.validate_comparison(value);
     if (pred.leftExpression.expressionType == NSKeyPathExpressionType) {
         add_constraint(pred.predicateOperatorType, pred.options, std::move(column), value);
     } else {
@@ -1742,9 +1492,7 @@ void QueryBuilder::apply_value_expression(RLMObjectSchema *desc,
     }
 }
 
-void QueryBuilder::apply_column_expression(RLMObjectSchema *desc,
-                                           NSString *leftKeyPath, NSString *rightKeyPath,
-                                           NSComparisonPredicate *predicate)
+void QueryBuilder::apply_column_expression(KeyPath&& leftKeyPath, KeyPath&& rightKeyPath, NSComparisonPredicate *predicate)
 {
     bool left_key_path_contains_collection_operator = key_path_contains_collection_operator(leftKeyPath);
     bool right_key_path_contains_collection_operator = key_path_contains_collection_operator(rightKeyPath);
@@ -1753,24 +1501,24 @@ void QueryBuilder::apply_column_expression(RLMObjectSchema *desc,
     }
 
     if (left_key_path_contains_collection_operator) {
-        CollectionOperation left = collection_operation_from_key_path(desc, leftKeyPath);
-        ColumnReference right = column_reference_from_key_path(desc, rightKeyPath, false);
+        CollectionOperation left = collection_operation_from_key_path(std::move(leftKeyPath));
+        ColumnReference right = column_reference_from_key_path(std::move(rightKeyPath), false);
         left.validate_comparison(right);
-        add_collection_operation_constraint(predicate.predicateOperatorType, left, std::move(right));
+        add_collection_operation_constraint(predicate.predicateOperatorType, std::move(left), std::move(right), predicate.options);
         return;
     }
     if (right_key_path_contains_collection_operator) {
-        ColumnReference left = column_reference_from_key_path(desc, leftKeyPath, false);
-        CollectionOperation right = collection_operation_from_key_path(desc, rightKeyPath);
+        ColumnReference left = column_reference_from_key_path(std::move(leftKeyPath), false);
+        CollectionOperation right = collection_operation_from_key_path(std::move(rightKeyPath));
         right.validate_comparison(left);
         add_collection_operation_constraint(invert_comparison_operator(predicate.predicateOperatorType),
-                                            right, std::move(left));
+                                            std::move(right), std::move(left), predicate.options);
         return;
     }
 
     bool isAny = false;
-    ColumnReference left = column_reference_from_key_path(desc, leftKeyPath, isAny);
-    ColumnReference right = column_reference_from_key_path(desc, rightKeyPath, isAny);
+    ColumnReference left = column_reference_from_key_path(std::move(leftKeyPath), isAny);
+    ColumnReference right = column_reference_from_key_path(std::move(rightKeyPath), isAny);
 
     // NOTE: It's assumed that column type must match and no automatic type conversion is supported.
     RLMPrecondition(left.type() == right.type(),
@@ -1823,10 +1571,10 @@ void QueryBuilder::apply_map_expression(RLMObjectSchema *objectSchema, NSExpress
         mapKey = [functionExpression.arguments[1] constantValue];
     }
 
-    ColumnReference collectionColumn = column_reference_from_key_path(objectSchema, keyPath, true);
-    RLMPrecondition(collectionColumn.property().dictionary,
-                    @"Invalid predicate", @"Only dictionaries support subscript predicates.");
-    add_mixed_constraint(operatorType, options, collectionColumn.resolve<Dictionary>().key([mapKey UTF8String]), [right constantValue]);
+    ColumnReference collectionColumn = column_reference_from_key_path(key_path_from_string(m_schema, objectSchema, keyPath), true);
+    RLMPrecondition(collectionColumn.property().dictionary, @"Invalid predicate",
+                    @"Invalid keypath '%@': only dictionaries support subscript predicates.", functionExpression);
+    add_mixed_constraint(operatorType, options, collectionColumn.resolve<Dictionary>().key(mapKey.UTF8String), right.constantValue);
 }
 
 void QueryBuilder::apply_function_expression(RLMObjectSchema *objectSchema, NSExpression *functionExpression,
@@ -1845,7 +1593,7 @@ void QueryBuilder::apply_function_expression(RLMObjectSchema *objectSchema, NSEx
     NSExpression *subqueryExpression = functionExpression.operand;
     int64_t value = [right.constantValue integerValue];
 
-    ColumnReference collectionColumn = column_reference_from_key_path(objectSchema, [subqueryExpression.collection keyPath], true);
+    ColumnReference collectionColumn = column_reference_from_key_path(key_path_from_string(m_schema, objectSchema, [subqueryExpression.collection keyPath]), true);
     RLMObjectSchema *collectionMemberObjectSchema = m_schema[collectionColumn.property().objectClassName];
 
     // Eliminate references to the iteration variable in the subquery.
@@ -1908,13 +1656,6 @@ void QueryBuilder::apply_predicate(NSPredicate *predicate, RLMObjectSchema *obje
         NSExpressionType exp1Type = compp.leftExpression.expressionType;
         NSExpressionType exp2Type = compp.rightExpression.expressionType;
 
-        if (compp.comparisonPredicateModifier == NSAnyPredicateModifier) {
-            // for ANY queries
-            RLMPrecondition(exp1Type == NSKeyPathExpressionType && exp2Type == NSConstantValueExpressionType,
-                            @"Invalid predicate",
-                            @"Predicate with ANY modifier must compare a KeyPath with a Realm collection with a value");
-        }
-
         if (compp.predicateOperatorType == NSBetweenPredicateOperatorType || compp.predicateOperatorType == NSInPredicateOperatorType) {
             // Inserting an array via %@ gives NSConstantValueExpressionType, but including it directly gives NSAggregateExpressionType
             if (exp1Type == NSKeyPathExpressionType && (exp2Type == NSAggregateExpressionType || exp2Type == NSConstantValueExpressionType)) {
@@ -1942,15 +1683,19 @@ void QueryBuilder::apply_predicate(NSPredicate *predicate, RLMObjectSchema *obje
 
         if (exp1Type == NSKeyPathExpressionType && exp2Type == NSKeyPathExpressionType) {
             // both expression are KeyPaths
-            apply_column_expression(objectSchema, compp.leftExpression.keyPath, compp.rightExpression.keyPath, compp);
+            apply_column_expression(key_path_from_string(m_schema, objectSchema, compp.leftExpression.keyPath),
+                                    key_path_from_string(m_schema, objectSchema, compp.rightExpression.keyPath),
+                                    compp);
         }
         else if (exp1Type == NSKeyPathExpressionType && exp2Type == NSConstantValueExpressionType) {
             // comparing keypath to value
-            apply_value_expression(objectSchema, compp.leftExpression.keyPath, compp.rightExpression.constantValue, compp);
+            apply_value_expression(key_path_from_string(m_schema, objectSchema, compp.leftExpression.keyPath),
+                                   compp.rightExpression.constantValue, compp);
         }
         else if (exp1Type == NSConstantValueExpressionType && exp2Type == NSKeyPathExpressionType) {
             // comparing value to keypath
-            apply_value_expression(objectSchema, compp.rightExpression.keyPath, compp.leftExpression.constantValue, compp);
+            apply_value_expression(key_path_from_string(m_schema, objectSchema, compp.rightExpression.keyPath),
+                                   compp.leftExpression.constantValue, compp);
         }
         else if (exp1Type == NSFunctionExpressionType) {
             if (compp.leftExpression.operand.expressionType == NSSubqueryExpressionType) {

--- a/Realm/Tests/PrimitiveArrayPropertyTests.m
+++ b/Realm/Tests/PrimitiveArrayPropertyTests.m
@@ -61,34 +61,6 @@ static double average(NSArray *values) {
     return sum / c;
 }
 
-// XCTest assertions wrap each assertion in a try/catch to provide nice
-// reporting if an assertion unexpectedly throws an exception. This is normally
-// quite nice, but becomes a problem with the very large number of assertions
-// in this file and makes this file take several minutes to compile in release
-// builds. Replacing these with assertions which do not try/catch cuts this by
-// about 75%.
-#define uncheckedAssertEqual(ex1, ex2) do { \
-    __typeof__(ex1) value1 = (ex1); \
-    __typeof__(ex2) value2 = (ex2); \
-    if (value1 != value2) { \
-        NSValue *box1 = [NSValue value:&value1 withObjCType:@encode(__typeof__(ex1))]; \
-        NSValue *box2 = [NSValue value:&value2 withObjCType:@encode(__typeof__(ex2))]; \
-        _XCTRegisterFailure(nil, _XCTFailureDescription(_XCTAssertion_Equal, 0, @#ex1, @#ex2, _XCTDescriptionForValue(box1), _XCTDescriptionForValue(box2))); \
-    } \
-} while (0)
-
-#define uncheckedAssertEqualObjects(ex1, ex2) do { \
-    id value1 = (ex1); \
-    id value2 = (ex2); \
-    if (value1 != value2 && ![(id)value1 isEqual:value2]) { \
-        _XCTRegisterFailure(nil, _XCTFailureDescription(_XCTAssertion_EqualObjects, 0, @#ex1, @#ex2, value1, value2)); \
-    } \
-} while (0)
-
-#define uncheckedAssertTrue(ex) uncheckedAssertEqual(ex, true)
-#define uncheckedAssertFalse(ex) uncheckedAssertEqual(ex, false)
-#define uncheckedAssertNil(ex) uncheckedAssertEqual(ex, nil)
-
 @interface LinkToAllPrimitiveArrays : RLMObject
 @property (nonatomic) AllPrimitiveArrays *link;
 @end
@@ -9160,25 +9132,25 @@ static NSArray *sortedDistinctUnion(id array, NSString *type, NSString *prop) {
     [realm deleteAllObjects];
 
     RLMAssertThrowsWithReason(([AllPrimitiveArrays objectsInRealm:realm where:@"boolObj.@sum = %@", @NO]),
-                              @"@sum can only be applied to a numeric property.");
+                              @"Invalid keypath 'boolObj.@sum': @sum can only be applied to a collection of numeric values.");
     RLMAssertThrowsWithReason(([AllPrimitiveArrays objectsInRealm:realm where:@"stringObj.@sum = %@", @"a"]),
-                              @"@sum can only be applied to a numeric property.");
+                              @"Invalid keypath 'stringObj.@sum': @sum can only be applied to a collection of numeric values.");
     RLMAssertThrowsWithReason(([AllPrimitiveArrays objectsInRealm:realm where:@"dataObj.@sum = %@", data(1)]),
-                              @"@sum can only be applied to a numeric property.");
+                              @"Invalid keypath 'dataObj.@sum': @sum can only be applied to a collection of numeric values.");
     RLMAssertThrowsWithReason(([AllPrimitiveArrays objectsInRealm:realm where:@"objectIdObj.@sum = %@", objectId(1)]),
-                              @"@sum can only be applied to a numeric property.");
+                              @"Invalid keypath 'objectIdObj.@sum': @sum can only be applied to a collection of numeric values.");
     RLMAssertThrowsWithReason(([AllPrimitiveArrays objectsInRealm:realm where:@"uuidObj.@sum = %@", uuid(@"00000000-0000-0000-0000-000000000000")]),
-                              @"@sum can only be applied to a numeric property.");
+                              @"Invalid keypath 'uuidObj.@sum': @sum can only be applied to a collection of numeric values.");
     RLMAssertThrowsWithReason(([AllOptionalPrimitiveArrays objectsInRealm:realm where:@"boolObj.@sum = %@", @NO]),
-                              @"@sum can only be applied to a numeric property.");
+                              @"Invalid keypath 'boolObj.@sum': @sum can only be applied to a collection of numeric values.");
     RLMAssertThrowsWithReason(([AllOptionalPrimitiveArrays objectsInRealm:realm where:@"stringObj.@sum = %@", @"a"]),
-                              @"@sum can only be applied to a numeric property.");
+                              @"Invalid keypath 'stringObj.@sum': @sum can only be applied to a collection of numeric values.");
     RLMAssertThrowsWithReason(([AllOptionalPrimitiveArrays objectsInRealm:realm where:@"dataObj.@sum = %@", data(1)]),
-                              @"@sum can only be applied to a numeric property.");
+                              @"Invalid keypath 'dataObj.@sum': @sum can only be applied to a collection of numeric values.");
     RLMAssertThrowsWithReason(([AllOptionalPrimitiveArrays objectsInRealm:realm where:@"objectIdObj.@sum = %@", objectId(1)]),
-                              @"@sum can only be applied to a numeric property.");
+                              @"Invalid keypath 'objectIdObj.@sum': @sum can only be applied to a collection of numeric values.");
     RLMAssertThrowsWithReason(([AllOptionalPrimitiveArrays objectsInRealm:realm where:@"uuidObj.@sum = %@", uuid(@"00000000-0000-0000-0000-000000000000")]),
-                              @"@sum can only be applied to a numeric property.");
+                              @"Invalid keypath 'uuidObj.@sum': @sum can only be applied to a collection of numeric values.");
     RLMAssertThrowsWithReason(([AllPrimitiveArrays objectsInRealm:realm where:@"dateObj.@sum = %@", date(1)]),
                               @"Cannot sum or average date properties");
     RLMAssertThrowsWithReason(([AllOptionalPrimitiveArrays objectsInRealm:realm where:@"dateObj.@sum = %@", date(1)]),
@@ -9201,21 +9173,21 @@ static NSArray *sortedDistinctUnion(id array, NSString *type, NSString *prop) {
     RLMAssertThrowsWithReason(([AllOptionalPrimitiveArrays objectsInRealm:realm where:@"decimalObj.@sum = %@", @"a"]),
                               @"@sum on a property of type decimal128 cannot be compared with 'a'");
     RLMAssertThrowsWithReason(([AllPrimitiveArrays objectsInRealm:realm where:@"intObj.@sum.prop = %@", @"a"]),
-                              @"Property 'intObj' is not a link in object of type 'AllPrimitiveArrays'");
+                              @"Invalid keypath 'intObj.@sum.prop': @sum on a collection of values must appear at the end of a keypath.");
     RLMAssertThrowsWithReason(([AllPrimitiveArrays objectsInRealm:realm where:@"floatObj.@sum.prop = %@", @"a"]),
-                              @"Property 'floatObj' is not a link in object of type 'AllPrimitiveArrays'");
+                              @"Invalid keypath 'floatObj.@sum.prop': @sum on a collection of values must appear at the end of a keypath.");
     RLMAssertThrowsWithReason(([AllPrimitiveArrays objectsInRealm:realm where:@"doubleObj.@sum.prop = %@", @"a"]),
-                              @"Property 'doubleObj' is not a link in object of type 'AllPrimitiveArrays'");
+                              @"Invalid keypath 'doubleObj.@sum.prop': @sum on a collection of values must appear at the end of a keypath.");
     RLMAssertThrowsWithReason(([AllPrimitiveArrays objectsInRealm:realm where:@"decimalObj.@sum.prop = %@", @"a"]),
-                              @"Property 'decimalObj' is not a link in object of type 'AllPrimitiveArrays'");
+                              @"Invalid keypath 'decimalObj.@sum.prop': @sum on a collection of values must appear at the end of a keypath.");
     RLMAssertThrowsWithReason(([AllOptionalPrimitiveArrays objectsInRealm:realm where:@"intObj.@sum.prop = %@", @"a"]),
-                              @"Property 'intObj' is not a link in object of type 'AllOptionalPrimitiveArrays'");
+                              @"Invalid keypath 'intObj.@sum.prop': @sum on a collection of values must appear at the end of a keypath.");
     RLMAssertThrowsWithReason(([AllOptionalPrimitiveArrays objectsInRealm:realm where:@"floatObj.@sum.prop = %@", @"a"]),
-                              @"Property 'floatObj' is not a link in object of type 'AllOptionalPrimitiveArrays'");
+                              @"Invalid keypath 'floatObj.@sum.prop': @sum on a collection of values must appear at the end of a keypath.");
     RLMAssertThrowsWithReason(([AllOptionalPrimitiveArrays objectsInRealm:realm where:@"doubleObj.@sum.prop = %@", @"a"]),
-                              @"Property 'doubleObj' is not a link in object of type 'AllOptionalPrimitiveArrays'");
+                              @"Invalid keypath 'doubleObj.@sum.prop': @sum on a collection of values must appear at the end of a keypath.");
     RLMAssertThrowsWithReason(([AllOptionalPrimitiveArrays objectsInRealm:realm where:@"decimalObj.@sum.prop = %@", @"a"]),
-                              @"Property 'decimalObj' is not a link in object of type 'AllOptionalPrimitiveArrays'");
+                              @"Invalid keypath 'decimalObj.@sum.prop': @sum on a collection of values must appear at the end of a keypath.");
     RLMAssertThrowsWithReason(([AllPrimitiveArrays objectsInRealm:realm where:@"intObj.@sum = %@", NSNull.null]),
                               @"@sum on a property of type int cannot be compared with '<null>'");
     RLMAssertThrowsWithReason(([AllPrimitiveArrays objectsInRealm:realm where:@"floatObj.@sum = %@", NSNull.null]),
@@ -9344,25 +9316,25 @@ static NSArray *sortedDistinctUnion(id array, NSString *type, NSString *prop) {
     [realm deleteAllObjects];
 
     RLMAssertThrowsWithReason(([AllPrimitiveArrays objectsInRealm:realm where:@"boolObj.@avg = %@", @NO]),
-                              @"@avg can only be applied to a numeric property.");
+                              @"Invalid keypath 'boolObj.@avg': @avg can only be applied to a collection of numeric values.");
     RLMAssertThrowsWithReason(([AllPrimitiveArrays objectsInRealm:realm where:@"stringObj.@avg = %@", @"a"]),
-                              @"@avg can only be applied to a numeric property.");
+                              @"Invalid keypath 'stringObj.@avg': @avg can only be applied to a collection of numeric values.");
     RLMAssertThrowsWithReason(([AllPrimitiveArrays objectsInRealm:realm where:@"dataObj.@avg = %@", data(1)]),
-                              @"@avg can only be applied to a numeric property.");
+                              @"Invalid keypath 'dataObj.@avg': @avg can only be applied to a collection of numeric values.");
     RLMAssertThrowsWithReason(([AllPrimitiveArrays objectsInRealm:realm where:@"objectIdObj.@avg = %@", objectId(1)]),
-                              @"@avg can only be applied to a numeric property.");
+                              @"Invalid keypath 'objectIdObj.@avg': @avg can only be applied to a collection of numeric values.");
     RLMAssertThrowsWithReason(([AllPrimitiveArrays objectsInRealm:realm where:@"uuidObj.@avg = %@", uuid(@"00000000-0000-0000-0000-000000000000")]),
-                              @"@avg can only be applied to a numeric property.");
+                              @"Invalid keypath 'uuidObj.@avg': @avg can only be applied to a collection of numeric values.");
     RLMAssertThrowsWithReason(([AllOptionalPrimitiveArrays objectsInRealm:realm where:@"boolObj.@avg = %@", @NO]),
-                              @"@avg can only be applied to a numeric property.");
+                              @"Invalid keypath 'boolObj.@avg': @avg can only be applied to a collection of numeric values.");
     RLMAssertThrowsWithReason(([AllOptionalPrimitiveArrays objectsInRealm:realm where:@"stringObj.@avg = %@", @"a"]),
-                              @"@avg can only be applied to a numeric property.");
+                              @"Invalid keypath 'stringObj.@avg': @avg can only be applied to a collection of numeric values.");
     RLMAssertThrowsWithReason(([AllOptionalPrimitiveArrays objectsInRealm:realm where:@"dataObj.@avg = %@", data(1)]),
-                              @"@avg can only be applied to a numeric property.");
+                              @"Invalid keypath 'dataObj.@avg': @avg can only be applied to a collection of numeric values.");
     RLMAssertThrowsWithReason(([AllOptionalPrimitiveArrays objectsInRealm:realm where:@"objectIdObj.@avg = %@", objectId(1)]),
-                              @"@avg can only be applied to a numeric property.");
+                              @"Invalid keypath 'objectIdObj.@avg': @avg can only be applied to a collection of numeric values.");
     RLMAssertThrowsWithReason(([AllOptionalPrimitiveArrays objectsInRealm:realm where:@"uuidObj.@avg = %@", uuid(@"00000000-0000-0000-0000-000000000000")]),
-                              @"@avg can only be applied to a numeric property.");
+                              @"Invalid keypath 'uuidObj.@avg': @avg can only be applied to a collection of numeric values.");
     RLMAssertThrowsWithReason(([AllPrimitiveArrays objectsInRealm:realm where:@"dateObj.@avg = %@", date(1)]),
                               @"Cannot sum or average date properties");
     RLMAssertThrowsWithReason(([AllOptionalPrimitiveArrays objectsInRealm:realm where:@"dateObj.@avg = %@", date(1)]),
@@ -9385,21 +9357,21 @@ static NSArray *sortedDistinctUnion(id array, NSString *type, NSString *prop) {
     RLMAssertThrowsWithReason(([AllOptionalPrimitiveArrays objectsInRealm:realm where:@"decimalObj.@avg = %@", @"a"]),
                               @"@avg on a property of type decimal128 cannot be compared with 'a'");
     RLMAssertThrowsWithReason(([AllPrimitiveArrays objectsInRealm:realm where:@"intObj.@avg.prop = %@", @"a"]),
-                              @"Property 'intObj' is not a link in object of type 'AllPrimitiveArrays'");
+                              @"Invalid keypath 'intObj.@avg.prop': @avg on a collection of values must appear at the end of a keypath.");
     RLMAssertThrowsWithReason(([AllPrimitiveArrays objectsInRealm:realm where:@"floatObj.@avg.prop = %@", @"a"]),
-                              @"Property 'floatObj' is not a link in object of type 'AllPrimitiveArrays'");
+                              @"Invalid keypath 'floatObj.@avg.prop': @avg on a collection of values must appear at the end of a keypath.");
     RLMAssertThrowsWithReason(([AllPrimitiveArrays objectsInRealm:realm where:@"doubleObj.@avg.prop = %@", @"a"]),
-                              @"Property 'doubleObj' is not a link in object of type 'AllPrimitiveArrays'");
+                              @"Invalid keypath 'doubleObj.@avg.prop': @avg on a collection of values must appear at the end of a keypath.");
     RLMAssertThrowsWithReason(([AllPrimitiveArrays objectsInRealm:realm where:@"decimalObj.@avg.prop = %@", @"a"]),
-                              @"Property 'decimalObj' is not a link in object of type 'AllPrimitiveArrays'");
+                              @"Invalid keypath 'decimalObj.@avg.prop': @avg on a collection of values must appear at the end of a keypath.");
     RLMAssertThrowsWithReason(([AllOptionalPrimitiveArrays objectsInRealm:realm where:@"intObj.@avg.prop = %@", @"a"]),
-                              @"Property 'intObj' is not a link in object of type 'AllOptionalPrimitiveArrays'");
+                              @"Invalid keypath 'intObj.@avg.prop': @avg on a collection of values must appear at the end of a keypath.");
     RLMAssertThrowsWithReason(([AllOptionalPrimitiveArrays objectsInRealm:realm where:@"floatObj.@avg.prop = %@", @"a"]),
-                              @"Property 'floatObj' is not a link in object of type 'AllOptionalPrimitiveArrays'");
+                              @"Invalid keypath 'floatObj.@avg.prop': @avg on a collection of values must appear at the end of a keypath.");
     RLMAssertThrowsWithReason(([AllOptionalPrimitiveArrays objectsInRealm:realm where:@"doubleObj.@avg.prop = %@", @"a"]),
-                              @"Property 'doubleObj' is not a link in object of type 'AllOptionalPrimitiveArrays'");
+                              @"Invalid keypath 'doubleObj.@avg.prop': @avg on a collection of values must appear at the end of a keypath.");
     RLMAssertThrowsWithReason(([AllOptionalPrimitiveArrays objectsInRealm:realm where:@"decimalObj.@avg.prop = %@", @"a"]),
-                              @"Property 'decimalObj' is not a link in object of type 'AllOptionalPrimitiveArrays'");
+                              @"Invalid keypath 'decimalObj.@avg.prop': @avg on a collection of values must appear at the end of a keypath.");
 
     [AllPrimitiveArrays createInRealm:realm withValue:@{
         @"intObj": @[],
@@ -9512,25 +9484,25 @@ static NSArray *sortedDistinctUnion(id array, NSString *type, NSString *prop) {
     [realm deleteAllObjects];
 
     RLMAssertThrowsWithReason(([AllPrimitiveArrays objectsInRealm:realm where:@"boolObj.@min = %@", @NO]),
-                              @"@min can only be applied to a numeric property.");
+                              @"Invalid keypath 'boolObj.@min': @min can only be applied to a collection of numeric values.");
     RLMAssertThrowsWithReason(([AllPrimitiveArrays objectsInRealm:realm where:@"stringObj.@min = %@", @"a"]),
-                              @"@min can only be applied to a numeric property.");
+                              @"Invalid keypath 'stringObj.@min': @min can only be applied to a collection of numeric values.");
     RLMAssertThrowsWithReason(([AllPrimitiveArrays objectsInRealm:realm where:@"dataObj.@min = %@", data(1)]),
-                              @"@min can only be applied to a numeric property.");
+                              @"Invalid keypath 'dataObj.@min': @min can only be applied to a collection of numeric values.");
     RLMAssertThrowsWithReason(([AllPrimitiveArrays objectsInRealm:realm where:@"objectIdObj.@min = %@", objectId(1)]),
-                              @"@min can only be applied to a numeric property.");
+                              @"Invalid keypath 'objectIdObj.@min': @min can only be applied to a collection of numeric values.");
     RLMAssertThrowsWithReason(([AllPrimitiveArrays objectsInRealm:realm where:@"uuidObj.@min = %@", uuid(@"00000000-0000-0000-0000-000000000000")]),
-                              @"@min can only be applied to a numeric property.");
+                              @"Invalid keypath 'uuidObj.@min': @min can only be applied to a collection of numeric values.");
     RLMAssertThrowsWithReason(([AllOptionalPrimitiveArrays objectsInRealm:realm where:@"boolObj.@min = %@", @NO]),
-                              @"@min can only be applied to a numeric property.");
+                              @"Invalid keypath 'boolObj.@min': @min can only be applied to a collection of numeric values.");
     RLMAssertThrowsWithReason(([AllOptionalPrimitiveArrays objectsInRealm:realm where:@"stringObj.@min = %@", @"a"]),
-                              @"@min can only be applied to a numeric property.");
+                              @"Invalid keypath 'stringObj.@min': @min can only be applied to a collection of numeric values.");
     RLMAssertThrowsWithReason(([AllOptionalPrimitiveArrays objectsInRealm:realm where:@"dataObj.@min = %@", data(1)]),
-                              @"@min can only be applied to a numeric property.");
+                              @"Invalid keypath 'dataObj.@min': @min can only be applied to a collection of numeric values.");
     RLMAssertThrowsWithReason(([AllOptionalPrimitiveArrays objectsInRealm:realm where:@"objectIdObj.@min = %@", objectId(1)]),
-                              @"@min can only be applied to a numeric property.");
+                              @"Invalid keypath 'objectIdObj.@min': @min can only be applied to a collection of numeric values.");
     RLMAssertThrowsWithReason(([AllOptionalPrimitiveArrays objectsInRealm:realm where:@"uuidObj.@min = %@", uuid(@"00000000-0000-0000-0000-000000000000")]),
-                              @"@min can only be applied to a numeric property.");
+                              @"Invalid keypath 'uuidObj.@min': @min can only be applied to a collection of numeric values.");
     RLMAssertThrowsWithReason(([AllPrimitiveArrays objectsInRealm:realm where:@"intObj.@min = %@", @"a"]),
                               @"@min on a property of type int cannot be compared with 'a'");
     RLMAssertThrowsWithReason(([AllPrimitiveArrays objectsInRealm:realm where:@"floatObj.@min = %@", @"a"]),
@@ -9552,35 +9524,35 @@ static NSArray *sortedDistinctUnion(id array, NSString *type, NSString *prop) {
     RLMAssertThrowsWithReason(([AllOptionalPrimitiveArrays objectsInRealm:realm where:@"decimalObj.@min = %@", @"a"]),
                               @"@min on a property of type decimal128 cannot be compared with 'a'");
     RLMAssertThrowsWithReason(([AllPrimitiveArrays objectsInRealm:realm where:@"intObj.@min.prop = %@", @"a"]),
-                              @"Property 'intObj' is not a link in object of type 'AllPrimitiveArrays'");
+                              @"Invalid keypath 'intObj.@min.prop': @min on a collection of values must appear at the end of a keypath.");
     RLMAssertThrowsWithReason(([AllPrimitiveArrays objectsInRealm:realm where:@"floatObj.@min.prop = %@", @"a"]),
-                              @"Property 'floatObj' is not a link in object of type 'AllPrimitiveArrays'");
+                              @"Invalid keypath 'floatObj.@min.prop': @min on a collection of values must appear at the end of a keypath.");
     RLMAssertThrowsWithReason(([AllPrimitiveArrays objectsInRealm:realm where:@"doubleObj.@min.prop = %@", @"a"]),
-                              @"Property 'doubleObj' is not a link in object of type 'AllPrimitiveArrays'");
+                              @"Invalid keypath 'doubleObj.@min.prop': @min on a collection of values must appear at the end of a keypath.");
     RLMAssertThrowsWithReason(([AllPrimitiveArrays objectsInRealm:realm where:@"dateObj.@min.prop = %@", @"a"]),
-                              @"Property 'dateObj' is not a link in object of type 'AllPrimitiveArrays'");
+                              @"Invalid keypath 'dateObj.@min.prop': @min on a collection of values must appear at the end of a keypath.");
     RLMAssertThrowsWithReason(([AllPrimitiveArrays objectsInRealm:realm where:@"decimalObj.@min.prop = %@", @"a"]),
-                              @"Property 'decimalObj' is not a link in object of type 'AllPrimitiveArrays'");
+                              @"Invalid keypath 'decimalObj.@min.prop': @min on a collection of values must appear at the end of a keypath.");
     RLMAssertThrowsWithReason(([AllPrimitiveArrays objectsInRealm:realm where:@"anyIntObj.@min.prop = %@", @"a"]),
-                              @"Property 'anyIntObj' is not a link in object of type 'AllPrimitiveArrays'");
+                              @"Invalid keypath 'anyIntObj.@min.prop': @min on a collection of values must appear at the end of a keypath.");
     RLMAssertThrowsWithReason(([AllPrimitiveArrays objectsInRealm:realm where:@"anyFloatObj.@min.prop = %@", @"a"]),
-                              @"Property 'anyFloatObj' is not a link in object of type 'AllPrimitiveArrays'");
+                              @"Invalid keypath 'anyFloatObj.@min.prop': @min on a collection of values must appear at the end of a keypath.");
     RLMAssertThrowsWithReason(([AllPrimitiveArrays objectsInRealm:realm where:@"anyDoubleObj.@min.prop = %@", @"a"]),
-                              @"Property 'anyDoubleObj' is not a link in object of type 'AllPrimitiveArrays'");
+                              @"Invalid keypath 'anyDoubleObj.@min.prop': @min on a collection of values must appear at the end of a keypath.");
     RLMAssertThrowsWithReason(([AllPrimitiveArrays objectsInRealm:realm where:@"anyDateObj.@min.prop = %@", @"a"]),
-                              @"Property 'anyDateObj' is not a link in object of type 'AllPrimitiveArrays'");
+                              @"Invalid keypath 'anyDateObj.@min.prop': @min on a collection of values must appear at the end of a keypath.");
     RLMAssertThrowsWithReason(([AllPrimitiveArrays objectsInRealm:realm where:@"anyDecimalObj.@min.prop = %@", @"a"]),
-                              @"Property 'anyDecimalObj' is not a link in object of type 'AllPrimitiveArrays'");
+                              @"Invalid keypath 'anyDecimalObj.@min.prop': @min on a collection of values must appear at the end of a keypath.");
     RLMAssertThrowsWithReason(([AllOptionalPrimitiveArrays objectsInRealm:realm where:@"intObj.@min.prop = %@", @"a"]),
-                              @"Property 'intObj' is not a link in object of type 'AllOptionalPrimitiveArrays'");
+                              @"Invalid keypath 'intObj.@min.prop': @min on a collection of values must appear at the end of a keypath.");
     RLMAssertThrowsWithReason(([AllOptionalPrimitiveArrays objectsInRealm:realm where:@"floatObj.@min.prop = %@", @"a"]),
-                              @"Property 'floatObj' is not a link in object of type 'AllOptionalPrimitiveArrays'");
+                              @"Invalid keypath 'floatObj.@min.prop': @min on a collection of values must appear at the end of a keypath.");
     RLMAssertThrowsWithReason(([AllOptionalPrimitiveArrays objectsInRealm:realm where:@"doubleObj.@min.prop = %@", @"a"]),
-                              @"Property 'doubleObj' is not a link in object of type 'AllOptionalPrimitiveArrays'");
+                              @"Invalid keypath 'doubleObj.@min.prop': @min on a collection of values must appear at the end of a keypath.");
     RLMAssertThrowsWithReason(([AllOptionalPrimitiveArrays objectsInRealm:realm where:@"dateObj.@min.prop = %@", @"a"]),
-                              @"Property 'dateObj' is not a link in object of type 'AllOptionalPrimitiveArrays'");
+                              @"Invalid keypath 'dateObj.@min.prop': @min on a collection of values must appear at the end of a keypath.");
     RLMAssertThrowsWithReason(([AllOptionalPrimitiveArrays objectsInRealm:realm where:@"decimalObj.@min.prop = %@", @"a"]),
-                              @"Property 'decimalObj' is not a link in object of type 'AllOptionalPrimitiveArrays'");
+                              @"Invalid keypath 'decimalObj.@min.prop': @min on a collection of values must appear at the end of a keypath.");
 
     // No objects, so count is zero
     RLMAssertCount(AllPrimitiveArrays, 0U, @"intObj.@min == %@", @2);
@@ -9790,25 +9762,25 @@ static NSArray *sortedDistinctUnion(id array, NSString *type, NSString *prop) {
     [realm deleteAllObjects];
 
     RLMAssertThrowsWithReason(([AllPrimitiveArrays objectsInRealm:realm where:@"boolObj.@max = %@", @NO]),
-                              @"@max can only be applied to a numeric property.");
+                              @"Invalid keypath 'boolObj.@max': @max can only be applied to a collection of numeric values.");
     RLMAssertThrowsWithReason(([AllPrimitiveArrays objectsInRealm:realm where:@"stringObj.@max = %@", @"a"]),
-                              @"@max can only be applied to a numeric property.");
+                              @"Invalid keypath 'stringObj.@max': @max can only be applied to a collection of numeric values.");
     RLMAssertThrowsWithReason(([AllPrimitiveArrays objectsInRealm:realm where:@"dataObj.@max = %@", data(1)]),
-                              @"@max can only be applied to a numeric property.");
+                              @"Invalid keypath 'dataObj.@max': @max can only be applied to a collection of numeric values.");
     RLMAssertThrowsWithReason(([AllPrimitiveArrays objectsInRealm:realm where:@"objectIdObj.@max = %@", objectId(1)]),
-                              @"@max can only be applied to a numeric property.");
+                              @"Invalid keypath 'objectIdObj.@max': @max can only be applied to a collection of numeric values.");
     RLMAssertThrowsWithReason(([AllPrimitiveArrays objectsInRealm:realm where:@"uuidObj.@max = %@", uuid(@"00000000-0000-0000-0000-000000000000")]),
-                              @"@max can only be applied to a numeric property.");
+                              @"Invalid keypath 'uuidObj.@max': @max can only be applied to a collection of numeric values.");
     RLMAssertThrowsWithReason(([AllOptionalPrimitiveArrays objectsInRealm:realm where:@"boolObj.@max = %@", @NO]),
-                              @"@max can only be applied to a numeric property.");
+                              @"Invalid keypath 'boolObj.@max': @max can only be applied to a collection of numeric values.");
     RLMAssertThrowsWithReason(([AllOptionalPrimitiveArrays objectsInRealm:realm where:@"stringObj.@max = %@", @"a"]),
-                              @"@max can only be applied to a numeric property.");
+                              @"Invalid keypath 'stringObj.@max': @max can only be applied to a collection of numeric values.");
     RLMAssertThrowsWithReason(([AllOptionalPrimitiveArrays objectsInRealm:realm where:@"dataObj.@max = %@", data(1)]),
-                              @"@max can only be applied to a numeric property.");
+                              @"Invalid keypath 'dataObj.@max': @max can only be applied to a collection of numeric values.");
     RLMAssertThrowsWithReason(([AllOptionalPrimitiveArrays objectsInRealm:realm where:@"objectIdObj.@max = %@", objectId(1)]),
-                              @"@max can only be applied to a numeric property.");
+                              @"Invalid keypath 'objectIdObj.@max': @max can only be applied to a collection of numeric values.");
     RLMAssertThrowsWithReason(([AllOptionalPrimitiveArrays objectsInRealm:realm where:@"uuidObj.@max = %@", uuid(@"00000000-0000-0000-0000-000000000000")]),
-                              @"@max can only be applied to a numeric property.");
+                              @"Invalid keypath 'uuidObj.@max': @max can only be applied to a collection of numeric values.");
     RLMAssertThrowsWithReason(([AllPrimitiveArrays objectsInRealm:realm where:@"intObj.@max = %@", @"a"]),
                               @"@max on a property of type int cannot be compared with 'a'");
     RLMAssertThrowsWithReason(([AllPrimitiveArrays objectsInRealm:realm where:@"floatObj.@max = %@", @"a"]),
@@ -9830,35 +9802,35 @@ static NSArray *sortedDistinctUnion(id array, NSString *type, NSString *prop) {
     RLMAssertThrowsWithReason(([AllOptionalPrimitiveArrays objectsInRealm:realm where:@"decimalObj.@max = %@", @"a"]),
                               @"@max on a property of type decimal128 cannot be compared with 'a'");
     RLMAssertThrowsWithReason(([AllPrimitiveArrays objectsInRealm:realm where:@"intObj.@max.prop = %@", @"a"]),
-                              @"Property 'intObj' is not a link in object of type 'AllPrimitiveArrays'");
+                              @"Invalid keypath 'intObj.@max.prop': @max on a collection of values must appear at the end of a keypath.");
     RLMAssertThrowsWithReason(([AllPrimitiveArrays objectsInRealm:realm where:@"floatObj.@max.prop = %@", @"a"]),
-                              @"Property 'floatObj' is not a link in object of type 'AllPrimitiveArrays'");
+                              @"Invalid keypath 'floatObj.@max.prop': @max on a collection of values must appear at the end of a keypath.");
     RLMAssertThrowsWithReason(([AllPrimitiveArrays objectsInRealm:realm where:@"doubleObj.@max.prop = %@", @"a"]),
-                              @"Property 'doubleObj' is not a link in object of type 'AllPrimitiveArrays'");
+                              @"Invalid keypath 'doubleObj.@max.prop': @max on a collection of values must appear at the end of a keypath.");
     RLMAssertThrowsWithReason(([AllPrimitiveArrays objectsInRealm:realm where:@"dateObj.@max.prop = %@", @"a"]),
-                              @"Property 'dateObj' is not a link in object of type 'AllPrimitiveArrays'");
+                              @"Invalid keypath 'dateObj.@max.prop': @max on a collection of values must appear at the end of a keypath.");
     RLMAssertThrowsWithReason(([AllPrimitiveArrays objectsInRealm:realm where:@"decimalObj.@max.prop = %@", @"a"]),
-                              @"Property 'decimalObj' is not a link in object of type 'AllPrimitiveArrays'");
+                              @"Invalid keypath 'decimalObj.@max.prop': @max on a collection of values must appear at the end of a keypath.");
     RLMAssertThrowsWithReason(([AllPrimitiveArrays objectsInRealm:realm where:@"anyIntObj.@max.prop = %@", @"a"]),
-                              @"Property 'anyIntObj' is not a link in object of type 'AllPrimitiveArrays'");
+                              @"Invalid keypath 'anyIntObj.@max.prop': @max on a collection of values must appear at the end of a keypath.");
     RLMAssertThrowsWithReason(([AllPrimitiveArrays objectsInRealm:realm where:@"anyFloatObj.@max.prop = %@", @"a"]),
-                              @"Property 'anyFloatObj' is not a link in object of type 'AllPrimitiveArrays'");
+                              @"Invalid keypath 'anyFloatObj.@max.prop': @max on a collection of values must appear at the end of a keypath.");
     RLMAssertThrowsWithReason(([AllPrimitiveArrays objectsInRealm:realm where:@"anyDoubleObj.@max.prop = %@", @"a"]),
-                              @"Property 'anyDoubleObj' is not a link in object of type 'AllPrimitiveArrays'");
+                              @"Invalid keypath 'anyDoubleObj.@max.prop': @max on a collection of values must appear at the end of a keypath.");
     RLMAssertThrowsWithReason(([AllPrimitiveArrays objectsInRealm:realm where:@"anyDateObj.@max.prop = %@", @"a"]),
-                              @"Property 'anyDateObj' is not a link in object of type 'AllPrimitiveArrays'");
+                              @"Invalid keypath 'anyDateObj.@max.prop': @max on a collection of values must appear at the end of a keypath.");
     RLMAssertThrowsWithReason(([AllPrimitiveArrays objectsInRealm:realm where:@"anyDecimalObj.@max.prop = %@", @"a"]),
-                              @"Property 'anyDecimalObj' is not a link in object of type 'AllPrimitiveArrays'");
+                              @"Invalid keypath 'anyDecimalObj.@max.prop': @max on a collection of values must appear at the end of a keypath.");
     RLMAssertThrowsWithReason(([AllOptionalPrimitiveArrays objectsInRealm:realm where:@"intObj.@max.prop = %@", @"a"]),
-                              @"Property 'intObj' is not a link in object of type 'AllOptionalPrimitiveArrays'");
+                              @"Invalid keypath 'intObj.@max.prop': @max on a collection of values must appear at the end of a keypath.");
     RLMAssertThrowsWithReason(([AllOptionalPrimitiveArrays objectsInRealm:realm where:@"floatObj.@max.prop = %@", @"a"]),
-                              @"Property 'floatObj' is not a link in object of type 'AllOptionalPrimitiveArrays'");
+                              @"Invalid keypath 'floatObj.@max.prop': @max on a collection of values must appear at the end of a keypath.");
     RLMAssertThrowsWithReason(([AllOptionalPrimitiveArrays objectsInRealm:realm where:@"doubleObj.@max.prop = %@", @"a"]),
-                              @"Property 'doubleObj' is not a link in object of type 'AllOptionalPrimitiveArrays'");
+                              @"Invalid keypath 'doubleObj.@max.prop': @max on a collection of values must appear at the end of a keypath.");
     RLMAssertThrowsWithReason(([AllOptionalPrimitiveArrays objectsInRealm:realm where:@"dateObj.@max.prop = %@", @"a"]),
-                              @"Property 'dateObj' is not a link in object of type 'AllOptionalPrimitiveArrays'");
+                              @"Invalid keypath 'dateObj.@max.prop': @max on a collection of values must appear at the end of a keypath.");
     RLMAssertThrowsWithReason(([AllOptionalPrimitiveArrays objectsInRealm:realm where:@"decimalObj.@max.prop = %@", @"a"]),
-                              @"Property 'decimalObj' is not a link in object of type 'AllOptionalPrimitiveArrays'");
+                              @"Invalid keypath 'decimalObj.@max.prop': @max on a collection of values must appear at the end of a keypath.");
 
     // No objects, so count is zero
     RLMAssertCount(AllPrimitiveArrays, 0U, @"intObj.@max == %@", @2);
@@ -10680,21 +10652,21 @@ static NSArray *sortedDistinctUnion(id array, NSString *type, NSString *prop) {
     void (^testNull)(NSString *, NSUInteger) = ^(NSString *operator, NSUInteger count) {
         NSString *query = [NSString stringWithFormat:@"ANY stringObj %@ nil", operator];
         RLMAssertThrowsWithReason([AllPrimitiveArrays objectsInRealm:realm where:query],
-                                  @"Expected object of type string for property 'stringObj' on object of type 'AllPrimitiveArrays', but received: (null)");
+                                  @"Cannot compare value '(null)' of type '(null)' to property 'stringObj' of type 'string'");
         RLMAssertCount(AllOptionalPrimitiveArrays, count, query, NSNull.null);
         query = [NSString stringWithFormat:@"ANY link.stringObj %@ nil", operator];
         RLMAssertThrowsWithReason([LinkToAllPrimitiveArrays objectsInRealm:realm where:query],
-                                  @"Expected object of type string for property 'link.stringObj' on object of type 'LinkToAllPrimitiveArrays', but received: (null)");
+                                  @"Cannot compare value '(null)' of type '(null)' to property 'stringObj' of type 'string'");
         RLMAssertCount(LinkToAllOptionalPrimitiveArrays, count, query, NSNull.null);
 
         query = [NSString stringWithFormat:@"ANY dataObj %@ nil", operator];
         RLMAssertThrowsWithReason([AllPrimitiveArrays objectsInRealm:realm where:query],
-                                  @"Expected object of type data for property 'dataObj' on object of type 'AllPrimitiveArrays', but received: (null)");
+                                  @"Cannot compare value '(null)' of type '(null)' to property 'dataObj' of type 'data'");
         RLMAssertCount(AllOptionalPrimitiveArrays, count, query, NSNull.null);
 
         query = [NSString stringWithFormat:@"ANY link.dataObj %@ nil", operator];
         RLMAssertThrowsWithReason([LinkToAllPrimitiveArrays objectsInRealm:realm where:query],
-                                  @"Expected object of type data for property 'link.dataObj' on object of type 'LinkToAllPrimitiveArrays', but received: (null)");
+                                  @"Cannot compare value '(null)' of type '(null)' to property 'dataObj' of type 'data'");
         RLMAssertCount(LinkToAllOptionalPrimitiveArrays, count, query, NSNull.null);
     };
 

--- a/Realm/Tests/PrimitiveArrayPropertyTests.tpl.m
+++ b/Realm/Tests/PrimitiveArrayPropertyTests.tpl.m
@@ -1123,11 +1123,11 @@ static NSArray *sortedDistinctUnion(id array, NSString *type, NSString *prop) {
 - (void)testQuerySum {
     [realm deleteAllObjects];
 
-    %noany %nodate %nosum %man RLMAssertThrowsWithReason(([$class objectsInRealm:realm where:@"$prop.@sum = %@", $v0]), ^n @"@sum can only be applied to a numeric property.");
+    %noany %nodate %nosum %man RLMAssertThrowsWithReason(([$class objectsInRealm:realm where:@"$prop.@sum = %@", $v0]), ^n @"Invalid keypath '$prop.@sum': @sum can only be applied to a collection of numeric values.");
     %noany %date %man RLMAssertThrowsWithReason(([$class objectsInRealm:realm where:@"$prop.@sum = %@", $v0]), ^n @"Cannot sum or average date properties");
 
     %noany %sum %man RLMAssertThrowsWithReason(([$class objectsInRealm:realm where:@"$prop.@sum = %@", $wrong]), ^n @"@sum on a property of type $basetype cannot be compared with '$wdesc'");
-    %noany %sum %man RLMAssertThrowsWithReason(([$class objectsInRealm:realm where:@"$prop.@sum.prop = %@", $wrong]), ^n @"Property '$prop' is not a link in object of type '$class'");
+    %noany %sum %man RLMAssertThrowsWithReason(([$class objectsInRealm:realm where:@"$prop.@sum.prop = %@", $wrong]), ^n @"Invalid keypath '$prop.@sum.prop': @sum on a collection of values must appear at the end of a keypath.");
     %noany %sum %man RLMAssertThrowsWithReason(([$class objectsInRealm:realm where:@"$prop.@sum = %@", NSNull.null]), ^n @"@sum on a property of type $basetype cannot be compared with '<null>'");
 
     [AllPrimitiveArrays createInRealm:realm withValue:@{
@@ -1167,12 +1167,12 @@ static NSArray *sortedDistinctUnion(id array, NSString *type, NSString *prop) {
 - (void)testQueryAverage {
     [realm deleteAllObjects];
 
-    %noany %nodate %noavg %man RLMAssertThrowsWithReason(([$class objectsInRealm:realm where:@"$prop.@avg = %@", $v0]), ^n @"@avg can only be applied to a numeric property.");
+    %noany %nodate %noavg %man RLMAssertThrowsWithReason(([$class objectsInRealm:realm where:@"$prop.@avg = %@", $v0]), ^n @"Invalid keypath '$prop.@avg': @avg can only be applied to a collection of numeric values.");
     %noany %date %man RLMAssertThrowsWithReason(([$class objectsInRealm:realm where:@"$prop.@avg = %@", $v0]), ^n @"Cannot sum or average date properties");
     %noany %any %date %man RLMAssertThrowsWithReason(([$class objectsInRealm:realm where:@"$prop.@avg = %@", $v0]), ^n @"Cannot sum or average date properties");
 
     %noany %avg %man RLMAssertThrowsWithReason(([$class objectsInRealm:realm where:@"$prop.@avg = %@", $wrong]), ^n @"@avg on a property of type $basetype cannot be compared with '$wdesc'");
-    %noany %avg %man RLMAssertThrowsWithReason(([$class objectsInRealm:realm where:@"$prop.@avg.prop = %@", $wrong]), ^n @"Property '$prop' is not a link in object of type '$class'");
+    %noany %avg %man RLMAssertThrowsWithReason(([$class objectsInRealm:realm where:@"$prop.@avg.prop = %@", $wrong]), ^n @"Invalid keypath '$prop.@avg.prop': @avg on a collection of values must appear at the end of a keypath.");
 
     [AllPrimitiveArrays createInRealm:realm withValue:@{
         %man %r %avg @"$prop": @[],
@@ -1211,9 +1211,9 @@ static NSArray *sortedDistinctUnion(id array, NSString *type, NSString *prop) {
 - (void)testQueryMin {
     [realm deleteAllObjects];
 
-    %noany %nominmax %man RLMAssertThrowsWithReason(([$class objectsInRealm:realm where:@"$prop.@min = %@", $v0]), ^n @"@min can only be applied to a numeric property.");
+    %noany %nominmax %man RLMAssertThrowsWithReason(([$class objectsInRealm:realm where:@"$prop.@min = %@", $v0]), ^n @"Invalid keypath '$prop.@min': @min can only be applied to a collection of numeric values.");
     %noany %minmax %man RLMAssertThrowsWithReason(([$class objectsInRealm:realm where:@"$prop.@min = %@", $wrong]), ^n @"@min on a property of type $basetype cannot be compared with '$wdesc'");
-    %minmax %man RLMAssertThrowsWithReason(([$class objectsInRealm:realm where:@"$prop.@min.prop = %@", $wrong]), ^n @"Property '$prop' is not a link in object of type '$class'");
+    %minmax %man RLMAssertThrowsWithReason(([$class objectsInRealm:realm where:@"$prop.@min.prop = %@", $wrong]), ^n @"Invalid keypath '$prop.@min.prop': @min on a collection of values must appear at the end of a keypath.");
 
     // No objects, so count is zero
     %minmax %man RLMAssertCount($class, 0U, @"$prop.@min == %@", $v0);
@@ -1256,9 +1256,9 @@ static NSArray *sortedDistinctUnion(id array, NSString *type, NSString *prop) {
 - (void)testQueryMax {
     [realm deleteAllObjects];
 
-    %noany %nominmax %man RLMAssertThrowsWithReason(([$class objectsInRealm:realm where:@"$prop.@max = %@", $v0]), ^n @"@max can only be applied to a numeric property.");
+    %noany %nominmax %man RLMAssertThrowsWithReason(([$class objectsInRealm:realm where:@"$prop.@max = %@", $v0]), ^n @"Invalid keypath '$prop.@max': @max can only be applied to a collection of numeric values.");
     %noany %minmax %man RLMAssertThrowsWithReason(([$class objectsInRealm:realm where:@"$prop.@max = %@", $wrong]), ^n @"@max on a property of type $basetype cannot be compared with '$wdesc'");
-    %minmax %man RLMAssertThrowsWithReason(([$class objectsInRealm:realm where:@"$prop.@max.prop = %@", $wrong]), ^n @"Property '$prop' is not a link in object of type '$class'");
+    %minmax %man RLMAssertThrowsWithReason(([$class objectsInRealm:realm where:@"$prop.@max.prop = %@", $wrong]), ^n @"Invalid keypath '$prop.@max.prop': @max on a collection of values must appear at the end of a keypath.");
 
     // No objects, so count is zero
     %minmax %man RLMAssertCount($class, 0U, @"$prop.@max == %@", $v0);
@@ -1387,21 +1387,21 @@ static NSArray *sortedDistinctUnion(id array, NSString *type, NSString *prop) {
     void (^testNull)(NSString *, NSUInteger) = ^(NSString *operator, NSUInteger count) {
         NSString *query = [NSString stringWithFormat:@"ANY stringObj %@ nil", operator];
         RLMAssertThrowsWithReason([AllPrimitiveArrays objectsInRealm:realm where:query],
-                                  @"Expected object of type string for property 'stringObj' on object of type 'AllPrimitiveArrays', but received: (null)");
+                                  @"Cannot compare value '(null)' of type '(null)' to property 'stringObj' of type 'string'");
         RLMAssertCount(AllOptionalPrimitiveArrays, count, query, NSNull.null);
         query = [NSString stringWithFormat:@"ANY link.stringObj %@ nil", operator];
         RLMAssertThrowsWithReason([LinkToAllPrimitiveArrays objectsInRealm:realm where:query],
-                                  @"Expected object of type string for property 'link.stringObj' on object of type 'LinkToAllPrimitiveArrays', but received: (null)");
+                                  @"Cannot compare value '(null)' of type '(null)' to property 'stringObj' of type 'string'");
         RLMAssertCount(LinkToAllOptionalPrimitiveArrays, count, query, NSNull.null);
 
         query = [NSString stringWithFormat:@"ANY dataObj %@ nil", operator];
         RLMAssertThrowsWithReason([AllPrimitiveArrays objectsInRealm:realm where:query],
-                                  @"Expected object of type data for property 'dataObj' on object of type 'AllPrimitiveArrays', but received: (null)");
+                                  @"Cannot compare value '(null)' of type '(null)' to property 'dataObj' of type 'data'");
         RLMAssertCount(AllOptionalPrimitiveArrays, count, query, NSNull.null);
 
         query = [NSString stringWithFormat:@"ANY link.dataObj %@ nil", operator];
         RLMAssertThrowsWithReason([LinkToAllPrimitiveArrays objectsInRealm:realm where:query],
-                                  @"Expected object of type data for property 'link.dataObj' on object of type 'LinkToAllPrimitiveArrays', but received: (null)");
+                                  @"Cannot compare value '(null)' of type '(null)' to property 'dataObj' of type 'data'");
         RLMAssertCount(LinkToAllOptionalPrimitiveArrays, count, query, NSNull.null);
     };
 

--- a/Realm/Tests/PrimitiveDictionaryPropertyTests.m
+++ b/Realm/Tests/PrimitiveDictionaryPropertyTests.m
@@ -5393,13 +5393,13 @@ static double average(NSDictionary *dictionary) {
     [realm deleteAllObjects];
 
     RLMAssertThrowsWithReason(([AllPrimitiveDictionaries objectsInRealm:realm where:@"boolObj.@sum = %@", @NO]),
-                              @"@sum can only be applied to a numeric property.");
+                              @"Invalid keypath 'boolObj.@sum': @sum can only be applied to a collection of numeric values.");
     RLMAssertThrowsWithReason(([AllOptionalPrimitiveDictionaries objectsInRealm:realm where:@"boolObj.@sum = %@", @NO]),
-                              @"@sum can only be applied to a numeric property.");
+                              @"Invalid keypath 'boolObj.@sum': @sum can only be applied to a collection of numeric values.");
     RLMAssertThrowsWithReason(([AllPrimitiveDictionaries objectsInRealm:realm where:@"stringObj.@sum = %@", @"bar"]),
-                              @"@sum can only be applied to a numeric property.");
+                              @"Invalid keypath 'stringObj.@sum': @sum can only be applied to a collection of numeric values.");
     RLMAssertThrowsWithReason(([AllOptionalPrimitiveDictionaries objectsInRealm:realm where:@"stringObj.@sum = %@", @"bar"]),
-                              @"@sum can only be applied to a numeric property.");
+                              @"Invalid keypath 'stringObj.@sum': @sum can only be applied to a collection of numeric values.");
     RLMAssertThrowsWithReason(([AllPrimitiveDictionaries objectsInRealm:realm where:@"dateObj.@sum = %@", date(1)]),
                               @"Cannot sum or average date properties");
     RLMAssertThrowsWithReason(([AllOptionalPrimitiveDictionaries objectsInRealm:realm where:@"dateObj.@sum = %@", date(1)]),
@@ -5410,17 +5410,17 @@ static double average(NSDictionary *dictionary) {
     RLMAssertThrowsWithReason(([AllOptionalPrimitiveDictionaries objectsInRealm:realm where:@"intObj.@sum = %@", @"a"]),
                               @"@sum on a property of type int cannot be compared with 'a'");
     RLMAssertThrowsWithReason(([AllPrimitiveDictionaries objectsInRealm:realm where:@"intObj.@sum.prop = %@", @"a"]),
-                              @"Property 'intObj' is not a link in object of type 'AllPrimitiveDictionaries'");
+                              @"Invalid keypath 'intObj.@sum.prop': @sum on a collection of values must appear at the end of a keypath.");
     RLMAssertThrowsWithReason(([AllOptionalPrimitiveDictionaries objectsInRealm:realm where:@"intObj.@sum.prop = %@", @"a"]),
-                              @"Property 'intObj' is not a link in object of type 'AllOptionalPrimitiveDictionaries'");
+                              @"Invalid keypath 'intObj.@sum.prop': @sum on a collection of values must appear at the end of a keypath.");
     RLMAssertThrowsWithReason(([AllPrimitiveDictionaries objectsInRealm:realm where:@"anyIntObj.@sum.prop = %@", @"a"]),
-                              @"Property 'anyIntObj' is not a link in object of type 'AllPrimitiveDictionaries'");
+                              @"Invalid keypath 'anyIntObj.@sum.prop': @sum on a collection of values must appear at the end of a keypath.");
     RLMAssertThrowsWithReason(([AllPrimitiveDictionaries objectsInRealm:realm where:@"anyFloatObj.@sum.prop = %@", @"a"]),
-                              @"Property 'anyFloatObj' is not a link in object of type 'AllPrimitiveDictionaries'");
+                              @"Invalid keypath 'anyFloatObj.@sum.prop': @sum on a collection of values must appear at the end of a keypath.");
     RLMAssertThrowsWithReason(([AllPrimitiveDictionaries objectsInRealm:realm where:@"anyDoubleObj.@sum.prop = %@", @"a"]),
-                              @"Property 'anyDoubleObj' is not a link in object of type 'AllPrimitiveDictionaries'");
+                              @"Invalid keypath 'anyDoubleObj.@sum.prop': @sum on a collection of values must appear at the end of a keypath.");
     RLMAssertThrowsWithReason(([AllPrimitiveDictionaries objectsInRealm:realm where:@"anyDecimalObj.@sum.prop = %@", @"a"]),
-                              @"Property 'anyDecimalObj' is not a link in object of type 'AllPrimitiveDictionaries'");
+                              @"Invalid keypath 'anyDecimalObj.@sum.prop': @sum on a collection of values must appear at the end of a keypath.");
     RLMAssertThrowsWithReason(([AllPrimitiveDictionaries objectsInRealm:realm where:@"intObj.@sum = %@", (id)NSNull.null]),
                               @"@sum on a property of type int cannot be compared with '<null>'");
     RLMAssertThrowsWithReason(([AllOptionalPrimitiveDictionaries objectsInRealm:realm where:@"intObj.@sum = %@", (id)NSNull.null]),
@@ -5523,13 +5523,13 @@ static double average(NSDictionary *dictionary) {
     [realm deleteAllObjects];
 
     RLMAssertThrowsWithReason(([AllPrimitiveDictionaries objectsInRealm:realm where:@"boolObj.@avg = %@", @NO]),
-                              @"@avg can only be applied to a numeric property.");
+                              @"Invalid keypath 'boolObj.@avg': @avg can only be applied to a collection of numeric values.");
     RLMAssertThrowsWithReason(([AllOptionalPrimitiveDictionaries objectsInRealm:realm where:@"boolObj.@avg = %@", @NO]),
-                              @"@avg can only be applied to a numeric property.");
+                              @"Invalid keypath 'boolObj.@avg': @avg can only be applied to a collection of numeric values.");
     RLMAssertThrowsWithReason(([AllPrimitiveDictionaries objectsInRealm:realm where:@"stringObj.@avg = %@", @"bar"]),
-                              @"@avg can only be applied to a numeric property.");
+                              @"Invalid keypath 'stringObj.@avg': @avg can only be applied to a collection of numeric values.");
     RLMAssertThrowsWithReason(([AllOptionalPrimitiveDictionaries objectsInRealm:realm where:@"stringObj.@avg = %@", @"bar"]),
-                              @"@avg can only be applied to a numeric property.");
+                              @"Invalid keypath 'stringObj.@avg': @avg can only be applied to a collection of numeric values.");
     RLMAssertThrowsWithReason(([AllPrimitiveDictionaries objectsInRealm:realm where:@"dateObj.@avg = %@", date(1)]),
                               @"Cannot sum or average date properties");
     RLMAssertThrowsWithReason(([AllOptionalPrimitiveDictionaries objectsInRealm:realm where:@"dateObj.@avg = %@", date(1)]),
@@ -5540,17 +5540,17 @@ static double average(NSDictionary *dictionary) {
     RLMAssertThrowsWithReason(([AllOptionalPrimitiveDictionaries objectsInRealm:realm where:@"intObj.@avg = %@", @"a"]),
                               @"@avg on a property of type int cannot be compared with 'a'");
     RLMAssertThrowsWithReason(([AllPrimitiveDictionaries objectsInRealm:realm where:@"intObj.@avg.prop = %@", @"a"]),
-                              @"Property 'intObj' is not a link in object of type 'AllPrimitiveDictionaries'");
+                              @"Invalid keypath 'intObj.@avg.prop': @avg on a collection of values must appear at the end of a keypath.");
     RLMAssertThrowsWithReason(([AllOptionalPrimitiveDictionaries objectsInRealm:realm where:@"intObj.@avg.prop = %@", @"a"]),
-                              @"Property 'intObj' is not a link in object of type 'AllOptionalPrimitiveDictionaries'");
+                              @"Invalid keypath 'intObj.@avg.prop': @avg on a collection of values must appear at the end of a keypath.");
     RLMAssertThrowsWithReason(([AllPrimitiveDictionaries objectsInRealm:realm where:@"anyIntObj.@avg.prop = %@", @"a"]),
-                              @"Property 'anyIntObj' is not a link in object of type 'AllPrimitiveDictionaries'");
+                              @"Invalid keypath 'anyIntObj.@avg.prop': @avg on a collection of values must appear at the end of a keypath.");
     RLMAssertThrowsWithReason(([AllPrimitiveDictionaries objectsInRealm:realm where:@"anyFloatObj.@avg.prop = %@", @"a"]),
-                              @"Property 'anyFloatObj' is not a link in object of type 'AllPrimitiveDictionaries'");
+                              @"Invalid keypath 'anyFloatObj.@avg.prop': @avg on a collection of values must appear at the end of a keypath.");
     RLMAssertThrowsWithReason(([AllPrimitiveDictionaries objectsInRealm:realm where:@"anyDoubleObj.@avg.prop = %@", @"a"]),
-                              @"Property 'anyDoubleObj' is not a link in object of type 'AllPrimitiveDictionaries'");
+                              @"Invalid keypath 'anyDoubleObj.@avg.prop': @avg on a collection of values must appear at the end of a keypath.");
     RLMAssertThrowsWithReason(([AllPrimitiveDictionaries objectsInRealm:realm where:@"anyDecimalObj.@avg.prop = %@", @"a"]),
-                              @"Property 'anyDecimalObj' is not a link in object of type 'AllPrimitiveDictionaries'");
+                              @"Invalid keypath 'anyDecimalObj.@avg.prop': @avg on a collection of values must appear at the end of a keypath.");
 
     [AllPrimitiveDictionaries createInRealm:realm withValue:@{
         @"intObj": @{},
@@ -5642,13 +5642,13 @@ static double average(NSDictionary *dictionary) {
     [realm deleteAllObjects];
 
     RLMAssertThrowsWithReason(([AllPrimitiveDictionaries objectsInRealm:realm where:@"boolObj.@min = %@", @NO]),
-                              @"@min can only be applied to a numeric property.");
+                              @"Invalid keypath 'boolObj.@min': @min can only be applied to a collection of numeric values.");
     RLMAssertThrowsWithReason(([AllOptionalPrimitiveDictionaries objectsInRealm:realm where:@"boolObj.@min = %@", @NO]),
-                              @"@min can only be applied to a numeric property.");
+                              @"Invalid keypath 'boolObj.@min': @min can only be applied to a collection of numeric values.");
     RLMAssertThrowsWithReason(([AllPrimitiveDictionaries objectsInRealm:realm where:@"stringObj.@min = %@", @"bar"]),
-                              @"@min can only be applied to a numeric property.");
+                              @"Invalid keypath 'stringObj.@min': @min can only be applied to a collection of numeric values.");
     RLMAssertThrowsWithReason(([AllOptionalPrimitiveDictionaries objectsInRealm:realm where:@"stringObj.@min = %@", @"bar"]),
-                              @"@min can only be applied to a numeric property.");
+                              @"Invalid keypath 'stringObj.@min': @min can only be applied to a collection of numeric values.");
     RLMAssertThrowsWithReason(([AllPrimitiveDictionaries objectsInRealm:realm where:@"intObj.@min = %@", @"a"]),
                               @"@min on a property of type int cannot be compared with 'a'");
     RLMAssertThrowsWithReason(([AllOptionalPrimitiveDictionaries objectsInRealm:realm where:@"intObj.@min = %@", @"a"]),
@@ -5658,19 +5658,19 @@ static double average(NSDictionary *dictionary) {
     RLMAssertThrowsWithReason(([AllOptionalPrimitiveDictionaries objectsInRealm:realm where:@"dateObj.@min = %@", @"a"]),
                               @"@min on a property of type date cannot be compared with 'a'");
     RLMAssertThrowsWithReason(([AllPrimitiveDictionaries objectsInRealm:realm where:@"intObj.@min.prop = %@", @"a"]),
-                              @"Property 'intObj' is not a link in object of type 'AllPrimitiveDictionaries'");
+                              @"Invalid keypath 'intObj.@min.prop': @min on a collection of values must appear at the end of a keypath.");
     RLMAssertThrowsWithReason(([AllOptionalPrimitiveDictionaries objectsInRealm:realm where:@"intObj.@min.prop = %@", @"a"]),
-                              @"Property 'intObj' is not a link in object of type 'AllOptionalPrimitiveDictionaries'");
+                              @"Invalid keypath 'intObj.@min.prop': @min on a collection of values must appear at the end of a keypath.");
     RLMAssertThrowsWithReason(([AllPrimitiveDictionaries objectsInRealm:realm where:@"dateObj.@min.prop = %@", @"a"]),
-                              @"Property 'dateObj' is not a link in object of type 'AllPrimitiveDictionaries'");
+                              @"Invalid keypath 'dateObj.@min.prop': @min on a collection of values must appear at the end of a keypath.");
     RLMAssertThrowsWithReason(([AllOptionalPrimitiveDictionaries objectsInRealm:realm where:@"dateObj.@min.prop = %@", @"a"]),
-                              @"Property 'dateObj' is not a link in object of type 'AllOptionalPrimitiveDictionaries'");
+                              @"Invalid keypath 'dateObj.@min.prop': @min on a collection of values must appear at the end of a keypath.");
     RLMAssertThrowsWithReason(([AllPrimitiveDictionaries objectsInRealm:realm where:@"anyFloatObj.@min.prop = %@", @"a"]),
-                              @"Property 'anyFloatObj' is not a link in object of type 'AllPrimitiveDictionaries'");
+                              @"Invalid keypath 'anyFloatObj.@min.prop': @min on a collection of values must appear at the end of a keypath.");
     RLMAssertThrowsWithReason(([AllPrimitiveDictionaries objectsInRealm:realm where:@"anyDoubleObj.@min.prop = %@", @"a"]),
-                              @"Property 'anyDoubleObj' is not a link in object of type 'AllPrimitiveDictionaries'");
+                              @"Invalid keypath 'anyDoubleObj.@min.prop': @min on a collection of values must appear at the end of a keypath.");
     RLMAssertThrowsWithReason(([AllPrimitiveDictionaries objectsInRealm:realm where:@"anyDecimalObj.@min.prop = %@", @"a"]),
-                              @"Property 'anyDecimalObj' is not a link in object of type 'AllPrimitiveDictionaries'");
+                              @"Invalid keypath 'anyDecimalObj.@min.prop': @min on a collection of values must appear at the end of a keypath.");
 
     // No objects, so count is zero
     RLMAssertCount(AllPrimitiveDictionaries, 0U, @"intObj.@min == %@", @2);
@@ -5738,13 +5738,13 @@ static double average(NSDictionary *dictionary) {
     [realm deleteAllObjects];
 
     RLMAssertThrowsWithReason(([AllPrimitiveDictionaries objectsInRealm:realm where:@"boolObj.@max = %@", @NO]),
-                              @"@max can only be applied to a numeric property.");
+                              @"Invalid keypath 'boolObj.@max': @max can only be applied to a collection of numeric values.");
     RLMAssertThrowsWithReason(([AllOptionalPrimitiveDictionaries objectsInRealm:realm where:@"boolObj.@max = %@", @NO]),
-                              @"@max can only be applied to a numeric property.");
+                              @"Invalid keypath 'boolObj.@max': @max can only be applied to a collection of numeric values.");
     RLMAssertThrowsWithReason(([AllPrimitiveDictionaries objectsInRealm:realm where:@"stringObj.@max = %@", @"bar"]),
-                              @"@max can only be applied to a numeric property.");
+                              @"Invalid keypath 'stringObj.@max': @max can only be applied to a collection of numeric values.");
     RLMAssertThrowsWithReason(([AllOptionalPrimitiveDictionaries objectsInRealm:realm where:@"stringObj.@max = %@", @"bar"]),
-                              @"@max can only be applied to a numeric property.");
+                              @"Invalid keypath 'stringObj.@max': @max can only be applied to a collection of numeric values.");
     RLMAssertThrowsWithReason(([AllPrimitiveDictionaries objectsInRealm:realm where:@"intObj.@max = %@", @"a"]),
                               @"@max on a property of type int cannot be compared with 'a'");
     RLMAssertThrowsWithReason(([AllOptionalPrimitiveDictionaries objectsInRealm:realm where:@"intObj.@max = %@", @"a"]),
@@ -5754,19 +5754,19 @@ static double average(NSDictionary *dictionary) {
     RLMAssertThrowsWithReason(([AllOptionalPrimitiveDictionaries objectsInRealm:realm where:@"dateObj.@max = %@", @"a"]),
                               @"@max on a property of type date cannot be compared with 'a'");
     RLMAssertThrowsWithReason(([AllPrimitiveDictionaries objectsInRealm:realm where:@"intObj.@max.prop = %@", @"a"]),
-                              @"Property 'intObj' is not a link in object of type 'AllPrimitiveDictionaries'");
+                              @"Invalid keypath 'intObj.@max.prop': @max on a collection of values must appear at the end of a keypath.");
     RLMAssertThrowsWithReason(([AllOptionalPrimitiveDictionaries objectsInRealm:realm where:@"intObj.@max.prop = %@", @"a"]),
-                              @"Property 'intObj' is not a link in object of type 'AllOptionalPrimitiveDictionaries'");
+                              @"Invalid keypath 'intObj.@max.prop': @max on a collection of values must appear at the end of a keypath.");
     RLMAssertThrowsWithReason(([AllPrimitiveDictionaries objectsInRealm:realm where:@"dateObj.@max.prop = %@", @"a"]),
-                              @"Property 'dateObj' is not a link in object of type 'AllPrimitiveDictionaries'");
+                              @"Invalid keypath 'dateObj.@max.prop': @max on a collection of values must appear at the end of a keypath.");
     RLMAssertThrowsWithReason(([AllOptionalPrimitiveDictionaries objectsInRealm:realm where:@"dateObj.@max.prop = %@", @"a"]),
-                              @"Property 'dateObj' is not a link in object of type 'AllOptionalPrimitiveDictionaries'");
+                              @"Invalid keypath 'dateObj.@max.prop': @max on a collection of values must appear at the end of a keypath.");
     RLMAssertThrowsWithReason(([AllPrimitiveDictionaries objectsInRealm:realm where:@"anyFloatObj.@max.prop = %@", @"a"]),
-                              @"Property 'anyFloatObj' is not a link in object of type 'AllPrimitiveDictionaries'");
+                              @"Invalid keypath 'anyFloatObj.@max.prop': @max on a collection of values must appear at the end of a keypath.");
     RLMAssertThrowsWithReason(([AllPrimitiveDictionaries objectsInRealm:realm where:@"anyDoubleObj.@max.prop = %@", @"a"]),
-                              @"Property 'anyDoubleObj' is not a link in object of type 'AllPrimitiveDictionaries'");
+                              @"Invalid keypath 'anyDoubleObj.@max.prop': @max on a collection of values must appear at the end of a keypath.");
     RLMAssertThrowsWithReason(([AllPrimitiveDictionaries objectsInRealm:realm where:@"anyDecimalObj.@max.prop = %@", @"a"]),
-                              @"Property 'anyDecimalObj' is not a link in object of type 'AllPrimitiveDictionaries'");
+                              @"Invalid keypath 'anyDecimalObj.@max.prop': @max on a collection of values must appear at the end of a keypath.");
 
     // No objects, so count is zero
     RLMAssertCount(AllPrimitiveDictionaries, 0U, @"intObj.@max == %@", @2);
@@ -6075,21 +6075,21 @@ static double average(NSDictionary *dictionary) {
     void (^testNull)(NSString *, NSUInteger) = ^(NSString *operator, NSUInteger count) {
         NSString *query = [NSString stringWithFormat:@"ANY stringObj %@ nil", operator];
         RLMAssertThrowsWithReason([AllPrimitiveDictionaries objectsInRealm:realm where:query],
-                                  @"Expected object of type string for property 'stringObj' on object of type 'AllPrimitiveDictionaries', but received: (null)");
+                                  @"Cannot compare value '(null)' of type '(null)' to property 'stringObj' of type 'string'");
         RLMAssertCount(AllOptionalPrimitiveDictionaries, count, query, NSNull.null);
         query = [NSString stringWithFormat:@"ANY link.stringObj %@ nil", operator];
         RLMAssertThrowsWithReason([LinkToAllPrimitiveDictionaries objectsInRealm:realm where:query],
-                                  @"Expected object of type string for property 'link.stringObj' on object of type 'LinkToAllPrimitiveDictionaries', but received: (null)");
+                                  @"Cannot compare value '(null)' of type '(null)' to property 'stringObj' of type 'string'");
         RLMAssertCount(LinkToAllOptionalPrimitiveDictionaries, count, query, NSNull.null);
 
         query = [NSString stringWithFormat:@"ANY dataObj %@ nil", operator];
         RLMAssertThrowsWithReason([AllPrimitiveDictionaries objectsInRealm:realm where:query],
-                                  @"Expected object of type data for property 'dataObj' on object of type 'AllPrimitiveDictionaries', but received: (null)");
+                                  @"Cannot compare value '(null)' of type '(null)' to property 'dataObj' of type 'data'");
         RLMAssertCount(AllOptionalPrimitiveDictionaries, count, query, NSNull.null);
 
         query = [NSString stringWithFormat:@"ANY link.dataObj %@ nil", operator];
         RLMAssertThrowsWithReason([LinkToAllPrimitiveDictionaries objectsInRealm:realm where:query],
-                                  @"Expected object of type data for property 'link.dataObj' on object of type 'LinkToAllPrimitiveDictionaries', but received: (null)");
+                                  @"Cannot compare value '(null)' of type '(null)' to property 'dataObj' of type 'data'");
         RLMAssertCount(LinkToAllOptionalPrimitiveDictionaries, count, query, NSNull.null);
     };
 

--- a/Realm/Tests/PrimitiveDictionaryPropertyTests.tpl.m
+++ b/Realm/Tests/PrimitiveDictionaryPropertyTests.tpl.m
@@ -796,11 +796,11 @@ static double average(NSDictionary *dictionary) {
 - (void)testQuerySum {
     [realm deleteAllObjects];
 
-    %noany %nodate %nosum %man RLMAssertThrowsWithReason(([$class objectsInRealm:realm where:@"$prop.@sum = %@", $v0]), ^n @"@sum can only be applied to a numeric property.");
+    %noany %nodate %nosum %man RLMAssertThrowsWithReason(([$class objectsInRealm:realm where:@"$prop.@sum = %@", $v0]), ^n @"Invalid keypath '$prop.@sum': @sum can only be applied to a collection of numeric values.");
     %date %man RLMAssertThrowsWithReason(([$class objectsInRealm:realm where:@"$prop.@sum = %@", $v0]), ^n @"Cannot sum or average date properties");
 
     %noany %sum %man RLMAssertThrowsWithReason(([$class objectsInRealm:realm where:@"$prop.@sum = %@", $wrong]), ^n @"@sum on a property of type $basetype cannot be compared with '$wdesc'");
-    %sum %man RLMAssertThrowsWithReason(([$class objectsInRealm:realm where:@"$prop.@sum.prop = %@", $wrong]), ^n @"Property '$prop' is not a link in object of type '$class'");
+    %sum %man RLMAssertThrowsWithReason(([$class objectsInRealm:realm where:@"$prop.@sum.prop = %@", $wrong]), ^n @"Invalid keypath '$prop.@sum.prop': @sum on a collection of values must appear at the end of a keypath.");
     %sum %man RLMAssertThrowsWithReason(([$class objectsInRealm:realm where:@"$prop.@sum = %@", (id)NSNull.null]), ^n @"@sum on a property of type $basetype cannot be compared with '<null>'");
 
     [AllPrimitiveDictionaries createInRealm:realm withValue:@{
@@ -845,11 +845,11 @@ static double average(NSDictionary *dictionary) {
 - (void)testQueryAverage {
     [realm deleteAllObjects];
 
-    %noany %nodate %noavg %man RLMAssertThrowsWithReason(([$class objectsInRealm:realm where:@"$prop.@avg = %@", $v0]), ^n @"@avg can only be applied to a numeric property.");
+    %noany %nodate %noavg %man RLMAssertThrowsWithReason(([$class objectsInRealm:realm where:@"$prop.@avg = %@", $v0]), ^n @"Invalid keypath '$prop.@avg': @avg can only be applied to a collection of numeric values.");
     %date %man RLMAssertThrowsWithReason(([$class objectsInRealm:realm where:@"$prop.@avg = %@", $v0]), ^n @"Cannot sum or average date properties");
 
     %noany %avg %man RLMAssertThrowsWithReason(([$class objectsInRealm:realm where:@"$prop.@avg = %@", $wrong]), ^n @"@avg on a property of type $basetype cannot be compared with '$wdesc'");
-    %avg %man RLMAssertThrowsWithReason(([$class objectsInRealm:realm where:@"$prop.@avg.prop = %@", $wrong]), ^n @"Property '$prop' is not a link in object of type '$class'");
+    %avg %man RLMAssertThrowsWithReason(([$class objectsInRealm:realm where:@"$prop.@avg.prop = %@", $wrong]), ^n @"Invalid keypath '$prop.@avg.prop': @avg on a collection of values must appear at the end of a keypath.");
 
     [AllPrimitiveDictionaries createInRealm:realm withValue:@{
         %man %r %avg @"$prop": @{},
@@ -894,9 +894,9 @@ static double average(NSDictionary *dictionary) {
 - (void)testQueryMin {
     [realm deleteAllObjects];
 
-    %noany %nominmax %man RLMAssertThrowsWithReason(([$class objectsInRealm:realm where:@"$prop.@min = %@", $v0]), ^n @"@min can only be applied to a numeric property.");
+    %noany %nominmax %man RLMAssertThrowsWithReason(([$class objectsInRealm:realm where:@"$prop.@min = %@", $v0]), ^n @"Invalid keypath '$prop.@min': @min can only be applied to a collection of numeric values.");
     %noany %minmax %man RLMAssertThrowsWithReason(([$class objectsInRealm:realm where:@"$prop.@min = %@", $wrong]), ^n @"@min on a property of type $basetype cannot be compared with '$wdesc'");
-    %minmax %man RLMAssertThrowsWithReason(([$class objectsInRealm:realm where:@"$prop.@min.prop = %@", $wrong]), ^n @"Property '$prop' is not a link in object of type '$class'");
+    %minmax %man RLMAssertThrowsWithReason(([$class objectsInRealm:realm where:@"$prop.@min.prop = %@", $wrong]), ^n @"Invalid keypath '$prop.@min.prop': @min on a collection of values must appear at the end of a keypath.");
 
     // No objects, so count is zero
     %minmax %man RLMAssertCount($class, 0U, @"$prop.@min == %@", $v0);
@@ -923,9 +923,9 @@ static double average(NSDictionary *dictionary) {
 - (void)testQueryMax {
     [realm deleteAllObjects];
 
-    %noany %nominmax %man RLMAssertThrowsWithReason(([$class objectsInRealm:realm where:@"$prop.@max = %@", $v0]), ^n @"@max can only be applied to a numeric property.");
+    %noany %nominmax %man RLMAssertThrowsWithReason(([$class objectsInRealm:realm where:@"$prop.@max = %@", $v0]), ^n @"Invalid keypath '$prop.@max': @max can only be applied to a collection of numeric values.");
     %noany %minmax %man RLMAssertThrowsWithReason(([$class objectsInRealm:realm where:@"$prop.@max = %@", $wrong]), ^n @"@max on a property of type $basetype cannot be compared with '$wdesc'");
-    %minmax %man RLMAssertThrowsWithReason(([$class objectsInRealm:realm where:@"$prop.@max.prop = %@", $wrong]), ^n @"Property '$prop' is not a link in object of type '$class'");
+    %minmax %man RLMAssertThrowsWithReason(([$class objectsInRealm:realm where:@"$prop.@max.prop = %@", $wrong]), ^n @"Invalid keypath '$prop.@max.prop': @max on a collection of values must appear at the end of a keypath.");
 
     // No objects, so count is zero
     %minmax %man RLMAssertCount($class, 0U, @"$prop.@max == %@", $v0);
@@ -1030,21 +1030,21 @@ static double average(NSDictionary *dictionary) {
     void (^testNull)(NSString *, NSUInteger) = ^(NSString *operator, NSUInteger count) {
         NSString *query = [NSString stringWithFormat:@"ANY stringObj %@ nil", operator];
         RLMAssertThrowsWithReason([AllPrimitiveDictionaries objectsInRealm:realm where:query],
-                                  @"Expected object of type string for property 'stringObj' on object of type 'AllPrimitiveDictionaries', but received: (null)");
+                                  @"Cannot compare value '(null)' of type '(null)' to property 'stringObj' of type 'string'");
         RLMAssertCount(AllOptionalPrimitiveDictionaries, count, query, NSNull.null);
         query = [NSString stringWithFormat:@"ANY link.stringObj %@ nil", operator];
         RLMAssertThrowsWithReason([LinkToAllPrimitiveDictionaries objectsInRealm:realm where:query],
-                                  @"Expected object of type string for property 'link.stringObj' on object of type 'LinkToAllPrimitiveDictionaries', but received: (null)");
+                                  @"Cannot compare value '(null)' of type '(null)' to property 'stringObj' of type 'string'");
         RLMAssertCount(LinkToAllOptionalPrimitiveDictionaries, count, query, NSNull.null);
 
         query = [NSString stringWithFormat:@"ANY dataObj %@ nil", operator];
         RLMAssertThrowsWithReason([AllPrimitiveDictionaries objectsInRealm:realm where:query],
-                                  @"Expected object of type data for property 'dataObj' on object of type 'AllPrimitiveDictionaries', but received: (null)");
+                                  @"Cannot compare value '(null)' of type '(null)' to property 'dataObj' of type 'data'");
         RLMAssertCount(AllOptionalPrimitiveDictionaries, count, query, NSNull.null);
 
         query = [NSString stringWithFormat:@"ANY link.dataObj %@ nil", operator];
         RLMAssertThrowsWithReason([LinkToAllPrimitiveDictionaries objectsInRealm:realm where:query],
-                                  @"Expected object of type data for property 'link.dataObj' on object of type 'LinkToAllPrimitiveDictionaries', but received: (null)");
+                                  @"Cannot compare value '(null)' of type '(null)' to property 'dataObj' of type 'data'");
         RLMAssertCount(LinkToAllOptionalPrimitiveDictionaries, count, query, NSNull.null);
     };
 

--- a/Realm/Tests/PrimitiveSetPropertyTests.m
+++ b/Realm/Tests/PrimitiveSetPropertyTests.m
@@ -6964,29 +6964,28 @@ static double average(NSArray *values) {
     [realm deleteAllObjects];
 
     RLMAssertThrowsWithReason(([AllPrimitiveSets objectsInRealm:realm where:@"boolObj.@sum = %@", @NO]), 
-                              @"@sum can only be applied to a numeric property.");
+                              @"Invalid keypath 'boolObj.@sum': @sum can only be applied to a collection of numeric values.");
     RLMAssertThrowsWithReason(([AllPrimitiveSets objectsInRealm:realm where:@"stringObj.@sum = %@", @"a"]), 
-                              @"@sum can only be applied to a numeric property.");
+                              @"Invalid keypath 'stringObj.@sum': @sum can only be applied to a collection of numeric values.");
     RLMAssertThrowsWithReason(([AllPrimitiveSets objectsInRealm:realm where:@"dataObj.@sum = %@", data(1)]), 
-                              @"@sum can only be applied to a numeric property.");
+                              @"Invalid keypath 'dataObj.@sum': @sum can only be applied to a collection of numeric values.");
     RLMAssertThrowsWithReason(([AllPrimitiveSets objectsInRealm:realm where:@"objectIdObj.@sum = %@", objectId(1)]), 
-                              @"@sum can only be applied to a numeric property.");
+                              @"Invalid keypath 'objectIdObj.@sum': @sum can only be applied to a collection of numeric values.");
     RLMAssertThrowsWithReason(([AllPrimitiveSets objectsInRealm:realm where:@"uuidObj.@sum = %@", uuid(@"137DECC8-B300-4954-A233-F89909F4FD89")]), 
-                              @"@sum can only be applied to a numeric property.");
+                              @"Invalid keypath 'uuidObj.@sum': @sum can only be applied to a collection of numeric values.");
     RLMAssertThrowsWithReason(([AllOptionalPrimitiveSets objectsInRealm:realm where:@"boolObj.@sum = %@", NSNull.null]), 
-                              @"@sum can only be applied to a numeric property.");
+                              @"Invalid keypath 'boolObj.@sum': @sum can only be applied to a collection of numeric values.");
     RLMAssertThrowsWithReason(([AllOptionalPrimitiveSets objectsInRealm:realm where:@"stringObj.@sum = %@", NSNull.null]), 
-                              @"@sum can only be applied to a numeric property.");
+                              @"Invalid keypath 'stringObj.@sum': @sum can only be applied to a collection of numeric values.");
     RLMAssertThrowsWithReason(([AllOptionalPrimitiveSets objectsInRealm:realm where:@"dataObj.@sum = %@", NSNull.null]), 
-                              @"@sum can only be applied to a numeric property.");
+                              @"Invalid keypath 'dataObj.@sum': @sum can only be applied to a collection of numeric values.");
     RLMAssertThrowsWithReason(([AllOptionalPrimitiveSets objectsInRealm:realm where:@"objectIdObj.@sum = %@", NSNull.null]), 
-                              @"@sum can only be applied to a numeric property.");
+                              @"Invalid keypath 'objectIdObj.@sum': @sum can only be applied to a collection of numeric values.");
     RLMAssertThrowsWithReason(([AllOptionalPrimitiveSets objectsInRealm:realm where:@"uuidObj.@sum = %@", NSNull.null]), 
-                              @"@sum can only be applied to a numeric property.");
-    RLMAssertThrowsWithReason(([AllPrimitiveSets objectsInRealm:realm where:@"dateObj.@sum = %@", date(2)]), 
+                              @"Invalid keypath 'uuidObj.@sum': @sum can only be applied to a collection of numeric values.");
+    RLMAssertThrowsWithReason(([AllPrimitiveSets objectsInRealm:realm where:@"dateObj.@sum = %@", date(1)]), 
                               @"Cannot sum or average date properties");
-    RLMAssertThrowsWithReason(([AllOptionalPrimitiveSets objectsInRealm:realm where:@"dateObj.@sum = %@", date(1)]), 
-                              @"Cannot sum or average date properties");
+
     RLMAssertThrowsWithReason(([AllPrimitiveSets objectsInRealm:realm where:@"intObj.@sum = %@", @"a"]), 
                               @"@sum on a property of type int cannot be compared with 'a'");
     RLMAssertThrowsWithReason(([AllPrimitiveSets objectsInRealm:realm where:@"floatObj.@sum = %@", @"a"]), 
@@ -7004,29 +7003,21 @@ static double average(NSArray *values) {
     RLMAssertThrowsWithReason(([AllOptionalPrimitiveSets objectsInRealm:realm where:@"decimalObj.@sum = %@", @"a"]), 
                               @"@sum on a property of type decimal128 cannot be compared with 'a'");
     RLMAssertThrowsWithReason(([AllPrimitiveSets objectsInRealm:realm where:@"intObj.@sum.prop = %@", @"a"]), 
-                              @"Property 'intObj' is not a link in object of type 'AllPrimitiveSets'");
+                              @"Invalid keypath 'intObj.@sum.prop': @sum on a collection of values must appear at the end of a keypath.");
     RLMAssertThrowsWithReason(([AllPrimitiveSets objectsInRealm:realm where:@"floatObj.@sum.prop = %@", @"a"]), 
-                              @"Property 'floatObj' is not a link in object of type 'AllPrimitiveSets'");
+                              @"Invalid keypath 'floatObj.@sum.prop': @sum on a collection of values must appear at the end of a keypath.");
     RLMAssertThrowsWithReason(([AllPrimitiveSets objectsInRealm:realm where:@"doubleObj.@sum.prop = %@", @"a"]), 
-                              @"Property 'doubleObj' is not a link in object of type 'AllPrimitiveSets'");
+                              @"Invalid keypath 'doubleObj.@sum.prop': @sum on a collection of values must appear at the end of a keypath.");
     RLMAssertThrowsWithReason(([AllPrimitiveSets objectsInRealm:realm where:@"decimalObj.@sum.prop = %@", @"a"]), 
-                              @"Property 'decimalObj' is not a link in object of type 'AllPrimitiveSets'");
-    RLMAssertThrowsWithReason(([AllPrimitiveSets objectsInRealm:realm where:@"anyIntObj.@sum.prop = %@", @"a"]), 
-                              @"Property 'anyIntObj' is not a link in object of type 'AllPrimitiveSets'");
-    RLMAssertThrowsWithReason(([AllPrimitiveSets objectsInRealm:realm where:@"anyFloatObj.@sum.prop = %@", @"a"]), 
-                              @"Property 'anyFloatObj' is not a link in object of type 'AllPrimitiveSets'");
-    RLMAssertThrowsWithReason(([AllPrimitiveSets objectsInRealm:realm where:@"anyDoubleObj.@sum.prop = %@", @"a"]), 
-                              @"Property 'anyDoubleObj' is not a link in object of type 'AllPrimitiveSets'");
-    RLMAssertThrowsWithReason(([AllPrimitiveSets objectsInRealm:realm where:@"anyDecimalObj.@sum.prop = %@", @"a"]), 
-                              @"Property 'anyDecimalObj' is not a link in object of type 'AllPrimitiveSets'");
+                              @"Invalid keypath 'decimalObj.@sum.prop': @sum on a collection of values must appear at the end of a keypath.");
     RLMAssertThrowsWithReason(([AllOptionalPrimitiveSets objectsInRealm:realm where:@"intObj.@sum.prop = %@", @"a"]), 
-                              @"Property 'intObj' is not a link in object of type 'AllOptionalPrimitiveSets'");
+                              @"Invalid keypath 'intObj.@sum.prop': @sum on a collection of values must appear at the end of a keypath.");
     RLMAssertThrowsWithReason(([AllOptionalPrimitiveSets objectsInRealm:realm where:@"floatObj.@sum.prop = %@", @"a"]), 
-                              @"Property 'floatObj' is not a link in object of type 'AllOptionalPrimitiveSets'");
+                              @"Invalid keypath 'floatObj.@sum.prop': @sum on a collection of values must appear at the end of a keypath.");
     RLMAssertThrowsWithReason(([AllOptionalPrimitiveSets objectsInRealm:realm where:@"doubleObj.@sum.prop = %@", @"a"]), 
-                              @"Property 'doubleObj' is not a link in object of type 'AllOptionalPrimitiveSets'");
+                              @"Invalid keypath 'doubleObj.@sum.prop': @sum on a collection of values must appear at the end of a keypath.");
     RLMAssertThrowsWithReason(([AllOptionalPrimitiveSets objectsInRealm:realm where:@"decimalObj.@sum.prop = %@", @"a"]), 
-                              @"Property 'decimalObj' is not a link in object of type 'AllOptionalPrimitiveSets'");
+                              @"Invalid keypath 'decimalObj.@sum.prop': @sum on a collection of values must appear at the end of a keypath.");
     RLMAssertThrowsWithReason(([AllPrimitiveSets objectsInRealm:realm where:@"intObj.@sum = %@", NSNull.null]), 
                               @"@sum on a property of type int cannot be compared with '<null>'");
     RLMAssertThrowsWithReason(([AllPrimitiveSets objectsInRealm:realm where:@"floatObj.@sum = %@", NSNull.null]), 
@@ -7200,29 +7191,30 @@ static double average(NSArray *values) {
     [realm deleteAllObjects];
 
     RLMAssertThrowsWithReason(([AllPrimitiveSets objectsInRealm:realm where:@"boolObj.@avg = %@", @NO]), 
-                              @"@avg can only be applied to a numeric property.");
+                              @"Invalid keypath 'boolObj.@avg': @avg can only be applied to a collection of numeric values.");
     RLMAssertThrowsWithReason(([AllPrimitiveSets objectsInRealm:realm where:@"stringObj.@avg = %@", @"a"]), 
-                              @"@avg can only be applied to a numeric property.");
+                              @"Invalid keypath 'stringObj.@avg': @avg can only be applied to a collection of numeric values.");
     RLMAssertThrowsWithReason(([AllPrimitiveSets objectsInRealm:realm where:@"dataObj.@avg = %@", data(1)]), 
-                              @"@avg can only be applied to a numeric property.");
+                              @"Invalid keypath 'dataObj.@avg': @avg can only be applied to a collection of numeric values.");
     RLMAssertThrowsWithReason(([AllPrimitiveSets objectsInRealm:realm where:@"objectIdObj.@avg = %@", objectId(1)]), 
-                              @"@avg can only be applied to a numeric property.");
+                              @"Invalid keypath 'objectIdObj.@avg': @avg can only be applied to a collection of numeric values.");
     RLMAssertThrowsWithReason(([AllPrimitiveSets objectsInRealm:realm where:@"uuidObj.@avg = %@", uuid(@"137DECC8-B300-4954-A233-F89909F4FD89")]), 
-                              @"@avg can only be applied to a numeric property.");
+                              @"Invalid keypath 'uuidObj.@avg': @avg can only be applied to a collection of numeric values.");
     RLMAssertThrowsWithReason(([AllOptionalPrimitiveSets objectsInRealm:realm where:@"boolObj.@avg = %@", NSNull.null]), 
-                              @"@avg can only be applied to a numeric property.");
+                              @"Invalid keypath 'boolObj.@avg': @avg can only be applied to a collection of numeric values.");
     RLMAssertThrowsWithReason(([AllOptionalPrimitiveSets objectsInRealm:realm where:@"stringObj.@avg = %@", NSNull.null]), 
-                              @"@avg can only be applied to a numeric property.");
+                              @"Invalid keypath 'stringObj.@avg': @avg can only be applied to a collection of numeric values.");
     RLMAssertThrowsWithReason(([AllOptionalPrimitiveSets objectsInRealm:realm where:@"dataObj.@avg = %@", NSNull.null]), 
-                              @"@avg can only be applied to a numeric property.");
+                              @"Invalid keypath 'dataObj.@avg': @avg can only be applied to a collection of numeric values.");
     RLMAssertThrowsWithReason(([AllOptionalPrimitiveSets objectsInRealm:realm where:@"objectIdObj.@avg = %@", NSNull.null]), 
-                              @"@avg can only be applied to a numeric property.");
+                              @"Invalid keypath 'objectIdObj.@avg': @avg can only be applied to a collection of numeric values.");
     RLMAssertThrowsWithReason(([AllOptionalPrimitiveSets objectsInRealm:realm where:@"uuidObj.@avg = %@", NSNull.null]), 
-                              @"@avg can only be applied to a numeric property.");
+                              @"Invalid keypath 'uuidObj.@avg': @avg can only be applied to a collection of numeric values.");
     RLMAssertThrowsWithReason(([AllPrimitiveSets objectsInRealm:realm where:@"dateObj.@avg = %@", date(1)]), 
                               @"Cannot sum or average date properties");
     RLMAssertThrowsWithReason(([AllOptionalPrimitiveSets objectsInRealm:realm where:@"dateObj.@avg = %@", NSNull.null]), 
                               @"Cannot sum or average date properties");
+
     RLMAssertThrowsWithReason(([AllPrimitiveSets objectsInRealm:realm where:@"intObj.@avg = %@", @"a"]), 
                               @"@avg on a property of type int cannot be compared with 'a'");
     RLMAssertThrowsWithReason(([AllPrimitiveSets objectsInRealm:realm where:@"floatObj.@avg = %@", @"a"]), 
@@ -7240,21 +7232,21 @@ static double average(NSArray *values) {
     RLMAssertThrowsWithReason(([AllOptionalPrimitiveSets objectsInRealm:realm where:@"decimalObj.@avg = %@", @"a"]), 
                               @"@avg on a property of type decimal128 cannot be compared with 'a'");
     RLMAssertThrowsWithReason(([AllPrimitiveSets objectsInRealm:realm where:@"intObj.@avg.prop = %@", @"a"]), 
-                              @"Property 'intObj' is not a link in object of type 'AllPrimitiveSets'");
+                              @"Invalid keypath 'intObj.@avg.prop': @avg on a collection of values must appear at the end of a keypath.");
     RLMAssertThrowsWithReason(([AllPrimitiveSets objectsInRealm:realm where:@"floatObj.@avg.prop = %@", @"a"]), 
-                              @"Property 'floatObj' is not a link in object of type 'AllPrimitiveSets'");
+                              @"Invalid keypath 'floatObj.@avg.prop': @avg on a collection of values must appear at the end of a keypath.");
     RLMAssertThrowsWithReason(([AllPrimitiveSets objectsInRealm:realm where:@"doubleObj.@avg.prop = %@", @"a"]), 
-                              @"Property 'doubleObj' is not a link in object of type 'AllPrimitiveSets'");
+                              @"Invalid keypath 'doubleObj.@avg.prop': @avg on a collection of values must appear at the end of a keypath.");
     RLMAssertThrowsWithReason(([AllPrimitiveSets objectsInRealm:realm where:@"decimalObj.@avg.prop = %@", @"a"]), 
-                              @"Property 'decimalObj' is not a link in object of type 'AllPrimitiveSets'");
+                              @"Invalid keypath 'decimalObj.@avg.prop': @avg on a collection of values must appear at the end of a keypath.");
     RLMAssertThrowsWithReason(([AllOptionalPrimitiveSets objectsInRealm:realm where:@"intObj.@avg.prop = %@", @"a"]), 
-                              @"Property 'intObj' is not a link in object of type 'AllOptionalPrimitiveSets'");
+                              @"Invalid keypath 'intObj.@avg.prop': @avg on a collection of values must appear at the end of a keypath.");
     RLMAssertThrowsWithReason(([AllOptionalPrimitiveSets objectsInRealm:realm where:@"floatObj.@avg.prop = %@", @"a"]), 
-                              @"Property 'floatObj' is not a link in object of type 'AllOptionalPrimitiveSets'");
+                              @"Invalid keypath 'floatObj.@avg.prop': @avg on a collection of values must appear at the end of a keypath.");
     RLMAssertThrowsWithReason(([AllOptionalPrimitiveSets objectsInRealm:realm where:@"doubleObj.@avg.prop = %@", @"a"]), 
-                              @"Property 'doubleObj' is not a link in object of type 'AllOptionalPrimitiveSets'");
+                              @"Invalid keypath 'doubleObj.@avg.prop': @avg on a collection of values must appear at the end of a keypath.");
     RLMAssertThrowsWithReason(([AllOptionalPrimitiveSets objectsInRealm:realm where:@"decimalObj.@avg.prop = %@", @"a"]), 
-                              @"Property 'decimalObj' is not a link in object of type 'AllOptionalPrimitiveSets'");
+                              @"Invalid keypath 'decimalObj.@avg.prop': @avg on a collection of values must appear at the end of a keypath.");
 
     [AllPrimitiveSets createInRealm:realm withValue:@{
         @"intObj": @[],
@@ -7411,25 +7403,25 @@ static double average(NSArray *values) {
     [realm deleteAllObjects];
 
     RLMAssertThrowsWithReason(([AllPrimitiveSets objectsInRealm:realm where:@"boolObj.@min = %@", @NO]), 
-                              @"@min can only be applied to a numeric property.");
+                              @"Invalid keypath 'boolObj.@min': @min can only be applied to a collection of numeric values.");
     RLMAssertThrowsWithReason(([AllPrimitiveSets objectsInRealm:realm where:@"stringObj.@min = %@", @"a"]), 
-                              @"@min can only be applied to a numeric property.");
+                              @"Invalid keypath 'stringObj.@min': @min can only be applied to a collection of numeric values.");
     RLMAssertThrowsWithReason(([AllPrimitiveSets objectsInRealm:realm where:@"dataObj.@min = %@", data(1)]), 
-                              @"@min can only be applied to a numeric property.");
+                              @"Invalid keypath 'dataObj.@min': @min can only be applied to a collection of numeric values.");
     RLMAssertThrowsWithReason(([AllPrimitiveSets objectsInRealm:realm where:@"objectIdObj.@min = %@", objectId(1)]), 
-                              @"@min can only be applied to a numeric property.");
+                              @"Invalid keypath 'objectIdObj.@min': @min can only be applied to a collection of numeric values.");
     RLMAssertThrowsWithReason(([AllPrimitiveSets objectsInRealm:realm where:@"uuidObj.@min = %@", uuid(@"137DECC8-B300-4954-A233-F89909F4FD89")]), 
-                              @"@min can only be applied to a numeric property.");
+                              @"Invalid keypath 'uuidObj.@min': @min can only be applied to a collection of numeric values.");
     RLMAssertThrowsWithReason(([AllOptionalPrimitiveSets objectsInRealm:realm where:@"boolObj.@min = %@", NSNull.null]), 
-                              @"@min can only be applied to a numeric property.");
+                              @"Invalid keypath 'boolObj.@min': @min can only be applied to a collection of numeric values.");
     RLMAssertThrowsWithReason(([AllOptionalPrimitiveSets objectsInRealm:realm where:@"stringObj.@min = %@", NSNull.null]), 
-                              @"@min can only be applied to a numeric property.");
+                              @"Invalid keypath 'stringObj.@min': @min can only be applied to a collection of numeric values.");
     RLMAssertThrowsWithReason(([AllOptionalPrimitiveSets objectsInRealm:realm where:@"dataObj.@min = %@", NSNull.null]), 
-                              @"@min can only be applied to a numeric property.");
+                              @"Invalid keypath 'dataObj.@min': @min can only be applied to a collection of numeric values.");
     RLMAssertThrowsWithReason(([AllOptionalPrimitiveSets objectsInRealm:realm where:@"objectIdObj.@min = %@", NSNull.null]), 
-                              @"@min can only be applied to a numeric property.");
+                              @"Invalid keypath 'objectIdObj.@min': @min can only be applied to a collection of numeric values.");
     RLMAssertThrowsWithReason(([AllOptionalPrimitiveSets objectsInRealm:realm where:@"uuidObj.@min = %@", NSNull.null]), 
-                              @"@min can only be applied to a numeric property.");
+                              @"Invalid keypath 'uuidObj.@min': @min can only be applied to a collection of numeric values.");
     RLMAssertThrowsWithReason(([AllPrimitiveSets objectsInRealm:realm where:@"intObj.@min = %@", @"a"]), 
                               @"@min on a property of type int cannot be compared with 'a'");
     RLMAssertThrowsWithReason(([AllPrimitiveSets objectsInRealm:realm where:@"floatObj.@min = %@", @"a"]), 
@@ -7451,35 +7443,35 @@ static double average(NSArray *values) {
     RLMAssertThrowsWithReason(([AllOptionalPrimitiveSets objectsInRealm:realm where:@"decimalObj.@min = %@", @"a"]), 
                               @"@min on a property of type decimal128 cannot be compared with 'a'");
     RLMAssertThrowsWithReason(([AllPrimitiveSets objectsInRealm:realm where:@"intObj.@min.prop = %@", @"a"]), 
-                              @"Property 'intObj' is not a link in object of type 'AllPrimitiveSets'");
+                              @"Invalid keypath 'intObj.@min.prop': @min on a collection of values must appear at the end of a keypath.");
     RLMAssertThrowsWithReason(([AllPrimitiveSets objectsInRealm:realm where:@"floatObj.@min.prop = %@", @"a"]), 
-                              @"Property 'floatObj' is not a link in object of type 'AllPrimitiveSets'");
+                              @"Invalid keypath 'floatObj.@min.prop': @min on a collection of values must appear at the end of a keypath.");
     RLMAssertThrowsWithReason(([AllPrimitiveSets objectsInRealm:realm where:@"doubleObj.@min.prop = %@", @"a"]), 
-                              @"Property 'doubleObj' is not a link in object of type 'AllPrimitiveSets'");
+                              @"Invalid keypath 'doubleObj.@min.prop': @min on a collection of values must appear at the end of a keypath.");
     RLMAssertThrowsWithReason(([AllPrimitiveSets objectsInRealm:realm where:@"dateObj.@min.prop = %@", @"a"]), 
-                              @"Property 'dateObj' is not a link in object of type 'AllPrimitiveSets'");
+                              @"Invalid keypath 'dateObj.@min.prop': @min on a collection of values must appear at the end of a keypath.");
     RLMAssertThrowsWithReason(([AllPrimitiveSets objectsInRealm:realm where:@"decimalObj.@min.prop = %@", @"a"]), 
-                              @"Property 'decimalObj' is not a link in object of type 'AllPrimitiveSets'");
+                              @"Invalid keypath 'decimalObj.@min.prop': @min on a collection of values must appear at the end of a keypath.");
     RLMAssertThrowsWithReason(([AllPrimitiveSets objectsInRealm:realm where:@"anyIntObj.@min.prop = %@", @"a"]), 
-                              @"Property 'anyIntObj' is not a link in object of type 'AllPrimitiveSets'");
+                              @"Invalid keypath 'anyIntObj.@min.prop': @min on a collection of values must appear at the end of a keypath.");
     RLMAssertThrowsWithReason(([AllPrimitiveSets objectsInRealm:realm where:@"anyFloatObj.@min.prop = %@", @"a"]), 
-                              @"Property 'anyFloatObj' is not a link in object of type 'AllPrimitiveSets'");
+                              @"Invalid keypath 'anyFloatObj.@min.prop': @min on a collection of values must appear at the end of a keypath.");
     RLMAssertThrowsWithReason(([AllPrimitiveSets objectsInRealm:realm where:@"anyDoubleObj.@min.prop = %@", @"a"]), 
-                              @"Property 'anyDoubleObj' is not a link in object of type 'AllPrimitiveSets'");
+                              @"Invalid keypath 'anyDoubleObj.@min.prop': @min on a collection of values must appear at the end of a keypath.");
     RLMAssertThrowsWithReason(([AllPrimitiveSets objectsInRealm:realm where:@"anyDateObj.@min.prop = %@", @"a"]), 
-                              @"Property 'anyDateObj' is not a link in object of type 'AllPrimitiveSets'");
+                              @"Invalid keypath 'anyDateObj.@min.prop': @min on a collection of values must appear at the end of a keypath.");
     RLMAssertThrowsWithReason(([AllPrimitiveSets objectsInRealm:realm where:@"anyDecimalObj.@min.prop = %@", @"a"]), 
-                              @"Property 'anyDecimalObj' is not a link in object of type 'AllPrimitiveSets'");
+                              @"Invalid keypath 'anyDecimalObj.@min.prop': @min on a collection of values must appear at the end of a keypath.");
     RLMAssertThrowsWithReason(([AllOptionalPrimitiveSets objectsInRealm:realm where:@"intObj.@min.prop = %@", @"a"]), 
-                              @"Property 'intObj' is not a link in object of type 'AllOptionalPrimitiveSets'");
+                              @"Invalid keypath 'intObj.@min.prop': @min on a collection of values must appear at the end of a keypath.");
     RLMAssertThrowsWithReason(([AllOptionalPrimitiveSets objectsInRealm:realm where:@"floatObj.@min.prop = %@", @"a"]), 
-                              @"Property 'floatObj' is not a link in object of type 'AllOptionalPrimitiveSets'");
+                              @"Invalid keypath 'floatObj.@min.prop': @min on a collection of values must appear at the end of a keypath.");
     RLMAssertThrowsWithReason(([AllOptionalPrimitiveSets objectsInRealm:realm where:@"doubleObj.@min.prop = %@", @"a"]), 
-                              @"Property 'doubleObj' is not a link in object of type 'AllOptionalPrimitiveSets'");
+                              @"Invalid keypath 'doubleObj.@min.prop': @min on a collection of values must appear at the end of a keypath.");
     RLMAssertThrowsWithReason(([AllOptionalPrimitiveSets objectsInRealm:realm where:@"dateObj.@min.prop = %@", @"a"]), 
-                              @"Property 'dateObj' is not a link in object of type 'AllOptionalPrimitiveSets'");
+                              @"Invalid keypath 'dateObj.@min.prop': @min on a collection of values must appear at the end of a keypath.");
     RLMAssertThrowsWithReason(([AllOptionalPrimitiveSets objectsInRealm:realm where:@"decimalObj.@min.prop = %@", @"a"]), 
-                              @"Property 'decimalObj' is not a link in object of type 'AllOptionalPrimitiveSets'");
+                              @"Invalid keypath 'decimalObj.@min.prop': @min on a collection of values must appear at the end of a keypath.");
 
     // No objects, so count is zero
     RLMAssertCount(AllPrimitiveSets, 0U, @"intObj.@min == %@", @2);
@@ -7625,25 +7617,25 @@ static double average(NSArray *values) {
     [realm deleteAllObjects];
 
     RLMAssertThrowsWithReason(([AllPrimitiveSets objectsInRealm:realm where:@"boolObj.@max = %@", @NO]), 
-                              @"@max can only be applied to a numeric property.");
+                              @"Invalid keypath 'boolObj.@max': @max can only be applied to a collection of numeric values.");
     RLMAssertThrowsWithReason(([AllPrimitiveSets objectsInRealm:realm where:@"stringObj.@max = %@", @"a"]), 
-                              @"@max can only be applied to a numeric property.");
+                              @"Invalid keypath 'stringObj.@max': @max can only be applied to a collection of numeric values.");
     RLMAssertThrowsWithReason(([AllPrimitiveSets objectsInRealm:realm where:@"dataObj.@max = %@", data(1)]), 
-                              @"@max can only be applied to a numeric property.");
+                              @"Invalid keypath 'dataObj.@max': @max can only be applied to a collection of numeric values.");
     RLMAssertThrowsWithReason(([AllPrimitiveSets objectsInRealm:realm where:@"objectIdObj.@max = %@", objectId(1)]), 
-                              @"@max can only be applied to a numeric property.");
+                              @"Invalid keypath 'objectIdObj.@max': @max can only be applied to a collection of numeric values.");
     RLMAssertThrowsWithReason(([AllPrimitiveSets objectsInRealm:realm where:@"uuidObj.@max = %@", uuid(@"137DECC8-B300-4954-A233-F89909F4FD89")]), 
-                              @"@max can only be applied to a numeric property.");
+                              @"Invalid keypath 'uuidObj.@max': @max can only be applied to a collection of numeric values.");
     RLMAssertThrowsWithReason(([AllOptionalPrimitiveSets objectsInRealm:realm where:@"boolObj.@max = %@", NSNull.null]), 
-                              @"@max can only be applied to a numeric property.");
+                              @"Invalid keypath 'boolObj.@max': @max can only be applied to a collection of numeric values.");
     RLMAssertThrowsWithReason(([AllOptionalPrimitiveSets objectsInRealm:realm where:@"stringObj.@max = %@", NSNull.null]), 
-                              @"@max can only be applied to a numeric property.");
+                              @"Invalid keypath 'stringObj.@max': @max can only be applied to a collection of numeric values.");
     RLMAssertThrowsWithReason(([AllOptionalPrimitiveSets objectsInRealm:realm where:@"dataObj.@max = %@", NSNull.null]), 
-                              @"@max can only be applied to a numeric property.");
+                              @"Invalid keypath 'dataObj.@max': @max can only be applied to a collection of numeric values.");
     RLMAssertThrowsWithReason(([AllOptionalPrimitiveSets objectsInRealm:realm where:@"objectIdObj.@max = %@", NSNull.null]), 
-                              @"@max can only be applied to a numeric property.");
+                              @"Invalid keypath 'objectIdObj.@max': @max can only be applied to a collection of numeric values.");
     RLMAssertThrowsWithReason(([AllOptionalPrimitiveSets objectsInRealm:realm where:@"uuidObj.@max = %@", NSNull.null]), 
-                              @"@max can only be applied to a numeric property.");
+                              @"Invalid keypath 'uuidObj.@max': @max can only be applied to a collection of numeric values.");
     RLMAssertThrowsWithReason(([AllPrimitiveSets objectsInRealm:realm where:@"intObj.@max = %@", @"a"]), 
                               @"@max on a property of type int cannot be compared with 'a'");
     RLMAssertThrowsWithReason(([AllPrimitiveSets objectsInRealm:realm where:@"floatObj.@max = %@", @"a"]), 
@@ -7665,35 +7657,35 @@ static double average(NSArray *values) {
     RLMAssertThrowsWithReason(([AllOptionalPrimitiveSets objectsInRealm:realm where:@"decimalObj.@max = %@", @"a"]), 
                               @"@max on a property of type decimal128 cannot be compared with 'a'");
     RLMAssertThrowsWithReason(([AllPrimitiveSets objectsInRealm:realm where:@"intObj.@max.prop = %@", @"a"]), 
-                              @"Property 'intObj' is not a link in object of type 'AllPrimitiveSets'");
+                              @"Invalid keypath 'intObj.@max.prop': @max on a collection of values must appear at the end of a keypath.");
     RLMAssertThrowsWithReason(([AllPrimitiveSets objectsInRealm:realm where:@"floatObj.@max.prop = %@", @"a"]), 
-                              @"Property 'floatObj' is not a link in object of type 'AllPrimitiveSets'");
+                              @"Invalid keypath 'floatObj.@max.prop': @max on a collection of values must appear at the end of a keypath.");
     RLMAssertThrowsWithReason(([AllPrimitiveSets objectsInRealm:realm where:@"doubleObj.@max.prop = %@", @"a"]), 
-                              @"Property 'doubleObj' is not a link in object of type 'AllPrimitiveSets'");
+                              @"Invalid keypath 'doubleObj.@max.prop': @max on a collection of values must appear at the end of a keypath.");
     RLMAssertThrowsWithReason(([AllPrimitiveSets objectsInRealm:realm where:@"dateObj.@max.prop = %@", @"a"]), 
-                              @"Property 'dateObj' is not a link in object of type 'AllPrimitiveSets'");
+                              @"Invalid keypath 'dateObj.@max.prop': @max on a collection of values must appear at the end of a keypath.");
     RLMAssertThrowsWithReason(([AllPrimitiveSets objectsInRealm:realm where:@"decimalObj.@max.prop = %@", @"a"]), 
-                              @"Property 'decimalObj' is not a link in object of type 'AllPrimitiveSets'");
+                              @"Invalid keypath 'decimalObj.@max.prop': @max on a collection of values must appear at the end of a keypath.");
     RLMAssertThrowsWithReason(([AllPrimitiveSets objectsInRealm:realm where:@"anyIntObj.@max.prop = %@", @"a"]), 
-                              @"Property 'anyIntObj' is not a link in object of type 'AllPrimitiveSets'");
+                              @"Invalid keypath 'anyIntObj.@max.prop': @max on a collection of values must appear at the end of a keypath.");
     RLMAssertThrowsWithReason(([AllPrimitiveSets objectsInRealm:realm where:@"anyFloatObj.@max.prop = %@", @"a"]), 
-                              @"Property 'anyFloatObj' is not a link in object of type 'AllPrimitiveSets'");
+                              @"Invalid keypath 'anyFloatObj.@max.prop': @max on a collection of values must appear at the end of a keypath.");
     RLMAssertThrowsWithReason(([AllPrimitiveSets objectsInRealm:realm where:@"anyDoubleObj.@max.prop = %@", @"a"]), 
-                              @"Property 'anyDoubleObj' is not a link in object of type 'AllPrimitiveSets'");
+                              @"Invalid keypath 'anyDoubleObj.@max.prop': @max on a collection of values must appear at the end of a keypath.");
     RLMAssertThrowsWithReason(([AllPrimitiveSets objectsInRealm:realm where:@"anyDateObj.@max.prop = %@", @"a"]), 
-                              @"Property 'anyDateObj' is not a link in object of type 'AllPrimitiveSets'");
+                              @"Invalid keypath 'anyDateObj.@max.prop': @max on a collection of values must appear at the end of a keypath.");
     RLMAssertThrowsWithReason(([AllPrimitiveSets objectsInRealm:realm where:@"anyDecimalObj.@max.prop = %@", @"a"]), 
-                              @"Property 'anyDecimalObj' is not a link in object of type 'AllPrimitiveSets'");
+                              @"Invalid keypath 'anyDecimalObj.@max.prop': @max on a collection of values must appear at the end of a keypath.");
     RLMAssertThrowsWithReason(([AllOptionalPrimitiveSets objectsInRealm:realm where:@"intObj.@max.prop = %@", @"a"]), 
-                              @"Property 'intObj' is not a link in object of type 'AllOptionalPrimitiveSets'");
+                              @"Invalid keypath 'intObj.@max.prop': @max on a collection of values must appear at the end of a keypath.");
     RLMAssertThrowsWithReason(([AllOptionalPrimitiveSets objectsInRealm:realm where:@"floatObj.@max.prop = %@", @"a"]), 
-                              @"Property 'floatObj' is not a link in object of type 'AllOptionalPrimitiveSets'");
+                              @"Invalid keypath 'floatObj.@max.prop': @max on a collection of values must appear at the end of a keypath.");
     RLMAssertThrowsWithReason(([AllOptionalPrimitiveSets objectsInRealm:realm where:@"doubleObj.@max.prop = %@", @"a"]), 
-                              @"Property 'doubleObj' is not a link in object of type 'AllOptionalPrimitiveSets'");
+                              @"Invalid keypath 'doubleObj.@max.prop': @max on a collection of values must appear at the end of a keypath.");
     RLMAssertThrowsWithReason(([AllOptionalPrimitiveSets objectsInRealm:realm where:@"dateObj.@max.prop = %@", @"a"]), 
-                              @"Property 'dateObj' is not a link in object of type 'AllOptionalPrimitiveSets'");
+                              @"Invalid keypath 'dateObj.@max.prop': @max on a collection of values must appear at the end of a keypath.");
     RLMAssertThrowsWithReason(([AllOptionalPrimitiveSets objectsInRealm:realm where:@"decimalObj.@max.prop = %@", @"a"]), 
-                              @"Property 'decimalObj' is not a link in object of type 'AllOptionalPrimitiveSets'");
+                              @"Invalid keypath 'decimalObj.@max.prop': @max on a collection of values must appear at the end of a keypath.");
 
     // No objects, so count is zero
     RLMAssertCount(AllPrimitiveSets, 0U, @"intObj.@max == %@", @2);
@@ -8226,21 +8218,21 @@ static double average(NSArray *values) {
     void (^testNull)(NSString *, NSUInteger) = ^(NSString *operator, NSUInteger count) {
         NSString *query = [NSString stringWithFormat:@"ANY stringObj %@ nil", operator];
         RLMAssertThrowsWithReason([AllPrimitiveSets objectsInRealm:realm where:query],
-                                  @"Expected object of type string for property 'stringObj' on object of type 'AllPrimitiveSets', but received: (null)");
+                                  @"Cannot compare value '(null)' of type '(null)' to property 'stringObj' of type 'string'");
         RLMAssertCount(AllOptionalPrimitiveSets, count, query, NSNull.null);
         query = [NSString stringWithFormat:@"ANY link.stringObj %@ nil", operator];
         RLMAssertThrowsWithReason([LinkToAllPrimitiveSets objectsInRealm:realm where:query],
-                                  @"Expected object of type string for property 'link.stringObj' on object of type 'LinkToAllPrimitiveSets', but received: (null)");
+                                  @"Cannot compare value '(null)' of type '(null)' to property 'stringObj' of type 'string'");
         RLMAssertCount(LinkToAllOptionalPrimitiveSets, count, query, NSNull.null);
 
         query = [NSString stringWithFormat:@"ANY dataObj %@ nil", operator];
         RLMAssertThrowsWithReason([AllPrimitiveSets objectsInRealm:realm where:query],
-                                  @"Expected object of type data for property 'dataObj' on object of type 'AllPrimitiveSets', but received: (null)");
+                                  @"Cannot compare value '(null)' of type '(null)' to property 'dataObj' of type 'data'");
         RLMAssertCount(AllOptionalPrimitiveSets, count, query, NSNull.null);
 
         query = [NSString stringWithFormat:@"ANY link.dataObj %@ nil", operator];
         RLMAssertThrowsWithReason([LinkToAllPrimitiveSets objectsInRealm:realm where:query],
-                                  @"Expected object of type data for property 'link.dataObj' on object of type 'LinkToAllPrimitiveSets', but received: (null)");
+                                  @"Cannot compare value '(null)' of type '(null)' to property 'dataObj' of type 'data'");
         RLMAssertCount(LinkToAllOptionalPrimitiveSets, count, query, NSNull.null);
     };
 

--- a/Realm/Tests/PrimitiveSetPropertyTests.tpl.m
+++ b/Realm/Tests/PrimitiveSetPropertyTests.tpl.m
@@ -846,10 +846,11 @@ static double average(NSArray *values) {
 - (void)testQuerySum {
     [realm deleteAllObjects];
 
-    %noany %nodate %nosum %man RLMAssertThrowsWithReason(([$class objectsInRealm:realm where:@"$prop.@sum = %@", $v0]), ^n @"@sum can only be applied to a numeric property.");
-    %noany %date %man RLMAssertThrowsWithReason(([$class objectsInRealm:realm where:@"$prop.@sum = %@", $v1]), ^n @"Cannot sum or average date properties");
+    %noany %nodate %nosum %man RLMAssertThrowsWithReason(([$class objectsInRealm:realm where:@"$prop.@sum = %@", $v0]), ^n @"Invalid keypath '$prop.@sum': @sum can only be applied to a collection of numeric values.");
+    %r %noany %date %man RLMAssertThrowsWithReason(([$class objectsInRealm:realm where:@"$prop.@sum = %@", $v0]), ^n @"Cannot sum or average date properties");
+
     %noany %sum %man RLMAssertThrowsWithReason(([$class objectsInRealm:realm where:@"$prop.@sum = %@", $wrong]), ^n @"@sum on a property of type $basetype cannot be compared with '$wdesc'");
-    %sum %man RLMAssertThrowsWithReason(([$class objectsInRealm:realm where:@"$prop.@sum.prop = %@", $wrong]), ^n @"Property '$prop' is not a link in object of type '$class'");
+    %noany %sum %man RLMAssertThrowsWithReason(([$class objectsInRealm:realm where:@"$prop.@sum.prop = %@", $wrong]), ^n @"Invalid keypath '$prop.@sum.prop': @sum on a collection of values must appear at the end of a keypath.");
     %noany %sum %man RLMAssertThrowsWithReason(([$class objectsInRealm:realm where:@"$prop.@sum = %@", NSNull.null]), ^n @"@sum on a property of type $basetype cannot be compared with '<null>'");
 
     [AllPrimitiveSets createInRealm:realm withValue:@{
@@ -897,10 +898,12 @@ static double average(NSArray *values) {
 - (void)testQueryAverage {
     [realm deleteAllObjects];
 
-    %noany %nodate %noavg %man RLMAssertThrowsWithReason(([$class objectsInRealm:realm where:@"$prop.@avg = %@", $v0]), ^n @"@avg can only be applied to a numeric property.");
+    %noany %nodate %noavg %man RLMAssertThrowsWithReason(([$class objectsInRealm:realm where:@"$prop.@avg = %@", $v0]), ^n @"Invalid keypath '$prop.@avg': @avg can only be applied to a collection of numeric values.");
     %noany %date %man RLMAssertThrowsWithReason(([$class objectsInRealm:realm where:@"$prop.@avg = %@", $v0]), ^n @"Cannot sum or average date properties");
+    %noany %any %date %man RLMAssertThrowsWithReason(([$class objectsInRealm:realm where:@"$prop.@avg = %@", $v0]), ^n @"Cannot sum or average date properties");
+
     %noany %avg %man RLMAssertThrowsWithReason(([$class objectsInRealm:realm where:@"$prop.@avg = %@", $wrong]), ^n @"@avg on a property of type $basetype cannot be compared with '$wdesc'");
-    %noany %avg %man RLMAssertThrowsWithReason(([$class objectsInRealm:realm where:@"$prop.@avg.prop = %@", $wrong]), ^n @"Property '$prop' is not a link in object of type '$class'");
+    %noany %avg %man RLMAssertThrowsWithReason(([$class objectsInRealm:realm where:@"$prop.@avg.prop = %@", $wrong]), ^n @"Invalid keypath '$prop.@avg.prop': @avg on a collection of values must appear at the end of a keypath.");
 
     [AllPrimitiveSets createInRealm:realm withValue:@{
         %man %r %avg @"$prop": @[],
@@ -945,9 +948,9 @@ static double average(NSArray *values) {
 - (void)testQueryMin {
     [realm deleteAllObjects];
 
-    %noany %nominmax %man RLMAssertThrowsWithReason(([$class objectsInRealm:realm where:@"$prop.@min = %@", $v0]), ^n @"@min can only be applied to a numeric property.");
+    %noany %nominmax %man RLMAssertThrowsWithReason(([$class objectsInRealm:realm where:@"$prop.@min = %@", $v0]), ^n @"Invalid keypath '$prop.@min': @min can only be applied to a collection of numeric values.");
     %noany %minmax %man RLMAssertThrowsWithReason(([$class objectsInRealm:realm where:@"$prop.@min = %@", $wrong]), ^n @"@min on a property of type $basetype cannot be compared with '$wdesc'");
-    %minmax %man RLMAssertThrowsWithReason(([$class objectsInRealm:realm where:@"$prop.@min.prop = %@", $wrong]), ^n @"Property '$prop' is not a link in object of type '$class'");
+    %minmax %man RLMAssertThrowsWithReason(([$class objectsInRealm:realm where:@"$prop.@min.prop = %@", $wrong]), ^n @"Invalid keypath '$prop.@min.prop': @min on a collection of values must appear at the end of a keypath.");
 
     // No objects, so count is zero
     %minmax %man RLMAssertCount($class, 0U, @"$prop.@min == %@", $v0);
@@ -987,9 +990,9 @@ static double average(NSArray *values) {
 - (void)testQueryMax {
     [realm deleteAllObjects];
 
-    %noany %nominmax %man RLMAssertThrowsWithReason(([$class objectsInRealm:realm where:@"$prop.@max = %@", $v0]), ^n @"@max can only be applied to a numeric property.");
+    %noany %nominmax %man RLMAssertThrowsWithReason(([$class objectsInRealm:realm where:@"$prop.@max = %@", $v0]), ^n @"Invalid keypath '$prop.@max': @max can only be applied to a collection of numeric values.");
     %noany %minmax %man RLMAssertThrowsWithReason(([$class objectsInRealm:realm where:@"$prop.@max = %@", $wrong]), ^n @"@max on a property of type $basetype cannot be compared with '$wdesc'");
-    %minmax %man RLMAssertThrowsWithReason(([$class objectsInRealm:realm where:@"$prop.@max.prop = %@", $wrong]), ^n @"Property '$prop' is not a link in object of type '$class'");
+    %minmax %man RLMAssertThrowsWithReason(([$class objectsInRealm:realm where:@"$prop.@max.prop = %@", $wrong]), ^n @"Invalid keypath '$prop.@max.prop': @max on a collection of values must appear at the end of a keypath.");
 
     // No objects, so count is zero
     %minmax %man RLMAssertCount($class, 0U, @"$prop.@max == %@", $v0);
@@ -1116,21 +1119,21 @@ static double average(NSArray *values) {
     void (^testNull)(NSString *, NSUInteger) = ^(NSString *operator, NSUInteger count) {
         NSString *query = [NSString stringWithFormat:@"ANY stringObj %@ nil", operator];
         RLMAssertThrowsWithReason([AllPrimitiveSets objectsInRealm:realm where:query],
-                                  @"Expected object of type string for property 'stringObj' on object of type 'AllPrimitiveSets', but received: (null)");
+                                  @"Cannot compare value '(null)' of type '(null)' to property 'stringObj' of type 'string'");
         RLMAssertCount(AllOptionalPrimitiveSets, count, query, NSNull.null);
         query = [NSString stringWithFormat:@"ANY link.stringObj %@ nil", operator];
         RLMAssertThrowsWithReason([LinkToAllPrimitiveSets objectsInRealm:realm where:query],
-                                  @"Expected object of type string for property 'link.stringObj' on object of type 'LinkToAllPrimitiveSets', but received: (null)");
+                                  @"Cannot compare value '(null)' of type '(null)' to property 'stringObj' of type 'string'");
         RLMAssertCount(LinkToAllOptionalPrimitiveSets, count, query, NSNull.null);
 
         query = [NSString stringWithFormat:@"ANY dataObj %@ nil", operator];
         RLMAssertThrowsWithReason([AllPrimitiveSets objectsInRealm:realm where:query],
-                                  @"Expected object of type data for property 'dataObj' on object of type 'AllPrimitiveSets', but received: (null)");
+                                  @"Cannot compare value '(null)' of type '(null)' to property 'dataObj' of type 'data'");
         RLMAssertCount(AllOptionalPrimitiveSets, count, query, NSNull.null);
 
         query = [NSString stringWithFormat:@"ANY link.dataObj %@ nil", operator];
         RLMAssertThrowsWithReason([LinkToAllPrimitiveSets objectsInRealm:realm where:query],
-                                  @"Expected object of type data for property 'link.dataObj' on object of type 'LinkToAllPrimitiveSets', but received: (null)");
+                                  @"Cannot compare value '(null)' of type '(null)' to property 'dataObj' of type 'data'");
         RLMAssertCount(LinkToAllOptionalPrimitiveSets, count, query, NSNull.null);
     };
 

--- a/Realm/Tests/QueryTests.m
+++ b/Realm/Tests/QueryTests.m
@@ -214,8 +214,10 @@
     RLMAssertThrowsWithReasonMatching([PersonLinkObject objectsWhere:@"ALL person.age > 5"], @"ALL modifier not supported");
     RLMAssertThrowsWithReasonMatching([PersonLinkObject objectsWhere:@"SOME person.age > 5"], @"Aggregate operations can only.*collection property");
     RLMAssertThrowsWithReasonMatching([PersonLinkObject objectsWhere:@"NONE person.age > 5"], @"Aggregate operations can only.*collection property");
-    RLMAssertThrowsWithReasonMatching([PersonObject objectsWhere:@"age.@count > 5"], @"Aggregate operations can only.*collection property");
-    RLMAssertThrowsWithReasonMatching([PersonObject objectsWhere:@"age.@sum > 5"], @"Aggregate operations can only.*collection property");
+    RLMAssertThrowsWithReason([PersonObject objectsWhere:@"age.@count > 5"],
+                              @"Invalid keypath 'age.@count': Property 'PersonObject.age' is not a link or collection and can only appear at the end of a keypath.");
+    RLMAssertThrowsWithReason([PersonObject objectsWhere:@"age.@sum > 5"],
+                              @"Invalid keypath 'age.@sum': Property 'PersonObject.age' is not a link or collection and can only appear at the end of a keypath.");
 
     // comparing two constants
     RLMAssertThrowsWithReason([PersonObject objectsWhere:@"5 = 5"],
@@ -250,60 +252,54 @@
 {
     RLMRealm *realm = [RLMRealm defaultRealm];
 
-    NSString *className = PersonObject.className;
-
     // invalid column/property name
-    RLMAssertThrowsWithReason([realm objects:className where:@"height > 72"],
+    RLMAssertThrowsWithReason([PersonObject objectsWhere:@"height > 72"],
                               @"Property 'height' not found in object of type 'PersonObject'");
 
     // wrong/invalid data types
-    RLMAssertThrowsWithReasonMatching([realm objects:className where:@"age != xyz"],
-                                      @"'xyz' not found in .* 'PersonObject'");
-    RLMAssertThrowsWithReasonMatching([realm objects:className where:@"name == 3"],
-                                      @"type string .* property 'name' .* 'PersonObject'.*: 3");
-    RLMAssertThrowsWithReasonMatching([realm objects:className where:@"age IN {'xyz'}"],
-                                      @"type int .* property 'age' .* 'PersonObject'.*: xyz");
-    XCTAssertThrows([realm objects:className where:@"name IN {3}"], @"invalid type");
-
-    className = AllTypesObject.className;
+    RLMAssertThrowsWithReason([PersonObject objectsWhere:@"age != xyz"],
+                                      @"Invalid keypath 'xyz': Property 'xyz' not found in object of type 'PersonObject'");
+    RLMAssertThrowsWithReason([PersonObject objectsWhere:@"name == 3"],
+                                      @"Cannot compare value '3' of type '__NSCFNumber' to property 'name' of type 'string'");
+    RLMAssertThrowsWithReason([PersonObject objectsWhere:@"age IN {'xyz'}"],
+                                      @"Cannot compare value 'xyz' of type 'NSTaggedPointerString' to property 'age' of type 'int'");
+    XCTAssertThrows([PersonObject objectsWhere:@"name IN {3}"], @"asdf");
 
     // compare columns to incorrect type of constant value
-    RLMAssertThrowsWithReason([realm objects:className where:@"boolCol == 'Foo'"],
-                              @"Expected object of type bool");
-    RLMAssertThrowsWithReason([realm objects:className where:@"boolCol == 2"],
-                              @"Expected object of type bool");
-    RLMAssertThrowsWithReason([realm objects:className where:@"dateCol == 7"],
-                              @"Expected object of type date");
-    RLMAssertThrowsWithReason([realm objects:className where:@"doubleCol == 'The'"],
-                              @"Expected object of type double");
-    RLMAssertThrowsWithReason([realm objects:className where:@"floatCol == 'Bar'"],
-                              @"Expected object of type float");
-    RLMAssertThrowsWithReason([realm objects:className where:@"intCol == 'Baz'"],
-                              @"Expected object of type int");
-
-    className = PersonObject.className;
+    RLMAssertThrowsWithReason([AllTypesObject objectsWhere:@"boolCol == 'Foo'"],
+                              @"Cannot compare value 'Foo' of type 'NSTaggedPointerString' to property 'boolCol' of type 'bool'");
+    RLMAssertThrowsWithReason([AllTypesObject objectsWhere:@"boolCol == 2"],
+                              @"Cannot compare value '2' of type '__NSCFNumber' to property 'boolCol' of type 'bool'");
+    RLMAssertThrowsWithReason([AllTypesObject objectsWhere:@"dateCol == 7"],
+                              @"Cannot compare value '7' of type '__NSCFNumber' to property 'dateCol' of type 'date'");
+    RLMAssertThrowsWithReason([AllTypesObject objectsWhere:@"doubleCol == 'The'"],
+                              @"Cannot compare value 'The' of type 'NSTaggedPointerString' to property 'doubleCol' of type 'double'");
+    RLMAssertThrowsWithReason([AllTypesObject objectsWhere:@"floatCol == 'Bar'"],
+                              @"Cannot compare value 'Bar' of type 'NSTaggedPointerString' to property 'floatCol' of type 'float'");
+    RLMAssertThrowsWithReason([AllTypesObject objectsWhere:@"intCol == 'Baz'"],
+                              @"Cannot compare value 'Baz' of type 'NSTaggedPointerString' to property 'intCol' of type 'int'");
 
     // compare two constants
-    XCTAssertThrows([realm objects:className where:@"3 == 3"], @"comparing 2 constants");
+    XCTAssertThrows([PersonObject objectsWhere:@"3 == 3"], @"comparing 2 constants");
 
     // invalid strings
-    RLMAssertThrowsWithReason([realm objects:className where:@""],
+    RLMAssertThrowsWithReason([PersonObject objectsWhere:@""],
                               @"Unable to parse the format string");
-    RLMAssertThrowsWithReason([realm objects:className where:@"age"],
+    RLMAssertThrowsWithReason([PersonObject objectsWhere:@"age"],
                               @"Unable to parse the format string");
-    RLMAssertThrowsWithReason([realm objects:className where:@"sdlfjasdflj"],
+    RLMAssertThrowsWithReason([PersonObject objectsWhere:@"sdlfjasdflj"],
                               @"Unable to parse the format string");
-    RLMAssertThrowsWithReason([realm objects:className where:@"age * 25"],
+    RLMAssertThrowsWithReason([PersonObject objectsWhere:@"age * 25"],
                               @"Unable to parse the format string");
-    RLMAssertThrowsWithReason([realm objects:className where:@"age === 25"],
+    RLMAssertThrowsWithReason([PersonObject objectsWhere:@"age === 25"],
                               @"Unable to parse the format string");
-    RLMAssertThrowsWithReason([realm objects:className where:@","],
+    RLMAssertThrowsWithReason([PersonObject objectsWhere:@","],
                               @"Unable to parse the format string");
-    RLMAssertThrowsWithReason([realm objects:className where:@"()"],
+    RLMAssertThrowsWithReason([PersonObject objectsWhere:@"()"],
                               @"Unable to parse the format string");
 
     // Misspelled keypath (should be %K)
-    RLMAssertThrowsWithReason([realm objects:className where:@"@K == YES"], @"'@K' is not a valid key path'");
+    RLMAssertThrowsWithReason([PersonObject objectsWhere:@"@K == YES"], @"Unsupported collection operation '@K'");
 
     NSPredicate *(^predicateWithKeyPath)(NSString *) = ^(NSString *keyPath) {
         return  [NSComparisonPredicate predicateWithLeftExpression:[NSExpression expressionForKeyPath:keyPath]
@@ -314,59 +310,65 @@
     };
 
     // malformed keypath operators
-    RLMAssertThrowsWithReason([realm objects:className where:@"@count == 0"],
-                              @"'@count' is not a valid key path");
+    RLMAssertThrowsWithReason([PersonObject objectsWhere:@"@count == 0"],
+                              @"Invalid keypath '@count': collection operation '@count' must be applied to a collection");
     NSPredicate *pred = [NSComparisonPredicate predicateWithLeftExpression:[NSExpression expressionForKeyPath:@"name.@"] rightExpression:[NSExpression expressionForConstantValue:@0] modifier:0 type:NSEqualToPredicateOperatorType options:0];
-    RLMAssertThrowsWithReason([realm objects:className withPredicate:predicateWithKeyPath(@"name.@")],
-                              @"'name.@' is not a valid key path");
-    RLMAssertThrowsWithReason([realm objects:className withPredicate:predicateWithKeyPath(@"name@")],
-                              @"'name@' is not a valid key path");
-    RLMAssertThrowsWithReason([realm objects:className withPredicate:predicateWithKeyPath(@"name@length")],
-                              @"'name@length' is not a valid key path");
-    RLMAssertThrowsWithReason([realm objects:className withPredicate:predicateWithKeyPath(@".name")],
-                              @"Property '' not found in object of type 'PersonObject'");
-    RLMAssertThrowsWithReason([realm objects:className withPredicate:predicateWithKeyPath(@"children.")],
-                              @"Property '' not found in object of type 'PersonObject'");
+    RLMAssertThrowsWithReason([PersonObject objectsWithPredicate:predicateWithKeyPath(@"children.@")],
+                              @"Unsupported collection operation '@'");
+    RLMAssertThrowsWithReason([PersonObject objectsWithPredicate:predicateWithKeyPath(@"children@")],
+                              @"Invalid keypath 'children@': Property 'children@' not found in object of type 'PersonObject'");
+    RLMAssertThrowsWithReason([PersonObject objectsWithPredicate:predicateWithKeyPath(@"name@length")],
+                              @"Invalid keypath 'name@length': Property 'name@length' not found in object of type 'PersonObject'");
+    RLMAssertThrowsWithReason([PersonObject objectsWithPredicate:predicateWithKeyPath(@".name")],
+                              @"Invalid keypath '.name': no key name before '.'");
+    RLMAssertThrowsWithReason([PersonObject objectsWithPredicate:predicateWithKeyPath(@"children.")],
+                              @"Invalid keypath 'children.': no key name after last '.'");
 
     // not a link column
-    RLMAssertThrowsWithReason([realm objects:className where:@"age.age == 25"],
-                              @"Property 'age' is not a link in object of type 'PersonObject'");
-    RLMAssertThrowsWithReason([realm objects:className where:@"age.age.age == 25"],
-                              @"Property 'age' is not a link in object of type 'PersonObject'");
+    RLMAssertThrowsWithReason([PersonObject objectsWhere:@"age.age == 25"],
+                              @"Invalid keypath 'age.age': Property 'PersonObject.age' is not a link or collection and can only appear at the end of a keypath.");
+    RLMAssertThrowsWithReason([PersonObject objectsWhere:@"age.age.age == 25"],
+                              @"Invalid keypath 'age.age.age': Property 'PersonObject.age' is not a link or collection and can only appear at the end of a keypath.");
+    RLMAssertThrowsWithReason([AllPrimitiveArrays objectsWhere:@"intObj.foo == 25"],
+                              @"Invalid keypath 'intObj.foo': RLMArray<int> property intObj can only be followed by a collection operation");
+    RLMAssertThrowsWithReason([AllPrimitiveSets objectsWhere:@"intObj.foo == 25"],
+                              @"Invalid keypath 'intObj.foo': RLMSet<int> property intObj can only be followed by a collection operation");
+    RLMAssertThrowsWithReason([AllPrimitiveDictionaries objectsWhere:@"intObj.foo == 25"],
+                              @"Invalid keypath 'intObj.foo': RLMDictionary<int> property intObj can only be followed by a collection operation");
 
     // abuse of BETWEEN
-    RLMAssertThrowsWithReason([realm objects:className where:@"age BETWEEN 25"], @"type NSArray for BETWEEN");
-    RLMAssertThrowsWithReason([realm objects:className where:@"age BETWEEN Foo"], @"BETWEEN operator must compare a KeyPath with an aggregate");
-    RLMAssertThrowsWithReason([realm objects:className where:@"age BETWEEN {age, age}"], @"must be constant values");
-    RLMAssertThrowsWithReason([realm objects:className where:@"age BETWEEN {age, 0}"], @"must be constant values");
-    RLMAssertThrowsWithReason([realm objects:className where:@"age BETWEEN {0, age}"], @"must be constant values");
-    RLMAssertThrowsWithReason([realm objects:className where:@"age BETWEEN {0, {1, 10}}"], @"must be constant values");
+    RLMAssertThrowsWithReason([PersonObject objectsWhere:@"age BETWEEN 25"], @"type NSArray for BETWEEN");
+    RLMAssertThrowsWithReason([PersonObject objectsWhere:@"age BETWEEN Foo"], @"BETWEEN operator must compare a KeyPath with an aggregate");
+    RLMAssertThrowsWithReason([PersonObject objectsWhere:@"age BETWEEN {age, age}"], @"must be constant values");
+    RLMAssertThrowsWithReason([PersonObject objectsWhere:@"age BETWEEN {age, 0}"], @"must be constant values");
+    RLMAssertThrowsWithReason([PersonObject objectsWhere:@"age BETWEEN {0, age}"], @"must be constant values");
+    RLMAssertThrowsWithReason([PersonObject objectsWhere:@"age BETWEEN {0, {1, 10}}"], @"must be constant values");
 
     pred = [NSPredicate predicateWithFormat:@"age BETWEEN %@", @[@1]];
-    RLMAssertThrowsWithReason([realm objects:className withPredicate:pred], @"exactly two objects");
+    RLMAssertThrowsWithReason([PersonObject objectsWithPredicate:pred], @"exactly two objects");
 
     pred = [NSPredicate predicateWithFormat:@"age BETWEEN %@", @[@1, @2, @3]];
-    RLMAssertThrowsWithReason([realm objects:className withPredicate:pred], @"exactly two objects");
+    RLMAssertThrowsWithReason([PersonObject objectsWithPredicate:pred], @"exactly two objects");
 
     pred = [NSPredicate predicateWithFormat:@"age BETWEEN %@", @[@"Foo", @"Bar"]];
-    RLMAssertThrowsWithReason([realm objects:className withPredicate:pred], @"type int for BETWEEN");
+    RLMAssertThrowsWithReason([PersonObject objectsWithPredicate:pred], @"type int for BETWEEN");
 
     pred = [NSPredicate predicateWithFormat:@"age BETWEEN %@", @[@1.5, @2.5]];
-    RLMAssertThrowsWithReason([realm objects:className withPredicate:pred], @"type int for BETWEEN");
+    RLMAssertThrowsWithReason([PersonObject objectsWithPredicate:pred], @"type int for BETWEEN");
 
     pred = [NSPredicate predicateWithFormat:@"age BETWEEN %@", @[@1, @[@2, @3]]];
-    RLMAssertThrowsWithReason([realm objects:className withPredicate:pred], @"type int for BETWEEN");
+    RLMAssertThrowsWithReason([PersonObject objectsWithPredicate:pred], @"type int for BETWEEN");
 
     pred = [NSPredicate predicateWithFormat:@"age BETWEEN %@", @{@25: @35}];
-    RLMAssertThrowsWithReason([realm objects:className withPredicate:pred], @"type NSArray for BETWEEN");
+    RLMAssertThrowsWithReason([PersonObject objectsWithPredicate:pred], @"type NSArray for BETWEEN");
 
     pred = [NSPredicate predicateWithFormat:@"height BETWEEN %@", @[@25, @35]];
-    RLMAssertThrowsWithReason([realm objects:className withPredicate:pred],
+    RLMAssertThrowsWithReason([PersonObject objectsWithPredicate:pred],
                               @"Property 'height' not found in object of type 'PersonObject'");
 
     // bad type in link IN
     RLMAssertThrowsWithReason([PersonLinkObject objectsInRealm:realm where:@"person.age IN {'Tim'}"],
-                              @"Expected object of type int in IN clause for property 'person.age' on object of type 'PersonLinkObject'");
+                              @"Cannot compare value 'Tim' of type 'NSTaggedPointerString' to property 'age' of type 'int'");
 }
 
 - (void)testStringUnsupportedOperations
@@ -1286,49 +1288,49 @@
     [realm commitWriteTransaction];
 
     void (^testBlock)(NSString *, NSString *, Class) = ^(NSString * objectCol, NSString *colName, Class cls) {
-        RLMAssertCount(cls, 1U, [NSString stringWithFormat:@"%@ BEGINSWITH 'a'", colName]);
-        RLMAssertCount(cls, 1U, [NSString stringWithFormat:@"%@ BEGINSWITH 'ab'", colName]);
-        RLMAssertCount(cls, 1U, [NSString stringWithFormat:@"%@ BEGINSWITH 'abc'", colName]);
-        RLMAssertCount(cls, 0U, [NSString stringWithFormat:@"%@ BEGINSWITH 'abcd'", colName]);
-        RLMAssertCount(cls, 0U, [NSString stringWithFormat:@"%@ BEGINSWITH 'abd'", colName]);
-        RLMAssertCount(cls, 0U, [NSString stringWithFormat:@"%@ BEGINSWITH 'c'", colName]);
-        RLMAssertCount(cls, 0U, [NSString stringWithFormat:@"%@ BEGINSWITH 'A'", colName]);
-        RLMAssertCount(cls, 0U, [NSString stringWithFormat:@"%@ BEGINSWITH ''", colName]);
-        RLMAssertCount(cls, 1U, [NSString stringWithFormat:@"%@ BEGINSWITH[c] 'a'", colName]);
-        RLMAssertCount(cls, 1U, [NSString stringWithFormat:@"%@ BEGINSWITH[c] 'A'", colName]);
-        RLMAssertCount(cls, 0U, [NSString stringWithFormat:@"%@ BEGINSWITH[c] ''", colName]);
-        RLMAssertCount(cls, 0U, [NSString stringWithFormat:@"%@ BEGINSWITH[d] ''", colName]);
-        RLMAssertCount(cls, 0U, [NSString stringWithFormat:@"%@ BEGINSWITH[cd] ''", colName]);
+        RLMAssertCount(cls, 1U, @"%K BEGINSWITH 'a'", colName);
+        RLMAssertCount(cls, 1U, @"%K BEGINSWITH 'ab'", colName);
+        RLMAssertCount(cls, 1U, @"%K BEGINSWITH 'abc'", colName);
+        RLMAssertCount(cls, 0U, @"%K BEGINSWITH 'abcd'", colName);
+        RLMAssertCount(cls, 0U, @"%K BEGINSWITH 'abd'", colName);
+        RLMAssertCount(cls, 0U, @"%K BEGINSWITH 'c'", colName);
+        RLMAssertCount(cls, 0U, @"%K BEGINSWITH 'A'", colName);
+        RLMAssertCount(cls, 0U, @"%K BEGINSWITH ''", colName);
+        RLMAssertCount(cls, 1U, @"%K BEGINSWITH[c] 'a'", colName);
+        RLMAssertCount(cls, 1U, @"%K BEGINSWITH[c] 'A'", colName);
+        RLMAssertCount(cls, 0U, @"%K BEGINSWITH[c] ''", colName);
+        RLMAssertCount(cls, 0U, @"%K BEGINSWITH[d] ''", colName);
+        RLMAssertCount(cls, 0U, @"%K BEGINSWITH[cd] ''", colName);
 
-        RLMAssertCount(cls, 1U, [NSString stringWithFormat:@"%@ BEGINSWITH 'u'", colName]);
-        RLMAssertCount(cls, 1U, [NSString stringWithFormat:@"%@ BEGINSWITH[c] 'U'", colName]);
-        RLMAssertCount(cls, 3U, [NSString stringWithFormat:@"%@ BEGINSWITH[d] 'u'", colName]);
-        RLMAssertCount(cls, 3U, [NSString stringWithFormat:@"%@ BEGINSWITH[cd] 'U'", colName]);
+        RLMAssertCount(cls, 1U, @"%K BEGINSWITH 'u'", colName);
+        RLMAssertCount(cls, 1U, @"%K BEGINSWITH[c] 'U'", colName);
+        RLMAssertCount(cls, 3U, @"%K BEGINSWITH[d] 'u'", colName);
+        RLMAssertCount(cls, 3U, @"%K BEGINSWITH[cd] 'U'", colName);
 
-        RLMAssertCount(cls, 1U, [NSString stringWithFormat:@"%@ BEGINSWITH 'ü'", colName]);
-        RLMAssertCount(cls, 0U, [NSString stringWithFormat:@"%@ BEGINSWITH[c] 'Ü'", colName]);
-        RLMAssertCount(cls, 3U, [NSString stringWithFormat:@"%@ BEGINSWITH[d] 'ü'", colName]);
-        RLMAssertCount(cls, 3U, [NSString stringWithFormat:@"%@ BEGINSWITH[cd] 'Ü'", colName]);
+        RLMAssertCount(cls, 1U, @"%K BEGINSWITH 'ü'", colName);
+        RLMAssertCount(cls, 0U, @"%K BEGINSWITH[c] 'Ü'", colName);
+        RLMAssertCount(cls, 3U, @"%K BEGINSWITH[d] 'ü'", colName);
+        RLMAssertCount(cls, 3U, @"%K BEGINSWITH[cd] 'Ü'", colName);
 
-        RLMAssertCount(cls, 0U, [NSString stringWithFormat:@"%@ BEGINSWITH NULL", colName]);
-        RLMAssertCount(cls, 0U, [NSString stringWithFormat:@"%@ BEGINSWITH[c] NULL", colName]);
-        RLMAssertCount(cls, 0U, [NSString stringWithFormat:@"%@ BEGINSWITH[d] NULL", colName]);
-        RLMAssertCount(cls, 0U, [NSString stringWithFormat:@"%@ BEGINSWITH[cd] NULL", colName]);
+        RLMAssertCount(cls, 0U, @"%K BEGINSWITH NULL", colName);
+        RLMAssertCount(cls, 0U, @"%K BEGINSWITH[c] NULL", colName);
+        RLMAssertCount(cls, 0U, @"%K BEGINSWITH[d] NULL", colName);
+        RLMAssertCount(cls, 0U, @"%K BEGINSWITH[cd] NULL", colName);
 
-        RLMAssertCount(AllTypesObject, 1U, [NSString stringWithFormat:@"%@.%@ BEGINSWITH 'a'", objectCol, colName]);
-        RLMAssertCount(AllTypesObject, 0U, [NSString stringWithFormat:@"%@.%@ BEGINSWITH 'c'", objectCol, colName]);
-        RLMAssertCount(AllTypesObject, 0U, [NSString stringWithFormat:@"%@.%@ BEGINSWITH 'A'", objectCol, colName]);
-        RLMAssertCount(AllTypesObject, 0U, [NSString stringWithFormat:@"%@.%@ BEGINSWITH ''", objectCol, colName]);
-        RLMAssertCount(AllTypesObject, 1U, [NSString stringWithFormat:@"%@.%@ BEGINSWITH[c] 'a'", objectCol, colName]);
-        RLMAssertCount(AllTypesObject, 1U, [NSString stringWithFormat:@"%@.%@ BEGINSWITH[c] 'A'", objectCol, colName]);
-        RLMAssertCount(AllTypesObject, 0U, [NSString stringWithFormat:@"%@.%@ BEGINSWITH[c] ''", objectCol, colName]);
-        RLMAssertCount(AllTypesObject, 0U, [NSString stringWithFormat:@"%@.%@ BEGINSWITH[d] ''", objectCol, colName]);
-        RLMAssertCount(AllTypesObject, 0U, [NSString stringWithFormat:@"%@.%@ BEGINSWITH[cd] ''", objectCol, colName]);
+        RLMAssertCount(AllTypesObject, 1U, @"%K.%K BEGINSWITH 'a'", objectCol, colName);
+        RLMAssertCount(AllTypesObject, 0U, @"%K.%K BEGINSWITH 'c'", objectCol, colName);
+        RLMAssertCount(AllTypesObject, 0U, @"%K.%K BEGINSWITH 'A'", objectCol, colName);
+        RLMAssertCount(AllTypesObject, 0U, @"%K.%K BEGINSWITH ''", objectCol, colName);
+        RLMAssertCount(AllTypesObject, 1U, @"%K.%K BEGINSWITH[c] 'a'", objectCol, colName);
+        RLMAssertCount(AllTypesObject, 1U, @"%K.%K BEGINSWITH[c] 'A'", objectCol, colName);
+        RLMAssertCount(AllTypesObject, 0U, @"%K.%K BEGINSWITH[c] ''", objectCol, colName);
+        RLMAssertCount(AllTypesObject, 0U, @"%K.%K BEGINSWITH[d] ''", objectCol, colName);
+        RLMAssertCount(AllTypesObject, 0U, @"%K.%K BEGINSWITH[cd] ''", objectCol, colName);
 
-        RLMAssertCount(AllTypesObject, 0U, [NSString stringWithFormat:@"%@.%@ BEGINSWITH NULL", objectCol, colName]);
-        RLMAssertCount(AllTypesObject, 0U, [NSString stringWithFormat:@"%@.%@ BEGINSWITH[c] NULL", objectCol, colName]);
-        RLMAssertCount(AllTypesObject, 0U, [NSString stringWithFormat:@"%@.%@ BEGINSWITH[d] NULL", objectCol, colName]);
-        RLMAssertCount(AllTypesObject, 0U, [NSString stringWithFormat:@"%@.%@ BEGINSWITH[cd] NULL", objectCol, colName]);
+        RLMAssertCount(AllTypesObject, 0U, @"%K.%K BEGINSWITH NULL", objectCol, colName);
+        RLMAssertCount(AllTypesObject, 0U, @"%K.%K BEGINSWITH[c] NULL", objectCol, colName);
+        RLMAssertCount(AllTypesObject, 0U, @"%K.%K BEGINSWITH[d] NULL", objectCol, colName);
+        RLMAssertCount(AllTypesObject, 0U, @"%K.%K BEGINSWITH[cd] NULL", objectCol, colName);
     };
 
     testBlock(@"objectCol", @"stringCol", [StringObject class]);
@@ -1356,49 +1358,49 @@
     [realm commitWriteTransaction];
 
     void (^testBlock)(NSString *, NSString *, Class) = ^(NSString *objectCol, NSString *colName, Class cls) {
-        RLMAssertCount(cls, 1U, [NSString stringWithFormat:@"%@ ENDSWITH 'c'", colName]);
-        RLMAssertCount(cls, 1U, [NSString stringWithFormat:@"%@ ENDSWITH 'bc'", colName]);
-        RLMAssertCount(cls, 1U, [NSString stringWithFormat:@"%@ ENDSWITH 'abc'", colName]);
-        RLMAssertCount(cls, 0U, [NSString stringWithFormat:@"%@ ENDSWITH 'aabc'", colName]);
-        RLMAssertCount(cls, 0U, [NSString stringWithFormat:@"%@ ENDSWITH 'bbc'", colName]);
-        RLMAssertCount(cls, 0U, [NSString stringWithFormat:@"%@ ENDSWITH 'a'", colName]);
-        RLMAssertCount(cls, 0U, [NSString stringWithFormat:@"%@ ENDSWITH 'C'", colName]);
-        RLMAssertCount(cls, 0U, [NSString stringWithFormat:@"%@ ENDSWITH ''", colName]);
-        RLMAssertCount(cls, 1U, [NSString stringWithFormat:@"%@ ENDSWITH[c] 'c'", colName]);
-        RLMAssertCount(cls, 1U, [NSString stringWithFormat:@"%@ ENDSWITH[c] 'C'", colName]);
-        RLMAssertCount(cls, 0U, [NSString stringWithFormat:@"%@ ENDSWITH[c] ''", colName]);
-        RLMAssertCount(cls, 0U, [NSString stringWithFormat:@"%@ ENDSWITH[d] ''", colName]);
-        RLMAssertCount(cls, 0U, [NSString stringWithFormat:@"%@ ENDSWITH[cd] ''", colName]);
+        RLMAssertCount(cls, 1U, @"%K ENDSWITH 'c'", colName);
+        RLMAssertCount(cls, 1U, @"%K ENDSWITH 'bc'", colName);
+        RLMAssertCount(cls, 1U, @"%K ENDSWITH 'abc'", colName);
+        RLMAssertCount(cls, 0U, @"%K ENDSWITH 'aabc'", colName);
+        RLMAssertCount(cls, 0U, @"%K ENDSWITH 'bbc'", colName);
+        RLMAssertCount(cls, 0U, @"%K ENDSWITH 'a'", colName);
+        RLMAssertCount(cls, 0U, @"%K ENDSWITH 'C'", colName);
+        RLMAssertCount(cls, 0U, @"%K ENDSWITH ''", colName);
+        RLMAssertCount(cls, 1U, @"%K ENDSWITH[c] 'c'", colName);
+        RLMAssertCount(cls, 1U, @"%K ENDSWITH[c] 'C'", colName);
+        RLMAssertCount(cls, 0U, @"%K ENDSWITH[c] ''", colName);
+        RLMAssertCount(cls, 0U, @"%K ENDSWITH[d] ''", colName);
+        RLMAssertCount(cls, 0U, @"%K ENDSWITH[cd] ''", colName);
 
-        RLMAssertCount(cls, 1U, [NSString stringWithFormat:@"%@ ENDSWITH 'u'", colName]);
-        RLMAssertCount(cls, 1U, [NSString stringWithFormat:@"%@ ENDSWITH[c] 'U'", colName]);
-        RLMAssertCount(cls, 2U, [NSString stringWithFormat:@"%@ ENDSWITH[d] 'u'", colName]);
-        RLMAssertCount(cls, 2U, [NSString stringWithFormat:@"%@ ENDSWITH[cd] 'U'", colName]);
+        RLMAssertCount(cls, 1U, @"%K ENDSWITH 'u'", colName);
+        RLMAssertCount(cls, 1U, @"%K ENDSWITH[c] 'U'", colName);
+        RLMAssertCount(cls, 2U, @"%K ENDSWITH[d] 'u'", colName);
+        RLMAssertCount(cls, 2U, @"%K ENDSWITH[cd] 'U'", colName);
 
-        RLMAssertCount(cls, 1U, [NSString stringWithFormat:@"%@ ENDSWITH 'ü'", colName]);
-        RLMAssertCount(cls, 0U, [NSString stringWithFormat:@"%@ ENDSWITH[c] 'Ü'", colName]);
-        RLMAssertCount(cls, 2U, [NSString stringWithFormat:@"%@ ENDSWITH[d] 'ü'", colName]);
-        RLMAssertCount(cls, 2U, [NSString stringWithFormat:@"%@ ENDSWITH[cd] 'Ü'", colName]);
+        RLMAssertCount(cls, 1U, @"%K ENDSWITH 'ü'", colName);
+        RLMAssertCount(cls, 0U, @"%K ENDSWITH[c] 'Ü'", colName);
+        RLMAssertCount(cls, 2U, @"%K ENDSWITH[d] 'ü'", colName);
+        RLMAssertCount(cls, 2U, @"%K ENDSWITH[cd] 'Ü'", colName);
 
-        RLMAssertCount(cls, 0U, [NSString stringWithFormat:@"%@ ENDSWITH NULL", colName]);
-        RLMAssertCount(cls, 0U, [NSString stringWithFormat:@"%@ ENDSWITH[c] NULL", colName]);
-        RLMAssertCount(cls, 0U, [NSString stringWithFormat:@"%@ ENDSWITH[d] NULL", colName]);
-        RLMAssertCount(cls, 0U, [NSString stringWithFormat:@"%@ ENDSWITH[cd] NULL", colName]);
+        RLMAssertCount(cls, 0U, @"%K ENDSWITH NULL", colName);
+        RLMAssertCount(cls, 0U, @"%K ENDSWITH[c] NULL", colName);
+        RLMAssertCount(cls, 0U, @"%K ENDSWITH[d] NULL", colName);
+        RLMAssertCount(cls, 0U, @"%K ENDSWITH[cd] NULL", colName);
 
-        RLMAssertCount(AllTypesObject, 1U, [NSString stringWithFormat:@"%@.%@ ENDSWITH 'c'", objectCol, colName]);
-        RLMAssertCount(AllTypesObject, 0U, [NSString stringWithFormat:@"%@.%@ ENDSWITH 'a'", objectCol, colName]);
-        RLMAssertCount(AllTypesObject, 0U, [NSString stringWithFormat:@"%@.%@ ENDSWITH 'C'", objectCol, colName]);
-        RLMAssertCount(AllTypesObject, 0U, [NSString stringWithFormat:@"%@.%@ ENDSWITH ''", objectCol, colName]);
-        RLMAssertCount(AllTypesObject, 1U, [NSString stringWithFormat:@"%@.%@ ENDSWITH[c] 'c'", objectCol, colName]);
-        RLMAssertCount(AllTypesObject, 1U, [NSString stringWithFormat:@"%@.%@ ENDSWITH[c] 'C'", objectCol, colName]);
-        RLMAssertCount(AllTypesObject, 0U, [NSString stringWithFormat:@"%@.%@ ENDSWITH[c] ''", objectCol, colName]);
-        RLMAssertCount(AllTypesObject, 0U, [NSString stringWithFormat:@"%@.%@ ENDSWITH[d] ''", objectCol, colName]);
-        RLMAssertCount(AllTypesObject, 0U, [NSString stringWithFormat:@"%@.%@ ENDSWITH[cd] ''", objectCol, colName]);
+        RLMAssertCount(AllTypesObject, 1U, @"%K.%K ENDSWITH 'c'", objectCol, colName);
+        RLMAssertCount(AllTypesObject, 0U, @"%K.%K ENDSWITH 'a'", objectCol, colName);
+        RLMAssertCount(AllTypesObject, 0U, @"%K.%K ENDSWITH 'C'", objectCol, colName);
+        RLMAssertCount(AllTypesObject, 0U, @"%K.%K ENDSWITH ''", objectCol, colName);
+        RLMAssertCount(AllTypesObject, 1U, @"%K.%K ENDSWITH[c] 'c'", objectCol, colName);
+        RLMAssertCount(AllTypesObject, 1U, @"%K.%K ENDSWITH[c] 'C'", objectCol, colName);
+        RLMAssertCount(AllTypesObject, 0U, @"%K.%K ENDSWITH[c] ''", objectCol, colName);
+        RLMAssertCount(AllTypesObject, 0U, @"%K.%K ENDSWITH[d] ''", objectCol, colName);
+        RLMAssertCount(AllTypesObject, 0U, @"%K.%K ENDSWITH[cd] ''", objectCol, colName);
 
-        RLMAssertCount(AllTypesObject, 0U, [NSString stringWithFormat:@"%@.%@ ENDSWITH NULL", objectCol, colName]);
-        RLMAssertCount(AllTypesObject, 0U, [NSString stringWithFormat:@"%@.%@ ENDSWITH[c] NULL", objectCol, colName]);
-        RLMAssertCount(AllTypesObject, 0U, [NSString stringWithFormat:@"%@.%@ ENDSWITH[d] NULL", objectCol, colName]);
-        RLMAssertCount(AllTypesObject, 0U, [NSString stringWithFormat:@"%@.%@ ENDSWITH[cd] NULL", objectCol, colName]);
+        RLMAssertCount(AllTypesObject, 0U, @"%K.%K ENDSWITH NULL", objectCol, colName);
+        RLMAssertCount(AllTypesObject, 0U, @"%K.%K ENDSWITH[c] NULL", objectCol, colName);
+        RLMAssertCount(AllTypesObject, 0U, @"%K.%K ENDSWITH[d] NULL", objectCol, colName);
+        RLMAssertCount(AllTypesObject, 0U, @"%K.%K ENDSWITH[cd] NULL", objectCol, colName);
     };
     testBlock(@"objectCol", @"stringCol", [StringObject class]);
     testBlock(@"mixedObjectCol", @"anyCol", [MixedObject class]);
@@ -1423,53 +1425,53 @@
     [realm commitWriteTransaction];
 
     void (^testBlock)(NSString *, NSString *, Class) = ^(NSString *objectCol, NSString *colName, Class cls) {
-        RLMAssertCount(cls, 1U, [NSString stringWithFormat:@"%@ CONTAINS 'a'", colName]);
-        RLMAssertCount(cls, 1U, [NSString stringWithFormat:@"%@ CONTAINS 'b'", colName]);
-        RLMAssertCount(cls, 1U, [NSString stringWithFormat:@"%@ CONTAINS 'c'", colName]);
-        RLMAssertCount(cls, 1U, [NSString stringWithFormat:@"%@ CONTAINS 'ab'", colName]);
-        RLMAssertCount(cls, 1U, [NSString stringWithFormat:@"%@ CONTAINS 'bc'", colName]);
-        RLMAssertCount(cls, 1U, [NSString stringWithFormat:@"%@ CONTAINS 'abc'", colName]);
-        RLMAssertCount(cls, 0U, [NSString stringWithFormat:@"%@ CONTAINS 'd'", colName]);
-        RLMAssertCount(cls, 0U, [NSString stringWithFormat:@"%@ CONTAINS 'aabc'", colName]);
-        RLMAssertCount(cls, 0U, [NSString stringWithFormat:@"%@ CONTAINS 'bbc'", colName]);
-        RLMAssertCount(cls, 0U, [NSString stringWithFormat:@"%@ CONTAINS ''", colName]);
+        RLMAssertCount(cls, 1U, @"%K CONTAINS 'a'", colName);
+        RLMAssertCount(cls, 1U, @"%K CONTAINS 'b'", colName);
+        RLMAssertCount(cls, 1U, @"%K CONTAINS 'c'", colName);
+        RLMAssertCount(cls, 1U, @"%K CONTAINS 'ab'", colName);
+        RLMAssertCount(cls, 1U, @"%K CONTAINS 'bc'", colName);
+        RLMAssertCount(cls, 1U, @"%K CONTAINS 'abc'", colName);
+        RLMAssertCount(cls, 0U, @"%K CONTAINS 'd'", colName);
+        RLMAssertCount(cls, 0U, @"%K CONTAINS 'aabc'", colName);
+        RLMAssertCount(cls, 0U, @"%K CONTAINS 'bbc'", colName);
+        RLMAssertCount(cls, 0U, @"%K CONTAINS ''", colName);
 
-        RLMAssertCount(cls, 0U, [NSString stringWithFormat:@"%@ CONTAINS 'C'", colName]);
-        RLMAssertCount(cls, 1U, [NSString stringWithFormat:@"%@ CONTAINS[c] 'c'", colName]);
-        RLMAssertCount(cls, 1U, [NSString stringWithFormat:@"%@ CONTAINS[c] 'C'", colName]);
-        RLMAssertCount(cls, 0U, [NSString stringWithFormat:@"%@ CONTAINS[c] ''", colName]);
+        RLMAssertCount(cls, 0U, @"%K CONTAINS 'C'", colName);
+        RLMAssertCount(cls, 1U, @"%K CONTAINS[c] 'c'", colName);
+        RLMAssertCount(cls, 1U, @"%K CONTAINS[c] 'C'", colName);
+        RLMAssertCount(cls, 0U, @"%K CONTAINS[c] ''", colName);
 
-        RLMAssertCount(cls, 1U, [NSString stringWithFormat:@"%@ CONTAINS 'u'", colName]);
-        RLMAssertCount(cls, 1U, [NSString stringWithFormat:@"%@ CONTAINS[c] 'U'", colName]);
-        RLMAssertCount(cls, 3U, [NSString stringWithFormat:@"%@ CONTAINS[d] 'u'", colName]);
-        RLMAssertCount(cls, 3U, [NSString stringWithFormat:@"%@ CONTAINS[cd] 'U'", colName]);
-        RLMAssertCount(cls, 0U, [NSString stringWithFormat:@"%@ CONTAINS[d] ''", colName]);
-        RLMAssertCount(cls, 0U, [NSString stringWithFormat:@"%@ CONTAINS[cd] ''", colName]);
+        RLMAssertCount(cls, 1U, @"%K CONTAINS 'u'", colName);
+        RLMAssertCount(cls, 1U, @"%K CONTAINS[c] 'U'", colName);
+        RLMAssertCount(cls, 3U, @"%K CONTAINS[d] 'u'", colName);
+        RLMAssertCount(cls, 3U, @"%K CONTAINS[cd] 'U'", colName);
+        RLMAssertCount(cls, 0U, @"%K CONTAINS[d] ''", colName);
+        RLMAssertCount(cls, 0U, @"%K CONTAINS[cd] ''", colName);
 
-        RLMAssertCount(cls, 1U, [NSString stringWithFormat:@"%@ CONTAINS 'ü'", colName]);
-        RLMAssertCount(cls, 0U, [NSString stringWithFormat:@"%@ CONTAINS[c] 'Ü'", colName]);
-        RLMAssertCount(cls, 3U, [NSString stringWithFormat:@"%@ CONTAINS[d] 'ü'", colName]);
-        RLMAssertCount(cls, 3U, [NSString stringWithFormat:@"%@ CONTAINS[cd] 'Ü'", colName]);
+        RLMAssertCount(cls, 1U, @"%K CONTAINS 'ü'", colName);
+        RLMAssertCount(cls, 0U, @"%K CONTAINS[c] 'Ü'", colName);
+        RLMAssertCount(cls, 3U, @"%K CONTAINS[d] 'ü'", colName);
+        RLMAssertCount(cls, 3U, @"%K CONTAINS[cd] 'Ü'", colName);
 
-        RLMAssertCount(cls, 0U, [NSString stringWithFormat:@"%@ CONTAINS NULL", colName]);
-        RLMAssertCount(cls, 0U, [NSString stringWithFormat:@"%@ CONTAINS[c] NULL", colName]);
-        RLMAssertCount(cls, 0U, [NSString stringWithFormat:@"%@ CONTAINS[d] NULL", colName]);
-        RLMAssertCount(cls, 0U, [NSString stringWithFormat:@"%@ CONTAINS[cd] NULL", colName]);
+        RLMAssertCount(cls, 0U, @"%K CONTAINS NULL", colName);
+        RLMAssertCount(cls, 0U, @"%K CONTAINS[c] NULL", colName);
+        RLMAssertCount(cls, 0U, @"%K CONTAINS[d] NULL", colName);
+        RLMAssertCount(cls, 0U, @"%K CONTAINS[cd] NULL", colName);
 
-        RLMAssertCount(AllTypesObject, 0U, [NSString stringWithFormat:@"%@.%@ CONTAINS 'd'", objectCol, colName]);
-        RLMAssertCount(AllTypesObject, 1U, [NSString stringWithFormat:@"%@.%@ CONTAINS 'c'", objectCol, colName]);
-        RLMAssertCount(AllTypesObject, 0U, [NSString stringWithFormat:@"%@.%@ CONTAINS 'C'", objectCol, colName]);
-        RLMAssertCount(AllTypesObject, 0U, [NSString stringWithFormat:@"%@.%@ CONTAINS ''", objectCol, colName]);
-        RLMAssertCount(AllTypesObject, 1U, [NSString stringWithFormat:@"%@.%@ CONTAINS[c] 'c'", objectCol, colName]);
-        RLMAssertCount(AllTypesObject, 1U, [NSString stringWithFormat:@"%@.%@ CONTAINS[c] 'C'", objectCol, colName]);
-        RLMAssertCount(AllTypesObject, 0U, [NSString stringWithFormat:@"%@.%@ CONTAINS[c] ''", objectCol, colName]);
-        RLMAssertCount(AllTypesObject, 0U, [NSString stringWithFormat:@"%@.%@ CONTAINS[d] ''", objectCol, colName]);
-        RLMAssertCount(AllTypesObject, 0U, [NSString stringWithFormat:@"%@.%@ CONTAINS[cd] ''", objectCol, colName]);
+        RLMAssertCount(AllTypesObject, 0U, @"%K.%K CONTAINS 'd'", objectCol, colName);
+        RLMAssertCount(AllTypesObject, 1U, @"%K.%K CONTAINS 'c'", objectCol, colName);
+        RLMAssertCount(AllTypesObject, 0U, @"%K.%K CONTAINS 'C'", objectCol, colName);
+        RLMAssertCount(AllTypesObject, 0U, @"%K.%K CONTAINS ''", objectCol, colName);
+        RLMAssertCount(AllTypesObject, 1U, @"%K.%K CONTAINS[c] 'c'", objectCol, colName);
+        RLMAssertCount(AllTypesObject, 1U, @"%K.%K CONTAINS[c] 'C'", objectCol, colName);
+        RLMAssertCount(AllTypesObject, 0U, @"%K.%K CONTAINS[c] ''", objectCol, colName);
+        RLMAssertCount(AllTypesObject, 0U, @"%K.%K CONTAINS[d] ''", objectCol, colName);
+        RLMAssertCount(AllTypesObject, 0U, @"%K.%K CONTAINS[cd] ''", objectCol, colName);
 
-        RLMAssertCount(AllTypesObject, 0U, [NSString stringWithFormat:@"%@.%@ CONTAINS NULL", objectCol, colName]);
-        RLMAssertCount(AllTypesObject, 0U, [NSString stringWithFormat:@"%@.%@ CONTAINS[c] NULL", objectCol, colName]);
-        RLMAssertCount(AllTypesObject, 0U, [NSString stringWithFormat:@"%@.%@ CONTAINS[d] NULL", objectCol, colName]);
-        RLMAssertCount(AllTypesObject, 0U, [NSString stringWithFormat:@"%@.%@ CONTAINS[cd] NULL", objectCol, colName]);
+        RLMAssertCount(AllTypesObject, 0U, @"%K.%K CONTAINS NULL", objectCol, colName);
+        RLMAssertCount(AllTypesObject, 0U, @"%K.%K CONTAINS[c] NULL", objectCol, colName);
+        RLMAssertCount(AllTypesObject, 0U, @"%K.%K CONTAINS[d] NULL", objectCol, colName);
+        RLMAssertCount(AllTypesObject, 0U, @"%K.%K CONTAINS[cd] NULL", objectCol, colName);
     };
 
     testBlock(@"objectCol", @"stringCol", [StringObject class]);
@@ -1487,41 +1489,39 @@
     [realm commitWriteTransaction];
 
     void (^testBlock)(NSString *, NSString *, Class) = ^(NSString *objectCol, NSString *colName, Class cls) {
-        RLMAssertCount(cls, 1U, [NSString stringWithFormat:@"%@ LIKE '*a*'", colName]);
-        RLMAssertCount(cls, 1U, [NSString stringWithFormat:@"%@ LIKE '*b*'", colName]);
-        RLMAssertCount(cls, 1U, [NSString stringWithFormat:@"%@ LIKE '*c'", colName]);
-        RLMAssertCount(cls, 1U, [NSString stringWithFormat:@"%@ LIKE 'ab*'", colName]);
-        RLMAssertCount(cls, 1U, [NSString stringWithFormat:@"%@ LIKE '*bc'", colName]);
-        RLMAssertCount(cls, 1U, [NSString stringWithFormat:@"%@ LIKE 'a*bc'", colName]);
-        RLMAssertCount(cls, 1U, [NSString stringWithFormat:@"%@ LIKE '*abc*'", colName]);
-        RLMAssertCount(cls, 0U, [NSString stringWithFormat:@"%@ LIKE '*d*'", colName]);
-        RLMAssertCount(cls, 0U, [NSString stringWithFormat:@"%@ LIKE 'aabc'", colName]);
-        RLMAssertCount(cls, 0U, [NSString stringWithFormat:@"%@ LIKE 'b*bc'", colName]);
+        RLMAssertCount(cls, 1U, @"%K LIKE '*a*'", colName);
+        RLMAssertCount(cls, 1U, @"%K LIKE '*b*'", colName);
+        RLMAssertCount(cls, 1U, @"%K LIKE '*c'", colName);
+        RLMAssertCount(cls, 1U, @"%K LIKE 'ab*'", colName);
+        RLMAssertCount(cls, 1U, @"%K LIKE '*bc'", colName);
+        RLMAssertCount(cls, 1U, @"%K LIKE 'a*bc'", colName);
+        RLMAssertCount(cls, 1U, @"%K LIKE '*abc*'", colName);
+        RLMAssertCount(cls, 0U, @"%K LIKE '*d*'", colName);
+        RLMAssertCount(cls, 0U, @"%K LIKE 'aabc'", colName);
+        RLMAssertCount(cls, 0U, @"%K LIKE 'b*bc'", colName);
 
-        RLMAssertCount(cls, 1U, [NSString stringWithFormat:@"%@ LIKE 'a?" "?'", colName]);
-        RLMAssertCount(cls, 1U, [NSString stringWithFormat:@"%@ LIKE '?b?'", colName]);
-        RLMAssertCount(cls, 1U, [NSString stringWithFormat:@"%@ LIKE '*?c'", colName]);
-        RLMAssertCount(cls, 1U, [NSString stringWithFormat:@"%@ LIKE 'ab?'", colName]);
-        RLMAssertCount(cls, 1U, [NSString stringWithFormat:@"%@ LIKE '?bc'", colName]);
-        RLMAssertCount(cls, 0U, [NSString stringWithFormat:@"%@ LIKE '?d?'", colName]);
-        RLMAssertCount(cls, 0U, [NSString stringWithFormat:@"%@ LIKE '?abc'", colName]);
-        RLMAssertCount(cls, 0U, [NSString stringWithFormat:@"%@ LIKE 'b?bc'", colName]);
+        RLMAssertCount(cls, 1U, @"%K LIKE 'a?" "?'", colName);
+        RLMAssertCount(cls, 1U, @"%K LIKE '?b?'", colName);
+        RLMAssertCount(cls, 1U, @"%K LIKE '*?c'", colName);
+        RLMAssertCount(cls, 1U, @"%K LIKE 'ab?'", colName);
+        RLMAssertCount(cls, 1U, @"%K LIKE '?bc'", colName);
+        RLMAssertCount(cls, 0U, @"%K LIKE '?d?'", colName);
+        RLMAssertCount(cls, 0U, @"%K LIKE '?abc'", colName);
+        RLMAssertCount(cls, 0U, @"%K LIKE 'b?bc'", colName);
 
-        RLMAssertCount(cls, 0U, [NSString stringWithFormat:@"%@ LIKE '*C*'", colName]);
-        RLMAssertCount(cls, 1U, [NSString stringWithFormat:@"%@ LIKE[c] '*c*'", colName]);
-        RLMAssertCount(cls, 1U, [NSString stringWithFormat:@"%@ LIKE[c] '*C*'", colName]);
+        RLMAssertCount(cls, 0U, @"%K LIKE '*C*'", colName);
+        RLMAssertCount(cls, 1U, @"%K LIKE[c] '*c*'", colName);
+        RLMAssertCount(cls, 1U, @"%K LIKE[c] '*C*'", colName);
 
-        RLMAssertCount(AllTypesObject, 0U, [NSString stringWithFormat:@"%@.%@ LIKE '*d*'", objectCol, colName]);
-        RLMAssertCount(AllTypesObject, 1U, [NSString stringWithFormat:@"%@.%@ LIKE '*c*'", objectCol, colName]);
-        RLMAssertCount(AllTypesObject, 0U, [NSString stringWithFormat:@"%@.%@ LIKE '*C*'", objectCol, colName]);
-        RLMAssertCount(AllTypesObject, 1U, [NSString stringWithFormat:@"%@.%@ LIKE[c] '*c*'", objectCol, colName]);
-        RLMAssertCount(AllTypesObject, 1U, [NSString stringWithFormat:@"%@.%@ LIKE[c] '*C*'", objectCol, colName]);
+        RLMAssertCount(AllTypesObject, 0U, @"%K.%K LIKE '*d*'", objectCol, colName);
+        RLMAssertCount(AllTypesObject, 1U, @"%K.%K LIKE '*c*'", objectCol, colName);
+        RLMAssertCount(AllTypesObject, 0U, @"%K.%K LIKE '*C*'", objectCol, colName);
+        RLMAssertCount(AllTypesObject, 1U, @"%K.%K LIKE[c] '*c*'", objectCol, colName);
+        RLMAssertCount(AllTypesObject, 1U, @"%K.%K LIKE[c] '*C*'", objectCol, colName);
 
-        NSString *queryStr = [NSString stringWithFormat:@"%@ LIKE[d] '*'", colName];
-        RLMAssertThrowsWithReasonMatching([cls objectsWhere:queryStr],
+        RLMAssertThrowsWithReasonMatching(([cls objectsWhere:@"%K LIKE[d] '*'", colName]),
                                           @"'LIKE' not supported .* diacritic-insensitive");
-        queryStr = [NSString stringWithFormat:@"%@ LIKE[cd] '*'", colName];
-        RLMAssertThrowsWithReasonMatching([cls objectsWhere:queryStr],
+        RLMAssertThrowsWithReasonMatching(([cls objectsWhere:@"%K LIKE[cd] '*'", colName]),
                                           @"'LIKE' not supported .* diacritic-insensitive");
     };
 
@@ -1548,34 +1548,34 @@
     [realm commitWriteTransaction];
 
     void (^testBlock)(NSString *, NSString *, Class) = ^(NSString *objectCol, NSString *colName, Class cls) {
-        RLMAssertCount(cls, 1U, [NSString stringWithFormat:@"%@ == 'abc'", colName]);
-        RLMAssertCount(cls, 4U, [NSString stringWithFormat:@"%@ != 'def'", colName]);
-        RLMAssertCount(cls, 1U, [NSString stringWithFormat:@"%@ ==[c] 'abc'", colName]);
-        RLMAssertCount(cls, 1U, [NSString stringWithFormat:@"%@ ==[c] 'ABC'", colName]);
+        RLMAssertCount(cls, 1U, @"%K == 'abc'", colName);
+        RLMAssertCount(cls, 4U, @"%K != 'def'", colName);
+        RLMAssertCount(cls, 1U, @"%K ==[c] 'abc'", colName);
+        RLMAssertCount(cls, 1U, @"%K ==[c] 'ABC'", colName);
 
-        RLMAssertCount(cls, 3U, [NSString stringWithFormat:@"%@ != 'abc'", colName]);
-        RLMAssertCount(cls, 0U, [NSString stringWithFormat:@"%@ == 'def'", colName]);
-        RLMAssertCount(cls, 0U, [NSString stringWithFormat:@"%@ == 'ABC'", colName]);
+        RLMAssertCount(cls, 3U, @"%K != 'abc'", colName);
+        RLMAssertCount(cls, 0U, @"%K == 'def'", colName);
+        RLMAssertCount(cls, 0U, @"%K == 'ABC'", colName);
 
-        RLMAssertCount(cls, 1U, [NSString stringWithFormat:@"%@ == 'tuv'", colName]);
-        RLMAssertCount(cls, 1U, [NSString stringWithFormat:@"%@ ==[c] 'TUV'", colName]);
-        RLMAssertCount(cls, 3U, [NSString stringWithFormat:@"%@ ==[d] 'tuv'", colName]);
-        RLMAssertCount(cls, 3U, [NSString stringWithFormat:@"%@ ==[cd] 'TUV'", colName]);
+        RLMAssertCount(cls, 1U, @"%K == 'tuv'", colName);
+        RLMAssertCount(cls, 1U, @"%K ==[c] 'TUV'", colName);
+        RLMAssertCount(cls, 3U, @"%K ==[d] 'tuv'", colName);
+        RLMAssertCount(cls, 3U, @"%K ==[cd] 'TUV'", colName);
 
-        RLMAssertCount(cls, 3U, [NSString stringWithFormat:@"%@ != 'tuv'", colName]);
-        RLMAssertCount(cls, 3U, [NSString stringWithFormat:@"%@ !=[c] 'TUV'", colName]);
-        RLMAssertCount(cls, 1U, [NSString stringWithFormat:@"%@ !=[d] 'tuv'", colName]);
-        RLMAssertCount(cls, 1U, [NSString stringWithFormat:@"%@ !=[cd] 'TUV'", colName]);
+        RLMAssertCount(cls, 3U, @"%K != 'tuv'", colName);
+        RLMAssertCount(cls, 3U, @"%K !=[c] 'TUV'", colName);
+        RLMAssertCount(cls, 1U, @"%K !=[d] 'tuv'", colName);
+        RLMAssertCount(cls, 1U, @"%K !=[cd] 'TUV'", colName);
 
-        RLMAssertCount(AllTypesObject, 1U, [NSString stringWithFormat:@"%@.%@ == 'abc'", objectCol, colName]);
-        RLMAssertCount(AllTypesObject, 1U, [NSString stringWithFormat:@"%@.%@ != 'def'", objectCol, colName]);
+        RLMAssertCount(AllTypesObject, 1U, @"%K.%K == 'abc'", objectCol, colName);
+        RLMAssertCount(AllTypesObject, 1U, @"%K.%K != 'def'", objectCol, colName);
 
-        RLMAssertCount(AllTypesObject, 1U, [NSString stringWithFormat:@"%@.%@ ==[c] 'abc'", objectCol, colName]);
-        RLMAssertCount(AllTypesObject, 1U, [NSString stringWithFormat:@"%@.%@ ==[c] 'ABC'", objectCol, colName]);
+        RLMAssertCount(AllTypesObject, 1U, @"%K.%K ==[c] 'abc'", objectCol, colName);
+        RLMAssertCount(AllTypesObject, 1U, @"%K.%K ==[c] 'ABC'", objectCol, colName);
 
-        RLMAssertCount(AllTypesObject, 0U, [NSString stringWithFormat:@"%@.%@ != 'abc'", objectCol, colName]);
-        RLMAssertCount(AllTypesObject, 0U, [NSString stringWithFormat:@"%@.%@ == 'def'", objectCol, colName]);
-        RLMAssertCount(AllTypesObject, 0U, [NSString stringWithFormat:@"%@.%@ == 'ABC'", objectCol, colName]);
+        RLMAssertCount(AllTypesObject, 0U, @"%K.%K != 'abc'", objectCol, colName);
+        RLMAssertCount(AllTypesObject, 0U, @"%K.%K == 'def'", objectCol, colName);
+        RLMAssertCount(AllTypesObject, 0U, @"%K.%K == 'ABC'", objectCol, colName);
     };
 
     testBlock(@"objectCol", @"stringCol", [StringObject class]);
@@ -1917,9 +1917,9 @@
 
     ArrayPropertyObject *arrPropObj1 = [[ArrayPropertyObject alloc] init];
     arrPropObj1.name = @"Test";
-    for(NSUInteger i=0; i<10; i++) {
+    for (NSUInteger i=0; i<10; i++) {
         StringObject *sobj = [[StringObject alloc] init];
-        sobj.stringCol = [NSString stringWithFormat:@"%lu", (unsigned long)i];
+        sobj.stringCol = @(i).stringValue;
         [arrPropObj1.array addObject:sobj];
         IntObject *iobj = [[IntObject alloc] init];
         iobj.intCol = (int)i;
@@ -1937,9 +1937,9 @@
 
     ArrayPropertyObject *arrPropObj2 = [[ArrayPropertyObject alloc] init];
     arrPropObj2.name = @"Test";
-    for(NSUInteger i=0; i<4; i++) {
+    for (NSUInteger i=0; i<4; i++) {
         StringObject *sobj = [[StringObject alloc] init];
-        sobj.stringCol = [NSString stringWithFormat:@"%lu", (unsigned long)i];
+        sobj.stringCol = @(i).stringValue;
         [arrPropObj2.array addObject:sobj];
         IntObject *iobj = [[IntObject alloc] init];
         iobj.intCol = (int)i;
@@ -1961,9 +1961,9 @@
 
     SetPropertyObject *setPropObj1 = [[SetPropertyObject alloc] init];
     setPropObj1.name = @"Test";
-    for(NSUInteger i=0; i<10; i++) {
+    for (NSUInteger i=0; i<10; i++) {
         StringObject *sobj = [[StringObject alloc] init];
-        sobj.stringCol = [NSString stringWithFormat:@"%lu", (unsigned long)i];
+        sobj.stringCol = @(i).stringValue;
         [setPropObj1.set addObject:sobj];
         IntObject *iobj = [[IntObject alloc] init];
         iobj.intCol = (int)i;
@@ -1982,9 +1982,9 @@
 
     SetPropertyObject *setPropObj2 = [[SetPropertyObject alloc] init];
     setPropObj2.name = @"Test";
-    for(NSUInteger i=0; i<4; i++) {
+    for (NSUInteger i=0; i<4; i++) {
         StringObject *sobj = [[StringObject alloc] init];
-        sobj.stringCol = [NSString stringWithFormat:@"%lu", (unsigned long)i];
+        sobj.stringCol = @(i).stringValue;
         [setPropObj2.set addObject:sobj];
         IntObject *iobj = [[IntObject alloc] init];
         iobj.intCol = (int)i;
@@ -2004,9 +2004,9 @@
     RLMRealm *realm = [self realm];
 
     DictionaryPropertyObject *dpo1 = [[DictionaryPropertyObject alloc] init];
-    for(NSUInteger i=0; i<10; i++) {
+    for (NSUInteger i=0; i<10; i++) {
         StringObject *sobj = [[StringObject alloc] init];
-        sobj.stringCol = [NSString stringWithFormat:@"%lu", (unsigned long)i];
+        sobj.stringCol = @(i).stringValue;
         dpo1.stringDictionary[sobj.stringCol] = sobj;
         IntObject *iobj = [[IntObject alloc] init];
         iobj.intCol = (int)i;
@@ -2023,9 +2023,9 @@
     RLMAssertCount(DictionaryPropertyObject, 1U, @"NONE intObjDictionary.intCol > 10");
 
     DictionaryPropertyObject *dpo2 = [[DictionaryPropertyObject alloc] init];
-    for(NSUInteger i=0; i<4; i++) {
+    for (NSUInteger i=0; i<4; i++) {
         StringObject *sobj = [[StringObject alloc] init];
-        sobj.stringCol = [NSString stringWithFormat:@"%lu", (unsigned long)i];
+        sobj.stringCol = @(i).stringValue;
         dpo2.stringDictionary[sobj.stringCol] = sobj;
         IntObject *iobj = [[IntObject alloc] init];
         iobj.intCol = (int)i;
@@ -2048,7 +2048,7 @@
     [realm beginWriteTransaction];
     CircleObject *circle = nil;
     for (int i = 0; i < 5; ++i) {
-        circle = [CircleObject createInRealm:realm withValue:@{@"data": [NSString stringWithFormat:@"%d", i],
+        circle = [CircleObject createInRealm:realm withValue:@{@"data": @(i).stringValue,
                                                                 @"next": circle ?: NSNull.null}];
     }
     [realm commitWriteTransaction];
@@ -2075,7 +2075,7 @@
     [realm beginWriteTransaction];
     CircleObject *circle = nil;
     for (int i = 0; i < 5; ++i) {
-        circle = [CircleObject createInRealm:realm withValue:@{@"data": [NSString stringWithFormat:@"%d", i],
+        circle = [CircleObject createInRealm:realm withValue:@{@"data": @(i).stringValue,
                                                                 @"next": circle ?: NSNull.null}];
     }
     [CircleArrayObject createInRealm:realm withValue:@[[CircleObject allObjectsInRealm:realm]]];
@@ -2107,7 +2107,7 @@
     [realm beginWriteTransaction];
     CircleObject *circle = nil;
     for (int i = 0; i < 5; ++i) {
-        circle = [CircleObject createInRealm:realm withValue:@{@"data": [NSString stringWithFormat:@"%d", i],
+        circle = [CircleObject createInRealm:realm withValue:@{@"data": @(i).stringValue,
                                                                 @"next": circle ?: NSNull.null}];
     }
     [CircleSetObject createInRealm:realm withValue:@[[CircleObject allObjectsInRealm:realm]]];
@@ -2138,7 +2138,7 @@
     [realm beginWriteTransaction];
     CircleObject *circle = nil;
     for (int i = 0; i < 5; ++i) {
-        circle = [CircleObject createInRealm:realm withValue:@{@"data": [NSString stringWithFormat:@"%d", i],
+        circle = [CircleObject createInRealm:realm withValue:@{@"data": @(i).stringValue,
                                                                 @"next": circle ?: NSNull.null}];
     }
     CircleDictionaryObject *cdo = [CircleDictionaryObject createInRealm:realm withValue:@{}];
@@ -3139,12 +3139,12 @@ static NSData *data(const char *str) {
     RLMAssertThrowsWithReasonMatching(([IntegerArrayPropertyObject objectsWhere:@"array.@count == array.@count"]),
                                       @"aggregate operations cannot be compared with other aggregate operations");
 
-    RLMAssertThrowsWithReasonMatching(([IntegerArrayPropertyObject objectsWhere:@"array.@count.foo.bar != 0"]),
-                                      @"single level key");
-    RLMAssertThrowsWithReasonMatching(([IntegerArrayPropertyObject objectsWhere:@"array.@count.intCol > 0"]),
-                                      @"@count does not have any properties");
-    RLMAssertThrowsWithReasonMatching(([IntegerArrayPropertyObject objectsWhere:@"array.@count != 'Hello'"]),
-                                      @"@count can only be compared with a numeric value");
+    RLMAssertThrowsWithReason(([IntegerArrayPropertyObject objectsWhere:@"array.@count.foo.bar != 0"]),
+                              @"Invalid keypath 'array.@count.foo.bar': @count must appear at the end of a keypath.");
+    RLMAssertThrowsWithReason(([IntegerArrayPropertyObject objectsWhere:@"array.@count.intCol > 0"]),
+                              @"Invalid keypath 'array.@count.intCol': @count must appear at the end of a keypath.");
+    RLMAssertThrowsWithReason(([IntegerArrayPropertyObject objectsWhere:@"array.@count != 'Hello'"]),
+                              @"@count can only be compared with a numeric value");
 }
 
 - (void)testCountOnSetCollection {
@@ -3175,15 +3175,15 @@ static NSData *data(const char *str) {
     RLMAssertCount(IntegerSetPropertyObject, 1U, @"number < set.@count");
 
     // We do not yet handle collection operations on both sides of the comparison.
-    RLMAssertThrowsWithReasonMatching(([IntegerSetPropertyObject objectsWhere:@"set.@count == set.@count"]),
-                                      @"aggregate operations cannot be compared with other aggregate operations");
+    RLMAssertThrowsWithReason(([IntegerSetPropertyObject objectsWhere:@"set.@count == set.@count"]),
+                              @"aggregate operations cannot be compared with other aggregate operations");
 
-    RLMAssertThrowsWithReasonMatching(([IntegerSetPropertyObject objectsWhere:@"set.@count.foo.bar != 0"]),
-                                      @"single level key");
-    RLMAssertThrowsWithReasonMatching(([IntegerSetPropertyObject objectsWhere:@"set.@count.intCol > 0"]),
-                                      @"@count does not have any properties");
-    RLMAssertThrowsWithReasonMatching(([IntegerSetPropertyObject objectsWhere:@"set.@count != 'Hello'"]),
-                                      @"@count can only be compared with a numeric value");
+    RLMAssertThrowsWithReason(([IntegerSetPropertyObject objectsWhere:@"set.@count.foo.bar != 0"]),
+                              @"Invalid keypath 'set.@count.foo.bar': @count must appear at the end of a keypath.");
+    RLMAssertThrowsWithReason(([IntegerSetPropertyObject objectsWhere:@"set.@count.intCol > 0"]),
+                              @"Invalid keypath 'set.@count.intCol': @count must appear at the end of a keypath.");
+    RLMAssertThrowsWithReason(([IntegerSetPropertyObject objectsWhere:@"set.@count != 'Hello'"]),
+                              @"@count can only be compared with a numeric value");
 }
 
 - (void)testCountOnDictionaryCollection {
@@ -3214,15 +3214,15 @@ static NSData *data(const char *str) {
     RLMAssertCount(IntegerDictionaryPropertyObject, 1U, @"number < dictionary.@count");
 
     // We do not yet handle collection operations on both sides of the comparison.
-    RLMAssertThrowsWithReasonMatching(([IntegerDictionaryPropertyObject objectsWhere:@"dictionary.@count == dictionary.@count"]),
-                                      @"aggregate operations cannot be compared with other aggregate operations");
+    RLMAssertThrowsWithReason(([IntegerDictionaryPropertyObject objectsWhere:@"dictionary.@count == dictionary.@count"]),
+                              @"aggregate operations cannot be compared with other aggregate operations");
 
-    RLMAssertThrowsWithReasonMatching(([IntegerDictionaryPropertyObject objectsWhere:@"dictionary.@count.foo.bar != 0"]),
-                                      @"single level key");
-    RLMAssertThrowsWithReasonMatching(([IntegerDictionaryPropertyObject objectsWhere:@"dictionary.@count.intCol > 0"]),
-                                      @"@count does not have any properties");
-    RLMAssertThrowsWithReasonMatching(([IntegerDictionaryPropertyObject objectsWhere:@"dictionary.@count != 'Hello'"]),
-                                      @"@count can only be compared with a numeric value");
+    RLMAssertThrowsWithReason(([IntegerDictionaryPropertyObject objectsWhere:@"dictionary.@count.foo.bar != 0"]),
+                              @"Invalid keypath 'dictionary.@count.foo.bar': @count must appear at the end of a keypath.");
+    RLMAssertThrowsWithReason(([IntegerDictionaryPropertyObject objectsWhere:@"dictionary.@count.intCol > 0"]),
+                              @"Invalid keypath 'dictionary.@count.intCol': @count must appear at the end of a keypath.");
+    RLMAssertThrowsWithReason(([IntegerDictionaryPropertyObject objectsWhere:@"dictionary.@count != 'Hello'"]),
+                              @"@count can only be compared with a numeric value");
 }
 
 - (void)testAggregateArrayCollectionOperators {
@@ -3273,17 +3273,25 @@ static NSData *data(const char *str) {
     RLMAssertCount(IntegerArrayPropertyObject, 2U, @"number > array.@avg.intCol");
 
     // We do not yet handle collection operations on both sides of the comparison.
-    RLMAssertThrowsWithReasonMatching(([IntegerArrayPropertyObject objectsWhere:@"array.@min.intCol == array.@min.intCol"]), @"aggregate operations cannot be compared with other aggregate operations");
+    RLMAssertThrowsWithReason(([IntegerArrayPropertyObject objectsWhere:@"array.@min.intCol == array.@min.intCol"]),
+                              @"aggregate operations cannot be compared with other aggregate operations");
 
-    RLMAssertThrowsWithReasonMatching(([IntegerArrayPropertyObject objectsWhere:@"array.@min.intCol.foo.bar == 1.23"]), @"single level key");
-    RLMAssertThrowsWithReasonMatching(([IntegerArrayPropertyObject objectsWhere:@"array.@max.intCol.foo.bar == 1.23"]), @"single level key");
-    RLMAssertThrowsWithReasonMatching(([IntegerArrayPropertyObject objectsWhere:@"array.@sum.intCol.foo.bar == 1.23"]), @"single level key");
-    RLMAssertThrowsWithReasonMatching(([IntegerArrayPropertyObject objectsWhere:@"array.@avg.intCol.foo.bar == 1.23"]), @"single level key");
+    RLMAssertThrowsWithReason(([IntegerArrayPropertyObject objectsWhere:@"array.@min.intCol.foo.bar == 1.23"]),
+                              @"Invalid keypath 'array.@min.intCol.foo.bar': Property 'IntObject.intCol' is not a link or collection and can only appear at the end of a keypath.");
+    RLMAssertThrowsWithReason(([IntegerArrayPropertyObject objectsWhere:@"array.@max.intCol.foo.bar == 1.23"]),
+                              @"Invalid keypath 'array.@max.intCol.foo.bar': Property 'IntObject.intCol' is not a link or collection and can only appear at the end of a keypath.");
+    RLMAssertThrowsWithReason(([IntegerArrayPropertyObject objectsWhere:@"array.@sum.intCol.foo.bar == 1.23"]),
+                              @"Invalid keypath 'array.@sum.intCol.foo.bar': Property 'IntObject.intCol' is not a link or collection and can only appear at the end of a keypath.");
+    RLMAssertThrowsWithReason(([IntegerArrayPropertyObject objectsWhere:@"array.@avg.intCol.foo.bar == 1.23"]),
+                              @"Invalid keypath 'array.@avg.intCol.foo.bar': Property 'IntObject.intCol' is not a link or collection and can only appear at the end of a keypath.");
 
     // Average is omitted from this test as its result is always a double.
-    RLMAssertThrowsWithReasonMatching(([IntegerArrayPropertyObject objectsWhere:@"array.@min.intCol == 1.23"]), @"@min.*type int cannot be compared");
-    RLMAssertThrowsWithReasonMatching(([IntegerArrayPropertyObject objectsWhere:@"array.@max.intCol == 1.23"]), @"@max.*type int cannot be compared");
-    RLMAssertThrowsWithReasonMatching(([IntegerArrayPropertyObject objectsWhere:@"array.@sum.intCol == 1.23"]), @"@sum.*type int cannot be compared");
+    RLMAssertThrowsWithReasonMatching(([IntegerArrayPropertyObject objectsWhere:@"array.@min.intCol == 1.23"]),
+                                      @"@min.*type int cannot be compared");
+    RLMAssertThrowsWithReasonMatching(([IntegerArrayPropertyObject objectsWhere:@"array.@max.intCol == 1.23"]),
+                                      @"@max.*type int cannot be compared");
+    RLMAssertThrowsWithReasonMatching(([IntegerArrayPropertyObject objectsWhere:@"array.@sum.intCol == 1.23"]),
+                                      @"@sum.*type int cannot be compared");
 }
 
 - (void)testAggregateSetCollectionOperators {
@@ -3334,17 +3342,25 @@ static NSData *data(const char *str) {
     RLMAssertCount(IntegerSetPropertyObject, 2U, @"number > set.@avg.intCol");
 
     // We do not yet handle collection operations on both sides of the comparison.
-    RLMAssertThrowsWithReasonMatching(([IntegerSetPropertyObject objectsWhere:@"set.@min.intCol == set.@min.intCol"]), @"aggregate operations cannot be compared with other aggregate operations");
+    RLMAssertThrowsWithReason(([IntegerSetPropertyObject objectsWhere:@"set.@min.intCol == set.@min.intCol"]),
+                              @"aggregate operations cannot be compared with other aggregate operations");
 
-    RLMAssertThrowsWithReasonMatching(([IntegerSetPropertyObject objectsWhere:@"set.@min.intCol.foo.bar == 1.23"]), @"single level key");
-    RLMAssertThrowsWithReasonMatching(([IntegerSetPropertyObject objectsWhere:@"set.@max.intCol.foo.bar == 1.23"]), @"single level key");
-    RLMAssertThrowsWithReasonMatching(([IntegerSetPropertyObject objectsWhere:@"set.@sum.intCol.foo.bar == 1.23"]), @"single level key");
-    RLMAssertThrowsWithReasonMatching(([IntegerSetPropertyObject objectsWhere:@"set.@avg.intCol.foo.bar == 1.23"]), @"single level key");
+    RLMAssertThrowsWithReason(([IntegerSetPropertyObject objectsWhere:@"set.@min.intCol.foo.bar == 1.23"]),
+                              @"Invalid keypath 'set.@min.intCol.foo.bar': Property 'IntObject.intCol' is not a link or collection and can only appear at the end of a keypath.");
+    RLMAssertThrowsWithReason(([IntegerSetPropertyObject objectsWhere:@"set.@max.intCol.foo.bar == 1.23"]),
+                              @"Invalid keypath 'set.@max.intCol.foo.bar': Property 'IntObject.intCol' is not a link or collection and can only appear at the end of a keypath.");
+    RLMAssertThrowsWithReason(([IntegerSetPropertyObject objectsWhere:@"set.@sum.intCol.foo.bar == 1.23"]),
+                              @"Invalid keypath 'set.@sum.intCol.foo.bar': Property 'IntObject.intCol' is not a link or collection and can only appear at the end of a keypath.");
+    RLMAssertThrowsWithReason(([IntegerSetPropertyObject objectsWhere:@"set.@avg.intCol.foo.bar == 1.23"]),
+                              @"Invalid keypath 'set.@avg.intCol.foo.bar': Property 'IntObject.intCol' is not a link or collection and can only appear at the end of a keypath.");
 
     // Average is omitted from this test as its result is always a double.
-    RLMAssertThrowsWithReasonMatching(([IntegerSetPropertyObject objectsWhere:@"set.@min.intCol == 1.23"]), @"@min.*type int cannot be compared");
-    RLMAssertThrowsWithReasonMatching(([IntegerSetPropertyObject objectsWhere:@"set.@max.intCol == 1.23"]), @"@max.*type int cannot be compared");
-    RLMAssertThrowsWithReasonMatching(([IntegerSetPropertyObject objectsWhere:@"set.@sum.intCol == 1.23"]), @"@sum.*type int cannot be compared");
+    RLMAssertThrowsWithReasonMatching(([IntegerSetPropertyObject objectsWhere:@"set.@min.intCol == 1.23"]),
+                                      @"@min.*type int cannot be compared");
+    RLMAssertThrowsWithReasonMatching(([IntegerSetPropertyObject objectsWhere:@"set.@max.intCol == 1.23"]),
+                                      @"@max.*type int cannot be compared");
+    RLMAssertThrowsWithReasonMatching(([IntegerSetPropertyObject objectsWhere:@"set.@sum.intCol == 1.23"]),
+                                      @"@sum.*type int cannot be compared");
 }
 
 - (void)testAggregateDictionaryCollectionOperators {
@@ -3395,12 +3411,17 @@ static NSData *data(const char *str) {
     RLMAssertCount(IntegerDictionaryPropertyObject, 2U, @"number > dictionary.@avg.intCol");
 
     // We do not yet handle collection operations on both sides of the comparison.
-    RLMAssertThrowsWithReasonMatching(([IntegerDictionaryPropertyObject objectsWhere:@"dictionary.@min.intCol == dictionary.@min.intCol"]), @"aggregate operations cannot be compared with other aggregate operations");
+    RLMAssertThrowsWithReason(([IntegerDictionaryPropertyObject objectsWhere:@"dictionary.@min.intCol == dictionary.@min.intCol"]),
+                              @"aggregate operations cannot be compared with other aggregate operations");
 
-    RLMAssertThrowsWithReasonMatching(([IntegerDictionaryPropertyObject objectsWhere:@"dictionary.@min.intCol.foo.bar == 1.23"]), @"single level key");
-    RLMAssertThrowsWithReasonMatching(([IntegerDictionaryPropertyObject objectsWhere:@"dictionary.@max.intCol.foo.bar == 1.23"]), @"single level key");
-    RLMAssertThrowsWithReasonMatching(([IntegerDictionaryPropertyObject objectsWhere:@"dictionary.@sum.intCol.foo.bar == 1.23"]), @"single level key");
-    RLMAssertThrowsWithReasonMatching(([IntegerDictionaryPropertyObject objectsWhere:@"dictionary.@avg.intCol.foo.bar == 1.23"]), @"single level key");
+    RLMAssertThrowsWithReason(([IntegerDictionaryPropertyObject objectsWhere:@"dictionary.@min.intCol.foo.bar == 1.23"]),
+                              @"Invalid keypath 'dictionary.@min.intCol.foo.bar': Property 'IntObject.intCol' is not a link or collection and can only appear at the end of a keypath.");
+    RLMAssertThrowsWithReason(([IntegerDictionaryPropertyObject objectsWhere:@"dictionary.@max.intCol.foo.bar == 1.23"]),
+                              @"Invalid keypath 'dictionary.@max.intCol.foo.bar': Property 'IntObject.intCol' is not a link or collection and can only appear at the end of a keypath.");
+    RLMAssertThrowsWithReason(([IntegerDictionaryPropertyObject objectsWhere:@"dictionary.@sum.intCol.foo.bar == 1.23"]),
+                              @"Invalid keypath 'dictionary.@sum.intCol.foo.bar': Property 'IntObject.intCol' is not a link or collection and can only appear at the end of a keypath.");
+    RLMAssertThrowsWithReason(([IntegerDictionaryPropertyObject objectsWhere:@"dictionary.@avg.intCol.foo.bar == 1.23"]),
+                              @"Invalid keypath 'dictionary.@avg.intCol.foo.bar': Property 'IntObject.intCol' is not a link or collection and can only appear at the end of a keypath.");
 
     // Average is omitted from this test as its result is always a double.
     RLMAssertThrowsWithReasonMatching(([IntegerDictionaryPropertyObject objectsWhere:@"dictionary.@min.intCol == 1.23"]), @"@min.*type int cannot be compared");
@@ -3422,40 +3443,41 @@ static NSData *data(const char *str) {
         [AllDictionariesObject createInRealm:realm withValue:@{property: @{@"lock1": value}}];
         [realm commitWriteTransaction];
 
-        RLMAssertCount(AllDictionariesObject, 0U, [NSString stringWithFormat:@"%@.@allKeys = 'key'", property]);
-        RLMAssertCount(AllDictionariesObject, 2U, [NSString stringWithFormat:@"%@.@allKeys = 'key1'", property]);
-        RLMAssertCount(AllDictionariesObject, 1U, [NSString stringWithFormat:@"ANY %@.@allKeys = 'key3'", property]);
-        RLMAssertCount(AllDictionariesObject, 7U, [NSString stringWithFormat:@"ANY %@.@allKeys != 'key3'", property]);
-        RLMAssertCount(AllDictionariesObject, 2U, [NSString stringWithFormat:@"ANY %@.@allKeys =[c] 'key3'", property]);
-        RLMAssertCount(AllDictionariesObject, 6U, [NSString stringWithFormat:@"ANY %@.@allKeys !=[c] 'key3'", property]);
-        RLMAssertCount(AllDictionariesObject, 2U, [NSString stringWithFormat:@"ANY %@.@allKeys =[cd] 'key3'", property]);
-        RLMAssertCount(AllDictionariesObject, 6U, [NSString stringWithFormat:@"ANY %@.@allKeys !=[cd] 'key3'", property]);
-        RLMAssertCount(AllDictionariesObject, 2U, [NSString stringWithFormat:@"NOT %@.@allKeys !=[cd] 'key3'", property]);
+        RLMAssertCount(AllDictionariesObject, 0U, @"ANY %K.@allKeys = 'key'", property);
+        RLMAssertCount(AllDictionariesObject, 2U, @"ANY %K.@allKeys = 'key1'", property);
+        RLMAssertCount(AllDictionariesObject, 1U, @"ANY %K.@allKeys = 'key3'", property);
+        RLMAssertCount(AllDictionariesObject, 7U, @"ANY %K.@allKeys != 'key3'", property);
+        RLMAssertCount(AllDictionariesObject, 2U, @"ANY %K.@allKeys =[c] 'key3'", property);
+        RLMAssertCount(AllDictionariesObject, 6U, @"ANY %K.@allKeys !=[c] 'key3'", property);
+        RLMAssertCount(AllDictionariesObject, 2U, @"ANY %K.@allKeys =[cd] 'key3'", property);
+        RLMAssertCount(AllDictionariesObject, 6U, @"ANY %K.@allKeys !=[cd] 'key3'", property);
+        RLMAssertCount(AllDictionariesObject, 2U, @"NOT ANY %K.@allKeys !=[cd] 'key3'", property);
         // BEGINSWITH
-        RLMAssertCount(AllDictionariesObject, 4U, [NSString stringWithFormat:@"%@.@allKeys BEGINSWITH 'ke'", property]);
-        RLMAssertCount(AllDictionariesObject, 4U, [NSString stringWithFormat:@"NOT %@.@allKeys BEGINSWITH 'ke'", property]);
-        RLMAssertCount(AllDictionariesObject, 6U, [NSString stringWithFormat:@"%@.@allKeys BEGINSWITH[c] 'ke'", property]);
-        RLMAssertCount(AllDictionariesObject, 7U, [NSString stringWithFormat:@"%@.@allKeys BEGINSWITH[cd] 'ke'", property]);
-        RLMAssertCount(AllDictionariesObject, 0U, [NSString stringWithFormat:@"%@.@allKeys BEGINSWITH NULL", property]);
+        RLMAssertCount(AllDictionariesObject, 4U, @"ANY %K.@allKeys BEGINSWITH 'ke'", property);
+        RLMAssertCount(AllDictionariesObject, 4U, @"NOT ANY %K.@allKeys BEGINSWITH 'ke'", property);
+        RLMAssertCount(AllDictionariesObject, 6U, @"ANY %K.@allKeys BEGINSWITH[c] 'ke'", property);
+        RLMAssertCount(AllDictionariesObject, 7U, @"ANY %K.@allKeys BEGINSWITH[cd] 'ke'", property);
+        RLMAssertCount(AllDictionariesObject, 0U, @"ANY %K.@allKeys BEGINSWITH NULL", property);
         // CONTAINS
-        RLMAssertCount(AllDictionariesObject, 4U, [NSString stringWithFormat:@"%@.@allKeys CONTAINS 'ey'", property]);
-        RLMAssertCount(AllDictionariesObject, 6U, [NSString stringWithFormat:@"%@.@allKeys CONTAINS[c] 'ey'", property]);
-        RLMAssertCount(AllDictionariesObject, 7U, [NSString stringWithFormat:@"%@.@allKeys CONTAINS[cd] 'ey'", property]);
-        RLMAssertCount(AllDictionariesObject, 0U, [NSString stringWithFormat:@"%@.@allKeys CONTAINS NULL", property]);
+        RLMAssertCount(AllDictionariesObject, 4U, @"ANY %K.@allKeys CONTAINS 'ey'", property);
+        RLMAssertCount(AllDictionariesObject, 6U, @"ANY %K.@allKeys CONTAINS[c] 'ey'", property);
+        RLMAssertCount(AllDictionariesObject, 7U, @"ANY %K.@allKeys CONTAINS[cd] 'ey'", property);
+        RLMAssertCount(AllDictionariesObject, 0U, @"ANY %K.@allKeys CONTAINS NULL", property);
         // ENDSWITH
-        RLMAssertCount(AllDictionariesObject, 1U, [NSString stringWithFormat:@"%@.@allKeys ENDSWITH 'y2'", property]);
-        RLMAssertCount(AllDictionariesObject, 2U, [NSString stringWithFormat:@"%@.@allKeys ENDSWITH[c] 'y2'", property]);
-        RLMAssertCount(AllDictionariesObject, 3U, [NSString stringWithFormat:@"%@.@allKeys ENDSWITH[cd] 'y2'", property]);
-        RLMAssertCount(AllDictionariesObject, 0U, [NSString stringWithFormat:@"%@.@allKeys ENDSWITH NULL", property]);
+        RLMAssertCount(AllDictionariesObject, 1U, @"ANY %K.@allKeys ENDSWITH 'y2'", property);
+        RLMAssertCount(AllDictionariesObject, 2U, @"ANY %K.@allKeys ENDSWITH[c] 'y2'", property);
+        RLMAssertCount(AllDictionariesObject, 3U, @"ANY %K.@allKeys ENDSWITH[cd] 'y2'", property);
+        RLMAssertCount(AllDictionariesObject, 0U, @"ANY %K.@allKeys ENDSWITH NULL", property);
         // LIKE
-        RLMAssertCount(AllDictionariesObject, 4U, [NSString stringWithFormat:@"%@.@allKeys LIKE 'key*'", property]);
-        RLMAssertCount(AllDictionariesObject, 6U, [NSString stringWithFormat:@"%@.@allKeys LIKE[c] 'key*'", property]);
-        RLMAssertCount(AllDictionariesObject, 0U, [NSString stringWithFormat:@"%@.@allKeys LIKE NULL", property]);
-        RLMAssertCount(AllDictionariesObject, 4U, [NSString stringWithFormat:@"NOT %@.@allKeys LIKE 'key*'", property]);
-        RLMAssertCount(AllDictionariesObject, 2U, [NSString stringWithFormat:@"NOT %@.@allKeys LIKE[c] 'key*'", property]);
-        RLMAssertCount(AllDictionariesObject, 8U, [NSString stringWithFormat:@"NOT %@.@allKeys LIKE NULL", property]);
-        RLMAssertThrowsWithReasonMatching(([realm objects:@"AllDictionariesObject" where:[NSString stringWithFormat:@"%@.@allKeys LIKE[cd] 'key*'", property]]), @"not supported");
-        
+        RLMAssertCount(AllDictionariesObject, 4U, @"ANY %K.@allKeys LIKE 'key*'", property);
+        RLMAssertCount(AllDictionariesObject, 6U, @"ANY %K.@allKeys LIKE[c] 'key*'", property);
+        RLMAssertCount(AllDictionariesObject, 0U, @"ANY %K.@allKeys LIKE NULL", property);
+        RLMAssertCount(AllDictionariesObject, 4U, @"NOT ANY %K.@allKeys LIKE 'key*'", property);
+        RLMAssertCount(AllDictionariesObject, 2U, @"NOT ANY %K.@allKeys LIKE[c] 'key*'", property);
+        RLMAssertCount(AllDictionariesObject, 8U, @"NOT ANY %K.@allKeys LIKE NULL", property);
+        RLMAssertThrowsWithReason(([AllDictionariesObject objectsInRealm:realm where:@"ANY %K.@allKeys LIKE[cd] 'key*'", property]),
+                                          @"Operator 'LIKE' not supported with diacritic-insensitive modifier.");
+
         [realm beginWriteTransaction];
         [realm deleteAllObjects];
         [realm commitWriteTransaction];
@@ -3474,182 +3496,176 @@ static NSData *data(const char *str) {
 }
 
 - (void)testDictionaryQueryAllValues_RLMObject {
-    void (^testObject)(NSString *, NSArray *) = ^(NSString *property, NSArray *values) {
-        RLMRealm *realm = [self realm];
-        [realm beginWriteTransaction];
-        [AllDictionariesObject createInRealm:realm withValue:@{property: @{@"aKey": values[0]}}];
-        [AllDictionariesObject createInRealm:realm withValue:@{property: @{@"aKey2": values[1]}}];
-        [AllDictionariesObject createInRealm:realm withValue:@{property: @{@"aKey3": values[2]}}];
-        [realm commitWriteTransaction];
+    NSString *property = @"stringObjDict";
+    NSArray *values = @[[[StringObject alloc] initWithValue:@[@"hello"]],
+                        [[StringObject alloc] initWithValue:@[@"Héllo"]],
+                        [[StringObject alloc] initWithValue:@[@"HELLO"]]];
 
-        StringObject *obj = [[StringObject objectsInRealm:realm where:@"stringCol = %@", [values[0] stringCol]] firstObject];
-        RLMAssertCount(AllDictionariesObject, 1U, @"ANY %K.@allValues = %@", property, obj);
-        RLMAssertCount(AllDictionariesObject, 2U, @"ANY %K.@allValues != %@", property, obj);
+    RLMRealm *realm = [self realm];
+    [realm beginWriteTransaction];
+    [AllDictionariesObject createInRealm:realm withValue:@{property: @{@"aKey": values[0]}}];
+    [AllDictionariesObject createInRealm:realm withValue:@{property: @{@"aKey2": values[1]}}];
+    [AllDictionariesObject createInRealm:realm withValue:@{property: @{@"aKey3": values[2]}}];
+    [realm commitWriteTransaction];
 
-        RLMAssertThrowsWithReasonMatching(([realm objects:@"AllDictionariesObject" where:[NSString stringWithFormat:@"%@.@allValues IN %@", property, @[obj]]]), @"not supported");
-        RLMAssertThrowsWithReasonMatching(([realm objects:@"AllDictionariesObject" where:[NSString stringWithFormat:@"%@.@allValues BETWEEN %@", property, @[obj]]]), @"not supported");
-        RLMAssertThrowsWithReasonMatching(([realm objects:@"AllDictionariesObject" where:[NSString stringWithFormat:@"%@.@allValues BEGINSWITH 'he'", property]]), @"not supported");
-        RLMAssertThrowsWithReasonMatching(([realm objects:@"AllDictionariesObject" where:[NSString stringWithFormat:@"%@.@allValues CONTAINS 'el'", property]]), @"not supported");
-        RLMAssertThrowsWithReasonMatching(([realm objects:@"AllDictionariesObject" where:[NSString stringWithFormat:@"%@.@allValues ENDSWITH 'lo'", property]]), @"not supported");
-        RLMAssertThrowsWithReasonMatching(([realm objects:@"AllDictionariesObject" where:[NSString stringWithFormat:@"%@.@allValues LIKE 'hel*'", property]]), @"not supported");
-        [realm beginWriteTransaction];
-        [realm deleteAllObjects];
-        [realm commitWriteTransaction];
-    };
+    StringObject *obj = [[StringObject objectsInRealm:realm where:@"stringCol = %@", [values[0] stringCol]] firstObject];
+    RLMAssertCount(AllDictionariesObject, 1U, @"ANY %K.@allValues = %@", property, obj);
+    RLMAssertCount(AllDictionariesObject, 2U, @"ANY %K.@allValues != %@", property, obj);
+    RLMAssertCount(AllDictionariesObject, 1U, @"ANY %K.@allValues IN %@", property, @[obj]);
+    RLMAssertCount(AllDictionariesObject, 0U, @"ANY %K.@allValues IN %@", property, @[]);
 
-    testObject(@"stringObjDict", @[[[StringObject alloc] initWithValue:@[@"hello"]],
-                                   [[StringObject alloc] initWithValue:@[@"Héllo"]],
-                                   [[StringObject alloc] initWithValue:@[@"HELLO"]]]);
+    RLMAssertCount(AllDictionariesObject, 1U, @"ANY %K.stringCol = %@", property, obj.stringCol);
+    RLMAssertCount(AllDictionariesObject, 2U, @"ANY %K.stringCol != %@", property, obj.stringCol);
+    RLMAssertCount(AllDictionariesObject, 1U, @"ANY %K.stringCol BEGINSWITH %@", property, @"h");
+    RLMAssertCount(AllDictionariesObject, 3U, @"ANY %K.stringCol BEGINSWITH[c] %@", property, @"h");
+    RLMAssertCount(AllDictionariesObject, 2U, @"ANY %K.stringCol BEGINSWITH[c] %@", property, @"he");
+    RLMAssertCount(AllDictionariesObject, 3U, @"ANY %K.stringCol BEGINSWITH[cd] %@", property, @"he");
+
+    RLMAssertThrowsWithReason(([AllDictionariesObject objectsInRealm:realm where:@"ANY %K.@allValues BETWEEN %@", property, @[obj, obj]]),
+                              @"Operator 'BETWEEN' not supported for type 'object'");
+    RLMAssertThrowsWithReason(([AllDictionariesObject objectsInRealm:realm where:@"ANY %K.@allValues BEGINSWITH %@", property, obj]),
+                              @"Operator 'BEGINSWITH' not supported for type 'object'");
+    RLMAssertThrowsWithReason(([AllDictionariesObject objectsInRealm:realm where:@"ANY %K.@allValues CONTAINS %@", property, obj]),
+                              @"Operator 'CONTAINS' not supported for type 'object'");
+    RLMAssertThrowsWithReason(([AllDictionariesObject objectsInRealm:realm where:@"ANY %K.@allValues ENDSWITH %@", property, obj]),
+                              @"Operator 'ENDSWITH' not supported for type 'object'");
+    RLMAssertThrowsWithReason(([AllDictionariesObject objectsInRealm:realm where:@"ANY %K.@allValues LIKE %@", property, obj]),
+                              @"Operator 'LIKE' not supported for type 'object'");
 }
 
 - (void)testDictionaryQueryAllValues_NSString {
-    void (^test)(NSString *, NSArray *) = ^(NSString *property, NSArray *values) {
-        RLMRealm *realm = [self realm];
-        [realm beginWriteTransaction];
-        [AllDictionariesObject createInRealm:realm withValue:@{property: @{@"aKey": values[0]}}];
-        [AllDictionariesObject createInRealm:realm withValue:@{property: @{@"aKey2": values[1]}}];
-        [AllDictionariesObject createInRealm:realm withValue:@{property: @{@"aKey3": values[2]}}];
-        [realm commitWriteTransaction];
+    NSString *property = @"stringDict";
+    NSArray *values = @[@"hello", @"Héllo", @"HELLO"];
 
-        RLMAssertCount(AllDictionariesObject, 1U, @"ANY %K.@allValues = %@", property, values[0]);
-        RLMAssertCount(AllDictionariesObject, 2U, @"ANY %K.@allValues != %@", property, values[0]);
-        RLMAssertCount(AllDictionariesObject, 2U, @"ANY %K.@allValues =[c] %@", property, values[0]);
-        RLMAssertCount(AllDictionariesObject, 1U, @"ANY %K.@allValues !=[c] %@", property, values[0]);
-        RLMAssertCount(AllDictionariesObject, 3U, @"ANY %K.@allValues =[cd] %@", property, values[0]);
-        RLMAssertCount(AllDictionariesObject, 0U, @"ANY %K.@allValues !=[cd] %@", property, values[0]);
-        // BEGINSWITH
-        RLMAssertCount(AllDictionariesObject, 1U, @"%K.@allValues BEGINSWITH 'he'", property);
-        RLMAssertCount(AllDictionariesObject, 2U, @"NOT %K.@allValues BEGINSWITH 'he'", property);
-        RLMAssertCount(AllDictionariesObject, 2U, @"%K.@allValues BEGINSWITH[c] 'he'", property);
-        RLMAssertCount(AllDictionariesObject, 3U, @"%K.@allValues BEGINSWITH[cd] 'he'", property);
-        RLMAssertCount(AllDictionariesObject, 0U, @"%K.@allValues BEGINSWITH NULL", property);
-        // CONTAINS
-        RLMAssertCount(AllDictionariesObject, 1U, @"%K.@allValues CONTAINS 'el'", property);
-        RLMAssertCount(AllDictionariesObject, 2U, @"%K.@allValues CONTAINS[c] 'el'", property);
-        RLMAssertCount(AllDictionariesObject, 3U, @"%K.@allValues CONTAINS[cd] 'el'", property);
-        RLMAssertCount(AllDictionariesObject, 0U, @"%K.@allValues CONTAINS NULL", property);
-        // ENDSWITH
-        RLMAssertCount(AllDictionariesObject, 2U, @"%K.@allValues ENDSWITH 'lo'", property);
-        RLMAssertCount(AllDictionariesObject, 3U, @"%K.@allValues ENDSWITH[c] 'lo'", property);
-        RLMAssertCount(AllDictionariesObject, 3U, @"%K.@allValues ENDSWITH[cd] 'lo'", property);
-        RLMAssertCount(AllDictionariesObject, 0U, @"%K.@allValues ENDSWITH NULL", property);
-        // LIKE
-        RLMAssertCount(AllDictionariesObject, 1U, @"%K.@allValues LIKE 'hel*'", property);
-        RLMAssertCount(AllDictionariesObject, 2U, @"%K.@allValues LIKE[c] 'hel*'", property);
-        RLMAssertCount(AllDictionariesObject, 0U, @"%K.@allValues LIKE NULL", property);
-        RLMAssertCount(AllDictionariesObject, 2U, @"NOT %K.@allValues LIKE 'hel*'", property);
-        RLMAssertCount(AllDictionariesObject, 1U, @"NOT %K.@allValues LIKE[c] 'hel*'", property);
-        RLMAssertCount(AllDictionariesObject, 3U, @"NOT %K.@allValues LIKE NULL", property);
-        RLMAssertThrowsWithReasonMatching(([realm objects:@"AllDictionariesObject" where:@"%K.@allValues LIKE[cd] 'hel*'", property]), @"not supported");
+    RLMRealm *realm = [self realm];
+    [realm beginWriteTransaction];
+    [AllDictionariesObject createInRealm:realm withValue:@{property: @{@"aKey": values[0]}}];
+    [AllDictionariesObject createInRealm:realm withValue:@{property: @{@"aKey2": values[1]}}];
+    [AllDictionariesObject createInRealm:realm withValue:@{property: @{@"aKey3": values[2]}}];
+    [realm commitWriteTransaction];
 
-        [realm beginWriteTransaction];
-        [realm deleteAllObjects];
-        [realm commitWriteTransaction];
-    };
-    test(@"stringDict", @[@"hello", @"Héllo", @"HELLO"]);
+    RLMAssertCount(AllDictionariesObject, 1U, @"ANY %K.@allValues = %@", property, values[0]);
+    RLMAssertCount(AllDictionariesObject, 2U, @"ANY %K.@allValues != %@", property, values[0]);
+    RLMAssertCount(AllDictionariesObject, 2U, @"ANY %K.@allValues =[c] %@", property, values[0]);
+    RLMAssertCount(AllDictionariesObject, 1U, @"ANY %K.@allValues !=[c] %@", property, values[0]);
+    RLMAssertCount(AllDictionariesObject, 3U, @"ANY %K.@allValues =[cd] %@", property, values[0]);
+    RLMAssertCount(AllDictionariesObject, 0U, @"ANY %K.@allValues !=[cd] %@", property, values[0]);
+    // BEGINSWITH
+    RLMAssertCount(AllDictionariesObject, 1U, @"ANY %K.@allValues BEGINSWITH 'he'", property);
+    RLMAssertCount(AllDictionariesObject, 2U, @"NOT ANY %K.@allValues BEGINSWITH 'he'", property);
+    RLMAssertCount(AllDictionariesObject, 2U, @"ANY %K.@allValues BEGINSWITH[c] 'he'", property);
+    RLMAssertCount(AllDictionariesObject, 3U, @"ANY %K.@allValues BEGINSWITH[cd] 'he'", property);
+    RLMAssertCount(AllDictionariesObject, 0U, @"ANY %K.@allValues BEGINSWITH NULL", property);
+    // CONTAINS
+    RLMAssertCount(AllDictionariesObject, 1U, @"ANY %K.@allValues CONTAINS 'el'", property);
+    RLMAssertCount(AllDictionariesObject, 2U, @"ANY %K.@allValues CONTAINS[c] 'el'", property);
+    RLMAssertCount(AllDictionariesObject, 3U, @"ANY %K.@allValues CONTAINS[cd] 'el'", property);
+    RLMAssertCount(AllDictionariesObject, 0U, @"ANY %K.@allValues CONTAINS NULL", property);
+    // ENDSWITH
+    RLMAssertCount(AllDictionariesObject, 2U, @"ANY %K.@allValues ENDSWITH 'lo'", property);
+    RLMAssertCount(AllDictionariesObject, 3U, @"ANY %K.@allValues ENDSWITH[c] 'lo'", property);
+    RLMAssertCount(AllDictionariesObject, 3U, @"ANY %K.@allValues ENDSWITH[cd] 'lo'", property);
+    RLMAssertCount(AllDictionariesObject, 0U, @"ANY %K.@allValues ENDSWITH NULL", property);
+    // LIKE
+    RLMAssertCount(AllDictionariesObject, 1U, @"ANY %K.@allValues LIKE 'hel*'", property);
+    RLMAssertCount(AllDictionariesObject, 2U, @"ANY %K.@allValues LIKE[c] 'hel*'", property);
+    RLMAssertCount(AllDictionariesObject, 0U, @"ANY %K.@allValues LIKE NULL", property);
+    RLMAssertCount(AllDictionariesObject, 2U, @"NOT ANY %K.@allValues LIKE 'hel*'", property);
+    RLMAssertCount(AllDictionariesObject, 1U, @"NOT ANY %K.@allValues LIKE[c] 'hel*'", property);
+    RLMAssertCount(AllDictionariesObject, 3U, @"NOT ANY %K.@allValues LIKE NULL", property);
+    RLMAssertThrowsWithReason(([AllDictionariesObject objectsInRealm:realm where:@"ANY %K.@allValues LIKE[cd] 'hel*'", property]),
+                              @"Operator 'LIKE' not supported with diacritic-insensitive modifier.");
 }
 
 - (void)testDictionaryQueryAllValues_ObjectId {
-    void (^test)(NSString *, NSArray *) = ^(NSString *property, NSArray *values) {
-        RLMRealm *realm = [self realm];
-        [realm beginWriteTransaction];
-        [AllDictionariesObject createInRealm:realm withValue:@{property: @{@"aKey": values[0]}}];
-        [AllDictionariesObject createInRealm:realm withValue:@{property: @{@"aKey2": values[1]}}];
-        [AllDictionariesObject createInRealm:realm withValue:@{property: @{@"aKey3": values[2]}}];
-        [realm commitWriteTransaction];
+    NSString *property = @"objectIdDict";
+    NSArray *values = @[[[RLMObjectId alloc] initWithString:@"60425fff91d7a195d5ddac1b" error:nil],
+                        [[RLMObjectId alloc] initWithString:@"60425fff91d7a195d5ddac1a" error:nil],
+                        [[RLMObjectId alloc] initWithString:@"60425fff91d7a195d5ddac1c" error:nil]];
 
-        RLMAssertCount(AllDictionariesObject, 1U, @"%K.@allValues = %@", property, values[0]);
-        RLMAssertCount(AllDictionariesObject, 2U, @"%K.@allValues != %@", property, values[0]);
-        RLMAssertCount(AllDictionariesObject, 1U, @"%K.@allValues =[c] %@", property, values[0]);
-        RLMAssertCount(AllDictionariesObject, 1U, @"%K.@allValues =[cd] %@", property, values[0]);
-        // Unsupported
-        RLMAssertThrowsWithReasonMatching(([realm objects:@"AllDictionariesObject" where:@"%K.@allValues LIKE '*a'", property]), @"not supported");
-        RLMAssertThrowsWithReasonMatching(([realm objects:@"AllDictionariesObject" where:@"%K.@allValues BEGINSWITH 'a'", property]), @"not supported");
-        RLMAssertThrowsWithReasonMatching(([realm objects:@"AllDictionariesObject" where:@"%K.@allValues CONTAINS 'a'", property]), @"not supported");
-        RLMAssertThrowsWithReasonMatching(([realm objects:@"AllDictionariesObject" where:@"%K.@allValues ENDSWITH 'a'", property]), @"not supported");
-        RLMAssertThrowsWithReasonMatching(([realm objects:@"AllDictionariesObject" where:@"%K.@allValues < %@", property, values[0]]), @"not supported");
-        RLMAssertThrowsWithReasonMatching(([realm objects:@"AllDictionariesObject" where:@"%K.@allValues > %@", property, values[0]]), @"not supported");
+    RLMRealm *realm = [self realm];
+    [realm beginWriteTransaction];
+    [AllDictionariesObject createInRealm:realm withValue:@{property: @{@"aKey": values[0]}}];
+    [AllDictionariesObject createInRealm:realm withValue:@{property: @{@"aKey2": values[1]}}];
+    [AllDictionariesObject createInRealm:realm withValue:@{property: @{@"aKey3": values[2]}}];
+    [realm commitWriteTransaction];
 
-        [realm beginWriteTransaction];
-        [realm deleteAllObjects];
-        [realm commitWriteTransaction];
-    };
+    RLMAssertCount(AllDictionariesObject, 1U, @"ANY %K.@allValues = %@", property, values[0]);
+    RLMAssertCount(AllDictionariesObject, 2U, @"ANY %K.@allValues != %@", property, values[0]);
+    RLMAssertCount(AllDictionariesObject, 1U, @"ANY %K.@allValues =[c] %@", property, values[0]);
+    RLMAssertCount(AllDictionariesObject, 1U, @"ANY %K.@allValues =[cd] %@", property, values[0]);
 
-    test(@"objectIdDict", @[[[RLMObjectId alloc] initWithString:@"60425fff91d7a195d5ddac1b" error:nil],
-                            [[RLMObjectId alloc] initWithString:@"60425fff91d7a195d5ddac1a" error:nil],
-                            [[RLMObjectId alloc] initWithString:@"60425fff91d7a195d5ddac1c" error:nil]]);
+    // Unsupported
+    RLMAssertThrowsWithReason(([AllDictionariesObject objectsInRealm:realm where:@"ANY %K.@allValues > %@", property, values[0]]), @"Operator '>' not supported for type 'object id'");
+    RLMAssertThrowsWithReason(([AllDictionariesObject objectsInRealm:realm where:@"ANY %K.@allValues < %@", property, values[0]]), @"Operator '<' not supported for type 'object id'");
+    RLMAssertThrowsWithReason(([AllDictionariesObject objectsInRealm:realm where:@"ANY %K.@allValues LIKE %@", property, values[0]]), @"Operator 'LIKE' not supported for type 'object id'");
+    RLMAssertThrowsWithReason(([AllDictionariesObject objectsInRealm:realm where:@"ANY %K.@allValues BEGINSWITH %@", property, values[0]]), @"Operator 'BEGINSWITH' not supported for type 'object id'");
+    RLMAssertThrowsWithReason(([AllDictionariesObject objectsInRealm:realm where:@"ANY %K.@allValues CONTAINS %@", property, values[0]]), @"Operator 'CONTAINS' not supported for type 'object id'");
+    RLMAssertThrowsWithReason(([AllDictionariesObject objectsInRealm:realm where:@"ANY %K.@allValues ENDSWITH %@", property, values[0]]), @"Operator 'ENDSWITH' not supported for type 'object id'");
 }
 
 - (void)testDictionaryQueryAllValues_UUID {
-    void (^test)(NSString *, NSArray *) = ^(NSString *property, NSArray *values) {
-        RLMRealm *realm = [self realm];
-        [realm beginWriteTransaction];
-        [AllDictionariesObject createInRealm:realm withValue:@{property: @{@"aKey": values[0]}}];
-        [AllDictionariesObject createInRealm:realm withValue:@{property: @{@"aKey2": values[1]}}];
-        [AllDictionariesObject createInRealm:realm withValue:@{property: @{@"aKey3": values[2]}}];
-        [realm commitWriteTransaction];
-
-        RLMAssertCount(AllDictionariesObject, 1U, @"ANY %K.@allValues = %@", property, values[0]);
-        RLMAssertCount(AllDictionariesObject, 1U, @"%K.@allValues = %@", property, values[0]);
-        RLMAssertCount(AllDictionariesObject, 2U, @"ANY %K.@allValues != %@", property, values[0]);
-        RLMAssertCount(AllDictionariesObject, 1U, @"ANY %K.@allValues =[c] %@", property, values[0]);
-        RLMAssertCount(AllDictionariesObject, 2U, @"ANY %K.@allValues !=[c] %@", property, values[0]);
-        RLMAssertCount(AllDictionariesObject, 2U, @"%K.@allValues !=[c] %@", property, values[0]);
-        RLMAssertCount(AllDictionariesObject, 1U, @"ANY %K.@allValues =[cd] %@", property, values[0]);
-        RLMAssertCount(AllDictionariesObject, 2U, @"ANY %K.@allValues !=[cd] %@", property, values[0]);
-
-        // Unsupported
-        RLMAssertThrowsWithReasonMatching(([realm objects:@"AllDictionariesObject" where:@"ANY %K.@allValues > %@", property, values[0]]), @"not supported");
-        RLMAssertThrowsWithReasonMatching(([realm objects:@"AllDictionariesObject" where:@"ANY %K.@allValues < %@", property, values[0]]), @"not supported");
-        RLMAssertThrowsWithReasonMatching(([realm objects:@"AllDictionariesObject" where:@"%K.@allValues LIKE %@", property, values[0]]), @"not supported");
-        RLMAssertThrowsWithReasonMatching(([realm objects:@"AllDictionariesObject" where:@"%K.@allValues BEGINSWITH %@", property, values[0]]), @"not supported");
-        RLMAssertThrowsWithReasonMatching(([realm objects:@"AllDictionariesObject" where:@"%K.@allValues CONTAINS %@", property, values[0]]), @"not supported");
-        RLMAssertThrowsWithReasonMatching(([realm objects:@"AllDictionariesObject" where:@"%K.@allValues ENDSWITH %@", property, values[0]]), @"not supported");
-
-        [realm beginWriteTransaction];
-        [realm deleteAllObjects];
-        [realm commitWriteTransaction];
-    };
-    test(@"uuidDict", @[[[NSUUID alloc] initWithUUIDString:@"137DECC8-B300-4954-A233-F89909F4FD88"],
+    NSString *property = @"uuidDict";
+    NSArray *values = @[[[NSUUID alloc] initWithUUIDString:@"137DECC8-B300-4954-A233-F89909F4FD88"],
                         [[NSUUID alloc] initWithUUIDString:@"137DECC8-B300-4954-A233-F89909F4FD87"],
-                        [[NSUUID alloc] initWithUUIDString:@"137DECC8-B300-4954-A233-F89909F4FD89"]]);
+                        [[NSUUID alloc] initWithUUIDString:@"137DECC8-B300-4954-A233-F89909F4FD89"]];
+    RLMRealm *realm = [self realm];
+    [realm beginWriteTransaction];
+    [AllDictionariesObject createInRealm:realm withValue:@{property: @{@"aKey": values[0]}}];
+    [AllDictionariesObject createInRealm:realm withValue:@{property: @{@"aKey2": values[1]}}];
+    [AllDictionariesObject createInRealm:realm withValue:@{property: @{@"aKey3": values[2]}}];
+    [realm commitWriteTransaction];
+
+    RLMAssertCount(AllDictionariesObject, 1U, @"ANY %K.@allValues = %@", property, values[0]);
+    RLMAssertCount(AllDictionariesObject, 2U, @"ANY %K.@allValues != %@", property, values[0]);
+    RLMAssertCount(AllDictionariesObject, 1U, @"ANY %K.@allValues =[c] %@", property, values[0]);
+    RLMAssertCount(AllDictionariesObject, 2U, @"ANY %K.@allValues !=[c] %@", property, values[0]);
+    RLMAssertCount(AllDictionariesObject, 1U, @"ANY %K.@allValues =[cd] %@", property, values[0]);
+    RLMAssertCount(AllDictionariesObject, 2U, @"ANY %K.@allValues !=[cd] %@", property, values[0]);
+
+    // Unsupported
+    RLMAssertThrowsWithReason(([AllDictionariesObject objectsInRealm:realm where:@"ANY %K.@allValues > %@", property, values[0]]), @"Operator '>' not supported for type 'uuid'");
+    RLMAssertThrowsWithReason(([AllDictionariesObject objectsInRealm:realm where:@"ANY %K.@allValues < %@", property, values[0]]), @"Operator '<' not supported for type 'uuid'");
+    RLMAssertThrowsWithReason(([AllDictionariesObject objectsInRealm:realm where:@"ANY %K.@allValues LIKE %@", property, values[0]]), @"Operator 'LIKE' not supported for type 'uuid'");
+    RLMAssertThrowsWithReason(([AllDictionariesObject objectsInRealm:realm where:@"ANY %K.@allValues BEGINSWITH %@", property, values[0]]), @"Operator 'BEGINSWITH' not supported for type 'uuid'");
+    RLMAssertThrowsWithReason(([AllDictionariesObject objectsInRealm:realm where:@"ANY %K.@allValues CONTAINS %@", property, values[0]]), @"Operator 'CONTAINS' not supported for type 'uuid'");
+    RLMAssertThrowsWithReason(([AllDictionariesObject objectsInRealm:realm where:@"ANY %K.@allValues ENDSWITH %@", property, values[0]]), @"Operator 'ENDSWITH' not supported for type 'uuid'");
 }
 
 - (void)testDictionaryQueryAllValues_Data {
-    void (^test)(NSString *, NSArray *) = ^(NSString *property, NSArray *values) {
-        RLMRealm *realm = [self realm];
-        [realm beginWriteTransaction];
-        [AllDictionariesObject createInRealm:realm withValue:@{property: @{@"aKey": values[0]}}];
-        [AllDictionariesObject createInRealm:realm withValue:@{property: @{@"aKey2": values[1]}}];
-        [AllDictionariesObject createInRealm:realm withValue:@{property: @{@"aKey3": values[2]}}];
-        [realm commitWriteTransaction];
-
-        RLMAssertCount(AllDictionariesObject, 1U, @"ANY %K.@allValues = %@", property, values[0]);
-        RLMAssertCount(AllDictionariesObject, 1U, @"%K.@allValues = %@", property, values[0]);
-        RLMAssertCount(AllDictionariesObject, 2U, @"ANY %K.@allValues != %@", property, values[0]);
-        RLMAssertCount(AllDictionariesObject, 1U, @"ANY %K.@allValues =[c] %@", property, values[0]);
-        RLMAssertCount(AllDictionariesObject, 2U, @"ANY %K.@allValues !=[c] %@", property, values[0]);
-        RLMAssertCount(AllDictionariesObject, 2U, @"%K.@allValues !=[c] %@", property, values[0]);
-        RLMAssertCount(AllDictionariesObject, 1U, @"ANY %K.@allValues =[cd] %@", property, values[0]);
-        RLMAssertCount(AllDictionariesObject, 2U, @"ANY %K.@allValues !=[cd] %@", property, values[0]);
-        
-        RLMAssertCount(AllDictionariesObject, 1U, @"%K.@allValues LIKE %@", property, [NSData dataWithBytes:"hello" length:5]);
-        RLMAssertCount(AllDictionariesObject, 2U, @"%K.@allValues LIKE %@", property, [NSData dataWithBytes:"he*" length:3]);
-        RLMAssertCount(AllDictionariesObject, 2U, @"%K.@allValues BEGINSWITH %@", property, [NSData dataWithBytes:"he" length:2]);
-        RLMAssertCount(AllDictionariesObject, 1U, @"%K.@allValues CONTAINS %@", property, [NSData dataWithBytes:"ell" length:3]);
-        RLMAssertCount(AllDictionariesObject, 1U, @"%K.@allValues ENDSWITH %@", property, [NSData dataWithBytes:"lo" length:2]);
-
-        // Unsupported
-        RLMAssertThrowsWithReasonMatching(([realm objects:@"AllDictionariesObject" where:@"ANY %K.@allValues > %@", property, values[0]]), @"not supported");
-        RLMAssertThrowsWithReasonMatching(([realm objects:@"AllDictionariesObject" where:@"ANY %K.@allValues < %@", property, values[0]]), @"not supported");
-
-        [realm beginWriteTransaction];
-        [realm deleteAllObjects];
-        [realm commitWriteTransaction];
-    };
-    test(@"dataDict", @[[NSData dataWithBytes:"hey" length:3],
+    NSString *property = @"dataDict";
+    NSArray *values = @[[NSData dataWithBytes:"hey" length:3],
                         [NSData dataWithBytes:"hi" length:2],
-                        [NSData dataWithBytes:"hello" length:5]]);
+                        [NSData dataWithBytes:"hello" length:5]];
+
+    RLMRealm *realm = [self realm];
+    [realm beginWriteTransaction];
+    [AllDictionariesObject createInRealm:realm withValue:@{property: @{@"aKey": values[0]}}];
+    [AllDictionariesObject createInRealm:realm withValue:@{property: @{@"aKey2": values[1]}}];
+    [AllDictionariesObject createInRealm:realm withValue:@{property: @{@"aKey3": values[2]}}];
+    [realm commitWriteTransaction];
+
+    RLMAssertCount(AllDictionariesObject, 1U, @"ANY %K.@allValues = %@", property, values[0]);
+    RLMAssertCount(AllDictionariesObject, 2U, @"ANY %K.@allValues != %@", property, values[0]);
+    RLMAssertCount(AllDictionariesObject, 1U, @"ANY %K.@allValues =[c] %@", property, values[0]);
+    RLMAssertCount(AllDictionariesObject, 2U, @"ANY %K.@allValues !=[c] %@", property, values[0]);
+    RLMAssertCount(AllDictionariesObject, 1U, @"ANY %K.@allValues =[cd] %@", property, values[0]);
+    RLMAssertCount(AllDictionariesObject, 2U, @"ANY %K.@allValues !=[cd] %@", property, values[0]);
+
+    RLMAssertCount(AllDictionariesObject, 1U, @"ANY %K.@allValues LIKE %@", property,
+                   [NSData dataWithBytes:"hello" length:5]);
+    RLMAssertCount(AllDictionariesObject, 2U, @"ANY %K.@allValues LIKE %@", property,
+                   [NSData dataWithBytes:"he*" length:3]);
+    RLMAssertCount(AllDictionariesObject, 2U, @"ANY %K.@allValues BEGINSWITH %@", property,
+                   [NSData dataWithBytes:"he" length:2]);
+    RLMAssertCount(AllDictionariesObject, 1U, @"ANY %K.@allValues CONTAINS %@", property,
+                   [NSData dataWithBytes:"ell" length:3]);
+    RLMAssertCount(AllDictionariesObject, 1U, @"ANY %K.@allValues ENDSWITH %@", property,
+                   [NSData dataWithBytes:"lo" length:2]);
+
+    // Unsupported
+    RLMAssertThrowsWithReasonMatching(([AllDictionariesObject objectsInRealm:realm where:@"ANY %K.@allValues > %@", property, values[0]]), @"not supported");
+    RLMAssertThrowsWithReasonMatching(([AllDictionariesObject objectsInRealm:realm where:@"ANY %K.@allValues < %@", property, values[0]]), @"not supported");
 }
 
 - (void)testDictionaryQueryAllValues {
@@ -3668,42 +3684,23 @@ static NSData *data(const char *str) {
             RLMAssertCount(AllDictionariesObject, 1U, @"ANY %K.@allValues !=[c] %@", property, values[0]);
             RLMAssertCount(AllDictionariesObject, 2U, @"ANY %K.@allValues =[cd] %@", property, values[0]);
             RLMAssertCount(AllDictionariesObject, 1U, @"ANY %K.@allValues !=[cd] %@", property, values[0]);
-            // Unsupported
-            RLMAssertThrowsWithReasonMatching(([realm objects:@"AllDictionariesObject" where:@"ANY %K.@allValues > %@", property, values[0]]), @"not supported");
-            RLMAssertThrowsWithReasonMatching(([realm objects:@"AllDictionariesObject" where:@"ANY %K.@allValues < %@", property, values[0]]), @"not supported");
-            RLMAssertThrowsWithReasonMatching(([realm objects:@"AllDictionariesObject" where:@"%K.@allValues BEGINSWITH 1", property]), @"not supported");
-            RLMAssertThrowsWithReasonMatching(([realm objects:@"AllDictionariesObject" where:@"%K.@allValues CONTAINS 1", property]), @"not supported");
-            RLMAssertThrowsWithReasonMatching(([realm objects:@"AllDictionariesObject" where:@"%K.@allValues ENDSWITH 1", property]), @"not supported");
-            RLMAssertThrowsWithReasonMatching(([realm objects:@"AllDictionariesObject" where:@"%K.@allValues LIKE 'key*'", property]), @"not supported");
         } else {
             RLMAssertCount(AllDictionariesObject, 1U, @"ANY %K.@allValues = %@", property, values[0]);
-            RLMAssertCount(AllDictionariesObject, 1U, @"%K.@allValues = %@", property, values[0]);
             RLMAssertCount(AllDictionariesObject, 2U, @"ANY %K.@allValues != %@", property, values[0]);
             RLMAssertCount(AllDictionariesObject, 1U, @"ANY %K.@allValues =[c] %@", property, values[0]);
             RLMAssertCount(AllDictionariesObject, 2U, @"ANY %K.@allValues !=[c] %@", property, values[0]);
-            RLMAssertCount(AllDictionariesObject, 2U, @"%K.@allValues !=[c] %@", property, values[0]);
             RLMAssertCount(AllDictionariesObject, 1U, @"ANY %K.@allValues =[cd] %@", property, values[0]);
             RLMAssertCount(AllDictionariesObject, 2U, @"ANY %K.@allValues !=[cd] %@", property, values[0]);
 
             RLMAssertCount(AllDictionariesObject, 1U, @"ANY %K.@allValues > %@", property, values[0]);
-            RLMAssertCount(AllDictionariesObject, 1U, @"%K.@allValues > %@", property, values[0]);
             RLMAssertCount(AllDictionariesObject, 2U, @"NOT ANY %K.@allValues > %@", property, values[0]);
-            RLMAssertCount(AllDictionariesObject, 2U, @"NOT %K.@allValues > %@", property, values[0]);
             RLMAssertCount(AllDictionariesObject, 1U, @"ANY %K.@allValues >[c] %@", property, values[0]);
             RLMAssertCount(AllDictionariesObject, 1U, @"ANY %K.@allValues >[cd] %@", property, values[0]);
 
             RLMAssertCount(AllDictionariesObject, 1U, @"ANY %K.@allValues < %@", property, values[0]);
-            RLMAssertCount(AllDictionariesObject, 1U, @"%K.@allValues < %@", property, values[0]);
             RLMAssertCount(AllDictionariesObject, 2U, @"NOT ANY %K.@allValues < %@", property, values[0]);
-            RLMAssertCount(AllDictionariesObject, 2U, @"NOT %K.@allValues < %@", property, values[0]);
             RLMAssertCount(AllDictionariesObject, 1U, @"ANY %K.@allValues <[c] %@", property, values[0]);
             RLMAssertCount(AllDictionariesObject, 1U, @"ANY %K.@allValues <[cd] %@", property, values[0]);
-
-            // Unsupported
-            RLMAssertThrowsWithReasonMatching(([realm objects:@"AllDictionariesObject" where:@"%K.@allValues LIKE '*1'", property]), @"not supported");
-            RLMAssertThrowsWithReasonMatching(([realm objects:@"AllDictionariesObject" where:@"%K.@allValues BEGINSWITH 1", property]), @"not supported");
-            RLMAssertThrowsWithReasonMatching(([realm objects:@"AllDictionariesObject" where:@"%K.@allValues CONTAINS 1", property]), @"not supported");
-            RLMAssertThrowsWithReasonMatching(([realm objects:@"AllDictionariesObject" where:@"%K.@allValues ENDSWITH 1", property]), @"not supported");
         }
         [realm beginWriteTransaction];
         [realm deleteAllObjects];
@@ -3772,7 +3769,7 @@ static NSData *data(const char *str) {
             RLMAssertCount(AllDictionariesObject, 2U, @"NOT %K['aKey'] LIKE 'hel*'", property);
             RLMAssertCount(AllDictionariesObject, 2U, @"NOT %K['aKey'] LIKE[c] 'hel*'", property);
             RLMAssertCount(AllDictionariesObject, 1U, @"NOT %K['aKey'] LIKE NULL", property);
-            RLMAssertThrowsWithReasonMatching(([realm objects:@"AllDictionariesObject" where:@"%K['aKey'] LIKE[cd] 'hel*'", property]), @"not supported");
+            RLMAssertThrowsWithReasonMatching(([AllDictionariesObject objectsInRealm:realm where:@"%K['aKey'] LIKE[cd] 'hel*'", property]), @"not supported");
         }
 
         [realm beginWriteTransaction];
@@ -3782,8 +3779,12 @@ static NSData *data(const char *str) {
     test(@"intDict", @[@456, @123, @789], YES);
     test(@"doubleDict", @[@456.123, @123.123, @789.123], YES);
     test(@"boolDict", @[@NO, @NO, @YES], YES);
-    test(@"decimalDict", @[[RLMDecimal128 decimalWithNumber:@456.123], [RLMDecimal128 decimalWithNumber:@123.123], [RLMDecimal128 decimalWithNumber:@789.123]], YES);
-    test(@"dateDict", @[[NSDate dateWithTimeIntervalSince1970:4000], [NSDate dateWithTimeIntervalSince1970:2000], [NSDate dateWithTimeIntervalSince1970:8000]], YES);
+    test(@"decimalDict", @[[RLMDecimal128 decimalWithNumber:@456.123],
+                           [RLMDecimal128 decimalWithNumber:@123.123],
+                           [RLMDecimal128 decimalWithNumber:@789.123]], YES);
+    test(@"dateDict", @[[NSDate dateWithTimeIntervalSince1970:4000],
+                        [NSDate dateWithTimeIntervalSince1970:2000],
+                        [NSDate dateWithTimeIntervalSince1970:8000]], YES);
     test(@"dataDict", @[[NSData dataWithBytes:"hello" length:5],
                         [NSData dataWithBytes:"Héllo" length:5],
                         [NSData dataWithBytes:"HELLO" length:5]], NO);
@@ -3804,20 +3805,54 @@ static NSData *data(const char *str) {
 
 - (void)testDictionarySubscriptThrowsException {
     RLMRealm *realm = [self realm];
-    RLMAssertThrowsWithReasonMatching(([realm objects:@"ArrayPropertyObject" where:@"array['invalid'] = NULL"]), @"Only dictionaries support subscript predicates.");
-    RLMAssertThrowsWithReasonMatching(([realm objects:@"SetPropertyObject" where:@"set['invalid'] = NULL"]), @"Only dictionaries support subscript predicates.");
-    RLMAssertThrowsWithReasonMatching(([realm objects:@"OwnerObject" where:@"dog['dogName'] = NULL"]), @"Aggregate operations can only be used on key paths that include an collection property");
+    RLMAssertThrowsWithReason(([realm objects:@"ArrayPropertyObject" where:@"array['invalid'] = NULL"]),
+                              @"Invalid keypath 'array[\"invalid\"]': only dictionaries support subscript predicates.");
+    RLMAssertThrowsWithReason(([realm objects:@"SetPropertyObject" where:@"set['invalid'] = NULL"]),
+                              @"Invalid keypath 'set[\"invalid\"]': only dictionaries support subscript predicates.");
+    RLMAssertThrowsWithReason(([realm objects:@"OwnerObject" where:@"dog['dogName'] = NULL"]),
+                              @"Aggregate operations can only be used on key paths that include an collection property");
 }
 
 - (void)testCollectionsQueryAllValuesAllKeys {
     RLMRealm *realm = [self realm];
     [realm beginWriteTransaction];
     StringObject *so1 = [StringObject createInRealm:realm withValue:@[@"value1"]];
-    RLMAssertThrowsWithReasonMatching(([realm objects:@"ArrayPropertyObject" where:@"ANY array.@allValues = %@", so1]), @"@allValues is only valid for dictionary");
-    RLMAssertThrowsWithReasonMatching(([realm objects:@"ArrayPropertyObject" where:@"ANY array.@allKeys = %@", so1]), @"@allKeys is only valid for dictionary");
-    RLMAssertThrowsWithReasonMatching(([realm objects:@"SetPropertyObject" where:@"ANY set.@allValues = %@", so1]), @"@allValues is only valid for dictionary");
-    RLMAssertThrowsWithReasonMatching(([realm objects:@"SetPropertyObject" where:@"ANY set.@allKeys = %@", so1]), @"@allKeys is only valid for dictionary");
+    RLMAssertThrowsWithReason(([realm objects:@"ArrayPropertyObject" where:@"ANY array.@allValues = %@", so1]),
+                              @"Invalid keypath 'array.@allValues': @allValues must follow a dictionary property.");
+    RLMAssertThrowsWithReason(([realm objects:@"ArrayPropertyObject" where:@"ANY array.@allKeys = %@", so1]),
+                              @"Invalid keypath 'array.@allKeys': @allKeys must follow a dictionary property.");
+    RLMAssertThrowsWithReason(([realm objects:@"SetPropertyObject" where:@"ANY set.@allValues = %@", so1]),
+                              @"Invalid keypath 'set.@allValues': @allValues must follow a dictionary property.");
+    RLMAssertThrowsWithReason(([realm objects:@"SetPropertyObject" where:@"ANY set.@allKeys = %@", so1]),
+                              @"Invalid keypath 'set.@allKeys': @allKeys must follow a dictionary property.");
     [realm cancelWriteTransaction];
+}
+
+- (void)testDictionaryKeyComparedToColumn {
+    RLMRealm *realm = [self realm];
+    [realm beginWriteTransaction];
+    EmployeeObject *eo = [[EmployeeObject alloc] init];
+    [CompanyObject createInRealm:realm withValue:@{@"name": @"a", @"employeeDict": @{@"a": eo}}];
+    [CompanyObject createInRealm:realm withValue:@{@"name": @"a", @"employeeDict": @{@"aa": eo}}];
+    [CompanyObject createInRealm:realm withValue:@{@"name": @"a", @"employeeDict": @{@"A": eo}}];
+    [CompanyObject createInRealm:realm withValue:@{@"name": @"a", @"employeeDict": @{@"AA": eo}}];
+    [realm commitWriteTransaction];
+
+    RLMAssertCount(CompanyObject, 1U, @"ANY employeeDict.@allKeys = name");
+    RLMAssertCount(CompanyObject, 2U, @"ANY employeeDict.@allKeys =[c] name");
+    RLMAssertCount(CompanyObject, 3U, @"ANY employeeDict.@allKeys != name");
+    RLMAssertCount(CompanyObject, 2U, @"ANY employeeDict.@allKeys !=[c] name");
+    RLMAssertCount(CompanyObject, 2U, @"ANY employeeDict.@allKeys BEGINSWITH name");
+    RLMAssertCount(CompanyObject, 4U, @"ANY employeeDict.@allKeys BEGINSWITH[c] name");
+    RLMAssertCount(CompanyObject, 2U, @"ANY employeeDict.@allKeys ENDSWITH name");
+    RLMAssertCount(CompanyObject, 4U, @"ANY employeeDict.@allKeys ENDSWITH[c] name");
+    RLMAssertCount(CompanyObject, 2U, @"ANY employeeDict.@allKeys CONTAINS name");
+    RLMAssertCount(CompanyObject, 4U, @"ANY employeeDict.@allKeys CONTAINS[c] name");
+
+    RLMAssertThrowsWithReason(([CompanyObject objectsInRealm:realm where:@"ANY employeeDict.@allKeys = 1"]),
+                              @"@allKeys can only be compared with a string value.");
+    RLMAssertThrowsWithReason(([IntegerDictionaryPropertyObject objectsInRealm:realm where:@"ANY dictionary.@allKeys = number"]),
+                              @"@allKeys can only be compared with a string value.");
 }
 
 @end

--- a/RealmSwift/Query.swift
+++ b/RealmSwift/Query.swift
@@ -416,7 +416,7 @@ extension Query where T: RealmKeyedCollection {
     }
     /// Allows a query over all values in the Map.
     public var values: Query<T.Value> {
-        .init(keyPathErasingAnyPrefix(appending: "@allValues"))
+        .init(appendKeyPath("@allValues", options: []))
     }
     /// :nodoc:
     public subscript(member: T.Key) -> Query<T.Value> {
@@ -427,7 +427,7 @@ extension Query where T: RealmKeyedCollection {
 extension Query where T: RealmKeyedCollection, T.Value: OptionalProtocol, T.Value.Wrapped: _RealmSchemaDiscoverable {
     /// Allows a query over all values in the Map.
     public var values: Query<T.Value.Wrapped> {
-        .init(keyPathErasingAnyPrefix(appending: "@allValues"))
+        .init(appendKeyPath("@allValues", options: []))
     }
     /// :nodoc:
     public subscript(member: T.Key) -> Query<T.Value.Wrapped> {
@@ -442,7 +442,7 @@ extension Query where T: RealmKeyedCollection, T.Value: OptionalProtocol, T.Valu
 extension Query where T: RealmKeyedCollection, T.Key == String {
     /// Allows a query over all keys in the `Map`.
     public var keys: Query<String> {
-        .init(keyPathErasingAnyPrefix(appending: "@allKeys"))
+        .init(appendKeyPath("@allKeys", options: []))
     }
 }
 

--- a/RealmSwift/Tests/QueryTests.swift
+++ b/RealmSwift/Tests/QueryTests.swift
@@ -2544,43 +2544,43 @@ class QueryTests: TestCase {
 
     private func validateAllKeys<Root: Object, T: RealmKeyedCollection>(_ name: String, _ lhs: (Query<Root>) -> Query<T>)
             where T.Key == String {
-        assertQuery(Root.self, "(\(name).@allKeys == %@)", "foo", count: 1) {
+        assertQuery(Root.self, "(ANY \(name).@allKeys == %@)", "foo", count: 1) {
             lhs($0).keys == "foo"
         }
 
-        assertQuery(Root.self, "(\(name).@allKeys != %@)", "foo", count: 1) {
+        assertQuery(Root.self, "(ANY \(name).@allKeys != %@)", "foo", count: 1) {
             lhs($0).keys != "foo"
         }
 
-        assertQuery(Root.self, "(\(name).@allKeys CONTAINS[cd] %@)", "foo", count: 1) {
+        assertQuery(Root.self, "(ANY \(name).@allKeys CONTAINS[cd] %@)", "foo", count: 1) {
             lhs($0).keys.contains("foo", options: [.caseInsensitive, .diacriticInsensitive])
         }
 
-        assertQuery(Root.self, "(\(name).@allKeys CONTAINS %@)", "foo", count: 1) {
+        assertQuery(Root.self, "(ANY \(name).@allKeys CONTAINS %@)", "foo", count: 1) {
             lhs($0).keys.contains("foo")
         }
 
-        assertQuery(Root.self, "(\(name).@allKeys BEGINSWITH[cd] %@)", "foo", count: 1) {
+        assertQuery(Root.self, "(ANY \(name).@allKeys BEGINSWITH[cd] %@)", "foo", count: 1) {
             lhs($0).keys.starts(with: "foo", options: [.caseInsensitive, .diacriticInsensitive])
         }
 
-        assertQuery(Root.self, "(\(name).@allKeys BEGINSWITH %@)", "foo", count: 1) {
+        assertQuery(Root.self, "(ANY \(name).@allKeys BEGINSWITH %@)", "foo", count: 1) {
             lhs($0).keys.starts(with: "foo")
         }
 
-        assertQuery(Root.self, "(\(name).@allKeys ENDSWITH[cd] %@)", "foo", count: 1) {
+        assertQuery(Root.self, "(ANY \(name).@allKeys ENDSWITH[cd] %@)", "foo", count: 1) {
             lhs($0).keys.ends(with: "foo", options: [.caseInsensitive, .diacriticInsensitive])
         }
 
-        assertQuery(Root.self, "(\(name).@allKeys ENDSWITH %@)", "foo", count: 1) {
+        assertQuery(Root.self, "(ANY \(name).@allKeys ENDSWITH %@)", "foo", count: 1) {
             lhs($0).keys.ends(with: "foo")
         }
 
-        assertQuery(Root.self, "(\(name).@allKeys LIKE[c] %@)", "foo", count: 1) {
+        assertQuery(Root.self, "(ANY \(name).@allKeys LIKE[c] %@)", "foo", count: 1) {
             lhs($0).keys.like("foo", caseInsensitive: true)
         }
 
-        assertQuery(Root.self, "(\(name).@allKeys LIKE %@)", "foo", count: 1) {
+        assertQuery(Root.self, "(ANY \(name).@allKeys LIKE %@)", "foo", count: 1) {
             lhs($0).keys.like("foo")
         }
     }
@@ -2634,936 +2634,936 @@ class QueryTests: TestCase {
     }
 
     func testMapAllValues() {
-        assertQuery(ModernAllTypesObject.self, "(mapBool.@allValues == %@)", true, count: 1) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapBool.@allValues == %@)", true, count: 1) {
             $0.mapBool.values == true
         }
 
-        assertQuery(ModernAllTypesObject.self, "(mapBool.@allValues != %@)", true, count: 0) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapBool.@allValues != %@)", true, count: 0) {
             $0.mapBool.values != true
         }
 
-        assertQuery(ModernAllTypesObject.self, "(mapInt.@allValues == %@)", 5, count: 1) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapInt.@allValues == %@)", 5, count: 1) {
             $0.mapInt.values == 5
         }
 
-        assertQuery(ModernAllTypesObject.self, "(mapInt.@allValues != %@)", 5, count: 1) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapInt.@allValues != %@)", 5, count: 1) {
             $0.mapInt.values != 5
         }
-        assertQuery(ModernAllTypesObject.self, "(mapInt.@allValues > %@)", 5, count: 1) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapInt.@allValues > %@)", 5, count: 1) {
             $0.mapInt.values > 5
         }
 
-        assertQuery(ModernAllTypesObject.self, "(mapInt.@allValues >= %@)", 5, count: 1) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapInt.@allValues >= %@)", 5, count: 1) {
             $0.mapInt.values >= 5
         }
-        assertQuery(ModernAllTypesObject.self, "(mapInt.@allValues < %@)", 5, count: 0) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapInt.@allValues < %@)", 5, count: 0) {
             $0.mapInt.values < 5
         }
 
-        assertQuery(ModernAllTypesObject.self, "(mapInt.@allValues <= %@)", 5, count: 1) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapInt.@allValues <= %@)", 5, count: 1) {
             $0.mapInt.values <= 5
         }
 
-        assertQuery(ModernAllTypesObject.self, "(mapInt8.@allValues == %@)", Int8(8), count: 1) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapInt8.@allValues == %@)", Int8(8), count: 1) {
             $0.mapInt8.values == Int8(8)
         }
 
-        assertQuery(ModernAllTypesObject.self, "(mapInt8.@allValues != %@)", Int8(8), count: 1) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapInt8.@allValues != %@)", Int8(8), count: 1) {
             $0.mapInt8.values != Int8(8)
         }
-        assertQuery(ModernAllTypesObject.self, "(mapInt8.@allValues > %@)", Int8(8), count: 1) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapInt8.@allValues > %@)", Int8(8), count: 1) {
             $0.mapInt8.values > Int8(8)
         }
 
-        assertQuery(ModernAllTypesObject.self, "(mapInt8.@allValues >= %@)", Int8(8), count: 1) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapInt8.@allValues >= %@)", Int8(8), count: 1) {
             $0.mapInt8.values >= Int8(8)
         }
-        assertQuery(ModernAllTypesObject.self, "(mapInt8.@allValues < %@)", Int8(8), count: 0) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapInt8.@allValues < %@)", Int8(8), count: 0) {
             $0.mapInt8.values < Int8(8)
         }
 
-        assertQuery(ModernAllTypesObject.self, "(mapInt8.@allValues <= %@)", Int8(8), count: 1) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapInt8.@allValues <= %@)", Int8(8), count: 1) {
             $0.mapInt8.values <= Int8(8)
         }
 
-        assertQuery(ModernAllTypesObject.self, "(mapInt16.@allValues == %@)", Int16(16), count: 1) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapInt16.@allValues == %@)", Int16(16), count: 1) {
             $0.mapInt16.values == Int16(16)
         }
 
-        assertQuery(ModernAllTypesObject.self, "(mapInt16.@allValues != %@)", Int16(16), count: 1) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapInt16.@allValues != %@)", Int16(16), count: 1) {
             $0.mapInt16.values != Int16(16)
         }
-        assertQuery(ModernAllTypesObject.self, "(mapInt16.@allValues > %@)", Int16(16), count: 1) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapInt16.@allValues > %@)", Int16(16), count: 1) {
             $0.mapInt16.values > Int16(16)
         }
 
-        assertQuery(ModernAllTypesObject.self, "(mapInt16.@allValues >= %@)", Int16(16), count: 1) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapInt16.@allValues >= %@)", Int16(16), count: 1) {
             $0.mapInt16.values >= Int16(16)
         }
-        assertQuery(ModernAllTypesObject.self, "(mapInt16.@allValues < %@)", Int16(16), count: 0) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapInt16.@allValues < %@)", Int16(16), count: 0) {
             $0.mapInt16.values < Int16(16)
         }
 
-        assertQuery(ModernAllTypesObject.self, "(mapInt16.@allValues <= %@)", Int16(16), count: 1) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapInt16.@allValues <= %@)", Int16(16), count: 1) {
             $0.mapInt16.values <= Int16(16)
         }
 
-        assertQuery(ModernAllTypesObject.self, "(mapInt32.@allValues == %@)", Int32(32), count: 1) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapInt32.@allValues == %@)", Int32(32), count: 1) {
             $0.mapInt32.values == Int32(32)
         }
 
-        assertQuery(ModernAllTypesObject.self, "(mapInt32.@allValues != %@)", Int32(32), count: 1) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapInt32.@allValues != %@)", Int32(32), count: 1) {
             $0.mapInt32.values != Int32(32)
         }
-        assertQuery(ModernAllTypesObject.self, "(mapInt32.@allValues > %@)", Int32(32), count: 1) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapInt32.@allValues > %@)", Int32(32), count: 1) {
             $0.mapInt32.values > Int32(32)
         }
 
-        assertQuery(ModernAllTypesObject.self, "(mapInt32.@allValues >= %@)", Int32(32), count: 1) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapInt32.@allValues >= %@)", Int32(32), count: 1) {
             $0.mapInt32.values >= Int32(32)
         }
-        assertQuery(ModernAllTypesObject.self, "(mapInt32.@allValues < %@)", Int32(32), count: 0) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapInt32.@allValues < %@)", Int32(32), count: 0) {
             $0.mapInt32.values < Int32(32)
         }
 
-        assertQuery(ModernAllTypesObject.self, "(mapInt32.@allValues <= %@)", Int32(32), count: 1) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapInt32.@allValues <= %@)", Int32(32), count: 1) {
             $0.mapInt32.values <= Int32(32)
         }
 
-        assertQuery(ModernAllTypesObject.self, "(mapInt64.@allValues == %@)", Int64(64), count: 1) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapInt64.@allValues == %@)", Int64(64), count: 1) {
             $0.mapInt64.values == Int64(64)
         }
 
-        assertQuery(ModernAllTypesObject.self, "(mapInt64.@allValues != %@)", Int64(64), count: 1) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapInt64.@allValues != %@)", Int64(64), count: 1) {
             $0.mapInt64.values != Int64(64)
         }
-        assertQuery(ModernAllTypesObject.self, "(mapInt64.@allValues > %@)", Int64(64), count: 1) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapInt64.@allValues > %@)", Int64(64), count: 1) {
             $0.mapInt64.values > Int64(64)
         }
 
-        assertQuery(ModernAllTypesObject.self, "(mapInt64.@allValues >= %@)", Int64(64), count: 1) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapInt64.@allValues >= %@)", Int64(64), count: 1) {
             $0.mapInt64.values >= Int64(64)
         }
-        assertQuery(ModernAllTypesObject.self, "(mapInt64.@allValues < %@)", Int64(64), count: 0) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapInt64.@allValues < %@)", Int64(64), count: 0) {
             $0.mapInt64.values < Int64(64)
         }
 
-        assertQuery(ModernAllTypesObject.self, "(mapInt64.@allValues <= %@)", Int64(64), count: 1) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapInt64.@allValues <= %@)", Int64(64), count: 1) {
             $0.mapInt64.values <= Int64(64)
         }
 
-        assertQuery(ModernAllTypesObject.self, "(mapFloat.@allValues == %@)", Float(5.55444333), count: 1) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapFloat.@allValues == %@)", Float(5.55444333), count: 1) {
             $0.mapFloat.values == Float(5.55444333)
         }
 
-        assertQuery(ModernAllTypesObject.self, "(mapFloat.@allValues != %@)", Float(5.55444333), count: 1) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapFloat.@allValues != %@)", Float(5.55444333), count: 1) {
             $0.mapFloat.values != Float(5.55444333)
         }
-        assertQuery(ModernAllTypesObject.self, "(mapFloat.@allValues > %@)", Float(5.55444333), count: 1) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapFloat.@allValues > %@)", Float(5.55444333), count: 1) {
             $0.mapFloat.values > Float(5.55444333)
         }
 
-        assertQuery(ModernAllTypesObject.self, "(mapFloat.@allValues >= %@)", Float(5.55444333), count: 1) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapFloat.@allValues >= %@)", Float(5.55444333), count: 1) {
             $0.mapFloat.values >= Float(5.55444333)
         }
-        assertQuery(ModernAllTypesObject.self, "(mapFloat.@allValues < %@)", Float(5.55444333), count: 0) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapFloat.@allValues < %@)", Float(5.55444333), count: 0) {
             $0.mapFloat.values < Float(5.55444333)
         }
 
-        assertQuery(ModernAllTypesObject.self, "(mapFloat.@allValues <= %@)", Float(5.55444333), count: 1) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapFloat.@allValues <= %@)", Float(5.55444333), count: 1) {
             $0.mapFloat.values <= Float(5.55444333)
         }
 
-        assertQuery(ModernAllTypesObject.self, "(mapDouble.@allValues == %@)", 123.456, count: 1) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapDouble.@allValues == %@)", 123.456, count: 1) {
             $0.mapDouble.values == 123.456
         }
 
-        assertQuery(ModernAllTypesObject.self, "(mapDouble.@allValues != %@)", 123.456, count: 1) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapDouble.@allValues != %@)", 123.456, count: 1) {
             $0.mapDouble.values != 123.456
         }
-        assertQuery(ModernAllTypesObject.self, "(mapDouble.@allValues > %@)", 123.456, count: 1) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapDouble.@allValues > %@)", 123.456, count: 1) {
             $0.mapDouble.values > 123.456
         }
 
-        assertQuery(ModernAllTypesObject.self, "(mapDouble.@allValues >= %@)", 123.456, count: 1) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapDouble.@allValues >= %@)", 123.456, count: 1) {
             $0.mapDouble.values >= 123.456
         }
-        assertQuery(ModernAllTypesObject.self, "(mapDouble.@allValues < %@)", 123.456, count: 0) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapDouble.@allValues < %@)", 123.456, count: 0) {
             $0.mapDouble.values < 123.456
         }
 
-        assertQuery(ModernAllTypesObject.self, "(mapDouble.@allValues <= %@)", 123.456, count: 1) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapDouble.@allValues <= %@)", 123.456, count: 1) {
             $0.mapDouble.values <= 123.456
         }
 
-        assertQuery(ModernAllTypesObject.self, "(mapString.@allValues == %@)", "Foo", count: 1) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapString.@allValues == %@)", "Foo", count: 1) {
             $0.mapString.values == "Foo"
         }
 
-        assertQuery(ModernAllTypesObject.self, "(mapString.@allValues != %@)", "Foo", count: 1) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapString.@allValues != %@)", "Foo", count: 1) {
             $0.mapString.values != "Foo"
         }
 
-        assertQuery(ModernAllTypesObject.self, "(mapString.@allValues CONTAINS[cd] %@)", "Foo", count: 1) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapString.@allValues CONTAINS[cd] %@)", "Foo", count: 1) {
             $0.mapString.values.contains("Foo", options: [.caseInsensitive, .diacriticInsensitive])
         }
 
-        assertQuery(ModernAllTypesObject.self, "(mapString.@allValues CONTAINS %@)", "Foo", count: 1) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapString.@allValues CONTAINS %@)", "Foo", count: 1) {
             $0.mapString.values.contains("Foo")
         }
 
-        assertQuery(ModernAllTypesObject.self, "(mapString.@allValues BEGINSWITH[cd] %@)", "Foo", count: 1) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapString.@allValues BEGINSWITH[cd] %@)", "Foo", count: 1) {
             $0.mapString.values.starts(with: "Foo", options: [.caseInsensitive, .diacriticInsensitive])
         }
 
-        assertQuery(ModernAllTypesObject.self, "(mapString.@allValues BEGINSWITH %@)", "Foo", count: 1) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapString.@allValues BEGINSWITH %@)", "Foo", count: 1) {
             $0.mapString.values.starts(with: "Foo")
         }
 
-        assertQuery(ModernAllTypesObject.self, "(mapString.@allValues ENDSWITH[cd] %@)", "Foo", count: 1) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapString.@allValues ENDSWITH[cd] %@)", "Foo", count: 1) {
             $0.mapString.values.ends(with: "Foo", options: [.caseInsensitive, .diacriticInsensitive])
         }
 
-        assertQuery(ModernAllTypesObject.self, "(mapString.@allValues ENDSWITH %@)", "Foo", count: 1) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapString.@allValues ENDSWITH %@)", "Foo", count: 1) {
             $0.mapString.values.ends(with: "Foo")
         }
 
-        assertQuery(ModernAllTypesObject.self, "(mapString.@allValues LIKE[c] %@)", "Foo", count: 1) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapString.@allValues LIKE[c] %@)", "Foo", count: 1) {
             $0.mapString.values.like("Foo", caseInsensitive: true)
         }
 
-        assertQuery(ModernAllTypesObject.self, "(mapString.@allValues LIKE %@)", "Foo", count: 1) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapString.@allValues LIKE %@)", "Foo", count: 1) {
             $0.mapString.values.like("Foo")
         }
-        assertQuery(ModernAllTypesObject.self, "(mapBinary.@allValues == %@)", Data(count: 64), count: 1) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapBinary.@allValues == %@)", Data(count: 64), count: 1) {
             $0.mapBinary.values == Data(count: 64)
         }
 
-        assertQuery(ModernAllTypesObject.self, "(mapBinary.@allValues != %@)", Data(count: 64), count: 1) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapBinary.@allValues != %@)", Data(count: 64), count: 1) {
             $0.mapBinary.values != Data(count: 64)
         }
 
-        assertQuery(ModernAllTypesObject.self, "(mapDate.@allValues == %@)", Date(timeIntervalSince1970: 1000000), count: 1) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapDate.@allValues == %@)", Date(timeIntervalSince1970: 1000000), count: 1) {
             $0.mapDate.values == Date(timeIntervalSince1970: 1000000)
         }
 
-        assertQuery(ModernAllTypesObject.self, "(mapDate.@allValues != %@)", Date(timeIntervalSince1970: 1000000), count: 1) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapDate.@allValues != %@)", Date(timeIntervalSince1970: 1000000), count: 1) {
             $0.mapDate.values != Date(timeIntervalSince1970: 1000000)
         }
-        assertQuery(ModernAllTypesObject.self, "(mapDate.@allValues > %@)", Date(timeIntervalSince1970: 1000000), count: 1) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapDate.@allValues > %@)", Date(timeIntervalSince1970: 1000000), count: 1) {
             $0.mapDate.values > Date(timeIntervalSince1970: 1000000)
         }
 
-        assertQuery(ModernAllTypesObject.self, "(mapDate.@allValues >= %@)", Date(timeIntervalSince1970: 1000000), count: 1) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapDate.@allValues >= %@)", Date(timeIntervalSince1970: 1000000), count: 1) {
             $0.mapDate.values >= Date(timeIntervalSince1970: 1000000)
         }
-        assertQuery(ModernAllTypesObject.self, "(mapDate.@allValues < %@)", Date(timeIntervalSince1970: 1000000), count: 0) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapDate.@allValues < %@)", Date(timeIntervalSince1970: 1000000), count: 0) {
             $0.mapDate.values < Date(timeIntervalSince1970: 1000000)
         }
 
-        assertQuery(ModernAllTypesObject.self, "(mapDate.@allValues <= %@)", Date(timeIntervalSince1970: 1000000), count: 1) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapDate.@allValues <= %@)", Date(timeIntervalSince1970: 1000000), count: 1) {
             $0.mapDate.values <= Date(timeIntervalSince1970: 1000000)
         }
 
-        assertQuery(ModernAllTypesObject.self, "(mapDecimal.@allValues == %@)", Decimal128(123.456), count: 1) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapDecimal.@allValues == %@)", Decimal128(123.456), count: 1) {
             $0.mapDecimal.values == Decimal128(123.456)
         }
 
-        assertQuery(ModernAllTypesObject.self, "(mapDecimal.@allValues != %@)", Decimal128(123.456), count: 1) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapDecimal.@allValues != %@)", Decimal128(123.456), count: 1) {
             $0.mapDecimal.values != Decimal128(123.456)
         }
-        assertQuery(ModernAllTypesObject.self, "(mapDecimal.@allValues > %@)", Decimal128(123.456), count: 1) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapDecimal.@allValues > %@)", Decimal128(123.456), count: 1) {
             $0.mapDecimal.values > Decimal128(123.456)
         }
 
-        assertQuery(ModernAllTypesObject.self, "(mapDecimal.@allValues >= %@)", Decimal128(123.456), count: 1) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapDecimal.@allValues >= %@)", Decimal128(123.456), count: 1) {
             $0.mapDecimal.values >= Decimal128(123.456)
         }
-        assertQuery(ModernAllTypesObject.self, "(mapDecimal.@allValues < %@)", Decimal128(123.456), count: 0) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapDecimal.@allValues < %@)", Decimal128(123.456), count: 0) {
             $0.mapDecimal.values < Decimal128(123.456)
         }
 
-        assertQuery(ModernAllTypesObject.self, "(mapDecimal.@allValues <= %@)", Decimal128(123.456), count: 1) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapDecimal.@allValues <= %@)", Decimal128(123.456), count: 1) {
             $0.mapDecimal.values <= Decimal128(123.456)
         }
 
-        assertQuery(ModernAllTypesObject.self, "(mapObjectId.@allValues == %@)", ObjectId("61184062c1d8f096a3695046"), count: 1) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapObjectId.@allValues == %@)", ObjectId("61184062c1d8f096a3695046"), count: 1) {
             $0.mapObjectId.values == ObjectId("61184062c1d8f096a3695046")
         }
 
-        assertQuery(ModernAllTypesObject.self, "(mapObjectId.@allValues != %@)", ObjectId("61184062c1d8f096a3695046"), count: 1) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapObjectId.@allValues != %@)", ObjectId("61184062c1d8f096a3695046"), count: 1) {
             $0.mapObjectId.values != ObjectId("61184062c1d8f096a3695046")
         }
 
-        assertQuery(ModernAllTypesObject.self, "(mapUuid.@allValues == %@)", UUID(uuidString: "33041937-05b2-464a-98ad-3910cbe0d09e")!, count: 1) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapUuid.@allValues == %@)", UUID(uuidString: "33041937-05b2-464a-98ad-3910cbe0d09e")!, count: 1) {
             $0.mapUuid.values == UUID(uuidString: "33041937-05b2-464a-98ad-3910cbe0d09e")!
         }
 
-        assertQuery(ModernAllTypesObject.self, "(mapUuid.@allValues != %@)", UUID(uuidString: "33041937-05b2-464a-98ad-3910cbe0d09e")!, count: 1) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapUuid.@allValues != %@)", UUID(uuidString: "33041937-05b2-464a-98ad-3910cbe0d09e")!, count: 1) {
             $0.mapUuid.values != UUID(uuidString: "33041937-05b2-464a-98ad-3910cbe0d09e")!
         }
 
-        assertQuery(ModernAllTypesObject.self, "(mapAny.@allValues == %@)", AnyRealmValue.objectId(ObjectId("61184062c1d8f096a3695046")), count: 1) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapAny.@allValues == %@)", AnyRealmValue.objectId(ObjectId("61184062c1d8f096a3695046")), count: 1) {
             $0.mapAny.values == AnyRealmValue.objectId(ObjectId("61184062c1d8f096a3695046"))
         }
 
-        assertQuery(ModernAllTypesObject.self, "(mapAny.@allValues != %@)", AnyRealmValue.objectId(ObjectId("61184062c1d8f096a3695046")), count: 1) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapAny.@allValues != %@)", AnyRealmValue.objectId(ObjectId("61184062c1d8f096a3695046")), count: 1) {
             $0.mapAny.values != AnyRealmValue.objectId(ObjectId("61184062c1d8f096a3695046"))
         }
 
-        assertQuery(ModernCollectionsOfEnums.self, "(mapInt.@allValues == %@)", EnumInt.value1, count: 1) {
+        assertQuery(ModernCollectionsOfEnums.self, "(ANY mapInt.@allValues == %@)", EnumInt.value1, count: 1) {
             $0.mapInt.values == .value1
         }
 
-        assertQuery(ModernCollectionsOfEnums.self, "(mapInt.@allValues != %@)", EnumInt.value1, count: 1) {
+        assertQuery(ModernCollectionsOfEnums.self, "(ANY mapInt.@allValues != %@)", EnumInt.value1, count: 1) {
             $0.mapInt.values != .value1
         }
-        assertQuery(ModernCollectionsOfEnums.self, "(mapInt.@allValues > %@)", EnumInt.value1, count: 1) {
+        assertQuery(ModernCollectionsOfEnums.self, "(ANY mapInt.@allValues > %@)", EnumInt.value1, count: 1) {
             $0.mapInt.values > .value1
         }
 
-        assertQuery(ModernCollectionsOfEnums.self, "(mapInt.@allValues >= %@)", EnumInt.value1, count: 1) {
+        assertQuery(ModernCollectionsOfEnums.self, "(ANY mapInt.@allValues >= %@)", EnumInt.value1, count: 1) {
             $0.mapInt.values >= .value1
         }
-        assertQuery(ModernCollectionsOfEnums.self, "(mapInt.@allValues < %@)", EnumInt.value1, count: 0) {
+        assertQuery(ModernCollectionsOfEnums.self, "(ANY mapInt.@allValues < %@)", EnumInt.value1, count: 0) {
             $0.mapInt.values < .value1
         }
 
-        assertQuery(ModernCollectionsOfEnums.self, "(mapInt.@allValues <= %@)", EnumInt.value1, count: 1) {
+        assertQuery(ModernCollectionsOfEnums.self, "(ANY mapInt.@allValues <= %@)", EnumInt.value1, count: 1) {
             $0.mapInt.values <= .value1
         }
 
-        assertQuery(ModernCollectionsOfEnums.self, "(mapInt8.@allValues == %@)", EnumInt8.value1, count: 1) {
+        assertQuery(ModernCollectionsOfEnums.self, "(ANY mapInt8.@allValues == %@)", EnumInt8.value1, count: 1) {
             $0.mapInt8.values == .value1
         }
 
-        assertQuery(ModernCollectionsOfEnums.self, "(mapInt8.@allValues != %@)", EnumInt8.value1, count: 1) {
+        assertQuery(ModernCollectionsOfEnums.self, "(ANY mapInt8.@allValues != %@)", EnumInt8.value1, count: 1) {
             $0.mapInt8.values != .value1
         }
-        assertQuery(ModernCollectionsOfEnums.self, "(mapInt8.@allValues > %@)", EnumInt8.value1, count: 1) {
+        assertQuery(ModernCollectionsOfEnums.self, "(ANY mapInt8.@allValues > %@)", EnumInt8.value1, count: 1) {
             $0.mapInt8.values > .value1
         }
 
-        assertQuery(ModernCollectionsOfEnums.self, "(mapInt8.@allValues >= %@)", EnumInt8.value1, count: 1) {
+        assertQuery(ModernCollectionsOfEnums.self, "(ANY mapInt8.@allValues >= %@)", EnumInt8.value1, count: 1) {
             $0.mapInt8.values >= .value1
         }
-        assertQuery(ModernCollectionsOfEnums.self, "(mapInt8.@allValues < %@)", EnumInt8.value1, count: 0) {
+        assertQuery(ModernCollectionsOfEnums.self, "(ANY mapInt8.@allValues < %@)", EnumInt8.value1, count: 0) {
             $0.mapInt8.values < .value1
         }
 
-        assertQuery(ModernCollectionsOfEnums.self, "(mapInt8.@allValues <= %@)", EnumInt8.value1, count: 1) {
+        assertQuery(ModernCollectionsOfEnums.self, "(ANY mapInt8.@allValues <= %@)", EnumInt8.value1, count: 1) {
             $0.mapInt8.values <= .value1
         }
 
-        assertQuery(ModernCollectionsOfEnums.self, "(mapInt16.@allValues == %@)", EnumInt16.value1, count: 1) {
+        assertQuery(ModernCollectionsOfEnums.self, "(ANY mapInt16.@allValues == %@)", EnumInt16.value1, count: 1) {
             $0.mapInt16.values == .value1
         }
 
-        assertQuery(ModernCollectionsOfEnums.self, "(mapInt16.@allValues != %@)", EnumInt16.value1, count: 1) {
+        assertQuery(ModernCollectionsOfEnums.self, "(ANY mapInt16.@allValues != %@)", EnumInt16.value1, count: 1) {
             $0.mapInt16.values != .value1
         }
-        assertQuery(ModernCollectionsOfEnums.self, "(mapInt16.@allValues > %@)", EnumInt16.value1, count: 1) {
+        assertQuery(ModernCollectionsOfEnums.self, "(ANY mapInt16.@allValues > %@)", EnumInt16.value1, count: 1) {
             $0.mapInt16.values > .value1
         }
 
-        assertQuery(ModernCollectionsOfEnums.self, "(mapInt16.@allValues >= %@)", EnumInt16.value1, count: 1) {
+        assertQuery(ModernCollectionsOfEnums.self, "(ANY mapInt16.@allValues >= %@)", EnumInt16.value1, count: 1) {
             $0.mapInt16.values >= .value1
         }
-        assertQuery(ModernCollectionsOfEnums.self, "(mapInt16.@allValues < %@)", EnumInt16.value1, count: 0) {
+        assertQuery(ModernCollectionsOfEnums.self, "(ANY mapInt16.@allValues < %@)", EnumInt16.value1, count: 0) {
             $0.mapInt16.values < .value1
         }
 
-        assertQuery(ModernCollectionsOfEnums.self, "(mapInt16.@allValues <= %@)", EnumInt16.value1, count: 1) {
+        assertQuery(ModernCollectionsOfEnums.self, "(ANY mapInt16.@allValues <= %@)", EnumInt16.value1, count: 1) {
             $0.mapInt16.values <= .value1
         }
 
-        assertQuery(ModernCollectionsOfEnums.self, "(mapInt32.@allValues == %@)", EnumInt32.value1, count: 1) {
+        assertQuery(ModernCollectionsOfEnums.self, "(ANY mapInt32.@allValues == %@)", EnumInt32.value1, count: 1) {
             $0.mapInt32.values == .value1
         }
 
-        assertQuery(ModernCollectionsOfEnums.self, "(mapInt32.@allValues != %@)", EnumInt32.value1, count: 1) {
+        assertQuery(ModernCollectionsOfEnums.self, "(ANY mapInt32.@allValues != %@)", EnumInt32.value1, count: 1) {
             $0.mapInt32.values != .value1
         }
-        assertQuery(ModernCollectionsOfEnums.self, "(mapInt32.@allValues > %@)", EnumInt32.value1, count: 1) {
+        assertQuery(ModernCollectionsOfEnums.self, "(ANY mapInt32.@allValues > %@)", EnumInt32.value1, count: 1) {
             $0.mapInt32.values > .value1
         }
 
-        assertQuery(ModernCollectionsOfEnums.self, "(mapInt32.@allValues >= %@)", EnumInt32.value1, count: 1) {
+        assertQuery(ModernCollectionsOfEnums.self, "(ANY mapInt32.@allValues >= %@)", EnumInt32.value1, count: 1) {
             $0.mapInt32.values >= .value1
         }
-        assertQuery(ModernCollectionsOfEnums.self, "(mapInt32.@allValues < %@)", EnumInt32.value1, count: 0) {
+        assertQuery(ModernCollectionsOfEnums.self, "(ANY mapInt32.@allValues < %@)", EnumInt32.value1, count: 0) {
             $0.mapInt32.values < .value1
         }
 
-        assertQuery(ModernCollectionsOfEnums.self, "(mapInt32.@allValues <= %@)", EnumInt32.value1, count: 1) {
+        assertQuery(ModernCollectionsOfEnums.self, "(ANY mapInt32.@allValues <= %@)", EnumInt32.value1, count: 1) {
             $0.mapInt32.values <= .value1
         }
 
-        assertQuery(ModernCollectionsOfEnums.self, "(mapInt64.@allValues == %@)", EnumInt64.value1, count: 1) {
+        assertQuery(ModernCollectionsOfEnums.self, "(ANY mapInt64.@allValues == %@)", EnumInt64.value1, count: 1) {
             $0.mapInt64.values == .value1
         }
 
-        assertQuery(ModernCollectionsOfEnums.self, "(mapInt64.@allValues != %@)", EnumInt64.value1, count: 1) {
+        assertQuery(ModernCollectionsOfEnums.self, "(ANY mapInt64.@allValues != %@)", EnumInt64.value1, count: 1) {
             $0.mapInt64.values != .value1
         }
-        assertQuery(ModernCollectionsOfEnums.self, "(mapInt64.@allValues > %@)", EnumInt64.value1, count: 1) {
+        assertQuery(ModernCollectionsOfEnums.self, "(ANY mapInt64.@allValues > %@)", EnumInt64.value1, count: 1) {
             $0.mapInt64.values > .value1
         }
 
-        assertQuery(ModernCollectionsOfEnums.self, "(mapInt64.@allValues >= %@)", EnumInt64.value1, count: 1) {
+        assertQuery(ModernCollectionsOfEnums.self, "(ANY mapInt64.@allValues >= %@)", EnumInt64.value1, count: 1) {
             $0.mapInt64.values >= .value1
         }
-        assertQuery(ModernCollectionsOfEnums.self, "(mapInt64.@allValues < %@)", EnumInt64.value1, count: 0) {
+        assertQuery(ModernCollectionsOfEnums.self, "(ANY mapInt64.@allValues < %@)", EnumInt64.value1, count: 0) {
             $0.mapInt64.values < .value1
         }
 
-        assertQuery(ModernCollectionsOfEnums.self, "(mapInt64.@allValues <= %@)", EnumInt64.value1, count: 1) {
+        assertQuery(ModernCollectionsOfEnums.self, "(ANY mapInt64.@allValues <= %@)", EnumInt64.value1, count: 1) {
             $0.mapInt64.values <= .value1
         }
 
-        assertQuery(ModernCollectionsOfEnums.self, "(mapFloat.@allValues == %@)", EnumFloat.value1, count: 1) {
+        assertQuery(ModernCollectionsOfEnums.self, "(ANY mapFloat.@allValues == %@)", EnumFloat.value1, count: 1) {
             $0.mapFloat.values == .value1
         }
 
-        assertQuery(ModernCollectionsOfEnums.self, "(mapFloat.@allValues != %@)", EnumFloat.value1, count: 1) {
+        assertQuery(ModernCollectionsOfEnums.self, "(ANY mapFloat.@allValues != %@)", EnumFloat.value1, count: 1) {
             $0.mapFloat.values != .value1
         }
-        assertQuery(ModernCollectionsOfEnums.self, "(mapFloat.@allValues > %@)", EnumFloat.value1, count: 1) {
+        assertQuery(ModernCollectionsOfEnums.self, "(ANY mapFloat.@allValues > %@)", EnumFloat.value1, count: 1) {
             $0.mapFloat.values > .value1
         }
 
-        assertQuery(ModernCollectionsOfEnums.self, "(mapFloat.@allValues >= %@)", EnumFloat.value1, count: 1) {
+        assertQuery(ModernCollectionsOfEnums.self, "(ANY mapFloat.@allValues >= %@)", EnumFloat.value1, count: 1) {
             $0.mapFloat.values >= .value1
         }
-        assertQuery(ModernCollectionsOfEnums.self, "(mapFloat.@allValues < %@)", EnumFloat.value1, count: 0) {
+        assertQuery(ModernCollectionsOfEnums.self, "(ANY mapFloat.@allValues < %@)", EnumFloat.value1, count: 0) {
             $0.mapFloat.values < .value1
         }
 
-        assertQuery(ModernCollectionsOfEnums.self, "(mapFloat.@allValues <= %@)", EnumFloat.value1, count: 1) {
+        assertQuery(ModernCollectionsOfEnums.self, "(ANY mapFloat.@allValues <= %@)", EnumFloat.value1, count: 1) {
             $0.mapFloat.values <= .value1
         }
 
-        assertQuery(ModernCollectionsOfEnums.self, "(mapDouble.@allValues == %@)", EnumDouble.value1, count: 1) {
+        assertQuery(ModernCollectionsOfEnums.self, "(ANY mapDouble.@allValues == %@)", EnumDouble.value1, count: 1) {
             $0.mapDouble.values == .value1
         }
 
-        assertQuery(ModernCollectionsOfEnums.self, "(mapDouble.@allValues != %@)", EnumDouble.value1, count: 1) {
+        assertQuery(ModernCollectionsOfEnums.self, "(ANY mapDouble.@allValues != %@)", EnumDouble.value1, count: 1) {
             $0.mapDouble.values != .value1
         }
-        assertQuery(ModernCollectionsOfEnums.self, "(mapDouble.@allValues > %@)", EnumDouble.value1, count: 1) {
+        assertQuery(ModernCollectionsOfEnums.self, "(ANY mapDouble.@allValues > %@)", EnumDouble.value1, count: 1) {
             $0.mapDouble.values > .value1
         }
 
-        assertQuery(ModernCollectionsOfEnums.self, "(mapDouble.@allValues >= %@)", EnumDouble.value1, count: 1) {
+        assertQuery(ModernCollectionsOfEnums.self, "(ANY mapDouble.@allValues >= %@)", EnumDouble.value1, count: 1) {
             $0.mapDouble.values >= .value1
         }
-        assertQuery(ModernCollectionsOfEnums.self, "(mapDouble.@allValues < %@)", EnumDouble.value1, count: 0) {
+        assertQuery(ModernCollectionsOfEnums.self, "(ANY mapDouble.@allValues < %@)", EnumDouble.value1, count: 0) {
             $0.mapDouble.values < .value1
         }
 
-        assertQuery(ModernCollectionsOfEnums.self, "(mapDouble.@allValues <= %@)", EnumDouble.value1, count: 1) {
+        assertQuery(ModernCollectionsOfEnums.self, "(ANY mapDouble.@allValues <= %@)", EnumDouble.value1, count: 1) {
             $0.mapDouble.values <= .value1
         }
 
-        assertQuery(ModernCollectionsOfEnums.self, "(mapString.@allValues == %@)", EnumString.value1, count: 1) {
+        assertQuery(ModernCollectionsOfEnums.self, "(ANY mapString.@allValues == %@)", EnumString.value1, count: 1) {
             $0.mapString.values == .value1
         }
 
-        assertQuery(ModernCollectionsOfEnums.self, "(mapString.@allValues != %@)", EnumString.value1, count: 1) {
+        assertQuery(ModernCollectionsOfEnums.self, "(ANY mapString.@allValues != %@)", EnumString.value1, count: 1) {
             $0.mapString.values != .value1
         }
 
-        assertQuery(ModernCollectionsOfEnums.self, "(mapString.@allValues CONTAINS[cd] %@)", EnumString.value1, count: 1) {
+        assertQuery(ModernCollectionsOfEnums.self, "(ANY mapString.@allValues CONTAINS[cd] %@)", EnumString.value1, count: 1) {
             $0.mapString.values.contains(.value1, options: [.caseInsensitive, .diacriticInsensitive])
         }
 
-        assertQuery(ModernCollectionsOfEnums.self, "(mapString.@allValues CONTAINS %@)", EnumString.value1, count: 1) {
+        assertQuery(ModernCollectionsOfEnums.self, "(ANY mapString.@allValues CONTAINS %@)", EnumString.value1, count: 1) {
             $0.mapString.values.contains(.value1)
         }
 
-        assertQuery(ModernCollectionsOfEnums.self, "(mapString.@allValues BEGINSWITH[cd] %@)", EnumString.value1, count: 1) {
+        assertQuery(ModernCollectionsOfEnums.self, "(ANY mapString.@allValues BEGINSWITH[cd] %@)", EnumString.value1, count: 1) {
             $0.mapString.values.starts(with: .value1, options: [.caseInsensitive, .diacriticInsensitive])
         }
 
-        assertQuery(ModernCollectionsOfEnums.self, "(mapString.@allValues BEGINSWITH %@)", EnumString.value1, count: 1) {
+        assertQuery(ModernCollectionsOfEnums.self, "(ANY mapString.@allValues BEGINSWITH %@)", EnumString.value1, count: 1) {
             $0.mapString.values.starts(with: .value1)
         }
 
-        assertQuery(ModernCollectionsOfEnums.self, "(mapString.@allValues ENDSWITH[cd] %@)", EnumString.value1, count: 1) {
+        assertQuery(ModernCollectionsOfEnums.self, "(ANY mapString.@allValues ENDSWITH[cd] %@)", EnumString.value1, count: 1) {
             $0.mapString.values.ends(with: .value1, options: [.caseInsensitive, .diacriticInsensitive])
         }
 
-        assertQuery(ModernCollectionsOfEnums.self, "(mapString.@allValues ENDSWITH %@)", EnumString.value1, count: 1) {
+        assertQuery(ModernCollectionsOfEnums.self, "(ANY mapString.@allValues ENDSWITH %@)", EnumString.value1, count: 1) {
             $0.mapString.values.ends(with: .value1)
         }
 
-        assertQuery(ModernCollectionsOfEnums.self, "(mapString.@allValues LIKE[c] %@)", EnumString.value1, count: 1) {
+        assertQuery(ModernCollectionsOfEnums.self, "(ANY mapString.@allValues LIKE[c] %@)", EnumString.value1, count: 1) {
             $0.mapString.values.like(.value1, caseInsensitive: true)
         }
 
-        assertQuery(ModernCollectionsOfEnums.self, "(mapString.@allValues LIKE %@)", EnumString.value1, count: 1) {
+        assertQuery(ModernCollectionsOfEnums.self, "(ANY mapString.@allValues LIKE %@)", EnumString.value1, count: 1) {
             $0.mapString.values.like(.value1)
         }
-        assertQuery(ModernAllTypesObject.self, "(mapOptBool.@allValues == %@)", true, count: 1) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapOptBool.@allValues == %@)", true, count: 1) {
             $0.mapOptBool.values == true
         }
 
-        assertQuery(ModernAllTypesObject.self, "(mapOptBool.@allValues != %@)", true, count: 0) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapOptBool.@allValues != %@)", true, count: 0) {
             $0.mapOptBool.values != true
         }
 
-        assertQuery(ModernAllTypesObject.self, "(mapOptInt.@allValues == %@)", 5, count: 1) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapOptInt.@allValues == %@)", 5, count: 1) {
             $0.mapOptInt.values == 5
         }
 
-        assertQuery(ModernAllTypesObject.self, "(mapOptInt.@allValues != %@)", 5, count: 1) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapOptInt.@allValues != %@)", 5, count: 1) {
             $0.mapOptInt.values != 5
         }
-        assertQuery(ModernAllTypesObject.self, "(mapOptInt.@allValues > %@)", 5, count: 1) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapOptInt.@allValues > %@)", 5, count: 1) {
             $0.mapOptInt.values > 5
         }
 
-        assertQuery(ModernAllTypesObject.self, "(mapOptInt.@allValues >= %@)", 5, count: 1) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapOptInt.@allValues >= %@)", 5, count: 1) {
             $0.mapOptInt.values >= 5
         }
-        assertQuery(ModernAllTypesObject.self, "(mapOptInt.@allValues < %@)", 5, count: 0) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapOptInt.@allValues < %@)", 5, count: 0) {
             $0.mapOptInt.values < 5
         }
 
-        assertQuery(ModernAllTypesObject.self, "(mapOptInt.@allValues <= %@)", 5, count: 1) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapOptInt.@allValues <= %@)", 5, count: 1) {
             $0.mapOptInt.values <= 5
         }
 
-        assertQuery(ModernAllTypesObject.self, "(mapOptInt8.@allValues == %@)", Int8(8), count: 1) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapOptInt8.@allValues == %@)", Int8(8), count: 1) {
             $0.mapOptInt8.values == Int8(8)
         }
 
-        assertQuery(ModernAllTypesObject.self, "(mapOptInt8.@allValues != %@)", Int8(8), count: 1) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapOptInt8.@allValues != %@)", Int8(8), count: 1) {
             $0.mapOptInt8.values != Int8(8)
         }
-        assertQuery(ModernAllTypesObject.self, "(mapOptInt8.@allValues > %@)", Int8(8), count: 1) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapOptInt8.@allValues > %@)", Int8(8), count: 1) {
             $0.mapOptInt8.values > Int8(8)
         }
 
-        assertQuery(ModernAllTypesObject.self, "(mapOptInt8.@allValues >= %@)", Int8(8), count: 1) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapOptInt8.@allValues >= %@)", Int8(8), count: 1) {
             $0.mapOptInt8.values >= Int8(8)
         }
-        assertQuery(ModernAllTypesObject.self, "(mapOptInt8.@allValues < %@)", Int8(8), count: 0) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapOptInt8.@allValues < %@)", Int8(8), count: 0) {
             $0.mapOptInt8.values < Int8(8)
         }
 
-        assertQuery(ModernAllTypesObject.self, "(mapOptInt8.@allValues <= %@)", Int8(8), count: 1) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapOptInt8.@allValues <= %@)", Int8(8), count: 1) {
             $0.mapOptInt8.values <= Int8(8)
         }
 
-        assertQuery(ModernAllTypesObject.self, "(mapOptInt16.@allValues == %@)", Int16(16), count: 1) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapOptInt16.@allValues == %@)", Int16(16), count: 1) {
             $0.mapOptInt16.values == Int16(16)
         }
 
-        assertQuery(ModernAllTypesObject.self, "(mapOptInt16.@allValues != %@)", Int16(16), count: 1) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapOptInt16.@allValues != %@)", Int16(16), count: 1) {
             $0.mapOptInt16.values != Int16(16)
         }
-        assertQuery(ModernAllTypesObject.self, "(mapOptInt16.@allValues > %@)", Int16(16), count: 1) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapOptInt16.@allValues > %@)", Int16(16), count: 1) {
             $0.mapOptInt16.values > Int16(16)
         }
 
-        assertQuery(ModernAllTypesObject.self, "(mapOptInt16.@allValues >= %@)", Int16(16), count: 1) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapOptInt16.@allValues >= %@)", Int16(16), count: 1) {
             $0.mapOptInt16.values >= Int16(16)
         }
-        assertQuery(ModernAllTypesObject.self, "(mapOptInt16.@allValues < %@)", Int16(16), count: 0) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapOptInt16.@allValues < %@)", Int16(16), count: 0) {
             $0.mapOptInt16.values < Int16(16)
         }
 
-        assertQuery(ModernAllTypesObject.self, "(mapOptInt16.@allValues <= %@)", Int16(16), count: 1) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapOptInt16.@allValues <= %@)", Int16(16), count: 1) {
             $0.mapOptInt16.values <= Int16(16)
         }
 
-        assertQuery(ModernAllTypesObject.self, "(mapOptInt32.@allValues == %@)", Int32(32), count: 1) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapOptInt32.@allValues == %@)", Int32(32), count: 1) {
             $0.mapOptInt32.values == Int32(32)
         }
 
-        assertQuery(ModernAllTypesObject.self, "(mapOptInt32.@allValues != %@)", Int32(32), count: 1) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapOptInt32.@allValues != %@)", Int32(32), count: 1) {
             $0.mapOptInt32.values != Int32(32)
         }
-        assertQuery(ModernAllTypesObject.self, "(mapOptInt32.@allValues > %@)", Int32(32), count: 1) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapOptInt32.@allValues > %@)", Int32(32), count: 1) {
             $0.mapOptInt32.values > Int32(32)
         }
 
-        assertQuery(ModernAllTypesObject.self, "(mapOptInt32.@allValues >= %@)", Int32(32), count: 1) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapOptInt32.@allValues >= %@)", Int32(32), count: 1) {
             $0.mapOptInt32.values >= Int32(32)
         }
-        assertQuery(ModernAllTypesObject.self, "(mapOptInt32.@allValues < %@)", Int32(32), count: 0) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapOptInt32.@allValues < %@)", Int32(32), count: 0) {
             $0.mapOptInt32.values < Int32(32)
         }
 
-        assertQuery(ModernAllTypesObject.self, "(mapOptInt32.@allValues <= %@)", Int32(32), count: 1) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapOptInt32.@allValues <= %@)", Int32(32), count: 1) {
             $0.mapOptInt32.values <= Int32(32)
         }
 
-        assertQuery(ModernAllTypesObject.self, "(mapOptInt64.@allValues == %@)", Int64(64), count: 1) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapOptInt64.@allValues == %@)", Int64(64), count: 1) {
             $0.mapOptInt64.values == Int64(64)
         }
 
-        assertQuery(ModernAllTypesObject.self, "(mapOptInt64.@allValues != %@)", Int64(64), count: 1) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapOptInt64.@allValues != %@)", Int64(64), count: 1) {
             $0.mapOptInt64.values != Int64(64)
         }
-        assertQuery(ModernAllTypesObject.self, "(mapOptInt64.@allValues > %@)", Int64(64), count: 1) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapOptInt64.@allValues > %@)", Int64(64), count: 1) {
             $0.mapOptInt64.values > Int64(64)
         }
 
-        assertQuery(ModernAllTypesObject.self, "(mapOptInt64.@allValues >= %@)", Int64(64), count: 1) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapOptInt64.@allValues >= %@)", Int64(64), count: 1) {
             $0.mapOptInt64.values >= Int64(64)
         }
-        assertQuery(ModernAllTypesObject.self, "(mapOptInt64.@allValues < %@)", Int64(64), count: 0) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapOptInt64.@allValues < %@)", Int64(64), count: 0) {
             $0.mapOptInt64.values < Int64(64)
         }
 
-        assertQuery(ModernAllTypesObject.self, "(mapOptInt64.@allValues <= %@)", Int64(64), count: 1) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapOptInt64.@allValues <= %@)", Int64(64), count: 1) {
             $0.mapOptInt64.values <= Int64(64)
         }
 
-        assertQuery(ModernAllTypesObject.self, "(mapOptFloat.@allValues == %@)", Float(5.55444333), count: 1) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapOptFloat.@allValues == %@)", Float(5.55444333), count: 1) {
             $0.mapOptFloat.values == Float(5.55444333)
         }
 
-        assertQuery(ModernAllTypesObject.self, "(mapOptFloat.@allValues != %@)", Float(5.55444333), count: 1) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapOptFloat.@allValues != %@)", Float(5.55444333), count: 1) {
             $0.mapOptFloat.values != Float(5.55444333)
         }
-        assertQuery(ModernAllTypesObject.self, "(mapOptFloat.@allValues > %@)", Float(5.55444333), count: 1) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapOptFloat.@allValues > %@)", Float(5.55444333), count: 1) {
             $0.mapOptFloat.values > Float(5.55444333)
         }
 
-        assertQuery(ModernAllTypesObject.self, "(mapOptFloat.@allValues >= %@)", Float(5.55444333), count: 1) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapOptFloat.@allValues >= %@)", Float(5.55444333), count: 1) {
             $0.mapOptFloat.values >= Float(5.55444333)
         }
-        assertQuery(ModernAllTypesObject.self, "(mapOptFloat.@allValues < %@)", Float(5.55444333), count: 0) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapOptFloat.@allValues < %@)", Float(5.55444333), count: 0) {
             $0.mapOptFloat.values < Float(5.55444333)
         }
 
-        assertQuery(ModernAllTypesObject.self, "(mapOptFloat.@allValues <= %@)", Float(5.55444333), count: 1) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapOptFloat.@allValues <= %@)", Float(5.55444333), count: 1) {
             $0.mapOptFloat.values <= Float(5.55444333)
         }
 
-        assertQuery(ModernAllTypesObject.self, "(mapOptDouble.@allValues == %@)", 123.456, count: 1) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapOptDouble.@allValues == %@)", 123.456, count: 1) {
             $0.mapOptDouble.values == 123.456
         }
 
-        assertQuery(ModernAllTypesObject.self, "(mapOptDouble.@allValues != %@)", 123.456, count: 1) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapOptDouble.@allValues != %@)", 123.456, count: 1) {
             $0.mapOptDouble.values != 123.456
         }
-        assertQuery(ModernAllTypesObject.self, "(mapOptDouble.@allValues > %@)", 123.456, count: 1) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapOptDouble.@allValues > %@)", 123.456, count: 1) {
             $0.mapOptDouble.values > 123.456
         }
 
-        assertQuery(ModernAllTypesObject.self, "(mapOptDouble.@allValues >= %@)", 123.456, count: 1) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapOptDouble.@allValues >= %@)", 123.456, count: 1) {
             $0.mapOptDouble.values >= 123.456
         }
-        assertQuery(ModernAllTypesObject.self, "(mapOptDouble.@allValues < %@)", 123.456, count: 0) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapOptDouble.@allValues < %@)", 123.456, count: 0) {
             $0.mapOptDouble.values < 123.456
         }
 
-        assertQuery(ModernAllTypesObject.self, "(mapOptDouble.@allValues <= %@)", 123.456, count: 1) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapOptDouble.@allValues <= %@)", 123.456, count: 1) {
             $0.mapOptDouble.values <= 123.456
         }
 
-        assertQuery(ModernAllTypesObject.self, "(mapOptString.@allValues == %@)", "Foo", count: 1) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapOptString.@allValues == %@)", "Foo", count: 1) {
             $0.mapOptString.values == "Foo"
         }
 
-        assertQuery(ModernAllTypesObject.self, "(mapOptString.@allValues != %@)", "Foo", count: 1) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapOptString.@allValues != %@)", "Foo", count: 1) {
             $0.mapOptString.values != "Foo"
         }
 
-        assertQuery(ModernAllTypesObject.self, "(mapOptString.@allValues CONTAINS[cd] %@)", "Foo", count: 1) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapOptString.@allValues CONTAINS[cd] %@)", "Foo", count: 1) {
             $0.mapOptString.values.contains("Foo", options: [.caseInsensitive, .diacriticInsensitive])
         }
 
-        assertQuery(ModernAllTypesObject.self, "(mapOptString.@allValues CONTAINS %@)", "Foo", count: 1) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapOptString.@allValues CONTAINS %@)", "Foo", count: 1) {
             $0.mapOptString.values.contains("Foo")
         }
 
-        assertQuery(ModernAllTypesObject.self, "(mapOptString.@allValues BEGINSWITH[cd] %@)", "Foo", count: 1) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapOptString.@allValues BEGINSWITH[cd] %@)", "Foo", count: 1) {
             $0.mapOptString.values.starts(with: "Foo", options: [.caseInsensitive, .diacriticInsensitive])
         }
 
-        assertQuery(ModernAllTypesObject.self, "(mapOptString.@allValues BEGINSWITH %@)", "Foo", count: 1) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapOptString.@allValues BEGINSWITH %@)", "Foo", count: 1) {
             $0.mapOptString.values.starts(with: "Foo")
         }
 
-        assertQuery(ModernAllTypesObject.self, "(mapOptString.@allValues ENDSWITH[cd] %@)", "Foo", count: 1) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapOptString.@allValues ENDSWITH[cd] %@)", "Foo", count: 1) {
             $0.mapOptString.values.ends(with: "Foo", options: [.caseInsensitive, .diacriticInsensitive])
         }
 
-        assertQuery(ModernAllTypesObject.self, "(mapOptString.@allValues ENDSWITH %@)", "Foo", count: 1) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapOptString.@allValues ENDSWITH %@)", "Foo", count: 1) {
             $0.mapOptString.values.ends(with: "Foo")
         }
 
-        assertQuery(ModernAllTypesObject.self, "(mapOptString.@allValues LIKE[c] %@)", "Foo", count: 1) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapOptString.@allValues LIKE[c] %@)", "Foo", count: 1) {
             $0.mapOptString.values.like("Foo", caseInsensitive: true)
         }
 
-        assertQuery(ModernAllTypesObject.self, "(mapOptString.@allValues LIKE %@)", "Foo", count: 1) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapOptString.@allValues LIKE %@)", "Foo", count: 1) {
             $0.mapOptString.values.like("Foo")
         }
-        assertQuery(ModernAllTypesObject.self, "(mapOptBinary.@allValues == %@)", Data(count: 64), count: 1) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapOptBinary.@allValues == %@)", Data(count: 64), count: 1) {
             $0.mapOptBinary.values == Data(count: 64)
         }
 
-        assertQuery(ModernAllTypesObject.self, "(mapOptBinary.@allValues != %@)", Data(count: 64), count: 1) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapOptBinary.@allValues != %@)", Data(count: 64), count: 1) {
             $0.mapOptBinary.values != Data(count: 64)
         }
 
-        assertQuery(ModernAllTypesObject.self, "(mapOptDate.@allValues == %@)", Date(timeIntervalSince1970: 1000000), count: 1) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapOptDate.@allValues == %@)", Date(timeIntervalSince1970: 1000000), count: 1) {
             $0.mapOptDate.values == Date(timeIntervalSince1970: 1000000)
         }
 
-        assertQuery(ModernAllTypesObject.self, "(mapOptDate.@allValues != %@)", Date(timeIntervalSince1970: 1000000), count: 1) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapOptDate.@allValues != %@)", Date(timeIntervalSince1970: 1000000), count: 1) {
             $0.mapOptDate.values != Date(timeIntervalSince1970: 1000000)
         }
-        assertQuery(ModernAllTypesObject.self, "(mapOptDate.@allValues > %@)", Date(timeIntervalSince1970: 1000000), count: 1) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapOptDate.@allValues > %@)", Date(timeIntervalSince1970: 1000000), count: 1) {
             $0.mapOptDate.values > Date(timeIntervalSince1970: 1000000)
         }
 
-        assertQuery(ModernAllTypesObject.self, "(mapOptDate.@allValues >= %@)", Date(timeIntervalSince1970: 1000000), count: 1) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapOptDate.@allValues >= %@)", Date(timeIntervalSince1970: 1000000), count: 1) {
             $0.mapOptDate.values >= Date(timeIntervalSince1970: 1000000)
         }
-        assertQuery(ModernAllTypesObject.self, "(mapOptDate.@allValues < %@)", Date(timeIntervalSince1970: 1000000), count: 0) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapOptDate.@allValues < %@)", Date(timeIntervalSince1970: 1000000), count: 0) {
             $0.mapOptDate.values < Date(timeIntervalSince1970: 1000000)
         }
 
-        assertQuery(ModernAllTypesObject.self, "(mapOptDate.@allValues <= %@)", Date(timeIntervalSince1970: 1000000), count: 1) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapOptDate.@allValues <= %@)", Date(timeIntervalSince1970: 1000000), count: 1) {
             $0.mapOptDate.values <= Date(timeIntervalSince1970: 1000000)
         }
 
-        assertQuery(ModernAllTypesObject.self, "(mapOptDecimal.@allValues == %@)", Decimal128(123.456), count: 1) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapOptDecimal.@allValues == %@)", Decimal128(123.456), count: 1) {
             $0.mapOptDecimal.values == Decimal128(123.456)
         }
 
-        assertQuery(ModernAllTypesObject.self, "(mapOptDecimal.@allValues != %@)", Decimal128(123.456), count: 1) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapOptDecimal.@allValues != %@)", Decimal128(123.456), count: 1) {
             $0.mapOptDecimal.values != Decimal128(123.456)
         }
-        assertQuery(ModernAllTypesObject.self, "(mapOptDecimal.@allValues > %@)", Decimal128(123.456), count: 1) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapOptDecimal.@allValues > %@)", Decimal128(123.456), count: 1) {
             $0.mapOptDecimal.values > Decimal128(123.456)
         }
 
-        assertQuery(ModernAllTypesObject.self, "(mapOptDecimal.@allValues >= %@)", Decimal128(123.456), count: 1) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapOptDecimal.@allValues >= %@)", Decimal128(123.456), count: 1) {
             $0.mapOptDecimal.values >= Decimal128(123.456)
         }
-        assertQuery(ModernAllTypesObject.self, "(mapOptDecimal.@allValues < %@)", Decimal128(123.456), count: 0) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapOptDecimal.@allValues < %@)", Decimal128(123.456), count: 0) {
             $0.mapOptDecimal.values < Decimal128(123.456)
         }
 
-        assertQuery(ModernAllTypesObject.self, "(mapOptDecimal.@allValues <= %@)", Decimal128(123.456), count: 1) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapOptDecimal.@allValues <= %@)", Decimal128(123.456), count: 1) {
             $0.mapOptDecimal.values <= Decimal128(123.456)
         }
 
-        assertQuery(ModernAllTypesObject.self, "(mapOptObjectId.@allValues == %@)", ObjectId("61184062c1d8f096a3695046"), count: 1) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapOptObjectId.@allValues == %@)", ObjectId("61184062c1d8f096a3695046"), count: 1) {
             $0.mapOptObjectId.values == ObjectId("61184062c1d8f096a3695046")
         }
 
-        assertQuery(ModernAllTypesObject.self, "(mapOptObjectId.@allValues != %@)", ObjectId("61184062c1d8f096a3695046"), count: 1) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapOptObjectId.@allValues != %@)", ObjectId("61184062c1d8f096a3695046"), count: 1) {
             $0.mapOptObjectId.values != ObjectId("61184062c1d8f096a3695046")
         }
 
-        assertQuery(ModernAllTypesObject.self, "(mapOptUuid.@allValues == %@)", UUID(uuidString: "33041937-05b2-464a-98ad-3910cbe0d09e")!, count: 1) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapOptUuid.@allValues == %@)", UUID(uuidString: "33041937-05b2-464a-98ad-3910cbe0d09e")!, count: 1) {
             $0.mapOptUuid.values == UUID(uuidString: "33041937-05b2-464a-98ad-3910cbe0d09e")!
         }
 
-        assertQuery(ModernAllTypesObject.self, "(mapOptUuid.@allValues != %@)", UUID(uuidString: "33041937-05b2-464a-98ad-3910cbe0d09e")!, count: 1) {
+        assertQuery(ModernAllTypesObject.self, "(ANY mapOptUuid.@allValues != %@)", UUID(uuidString: "33041937-05b2-464a-98ad-3910cbe0d09e")!, count: 1) {
             $0.mapOptUuid.values != UUID(uuidString: "33041937-05b2-464a-98ad-3910cbe0d09e")!
         }
 
-        assertQuery(ModernCollectionsOfEnums.self, "(mapIntOpt.@allValues == %@)", EnumInt.value1, count: 1) {
+        assertQuery(ModernCollectionsOfEnums.self, "(ANY mapIntOpt.@allValues == %@)", EnumInt.value1, count: 1) {
             $0.mapIntOpt.values == .value1
         }
 
-        assertQuery(ModernCollectionsOfEnums.self, "(mapIntOpt.@allValues != %@)", EnumInt.value1, count: 1) {
+        assertQuery(ModernCollectionsOfEnums.self, "(ANY mapIntOpt.@allValues != %@)", EnumInt.value1, count: 1) {
             $0.mapIntOpt.values != .value1
         }
-        assertQuery(ModernCollectionsOfEnums.self, "(mapIntOpt.@allValues > %@)", EnumInt.value1, count: 1) {
+        assertQuery(ModernCollectionsOfEnums.self, "(ANY mapIntOpt.@allValues > %@)", EnumInt.value1, count: 1) {
             $0.mapIntOpt.values > .value1
         }
 
-        assertQuery(ModernCollectionsOfEnums.self, "(mapIntOpt.@allValues >= %@)", EnumInt.value1, count: 1) {
+        assertQuery(ModernCollectionsOfEnums.self, "(ANY mapIntOpt.@allValues >= %@)", EnumInt.value1, count: 1) {
             $0.mapIntOpt.values >= .value1
         }
-        assertQuery(ModernCollectionsOfEnums.self, "(mapIntOpt.@allValues < %@)", EnumInt.value1, count: 0) {
+        assertQuery(ModernCollectionsOfEnums.self, "(ANY mapIntOpt.@allValues < %@)", EnumInt.value1, count: 0) {
             $0.mapIntOpt.values < .value1
         }
 
-        assertQuery(ModernCollectionsOfEnums.self, "(mapIntOpt.@allValues <= %@)", EnumInt.value1, count: 1) {
+        assertQuery(ModernCollectionsOfEnums.self, "(ANY mapIntOpt.@allValues <= %@)", EnumInt.value1, count: 1) {
             $0.mapIntOpt.values <= .value1
         }
 
-        assertQuery(ModernCollectionsOfEnums.self, "(mapInt8Opt.@allValues == %@)", EnumInt8.value1, count: 1) {
+        assertQuery(ModernCollectionsOfEnums.self, "(ANY mapInt8Opt.@allValues == %@)", EnumInt8.value1, count: 1) {
             $0.mapInt8Opt.values == .value1
         }
 
-        assertQuery(ModernCollectionsOfEnums.self, "(mapInt8Opt.@allValues != %@)", EnumInt8.value1, count: 1) {
+        assertQuery(ModernCollectionsOfEnums.self, "(ANY mapInt8Opt.@allValues != %@)", EnumInt8.value1, count: 1) {
             $0.mapInt8Opt.values != .value1
         }
-        assertQuery(ModernCollectionsOfEnums.self, "(mapInt8Opt.@allValues > %@)", EnumInt8.value1, count: 1) {
+        assertQuery(ModernCollectionsOfEnums.self, "(ANY mapInt8Opt.@allValues > %@)", EnumInt8.value1, count: 1) {
             $0.mapInt8Opt.values > .value1
         }
 
-        assertQuery(ModernCollectionsOfEnums.self, "(mapInt8Opt.@allValues >= %@)", EnumInt8.value1, count: 1) {
+        assertQuery(ModernCollectionsOfEnums.self, "(ANY mapInt8Opt.@allValues >= %@)", EnumInt8.value1, count: 1) {
             $0.mapInt8Opt.values >= .value1
         }
-        assertQuery(ModernCollectionsOfEnums.self, "(mapInt8Opt.@allValues < %@)", EnumInt8.value1, count: 0) {
+        assertQuery(ModernCollectionsOfEnums.self, "(ANY mapInt8Opt.@allValues < %@)", EnumInt8.value1, count: 0) {
             $0.mapInt8Opt.values < .value1
         }
 
-        assertQuery(ModernCollectionsOfEnums.self, "(mapInt8Opt.@allValues <= %@)", EnumInt8.value1, count: 1) {
+        assertQuery(ModernCollectionsOfEnums.self, "(ANY mapInt8Opt.@allValues <= %@)", EnumInt8.value1, count: 1) {
             $0.mapInt8Opt.values <= .value1
         }
 
-        assertQuery(ModernCollectionsOfEnums.self, "(mapInt16Opt.@allValues == %@)", EnumInt16.value1, count: 1) {
+        assertQuery(ModernCollectionsOfEnums.self, "(ANY mapInt16Opt.@allValues == %@)", EnumInt16.value1, count: 1) {
             $0.mapInt16Opt.values == .value1
         }
 
-        assertQuery(ModernCollectionsOfEnums.self, "(mapInt16Opt.@allValues != %@)", EnumInt16.value1, count: 1) {
+        assertQuery(ModernCollectionsOfEnums.self, "(ANY mapInt16Opt.@allValues != %@)", EnumInt16.value1, count: 1) {
             $0.mapInt16Opt.values != .value1
         }
-        assertQuery(ModernCollectionsOfEnums.self, "(mapInt16Opt.@allValues > %@)", EnumInt16.value1, count: 1) {
+        assertQuery(ModernCollectionsOfEnums.self, "(ANY mapInt16Opt.@allValues > %@)", EnumInt16.value1, count: 1) {
             $0.mapInt16Opt.values > .value1
         }
 
-        assertQuery(ModernCollectionsOfEnums.self, "(mapInt16Opt.@allValues >= %@)", EnumInt16.value1, count: 1) {
+        assertQuery(ModernCollectionsOfEnums.self, "(ANY mapInt16Opt.@allValues >= %@)", EnumInt16.value1, count: 1) {
             $0.mapInt16Opt.values >= .value1
         }
-        assertQuery(ModernCollectionsOfEnums.self, "(mapInt16Opt.@allValues < %@)", EnumInt16.value1, count: 0) {
+        assertQuery(ModernCollectionsOfEnums.self, "(ANY mapInt16Opt.@allValues < %@)", EnumInt16.value1, count: 0) {
             $0.mapInt16Opt.values < .value1
         }
 
-        assertQuery(ModernCollectionsOfEnums.self, "(mapInt16Opt.@allValues <= %@)", EnumInt16.value1, count: 1) {
+        assertQuery(ModernCollectionsOfEnums.self, "(ANY mapInt16Opt.@allValues <= %@)", EnumInt16.value1, count: 1) {
             $0.mapInt16Opt.values <= .value1
         }
 
-        assertQuery(ModernCollectionsOfEnums.self, "(mapInt32Opt.@allValues == %@)", EnumInt32.value1, count: 1) {
+        assertQuery(ModernCollectionsOfEnums.self, "(ANY mapInt32Opt.@allValues == %@)", EnumInt32.value1, count: 1) {
             $0.mapInt32Opt.values == .value1
         }
 
-        assertQuery(ModernCollectionsOfEnums.self, "(mapInt32Opt.@allValues != %@)", EnumInt32.value1, count: 1) {
+        assertQuery(ModernCollectionsOfEnums.self, "(ANY mapInt32Opt.@allValues != %@)", EnumInt32.value1, count: 1) {
             $0.mapInt32Opt.values != .value1
         }
-        assertQuery(ModernCollectionsOfEnums.self, "(mapInt32Opt.@allValues > %@)", EnumInt32.value1, count: 1) {
+        assertQuery(ModernCollectionsOfEnums.self, "(ANY mapInt32Opt.@allValues > %@)", EnumInt32.value1, count: 1) {
             $0.mapInt32Opt.values > .value1
         }
 
-        assertQuery(ModernCollectionsOfEnums.self, "(mapInt32Opt.@allValues >= %@)", EnumInt32.value1, count: 1) {
+        assertQuery(ModernCollectionsOfEnums.self, "(ANY mapInt32Opt.@allValues >= %@)", EnumInt32.value1, count: 1) {
             $0.mapInt32Opt.values >= .value1
         }
-        assertQuery(ModernCollectionsOfEnums.self, "(mapInt32Opt.@allValues < %@)", EnumInt32.value1, count: 0) {
+        assertQuery(ModernCollectionsOfEnums.self, "(ANY mapInt32Opt.@allValues < %@)", EnumInt32.value1, count: 0) {
             $0.mapInt32Opt.values < .value1
         }
 
-        assertQuery(ModernCollectionsOfEnums.self, "(mapInt32Opt.@allValues <= %@)", EnumInt32.value1, count: 1) {
+        assertQuery(ModernCollectionsOfEnums.self, "(ANY mapInt32Opt.@allValues <= %@)", EnumInt32.value1, count: 1) {
             $0.mapInt32Opt.values <= .value1
         }
 
-        assertQuery(ModernCollectionsOfEnums.self, "(mapInt64Opt.@allValues == %@)", EnumInt64.value1, count: 1) {
+        assertQuery(ModernCollectionsOfEnums.self, "(ANY mapInt64Opt.@allValues == %@)", EnumInt64.value1, count: 1) {
             $0.mapInt64Opt.values == .value1
         }
 
-        assertQuery(ModernCollectionsOfEnums.self, "(mapInt64Opt.@allValues != %@)", EnumInt64.value1, count: 1) {
+        assertQuery(ModernCollectionsOfEnums.self, "(ANY mapInt64Opt.@allValues != %@)", EnumInt64.value1, count: 1) {
             $0.mapInt64Opt.values != .value1
         }
-        assertQuery(ModernCollectionsOfEnums.self, "(mapInt64Opt.@allValues > %@)", EnumInt64.value1, count: 1) {
+        assertQuery(ModernCollectionsOfEnums.self, "(ANY mapInt64Opt.@allValues > %@)", EnumInt64.value1, count: 1) {
             $0.mapInt64Opt.values > .value1
         }
 
-        assertQuery(ModernCollectionsOfEnums.self, "(mapInt64Opt.@allValues >= %@)", EnumInt64.value1, count: 1) {
+        assertQuery(ModernCollectionsOfEnums.self, "(ANY mapInt64Opt.@allValues >= %@)", EnumInt64.value1, count: 1) {
             $0.mapInt64Opt.values >= .value1
         }
-        assertQuery(ModernCollectionsOfEnums.self, "(mapInt64Opt.@allValues < %@)", EnumInt64.value1, count: 0) {
+        assertQuery(ModernCollectionsOfEnums.self, "(ANY mapInt64Opt.@allValues < %@)", EnumInt64.value1, count: 0) {
             $0.mapInt64Opt.values < .value1
         }
 
-        assertQuery(ModernCollectionsOfEnums.self, "(mapInt64Opt.@allValues <= %@)", EnumInt64.value1, count: 1) {
+        assertQuery(ModernCollectionsOfEnums.self, "(ANY mapInt64Opt.@allValues <= %@)", EnumInt64.value1, count: 1) {
             $0.mapInt64Opt.values <= .value1
         }
 
-        assertQuery(ModernCollectionsOfEnums.self, "(mapFloatOpt.@allValues == %@)", EnumFloat.value1, count: 1) {
+        assertQuery(ModernCollectionsOfEnums.self, "(ANY mapFloatOpt.@allValues == %@)", EnumFloat.value1, count: 1) {
             $0.mapFloatOpt.values == .value1
         }
 
-        assertQuery(ModernCollectionsOfEnums.self, "(mapFloatOpt.@allValues != %@)", EnumFloat.value1, count: 1) {
+        assertQuery(ModernCollectionsOfEnums.self, "(ANY mapFloatOpt.@allValues != %@)", EnumFloat.value1, count: 1) {
             $0.mapFloatOpt.values != .value1
         }
-        assertQuery(ModernCollectionsOfEnums.self, "(mapFloatOpt.@allValues > %@)", EnumFloat.value1, count: 1) {
+        assertQuery(ModernCollectionsOfEnums.self, "(ANY mapFloatOpt.@allValues > %@)", EnumFloat.value1, count: 1) {
             $0.mapFloatOpt.values > .value1
         }
 
-        assertQuery(ModernCollectionsOfEnums.self, "(mapFloatOpt.@allValues >= %@)", EnumFloat.value1, count: 1) {
+        assertQuery(ModernCollectionsOfEnums.self, "(ANY mapFloatOpt.@allValues >= %@)", EnumFloat.value1, count: 1) {
             $0.mapFloatOpt.values >= .value1
         }
-        assertQuery(ModernCollectionsOfEnums.self, "(mapFloatOpt.@allValues < %@)", EnumFloat.value1, count: 0) {
+        assertQuery(ModernCollectionsOfEnums.self, "(ANY mapFloatOpt.@allValues < %@)", EnumFloat.value1, count: 0) {
             $0.mapFloatOpt.values < .value1
         }
 
-        assertQuery(ModernCollectionsOfEnums.self, "(mapFloatOpt.@allValues <= %@)", EnumFloat.value1, count: 1) {
+        assertQuery(ModernCollectionsOfEnums.self, "(ANY mapFloatOpt.@allValues <= %@)", EnumFloat.value1, count: 1) {
             $0.mapFloatOpt.values <= .value1
         }
 
-        assertQuery(ModernCollectionsOfEnums.self, "(mapDoubleOpt.@allValues == %@)", EnumDouble.value1, count: 1) {
+        assertQuery(ModernCollectionsOfEnums.self, "(ANY mapDoubleOpt.@allValues == %@)", EnumDouble.value1, count: 1) {
             $0.mapDoubleOpt.values == .value1
         }
 
-        assertQuery(ModernCollectionsOfEnums.self, "(mapDoubleOpt.@allValues != %@)", EnumDouble.value1, count: 1) {
+        assertQuery(ModernCollectionsOfEnums.self, "(ANY mapDoubleOpt.@allValues != %@)", EnumDouble.value1, count: 1) {
             $0.mapDoubleOpt.values != .value1
         }
-        assertQuery(ModernCollectionsOfEnums.self, "(mapDoubleOpt.@allValues > %@)", EnumDouble.value1, count: 1) {
+        assertQuery(ModernCollectionsOfEnums.self, "(ANY mapDoubleOpt.@allValues > %@)", EnumDouble.value1, count: 1) {
             $0.mapDoubleOpt.values > .value1
         }
 
-        assertQuery(ModernCollectionsOfEnums.self, "(mapDoubleOpt.@allValues >= %@)", EnumDouble.value1, count: 1) {
+        assertQuery(ModernCollectionsOfEnums.self, "(ANY mapDoubleOpt.@allValues >= %@)", EnumDouble.value1, count: 1) {
             $0.mapDoubleOpt.values >= .value1
         }
-        assertQuery(ModernCollectionsOfEnums.self, "(mapDoubleOpt.@allValues < %@)", EnumDouble.value1, count: 0) {
+        assertQuery(ModernCollectionsOfEnums.self, "(ANY mapDoubleOpt.@allValues < %@)", EnumDouble.value1, count: 0) {
             $0.mapDoubleOpt.values < .value1
         }
 
-        assertQuery(ModernCollectionsOfEnums.self, "(mapDoubleOpt.@allValues <= %@)", EnumDouble.value1, count: 1) {
+        assertQuery(ModernCollectionsOfEnums.self, "(ANY mapDoubleOpt.@allValues <= %@)", EnumDouble.value1, count: 1) {
             $0.mapDoubleOpt.values <= .value1
         }
 
-        assertQuery(ModernCollectionsOfEnums.self, "(mapStringOpt.@allValues == %@)", EnumString.value1, count: 1) {
+        assertQuery(ModernCollectionsOfEnums.self, "(ANY mapStringOpt.@allValues == %@)", EnumString.value1, count: 1) {
             $0.mapStringOpt.values == .value1
         }
 
-        assertQuery(ModernCollectionsOfEnums.self, "(mapStringOpt.@allValues != %@)", EnumString.value1, count: 1) {
+        assertQuery(ModernCollectionsOfEnums.self, "(ANY mapStringOpt.@allValues != %@)", EnumString.value1, count: 1) {
             $0.mapStringOpt.values != .value1
         }
 
-        assertQuery(ModernCollectionsOfEnums.self, "(mapStringOpt.@allValues CONTAINS[cd] %@)", EnumString.value1, count: 1) {
+        assertQuery(ModernCollectionsOfEnums.self, "(ANY mapStringOpt.@allValues CONTAINS[cd] %@)", EnumString.value1, count: 1) {
             $0.mapStringOpt.values.contains(.value1, options: [.caseInsensitive, .diacriticInsensitive])
         }
 
-        assertQuery(ModernCollectionsOfEnums.self, "(mapStringOpt.@allValues CONTAINS %@)", EnumString.value1, count: 1) {
+        assertQuery(ModernCollectionsOfEnums.self, "(ANY mapStringOpt.@allValues CONTAINS %@)", EnumString.value1, count: 1) {
             $0.mapStringOpt.values.contains(.value1)
         }
 
-        assertQuery(ModernCollectionsOfEnums.self, "(mapStringOpt.@allValues BEGINSWITH[cd] %@)", EnumString.value1, count: 1) {
+        assertQuery(ModernCollectionsOfEnums.self, "(ANY mapStringOpt.@allValues BEGINSWITH[cd] %@)", EnumString.value1, count: 1) {
             $0.mapStringOpt.values.starts(with: .value1, options: [.caseInsensitive, .diacriticInsensitive])
         }
 
-        assertQuery(ModernCollectionsOfEnums.self, "(mapStringOpt.@allValues BEGINSWITH %@)", EnumString.value1, count: 1) {
+        assertQuery(ModernCollectionsOfEnums.self, "(ANY mapStringOpt.@allValues BEGINSWITH %@)", EnumString.value1, count: 1) {
             $0.mapStringOpt.values.starts(with: .value1)
         }
 
-        assertQuery(ModernCollectionsOfEnums.self, "(mapStringOpt.@allValues ENDSWITH[cd] %@)", EnumString.value1, count: 1) {
+        assertQuery(ModernCollectionsOfEnums.self, "(ANY mapStringOpt.@allValues ENDSWITH[cd] %@)", EnumString.value1, count: 1) {
             $0.mapStringOpt.values.ends(with: .value1, options: [.caseInsensitive, .diacriticInsensitive])
         }
 
-        assertQuery(ModernCollectionsOfEnums.self, "(mapStringOpt.@allValues ENDSWITH %@)", EnumString.value1, count: 1) {
+        assertQuery(ModernCollectionsOfEnums.self, "(ANY mapStringOpt.@allValues ENDSWITH %@)", EnumString.value1, count: 1) {
             $0.mapStringOpt.values.ends(with: .value1)
         }
 
-        assertQuery(ModernCollectionsOfEnums.self, "(mapStringOpt.@allValues LIKE[c] %@)", EnumString.value1, count: 1) {
+        assertQuery(ModernCollectionsOfEnums.self, "(ANY mapStringOpt.@allValues LIKE[c] %@)", EnumString.value1, count: 1) {
             $0.mapStringOpt.values.like(.value1, caseInsensitive: true)
         }
 
-        assertQuery(ModernCollectionsOfEnums.self, "(mapStringOpt.@allValues LIKE %@)", EnumString.value1, count: 1) {
+        assertQuery(ModernCollectionsOfEnums.self, "(ANY mapStringOpt.@allValues LIKE %@)", EnumString.value1, count: 1) {
             $0.mapStringOpt.values.like(.value1)
         }
     }
@@ -6673,16 +6673,16 @@ class QueryTests: TestCase {
 
     func testAggregateNotSupported() {
         assertThrows(assertQuery("", count: 0) { $0.intCol.avg == 1 },
-                     reason: "Aggregate operations can only be used on key paths that include an collection property")
+                     reason: "Invalid keypath 'intCol.@avg': Property 'ModernAllTypesObject.intCol' is not a link or collection and can only appear at the end of a keypath.")
 
         assertThrows(assertQuery("", count: 0) { $0.doubleCol.max != 1 },
-                     reason: "Aggregate operations can only be used on key paths that include an collection property")
+                     reason: "Invalid keypath 'doubleCol.@max': Property 'ModernAllTypesObject.doubleCol' is not a link or collection and can only appear at the end of a keypath.")
 
         assertThrows(assertQuery("", count: 0) { $0.dateCol.min > Date() },
-                     reason: "Aggregate operations can only be used on key paths that include an collection property")
+                     reason: "Invalid keypath 'dateCol.@min': Property 'ModernAllTypesObject.dateCol' is not a link or collection and can only appear at the end of a keypath.")
 
         assertThrows(assertQuery("", count: 0) { $0.decimalCol.sum < 1 },
-                     reason: "Aggregate operations can only be used on key paths that include an collection property")
+                     reason: "Invalid keypath 'decimalCol.@sum': Property 'ModernAllTypesObject.decimalCol' is not a link or collection and can only appear at the end of a keypath.")
     }
 
     // MARK: Column comparison

--- a/RealmSwift/Tests/QueryTests.swift.gyb
+++ b/RealmSwift/Tests/QueryTests.swift.gyb
@@ -909,43 +909,43 @@ class QueryTests: TestCase {
 
     private func validateAllKeys<Root: Object, T: RealmKeyedCollection>(_ name: String, _ lhs: (Query<Root>) -> Query<T>)
             where T.Key == String {
-        assertQuery(Root.self, "(\(name).@allKeys == %@)", "foo", count: 1) {
+        assertQuery(Root.self, "(ANY \(name).@allKeys == %@)", "foo", count: 1) {
             lhs($0).keys == "foo"
         }
 
-        assertQuery(Root.self, "(\(name).@allKeys != %@)", "foo", count: 1) {
+        assertQuery(Root.self, "(ANY \(name).@allKeys != %@)", "foo", count: 1) {
             lhs($0).keys != "foo"
         }
 
-        assertQuery(Root.self, "(\(name).@allKeys CONTAINS[cd] %@)", "foo", count: 1) {
+        assertQuery(Root.self, "(ANY \(name).@allKeys CONTAINS[cd] %@)", "foo", count: 1) {
             lhs($0).keys.contains("foo", options: [.caseInsensitive, .diacriticInsensitive])
         }
 
-        assertQuery(Root.self, "(\(name).@allKeys CONTAINS %@)", "foo", count: 1) {
+        assertQuery(Root.self, "(ANY \(name).@allKeys CONTAINS %@)", "foo", count: 1) {
             lhs($0).keys.contains("foo")
         }
 
-        assertQuery(Root.self, "(\(name).@allKeys BEGINSWITH[cd] %@)", "foo", count: 1) {
+        assertQuery(Root.self, "(ANY \(name).@allKeys BEGINSWITH[cd] %@)", "foo", count: 1) {
             lhs($0).keys.starts(with: "foo", options: [.caseInsensitive, .diacriticInsensitive])
         }
 
-        assertQuery(Root.self, "(\(name).@allKeys BEGINSWITH %@)", "foo", count: 1) {
+        assertQuery(Root.self, "(ANY \(name).@allKeys BEGINSWITH %@)", "foo", count: 1) {
             lhs($0).keys.starts(with: "foo")
         }
 
-        assertQuery(Root.self, "(\(name).@allKeys ENDSWITH[cd] %@)", "foo", count: 1) {
+        assertQuery(Root.self, "(ANY \(name).@allKeys ENDSWITH[cd] %@)", "foo", count: 1) {
             lhs($0).keys.ends(with: "foo", options: [.caseInsensitive, .diacriticInsensitive])
         }
 
-        assertQuery(Root.self, "(\(name).@allKeys ENDSWITH %@)", "foo", count: 1) {
+        assertQuery(Root.self, "(ANY \(name).@allKeys ENDSWITH %@)", "foo", count: 1) {
             lhs($0).keys.ends(with: "foo")
         }
 
-        assertQuery(Root.self, "(\(name).@allKeys LIKE[c] %@)", "foo", count: 1) {
+        assertQuery(Root.self, "(ANY \(name).@allKeys LIKE[c] %@)", "foo", count: 1) {
             lhs($0).keys.like("foo", caseInsensitive: true)
         }
 
-        assertQuery(Root.self, "(\(name).@allKeys LIKE %@)", "foo", count: 1) {
+        assertQuery(Root.self, "(ANY \(name).@allKeys LIKE %@)", "foo", count: 1) {
             lhs($0).keys.like("foo")
         }
     }
@@ -958,61 +958,61 @@ class QueryTests: TestCase {
 
     func testMapAllValues() {
         % for property in mapProperties + optMapProperties:
-        assertQuery(${property.className}.self, "(${property.colName}.@allValues == %@)", ${property.enumValue(0)}, count: 1) {
+        assertQuery(${property.className}.self, "(ANY ${property.colName}.@allValues == %@)", ${property.enumValue(0)}, count: 1) {
             $0.${property.colName}.values == ${property.value(0)}
         }
 
         % count = 0 if property.category == 'bool' else 1
-        assertQuery(${property.className}.self, "(${property.colName}.@allValues != %@)", ${property.enumValue(0)}, count: ${count}) {
+        assertQuery(${property.className}.self, "(ANY ${property.colName}.@allValues != %@)", ${property.enumValue(0)}, count: ${count}) {
             $0.${property.colName}.values != ${property.value(0)}
         }
         % if property.category == 'numeric':
-        assertQuery(${property.className}.self, "(${property.colName}.@allValues > %@)", ${property.enumValue(0)}, count: 1) {
+        assertQuery(${property.className}.self, "(ANY ${property.colName}.@allValues > %@)", ${property.enumValue(0)}, count: 1) {
             $0.${property.colName}.values > ${property.value(0)}
         }
 
-        assertQuery(${property.className}.self, "(${property.colName}.@allValues >= %@)", ${property.enumValue(0)}, count: 1) {
+        assertQuery(${property.className}.self, "(ANY ${property.colName}.@allValues >= %@)", ${property.enumValue(0)}, count: 1) {
             $0.${property.colName}.values >= ${property.value(0)}
         }
-        assertQuery(${property.className}.self, "(${property.colName}.@allValues < %@)", ${property.enumValue(0)}, count: 0) {
+        assertQuery(${property.className}.self, "(ANY ${property.colName}.@allValues < %@)", ${property.enumValue(0)}, count: 0) {
             $0.${property.colName}.values < ${property.value(0)}
         }
 
-        assertQuery(${property.className}.self, "(${property.colName}.@allValues <= %@)", ${property.enumValue(0)}, count: 1) {
+        assertQuery(${property.className}.self, "(ANY ${property.colName}.@allValues <= %@)", ${property.enumValue(0)}, count: 1) {
             $0.${property.colName}.values <= ${property.value(0)}
         }
         % end
 
         % if property.category == 'string':
-        assertQuery(${property.className}.self, "(${property.colName}.@allValues CONTAINS[cd] %@)", ${property.enumValue(0)}, count: 1) {
+        assertQuery(${property.className}.self, "(ANY ${property.colName}.@allValues CONTAINS[cd] %@)", ${property.enumValue(0)}, count: 1) {
             $0.${property.colName}.values.contains(${property.value(0)}, options: [.caseInsensitive, .diacriticInsensitive])
         }
 
-        assertQuery(${property.className}.self, "(${property.colName}.@allValues CONTAINS %@)", ${property.enumValue(0)}, count: 1) {
+        assertQuery(${property.className}.self, "(ANY ${property.colName}.@allValues CONTAINS %@)", ${property.enumValue(0)}, count: 1) {
             $0.${property.colName}.values.contains(${property.value(0)})
         }
 
-        assertQuery(${property.className}.self, "(${property.colName}.@allValues BEGINSWITH[cd] %@)", ${property.enumValue(0)}, count: 1) {
+        assertQuery(${property.className}.self, "(ANY ${property.colName}.@allValues BEGINSWITH[cd] %@)", ${property.enumValue(0)}, count: 1) {
             $0.${property.colName}.values.starts(with: ${property.value(0)}, options: [.caseInsensitive, .diacriticInsensitive])
         }
 
-        assertQuery(${property.className}.self, "(${property.colName}.@allValues BEGINSWITH %@)", ${property.enumValue(0)}, count: 1) {
+        assertQuery(${property.className}.self, "(ANY ${property.colName}.@allValues BEGINSWITH %@)", ${property.enumValue(0)}, count: 1) {
             $0.${property.colName}.values.starts(with: ${property.value(0)})
         }
 
-        assertQuery(${property.className}.self, "(${property.colName}.@allValues ENDSWITH[cd] %@)", ${property.enumValue(0)}, count: 1) {
+        assertQuery(${property.className}.self, "(ANY ${property.colName}.@allValues ENDSWITH[cd] %@)", ${property.enumValue(0)}, count: 1) {
             $0.${property.colName}.values.ends(with: ${property.value(0)}, options: [.caseInsensitive, .diacriticInsensitive])
         }
 
-        assertQuery(${property.className}.self, "(${property.colName}.@allValues ENDSWITH %@)", ${property.enumValue(0)}, count: 1) {
+        assertQuery(${property.className}.self, "(ANY ${property.colName}.@allValues ENDSWITH %@)", ${property.enumValue(0)}, count: 1) {
             $0.${property.colName}.values.ends(with: ${property.value(0)})
         }
 
-        assertQuery(${property.className}.self, "(${property.colName}.@allValues LIKE[c] %@)", ${property.enumValue(0)}, count: 1) {
+        assertQuery(${property.className}.self, "(ANY ${property.colName}.@allValues LIKE[c] %@)", ${property.enumValue(0)}, count: 1) {
             $0.${property.colName}.values.like(${property.value(0)}, caseInsensitive: true)
         }
 
-        assertQuery(${property.className}.self, "(${property.colName}.@allValues LIKE %@)", ${property.enumValue(0)}, count: 1) {
+        assertQuery(${property.className}.self, "(ANY ${property.colName}.@allValues LIKE %@)", ${property.enumValue(0)}, count: 1) {
             $0.${property.colName}.values.like(${property.value(0)})
         }
         % end
@@ -1819,16 +1819,16 @@ class QueryTests: TestCase {
     %end
     func testAggregateNotSupported() {
         assertThrows(assertQuery("", count: 0) { $0.intCol.avg == 1 },
-                     reason: "Aggregate operations can only be used on key paths that include an collection property")
+                     reason: "Invalid keypath 'intCol.@avg': Property 'ModernAllTypesObject.intCol' is not a link or collection and can only appear at the end of a keypath.")
 
         assertThrows(assertQuery("", count: 0) { $0.doubleCol.max != 1 },
-                     reason: "Aggregate operations can only be used on key paths that include an collection property")
+                     reason: "Invalid keypath 'doubleCol.@max': Property 'ModernAllTypesObject.doubleCol' is not a link or collection and can only appear at the end of a keypath.")
 
         assertThrows(assertQuery("", count: 0) { $0.dateCol.min > Date() },
-                     reason: "Aggregate operations can only be used on key paths that include an collection property")
+                     reason: "Invalid keypath 'dateCol.@min': Property 'ModernAllTypesObject.dateCol' is not a link or collection and can only appear at the end of a keypath.")
 
         assertThrows(assertQuery("", count: 0) { $0.decimalCol.sum < 1 },
-                     reason: "Aggregate operations can only be used on key paths that include an collection property")
+                     reason: "Invalid keypath 'decimalCol.@sum': Property 'ModernAllTypesObject.decimalCol' is not a link or collection and can only appear at the end of a keypath.")
     }
 
     // MARK: Column comparison


### PR DESCRIPTION
While implementing memberwise comparisons for types mapped to embedded objects I found that some query things didn't work when the object was inside a dictionary. Fixing this ended up requiring significantly reworking how dictionaries on queries is implemented. `@allValues` being a collection operation meant that it couldn't have a keypath after it, so we couldn't query on the properties of objects in a dictionary. Changing it to be instead be treated as a normal keypath helps eliminate a lot of duplicated code and enables some more forms of queries. Our query keypath parsing didn't really support doing that, so I rewrote that. We now parse the keypath ASAP and operate on that parsed struct rather than passing around the string form and doing some odd logic on that.

Along the way I also found and fixed a few other dictionary bugs while writing tests for the bits of RLMQueryUtil which weren't covered.