### PR TITLE
Route all `delete` methods in `Realm.swift` through `RLMRealm`

### DIFF
--- a/RealmSwift/Realm.swift
+++ b/RealmSwift/Realm.swift
@@ -638,7 +638,7 @@ public typealias AsyncTransactionId = RLMAsyncTransactionId
      - parameter object: The object to be deleted.
      */
     public func delete(_ object: ObjectBase) {
-        RLMDeleteObjectFromRealm(object, rlmRealm)
+        rlmRealm.delete(unsafeDowncast(object, to: RLMObject.self))
     }
 
     /**
@@ -707,7 +707,7 @@ public typealias AsyncTransactionId = RLMAsyncTransactionId
      - warning: This method may only be called during a write transaction.
      */
     public func deleteAll() {
-        RLMDeleteAllObjectsFromRealm(rlmRealm)
+        rlmRealm.deleteAllObjects()
     }
 
     // MARK: Object Retrieval

--- a/RealmSwift/Realm.swift
+++ b/RealmSwift/Realm.swift
@@ -638,7 +638,7 @@ public typealias AsyncTransactionId = RLMAsyncTransactionId
      - parameter object: The object to be deleted.
      */
     public func delete(_ object: ObjectBase) {
-        rlmRealm.delete(unsafeDowncast(object, to: RLMObject.self))
+        rlmRealm.delete(unsafeBitCast(object, to: RLMObject.self))
     }
 
     /**

--- a/RealmSwift/Realm.swift
+++ b/RealmSwift/Realm.swift
@@ -638,7 +638,7 @@ public typealias AsyncTransactionId = RLMAsyncTransactionId
      - parameter object: The object to be deleted.
      */
     public func delete(_ object: ObjectBase) {
-        rlmRealm.delete(unsafeBitCast(object, to: RLMObject.self))
+        rlmRealm.delete(object.unsafeCastToRLMObject())
     }
 
     /**


### PR DESCRIPTION
Hey @tgoyne! Long time no see! Thanks so much for continuing to maintain the `community` branch of Realm!

I have a quick PR here. My use-case for it might be a little hacky, so if you know of a better way, I'm happy to amend this as needed.

For my use-case, I'm looking at building a third-party library to enable syncing data between Realm and CloudKit. Ideally, in a way where the developer just interacts with the Realm APIs as normal and the syncing mechanism occurs completely seamlessly in the background.

I can dynamically subscribe to Realm changes in order to receive fine-grained notifications when the user adds or modifies Realm objects, however this approach doesn't work when the user deletes an object. By the time the fine-grained notifications fire, the object is already deleted, so there's no way for me to capture its PK in order to forward that to CloudKit.

My idea here is to use swizzling to hook all of the Objective-C `[RLMRealm delete]` methods and use that to capture all of the objects just in time before they are deleted. In order to do this though, all of the Realm Swift APIs that are talking to the Object Store directly need to be modified so they go via `RLMRealm` instead.

Maybe not the most elegant solution on my behalf. I would imagine adding a `willDelete` event to the fine-grained notifications would be the most appropriate solution here. But I'm hoping this is the most superficial modification necessary to let me achieve the same outcome, with a negligible performance impact for everyone else. And, it also makes all of the delete methods go via `RLMRealm`, which is hopefully more consistent to boot.

Finally, I'm still very invested in Realm's future. If there's anything I can do to help support the community branch, please let me know. Thanks again so much!

