### PR TITLE
[RLMSchema] Don't iterate through runtime classes unnecessarily

### DIFF
--- a/Realm/RLMSchema.mm
+++ b/Realm/RLMSchema.mm
@@ -193,8 +193,8 @@ static void RLMRegisterClassLocalNames(Class *classes, NSUInteger count) {
 }
 
 - (RLMObjectSchema *)schemaForClassName:(NSString *)className {
-    if (RLMObjectSchema *schema = _objectSchemaByName[className]) {
-        return schema; // fast path for already-initialized schemas
+    if (_objectSchemaByName.count > 0) {
+        return _objectSchemaByName[className]; // fast path for already-initialized schemas
     } else if (Class cls = [RLMSchema classForString:className]) {
         [cls sharedSchema];                    // initialize the schema
         return _objectSchemaByName[className]; // try again


### PR DESCRIPTION
In my application, there are quite a few crashes with an unclear stack trace (see the screenshot). During my investigation, I found out what is happening:

1. We add a class to Realm.
2. We release a version.
3. We remove the class from the application's source code.
4. In the migration, we call `deleteData(forType:)`. Yes, I am aware of the crosslink issue; this is not that situation. I will look into that MR later with my experience on how to fix the deletion problem.
5. `deleteData(forType:)` tries to determine whether to clear or delete the table.
6. To do this, it calls `-schemaForClassName (RLMSchema)`.
7. I have explicitly defined all classes (in `objectSchemaByName` after `+(instancetype)schemaWithObjectClasses`), and none of them includes the one I'm deleting, which makes sense.
8. But it seems excessive that a search is performed in `+classForString (RLMSchema)`, which then goes to `RLMRegisterClassLocalNames` and iterates through all classes. And I remind you that I have explicitly specified the ones I am using.
9. We end up in `RLMIsObjectSubclass`.
10. And already in `class_getSuperclass`, something goes wrong.


I understand that it would be good to figure out which specific class is causing this issue, but I don't have that capability. However, it seems that this MR will eliminate the need to call class_getSuperclass unnecessarily.
<img width="1191" alt="389705538-fd872a2c-81bf-4bba-bff1-09cd78a838a2" src="https://github.com/user-attachments/assets/f5caa6bd-51d3-4df7-ad59-6224def69cd9">
