### PR TITLE
Fix broken link on RLMObject

### DIFF
--- a/Realm/RLMProperty.mm
+++ b/Realm/RLMProperty.mm
@@ -378,7 +378,7 @@ static std::optional<RLMPropertyType> typeFromProtocolString(const char *type) {
             @throw RLMException(@"Property '%@' is declared as '%@', which is not a supported RLMObject property type. "
                                 @"All properties must be primitives, NSString, NSDate, NSData, NSNumber, RLMArray, RLMSet, "
                                 @"RLMDictionary, RLMLinkingObjects, RLMDecimal128, RLMObjectId, or subclasses of RLMObject. "
-                                @"See https://www.mongodb.com/docs/realm-legacy/docs/objc/latest/api/Classes/RLMObject.html "
+                                @"See https://www.mongodb.com/docs/realm-sdks/objc/latest/Classes/RLMObject.html "
                                 @"for more information.", _name, className);
         }
 


### PR DESCRIPTION
Updates a link to an external resource that was returning a 404 error, replacing it with a new, valid URL. This ensures users can access the necessary resource without interruption.

This fix the issue #8795