### PR TITLE
[RealmCollectionImpl] annotate internal methods to avoid dyld crash

### DIFF
--- a/RealmSwift/Impl/RealmCollectionImpl.swift
+++ b/RealmSwift/Impl/RealmCollectionImpl.swift
@@ -27,6 +27,7 @@ import Realm
 // The functions don't need to be documented here because Xcode/DocC inherit
 // the documentation from the RealmCollection protocol definition, and jazzy
 // excludes this file entirely.
+@usableFromInline
 internal protocol RealmCollectionImpl: RealmCollection where Index == Int, SubSequence == Slice<Self>, Iterator == RLMIterator<Element> {
     var collection: RLMCollection { get }
     init(collection: RLMCollection)

--- a/RealmSwift/LinkingObjects.swift
+++ b/RealmSwift/LinkingObjects.swift
@@ -83,12 +83,12 @@ import Realm
         self.propertyName = propertyName
         self.handle = handle
     }
-    internal init(collection: RLMCollection) {
+    @usableFromInline internal init(collection: RLMCollection) {
         self.propertyName = ""
         self.handle = RLMLinkingObjectsHandle(linkingObjects: collection as! RLMResults<AnyObject>)
     }
 
-    internal var collection: RLMCollection {
+    @usableFromInline internal var collection: RLMCollection {
         return handle?.results ?? RLMResults<AnyObject>.emptyDetached()
     }
 

--- a/RealmSwift/List.swift
+++ b/RealmSwift/List.swift
@@ -38,7 +38,7 @@ public final class List<Element: RealmCollectionValue>: RLMSwiftCollectionBase, 
     internal var rlmArray: RLMArray<AnyObject> {
         unsafeDowncast(collection, to: RLMArray<AnyObject>.self)
     }
-    internal var collection: RLMCollection {
+    @usableFromInline internal var collection: RLMCollection {
         _rlmCollection
     }
 

--- a/RealmSwift/MutableSet.swift
+++ b/RealmSwift/MutableSet.swift
@@ -38,7 +38,7 @@ public final class MutableSet<Element: RealmCollectionValue>: RLMSwiftCollection
     internal var rlmSet: RLMSet<AnyObject> {
         unsafeDowncast(_rlmCollection, to: RLMSet.self)
     }
-    internal var collection: RLMCollection {
+    @usableFromInline internal var collection: RLMCollection {
         _rlmCollection
     }
 

--- a/RealmSwift/RealmCollection.swift
+++ b/RealmSwift/RealmCollection.swift
@@ -1823,9 +1823,9 @@ extension RealmCollection {
  collection directly.
  */
 @frozen public struct AnyRealmCollection<Element: RealmCollectionValue>: RealmCollectionImpl {
-    internal let collection: RLMCollection
+    @usableFromInline internal let collection: RLMCollection
     internal var lastAccessedNames: NSMutableArray?
-    internal init(collection: RLMCollection) {
+    @usableFromInline internal init(collection: RLMCollection) {
         self.collection = collection
     }
 

--- a/RealmSwift/Results.swift
+++ b/RealmSwift/Results.swift
@@ -110,7 +110,7 @@ extension Projection: KeypathSortable {}
  Results instances cannot be directly instantiated.
  */
 @frozen public struct Results<Element: RealmCollectionValue>: Equatable, RealmCollectionImpl {
-    internal let collection: RLMCollection
+    @usableFromInline internal let collection: RLMCollection
 
     /// A human-readable description of the objects represented by the results.
     public var description: String {
@@ -119,7 +119,7 @@ extension Projection: KeypathSortable {}
 
     // MARK: Initializers
 
-    internal init(collection: RLMCollection) {
+    @usableFromInline internal init(collection: RLMCollection) {
         self.collection = collection
     }
     internal init(_ collection: RLMCollection) {


### PR DESCRIPTION
I was seeing a crash after migrating from Carthage to SPM. The crash doesn't occur with a simple test project, but does occur with a large app that includes many modules and libraries that use RealmSwift. When this crash occurs the following is logged on launch:

```
dyld[31956]: Symbol not found: _$s10RealmSwift7ResultsVyxGAA0A14CollectionImplAAMc
  Referenced from: <CA2BB602-C363-37B9-A568-54CC4C3267C6> /Users/<user>/Library/Developer/Xcode/DerivedData/OneApp-dgeqzukjzdnhcfeyiwctkbxaxuxc/Build/Products/EnterprisePreProd-iphonesimulator/NVIOSSDK.framework/NVIOSSDK
  Expected in:     <58DD162C-52B4-3DE7-91B4-17ED89341E11> /Users/<user>/Library/Developer/Xcode/DerivedData/OneApp-dgeqzukjzdnhcfeyiwctkbxaxuxc/Build/Products/EnterprisePreProd-iphonesimulator/PackageFrameworks/RealmSwift.framework/RealmSwift
```

The unmangled version of that symbol is `protocol conformance descriptor for RealmSwift.Results<A> : RealmSwift.RealmCollectionImpl in RealmSwift`. 

Here are some other reports of a similar problem:
https://github.com/realm/realm-swift/issues/8402
https://github.com/realm/realm-swift/issues/8779
https://stackoverflow.com/questions/79512813/using-realmswift-in-a-framework-most-symbols-found-but-not-all

For our usage of RealmSwift, this crash is fixed by adding the [`@usableFromInline`](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0193-cross-module-inlining-and-specialization.md) annotation to about 8 internal methods in RealmSwift. 

```
ProductName:		macOS
ProductVersion:		15.7.4
BuildVersion:		24G517

/Applications/Xcode.app/Contents/Developer
Xcode 26.2
Build version 17C52

/Users/<user>/.rbenv/shims/pod
1.16.2

/bin/bash
GNU bash, version 3.2.57(1)-release (arm64-apple-darwin24)

/opt/homebrew/bin/carthage
0.40.0
(not in use here)

/opt/homebrew/bin/git
git version 2.51.0
```
