### PR TITLE
Require Xcode 13.2 for async/await

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,17 +7,20 @@ Xcode 12.4 is now the minimum supported version of Xcode.
 * None.
 
 ### Fixed
-* Add missing `Indexable` support for UUID. 
+* Add missing `Indexable` support for UUID.
   ([Cocoa #7545](https://github.com/realm/realm-cocoa/issues/7545), since v10.10.0)
 
-<!-- ### Breaking Changes - ONLY INCLUDE FOR NEW MAJOR version -->
+### Breaking Changes
+* All `async` functions now require Xcode 13.2 to work around an App
+  Store/TestFlight bug that results in apps built with 13.0/13.1 which do not
+  use libConcurrency but link a library which does crashing on startup.
 
 ### Compatibility
 * Realm Studio: 11.0.0 or later.
 * APIs are backwards compatible with all previous releases in the 10.x.y series.
-* Carthage release for Swift is built with Xcode 13.1.
+* Carthage release for Swift is built with Xcode 13.2.
 * CocoaPods: 1.10 or later.
-* Xcode: 12.2-13.2 beta 2.
+* Xcode: 12.2-13.2.
 
 ### Internal
 * Upgraded realm-core from ? to ?

--- a/Jenkinsfile.releasability
+++ b/Jenkinsfile.releasability
@@ -2,7 +2,7 @@ xcodeVersions = ['12.4', '12.5.1', '13.0', '13.1', '13.2']
 platforms = ['osx', 'ios', 'watchos', 'tvos', 'catalyst']
 carthagePlatforms = ['osx', 'ios', 'watchos', 'tvos']
 platformNames = ['osx': 'macOS', 'ios': 'iOS', 'watchos': 'watchOS', 'tvos': 'tvOS', 'catalyst': 'Catalyst']
-carthageXcodeVersion = '13.1'
+carthageXcodeVersion = '13.2'
 objcXcodeVersion = '12.4'
 docsSwiftVersion = '5.5.1'
 

--- a/Realm/ObjectServerTests/SwiftMongoClientTests.swift
+++ b/Realm/ObjectServerTests/SwiftMongoClientTests.swift
@@ -870,7 +870,7 @@ class SwiftMongoClientTests: SwiftSyncTestCase {
 }
 
 // MARK: - AsyncAwaitMongoClientTests
-#if swift(>=5.5) && canImport(_Concurrency)
+#if swift(>=5.5.2) && canImport(_Concurrency)
 @available(macOS 12.0, *)
 class AsyncAwaitMongoClientTests: SwiftSyncTestCase {
     func setupMongoCollection() async throws -> MongoCollection {

--- a/Realm/ObjectServerTests/SwiftObjectServerTests.swift
+++ b/Realm/ObjectServerTests/SwiftObjectServerTests.swift
@@ -2133,7 +2133,7 @@ class CombineObjectServerTests: SwiftSyncTestCase {
     }
 }
 
-#if swift(>=5.5) && canImport(_Concurrency)
+#if swift(>=5.5.2) && canImport(_Concurrency)
 
 @available(macOS 12.0, *)
 class AsyncAwaitObjectServerTests: SwiftSyncTestCase {

--- a/Realm/ObjectServerTests/SwiftSyncTestCase.swift
+++ b/Realm/ObjectServerTests/SwiftSyncTestCase.swift
@@ -200,7 +200,7 @@ open class SwiftSyncTestCase: RLMSyncTestCase {
     }
 }
 
-#if swift(>=5.5) && canImport(_Concurrency)
+#if swift(>=5.5.2) && canImport(_Concurrency)
 
 @available(macOS 12.0, *)
 extension SwiftSyncTestCase {

--- a/RealmSwift/App.swift
+++ b/RealmSwift/App.swift
@@ -547,7 +547,7 @@ public extension APIKeyAuth {
     }
 }
 
-#if swift(>=5.5) && canImport(_Concurrency)
+#if swift(>=5.5.2) && canImport(_Concurrency)
 @available(macOS 12.0, tvOS 15.0, iOS 15.0, watchOS 8.0, *)
 extension EmailPasswordAuth {
     /// Resets the password of an email identity using the

--- a/RealmSwift/MongoClient.swift
+++ b/RealmSwift/MongoClient.swift
@@ -703,7 +703,7 @@ extension MongoCollection {
     }
 }
 
-#if swift(>=5.5) && canImport(_Concurrency)
+#if swift(>=5.5.2) && canImport(_Concurrency)
 @available(macOS 12.0, tvOS 15.0, iOS 15.0, watchOS 8.0, *)
 extension MongoCollection {
     /// Encodes the provided value to BSON and inserts it. If the value is missing an identifier, one will be

--- a/RealmSwift/Realm.swift
+++ b/RealmSwift/Realm.swift
@@ -1001,7 +1001,7 @@ extension Realm {
 /// The type of a block to run for notification purposes when the data in a Realm is modified.
 public typealias NotificationBlock = (_ notification: Realm.Notification, _ realm: Realm) -> Void
 
-#if swift(>=5.5) && canImport(_Concurrency)
+#if swift(>=5.5.2) && canImport(_Concurrency)
 @available(macOS 12.0, tvOS 15.0, iOS 15.0, watchOS 8.0, *)
 extension Realm {
     /// Options for when to download all data from the server before opening

--- a/RealmSwift/Sync.swift
+++ b/RealmSwift/Sync.swift
@@ -749,7 +749,7 @@ public extension User {
     }
 }
 
-#if swift(>=5.5) && canImport(_Concurrency)
+#if swift(>=5.5.2) && canImport(_Concurrency)
 @available(macOS 12.0, tvOS 15.0, iOS 15.0, watchOS 8.0, *)
 public extension User {
     /// Links the currently authenticated user with a new identity, where the identity is defined by the credential

--- a/RealmSwift/ThreadSafeReference.swift
+++ b/RealmSwift/ThreadSafeReference.swift
@@ -218,7 +218,7 @@ extension Realm {
     }
 }
 
-#if swift(>=5.5) && canImport(_Concurrency)
+#if swift(>=5.5.2) && canImport(_Concurrency)
 extension ThreadSafeReference: Sendable {
 }
 extension RLMThreadSafeReference: @unchecked Sendable {

--- a/build.sh
+++ b/build.sh
@@ -1365,7 +1365,7 @@ x.y.z Release notes (yyyy-MM-dd)
 ### Compatibility
 * Realm Studio: 11.0.0 or later.
 * APIs are backwards compatible with all previous releases in the 10.x.y series.
-* Carthage release for Swift is built with Xcode 13.1.
+* Carthage release for Swift is built with Xcode 13.2.
 * CocoaPods: 1.10 or later.
 * Xcode: 12.4-13.2.
 


### PR DESCRIPTION
A workaround for #7562. Apple is trying to use bitcode to rebuild existing apps to now use async/await on iOS 14 but they're currently doing so incorrectly and actually just making things crash.

This is probably required anyway to properly support concurrency backdeployment so it's worth doing even if Apple fixes the bug. Presumably everyone using async/await is using bleeding-edge Xcode versions anyway.